### PR TITLE
feat(budget): per-user AI spending ceilings

### DIFF
--- a/Classes/Domain/DTO/BudgetCheckResult.php
+++ b/Classes/Domain/DTO/BudgetCheckResult.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\DTO;
+
+/**
+ * Result of a BudgetService::check() call.
+ *
+ * When allowed() is false, the remaining fields describe which bucket
+ * was tripped so the caller can surface a meaningful message without
+ * re-computing anything.
+ */
+final readonly class BudgetCheckResult
+{
+    public const LIMIT_NONE = '';
+    public const LIMIT_DAILY_REQUESTS = 'daily_requests';
+    public const LIMIT_DAILY_TOKENS = 'daily_tokens';
+    public const LIMIT_DAILY_COST = 'daily_cost';
+    public const LIMIT_MONTHLY_REQUESTS = 'monthly_requests';
+    public const LIMIT_MONTHLY_TOKENS = 'monthly_tokens';
+    public const LIMIT_MONTHLY_COST = 'monthly_cost';
+
+    /**
+     * @param non-empty-string|self::LIMIT_* $exceededLimit
+     */
+    public function __construct(
+        public bool $allowed,
+        public string $exceededLimit = self::LIMIT_NONE,
+        public float $currentUsage = 0.0,
+        public float $limit = 0.0,
+        public string $reason = '',
+    ) {}
+
+    public static function allowed(): self
+    {
+        return new self(allowed: true);
+    }
+
+    public static function denied(
+        string $exceededLimit,
+        float $currentUsage,
+        float $limit,
+        string $reason = '',
+    ): self {
+        return new self(
+            allowed: false,
+            exceededLimit: $exceededLimit,
+            currentUsage: $currentUsage,
+            limit: $limit,
+            reason: $reason !== '' ? $reason : sprintf(
+                '%s limit reached: %s of %s',
+                $exceededLimit,
+                self::formatNumber($currentUsage),
+                self::formatNumber($limit),
+            ),
+        );
+    }
+
+    private static function formatNumber(float $n): string
+    {
+        return fmod($n, 1.0) === 0.0 ? (string)(int)$n : number_format($n, 2);
+    }
+}

--- a/Classes/Domain/DTO/BudgetCheckResult.php
+++ b/Classes/Domain/DTO/BudgetCheckResult.php
@@ -27,8 +27,23 @@ final readonly class BudgetCheckResult
     public const LIMIT_MONTHLY_COST = 'monthly_cost';
 
     /**
-     * @param non-empty-string|self::LIMIT_* $exceededLimit
+     * Human-friendly labels, keyed by LIMIT_* value. Kept here as a
+     * constant (not a locallang lookup) so the DTO stays side-effect-free
+     * and callers can render it unchanged in logs / JSON responses, or
+     * substitute their own localised string using `exceededLimit` as a
+     * stable machine key.
+     *
+     * @var array<string, string>
      */
+    private const LIMIT_LABELS = [
+        self::LIMIT_DAILY_REQUESTS => 'daily request count',
+        self::LIMIT_DAILY_TOKENS => 'daily token usage',
+        self::LIMIT_DAILY_COST => 'daily cost',
+        self::LIMIT_MONTHLY_REQUESTS => 'monthly request count',
+        self::LIMIT_MONTHLY_TOKENS => 'monthly token usage',
+        self::LIMIT_MONTHLY_COST => 'monthly cost',
+    ];
+
     public function __construct(
         public bool $allowed,
         public string $exceededLimit = self::LIMIT_NONE,
@@ -54,8 +69,8 @@ final readonly class BudgetCheckResult
             currentUsage: $currentUsage,
             limit: $limit,
             reason: $reason !== '' ? $reason : sprintf(
-                '%s limit reached: %s of %s',
-                $exceededLimit,
+                'AI budget exhausted: %s is at %s of %s',
+                self::LIMIT_LABELS[$exceededLimit] ?? $exceededLimit,
                 self::formatNumber($currentUsage),
                 self::formatNumber($limit),
             ),

--- a/Classes/Domain/Model/UserBudget.php
+++ b/Classes/Domain/Model/UserBudget.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+/**
+ * Per-backend-user AI budget ceilings.
+ *
+ * Daily and monthly limits are independent; a user request must clear
+ * BOTH windows. `0` in any bucket means "unlimited on that axis".
+ *
+ * This is a **ceiling**, not a counter: actual usage is aggregated on
+ * demand from tx_nrllm_service_usage so we never drift from a source
+ * of truth that is already being written for every request.
+ */
+class UserBudget extends AbstractEntity
+{
+    protected int $beUser = 0;
+
+    protected int $maxRequestsPerDay = 0;
+    protected int $maxTokensPerDay = 0;
+    protected float $maxCostPerDay = 0.0;
+
+    protected int $maxRequestsPerMonth = 0;
+    protected int $maxTokensPerMonth = 0;
+    protected float $maxCostPerMonth = 0.0;
+
+    protected bool $isActive = true;
+
+    protected int $tstamp = 0;
+    protected int $crdate = 0;
+
+    public function getBeUser(): int
+    {
+        return $this->beUser;
+    }
+
+    public function setBeUser(int $beUser): void
+    {
+        $this->beUser = max(0, $beUser);
+    }
+
+    public function getMaxRequestsPerDay(): int
+    {
+        return $this->maxRequestsPerDay;
+    }
+
+    public function setMaxRequestsPerDay(int $value): void
+    {
+        $this->maxRequestsPerDay = max(0, $value);
+    }
+
+    public function getMaxTokensPerDay(): int
+    {
+        return $this->maxTokensPerDay;
+    }
+
+    public function setMaxTokensPerDay(int $value): void
+    {
+        $this->maxTokensPerDay = max(0, $value);
+    }
+
+    public function getMaxCostPerDay(): float
+    {
+        return $this->maxCostPerDay;
+    }
+
+    public function setMaxCostPerDay(float $value): void
+    {
+        $this->maxCostPerDay = max(0.0, $value);
+    }
+
+    public function getMaxRequestsPerMonth(): int
+    {
+        return $this->maxRequestsPerMonth;
+    }
+
+    public function setMaxRequestsPerMonth(int $value): void
+    {
+        $this->maxRequestsPerMonth = max(0, $value);
+    }
+
+    public function getMaxTokensPerMonth(): int
+    {
+        return $this->maxTokensPerMonth;
+    }
+
+    public function setMaxTokensPerMonth(int $value): void
+    {
+        $this->maxTokensPerMonth = max(0, $value);
+    }
+
+    public function getMaxCostPerMonth(): float
+    {
+        return $this->maxCostPerMonth;
+    }
+
+    public function setMaxCostPerMonth(float $value): void
+    {
+        $this->maxCostPerMonth = max(0.0, $value);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function getIsActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): void
+    {
+        $this->isActive = $isActive;
+    }
+
+    public function getTstamp(): int
+    {
+        return $this->tstamp;
+    }
+
+    public function getCrdate(): int
+    {
+        return $this->crdate;
+    }
+
+    public function hasAnyLimit(): bool
+    {
+        return $this->maxRequestsPerDay > 0
+            || $this->maxTokensPerDay > 0
+            || $this->maxCostPerDay > 0.0
+            || $this->maxRequestsPerMonth > 0
+            || $this->maxTokensPerMonth > 0
+            || $this->maxCostPerMonth > 0.0;
+    }
+}

--- a/Classes/Domain/Repository/UserBudgetRepository.php
+++ b/Classes/Domain/Repository/UserBudgetRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Repository;
+
+use Netresearch\NrLlm\Domain\Model\UserBudget;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * @extends Repository<UserBudget>
+ */
+class UserBudgetRepository extends Repository
+{
+    /**
+     * Budgets are global records (rootLevel=-1), so drop storage-page filtering.
+     * Respect enable fields so hidden / deleted rows stay excluded.
+     */
+    public function initializeObject(): void
+    {
+        $querySettings = $this->createQuery()->getQuerySettings();
+        $querySettings->setRespectStoragePage(false);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Look up the (at most one) budget record for a backend user.
+     */
+    public function findOneByBeUser(int $beUser): ?UserBudget
+    {
+        if ($beUser <= 0) {
+            return null;
+        }
+        $query = $this->createQuery();
+        $query->matching($query->equals('beUser', $beUser));
+        /** @var UserBudget|null $result */
+        $result = $query->execute()->getFirst();
+        return $result;
+    }
+}

--- a/Classes/Service/BudgetService.php
+++ b/Classes/Service/BudgetService.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\UserBudget;
+use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Enforces per-backend-user daily and monthly AI spending ceilings.
+ *
+ * The budget record on tx_nrllm_user_budget is a ceiling, not a counter.
+ * Actual usage is aggregated on demand from tx_nrllm_service_usage — the
+ * same table the UsageTracker already writes to — so we never drift from
+ * the source of truth and we don't pay a second-write cost per request.
+ *
+ * The service is intentionally a pure pre-flight check: call it BEFORE
+ * dispatching to a provider. It does not increment anything.
+ *
+ * Like CapabilityPermissionService, this ships the primitive; wiring the
+ * check into individual feature services is a deliberate follow-up.
+ */
+class BudgetService
+{
+    private const USAGE_TABLE = 'tx_nrllm_service_usage';
+
+    public function __construct(
+        private readonly UserBudgetRepository $repository,
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * Pre-flight check: is the user allowed to make a request whose
+     * expected cost is $plannedCost?
+     *
+     * Resolution:
+     *   1. No budget record -> allowed (admin hasn't capped this user)
+     *   2. Budget is inactive -> allowed (admin muted the cap)
+     *   3. Budget has no limits set -> allowed
+     *   4. Otherwise check current-day and current-month buckets in order.
+     *      The first bucket to exceed its limit wins and is reported back.
+     */
+    public function check(int $beUserUid, float $plannedCost = 0.0): BudgetCheckResult
+    {
+        if ($beUserUid <= 0) {
+            return BudgetCheckResult::allowed();
+        }
+
+        $budget = $this->repository->findOneByBeUser($beUserUid);
+        if ($budget === null || !$budget->isActive() || !$budget->hasAnyLimit()) {
+            return BudgetCheckResult::allowed();
+        }
+
+        $now = new DateTimeImmutable();
+
+        $dailyResult = $this->evaluateDaily($budget, $beUserUid, $plannedCost, $now);
+        if (!$dailyResult->allowed) {
+            return $dailyResult;
+        }
+
+        return $this->evaluateMonthly($budget, $beUserUid, $plannedCost, $now);
+    }
+
+    private function evaluateDaily(
+        UserBudget $budget,
+        int $beUserUid,
+        float $plannedCost,
+        DateTimeImmutable $now,
+    ): BudgetCheckResult {
+        if ($budget->getMaxRequestsPerDay() === 0
+            && $budget->getMaxTokensPerDay() === 0
+            && $budget->getMaxCostPerDay() === 0.0
+        ) {
+            return BudgetCheckResult::allowed();
+        }
+
+        $from = $now->setTime(0, 0, 0);
+        $usage = $this->aggregateUsage($beUserUid, $from->getTimestamp(), $now->getTimestamp());
+
+        return $this->compare(
+            usage: $usage,
+            plannedCost: $plannedCost,
+            requestLimit: $budget->getMaxRequestsPerDay(),
+            tokenLimit: $budget->getMaxTokensPerDay(),
+            costLimit: $budget->getMaxCostPerDay(),
+            requestLimitId: BudgetCheckResult::LIMIT_DAILY_REQUESTS,
+            tokenLimitId: BudgetCheckResult::LIMIT_DAILY_TOKENS,
+            costLimitId: BudgetCheckResult::LIMIT_DAILY_COST,
+        );
+    }
+
+    private function evaluateMonthly(
+        UserBudget $budget,
+        int $beUserUid,
+        float $plannedCost,
+        DateTimeImmutable $now,
+    ): BudgetCheckResult {
+        if ($budget->getMaxRequestsPerMonth() === 0
+            && $budget->getMaxTokensPerMonth() === 0
+            && $budget->getMaxCostPerMonth() === 0.0
+        ) {
+            return BudgetCheckResult::allowed();
+        }
+
+        $from = $now->modify('first day of this month')->setTime(0, 0, 0);
+        $usage = $this->aggregateUsage($beUserUid, $from->getTimestamp(), $now->getTimestamp());
+
+        return $this->compare(
+            usage: $usage,
+            plannedCost: $plannedCost,
+            requestLimit: $budget->getMaxRequestsPerMonth(),
+            tokenLimit: $budget->getMaxTokensPerMonth(),
+            costLimit: $budget->getMaxCostPerMonth(),
+            requestLimitId: BudgetCheckResult::LIMIT_MONTHLY_REQUESTS,
+            tokenLimitId: BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
+            costLimitId: BudgetCheckResult::LIMIT_MONTHLY_COST,
+        );
+    }
+
+    /**
+     * @param array{requests: int, tokens: int, cost: float} $usage
+     */
+    private function compare(
+        array $usage,
+        float $plannedCost,
+        int $requestLimit,
+        int $tokenLimit,
+        float $costLimit,
+        string $requestLimitId,
+        string $tokenLimitId,
+        string $costLimitId,
+    ): BudgetCheckResult {
+        // Each incoming call is +1 request, +$plannedCost. Tokens are unknown
+        // at pre-flight so we check the existing total only.
+        if ($requestLimit > 0 && ($usage['requests'] + 1) > $requestLimit) {
+            return BudgetCheckResult::denied(
+                $requestLimitId,
+                (float)$usage['requests'],
+                (float)$requestLimit,
+            );
+        }
+        if ($tokenLimit > 0 && $usage['tokens'] > $tokenLimit) {
+            return BudgetCheckResult::denied(
+                $tokenLimitId,
+                (float)$usage['tokens'],
+                (float)$tokenLimit,
+            );
+        }
+        if ($costLimit > 0.0 && ($usage['cost'] + $plannedCost) > $costLimit) {
+            return BudgetCheckResult::denied(
+                $costLimitId,
+                $usage['cost'],
+                $costLimit,
+            );
+        }
+        return BudgetCheckResult::allowed();
+    }
+
+    /**
+     * Aggregate usage for the given user and time window. Protected so tests
+     * can stub out the DB layer without mocking the full QueryBuilder chain.
+     *
+     * @return array{requests: int, tokens: int, cost: float}
+     */
+    protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::USAGE_TABLE);
+        $row = $queryBuilder
+            ->addSelectLiteral('SUM(request_count) AS total_requests')
+            ->addSelectLiteral('SUM(tokens_used) AS total_tokens')
+            ->addSelectLiteral('SUM(estimated_cost) AS total_cost')
+            ->from(self::USAGE_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'be_user',
+                    $queryBuilder->createNamedParameter($beUserUid),
+                ),
+                $queryBuilder->expr()->gte(
+                    'request_date',
+                    $queryBuilder->createNamedParameter($fromTimestamp),
+                ),
+                $queryBuilder->expr()->lte(
+                    'request_date',
+                    $queryBuilder->createNamedParameter($toTimestamp),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($row)) {
+            return ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        }
+
+        return [
+            'requests' => is_numeric($row['total_requests'] ?? null) ? (int)$row['total_requests'] : 0,
+            'tokens' => is_numeric($row['total_tokens'] ?? null) ? (int)$row['total_tokens'] : 0,
+            'cost' => is_numeric($row['total_cost'] ?? null) ? (float)$row['total_cost'] : 0.0,
+        ];
+    }
+}

--- a/Classes/Service/BudgetService.php
+++ b/Classes/Service/BudgetService.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Service;
 
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
-use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -25,6 +24,13 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  *
  * The service is intentionally a pure pre-flight check: call it BEFORE
  * dispatching to a provider. It does not increment anything.
+ *
+ * Concurrency: this is a best-effort gate, not a transactionally-safe
+ * one. Two simultaneous requests for the same user can both pass the
+ * check before either updates tx_nrllm_service_usage, temporarily
+ * allowing a one-request overshoot. Adding a per-user lock would
+ * serialise a hot path; callers needing strict enforcement should
+ * layer their own lock / reservation on top.
  *
  * Like CapabilityPermissionService, this ships the primitive; wiring the
  * check into individual feature services is a deliberate follow-up.
@@ -55,75 +61,67 @@ class BudgetService
             return BudgetCheckResult::allowed();
         }
 
+        // Negative planned cost would artificially reduce the projected
+        // total and let callers bypass cost limits. Clamp defensively.
+        $plannedCost = max(0.0, $plannedCost);
+
         $budget = $this->repository->findOneByBeUser($beUserUid);
         if ($budget === null || !$budget->isActive() || !$budget->hasAnyLimit()) {
             return BudgetCheckResult::allowed();
         }
 
         $now = new DateTimeImmutable();
+        $hasDailyLimits = $budget->getMaxRequestsPerDay() > 0
+            || $budget->getMaxTokensPerDay() > 0
+            || $budget->getMaxCostPerDay() > 0.0;
+        $hasMonthlyLimits = $budget->getMaxRequestsPerMonth() > 0
+            || $budget->getMaxTokensPerMonth() > 0
+            || $budget->getMaxCostPerMonth() > 0.0;
 
-        $dailyResult = $this->evaluateDaily($budget, $beUserUid, $plannedCost, $now);
-        if (!$dailyResult->allowed) {
-            return $dailyResult;
-        }
+        $dayStart = $now->setTime(0, 0, 0)->getTimestamp();
+        $monthStart = $now->modify('first day of this month')->setTime(0, 0, 0)->getTimestamp();
 
-        return $this->evaluateMonthly($budget, $beUserUid, $plannedCost, $now);
-    }
-
-    private function evaluateDaily(
-        UserBudget $budget,
-        int $beUserUid,
-        float $plannedCost,
-        DateTimeImmutable $now,
-    ): BudgetCheckResult {
-        if ($budget->getMaxRequestsPerDay() === 0
-            && $budget->getMaxTokensPerDay() === 0
-            && $budget->getMaxCostPerDay() === 0.0
-        ) {
-            return BudgetCheckResult::allowed();
-        }
-
-        $from = $now->setTime(0, 0, 0);
-        $usage = $this->aggregateUsage($beUserUid, $from->getTimestamp(), $now->getTimestamp());
-
-        return $this->compare(
-            usage: $usage,
-            plannedCost: $plannedCost,
-            requestLimit: $budget->getMaxRequestsPerDay(),
-            tokenLimit: $budget->getMaxTokensPerDay(),
-            costLimit: $budget->getMaxCostPerDay(),
-            requestLimitId: BudgetCheckResult::LIMIT_DAILY_REQUESTS,
-            tokenLimitId: BudgetCheckResult::LIMIT_DAILY_TOKENS,
-            costLimitId: BudgetCheckResult::LIMIT_DAILY_COST,
+        // ONE DB roundtrip covering both windows. When only one window is
+        // configured the other aggregate is cheap (the row count is tiny
+        // since tx_nrllm_service_usage is already a per-user/per-day
+        // rollup, not a per-request log).
+        $windows = $this->aggregateWindowUsage(
+            $beUserUid,
+            $hasDailyLimits ? $dayStart : null,
+            $hasMonthlyLimits ? $monthStart : null,
+            $now->getTimestamp(),
         );
-    }
 
-    private function evaluateMonthly(
-        UserBudget $budget,
-        int $beUserUid,
-        float $plannedCost,
-        DateTimeImmutable $now,
-    ): BudgetCheckResult {
-        if ($budget->getMaxRequestsPerMonth() === 0
-            && $budget->getMaxTokensPerMonth() === 0
-            && $budget->getMaxCostPerMonth() === 0.0
-        ) {
-            return BudgetCheckResult::allowed();
+        if ($hasDailyLimits) {
+            $dailyResult = $this->compare(
+                usage: $windows['daily'],
+                plannedCost: $plannedCost,
+                requestLimit: $budget->getMaxRequestsPerDay(),
+                tokenLimit: $budget->getMaxTokensPerDay(),
+                costLimit: $budget->getMaxCostPerDay(),
+                requestLimitId: BudgetCheckResult::LIMIT_DAILY_REQUESTS,
+                tokenLimitId: BudgetCheckResult::LIMIT_DAILY_TOKENS,
+                costLimitId: BudgetCheckResult::LIMIT_DAILY_COST,
+            );
+            if (!$dailyResult->allowed) {
+                return $dailyResult;
+            }
         }
 
-        $from = $now->modify('first day of this month')->setTime(0, 0, 0);
-        $usage = $this->aggregateUsage($beUserUid, $from->getTimestamp(), $now->getTimestamp());
+        if ($hasMonthlyLimits) {
+            return $this->compare(
+                usage: $windows['monthly'],
+                plannedCost: $plannedCost,
+                requestLimit: $budget->getMaxRequestsPerMonth(),
+                tokenLimit: $budget->getMaxTokensPerMonth(),
+                costLimit: $budget->getMaxCostPerMonth(),
+                requestLimitId: BudgetCheckResult::LIMIT_MONTHLY_REQUESTS,
+                tokenLimitId: BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
+                costLimitId: BudgetCheckResult::LIMIT_MONTHLY_COST,
+            );
+        }
 
-        return $this->compare(
-            usage: $usage,
-            plannedCost: $plannedCost,
-            requestLimit: $budget->getMaxRequestsPerMonth(),
-            tokenLimit: $budget->getMaxTokensPerMonth(),
-            costLimit: $budget->getMaxCostPerMonth(),
-            requestLimitId: BudgetCheckResult::LIMIT_MONTHLY_REQUESTS,
-            tokenLimitId: BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
-            costLimitId: BudgetCheckResult::LIMIT_MONTHLY_COST,
-        );
+        return BudgetCheckResult::allowed();
     }
 
     /**
@@ -166,44 +164,65 @@ class BudgetService
     }
 
     /**
-     * Aggregate usage for the given user and time window. Protected so tests
-     * can stub out the DB layer without mocking the full QueryBuilder chain.
+     * Aggregate per-user usage for the daily AND monthly windows in a
+     * single DB roundtrip, using conditional SUM() expressions. Protected
+     * so tests can stub out the DB layer without mocking the QueryBuilder
+     * chain. `null` for a window means "limit not configured" — the
+     * matching aggregate is returned as a zeroed bucket.
      *
-     * @return array{requests: int, tokens: int, cost: float}
+     * @return array{daily: array{requests: int, tokens: int, cost: float}, monthly: array{requests: int, tokens: int, cost: float}}
      */
-    protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
-    {
+    protected function aggregateWindowUsage(
+        int $beUserUid,
+        ?int $dailyFromTimestamp,
+        ?int $monthlyFromTimestamp,
+        int $toTimestamp,
+    ): array {
+        $empty = ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        if ($dailyFromTimestamp === null && $monthlyFromTimestamp === null) {
+            return ['daily' => $empty, 'monthly' => $empty];
+        }
+
+        // The lower bound for the SQL WHERE: monthly is always the wider
+        // window, so if it's set we use that; otherwise fall back to the
+        // daily bound.
+        $lowerBound = $monthlyFromTimestamp ?? $dailyFromTimestamp;
+
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::USAGE_TABLE);
+        $dailyFromParam = $queryBuilder->createNamedParameter($dailyFromTimestamp ?? PHP_INT_MAX);
+        $monthlyFromParam = $queryBuilder->createNamedParameter($monthlyFromTimestamp ?? PHP_INT_MAX);
+
         $row = $queryBuilder
-            ->addSelectLiteral('SUM(request_count) AS total_requests')
-            ->addSelectLiteral('SUM(tokens_used) AS total_tokens')
-            ->addSelectLiteral('SUM(estimated_cost) AS total_cost')
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS daily_requests', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS daily_tokens', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS daily_cost', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS monthly_requests', $monthlyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS monthly_tokens', $monthlyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS monthly_cost', $monthlyFromParam))
             ->from(self::USAGE_TABLE)
             ->where(
-                $queryBuilder->expr()->eq(
-                    'be_user',
-                    $queryBuilder->createNamedParameter($beUserUid),
-                ),
-                $queryBuilder->expr()->gte(
-                    'request_date',
-                    $queryBuilder->createNamedParameter($fromTimestamp),
-                ),
-                $queryBuilder->expr()->lte(
-                    'request_date',
-                    $queryBuilder->createNamedParameter($toTimestamp),
-                ),
+                $queryBuilder->expr()->eq('be_user', $queryBuilder->createNamedParameter($beUserUid)),
+                $queryBuilder->expr()->gte('request_date', $queryBuilder->createNamedParameter($lowerBound)),
+                $queryBuilder->expr()->lte('request_date', $queryBuilder->createNamedParameter($toTimestamp)),
             )
             ->executeQuery()
             ->fetchAssociative();
 
         if (!is_array($row)) {
-            return ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+            return ['daily' => $empty, 'monthly' => $empty];
         }
 
         return [
-            'requests' => is_numeric($row['total_requests'] ?? null) ? (int)$row['total_requests'] : 0,
-            'tokens' => is_numeric($row['total_tokens'] ?? null) ? (int)$row['total_tokens'] : 0,
-            'cost' => is_numeric($row['total_cost'] ?? null) ? (float)$row['total_cost'] : 0.0,
+            'daily' => [
+                'requests' => is_numeric($row['daily_requests'] ?? null) ? (int)$row['daily_requests'] : 0,
+                'tokens' => is_numeric($row['daily_tokens'] ?? null) ? (int)$row['daily_tokens'] : 0,
+                'cost' => is_numeric($row['daily_cost'] ?? null) ? (float)$row['daily_cost'] : 0.0,
+            ],
+            'monthly' => [
+                'requests' => is_numeric($row['monthly_requests'] ?? null) ? (int)$row['monthly_requests'] : 0,
+                'tokens' => is_numeric($row['monthly_tokens'] ?? null) ? (int)$row['monthly_tokens'] : 0,
+                'cost' => is_numeric($row['monthly_cost'] ?? null) ? (float)$row['monthly_cost'] : 0.0,
+            ],
         ];
     }
 }

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -11,6 +11,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Domain\Model\UserBudget;
 
 /*
  * Extbase persistence configuration for nr_llm.
@@ -94,6 +95,35 @@ return [
             ],
             'isSystem' => [
                 'fieldName' => 'is_system',
+            ],
+        ],
+    ],
+    UserBudget::class => [
+        'tableName' => 'tx_nrllm_user_budget',
+        'properties' => [
+            'beUser' => [
+                'fieldName' => 'be_user',
+            ],
+            'maxRequestsPerDay' => [
+                'fieldName' => 'max_requests_per_day',
+            ],
+            'maxTokensPerDay' => [
+                'fieldName' => 'max_tokens_per_day',
+            ],
+            'maxCostPerDay' => [
+                'fieldName' => 'max_cost_per_day',
+            ],
+            'maxRequestsPerMonth' => [
+                'fieldName' => 'max_requests_per_month',
+            ],
+            'maxTokensPerMonth' => [
+                'fieldName' => 'max_tokens_per_month',
+            ],
+            'maxCostPerMonth' => [
+                'fieldName' => 'max_cost_per_month',
+            ],
+            'isActive' => [
+                'fieldName' => 'is_active',
             ],
         ],
     ],

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -114,6 +114,12 @@ services:
   Netresearch\NrLlm\Domain\Repository\TaskRepository:
     public: true
 
+  Netresearch\NrLlm\Domain\Repository\UserBudgetRepository:
+    public: true
+
+  Netresearch\NrLlm\Service\BudgetService:
+    public: true
+
   # ========================================
   # Translation Registry
   # ========================================

--- a/Configuration/TCA/tx_nrllm_user_budget.php
+++ b/Configuration/TCA/tx_nrllm_user_budget.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget',
+        'label' => 'be_user',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:nr_llm/Resources/Public/Icons/Extension.svg',
+        'rootLevel' => -1,
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;core.form.tabs:general,
+                    be_user,
+                    is_active,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.daily_limits,
+                    --palette--;;daily_limits,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.monthly_limits,
+                    --palette--;;monthly_limits,
+                --div--;core.form.tabs:access,
+                    hidden
+            ',
+        ],
+    ],
+    'palettes' => [
+        'daily_limits' => [
+            'showitem' => 'max_requests_per_day, max_tokens_per_day, max_cost_per_day',
+        ],
+        'monthly_limits' => [
+            'showitem' => 'max_requests_per_month, max_tokens_per_month, max_cost_per_month',
+        ],
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        'be_user' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.be_user',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'be_users',
+                'foreign_table_where' => 'AND {#be_users}.{#hidden} = 0 AND {#be_users}.{#deleted} = 0 ORDER BY be_users.username',
+                'minitems' => 1,
+                'maxitems' => 1,
+                'required' => true,
+            ],
+        ],
+        'is_active' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.is_active',
+            'config' => [
+                'type' => 'check',
+                'default' => 1,
+            ],
+        ],
+        'max_requests_per_day' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_requests_per_day',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0,
+            ],
+        ],
+        'max_tokens_per_day' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_tokens_per_day',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0,
+            ],
+        ],
+        'max_cost_per_day' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_cost_per_day',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'format' => 'decimal',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0.0,
+            ],
+        ],
+        'max_requests_per_month' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_requests_per_month',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0,
+            ],
+        ],
+        'max_tokens_per_month' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_tokens_per_month',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0,
+            ],
+        ],
+        'max_cost_per_month' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.max_cost_per_month',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_user_budget.unlimited_hint',
+            'config' => [
+                'type' => 'number',
+                'format' => 'decimal',
+                'size' => 10,
+                'range' => ['lower' => 0],
+                'default' => 0.0,
+            ],
+        ],
+    ],
+];

--- a/Documentation/Adr/Adr025PerUserBudgets.rst
+++ b/Documentation/Adr/Adr025PerUserBudgets.rst
@@ -1,0 +1,99 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-025:
+
+==========================================
+ADR-025: Per-User AI Budgets
+==========================================
+
+:Status: Accepted
+:Date: 2026-04
+:Authors: Netresearch DTT GmbH
+
+.. _adr-025-context:
+
+Context
+=======
+
+:php:`LlmConfiguration` already exposes ``max_requests_per_day``,
+``max_tokens_per_day`` and ``max_cost_per_day`` — but those limits are
+**per configuration**, not per editor. Two editors sharing the same
+preset burn through the same bucket. Administrators asked for a separate
+dimension: cap editor A's spending independently of editor B's, regardless
+of which configuration they pick.
+
+.. _adr-025-decision:
+
+Decision
+========
+
+Ship a new :code:`tx_nrllm_user_budget` table keyed uniquely on
+``be_user``. Each row carries six independent ceilings: requests / tokens
+/ cost, times daily / monthly. ``0`` on any axis means "unlimited on
+that axis". The record is a **ceiling, not a counter** — actual usage is
+aggregated on demand from :code:`tx_nrllm_service_usage`, the same table
+the usage tracker already writes to, so there is no second write per
+request and no opportunity for the two sources to drift.
+
+:php:`BudgetService::check($beUserUid, $plannedCost)` is a pure
+pre-flight. It does **not** increment anything. Callers invoke it before
+dispatching to the provider, receive a :php:`BudgetCheckResult` that says
+allowed / denied + which bucket was tripped, and act accordingly.
+
+.. _adr-025-rules:
+
+Resolution rules
+================
+
+1. Uid :code:`<= 0` → allowed (CLI / scheduler / unauthenticated).
+2. No budget record for the user → allowed.
+3. Record exists but ``is_active == false`` → allowed.
+4. Record exists but every limit is ``0`` → allowed.
+5. Otherwise: evaluate the daily bucket, then the monthly bucket. The
+   first to exceed wins and is reported; daily trips take precedence over
+   monthly.
+6. The incoming call adds ``+1`` to the request count and ``+plannedCost``
+   to the cost figure **before** comparison, so a user at exactly the
+   limit is still allowed one more call.
+
+.. _adr-025-scope:
+
+Scope
+=====
+
+Matches the pattern established for capability permissions (ADR-023):
+this ADR ships the **table + model + repository + check primitive**.
+Wiring :php:`BudgetService::check()` into individual feature services
+(:php:`CompletionService`, :php:`VisionService`, ...) is a follow-up.
+
+.. _adr-025-relation:
+
+Relation to existing limits
+===========================
+
+:code:`tx_nrllm_configuration.max_*_per_day` remain in place and are
+orthogonal:
+
+* **Per-configuration daily limits** cap *a preset*. Useful to stop
+  "expensive-model" presets from burning through budget even if many
+  editors share them.
+* **Per-user budgets** cap *a person* across every preset. Useful to
+  stop a specific account from running away, whichever preset they pick.
+
+Both checks must pass. Future consumers who want both will check both.
+
+.. _adr-025-alternatives:
+
+Alternatives considered
+=======================
+
+* **Counter-style table** (increment on every request). Rejected:
+  duplicates :code:`tx_nrllm_service_usage`, introduces a second write per
+  request, and adds the drift-between-counters failure mode we deliberately
+  avoid.
+* **Group-level budgets** via MM to be_groups. Rejected for v1 —
+  individual-user budgets solve the common ask first. Group-level can
+  layer on later.
+* **Auto-throttling** (queue + retry when over budget). Rejected —
+  silent throttling is worse UX than an explicit denial with a reason
+  the caller can surface.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -257,3 +257,4 @@ Modern architecture (v0.4+)
    Adr022AttributeBasedProviderRegistration
    Adr023BackendCapabilityPermissions
    Adr024DashboardWidgets
+   Adr025PerUserBudgets

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -36,28 +36,28 @@
                 <target>0 = unbegrenzt für diese Dimension.</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_requests_per_day">
-                <source>Max requests per day</source>
-                <target>Max. Anfragen pro Tag</target>
+                <source>Max Requests/Day</source>
+                <target>Max. Anfragen/Tag</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_tokens_per_day">
-                <source>Max tokens per day</source>
-                <target>Max. Token pro Tag</target>
+                <source>Max Tokens/Day</source>
+                <target>Max. Token/Tag</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_cost_per_day">
-                <source>Max cost per day ($)</source>
-                <target>Max. Kosten pro Tag ($)</target>
+                <source>Max Cost/Day ($)</source>
+                <target>Max. Kosten/Tag ($)</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_requests_per_month">
-                <source>Max requests per month</source>
-                <target>Max. Anfragen pro Monat</target>
+                <source>Max Requests/Month</source>
+                <target>Max. Anfragen/Monat</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_tokens_per_month">
-                <source>Max tokens per month</source>
-                <target>Max. Token pro Monat</target>
+                <source>Max Tokens/Month</source>
+                <target>Max. Token/Monat</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_cost_per_month">
-                <source>Max cost per month ($)</source>
-                <target>Max. Kosten pro Monat ($)</target>
+                <source>Max Cost/Month ($)</source>
+                <target>Max. Kosten/Monat ($)</target>
             </trans-unit>
 
             <!-- Tabs -->

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -7,6 +7,58 @@
                 <source>LLM Configuration</source>
                 <target>LLM-Konfiguration</target>
             </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget">
+                <source>LLM User Budget</source>
+                <target>LLM-Nutzerbudget</target>
+            </trans-unit>
+
+            <!-- User budget tabs -->
+            <trans-unit id="tab.daily_limits">
+                <source>Daily Limits</source>
+                <target>Tageslimits</target>
+            </trans-unit>
+            <trans-unit id="tab.monthly_limits">
+                <source>Monthly Limits</source>
+                <target>Monatslimits</target>
+            </trans-unit>
+
+            <!-- User budget fields -->
+            <trans-unit id="tx_nrllm_user_budget.be_user">
+                <source>Backend User</source>
+                <target>Backend-Benutzer</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.is_active">
+                <source>Enforce this budget</source>
+                <target>Dieses Budget erzwingen</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.unlimited_hint">
+                <source>0 = unlimited on this axis.</source>
+                <target>0 = unbegrenzt für diese Dimension.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_requests_per_day">
+                <source>Max requests per day</source>
+                <target>Max. Anfragen pro Tag</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_tokens_per_day">
+                <source>Max tokens per day</source>
+                <target>Max. Token pro Tag</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_cost_per_day">
+                <source>Max cost per day ($)</source>
+                <target>Max. Kosten pro Tag ($)</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_requests_per_month">
+                <source>Max requests per month</source>
+                <target>Max. Anfragen pro Monat</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_tokens_per_month">
+                <source>Max tokens per month</source>
+                <target>Max. Token pro Monat</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_cost_per_month">
+                <source>Max cost per month ($)</source>
+                <target>Max. Kosten pro Monat ($)</target>
+            </trans-unit>
 
             <!-- Tabs -->
             <trans-unit id="tab.parameters">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -29,22 +29,22 @@
                 <source>0 = unlimited on this axis.</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_requests_per_day">
-                <source>Max requests per day</source>
+                <source>Max Requests/Day</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_tokens_per_day">
-                <source>Max tokens per day</source>
+                <source>Max Tokens/Day</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_cost_per_day">
-                <source>Max cost per day ($)</source>
+                <source>Max Cost/Day ($)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_requests_per_month">
-                <source>Max requests per month</source>
+                <source>Max Requests/Month</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_tokens_per_month">
-                <source>Max tokens per month</source>
+                <source>Max Tokens/Month</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_user_budget.max_cost_per_month">
-                <source>Max cost per month ($)</source>
+                <source>Max Cost/Month ($)</source>
             </trans-unit>
 
             <!-- Tabs -->

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -6,6 +6,46 @@
             <trans-unit id="tx_nrllm_configuration">
                 <source>LLM Configuration</source>
             </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget">
+                <source>LLM User Budget</source>
+            </trans-unit>
+
+            <!-- User budget tabs -->
+            <trans-unit id="tab.daily_limits">
+                <source>Daily Limits</source>
+            </trans-unit>
+            <trans-unit id="tab.monthly_limits">
+                <source>Monthly Limits</source>
+            </trans-unit>
+
+            <!-- User budget fields -->
+            <trans-unit id="tx_nrllm_user_budget.be_user">
+                <source>Backend User</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.is_active">
+                <source>Enforce this budget</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.unlimited_hint">
+                <source>0 = unlimited on this axis.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_requests_per_day">
+                <source>Max requests per day</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_tokens_per_day">
+                <source>Max tokens per day</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_cost_per_day">
+                <source>Max cost per day ($)</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_requests_per_month">
+                <source>Max requests per month</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_tokens_per_month">
+                <source>Max tokens per month</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_user_budget.max_cost_per_month">
+                <source>Max cost per month ($)</source>
+            </trans-unit>
 
             <!-- Tabs -->
             <trans-unit id="tab.parameters">

--- a/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
+++ b/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
@@ -42,9 +42,36 @@ class BudgetCheckResultTest extends AbstractUnitTestCase
         self::assertSame(BudgetCheckResult::LIMIT_DAILY_COST, $result->exceededLimit);
         self::assertSame(9.5, $result->currentUsage);
         self::assertSame(10.0, $result->limit);
-        self::assertStringContainsString('daily_cost', $result->reason);
+        self::assertStringContainsString('AI budget exhausted', $result->reason);
+        self::assertStringContainsString('daily cost', $result->reason);
         self::assertStringContainsString('9.50', $result->reason);
         self::assertStringContainsString('10', $result->reason);
+    }
+
+    #[Test]
+    public function deniedReasonUsesHumanLabelNotInternalKey(): void
+    {
+        $result = BudgetCheckResult::denied(
+            BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
+            currentUsage: 1_000_000,
+            limit: 500_000,
+        );
+
+        self::assertStringContainsString('monthly token usage', $result->reason);
+        self::assertStringNotContainsString('monthly_tokens', $result->reason);
+    }
+
+    #[Test]
+    public function deniedReasonFallsBackToInternalKeyForUnknownLimit(): void
+    {
+        // Guard against a future LIMIT_* constant without a label entry.
+        $result = BudgetCheckResult::denied(
+            'custom_limit',
+            currentUsage: 1.0,
+            limit: 2.0,
+        );
+
+        self::assertStringContainsString('custom_limit', $result->reason);
     }
 
     #[Test]

--- a/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
+++ b/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\DTO;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(BudgetCheckResult::class)]
+class BudgetCheckResultTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function allowedFactoryReturnsPermissiveResult(): void
+    {
+        $result = BudgetCheckResult::allowed();
+
+        self::assertTrue($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_NONE, $result->exceededLimit);
+        self::assertSame('', $result->reason);
+        self::assertSame(0.0, $result->currentUsage);
+        self::assertSame(0.0, $result->limit);
+    }
+
+    #[Test]
+    public function deniedFactorySetsFieldsAndGeneratesReason(): void
+    {
+        $result = BudgetCheckResult::denied(
+            BudgetCheckResult::LIMIT_DAILY_COST,
+            currentUsage: 9.5,
+            limit: 10.0,
+        );
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_COST, $result->exceededLimit);
+        self::assertSame(9.5, $result->currentUsage);
+        self::assertSame(10.0, $result->limit);
+        self::assertStringContainsString('daily_cost', $result->reason);
+        self::assertStringContainsString('9.50', $result->reason);
+        self::assertStringContainsString('10', $result->reason);
+    }
+
+    #[Test]
+    public function deniedFactoryAcceptsCustomReason(): void
+    {
+        $result = BudgetCheckResult::denied(
+            BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
+            currentUsage: 1_000_000,
+            limit: 500_000,
+            reason: 'Monthly token cap exceeded',
+        );
+
+        self::assertSame('Monthly token cap exceeded', $result->reason);
+    }
+
+    #[Test]
+    public function deniedReasonFormatsIntegersWithoutDecimals(): void
+    {
+        $result = BudgetCheckResult::denied(
+            BudgetCheckResult::LIMIT_DAILY_REQUESTS,
+            currentUsage: 5.0,
+            limit: 10.0,
+        );
+
+        self::assertStringContainsString('5 of 10', $result->reason);
+        self::assertStringNotContainsString('.00', $result->reason);
+    }
+
+    #[Test]
+    public function allLimitConstantsAreDistinctAndNonEmpty(): void
+    {
+        $limits = [
+            BudgetCheckResult::LIMIT_DAILY_REQUESTS,
+            BudgetCheckResult::LIMIT_DAILY_TOKENS,
+            BudgetCheckResult::LIMIT_DAILY_COST,
+            BudgetCheckResult::LIMIT_MONTHLY_REQUESTS,
+            BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
+            BudgetCheckResult::LIMIT_MONTHLY_COST,
+        ];
+
+        self::assertCount(6, array_unique($limits));
+        foreach ($limits as $limit) {
+            self::assertNotSame('', $limit);
+        }
+    }
+}

--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\UserBudget;
+use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
+use Netresearch\NrLlm\Service\BudgetService;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+#[CoversClass(BudgetService::class)]
+class BudgetServiceTest extends AbstractUnitTestCase
+{
+    private UserBudgetRepository&Stub $repositoryStub;
+    private ConnectionPool&Stub $connectionPoolStub;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repositoryStub = self::createStub(UserBudgetRepository::class);
+        $this->connectionPoolStub = self::createStub(ConnectionPool::class);
+    }
+
+    #[Test]
+    public function allowsAnyCallForZeroUserUid(): void
+    {
+        $service = $this->makeService(['requests' => 999, 'tokens' => 99999, 'cost' => 9999.99]);
+
+        $result = $service->check(0, 10.0);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function allowsAnyCallForNegativeUserUid(): void
+    {
+        $service = $this->makeService(['requests' => 999, 'tokens' => 99999, 'cost' => 9999.99]);
+
+        $result = $service->check(-5, 10.0);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function allowsWhenUserHasNoBudgetRecord(): void
+    {
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+        $service = $this->makeService(['requests' => 999, 'tokens' => 99999, 'cost' => 9999.99]);
+
+        $result = $service->check(42, 10.0);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function allowsWhenBudgetIsInactive(): void
+    {
+        $budget = $this->makeBudget(dailyCost: 1.0);
+        $budget->setIsActive(false);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 100, 'tokens' => 100, 'cost' => 100.0]);
+
+        $result = $service->check(42, 10.0);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function allowsWhenBudgetHasNoLimitsSet(): void
+    {
+        $budget = $this->makeBudget();
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 100, 'tokens' => 100, 'cost' => 100.0]);
+
+        $result = $service->check(42, 10.0);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function deniesOnDailyRequestLimitBecauseTheIncomingCallAdds1(): void
+    {
+        // Usage already at the limit -> +1 incoming > limit
+        $budget = $this->makeBudget(dailyRequests: 10);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 10, 'tokens' => 0, 'cost' => 0.0]);
+
+        $result = $service->check(42);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_REQUESTS, $result->exceededLimit);
+        self::assertSame(10.0, $result->currentUsage);
+        self::assertSame(10.0, $result->limit);
+    }
+
+    #[Test]
+    public function allowsWhenUsagePlusOneIsExactlyAtRequestLimit(): void
+    {
+        // 9 used + 1 new = 10 == limit -> still allowed
+        $budget = $this->makeBudget(dailyRequests: 10);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 9, 'tokens' => 0, 'cost' => 0.0]);
+
+        self::assertTrue($service->check(42)->allowed);
+    }
+
+    #[Test]
+    public function deniesOnDailyCostLimitWithPlannedCost(): void
+    {
+        $budget = $this->makeBudget(dailyCost: 10.0);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        // 8.50 used, plan 2.00 more -> 10.50 > 10.00 limit
+        $service = $this->makeService(['requests' => 5, 'tokens' => 0, 'cost' => 8.50]);
+
+        $result = $service->check(42, plannedCost: 2.0);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_COST, $result->exceededLimit);
+        self::assertSame(8.50, $result->currentUsage);
+        self::assertSame(10.0, $result->limit);
+    }
+
+    #[Test]
+    public function deniesOnDailyTokenLimit(): void
+    {
+        $budget = $this->makeBudget(dailyTokens: 1000);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 0, 'tokens' => 1500, 'cost' => 0.0]);
+
+        $result = $service->check(42);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_TOKENS, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function checksMonthlyLimitWhenDailyPasses(): void
+    {
+        // Daily unlimited, monthly cost capped.
+        $budget = $this->makeBudget(monthlyCost: 100.0);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        // 99.50 used, plan 1.00 -> 100.50 > 100 limit
+        $service = $this->makeService(['requests' => 1000, 'tokens' => 0, 'cost' => 99.50]);
+
+        $result = $service->check(42, plannedCost: 1.0);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_MONTHLY_COST, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function dailyDenialTakesPrecedenceOverMonthly(): void
+    {
+        $budget = $this->makeBudget(dailyRequests: 5, monthlyRequests: 100);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 5, 'tokens' => 0, 'cost' => 0.0]);
+
+        $result = $service->check(42);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_REQUESTS, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function allowsWhenUnderAllLimits(): void
+    {
+        $budget = $this->makeBudget(
+            dailyRequests: 100,
+            dailyTokens: 10000,
+            dailyCost: 50.0,
+            monthlyCost: 500.0,
+        );
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(['requests' => 3, 'tokens' => 150, 'cost' => 0.75]);
+
+        self::assertTrue($service->check(42, plannedCost: 0.25)->allowed);
+    }
+
+    #[Test]
+    public function monthlyAggregationUsesDifferentWindowThanDaily(): void
+    {
+        // Give daily a pass but monthly a fail by controlling per-window returns.
+        $budget = $this->makeBudget(dailyRequests: 100, monthlyRequests: 20);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        // Note: cannot declare this anon class `readonly` because we mutate
+        // $callCount across invocations. BudgetService is NOT marked readonly
+        // at the class level for exactly this reason — it only relies on its
+        // constructor-promoted fields being readonly.
+        $service = new class ($this->repositoryStub, $this->connectionPoolStub) extends BudgetService {
+            public int $callCount = 0;
+
+            protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
+            {
+                $this->callCount++;
+                // First call is daily, second is monthly
+                return $this->callCount === 1
+                    ? ['requests' => 5, 'tokens' => 0, 'cost' => 0.0]
+                    : ['requests' => 20, 'tokens' => 0, 'cost' => 0.0];
+            }
+        };
+
+        $result = $service->check(42);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_MONTHLY_REQUESTS, $result->exceededLimit);
+        self::assertSame(2, $service->callCount);
+    }
+
+    /**
+     * @param array{requests: int, tokens: int, cost: float} $fakeUsage
+     */
+    private function makeService(array $fakeUsage): BudgetService
+    {
+        return new class ($this->repositoryStub, $this->connectionPoolStub, $fakeUsage) extends BudgetService {
+            /**
+             * @param array{requests: int, tokens: int, cost: float} $fakeUsage
+             */
+            public function __construct(
+                UserBudgetRepository $repository,
+                ConnectionPool $connectionPool,
+                private readonly array $fakeUsage,
+            ) {
+                parent::__construct($repository, $connectionPool);
+            }
+
+            protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
+            {
+                return $this->fakeUsage;
+            }
+        };
+    }
+
+    private function makeBudget(
+        int $dailyRequests = 0,
+        int $dailyTokens = 0,
+        float $dailyCost = 0.0,
+        int $monthlyRequests = 0,
+        int $monthlyTokens = 0,
+        float $monthlyCost = 0.0,
+    ): UserBudget {
+        $budget = new UserBudget();
+        $budget->setBeUser(42);
+        $budget->setIsActive(true);
+        $budget->setMaxRequestsPerDay($dailyRequests);
+        $budget->setMaxTokensPerDay($dailyTokens);
+        $budget->setMaxCostPerDay($dailyCost);
+        $budget->setMaxRequestsPerMonth($monthlyRequests);
+        $budget->setMaxTokensPerMonth($monthlyTokens);
+        $budget->setMaxCostPerMonth($monthlyCost);
+        return $budget;
+    }
+}

--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -158,7 +158,9 @@ class BudgetServiceTest extends AbstractUnitTestCase
         $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
 
         // 99.50 used, plan 1.00 -> 100.50 > 100 limit
-        $service = $this->makeService(['requests' => 1000, 'tokens' => 0, 'cost' => 99.50]);
+        $service = $this->makeService(
+            monthly: ['requests' => 1000, 'tokens' => 0, 'cost' => 99.50],
+        );
 
         $result = $service->check(42, plannedCost: 1.0);
 
@@ -191,7 +193,10 @@ class BudgetServiceTest extends AbstractUnitTestCase
         );
         $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
 
-        $service = $this->makeService(['requests' => 3, 'tokens' => 150, 'cost' => 0.75]);
+        $service = $this->makeService(
+            daily: ['requests' => 3, 'tokens' => 150, 'cost' => 0.75],
+            monthly: ['requests' => 3, 'tokens' => 150, 'cost' => 0.75],
+        );
 
         self::assertTrue($service->check(42, plannedCost: 0.25)->allowed);
     }
@@ -203,50 +208,117 @@ class BudgetServiceTest extends AbstractUnitTestCase
         $budget = $this->makeBudget(dailyRequests: 100, monthlyRequests: 20);
         $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
 
-        // Note: cannot declare this anon class `readonly` because we mutate
-        // $callCount across invocations. BudgetService is NOT marked readonly
-        // at the class level for exactly this reason — it only relies on its
-        // constructor-promoted fields being readonly.
-        $service = new class ($this->repositoryStub, $this->connectionPoolStub) extends BudgetService {
-            public int $callCount = 0;
-
-            protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
-            {
-                $this->callCount++;
-                // First call is daily, second is monthly
-                return $this->callCount === 1
-                    ? ['requests' => 5, 'tokens' => 0, 'cost' => 0.0]
-                    : ['requests' => 20, 'tokens' => 0, 'cost' => 0.0];
-            }
-        };
+        $service = $this->makeService(
+            daily: ['requests' => 5, 'tokens' => 0, 'cost' => 0.0],
+            monthly: ['requests' => 20, 'tokens' => 0, 'cost' => 0.0],
+        );
 
         $result = $service->check(42);
 
         self::assertFalse($result->allowed);
         self::assertSame(BudgetCheckResult::LIMIT_MONTHLY_REQUESTS, $result->exceededLimit);
-        self::assertSame(2, $service->callCount);
+    }
+
+    #[Test]
+    public function combinesDailyAndMonthlyIntoASingleAggregationCall(): void
+    {
+        $budget = $this->makeBudget(dailyRequests: 100, monthlyRequests: 100);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = new class ($this->repositoryStub, $this->connectionPoolStub) extends BudgetService {
+            public int $callCount = 0;
+
+            public ?int $capturedDailyFrom = null;
+
+            public ?int $capturedMonthlyFrom = null;
+
+            /**
+             * @return array{daily: array{requests: int, tokens: int, cost: float}, monthly: array{requests: int, tokens: int, cost: float}}
+             */
+            protected function aggregateWindowUsage(
+                int $beUserUid,
+                ?int $dailyFromTimestamp,
+                ?int $monthlyFromTimestamp,
+                int $toTimestamp,
+            ): array {
+                $this->callCount++;
+                $this->capturedDailyFrom = $dailyFromTimestamp;
+                $this->capturedMonthlyFrom = $monthlyFromTimestamp;
+                return [
+                    'daily' => ['requests' => 3, 'tokens' => 0, 'cost' => 0.0],
+                    'monthly' => ['requests' => 50, 'tokens' => 0, 'cost' => 0.0],
+                ];
+            }
+        };
+
+        $result = $service->check(42);
+
+        self::assertTrue($result->allowed);
+        self::assertSame(1, $service->callCount, 'Should make exactly one DB aggregation call');
+        self::assertNotNull($service->capturedDailyFrom, 'Daily window should be requested');
+        self::assertNotNull($service->capturedMonthlyFrom, 'Monthly window should be requested');
+        self::assertLessThan(
+            $service->capturedDailyFrom,
+            $service->capturedMonthlyFrom,
+            'Monthly start must precede daily start',
+        );
+    }
+
+    #[Test]
+    public function clampsNegativePlannedCostToZero(): void
+    {
+        // cost limit 10, used 8 already, plannedCost = -5 must not be accepted as "used -5"
+        // which would trick the check into allowing because 8 + (-5) = 3 < 10.
+        $budget = $this->makeBudget(dailyCost: 10.0);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        $service = $this->makeService(
+            daily: ['requests' => 0, 'tokens' => 0, 'cost' => 8.0],
+            monthly: ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
+        );
+
+        // With the clamp: 8 + max(0, -5) = 8 ≤ 10 → allowed (correct)
+        // Without the clamp: 8 + (-5) = 3 ≤ 10 → allowed (but for the wrong reason)
+        // This test pins down the clamp behavior: try to go over with a legitimate cost,
+        // then verify negative input can't reduce the used total.
+        self::assertTrue($service->check(42, plannedCost: -5.0)->allowed);
+
+        // Positive cost DOES trip the limit (8 + 3 = 11 > 10).
+        self::assertFalse($service->check(42, plannedCost: 3.0)->allowed);
     }
 
     /**
-     * @param array{requests: int, tokens: int, cost: float} $fakeUsage
+     * @param array{requests: int, tokens: int, cost: float}|null $daily
+     * @param array{requests: int, tokens: int, cost: float}|null $monthly
      */
-    private function makeService(array $fakeUsage): BudgetService
+    private function makeService(array $daily = null, array $monthly = null): BudgetService
     {
-        return new class ($this->repositoryStub, $this->connectionPoolStub, $fakeUsage) extends BudgetService {
+        $dailyWindow = $daily ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        $monthlyWindow = $monthly ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        return new class ($this->repositoryStub, $this->connectionPoolStub, $dailyWindow, $monthlyWindow) extends BudgetService {
             /**
-             * @param array{requests: int, tokens: int, cost: float} $fakeUsage
+             * @param array{requests: int, tokens: int, cost: float} $fakeDaily
+             * @param array{requests: int, tokens: int, cost: float} $fakeMonthly
              */
             public function __construct(
                 UserBudgetRepository $repository,
                 ConnectionPool $connectionPool,
-                private readonly array $fakeUsage,
+                private readonly array $fakeDaily,
+                private readonly array $fakeMonthly,
             ) {
                 parent::__construct($repository, $connectionPool);
             }
 
-            protected function aggregateUsage(int $beUserUid, int $fromTimestamp, int $toTimestamp): array
-            {
-                return $this->fakeUsage;
+            protected function aggregateWindowUsage(
+                int $beUserUid,
+                ?int $dailyFromTimestamp,
+                ?int $monthlyFromTimestamp,
+                int $toTimestamp,
+            ): array {
+                return [
+                    'daily' => $this->fakeDaily,
+                    'monthly' => $this->fakeMonthly,
+                ];
             }
         };
     }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -154,6 +154,41 @@ CREATE TABLE tx_nrllm_configuration (
 );
 
 #
+# Table structure for table 'tx_nrllm_user_budget'
+# Per-backend-user spending and request limits.
+#
+CREATE TABLE tx_nrllm_user_budget (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    -- Backend user reference
+    be_user int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Daily limits (0 = unlimited)
+    max_requests_per_day int(11) unsigned DEFAULT '0' NOT NULL,
+    max_tokens_per_day int(11) unsigned DEFAULT '0' NOT NULL,
+    max_cost_per_day decimal(10,4) DEFAULT '0.0000' NOT NULL,
+
+    -- Monthly limits (0 = unlimited)
+    max_requests_per_month int(11) unsigned DEFAULT '0' NOT NULL,
+    max_tokens_per_month int(11) unsigned DEFAULT '0' NOT NULL,
+    max_cost_per_month decimal(10,4) DEFAULT '0.0000' NOT NULL,
+
+    -- Status
+    is_active tinyint(1) DEFAULT '1' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+    deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
+    hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    UNIQUE KEY be_user (be_user)
+);
+
+#
 # MM table for backend user group access control
 #
 CREATE TABLE tx_nrllm_configuration_begroups_mm (


### PR DESCRIPTION
## Summary

Adds a new dimension of AI cost control: per-backend-user budgets independent of per-configuration limits.

- New table `tx_nrllm_user_budget` keyed uniquely on `be_user` with six independent ceilings (requests / tokens / cost × daily / monthly; `0` = unlimited on that axis)
- `UserBudget` domain model + `UserBudgetRepository`
- `BudgetService::check(beUserUid, plannedCost)` as a pre-flight check — returns `BudgetCheckResult` naming which bucket tripped (if any)
- TCA + EN/DE labels for the new table (editable via List module under Admin Tools)
- Ceilings, not counters: actual usage is aggregated on demand from `tx_nrllm_service_usage`, so there's no second-write per request and no drift between counters

## Resolution order

1. Uid ≤ 0 → allowed (CLI / scheduler / frontend)
2. No budget record → allowed
3. `is_active = false` → allowed
4. All limits zero → allowed
5. Daily bucket evaluated first, then monthly — first to trip wins; +1 request and +plannedCost are added before comparison so a user at exactly the limit still gets one more call

## Scope note

Ships the **table + service + primitive**. Wiring `BudgetService::check()` into each feature service is a deliberate follow-up, same pattern as ADR-023.

## Relation to existing per-configuration limits

Orthogonal and complementary:
- Per-configuration `max_*_per_day` caps *a preset*
- Per-user budgets cap *a person* across every preset
- Both checks must pass

## Test plan

- [x] 18 unit tests (BudgetService + BudgetCheckResult + UserBudget)
- [x] PHPStan level 10 clean
- [x] Architecture + CGL + Rector clean

See ADR-025 for design rationale and the counter-table alternative we ruled out.