### PR TITLE
chore(deps): upgrade nr-vault from dev-main to ^0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^8.5",
-        "netresearch/nr-vault": "@dev",
+        "netresearch/nr-vault": "^0.3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",
@@ -49,12 +49,6 @@
         "ssch/typo3-rector": "^3.0",
         "typo3/testing-framework": "^9.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/netresearch/t3x-nr-vault.git"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "Netresearch\\NrLlm\\": "Classes/"


### PR DESCRIPTION
## Summary
- Switch nr-vault from dev-main to stable tagged release ^0.3.0
- Remove VCS repository definition (package now available on Packagist)
- v0.3.0 brings typed DTOs and OAuth 2.0 support (available for future use)

## Testing
- All 2288 unit tests pass
- PHPStan clean at level 10
- No breaking changes detected in VaultServiceInterface

## Test plan
- [ ] CI pipeline passes
- [ ] Extension functionality unchanged