### PR TITLE
chore: add SPDX copyright and license headers

### DIFF
--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/Controller/Backend/DTO/ExecuteTaskRequest.php
+++ b/Classes/Controller/Backend/DTO/ExecuteTaskRequest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\DTO;

--- a/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
+++ b/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\DTO;

--- a/Classes/Controller/Backend/DTO/LoadRecordDataRequest.php
+++ b/Classes/Controller/Backend/DTO/LoadRecordDataRequest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\DTO;

--- a/Classes/Controller/Backend/DTO/RefreshInputRequest.php
+++ b/Classes/Controller/Backend/DTO/RefreshInputRequest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\DTO;

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/Controller/Backend/Response/ErrorResponse.php
+++ b/Classes/Controller/Backend/Response/ErrorResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/ModelListItemResponse.php
+++ b/Classes/Controller/Backend/Response/ModelListItemResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/ModelListResponse.php
+++ b/Classes/Controller/Backend/Response/ModelListResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/ProviderModelsResponse.php
+++ b/Classes/Controller/Backend/Response/ProviderModelsResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/SuccessResponse.php
+++ b/Classes/Controller/Backend/Response/SuccessResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/TestConfigurationResponse.php
+++ b/Classes/Controller/Backend/Response/TestConfigurationResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/TestConnectionResponse.php
+++ b/Classes/Controller/Backend/Response/TestConnectionResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/ToggleActiveResponse.php
+++ b/Classes/Controller/Backend/Response/ToggleActiveResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/Response/UsageResponse.php
+++ b/Classes/Controller/Backend/Response/UsageResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;

--- a/Classes/DependencyInjection/ProviderCompilerPass.php
+++ b/Classes/DependencyInjection/ProviderCompilerPass.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\DependencyInjection;

--- a/Classes/Domain/DTO/ModelSelectionCriteria.php
+++ b/Classes/Domain/DTO/ModelSelectionCriteria.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\DTO;

--- a/Classes/Domain/Enum/ModelCapability.php
+++ b/Classes/Domain/Enum/ModelCapability.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;

--- a/Classes/Domain/Enum/ModelSelectionMode.php
+++ b/Classes/Domain/Enum/ModelSelectionMode.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;

--- a/Classes/Domain/Enum/TaskCategory.php
+++ b/Classes/Domain/Enum/TaskCategory.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;

--- a/Classes/Domain/Enum/TaskInputType.php
+++ b/Classes/Domain/Enum/TaskInputType.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;

--- a/Classes/Domain/Enum/TaskOutputFormat.php
+++ b/Classes/Domain/Enum/TaskOutputFormat.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;

--- a/Classes/Domain/Model/AdapterType.php
+++ b/Classes/Domain/Model/AdapterType.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/CompletionResponse.php
+++ b/Classes/Domain/Model/CompletionResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/PromptTemplate.php
+++ b/Classes/Domain/Model/PromptTemplate.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/RenderedPrompt.php
+++ b/Classes/Domain/Model/RenderedPrompt.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/TranslationResult.php
+++ b/Classes/Domain/Model/TranslationResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/UsageStatistics.php
+++ b/Classes/Domain/Model/UsageStatistics.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Model/VisionResponse.php
+++ b/Classes/Domain/Model/VisionResponse.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;

--- a/Classes/Domain/Repository/LlmConfigurationRepository.php
+++ b/Classes/Domain/Repository/LlmConfigurationRepository.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Repository;

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Repository;

--- a/Classes/Domain/Repository/PromptTemplateRepository.php
+++ b/Classes/Domain/Repository/PromptTemplateRepository.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Repository;

--- a/Classes/Domain/Repository/ProviderRepository.php
+++ b/Classes/Domain/Repository/ProviderRepository.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Repository;

--- a/Classes/Domain/Repository/TaskRepository.php
+++ b/Classes/Domain/Repository/TaskRepository.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Repository;

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;

--- a/Classes/Exception/AccessDeniedException.php
+++ b/Classes/Exception/AccessDeniedException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Exception;

--- a/Classes/Exception/ConfigurationNotFoundException.php
+++ b/Classes/Exception/ConfigurationNotFoundException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Exception;

--- a/Classes/Exception/InvalidArgumentException.php
+++ b/Classes/Exception/InvalidArgumentException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Exception;

--- a/Classes/Exception/PromptTemplateNotFoundException.php
+++ b/Classes/Exception/PromptTemplateNotFoundException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Exception;

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/Contract/ProviderInterface.php
+++ b/Classes/Provider/Contract/ProviderInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Contract;

--- a/Classes/Provider/Contract/StreamingCapableInterface.php
+++ b/Classes/Provider/Contract/StreamingCapableInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Contract;

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Contract;

--- a/Classes/Provider/Contract/VisionCapableInterface.php
+++ b/Classes/Provider/Contract/VisionCapableInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Contract;

--- a/Classes/Provider/Exception/ProviderConfigurationException.php
+++ b/Classes/Provider/Exception/ProviderConfigurationException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;

--- a/Classes/Provider/Exception/ProviderConnectionException.php
+++ b/Classes/Provider/Exception/ProviderConnectionException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;

--- a/Classes/Provider/Exception/ProviderException.php
+++ b/Classes/Provider/Exception/ProviderException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;

--- a/Classes/Provider/Exception/UnsupportedFeatureException.php
+++ b/Classes/Provider/Exception/UnsupportedFeatureException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/ProviderRegistry.php
+++ b/Classes/Provider/ProviderRegistry.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Provider/ResponseParserTrait.php
+++ b/Classes/Provider/ResponseParserTrait.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/CacheManagerInterface.php
+++ b/Classes/Service/CacheManagerInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;

--- a/Classes/Service/LlmConfigurationService.php
+++ b/Classes/Service/LlmConfigurationService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/Option/EmbeddingOptions.php
+++ b/Classes/Service/Option/EmbeddingOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/Option/VisionOptions.php
+++ b/Classes/Service/Option/VisionOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;

--- a/Classes/Service/PromptTemplateService.php
+++ b/Classes/Service/PromptTemplateService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard;

--- a/Classes/Service/SetupWizard/DTO/DetectedProvider.php
+++ b/Classes/Service/SetupWizard/DTO/DetectedProvider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard\DTO;

--- a/Classes/Service/SetupWizard/DTO/DiscoveredModel.php
+++ b/Classes/Service/SetupWizard/DTO/DiscoveredModel.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard\DTO;

--- a/Classes/Service/SetupWizard/DTO/SuggestedConfiguration.php
+++ b/Classes/Service/SetupWizard/DTO/SuggestedConfiguration.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard\DTO;

--- a/Classes/Service/SetupWizard/DTO/WizardResult.php
+++ b/Classes/Service/SetupWizard/DTO/WizardResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard\DTO;

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard;

--- a/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
+++ b/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard;

--- a/Classes/Service/SetupWizard/ProviderDetector.php
+++ b/Classes/Service/SetupWizard/ProviderDetector.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\SetupWizard;

--- a/Classes/Service/UsageTrackerService.php
+++ b/Classes/Service/UsageTrackerService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Service/UsageTrackerServiceInterface.php
+++ b/Classes/Service/UsageTrackerServiceInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;

--- a/Classes/Specialized/Exception/ImageGenerationException.php
+++ b/Classes/Specialized/Exception/ImageGenerationException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/ServiceConfigurationException.php
+++ b/Classes/Specialized/Exception/ServiceConfigurationException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/ServiceQuotaExceededException.php
+++ b/Classes/Specialized/Exception/ServiceQuotaExceededException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/ServiceUnavailableException.php
+++ b/Classes/Specialized/Exception/ServiceUnavailableException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/SpecializedServiceException.php
+++ b/Classes/Specialized/Exception/SpecializedServiceException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/SpeechServiceException.php
+++ b/Classes/Specialized/Exception/SpeechServiceException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/TranslatorException.php
+++ b/Classes/Specialized/Exception/TranslatorException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/UnsupportedFormatException.php
+++ b/Classes/Specialized/Exception/UnsupportedFormatException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Exception/UnsupportedLanguageException.php
+++ b/Classes/Specialized/Exception/UnsupportedLanguageException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Exception;

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;

--- a/Classes/Specialized/Image/ImageGenerationResult.php
+++ b/Classes/Specialized/Image/ImageGenerationResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;

--- a/Classes/Specialized/Option/DeepLOptions.php
+++ b/Classes/Specialized/Option/DeepLOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Option;

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Option;

--- a/Classes/Specialized/Option/SpeechSynthesisOptions.php
+++ b/Classes/Specialized/Option/SpeechSynthesisOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Option;

--- a/Classes/Specialized/Option/TranscriptionOptions.php
+++ b/Classes/Specialized/Option/TranscriptionOptions.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Option;

--- a/Classes/Specialized/Speech/Segment.php
+++ b/Classes/Specialized/Speech/Segment.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Speech/SpeechSynthesisResult.php
+++ b/Classes/Specialized/Speech/SpeechSynthesisResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Speech/TranscriptionResult.php
+++ b/Classes/Specialized/Speech/TranscriptionResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Speech/Word.php
+++ b/Classes/Specialized/Speech/Word.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Classes/Specialized/Translation/TranslatorInterface.php
+++ b/Classes/Specialized/Translation/TranslatorInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Classes/Specialized/Translation/TranslatorRegistry.php
+++ b/Classes/Specialized/Translation/TranslatorRegistry.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Classes/Specialized/Translation/TranslatorRegistryInterface.php
+++ b/Classes/Specialized/Translation/TranslatorRegistryInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Classes/Specialized/Translation/TranslatorResult.php
+++ b/Classes/Specialized/Translation/TranslatorResult.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;

--- a/Configuration/Caching.php
+++ b/Configuration/Caching.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend;

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use Netresearch\NrLlm\DependencyInjection\ProviderCompilerPass;

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 return [

--- a/Configuration/TCA/tx_nrllm_model.php
+++ b/Configuration/TCA/tx_nrllm_model.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 return [

--- a/Configuration/TCA/tx_nrllm_provider.php
+++ b/Configuration/TCA/tx_nrllm_provider.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use Netresearch\NrVault\TCA\VaultFieldHelper;

--- a/Configuration/TCA/tx_nrllm_task.php
+++ b/Configuration/TCA/tx_nrllm_task.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 return [

--- a/Resources/Private/Data/DefaultPrompts.php
+++ b/Resources/Private/Data/DefaultPrompts.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/Tests/Architecture/ControllerLayerTest.php
+++ b/Tests/Architecture/ControllerLayerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Architecture;

--- a/Tests/Architecture/DomainLayerTest.php
+++ b/Tests/Architecture/DomainLayerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Architecture;

--- a/Tests/Architecture/DtoLayerTest.php
+++ b/Tests/Architecture/DtoLayerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Architecture;

--- a/Tests/E2E/AbstractE2ETestCase.php
+++ b/Tests/E2E/AbstractE2ETestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E;

--- a/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
+++ b/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/DashboardE2ETest.php
+++ b/Tests/E2E/Backend/DashboardE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
+++ b/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/ModelManagementE2ETest.php
+++ b/Tests/E2E/Backend/ModelManagementE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/ProviderManagementE2ETest.php
+++ b/Tests/E2E/Backend/ProviderManagementE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/SetupWizardE2ETest.php
+++ b/Tests/E2E/Backend/SetupWizardE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\Backend;

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E;

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E;

--- a/Tests/E2E/TCA/TcaFieldCompletionTest.php
+++ b/Tests/E2E/TCA/TcaFieldCompletionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\E2E\TCA;

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional;

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
+++ b/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ModelControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ProviderControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/Controller/Backend/TaskControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;

--- a/Tests/Functional/FunctionalTestsBootstrap.php
+++ b/Tests/Functional/FunctionalTestsBootstrap.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use TYPO3\TestingFramework\Core\Testbase;

--- a/Tests/Functional/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Functional/Provider/ProviderAdapterRegistryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Provider;

--- a/Tests/Functional/Provider/ProviderConnectionTest.php
+++ b/Tests/Functional/Provider/ProviderConnectionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Provider;

--- a/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
+++ b/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Repository;

--- a/Tests/Functional/Repository/ModelRepositoryTest.php
+++ b/Tests/Functional/Repository/ModelRepositoryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Repository;

--- a/Tests/Functional/Repository/ProviderRepositoryTest.php
+++ b/Tests/Functional/Repository/ProviderRepositoryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Repository;

--- a/Tests/Functional/Repository/TaskRepositoryTest.php
+++ b/Tests/Functional/Repository/TaskRepositoryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Repository;

--- a/Tests/Functional/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Functional/Service/LlmConfigurationServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Service;

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Service;

--- a/Tests/Fuzzy/AbstractFuzzyTestCase.php
+++ b/Tests/Fuzzy/AbstractFuzzyTestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy;

--- a/Tests/Fuzzy/Domain/CompletionResponseFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/CompletionResponseFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Domain/EmbeddingResponseFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/EmbeddingResponseFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Domain/ModelFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/ModelFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Domain/ProviderFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/ProviderFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Domain/UsageStatisticsFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/UsageStatisticsFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Domain;

--- a/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
+++ b/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Security;

--- a/Tests/Fuzzy/Service/ChatOptionsFuzzyTest.php
+++ b/Tests/Fuzzy/Service/ChatOptionsFuzzyTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Fuzzy\Service;

--- a/Tests/Integration/AbstractIntegrationTestCase.php
+++ b/Tests/Integration/AbstractIntegrationTestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Integration;

--- a/Tests/Integration/Provider/ClaudeProviderIntegrationTest.php
+++ b/Tests/Integration/Provider/ClaudeProviderIntegrationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Integration\Provider;

--- a/Tests/Integration/Provider/OpenAiProviderIntegrationTest.php
+++ b/Tests/Integration/Provider/OpenAiProviderIntegrationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Integration\Provider;

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Integration\Service;

--- a/Tests/Unit/AbstractUnitTestCase.php
+++ b/Tests/Unit/AbstractUnitTestCase.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit;

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;

--- a/Tests/Unit/Controller/Backend/DTO/ExecuteTaskRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/ExecuteTaskRequestTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\DTO;

--- a/Tests/Unit/Controller/Backend/DTO/FetchRecordsRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/FetchRecordsRequestTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\DTO;

--- a/Tests/Unit/Controller/Backend/DTO/LoadRecordDataRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/LoadRecordDataRequestTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\DTO;

--- a/Tests/Unit/Controller/Backend/DTO/RefreshInputRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/RefreshInputRequestTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\DTO;

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;

--- a/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
+++ b/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\Response;

--- a/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\DependencyInjection;

--- a/Tests/Unit/Domain/Enum/ModelSelectionModeTest.php
+++ b/Tests/Unit/Domain/Enum/ModelSelectionModeTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;

--- a/Tests/Unit/Domain/Model/AdapterTypeTest.php
+++ b/Tests/Unit/Domain/Model/AdapterTypeTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/CompletionResponseTest.php
+++ b/Tests/Unit/Domain/Model/CompletionResponseTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
+++ b/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/ModelTest.php
+++ b/Tests/Unit/Domain/Model/ModelTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/PromptTemplateTest.php
+++ b/Tests/Unit/Domain/Model/PromptTemplateTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/RenderedPromptTest.php
+++ b/Tests/Unit/Domain/Model/RenderedPromptTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Domain/Model/UsageStatisticsTest.php
+++ b/Tests/Unit/Domain/Model/UsageStatisticsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;

--- a/Tests/Unit/Provider/AbstractProviderConfigureTest.php
+++ b/Tests/Unit/Provider/AbstractProviderConfigureTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/ClaudeProviderMutationTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/GeminiProviderMutationTest.php
+++ b/Tests/Unit/Provider/GeminiProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/GroqProviderMutationTest.php
+++ b/Tests/Unit/Provider/GroqProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/MistralProviderMutationTest.php
+++ b/Tests/Unit/Provider/MistralProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OllamaProviderMutationTest.php
+++ b/Tests/Unit/Provider/OllamaProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OpenAiProviderMutationTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OpenRouterProviderMutationTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Provider/ResponseParserTraitTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;

--- a/Tests/Unit/Service/CacheManagerMutationTest.php
+++ b/Tests/Unit/Service/CacheManagerMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/Feature/VisionServiceTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;

--- a/Tests/Unit/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Unit/Service/LlmConfigurationServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/ModelSelectionServiceTest.php
+++ b/Tests/Unit/Service/ModelSelectionServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/Option/ChatOptionsMutationTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
+++ b/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/Option/ToolOptionsTest.php
+++ b/Tests/Unit/Service/Option/ToolOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/Option/TranslationOptionsTest.php
+++ b/Tests/Unit/Service/Option/TranslationOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/Option/VisionOptionsTest.php
+++ b/Tests/Unit/Service/Option/VisionOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Option;

--- a/Tests/Unit/Service/PromptTemplateServiceTest.php
+++ b/Tests/Unit/Service/PromptTemplateServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard;

--- a/Tests/Unit/Service/SetupWizard/DTO/DetectedProviderTest.php
+++ b/Tests/Unit/Service/SetupWizard/DTO/DetectedProviderTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard\DTO;

--- a/Tests/Unit/Service/SetupWizard/DTO/DiscoveredModelTest.php
+++ b/Tests/Unit/Service/SetupWizard/DTO/DiscoveredModelTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard\DTO;

--- a/Tests/Unit/Service/SetupWizard/DTO/SuggestedConfigurationTest.php
+++ b/Tests/Unit/Service/SetupWizard/DTO/SuggestedConfigurationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard\DTO;

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard;

--- a/Tests/Unit/Service/SetupWizard/ProviderDetectorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ProviderDetectorTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard;

--- a/Tests/Unit/Service/UsageTrackerServiceTest.php
+++ b/Tests/Unit/Service/UsageTrackerServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;

--- a/Tests/Unit/Specialized/Exception/ImageGenerationExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/ImageGenerationExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/ServiceConfigurationExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/ServiceConfigurationExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/ServiceQuotaExceededExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/ServiceQuotaExceededExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/ServiceUnavailableExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/ServiceUnavailableExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/SpeechServiceExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/SpeechServiceExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/TranslatorExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/TranslatorExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/UnsupportedFormatExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/UnsupportedFormatExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Exception/UnsupportedLanguageExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/UnsupportedLanguageExceptionTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Exception;

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;

--- a/Tests/Unit/Specialized/Image/ImageGenerationResultTest.php
+++ b/Tests/Unit/Specialized/Image/ImageGenerationResultTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;

--- a/Tests/Unit/Specialized/Option/DeepLOptionsMutationTest.php
+++ b/Tests/Unit/Specialized/Option/DeepLOptionsMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Option;

--- a/Tests/Unit/Specialized/Option/DeepLOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/DeepLOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Option;

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Option;

--- a/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Option;

--- a/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Option;

--- a/Tests/Unit/Specialized/Speech/SegmentMutationTest.php
+++ b/Tests/Unit/Specialized/Speech/SegmentMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/SegmentTest.php
+++ b/Tests/Unit/Specialized/Speech/SegmentTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/SpeechSynthesisResultTest.php
+++ b/Tests/Unit/Specialized/Speech/SpeechSynthesisResultTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/TranscriptionResultMutationTest.php
+++ b/Tests/Unit/Specialized/Speech/TranscriptionResultMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/TranscriptionResultTest.php
+++ b/Tests/Unit/Specialized/Speech/TranscriptionResultTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Speech/WordTest.php
+++ b/Tests/Unit/Specialized/Speech/WordTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/Tests/Unit/Specialized/Translation/TranslatorRegistryTest.php
+++ b/Tests/Unit/Specialized/Translation/TranslatorRegistryTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/Tests/Unit/Specialized/Translation/TranslatorResultTest.php
+++ b/Tests/Unit/Specialized/Translation/TranslatorResultTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 $EM_CONF[$_EXTKEY] = [
     'title' => 'NR LLM - AI Provider Abstraction',
     'description' => 'Unified AI/LLM provider abstraction layer for TYPO3. Supports OpenAI, Claude, Gemini, and other providers with features like chat completion, embeddings, vision, and translation. - by Netresearch',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;


### PR DESCRIPTION
## Summary
- Add SPDX copyright (Netresearch DTT GmbH) and license (GPL-2.0-or-later) headers to all PHP source files (280 files)
- Covers `Classes/`, `Configuration/`, `Tests/`, `Resources/`, `ext_localconf.php`, `ext_emconf.php`
- Supports OpenSSF Best Practices Gold badge criteria (`copyright_per_file`, `license_per_file`)

## Note
- `Build/` and `claudedocs/` PHP files excluded from this PR (pre-existing PHPStan issues with GrumPHP when those files are staged)

## Test plan
- [x] GrumPHP pre-commit checks pass (phpcsfixer, phpstan, file_size, composer, composer_normalize, securitychecker_enlightn)
- [ ] CI passes (headers are comments only, no functional changes)