### PR TITLE
feat: add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add custom CodeQL workflow instead of GitHub Default Setup (ClickOps)
- Scan both `actions` and `javascript` languages
- Uses SHA-pinned actions with harden-runner

## Why Custom Workflow?
| Aspect | Default Setup | Custom codeql.yml |
|--------|--------------|-------------------|
| Auditability | Hidden in Settings | Code in repo, PR reviewable |
| Consistency | Varies per repo | Same template across all repos |
| Templatable | Cannot template UI clicks | Skill provides standard file |

## Test plan
- [ ] CodeQL workflow runs successfully on PR
- [ ] Both actions and javascript scans complete

---
## EntelligenceAI PR Summary 
 This PR adds automated CodeQL security analysis to the repository with scheduled and event-triggered scanning.
- Created new GitHub Actions workflow at `.github/workflows/codeql.yml`
- Configured triggers: push/PR to main branch and weekly schedule (Mondays at 6 AM UTC)
- Implemented matrix strategy to analyze GitHub Actions workflows and JavaScript code
- Applied security hardening: pinned action versions using commit SHAs and minimal permission grants
- Set permissions: contents read, security-events write, and actions read for analyze job 

