### PR TITLE
fix: correct greetings workflow parameters and apply Rector fixes

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue! We appreciate you taking the time to report this.
 
             A maintainer will review your issue soon. In the meantime, please make sure you've:
@@ -29,7 +29,7 @@ jobs:
             - Searched for [existing issues](https://github.com/netresearch/t3x-nr-llm/issues)
 
             If you have questions, feel free to use [Discussions](https://github.com/netresearch/t3x-nr-llm/discussions).
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request! We're excited to have you contribute.
 
             A maintainer will review your PR soon. Please ensure:

--- a/Classes/Provider/ResponseParserTrait.php
+++ b/Classes/Provider/ResponseParserTrait.php
@@ -353,7 +353,7 @@ trait ResponseParserTrait
         $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
         if (!is_array($decoded)) {
-            throw new InvalidArgumentException('Expected JSON object, got ' . gettype($decoded));
+            throw new InvalidArgumentException('Expected JSON object, got ' . gettype($decoded), 8142137949);
         }
 
         /** @var array<string, mixed> $decoded */

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+
 /*
  * Extbase persistence configuration for nr_llm.
  *
@@ -9,7 +11,7 @@ declare(strict_types=1);
  * the default Extbase naming convention.
  */
 return [
-    \Netresearch\NrLlm\Domain\Model\LlmConfiguration::class => [
+    LlmConfiguration::class => [
         'tableName' => 'tx_nrllm_configuration',
     ],
 ];

--- a/Tests/Functional/FunctionalTestsBootstrap.php
+++ b/Tests/Functional/FunctionalTestsBootstrap.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use TYPO3\TestingFramework\Core\Testbase;
+
 /*
  * Bootstrap for functional tests.
  *
@@ -19,7 +21,7 @@ if (!file_exists($autoloadFile)) {
 require_once $autoloadFile;
 
 // Initialize testing framework
-$testbase = new \TYPO3\TestingFramework\Core\Testbase();
+$testbase = new Testbase();
 $testbase->defineOriginalRootPath();
 /** @phpstan-ignore constant.notFound, binaryOp.invalid */
 $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');


### PR DESCRIPTION
## Summary

Fixes CI failures on main branch.

## Changes

### Greetings Workflow Fix
The `actions/first-interaction` action was updated to v3.1.0, which changed parameter names from hyphens to underscores:
- `repo-token` → `repo_token`
- `issue-message` → `issue_message`
- `pr-message` → `pr_message`

### Rector Fixes
Applied automatic Rector fixes:
- Add exception error code in `ResponseParserTrait`
- Use import statements instead of FQCN in `Classes.php` and `FunctionalTestsBootstrap.php`

## Test plan

- [x] PHPStan passes
- [x] php-cs-fixer shows 0 files to fix
- [x] Rector dry-run shows no changes needed