### PR TITLE
fix: use integer values for f:be.infobox state for v13 compatibility

### DIFF
--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -99,7 +99,7 @@
             <f:else>
                 <f:be.infobox
                     title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.empty.title', default: 'No Configurations Found')}"
-                    state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}"
+                    state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.empty.message" default="No LLM configurations found yet. Create your first configuration to get started." /></p>
                 </f:be.infobox>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -13,7 +13,7 @@
 
         <f:be.infobox
             title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.callout.title', default: 'New to LLM Integration?')}"
-            state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}"
+            state="-1"
         >
             <p>
                 <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.callout.message" default="Use the Setup Wizard to auto-configure your provider, discover models, and generate configuration presets." />

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -110,7 +110,7 @@
             <f:else>
                 <f:be.infobox
                     title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.empty.title', default: 'No Models Configured')}"
-                    state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}"
+                    state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.empty.message" default="No models configured yet. Create your first model to start using LLM services." /></p>
                     <f:if condition="{providers -> f:count()} == 0">

--- a/Resources/Private/Templates/Backend/Provider/List.html
+++ b/Resources/Private/Templates/Backend/Provider/List.html
@@ -101,7 +101,7 @@
             <f:else>
                 <f:be.infobox
                     title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.empty.title', default: 'No Providers Configured')}"
-                    state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}"
+                    state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.empty.message" default="No API providers configured yet. Create your first provider to connect to LLM services." /></p>
                 </f:be.infobox>

--- a/Resources/Private/Templates/Backend/Task/Execute.html
+++ b/Resources/Private/Templates/Backend/Task/Execute.html
@@ -10,7 +10,7 @@
 
         <f:be.infobox
             title="One-Shot Prompt"
-            state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::NOTICE')}"
+            state="-2"
         >
             <p>
                 This is a <strong>simple one-shot prompt</strong> - it sends your input to the LLM once and returns the response.

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -9,7 +9,7 @@
     <div class="container">
         <f:be.infobox
             title="One-Shot Prompt Tasks"
-            state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::NOTICE')}"
+            state="-2"
         >
             <p>
                 <strong>Important:</strong> Tasks are simple one-shot prompts with limited capabilities.
@@ -33,7 +33,7 @@
             <f:then>
                 <f:be.infobox
                     title="No Tasks Configured"
-                    state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}"
+                    state="-1"
                 >
                     <p>No tasks have been created yet. Use the seed data or create your first task.</p>
                 </f:be.infobox>


### PR DESCRIPTION
## Summary
- Replace `ContextualFeedbackSeverity` enum constants with integer values in `f:be.infobox` `state` attribute
- The `state` parameter is typed as `int` in TYPO3 v13 but `mixed` in v14; using the enum object causes 503 errors on v13
- Integer values work correctly on both v13 and v14

## Affected files
- Fluid template files under Resources/Private/Templates/Backend/
- Values: INFO=-1, OK=0, WARNING=1, ERROR=2