### PR TITLE
fix(ci): skip gitleaks on Dependabot PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     name: Secret Scanning
     runs-on: ubuntu-latest
     # gitleaks-action requires GITLEAKS_LICENSE which is unavailable to Dependabot PRs
-    if: github.event_name != 'merge_group' && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

- Skip the gitleaks Secret Scanning job when the actor is `dependabot[bot]`, since Dependabot PRs run in a restricted security context where the `GITLEAKS_LICENSE` repository secret is unavailable
- This unblocks PRs #60, #61, and #62 which are all failing with `missing gitleaks license`
- Security coverage is maintained: all code is scanned by gitleaks on push to `main` after merge

## Root cause

The `gitleaks/gitleaks-action@v2` requires a `GITLEAKS_LICENSE` secret for organization repos. GitHub does not expose repository secrets to workflows triggered by Dependabot PRs (`pull_request` event from forks/bots). The action fails immediately with:

```
##[error] missing gitleaks license. Go grab one at gitleaks.io and store it as a GitHub Secret named GITLEAKS_LICENSE.
```

This also causes the `Auto-merge dependency PRs` workflow to fail, since it waits for all checks to pass.

## Test plan

- [ ] This PR's own "Secret Scanning" check should still run (not a Dependabot PR)
- [ ] After merge, retrigger CI on PRs #60, #61, #62 -- Secret Scanning should be skipped and auto-merge should proceed
- [ ] Verify gitleaks still runs on push to `main` (scheduled + push events)