### PR TITLE
fix(deps): pin phpstan <2.1.34 for Rector compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,9 @@
         "infection/infection": "^0.32",
         "phpat/phpat": "^0.12",
         "phpro/grumphp": "^2.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.0 <2.1.34",
         "phpunit/phpunit": "^12.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.3.1",
         "ssch/typo3-rector": "^3.0",
         "typo3/testing-framework": "^9.0"
     },


### PR DESCRIPTION
## Summary

- Pin phpstan to <2.1.34 to fix Rector compatibility issue
- Also require rector ^2.3.1

## Problem

PHPStan 2.1.34 (released 2026-01-19) breaks Rector with errors:

```
[ERROR] Could not process "Classes/..." file, due to:
        "Service name must be a non-empty string.". On line: 291
```

Tracked in: https://github.com/rectorphp/rector/issues/9604

## Fix

Pin phpstan to `^2.0 <2.1.34` until Rector releases a compatible version.

## Test plan

- [ ] CI Rector job passes