### PR TITLE
docs: update guides.xml version to 0.1.2

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.1.0"
-        release="0.1.0"
+        version="0.1.2"
+        release="0.1.2"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 


### PR DESCRIPTION
## Summary
- Update documentation version in guides.xml from 0.1.0 to 0.1.2

This ensures the TYPO3 docs webhook (now configured) will publish the correct version.