### PR TITLE
chore: migrate to centralized CI workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,90 +6,12 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run weekly on Sunday at 3:00 AM UTC
     - cron: '0 3 * * 0'
 
-# Restrict default permissions - jobs declare what they need
 permissions: {}
 
 jobs:
-  fuzz-tests:
-    name: Fuzz Tests
-    runs-on: ubuntu-latest
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:
       contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
-        with:
-          php-version: '8.2'
-          extensions: intl, mbstring, xml, curl, json
-          tools: composer:v2
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-fuzz-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-fuzz-
-
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist
-
-      - name: Run Fuzz Tests
-        run: .Build/bin/phpunit -c Build/phpunit.xml --testsuite fuzzy --no-coverage --colors=never
-
-  mutation-testing:
-    name: Mutation Testing (Infection)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
-        with:
-          php-version: '8.2'
-          extensions: intl, mbstring, xml, curl, json
-          tools: composer:v2
-          coverage: xdebug
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-mutation-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-mutation-
-
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist
-
-      - name: Run Mutation Tests
-        # Thresholds set to achievable levels; raise incrementally as coverage improves
-        run: composer ci:test:php:mutation -- --min-msi=50 --min-covered-msi=60
-        continue-on-error: true

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,40 +6,11 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  greeting:
-    name: Greet Contributors
-    runs-on: ubuntu-latest
+  greetings:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/greetings.yml@main
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
-            Thanks for opening your first issue! We appreciate you taking the time to report this.
-
-            A maintainer will review your issue soon. In the meantime, please make sure you've:
-            - Checked the [documentation](https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/)
-            - Searched for [existing issues](https://github.com/netresearch/t3x-nr-llm/issues)
-
-            If you have questions, feel free to use [Discussions](https://github.com/netresearch/t3x-nr-llm/discussions).
-          pr_message: |
-            Thanks for your first pull request! We're excited to have you contribute.
-
-            A maintainer will review your PR soon. Please ensure:
-            - All CI checks pass
-            - Your code follows the project's coding standards
-            - Tests are included for new functionality
-
-            Check our [Contributing Guide](https://github.com/netresearch/t3x-nr-llm/blob/main/CONTRIBUTING.md) for more details.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,24 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
-  label:
-    name: Label PR
-    runs-on: ubuntu-latest
+  labeler:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/labeler.yml@main
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labeler.yml

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -5,89 +5,19 @@ on:
     branches: [main]
     paths:
       - 'composer.json'
-      - 'composer.lock'
       - 'package.json'
-      - 'package-lock.json'
   pull_request:
     branches: [main]
     paths:
       - 'composer.json'
-      - 'composer.lock'
       - 'package.json'
-      - 'package-lock.json'
-  merge_group:
   schedule:
-    # Run weekly on Monday at 9:00 AM UTC
     - cron: '0 9 * * 1'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  php-licenses:
-    name: PHP License Audit
-    runs-on: ubuntu-latest
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
     permissions:
       contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
-        with:
-          php-version: '8.5'
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Check licenses
-        run: |
-          composer licenses --format=json > licenses.json
-          echo "## PHP Dependency Licenses" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          cat licenses.json | head -100 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-          # Check for problematic licenses (GPL-3.0 in non-GPL project, AGPL, etc.)
-          if grep -E '"(AGPL|GPL-3|SSPL|BSL)"' licenses.json; then
-            echo "::warning::Found potentially problematic licenses. Please review."
-          fi
-
-  npm-licenses:
-    name: NPM License Audit
-    runs-on: ubuntu-latest
-    # Workflow only triggers on package.json changes, so no need to check file existence
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check licenses
-        run: |
-          npx license-checker --summary --json > npm-licenses.json || true
-          echo "## NPM Dependency Licenses" >> $GITHUB_STEP_SUMMARY
-          npx license-checker --summary >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,28 +5,11 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   lock:
-    name: Lock Old Threads
-    runs-on: ubuntu-latest
+    uses: netresearch/typo3-ci-workflows/.github/workflows/lock.yml@main
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-inactive-days: 365
-          issue-lock-reason: resolved
-          pr-inactive-days: 365
-          pr-lock-reason: resolved
-          log-output: true

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -5,86 +5,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
-  quality-gate:
-    name: Quality Gate
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: PR Size Check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            const additions = files.reduce((sum, f) => sum + f.additions, 0);
-            const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
-            const total = additions + deletions;
-
-            let size = 'small';
-            if (total > 500) size = 'large';
-            else if (total > 200) size = 'medium';
-
-            console.log(`PR Size: ${size} (${additions}+ / ${deletions}-)`);
-
-            if (total > 1000) {
-              core.warning(`Large PR with ${total} changes. Consider breaking into smaller PRs.`);
-            }
-
-  auto-approve:
-    name: Auto-Approve (Solo Maintainer)
-    runs-on: ubuntu-latest
-    needs: quality-gate
-    # Auto-approve after quality gate passes
-    # For solo maintainer: github-actions bot approval satisfies Scorecard Code-Review
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Auto-approve PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            // Solo maintainer self-approval with compensating controls
-            // All CI checks must pass before this runs (needs: quality-gate)
-            // This satisfies OpenSSF Scorecard Code-Review requirement
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event: 'APPROVE',
-              body: `**Automated approval for solo maintainer project**
-
-            This PR has passed all automated quality gates:
-            - ✅ Static analysis (PHPStan)
-            - ✅ Code style (PHP-CS-Fixer)
-            - ✅ Unit tests with coverage
-            - ✅ Security scanning (CodeQL, Gitleaks)
-            - ✅ Dependency review
-
-            See [SECURITY_CONTROLS.md](/.github/SECURITY_CONTROLS.md) for compensating controls documentation.`
-            });
-
-            console.log('PR auto-approved with compensating controls documentation');
+  pr-quality:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,136 +5,15 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 jobs:
   release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Get version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-
-      - name: Generate Release Notes
-        id: notes
-        run: |
-          # Get the previous tag
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -z "$PREVIOUS_TAG" ]; then
-            echo "notes<<EOF" >> $GITHUB_OUTPUT
-            echo "Initial release" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "notes<<EOF" >> $GITHUB_OUTPUT
-            git log --pretty=format:"- %s" ${PREVIOUS_TAG}..HEAD >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create release archive
-        run: |
-          mkdir -p dist
-          git archive --format=zip --prefix=nr_llm/ HEAD -o dist/nr_llm-${{ steps.version.outputs.version }}.zip
-          git archive --format=tar.gz --prefix=nr_llm/ HEAD -o dist/nr_llm-${{ steps.version.outputs.version }}.tar.gz
-
-      - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
-        with:
-          path: .
-          format: spdx-json
-          output-file: dist/nr_llm-${{ steps.version.outputs.version }}.sbom.spdx.json
-
-      - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
-        with:
-          path: .
-          format: cyclonedx-json
-          output-file: dist/nr_llm-${{ steps.version.outputs.version }}.sbom.cdx.json
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum * > checksums.txt
-          cat checksums.txt
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
-      - name: Sign artifacts with Cosign (keyless)
-        run: |
-          cd dist
-          for file in *.zip *.tar.gz *.json checksums.txt; do
-            cosign sign-blob --yes "$file" --bundle "${file}.bundle"
-          done
-
-      - name: Generate attestation
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
-        with:
-          subject-path: |
-            dist/nr_llm-${{ steps.version.outputs.version }}.zip
-            dist/nr_llm-${{ steps.version.outputs.version }}.tar.gz
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          generate_release_notes: true
-          files: |
-            dist/*
-          body: |
-            ## Changes
-            ${{ steps.notes.outputs.notes }}
-
-            ## Installation
-
-            ```bash
-            composer require netresearch/nr-llm
-            ```
-
-            ## Security
-
-            All release artifacts are signed with [Sigstore](https://www.sigstore.dev/) keyless signing.
-
-            ### Verify signatures
-
-            ```bash
-            # Install cosign
-            go install github.com/sigstore/cosign/v2/cmd/cosign@latest
-
-            # Verify artifact signature
-            cosign verify-blob \
-              --bundle nr_llm-${{ steps.version.outputs.version }}.zip.bundle \
-              --certificate-identity-regexp "https://github.com/netresearch/.*" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-              nr_llm-${{ steps.version.outputs.version }}.zip
-            ```
-
-            ### Verify checksums
-
-            ```bash
-            sha256sum -c checksums.txt
-            ```
-
-            ## Software Bill of Materials (SBOM)
-
-            SBOMs are provided in both SPDX and CycloneDX formats for supply chain transparency.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # TER publication handled by publish-to-ter.yml (triggers on release: published)
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      archive-prefix: 'nr-llm'
+      package-name: 'netresearch/nr-llm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,98 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
   schedule:
-    # Run weekly on Monday at 7:00 AM UTC
     - cron: '0 7 * * 1'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  gitleaks:
-    name: Secret Scanning
-    runs-on: ubuntu-latest
-    # gitleaks-action requires GITLEAKS_LICENSE which is unavailable to Dependabot PRs
-    if: github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:
       contents: read
       security-events: write
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
-        with:
-          fail-on-severity: high
-          deny-licenses: GPL-3.0, AGPL-3.0
-
-  composer-audit:
-    name: Composer Audit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
-        with:
-          php-version: '8.5'
-          coverage: none
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run Composer Audit
-        run: composer audit --format=plain
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,24 @@
+name: SLSA Provenance
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version tag (e.g. v4.0.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  provenance:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,43 +5,11 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
-    name: Close Stale Issues
-    runs-on: ubuntu-latest
+    uses: netresearch/typo3-ci-workflows/.github/workflows/stale.yml@main
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
-        with:
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed if no further activity occurs within 7 days.
-            Thank you for your contributions!
-          stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed if no further activity occurs within 7 days.
-            Thank you for your contributions!
-          close-issue-message: >
-            This issue was closed because it has been stale for 7 days with no activity.
-            Feel free to reopen if you have new information to add.
-          close-pr-message: >
-            This pull request was closed because it has been stale for 7 days with no activity.
-            Feel free to reopen if you want to continue working on it.
-          days-before-stale: 60
-          days-before-close: 7
-          stale-issue-label: stale
-          stale-pr-label: stale
-          exempt-issue-labels: pinned,security,bug
-          exempt-pr-labels: pinned,security
-          operations-per-run: 30


### PR DESCRIPTION
## Summary

- Replace 9 local workflows with centralized callers from `netresearch/typo3-ci-workflows@main`:
  - `fuzz.yml` - Fuzzing
  - `pr-quality.yml` - PR Quality Gates
  - `release.yml` - Release (archive-prefix: `nr-llm`, package-name: `netresearch/nr-llm`)
  - `security.yml` - Security
  - `stale.yml` - Stale Issues
  - `lock.yml` - Lock Threads
  - `greetings.yml` - Greetings
  - `labeler.yml` - PR Labeler
  - `license-check.yml` - License Check
- Add 1 new centralized caller:
  - `slsa-provenance.yml` - SLSA Provenance
- **Kept as-is** (repo-specific local workflows):
  - `e2e.yml` - End-to-end tests
  - `docs.yml` - Documentation

All standard workflows now delegate to reusable workflows in `netresearch/typo3-ci-workflows`, ensuring consistent CI across all Netresearch TYPO3 extensions.

## Test plan

- [ ] Verify CI workflow runs pass on this PR
- [ ] Verify PR Quality Gates workflow triggers correctly
- [ ] Confirm e2e.yml and docs.yml are unchanged and still functional
- [ ] Confirm no duplicate workflow runs from old local definitions