### PR TITLE
fix(ci): use correct org secret name for TER token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload to TER
         env:
-          TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+          TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           # Remove dev files before packaging (tailor will create the archive)


### PR DESCRIPTION
Uses `TYPO3_TER_ACCESS_TOKEN` (the actual org secret name) instead of `TYPO3_API_TOKEN`.

Also added t3x-nr-llm to the list of repos with access to this org secret.