### PR TITLE
fix: use 'tools' parent for v13 compatibility

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -17,8 +17,12 @@ use Netresearch\NrLlm\Controller\Backend\TaskController;
 /**
  * Backend module registration for nr_llm.
  *
- * Structure: Main module under 'admin', sub-modules as children of main module.
+ * Structure: Main module under 'tools', sub-modules as children of main module.
  * Sub-modules only appear in docheader dropdown, not in main navigation.
+ *
+ * Uses 'tools' as parent for v13+v14 compatibility:
+ * - v13: 'tools' exists natively as the admin tools group
+ * - v14: 'tools' is an alias for the new 'admin' group
  *
  * Pattern follows TYPO3 Styleguide extension:
  * - Main module identifier without prefix (e.g., 'nrllm' not 'tools_nrllm')
@@ -28,7 +32,7 @@ use Netresearch\NrLlm\Controller\Backend\TaskController;
 return [
     // Main dashboard module (parent container)
     'nrllm' => [
-        'parent' => 'admin',
+        'parent' => 'tools',
         'position' => ['after' => 'styleguide'],
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm',


### PR DESCRIPTION
## Summary

- Fix backend module using `parent => 'admin'` which only exists in TYPO3 v14
- On v13, the `admin` group doesn't exist — modules with a non-existent parent silently fail to register
- Changed to `parent => 'tools'` which works on both versions:
  - v13: `tools` exists natively as the admin tools group
  - v14: `tools` is an alias for the new `admin` group

## Context

`composer.json` declares `^13.4 || ^14.0` support, but the module registration only worked on v14.

Same issue was fixed in nr_vault: https://github.com/netresearch/t3x-nr-vault/pull/92

## Test plan

- [ ] Install nr_llm on TYPO3 v14 — LLM module appears under Admin Tools
- [ ] Install nr_llm on TYPO3 v13 — LLM module appears under Admin Tools
- [ ] All submodules (Providers, Models, Configurations, Tasks, Wizard) accessible from docheader dropdown