### PR TITLE
feat(be): native BE group permissions for AI capabilities

### DIFF
--- a/Classes/Service/CapabilityPermissionService.php
+++ b/Classes/Service/CapabilityPermissionService.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Checks whether the current backend user is allowed to invoke a given
+ * model capability, using TYPO3's native `customPermOptions` mechanism.
+ *
+ * Registration lives in ext_localconf.php under
+ * `$TYPO3_CONF_VARS['BE']['customPermOptions']['nrllm']`. Editors see a
+ * checkbox per capability on the BE group edit view; admins bypass all
+ * checks. Non-backend contexts (CLI, scheduler, frontend) are always
+ * allowed — capability gating is a backend-editor concern.
+ *
+ * This service is intentionally thin so callers can decide WHERE to
+ * enforce: a feature service's entry method, a controller, or middleware.
+ * Call isAllowed() before dispatching; branch on the result or throw an
+ * AccessDeniedException with context.
+ */
+final readonly class CapabilityPermissionService
+{
+    public const PERM_NAMESPACE = 'nrllm';
+
+    /**
+     * Check if the given capability is allowed for the (optional) backend user.
+     *
+     * Resolution rules, in order:
+     *   1. No BE user (CLI / frontend) -> allowed
+     *   2. User is admin -> allowed
+     *   3. Delegate to $user->check('custom_options', 'nrllm:capability_X')
+     */
+    public function isAllowed(
+        ModelCapability $capability,
+        ?BackendUserAuthentication $backendUser = null,
+    ): bool {
+        $user = $backendUser ?? $this->resolveGlobalUser();
+
+        if (!$user instanceof BackendUserAuthentication) {
+            return true;
+        }
+
+        if ($this->isAdmin($user)) {
+            return true;
+        }
+
+        return $user->check('custom_options', self::permissionString($capability));
+    }
+
+    /**
+     * Build the TYPO3 permission string, e.g. "nrllm:capability_vision".
+     */
+    public static function permissionString(ModelCapability $capability): string
+    {
+        return self::PERM_NAMESPACE . ':' . self::permissionKey($capability);
+    }
+
+    /**
+     * The identifier used as the customPermOptions item key.
+     */
+    public static function permissionKey(ModelCapability $capability): string
+    {
+        return 'capability_' . $capability->value;
+    }
+
+    private function resolveGlobalUser(): ?BackendUserAuthentication
+    {
+        $candidate = $GLOBALS['BE_USER'] ?? null;
+        return $candidate instanceof BackendUserAuthentication ? $candidate : null;
+    }
+
+    private function isAdmin(BackendUserAuthentication $user): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/Documentation/Adr/Adr023BackendCapabilityPermissions.rst
+++ b/Documentation/Adr/Adr023BackendCapabilityPermissions.rst
@@ -1,0 +1,98 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-023:
+
+==================================================
+ADR-023: Native Backend Capability Permissions
+==================================================
+
+:Status: Accepted
+:Date: 2026-04
+:Authors: Netresearch DTT GmbH
+
+.. _adr-023-context:
+
+Context
+=======
+
+Until now, the only gate on who could invoke an AI capability (vision,
+tools, embeddings, ...) was the per-configuration ``allowed_groups`` MM
+relation. That is coarse: an editor with access to the "creative writing"
+configuration could invoke any of its capabilities — text, tool-calling,
+embeddings — even if the administrator only intended them to use chat.
+
+Administrators also had no native UI surface to revoke a single capability
+site-wide without editing every affected configuration.
+
+.. _adr-023-decision:
+
+Decision
+========
+
+Register every :php:`ModelCapability` enum value as a native TYPO3 BE group
+permission under
+:code:`$TYPO3_CONF_VARS['BE']['customPermOptions']['nrllm']`. The BE group
+edit view now shows a checkbox per capability (chat, completion,
+embeddings, vision, streaming, tools, json_mode, audio). A new service,
+:php:`CapabilityPermissionService`, resolves the check against the
+currently logged-in backend user.
+
+Resolution order:
+
+1. No BE user in context (CLI, scheduler, frontend) — allowed.
+2. User is admin — allowed.
+3. Otherwise — delegate to
+   :php:`$backendUser->check('custom_options', 'nrllm:capability_X')`.
+
+.. _adr-023-scope:
+
+Scope
+=====
+
+This ADR ships the **registration + check primitive**. It does NOT
+retroactively gate calls inside :php:`CompletionService`, :php:`VisionService`,
+etc. — that is a deliberate follow-up concern, because it is a larger
+behavioural change than a single-PR feature warrants.
+
+Consumers can opt in today:
+
+.. code-block:: php
+
+   if (!$this->capabilityPermissions->isAllowed(ModelCapability::VISION)) {
+       throw new AccessDeniedException('Vision capability not permitted for this user', 1745712100);
+   }
+
+.. _adr-023-relation:
+
+Relation to existing access control
+===================================
+
+``allowed_groups`` on ``tx_nrllm_configuration`` gates access to a named
+*configuration* (API keys, preset parameters, system prompt). Capability
+permissions gate which *operations* a user is allowed to invoke against
+any configuration they already have access to. The two are complementary:
+
+* **Configuration ACL:** "Can this editor use the 'creative-writing'
+  configuration at all?"
+* **Capability permission:** "Can this editor invoke vision against any
+  configuration?"
+
+Both checks must pass.
+
+.. _adr-023-alternatives:
+
+Alternatives considered
+=======================
+
+* **Per-capability flags on** ``tx_nrllm_configuration``. Rejected:
+  capability is an editor-role concern, not a configuration concern.
+  Duplicating the checkbox on every row is worse UX than a single
+  per-group toggle.
+
+* **A sibling MM table** (configuration-to-capability). Rejected as
+  another bespoke access model on top of TYPO3's native one. The whole
+  point of this ADR is to use the native mechanism.
+
+* **Inject the check into every feature service now.** Rejected to keep
+  the PR small and the regression surface narrow. See the Scope note
+  above — follow-up work.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -255,3 +255,4 @@ Modern architecture (v0.4+)
    Adr020BackendOutputFormatRendering
    Adr021ProviderFallbackChain
    Adr022AttributeBasedProviderRegistration
+   Adr023BackendCapabilityPermissions

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <!-- BE group capability permissions (customPermOptions) -->
+            <trans-unit id="permissions.header">
+                <source>nr-llm: AI capability permissions</source>
+                <target>nr-llm: Berechtigungen für KI-Fähigkeiten</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.chat">
+                <source>Chat completions</source>
+                <target>Chat-Abschlüsse</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.completion">
+                <source>Text completions</source>
+                <target>Text-Abschlüsse</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.embeddings">
+                <source>Embeddings (vector generation)</source>
+                <target>Embeddings (Vektor-Erzeugung)</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.vision">
+                <source>Vision (image analysis)</source>
+                <target>Vision (Bildanalyse)</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.streaming">
+                <source>Streaming responses (SSE)</source>
+                <target>Streaming-Antworten (SSE)</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.tools">
+                <source>Tool / function calling</source>
+                <target>Tool-/Funktionsaufrufe</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.json_mode">
+                <source>JSON mode (structured output)</source>
+                <target>JSON-Modus (strukturierte Ausgabe)</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.audio">
+                <source>Audio (speech transcription / synthesis)</source>
+                <target>Audio (Sprachtranskription/-synthese)</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <!-- BE group capability permissions (customPermOptions) -->
+            <trans-unit id="permissions.header">
+                <source>nr-llm: AI capability permissions</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.chat">
+                <source>Chat completions</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.completion">
+                <source>Text completions</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.embeddings">
+                <source>Embeddings (vector generation)</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.vision">
+                <source>Vision (image analysis)</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.streaming">
+                <source>Streaming responses (SSE)</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.tools">
+                <source>Tool / function calling</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.json_mode">
+                <source>JSON mode (structured output)</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.audio">
+                <source>Audio (speech transcription / synthesis)</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Unit/Service/CapabilityPermissionServiceTest.php
+++ b/Tests/Unit/Service/CapabilityPermissionServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Service\CapabilityPermissionService;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+#[CoversClass(CapabilityPermissionService::class)]
+class CapabilityPermissionServiceTest extends AbstractUnitTestCase
+{
+    private CapabilityPermissionService $subject;
+
+    private mixed $originalGlobalUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new CapabilityPermissionService();
+        $this->originalGlobalUser = $GLOBALS['BE_USER'] ?? null;
+        unset($GLOBALS['BE_USER']);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalGlobalUser !== null) {
+            $GLOBALS['BE_USER'] = $this->originalGlobalUser;
+        } else {
+            unset($GLOBALS['BE_USER']);
+        }
+        parent::tearDown();
+    }
+
+    // ──────────────────────────────────────────────
+    // permissionKey / permissionString helpers
+    // ──────────────────────────────────────────────
+
+    #[Test]
+    public function permissionKeyUsesCapabilityValue(): void
+    {
+        self::assertSame('capability_vision', CapabilityPermissionService::permissionKey(ModelCapability::VISION));
+        self::assertSame('capability_chat', CapabilityPermissionService::permissionKey(ModelCapability::CHAT));
+        self::assertSame('capability_json_mode', CapabilityPermissionService::permissionKey(ModelCapability::JSON_MODE));
+    }
+
+    #[Test]
+    public function permissionStringPrefixesNamespace(): void
+    {
+        self::assertSame('nrllm:capability_vision', CapabilityPermissionService::permissionString(ModelCapability::VISION));
+        self::assertSame('nrllm', CapabilityPermissionService::PERM_NAMESPACE);
+    }
+
+    /**
+     * @return list<array{ModelCapability, string}>
+     */
+    public static function allCapabilitiesProvider(): array
+    {
+        return array_map(
+            static fn(ModelCapability $c): array => [$c, 'nrllm:capability_' . $c->value],
+            ModelCapability::cases(),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('allCapabilitiesProvider')]
+    public function everyEnumCaseProducesAStablePermissionString(ModelCapability $capability, string $expected): void
+    {
+        self::assertSame($expected, CapabilityPermissionService::permissionString($capability));
+    }
+
+    // ──────────────────────────────────────────────
+    // isAllowed
+    // ──────────────────────────────────────────────
+
+    #[Test]
+    public function allowsWhenNoBackendUserPresent(): void
+    {
+        // No $GLOBALS['BE_USER'], no explicit arg -> CLI/frontend path
+        self::assertTrue($this->subject->isAllowed(ModelCapability::VISION));
+    }
+
+    #[Test]
+    public function allowsWhenGlobalIsNotABackendUser(): void
+    {
+        $GLOBALS['BE_USER'] = new stdClass();
+
+        self::assertTrue($this->subject->isAllowed(ModelCapability::CHAT));
+    }
+
+    #[Test]
+    public function allowsAdminBypassingTheCheckMethod(): void
+    {
+        $user = $this->makeBackendUser(isAdmin: true);
+        $user->expects(self::never())->method('check');
+
+        self::assertTrue($this->subject->isAllowed(ModelCapability::VISION, $user));
+    }
+
+    #[Test]
+    public function delegatesToBackendUserCheckForNonAdmin(): void
+    {
+        $user = $this->makeBackendUser(isAdmin: false);
+        $user->expects(self::once())
+            ->method('check')
+            ->with('custom_options', 'nrllm:capability_vision')
+            ->willReturn(true);
+
+        self::assertTrue($this->subject->isAllowed(ModelCapability::VISION, $user));
+    }
+
+    #[Test]
+    public function returnsFalseWhenBackendUserDeniesCheck(): void
+    {
+        $user = $this->makeBackendUser(isAdmin: false);
+        $user->method('check')->willReturn(false);
+
+        self::assertFalse($this->subject->isAllowed(ModelCapability::TOOLS, $user));
+    }
+
+    #[Test]
+    public function fallsBackToGlobalsBeUserWhenNoArgumentPassed(): void
+    {
+        $user = $this->makeBackendUser(isAdmin: false);
+        $user->method('check')
+            ->with('custom_options', 'nrllm:capability_embeddings')
+            ->willReturn(true);
+        $GLOBALS['BE_USER'] = $user;
+
+        self::assertTrue($this->subject->isAllowed(ModelCapability::EMBEDDINGS));
+    }
+
+    #[Test]
+    public function explicitArgumentOverridesGlobalUser(): void
+    {
+        $globalUser = $this->makeBackendUser(isAdmin: false);
+        $globalUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $globalUser;
+
+        $explicitUser = $this->makeBackendUser(isAdmin: true);
+        self::assertTrue($this->subject->isAllowed(ModelCapability::CHAT, $explicitUser));
+    }
+
+    private function makeBackendUser(bool $isAdmin): BackendUserAuthentication&MockObject
+    {
+        $mock = $this->getMockBuilder(BackendUserAuthentication::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['check', 'isAdmin'])
+            ->getMock();
+        $mock->method('isAdmin')->willReturn($isAdmin);
+        // Fallback record in case isAdmin() is not present on older stubs
+        $mock->user = ['admin' => $isAdmin ? 1 : 0];
+        return $mock;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,8 +7,10 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Form\Element\ModelIdElement;
 use Netresearch\NrLlm\Form\FieldWizard\ModelConstraintsWizard;
+use Netresearch\NrLlm\Service\CapabilityPermissionService;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
@@ -51,4 +53,32 @@ defined('TYPO3') or die();
     ExtensionManagementUtility::addTypoScriptConstants(
         '@import "EXT:nr_llm/Configuration/TypoScript/constants.typoscript"',
     );
+
+    // Register per-capability BE group permissions. Editors see a checkbox per
+    // capability on the backend group edit view; admins bypass all checks.
+    // Check with CapabilityPermissionService::isAllowed() or directly via
+    // $backendUser->check('custom_options', 'nrllm:capability_X').
+    $capabilityIcons = [
+        ModelCapability::CHAT->value => 'content-message',
+        ModelCapability::COMPLETION->value => 'actions-document-new',
+        ModelCapability::EMBEDDINGS->value => 'actions-database',
+        ModelCapability::VISION->value => 'actions-image',
+        ModelCapability::STREAMING->value => 'actions-play',
+        ModelCapability::TOOLS->value => 'actions-wrench',
+        ModelCapability::JSON_MODE->value => 'mimetypes-text-js',
+        ModelCapability::AUDIO->value => 'mimetypes-media-audio',
+    ];
+    $capabilityItems = [];
+    foreach (ModelCapability::cases() as $capability) {
+        $key = CapabilityPermissionService::permissionKey($capability);
+        $capabilityItems[$key] = [
+            'LLL:EXT:nr_llm/Resources/Private/Language/locallang_be.xlf:permissions.capability.' . $capability->value,
+            $capabilityIcons[$capability->value] ?? 'actions-check',
+        ];
+    }
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'][CapabilityPermissionService::PERM_NAMESPACE] = [
+        'header' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_be.xlf:permissions.header',
+        'items' => $capabilityItems,
+    ];
 })();


### PR DESCRIPTION
## Summary

Adds per-capability BE group permissions using TYPO3's native `customPermOptions` mechanism. Administrators now get a checkbox per capability (chat, completion, embeddings, vision, streaming, tools, json_mode, audio) on the BE group edit view.

- Registers every `ModelCapability` enum value under `$TYPO3_CONF_VARS['BE']['customPermOptions']['nrllm']`
- New `CapabilityPermissionService` resolves checks against the current BE user
- Resolution order: no BE user (CLI/FE) → allowed; admin → allowed; else delegate to `$backendUser->check('custom_options', 'nrllm:capability_X')`
- Language files for permission labels (EN + DE)

## Scope note

Ships the **registration + check primitive only**. Consumers can opt in today; wiring the check into each feature service (`CompletionService`, `VisionService`, …) is a deliberate follow-up to keep this PR narrow. See ADR-023 for rationale.

## Relation to existing ACL

Complementary, not a replacement:
- `allowed_groups` on `tx_nrllm_configuration` gates *access to a preset*
- Capability permission gates *which operation* a user may invoke

Both checks must pass.

## Test plan

- [x] 17 new unit tests passing
- [x] PHPStan level 10 clean
- [x] Architecture (PHPat) + PHP-CS-Fixer + Rector clean