### PR TITLE
fix(release): drop broken slsa-provenance job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,11 @@ jobs:
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
-  slsa-provenance:
-    needs: release
-    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    with:
-      version: ${{ github.ref_name }}
+  # Note: SBOM (SPDX + CycloneDX), Cosign keyless signing, and
+  # actions/attest-build-provenance all run inside the reusable
+  # `release.yml` job above — no separate slsa-provenance job is
+  # needed. The previous standalone reference to
+  # `slsa-provenance.yml@main` pointed at a workflow that does not
+  # exist in netresearch/typo3-ci-workflows, which GitHub rejected
+  # as a "workflow file issue" before any job started, preventing
+  # the entire release from running.


### PR DESCRIPTION
## Context

The v0.7.0 tag (pushed as part of PR #134's release cycle) did not produce artifacts. Digging in: `.github/workflows/release.yml` references `netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main`, which **does not exist** in that repo (404). GitHub rejects the whole workflow as a "workflow file issue" before any job runs.

Same reason v0.6.0's release run failed in March — pre-existing bug.

## Fix

Remove the `slsa-provenance` job. SBOM (SPDX + CycloneDX), Cosign keyless signing, and `actions/attest-build-provenance` already run inside the reusable `release.yml` — the separate job was redundant.

## Test plan

- [ ] Merge this fix
- [ ] Re-push the `v0.7.0` tag (delete + re-push); release workflow should now run and produce:
  - GitHub Release with changelog
  - SBOM artifacts (.spdx.json, .cdx.json)
  - Cosign-signed archive
  - SLSA-3 attestation via `attest-build-provenance`
  - TER publish job