### PR TITLE
feat(provider): introduce middleware pipeline infrastructure

### DIFF
--- a/Classes/Provider/Middleware/MiddlewarePipeline.php
+++ b/Classes/Provider/Middleware/MiddlewarePipeline.php
@@ -41,7 +41,7 @@ final readonly class MiddlewarePipeline
     ) {
         $this->middleware = \is_array($middleware)
             ? \array_values($middleware)
-            : \array_values(\iterator_to_array($middleware, preserve_keys: false));
+            : \iterator_to_array($middleware, preserve_keys: false);
     }
 
     /**

--- a/Classes/Provider/Middleware/MiddlewarePipeline.php
+++ b/Classes/Provider/Middleware/MiddlewarePipeline.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Runs an ordered stack of ProviderMiddlewareInterface implementations around
+ * a terminal provider call.
+ *
+ * Ordering follows the PSR-15 convention: the first-registered middleware is
+ * the outermost layer of the onion -- it runs first on the way in and last on
+ * the way out. Registration order comes from the service container's tagged
+ * iterator; services can influence it with a `priority` tag attribute.
+ *
+ * The pipeline is side-effect-free on its own; every behavioural decision
+ * (retry on rate-limit, skip cache, record usage, ...) lives in a concrete
+ * middleware. Consumers call `run()` with the immutable call context, the
+ * primary configuration, and the terminal callable that performs the actual
+ * provider invocation.
+ */
+final readonly class MiddlewarePipeline
+{
+    /** @var list<ProviderMiddlewareInterface> */
+    private array $middleware;
+
+    /**
+     * @param iterable<ProviderMiddlewareInterface> $middleware
+     */
+    public function __construct(
+        #[AutowireIterator(ProviderMiddlewareInterface::TAG_NAME)]
+        iterable $middleware,
+    ) {
+        $this->middleware = \is_array($middleware)
+            ? \array_values($middleware)
+            : \array_values(\iterator_to_array($middleware, preserve_keys: false));
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(LlmConfiguration): T $terminal the actual provider call,
+     *                                                typically a closure over
+     *                                                messages / options /
+     *                                                adapter resolution
+     *
+     * @return T
+     */
+    public function run(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $terminal,
+    ): mixed {
+        $next = $terminal;
+        foreach (\array_reverse($this->middleware) as $middleware) {
+            $captured = $next;
+            $next = static fn(LlmConfiguration $config): mixed
+                => $middleware->handle($context, $config, $captured);
+        }
+
+        return $next($configuration);
+    }
+}

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
+use Symfony\Component\Uid\Uuid;
+
 /**
  * Immutable context threaded through a MiddlewarePipeline invocation.
  *
@@ -31,7 +33,11 @@ final readonly class ProviderCallContext
     ) {}
 
     /**
-     * Create a context with an auto-generated correlation id (16 hex chars).
+     * Create a context with an auto-generated UUID v4 correlation id.
+     *
+     * Callers that already hold a correlation id (e.g. propagated from an
+     * upstream trace / request id) should use the regular constructor instead
+     * of this factory so the incoming id survives end-to-end.
      *
      * @param array<string, mixed> $metadata
      */
@@ -39,7 +45,7 @@ final readonly class ProviderCallContext
     {
         return new self(
             operation: $operation,
-            correlationId: \bin2hex(\random_bytes(8)),
+            correlationId: Uuid::v4()->toRfc4122(),
             metadata: $metadata,
         );
     }

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+/**
+ * Immutable context threaded through a MiddlewarePipeline invocation.
+ *
+ * Carries what every middleware needs to know about the call without leaking
+ * the operation-specific payload (messages, embeddings input, tool specs).
+ * The payload stays captured in the terminal callable, which lets each
+ * feature service keep its typed signature.
+ */
+final readonly class ProviderCallContext
+{
+    /**
+     * @param array<string, mixed> $metadata additional cross-cutting data
+     *                                       (e.g. user id for budget checks,
+     *                                       cache-key inputs, trace tags)
+     */
+    public function __construct(
+        public ProviderOperation $operation,
+        public string $correlationId,
+        public array $metadata = [],
+    ) {}
+
+    /**
+     * Create a context with an auto-generated correlation id (16 hex chars).
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public static function for(ProviderOperation $operation, array $metadata = []): self
+    {
+        return new self(
+            operation: $operation,
+            correlationId: \bin2hex(\random_bytes(8)),
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * Return a new context with the given metadata merged on top of the current
+     * map. Useful for middleware that wants to annotate downstream handlers
+     * (cache hit/miss, budget remaining, retry attempt counter, etc.) without
+     * mutating state.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function withMetadata(array $metadata): self
+    {
+        return new self(
+            operation: $this->operation,
+            correlationId: $this->correlationId,
+            metadata: [...$this->metadata, ...$metadata],
+        );
+    }
+}

--- a/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
+++ b/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Middleware wrapping a single provider call.
+ *
+ * Implementations receive the immutable ProviderCallContext, the current
+ * LlmConfiguration, and a `$next` callable that continues the pipeline. Each
+ * middleware decides whether to:
+ *  - call `$next($configuration)` verbatim (pure pass-through),
+ *  - call `$next($otherConfiguration)` to substitute the configuration (that
+ *    is how a fallback middleware retries with a sibling config),
+ *  - short-circuit and return its own result without calling `$next` at all
+ *    (e.g. a cache-hit middleware returning the stored EmbeddingResponse),
+ *  - or wrap the call with before/after logic (logging, metrics, usage
+ *    tracking, budget accounting).
+ *
+ * Registered implementations are discovered via the `nr_llm.provider_middleware`
+ * tag (auto-applied by AutoconfigureTag) and composed by MiddlewarePipeline in
+ * registration order -- the first-registered middleware runs first on the
+ * "before" half and last on the "after" half, classic onion ordering.
+ *
+ * The return type is declared `mixed` because different operations return
+ * different typed responses (CompletionResponse, EmbeddingResponse,
+ * VisionResponse, Generator for streaming, etc.). Concrete middleware should
+ * keep the value unchanged unless its purpose is to transform it.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface ProviderMiddlewareInterface
+{
+    public const TAG_NAME = 'nr_llm.provider_middleware';
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed;
+}

--- a/Classes/Provider/Middleware/ProviderOperation.php
+++ b/Classes/Provider/Middleware/ProviderOperation.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+/**
+ * Identifies which provider operation a middleware call corresponds to.
+ *
+ * Middleware uses this to decide whether it applies (e.g. a cache middleware
+ * that caches deterministic embeddings but passes through stateful chat
+ * completions) and to emit meaningful log / trace / metric labels.
+ */
+enum ProviderOperation: string
+{
+    case Chat = 'chat';
+    case Completion = 'complete';
+    case Embedding = 'embed';
+    case Vision = 'vision';
+    case Tools = 'tools';
+    case Stream = 'stream';
+}

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -95,8 +95,8 @@ collected middleware via :php:`AutowireIterator`. Ordering follows tag
 priority; ``priority`` is an ordering hint only.
 
 Contributors can add behaviour without touching :code:`Services.yaml` —
-implement the interface, drop the class under :code:`Classes/Provider/`,
-you are done.
+implement the interface, drop the class under
+:code:`Classes/Provider/Middleware/`, you are done.
 
 .. _adr-026-scope:
 

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -1,0 +1,186 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-026:
+
+==========================================
+ADR-026: Provider Middleware Pipeline
+==========================================
+
+:Status: Proposed
+:Date: 2026-04
+:Authors: Netresearch DTT GmbH
+
+.. _adr-026-context:
+
+Context
+=======
+
+Every provider call in the extension is wrapped by the same
+cross-cutting concerns — or rather, it *should* be, but today those
+concerns are scattered:
+
+* :php:`FallbackChainExecutor` (:code:`Classes/Service/FallbackChainExecutor.php`)
+  is a ``try primary / catch / foreach fallbacks`` loop with two retryable
+  exception types hardcoded. It has no pre/post hooks and no composition
+  seam.
+* It is applied **only** to database-backed configuration paths in
+  :php:`LlmServiceManager::runWithFallback()`. Direct calls — ``chat()``,
+  ``complete()``, ``embed()``, ``vision()`` — bypass it entirely, which
+  silently splits retry semantics.
+* :php:`BudgetService::check()` (ADR-025) and
+  :php:`UsageTrackerService::trackUsage()` are primitives that no feature
+  service actually calls. Budget enforcement and usage accounting must
+  be remembered by every caller, which is a silent footgun.
+* HTTP-level retry with back-off lives inside :php:`AbstractProvider`
+  (``sendRequest()``). That is the wrong layer — a rate-limited provider
+  should be *swapped*, not retried in-place.
+* Cache lookup exists only inside :php:`EmbeddingService` as ad-hoc
+  branches. There is no way to plug it in for deterministic completion
+  scenarios (seed / temperature 0) without duplicating the branch.
+
+The end result is that every new cross-cutting requirement — PII
+redaction, prompt logging, trace correlation, per-provider rate limits,
+circuit breakers, a cost calculator — forces either a bespoke branch in
+every feature service or a subclass of one of the god classes.
+
+.. _adr-026-decision:
+
+Decision
+========
+
+Introduce a PSR-15-inspired middleware pipeline under
+:code:`Classes/Provider/Middleware/`:
+
+.. code-block:: php
+   :caption: the contract
+
+   interface ProviderMiddlewareInterface
+   {
+       public function handle(
+           ProviderCallContext $context,
+           LlmConfiguration $configuration,
+           callable $next,           // callable(LlmConfiguration): mixed
+       ): mixed;
+   }
+
+Each middleware receives
+
+1. an immutable :php:`ProviderCallContext` (operation kind, correlation
+   id, metadata map),
+2. the current :php:`LlmConfiguration`,
+3. a ``$next`` callable that continues the pipeline.
+
+and decides whether to pass through, short-circuit, swap the
+configuration, or wrap the call with before/after logic.
+:php:`MiddlewarePipeline::run()` composes an ordered stack of them
+around a terminal callable in classic onion fashion — the
+first-registered middleware is the outermost layer.
+
+The payload — messages, embedding input, tool specs, vision content —
+stays captured in the terminal callable. That keeps the existing typed
+response objects (:php:`CompletionResponse`, :php:`EmbeddingResponse`,
+:php:`VisionResponse`) intact on the return side and avoids inventing a
+generic ``ProviderRequest`` envelope that would then have to know about
+every operation variant.
+
+.. _adr-026-registration:
+
+Registration
+============
+
+Implementations are discovered via the ``nr_llm.provider_middleware``
+tag, which :php:`AutoconfigureTag` applies automatically to every class
+that implements the interface. The pipeline's constructor injects the
+collected middleware via :php:`AutowireIterator`. Ordering follows tag
+priority; ``priority`` is an ordering hint only.
+
+Contributors can add behaviour without touching :code:`Services.yaml` —
+implement the interface, drop the class under :code:`Classes/Provider/`,
+you are done.
+
+.. _adr-026-scope:
+
+Scope of this ADR
+=================
+
+Infrastructure only. No behaviour change in this PR:
+
+* :php:`ProviderMiddlewareInterface`, :php:`MiddlewarePipeline`,
+  :php:`ProviderCallContext`, :php:`ProviderOperation` enum.
+* Unit tests covering empty pipeline, single/multiple composition,
+  short-circuit, configuration substitution, context propagation,
+  generator-based iterables.
+* This ADR.
+
+:php:`FallbackChainExecutor` stays untouched. Feature services continue
+to work exactly as they do today. The pipeline is opt-in: consumers
+have to build a terminal callable and call :php:`MiddlewarePipeline::run()`
+to use it.
+
+.. _adr-026-followups:
+
+Follow-ups
+==========
+
+Each item below is a separate PR that lands one behaviour at a time, so
+the test matrix keeps green end-to-end:
+
+1. **FallbackMiddleware** — port :php:`FallbackChainExecutor` to the
+   interface. :php:`LlmServiceManager::runWithFallback()` stops
+   instantiating the executor directly and runs the pipeline instead.
+   Retry semantics become identical for *every* call path, not just
+   database-backed ones. Deprecate the standalone executor.
+2. **BudgetMiddleware** — call :php:`BudgetService::check()` before
+   ``$next``; throw a typed :php:`BudgetExceededException` on denial so
+   controllers can report which bucket tripped.
+3. **UsageMiddleware** — after ``$next`` returns, hand the response to
+   :php:`UsageTrackerService::trackUsage()`. Centralises cost/token
+   accounting regardless of which feature called in.
+4. **CacheMiddleware** — opt-in per operation via
+   :php:`ProviderOperation`. Embedding lookups start going through it;
+   the branch currently inside :php:`EmbeddingService` comes out.
+5. **Feature-service wiring** — every :php:`Service/Feature/*` builds
+   its terminal callable and invokes the pipeline, inheriting every
+   middleware registered above without writing any glue.
+
+Each follow-up is scoped to a single concern and keeps the codebase
+shippable after every step.
+
+.. _adr-026-alternatives:
+
+Alternatives considered
+=======================
+
+* **Per-operation pipelines** (separate middleware stacks for chat /
+  embed / vision / tools). Rejected: every middleware we can foresee
+  — fallback, budget, usage, cache, retry, tracing — wants to run for
+  multiple operations. Filtering inside a middleware via
+  :php:`ProviderCallContext::operation` is cheaper than maintaining N
+  parallel stacks.
+* **Generic ``ProviderRequest`` envelope** with a ``mixed $payload``.
+  Rejected: forces every provider / middleware / test to downcast
+  payloads. Keeping the payload inside the terminal closure preserves
+  the typed signatures already defined by :php:`ProviderInterface` and
+  the capability interfaces.
+* **PSR-15 directly** (``ServerRequestInterface`` / ``ResponseInterface``
+  shapes). Rejected: HTTP semantics do not fit an LLM call, mapping
+  OpenAI's message array onto a :php:`ServerRequestInterface` is lossy,
+  and the extension already owns :php:`LlmConfiguration` and typed
+  response objects that are a better fit than a generic PSR-7 request.
+* **Event dispatcher** (PSR-14) pre/post hooks. Rejected: events cannot
+  short-circuit, cannot substitute the call target, and cannot return a
+  response to the caller — all three are load-bearing for fallback and
+  cache middleware.
+
+.. _adr-026-references:
+
+References
+==========
+
+* Audit (2026-04-23): claim #1 — "No middleware pipeline — cross-cutting
+  concerns are scattered or absent". Locally stored under
+  :code:`claudedocs/audit-2026-04-23-architecture.md`.
+* ADR-021 — Provider Fallback Chain (the behaviour this pipeline will
+  eventually subsume).
+* ADR-025 — Per-User AI Budgets (budget primitive to be wired via
+  BudgetMiddleware).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -258,3 +258,4 @@ Modern architecture (v0.4+)
    Adr023BackendCapabilityPermissions
    Adr024DashboardWidgets
    Adr025PerUserBudgets
+   Adr026ProviderMiddlewarePipeline

--- a/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
+++ b/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MiddlewarePipeline::class)]
+#[CoversClass(ProviderCallContext::class)]
+final class MiddlewarePipelineTest extends TestCase
+{
+    #[Test]
+    public function runWithoutMiddlewareInvokesTerminalDirectly(): void
+    {
+        $pipeline = new MiddlewarePipeline([]);
+        $config   = $this->configuration('primary');
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $config,
+            terminal: static fn(LlmConfiguration $c): string => 'terminal:' . $c->getIdentifier(),
+        );
+
+        self::assertSame('terminal:primary', $result);
+    }
+
+    #[Test]
+    public function runWithSingleMiddlewareWrapsTerminal(): void
+    {
+        $middleware = $this->recordingMiddleware('A');
+        $pipeline   = new MiddlewarePipeline([$middleware]);
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration('primary'),
+            terminal: static fn(LlmConfiguration $c): string => 'terminal:' . $c->getIdentifier(),
+        );
+
+        self::assertSame('A(terminal:primary)', $result);
+    }
+
+    #[Test]
+    public function runComposesMiddlewareInRegisteredOrder(): void
+    {
+        $pipeline = new MiddlewarePipeline([
+            $this->recordingMiddleware('outer'),
+            $this->recordingMiddleware('middle'),
+            $this->recordingMiddleware('inner'),
+        ]);
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration('primary'),
+            terminal: static fn(LlmConfiguration $c): string => 'T(' . $c->getIdentifier() . ')',
+        );
+
+        // First-registered is outermost: outer(middle(inner(T)))
+        self::assertSame('outer(middle(inner(T(primary))))', $result);
+    }
+
+    #[Test]
+    public function middlewareCanShortCircuit(): void
+    {
+        $shortCircuit = new class implements ProviderMiddlewareInterface {
+            public function handle(
+                ProviderCallContext $context,
+                LlmConfiguration $configuration,
+                callable $next,
+            ): string {
+                return 'short-circuit';
+            }
+        };
+
+        $terminalWasCalled = false;
+        $pipeline          = new MiddlewarePipeline([$shortCircuit]);
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration('primary'),
+            terminal: static function (LlmConfiguration $c) use (&$terminalWasCalled): string {
+                $terminalWasCalled = true;
+
+                return 'terminal';
+            },
+        );
+
+        self::assertSame('short-circuit', $result);
+        self::assertFalse($terminalWasCalled, 'Terminal must not be called when middleware short-circuits.');
+    }
+
+    #[Test]
+    public function middlewareCanSubstituteConfigurationForDownstream(): void
+    {
+        $swap = new class ($this->configuration('fallback')) implements ProviderMiddlewareInterface {
+            public function __construct(private readonly LlmConfiguration $replacement) {}
+
+            public function handle(
+                ProviderCallContext $context,
+                LlmConfiguration $configuration,
+                callable $next,
+            ): mixed {
+                return $next($this->replacement);
+            }
+        };
+
+        $pipeline = new MiddlewarePipeline([$swap]);
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration('primary'),
+            terminal: static fn(LlmConfiguration $c): string => $c->getIdentifier(),
+        );
+
+        self::assertSame('fallback', $result);
+    }
+
+    #[Test]
+    public function contextIsPropagatedToEveryMiddleware(): void
+    {
+        $context = ProviderCallContext::for(
+            ProviderOperation::Vision,
+            ['user' => 42],
+        );
+
+        /** @var list<string> $seen */
+        $seen = [];
+
+        $pipeline = new MiddlewarePipeline([
+            $this->capturingMiddleware('first', $seen),
+            $this->capturingMiddleware('second', $seen),
+        ]);
+
+        $pipeline->run(
+            context: $context,
+            configuration: $this->configuration('primary'),
+            terminal: static fn(LlmConfiguration $c): string => 'done',
+        );
+
+        self::assertSame(
+            ['first:' . $context->correlationId, 'second:' . $context->correlationId],
+            $seen,
+        );
+    }
+
+    #[Test]
+    public function runAcceptsGeneratorAsMiddlewareIterable(): void
+    {
+        $generator = (static function (): iterable {
+            yield self::makeRecordingMiddleware('A');
+            yield self::makeRecordingMiddleware('B');
+        })();
+
+        $pipeline = new MiddlewarePipeline($generator);
+
+        $result = $pipeline->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration('primary'),
+            terminal: static fn(LlmConfiguration $c): string => 'T',
+        );
+
+        self::assertSame('A(B(T))', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function configuration(string $identifier): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier($identifier);
+
+        return $config;
+    }
+
+    private function recordingMiddleware(string $label): ProviderMiddlewareInterface
+    {
+        return self::makeRecordingMiddleware($label);
+    }
+
+    private static function makeRecordingMiddleware(string $label): ProviderMiddlewareInterface
+    {
+        return new class ($label) implements ProviderMiddlewareInterface {
+            public function __construct(private readonly string $label) {}
+
+            public function handle(
+                ProviderCallContext $context,
+                LlmConfiguration $configuration,
+                callable $next,
+            ): string {
+                $downstream = $next($configuration);
+                \assert(\is_string($downstream));
+
+                return $this->label . '(' . $downstream . ')';
+            }
+        };
+    }
+
+    /**
+     * @param list<string> $sink reference-bound collector
+     */
+    private function capturingMiddleware(string $label, array &$sink): ProviderMiddlewareInterface
+    {
+        $record = static function (string $line) use (&$sink): void {
+            $sink[] = $line;
+        };
+
+        return new class ($label, $record) implements ProviderMiddlewareInterface {
+            /**
+             * @param callable(string): void $record
+             */
+            public function __construct(
+                private readonly string $label,
+                /** @var callable(string): void */
+                private $record,
+            ) {}
+
+            public function handle(
+                ProviderCallContext $context,
+                LlmConfiguration $configuration,
+                callable $next,
+            ): mixed {
+                ($this->record)($this->label . ':' . $context->correlationId);
+
+                return $next($configuration);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a PSR-15-inspired middleware pipeline under `Classes/Provider/Middleware/` as the seam for every cross-cutting concern on a provider call. **No behaviour change in this PR.** `FallbackChainExecutor` stays untouched, feature services keep working as-is. Follow-up PRs land one behaviour at a time (fallback, budget, usage, cache) and wire the feature services through.

Addresses audit recommendation **#1** from the architecture audit (2026-04-23).

## Why

Today every cross-cutting concern on a provider call is either inlined, scattered, or outright missing:

| Concern | Today | Problem |
|---|---|---|
| Fallback on rate-limit | `FallbackChainExecutor`, a `try { primary } catch { foreach fallbacks }` loop | Hardcoded retryable exception types; applied only to DB-backed paths. `chat()`/`complete()`/`embed()`/`vision()` bypass it entirely. |
| Budget check | `BudgetService::check()` primitive | Exists, but no feature service calls it. Every caller must remember. |
| Usage tracking | `UsageTrackerService::trackUsage()` primitive | Same — silent footgun. |
| HTTP retry | `AbstractProvider::sendRequest()` | Wrong layer — a rate-limited provider should be *swapped*, not retried in-place. |
| Cache lookup | Ad-hoc branch inside `EmbeddingService` | Impossible to reuse for deterministic completion scenarios without duplicating. |

Every new cross-cutting requirement — PII redaction, prompt logging, trace correlation, per-provider rate limits, circuit breakers — forces bespoke branches in every feature service or a subclass of one of the god classes. This pipeline replaces that with composable seams.

## What

```php
interface ProviderMiddlewareInterface
{
    public function handle(
        ProviderCallContext $context,
        LlmConfiguration $configuration,
        callable $next,           // callable(LlmConfiguration): mixed
    ): mixed;
}
```

- **`ProviderMiddlewareInterface`** — the contract. `#[AutoconfigureTag('nr_llm.provider_middleware')]` on the interface automatically tags every implementation.
- **`MiddlewarePipeline`** — `final readonly` composer. `#[AutowireIterator]` collects middleware; classic onion composition with first-registered as outermost layer.
- **`ProviderCallContext`** — `final readonly` DTO carrying `ProviderOperation`, correlation id, and metadata map. `withMetadata()` for immutable annotation.
- **`ProviderOperation`** — enum (`Chat`, `Completion`, `Embedding`, `Vision`, `Tools`, `Stream`) so middleware can filter by operation and emit meaningful log / trace labels.

Contributors add behaviour by dropping a class under `Classes/Provider/Middleware/` that implements the interface — no `Services.yaml` entry needed.

## Design notes

- The operation payload (messages, embedding input, tool specs, vision content) stays captured in the terminal closure. Every operation keeps its typed response (`CompletionResponse` / `EmbeddingResponse` / `VisionResponse` / etc.) on the return side. **No generic `ProviderRequest` envelope.**
- Middleware can: pass through, short-circuit (return without calling `$next`), swap the `LlmConfiguration` for downstream (how a fallback middleware retries with a sibling config), or wrap with before/after logic.
- Rejected alternatives are documented in the ADR: per-operation stacks, generic payload envelope, PSR-15 directly, PSR-14 events.

## Scope of this PR

Infrastructure only. **Zero behaviour change.** Everything stays opt-in until a follow-up PR builds a terminal callable and invokes `MiddlewarePipeline::run()`.

## Follow-up PRs

Each of these is one commit one behaviour so the test matrix stays green end-to-end:

1. **FallbackMiddleware** — port `FallbackChainExecutor` to the interface. Retry semantics become identical for every call path, not just DB-backed ones. Deprecate the standalone executor.
2. **BudgetMiddleware** — call `BudgetService::check()` before `$next`; typed `BudgetExceededException` on denial.
3. **UsageMiddleware** — after `$next` returns, route the response through `UsageTrackerService::trackUsage()`.
4. **CacheMiddleware** — opt-in per `ProviderOperation`. Embeddings start going through it; the branch inside `EmbeddingService` comes out.
5. **Feature-service wiring** — every `Service/Feature/*` builds its terminal callable and invokes the pipeline, inheriting every registered middleware without writing glue.

## Tests

7 unit tests, all green, covering:

- empty pipeline calls terminal directly
- single middleware wraps terminal
- multi-middleware composes in registered order (first-registered is outermost)
- middleware can short-circuit without calling `$next`
- middleware can substitute `LlmConfiguration` for downstream
- context (operation + correlation id) is propagated to every middleware
- generator-based iterable input

Full local verification before push: **3113 unit tests**, PHPStan level 10, PHP-CS-Fixer, architecture tests — all green on PHP 8.4.

## ADR

`Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst` (status: Proposed). Full context, decision, registration mechanism, scope-of-this-PR, planned follow-ups, alternatives considered.

## Test plan
- [ ] CI green
- [ ] Review the ADR (Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst) — scope, follow-up order, rejected alternatives
- [ ] Scan the unit tests for any middleware shape I missed