### PR TITLE
feat: expose configuration-based chat methods on LlmServiceManagerInterface

### DIFF
--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -60,6 +60,22 @@ interface LlmServiceManagerInterface
     public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration): CompletionResponse;
 
     /**
+     * Chat using a specific LLM configuration (database-backed provider resolution).
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     */
+    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration): CompletionResponse;
+
+    /**
+     * Stream chat completion using a specific LLM configuration.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     *
+     * @return Generator<int, string, mixed, void>
+     */
+    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration): Generator;
+
+    /**
      * @param string|array<int, string> $input
      */
     public function embed(string|array $input, ?EmbeddingOptions $options = null): EmbeddingResponse;


### PR DESCRIPTION
## Summary
- Add `chatWithConfiguration()` and `streamChatWithConfiguration()` to `LlmServiceManagerInterface`
- These methods already exist on the concrete `LlmServiceManager` class but were missing from the interface
- Consumers (e.g., t3x-cowriter) need these to call configuration-based methods via the interface type-hint
- Without this, consumers must type-hint against the `final` concrete class, which prevents mocking in tests

## Changes
- `Classes/Service/LlmServiceManagerInterface.php`: Added 2 method signatures with PHPDoc