### PR TITLE
docs: catch up README + Documentation with 0.7.0 features

### DIFF
--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -48,3 +48,4 @@ left-hand navigation:
    Configurations
    Tasks
    Wizards
+   UserBudgets

--- a/Documentation/Administration/UserBudgets.rst
+++ b/Documentation/Administration/UserBudgets.rst
@@ -1,0 +1,139 @@
+..  include:: /Includes.rst.txt
+
+..  _administration-user-budgets:
+
+============================
+Per-user AI budgets
+============================
+
+The :sql:`tx_nrllm_user_budget` table caps per-backend-user AI spend
+independently of the per-configuration daily limits on
+:sql:`tx_nrllm_configuration`. A user request must clear BOTH layers:
+any limit on the preset they chose AND any limit on their personal
+budget record.
+
+..  _administration-user-budgets-what:
+
+What a budget caps
+==================
+
+Each row in :sql:`tx_nrllm_user_budget` binds to exactly one
+``be_user`` and defines six independent ceilings. ``0`` on any axis
+means "unlimited on this axis".
+
+..  list-table::
+    :header-rows: 1
+    :widths: 30 15 55
+
+    * - Field
+      - Unit
+      - Reset cadence
+    * - Max Requests/Day
+      - count
+      - Every day at 00:00 server-local time.
+    * - Max Tokens/Day
+      - count
+      - Every day at 00:00 server-local time.
+    * - Max Cost/Day ($)
+      - USD
+      - Every day at 00:00 server-local time.
+    * - Max Requests/Month
+      - count
+      - First of the month, 00:00 server-local time.
+    * - Max Tokens/Month
+      - count
+      - First of the month, 00:00 server-local time.
+    * - Max Cost/Month ($)
+      - USD
+      - First of the month, 00:00 server-local time.
+
+Usage is aggregated on demand from :sql:`tx_nrllm_service_usage` — the
+same table the UsageTracker already writes to per request — so there
+is no second write per request and no way for a separate counter to
+drift away from the source of truth.
+
+..  _administration-user-budgets-create:
+
+Creating a budget
+=================
+
+Budgets are plain records on the root page tree (``pid = 0``,
+``rootLevel = -1``). Admins create or edit them via the TYPO3 List
+module:
+
+1.  Open :guilabel:`Web > List` on any page.
+2.  Click :guilabel:`Create new record` at page UID 0 (the root).
+3.  Choose :guilabel:`LLM User Budget`.
+4.  Pick the backend user, set the ceilings, toggle
+    :guilabel:`Enforce this budget` on.
+5.  Save.
+
+..  note::
+    Only one budget row per backend user. The :code:`be_user` column
+    is unique. Re-editing the existing row is the correct way to
+    tighten or relax limits.
+
+..  _administration-user-budgets-how-checks-work:
+
+How the check runs
+==================
+
+Before dispatching a request the consuming extension calls
+:php:`\Netresearch\NrLlm\Service\BudgetService::check()`. The service:
+
+1.  Returns *allowed* when the user has no budget record, when
+    :guilabel:`Enforce this budget` is off, or when every ceiling
+    is ``0``.
+2.  Aggregates today's usage and this month's usage in a single
+    database roundtrip.
+3.  Evaluates the daily window first; the monthly window only if the
+    daily window passes.
+4.  Adds ``+1`` request and ``+plannedCost`` to the usage figures
+    before comparing, so a user at exactly the limit is still
+    allowed one more call.
+
+The returned :php:`BudgetCheckResult` names which bucket was tripped
+(``exceededLimit`` as a stable machine key, plus a human-friendly
+``reason`` string suitable for log output or caller-side wrapping).
+
+..  important::
+    The check is **best-effort**, not a transactionally-safe gate.
+    Two concurrent requests for the same user can both pass
+    :php:`check()` before either updates
+    :sql:`tx_nrllm_service_usage`, temporarily allowing a one-request
+    overshoot. Full serialisation would hot-path every AI request.
+    If strict enforcement matters, layer a per-user lock on top.
+
+..  _administration-user-budgets-vs-config:
+
+Budgets vs. configuration limits
+================================
+
+Both layers persist but cap different things:
+
+..  list-table::
+    :header-rows: 1
+    :widths: 25 35 40
+
+    * - Axis
+      - Configuration daily limits
+      - Per-user budgets
+    * - Bound to
+      - a preset (:sql:`tx_nrllm_configuration`)
+      - a backend user (:sql:`tx_nrllm_user_budget`)
+    * - Question answered
+      - "Can ANY editor keep using this preset today?"
+      - "Can THIS editor keep spending this month?"
+    * - Windows
+      - daily
+      - daily AND monthly
+    * - Dimensions
+      - requests, tokens, cost
+      - requests, tokens, cost
+    * - Both must pass
+      - yes
+      - yes
+
+See :ref:`adr-025` for the full design rationale, including the
+alternatives (counter table, group-level budgets, auto-throttling)
+we considered and why they were rejected.

--- a/Documentation/Administration/UserBudgets.rst
+++ b/Documentation/Administration/UserBudgets.rst
@@ -57,12 +57,15 @@ drift away from the source of truth.
 Creating a budget
 =================
 
-Budgets are plain records on the root page tree (``pid = 0``,
-``rootLevel = -1``). Admins create or edit them via the TYPO3 List
-module:
+Budget records have ``rootLevel = -1``, so admins can create them at
+the TYPO3 root (``pid = 0``) or on any regular page. Keeping them at
+the root is the convention because budgets are site-wide admin
+concerns, not page-scoped content; the recipe below follows that
+convention.
 
-1.  Open :guilabel:`Web > List` on any page.
-2.  Click :guilabel:`Create new record` at page UID 0 (the root).
+1.  Open :guilabel:`Web > List` in the root (page UID 0) — or on the
+    page where you keep other cross-site configuration records.
+2.  Click :guilabel:`Create new record`.
 3.  Choose :guilabel:`LLM User Budget`.
 4.  Pick the backend user, set the ceilings, toggle
     :guilabel:`Enforce this budget` on.

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,70 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-7-0:
+
+Version 0.7.0 (2026-04-22)
+===========================
+
+Added
+-----
+
+-   **Provider fallback chain.** :php:`LlmConfiguration` can now list
+    other configuration identifiers to retry against when the primary
+    fails with a retryable error (connection / HTTP 5xx / 429 rate-
+    limit). Non-retryable errors (4xx other than 429, configuration
+    problems, unsupported feature) bubble up unchanged. Streaming is
+    intentionally excluded from fallback because chunks cannot be
+    replayed against a different provider. See :ref:`adr-021` and
+    :ref:`developer-fallback-chain`.
+
+-   **Attribute-based provider registration.** New
+    :php:`#[AsLlmProvider(priority: N)]` attribute. Providers bearing
+    the attribute are automatically tagged and made public by
+    :php:`ProviderCompilerPass` at container compile time; no
+    ``services.yaml`` edit required. Legacy yaml tagging still works
+    for third-party providers and takes precedence when both
+    mechanisms are present. See :ref:`adr-022` and
+    :ref:`developer-provider-registration`.
+
+-   **Per-capability BE group permissions.** Every
+    :php:`ModelCapability` enum value is now a native TYPO3
+    ``customPermOptions`` entry under the ``nrllm`` namespace. BE
+    group editors see a checkbox per capability (chat, completion,
+    embeddings, vision, streaming, tools, json_mode, audio). New
+    :php:`CapabilityPermissionService` resolves checks against the
+    current BE user with admin short-circuit and CLI / frontend
+    bypass. See :ref:`adr-023` and :ref:`developer-capability-permissions`.
+
+-   **Dashboard widgets.** Two TYPO3 dashboard widgets sourced from
+    :sql:`tx_nrllm_service_usage`: *AI cost this month*
+    (:php:`NumberWithIconWidget`) and *AI requests by provider (7d)*
+    (:php:`BarChartWidget`). Loaded conditionally from
+    :file:`Configuration/Services.php` only when
+    :composer:`typo3/cms-dashboard` is installed. See :ref:`adr-024`.
+
+-   **Per-user AI budgets.** New :sql:`tx_nrllm_user_budget` table
+    with six independent ceilings (requests / tokens / cost × daily /
+    monthly). New :php:`BudgetService::check()` aggregates usage on
+    demand from :sql:`tx_nrllm_service_usage` — one DB roundtrip for
+    both windows via conditional ``SUM()``. Orthogonal to the
+    existing per-configuration daily limits: both checks must pass.
+    See :ref:`adr-025` and :ref:`administration-user-budgets`.
+
+Changed
+-------
+
+-   CI: mutation testing runs only on ``push``, ``merge_group`` and
+    ``schedule`` events. PR CI gets the fuzz suite + unit / functional
+    / PHPStan / rector / code style; the ~15 min mutation job is
+    deferred because its per-PR signal is hard for authors to action
+    locally.
+-   CI: :file:`.semgrepignore` added to exclude :path:`Tests/`,
+    :path:`Build/Scripts/` and vendor directories from Opengrep SAST.
+    Previously failing on legitimate ``unlink()`` fixture cleanup.
+-   CI: fuzz workflow now invoked with
+    ``fuzz-testsuite: fuzzy`` matching the phpunit.xml suite name.
+
 .. _version-0-6-0:
 
 Version 0.6.0 (2026-03-24)

--- a/Documentation/Configuration/ConfigFields.rst
+++ b/Documentation/Configuration/ConfigFields.rst
@@ -97,3 +97,24 @@ Optional
 
    Task type: ``chat``, ``completion``,
    ``embedding``, ``translation``.
+
+.. confval:: fallback_chain
+   :name: confval-config-fallback-chain
+   :type: JSON (text column)
+   :Default: (empty)
+
+   Ordered JSON list of other configuration
+   identifiers to retry against when the primary
+   fails with a retryable error (connection error,
+   HTTP 5xx, or HTTP 429 rate-limit). Non-retryable
+   errors bubble up unchanged. Streaming requests do
+   not trigger fallback — chunks cannot be replayed
+   against a different provider.
+
+   Example payload::
+
+       {"configurationIdentifiers": ["claude-sonnet", "ollama-local"]}
+
+   Identifiers are matched case-insensitively;
+   leave empty to disable fallback. See
+   :ref:`developer-fallback-chain`.

--- a/Documentation/Configuration/ConfigFields.rst
+++ b/Documentation/Configuration/ConfigFields.rst
@@ -103,13 +103,15 @@ Optional
    :type: JSON (text column)
    :Default: (empty)
 
-   Ordered JSON list of other configuration
-   identifiers to retry against when the primary
-   fails with a retryable error (connection error,
-   HTTP 5xx, or HTTP 429 rate-limit). Non-retryable
-   errors bubble up unchanged. Streaming requests do
-   not trigger fallback — chunks cannot be replayed
-   against a different provider.
+   JSON object with a single key,
+   ``configurationIdentifiers``, whose value is the
+   ordered list of other configuration identifiers
+   to retry against when the primary fails with a
+   retryable error (connection error, HTTP 5xx, or
+   HTTP 429 rate-limit). Non-retryable errors bubble
+   up unchanged. Streaming requests do not trigger
+   fallback — chunks cannot be replayed against a
+   different provider.
 
    Example payload::
 

--- a/Documentation/Developer/CapabilityPermissions.rst
+++ b/Documentation/Developer/CapabilityPermissions.rst
@@ -1,0 +1,108 @@
+..  include:: /Includes.rst.txt
+
+..  _developer-capability-permissions:
+
+==========================================
+BE group permission checks
+==========================================
+
+Every :php:`ModelCapability` enum value is registered as a native
+TYPO3 ``customPermOptions`` entry under the ``nrllm`` namespace.
+Administrators see a checkbox per capability (chat, completion,
+embeddings, vision, streaming, tools, json_mode, audio) on the
+:guilabel:`Backend Users > Access Options` tab when editing a BE
+group. Consumer code asks the
+:php:`\Netresearch\NrLlm\Service\CapabilityPermissionService`
+whether the capability is allowed for the current user.
+
+..  _developer-capability-permissions-check:
+
+Running a check
+===============
+
+Inject the service and call :php:`isAllowed()` before dispatching.
+The method accepts an optional :php:`BackendUserAuthentication` for
+tests; when omitted it reads :php:`$GLOBALS['BE_USER']`:
+
+..  code-block:: php
+    :caption: EXT:my_ext/Classes/Service/Caption.php
+
+    use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+    use Netresearch\NrLlm\Exception\AccessDeniedException;
+    use Netresearch\NrLlm\Service\CapabilityPermissionService;
+
+    final class Caption
+    {
+        public function __construct(
+            private readonly CapabilityPermissionService $permissions,
+        ) {}
+
+        public function describe(string $imageUrl): string
+        {
+            if (!$this->permissions->isAllowed(ModelCapability::VISION)) {
+                throw new AccessDeniedException(
+                    'Vision capability not permitted for this user',
+                    1745712100,
+                );
+            }
+            // ... dispatch to VisionService ...
+        }
+    }
+
+..  _developer-capability-permissions-rules:
+
+Resolution order
+================
+
+The check resolves in this order:
+
+1.  No BE user in context (CLI, scheduler, frontend) → **allowed**.
+    Capability gating is a backend-editor concern; background jobs
+    and frontend rendering are not subject to it.
+2.  User is admin → **allowed**. Admins bypass the native TYPO3
+    permission machinery by convention.
+3.  Delegates to
+    :php:`$backendUser->check('custom_options', 'nrllm:capability_X')`
+    — the native TYPO3 permission check. Returns what it returns.
+
+..  _developer-capability-permissions-scope:
+
+Complementary to configuration ACL
+===================================
+
+The ``allowed_groups`` MM relation on
+:sql:`tx_nrllm_configuration` gates access to a specific preset
+(API keys, system prompt, etc.). Capability permissions gate which
+*operations* a user may invoke against any preset they can already
+reach. The two are orthogonal and both checks must pass.
+
+-   **Configuration ACL:** "Can this editor use the
+    'creative-writing' configuration at all?"
+-   **Capability permission:** "Can this editor invoke vision
+    against any configuration?"
+
+..  _developer-capability-permissions-helpers:
+
+Stable keys
+===========
+
+:php:`CapabilityPermissionService::permissionString()` returns the
+TYPO3 permission string (e.g. ``nrllm:capability_vision``) for any
+enum case. Use it when you need to check directly without going
+through the service, for example in a Fluid ViewHelper or a TCA
+display condition:
+
+..  code-block:: php
+    :caption: Permission-string lookup
+
+    use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+    use Netresearch\NrLlm\Service\CapabilityPermissionService;
+
+    $permString = CapabilityPermissionService::permissionString(
+        ModelCapability::TOOLS,
+    );
+    // => "nrllm:capability_tools"
+
+See :ref:`adr-023` for the full design rationale and the
+alternatives (per-configuration flags, bespoke MM table, inline
+enforcement) we ruled out.

--- a/Documentation/Developer/FallbackChain.rst
+++ b/Documentation/Developer/FallbackChain.rst
@@ -1,0 +1,110 @@
+..  include:: /Includes.rst.txt
+
+..  _developer-fallback-chain:
+
+=================
+Fallback chain
+=================
+
+A :php:`LlmConfiguration` can carry an ordered list of other
+configuration identifiers to fall back to on *retryable* provider
+failures. The lookup happens transparently inside
+:php:`\Netresearch\NrLlm\Service\LlmServiceManager::chatWithConfiguration()`
+and :php:`completeWithConfiguration()`. Callers see a regular
+completion response or a typed exception; they never need to
+reach into retry mechanics.
+
+..  _developer-fallback-chain-config:
+
+Configuring a chain
+====================
+
+The :sql:`tx_nrllm_configuration.fallback_chain` column stores a
+JSON list of configuration identifiers:
+
+..  code-block:: json
+    :caption: Example payload stored in ``fallback_chain``
+
+    {"configurationIdentifiers": ["claude-sonnet", "ollama-local"]}
+
+Editors paste that JSON into the :guilabel:`Fallback Chain` tab in
+the backend form. The order is the retry order. Identifiers are
+matched case-insensitively against :sql:`tx_nrllm_configuration.identifier`.
+
+..  _developer-fallback-chain-retryable:
+
+Retryable vs. non-retryable errors
+==================================
+
+Fallback only triggers for errors the next provider might actually
+recover from:
+
+..  list-table::
+    :header-rows: 1
+    :widths: 40 60
+
+    * - Exception
+      - Retryable?
+    * - :php:`ProviderConnectionException` (network, timeout,
+        HTTP 5xx, retries exhausted)
+      - Yes
+    * - :php:`ProviderResponseException` with code ``429``
+        (rate-limited by this provider)
+      - Yes
+    * - :php:`ProviderResponseException` with any other 4xx
+        (authentication, bad request, not found, …)
+      - No. Bubbles up. A different provider with the same input
+        would fail the same way.
+    * - :php:`ProviderConfigurationException`
+      - No. Misconfiguration is a human problem.
+    * - :php:`UnsupportedFeatureException`
+      - No. Fallback won't make a text-only provider handle images.
+
+When every configuration in the chain trips a retryable error,
+:php:`\Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException`
+is thrown. It carries the per-attempt errors so consumers can
+surface the full failure sequence.
+
+..  _developer-fallback-chain-scope:
+
+Scope limits
+============
+
+v1 is deliberately narrow:
+
+-   **No streaming.** :php:`streamChatWithConfiguration()` does not
+    wrap the call. Once the first chunk has been yielded to the
+    caller, mid-stream provider-switching would be detectable and
+    surprising.
+-   **No recursion.** A fallback configuration's own chain is
+    ignored. This avoids cycles (``a -> b -> a``) and unbounded
+    attempt trees.
+-   **Single primary-only chain is a no-op.** If the configured
+    chain contains only the primary's own identifier, the primary's
+    original exception is rethrown verbatim rather than wrapped in
+    :php:`FallbackChainExhaustedException`.
+
+..  _developer-fallback-chain-example:
+
+Using the DTO directly
+======================
+
+For programmatic construction — e.g. a wizard that generates a
+configuration and also sets up fallback — use the
+:php:`\Netresearch\NrLlm\Domain\DTO\FallbackChain` value object:
+
+..  code-block:: php
+    :caption: EXT:my_ext/Classes/Service/Setup.php
+
+    use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+
+    $chain = (new FallbackChain())
+        ->withLink('claude-sonnet')
+        ->withLink('ollama-local');
+
+    $configuration->setFallbackChainDTO($chain);
+
+The DTO trims and lowercases identifiers on entry, deduplicates
+them, and silently rejects empty strings and non-string entries
+read from malformed JSON. See :ref:`adr-021` for the full design
+rationale and the alternatives we ruled out.

--- a/Documentation/Developer/FallbackChain.rst
+++ b/Documentation/Developer/FallbackChain.rst
@@ -20,7 +20,8 @@ Configuring a chain
 ====================
 
 The :sql:`tx_nrllm_configuration.fallback_chain` column stores a
-JSON list of configuration identifiers:
+JSON **object** with a single key, ``configurationIdentifiers``, whose
+value is the ordered array of target configuration identifiers:
 
 ..  code-block:: json
     :caption: Example payload stored in ``fallback_chain``
@@ -30,6 +31,9 @@ JSON list of configuration identifiers:
 Editors paste that JSON into the :guilabel:`Fallback Chain` tab in
 the backend form. The order is the retry order. Identifiers are
 matched case-insensitively against :sql:`tx_nrllm_configuration.identifier`.
+Using an object (rather than a bare top-level array) leaves room for
+future sibling fields — e.g. per-link retry policy — without a
+schema break.
 
 ..  _developer-fallback-chain-retryable:
 

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -234,5 +234,8 @@ Best practices
    Streaming
    ToolCalling
    CustomProviders
+   ProviderRegistration
+   FallbackChain
+   CapabilityPermissions
    IntegrationGuide
    FeatureServices/Index

--- a/Documentation/Developer/ProviderRegistration.rst
+++ b/Documentation/Developer/ProviderRegistration.rst
@@ -1,0 +1,99 @@
+..  include:: /Includes.rst.txt
+
+..  _developer-provider-registration:
+
+================================
+Registering a provider
+================================
+
+Two mechanisms pick up your provider class. Use the attribute when
+you can.
+
+..  _developer-provider-registration-attribute:
+
+Preferred: the ``#[AsLlmProvider]`` attribute
+==============================================
+
+Add the attribute to any provider class that lives under the
+``Netresearch\NrLlm\`` namespace. The compiler pass auto-tags the
+service, sets it public (so backend diagnostics can resolve it by
+class name), and registers it with
+:php:`LlmServiceManager` in priority order:
+
+..  code-block:: php
+    :caption: Classes/Provider/MyProvider.php
+
+    use Netresearch\NrLlm\Attribute\AsLlmProvider;
+    use Netresearch\NrLlm\Provider\AbstractProvider;
+
+    #[AsLlmProvider(priority: 85)]
+    final class MyProvider extends AbstractProvider
+    {
+        public function getIdentifier(): string
+        {
+            return 'my-provider';
+        }
+
+        public function getName(): string
+        {
+            return 'My LLM Service';
+        }
+
+        // ... chatCompletion(), embeddings(), supportsFeature()
+    }
+
+Priority is an ordering hint only. Providers are still resolved by
+their ``getIdentifier()`` at runtime. Higher priority wins when two
+providers otherwise tie.
+
+..  note::
+    The attribute scan is scoped to the ``Netresearch\NrLlm\``
+    namespace to keep container-build reflection bounded.
+    Third-party extensions shipping providers outside that namespace
+    must continue to use the yaml-tagging path described below.
+
+..  _developer-provider-registration-yaml:
+
+Third-party fallback: yaml tagging
+==================================
+
+Extensions that sit outside the ``Netresearch\NrLlm\`` namespace
+still work via the original mechanism — declare a service with the
+``nr_llm.provider`` tag:
+
+..  code-block:: yaml
+    :caption: EXT:my_ext/Configuration/Services.yaml
+
+    services:
+      Acme\MyExt\Provider\AcmeProvider:
+        public: true
+        tags:
+          - name: nr_llm.provider
+            priority: 85
+
+When both yaml tagging AND the attribute are present on the same
+service, the yaml wins (the attribute pass skips already-tagged
+services). Treat this as an override hook rather than an additive
+mechanism.
+
+..  _developer-provider-registration-interfaces:
+
+Capability interfaces
+=====================
+
+Priority governs registration order only; it says nothing about
+what a provider can do. Capabilities are advertised by implementing
+the relevant interface from :php:`Netresearch\NrLlm\Provider\Contract`:
+
+-   :php:`VisionCapableInterface` — image analysis
+-   :php:`StreamingCapableInterface` — SSE streaming
+-   :php:`ToolCapableInterface` — function / tool calling
+-   :php:`DocumentCapableInterface` — PDF / structured document input
+
+:php:`LlmServiceManager` dispatches to a provider only when the
+caller's requested operation matches a capability the provider
+actually advertises. A provider that doesn't implement
+:php:`VisionCapableInterface` can never be asked to describe an
+image, regardless of priority. See :ref:`adr-022` for the
+attribute-discovery design decision and the Symfony
+``registerAttributeForAutoconfiguration`` alternative we evaluated.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ The **Admin Tools > LLM** backend module gives you full control:
 - **Models** — Define which models are available and their capabilities
 - **Configurations** — Create use-case presets (temperature, system prompts, token limits)
 - **Tasks** — Define reusable prompt templates for editors
+- **User Budgets** — Cap per-backend-user spending across every preset (requests / tokens / cost × daily / monthly). See the [Administration guide](Documentation/Administration/UserBudgets.rst).
+
+### Resilience
+
+- **Fallback chain** — Each configuration can list other configurations to retry against on a connection error, HTTP 5xx, or rate-limit. Streaming requests are excluded (chunks can't be replayed). See [ADR-021](Documentation/Adr/Adr021ProviderFallbackChain.rst).
+- **Per-capability permissions** — Every AI capability (chat, vision, tools, embeddings, …) is a native TYPO3 `customPermOptions` entry. Check a box per BE group; admins bypass. See [ADR-023](Documentation/Adr/Adr023BackendCapabilityPermissions.rst).
+- **Dashboard widgets** — When `typo3/cms-dashboard` is installed, "AI cost this month" and "AI requests by provider (7d)" show on the dashboard sourced from the existing usage table. See [ADR-024](Documentation/Adr/Adr024DashboardWidgets.rst).
 
 ### Security by default
 


### PR DESCRIPTION
## Summary

Documentation refresh for the five feature PRs merged today (#128, #129, #130, #131, #132). No production-code changes.

**New pages**
- `Documentation/Administration/UserBudgets.rst` — table schema, pre-flight check semantics, relationship to per-configuration limits
- `Documentation/Developer/FallbackChain.rst` — retryable policy, scope limits, FallbackChain DTO usage
- `Documentation/Developer/ProviderRegistration.rst` — `#[AsLlmProvider]` vs. yaml-tag path, namespace scan scope
- `Documentation/Developer/CapabilityPermissions.rst` — `isAllowed()` flow, permission-string helpers, ACL relationship

**Updated**
- `Documentation/Changelog.rst` — new `0.7.0` entry (Added + Changed sections covering all five features + CI hygiene)
- `Documentation/Configuration/ConfigFields.rst` — `fallback_chain` confval with example payload
- `Documentation/Administration/Index.rst` + `Documentation/Developer/Index.rst` — toctree entries
- `README.md` — new Administrator block for User Budgets + a Resilience section linking to the ADRs

## Validation

- [x] `typo3-docs/scripts/validate_docs.sh` clean
- [x] `typo3-docs/scripts/render_docs.sh` — all 69 RST files render successfully
- [x] Render warnings only on pre-existing files I didn't touch (`Api/VisionService.rst`, `Developer/Streaming.rst`, `Developer/ToolCalling.rst` unresolved refs + a PlantUML highlighter warning in `Architecture/Index.rst`)
- [x] Every new page has a `.. _label:` anchor, `:caption:` on code blocks, RST tables and field lists where appropriate

## Test plan

- [ ] CI green (docs workflow renders with no new warnings)
- [ ] Manual spot-check: `Documentation-GENERATED-temp/Administration/UserBudgets.html` renders the table, note/important admonitions, and cross-refs to ADR-025