### PR TITLE
fix(ci): use correct commit SHA for codeql-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           publish_results: true
 
       - name: Upload to Code Scanning
-        uses: github/codeql-action/upload-sarif@04800457060cff48cb952d0b0355a5ab4b264a36 # v4.31.11
+        uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Fixes the OpenSSF Scorecard Analysis failure caused by using a tag object SHA instead of the actual commit SHA for `github/codeql-action/upload-sarif`.

**Error from Scorecard:**
```
imposter commit: 04800457060cff48cb952d0b0355a5ab4b264a36 does not belong to github/codeql-action/upload-sarif
```

## Root Cause

When pinning GitHub Actions to a SHA, we must use the **commit SHA**, not the **tag object SHA**. For annotated tags (like `v4.31.11`), these are different:

- Tag object SHA: `04800457060cff48cb952d0b0355a5ab4b264a36` ❌
- Actual commit SHA: `19b2f06db2b6f5108140aeb04014ef02b648f789` ✅

## Changes

- Updated `github/codeql-action/upload-sarif` SHA in `.github/workflows/scorecard.yml`

## Test plan

- [ ] Scorecard Analysis workflow passes
- [ ] SHA verification: `gh api repos/github/codeql-action/commits/19b2f06db2b6f5108140aeb04014ef02b648f789 --jq .sha` returns the same SHA