### PR TITLE
fix(ci): simplify TER upload workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,42 +160,15 @@ jobs:
       - name: Install tailor
         run: composer global require typo3/tailor --no-progress
 
-      - name: Create TER package
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          # Create zip archive for TER (excluding dev files)
-          zip -r "nr_llm_$VERSION.zip" . \
-            -x "*.git*" \
-            -x "*.github*" \
-            -x "Tests/*" \
-            -x "Build/*" \
-            -x ".php-cs-fixer*" \
-            -x "phpstan*" \
-            -x "phpunit*" \
-            -x "grumphp*" \
-            -x "rector*" \
-            -x "*.dist" \
-            -x "Makefile"
-
       - name: Upload to TER
         env:
           TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
         run: |
+          # Remove dev files before packaging (tailor will create the archive)
+          rm -rf .git .github Tests Build .php-cs-fixer* phpstan* phpunit* grumphp* rector* Makefile *.dist
+          # Publish to TER (tailor creates the package from current directory)
           ~/.composer/vendor/bin/tailor ter:publish "$VERSION" \
-            --artefact="nr_llm_$VERSION.zip" \
             --comment="Release $VERSION"
 
-  provenance:
-    name: Generate SLSA Provenance
-    needs: release
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: |
-        ${{ needs.release.outputs.version }}
-      upload-assets: true
+  # Note: SLSA provenance is already generated via actions/attest-build-provenance in the release job


### PR DESCRIPTION
## Summary
- Let tailor handle packaging instead of manual zip creation
- Remove broken SLSA provenance job (already covered by `actions/attest-build-provenance`)
- TER upload still requires `TYPO3_API_TOKEN` secret to be configured in org/repo secrets

## Issue
TER upload was failing with "No ext_emconf.php file found in the folder" because tailor validates the working directory even when `--artefact` is provided.

## Test plan
- [ ] CI passes
- [ ] After merge and new release tag, TER upload should work (if `TYPO3_API_TOKEN` is configured)