### PR TITLE
fix(ci): skip gitleaks on merge_group events

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,8 @@ jobs:
   gitleaks:
     name: Secret Scanning
     runs-on: ubuntu-latest
+    # gitleaks-action doesn't support merge_group events
+    if: github.event_name != 'merge_group'
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
gitleaks-action v2.3.9 doesn't support merge_group events, causing CI failures when PRs go through the merge queue.

Fixes https://github.com/netresearch/t3x-nr-llm/actions/runs/20830266068