### PR TITLE
feat(provider): port fallback chain into FallbackMiddleware

### DIFF
--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Walks the primary configuration's fallback chain on retryable failure.
+ *
+ * Retryable = the request might succeed against a different provider:
+ *  - ProviderConnectionException (network / timeout / 5xx / retries exhausted)
+ *  - ProviderResponseException with HTTP code 429 (rate-limited here)
+ *
+ * Non-retryable errors bubble up immediately (misconfiguration, unsupported
+ * feature, client-side 4xx, etc.) — fallback won't fix those.
+ *
+ * Streaming calls (Generator returning) should not be routed through this
+ * middleware: once chunks have been emitted to the caller, we cannot swap
+ * providers mid-stream. Build a pipeline without FallbackMiddleware for
+ * streaming, or use ProviderCallContext::operation === Stream as a
+ * short-circuit condition if a mixed pipeline is ever needed.
+ *
+ * Fallback is shallow: a fallback configuration's own chain is ignored to
+ * prevent recursion and cycles. Mirrors the behaviour of the legacy
+ * FallbackChainExecutor which this middleware supersedes.
+ */
+final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
+{
+    public function __construct(
+        private LlmConfigurationRepository $repository,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     *
+     * @throws FallbackChainExhaustedException when primary and all fallbacks fail
+     * @throws Throwable                       on the first non-retryable failure
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        if ($configuration->getFallbackChainDTO()->isEmpty()) {
+            return $next($configuration);
+        }
+
+        /** @var list<array{configuration: string, error: Throwable}> $attempts */
+        $attempts = [];
+
+        try {
+            return $next($configuration);
+        } catch (Throwable $e) {
+            if (!$this->isRetryable($e)) {
+                throw $e;
+            }
+            $attempts[] = [
+                'configuration' => $configuration->getIdentifier(),
+                'error'         => $e,
+            ];
+            $this->logger->warning(
+                'LLM primary configuration failed, trying fallback chain',
+                [
+                    'configuration'  => $configuration->getIdentifier(),
+                    'operation'      => $context->operation->value,
+                    'correlationId'  => $context->correlationId,
+                    'exception'      => $e,
+                    'exceptionClass' => $e::class,
+                ],
+            );
+        }
+
+        // Edge case: a chain that contains only the primary identifier becomes
+        // empty after filtering. No fallback was actually attempted — rethrow
+        // the primary's error verbatim instead of wrapping one attempt as
+        // "every configuration failed".
+        $chain = $configuration->getFallbackChainDTO()->without($configuration->getIdentifier());
+        if ($chain->isEmpty()) {
+            $this->logger->warning(
+                'LLM primary configuration failed; fallback chain contained only the primary, nothing left to try',
+                [
+                    'configuration'    => $configuration->getIdentifier(),
+                    'operation'        => $context->operation->value,
+                    'correlationId'    => $context->correlationId,
+                    'configured_chain' => $configuration->getFallbackChainDTO()->configurationIdentifiers,
+                ],
+            );
+            throw $attempts[0]['error'];
+        }
+
+        foreach ($chain->configurationIdentifiers as $identifier) {
+            $fallback = $this->repository->findOneByIdentifier($identifier);
+            if ($fallback === null) {
+                $this->logger->warning(
+                    'LLM fallback configuration not found, skipping',
+                    [
+                        'configuration' => $identifier,
+                        'correlationId' => $context->correlationId,
+                    ],
+                );
+                continue;
+            }
+            if (!$fallback->isActive()) {
+                $this->logger->warning(
+                    'LLM fallback configuration is inactive, skipping',
+                    [
+                        'configuration' => $identifier,
+                        'correlationId' => $context->correlationId,
+                    ],
+                );
+                continue;
+            }
+
+            try {
+                $result = $next($fallback);
+                $this->logger->info(
+                    'LLM fallback configuration succeeded',
+                    [
+                        'primary'          => $configuration->getIdentifier(),
+                        'fallback'         => $identifier,
+                        'operation'        => $context->operation->value,
+                        'correlationId'    => $context->correlationId,
+                        'skipped_attempts' => \count($attempts),
+                    ],
+                );
+
+                return $result;
+            } catch (Throwable $e) {
+                if (!$this->isRetryable($e)) {
+                    throw $e;
+                }
+                $attempts[] = [
+                    'configuration' => $identifier,
+                    'error'         => $e,
+                ];
+                $this->logger->warning(
+                    'LLM fallback configuration failed',
+                    [
+                        'configuration'  => $identifier,
+                        'operation'      => $context->operation->value,
+                        'correlationId'  => $context->correlationId,
+                        'exception'      => $e,
+                        'exceptionClass' => $e::class,
+                    ],
+                );
+            }
+        }
+
+        throw FallbackChainExhaustedException::fromAttempts($attempts);
+    }
+
+    private function isRetryable(Throwable $e): bool
+    {
+        if ($e instanceof ProviderConnectionException) {
+            return true;
+        }
+        if ($e instanceof ProviderResponseException) {
+            // Rate limit: a different provider might not be throttled
+            return $e->getCode() === 429;
+        }
+
+        return false;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -1,0 +1,494 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Mirrors the coverage of FallbackChainExecutorTest, rewritten against the
+ * middleware contract. Same retryable-exception matrix, same chain-walk
+ * semantics, same exhaustion / skip / inactive / self-reference edge cases.
+ */
+#[CoversClass(FallbackMiddleware::class)]
+#[CoversClass(MiddlewarePipeline::class)]
+final class FallbackMiddlewareTest extends AbstractUnitTestCase
+{
+    private LlmConfigurationRepository&Stub $repositoryStub;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repositoryStub = self::createStub(LlmConfigurationRepository::class);
+    }
+
+    #[Test]
+    public function returnsResultFromPrimaryOnSuccess(): void
+    {
+        $primary    = $this->makeConfig('primary', new FallbackChain(['fallback']));
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame(['primary'], $calls);
+    }
+
+    #[Test]
+    public function skipsFallbackWhenChainIsEmpty(): void
+    {
+        $primary    = $this->makeConfig('primary', new FallbackChain());
+        $pipeline = $this->makePipeline();
+        $err        = new ProviderConnectionException('down', 0);
+
+        $caught = $this->captureException(
+            ProviderConnectionException::class,
+            fn() => $pipeline->run(
+                ProviderCallContext::for(ProviderOperation::Chat),
+                $primary,
+                static function () use ($err): never {
+                    throw $err;
+                },
+            ),
+        );
+
+        self::assertSame($err, $caught);
+    }
+
+    #[Test]
+    public function fallsBackToNextConfigurationOnConnectionError(): void
+    {
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $alt     = $this->makeConfig('alt');
+
+        $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if ($config->getIdentifier() === 'primary') {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok-from-alt';
+            },
+        );
+
+        self::assertSame('ok-from-alt', $result);
+        self::assertSame(['primary', 'alt'], $calls);
+    }
+
+    #[Test]
+    public function retriesOnRateLimitResponse(): void
+    {
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $alt     = $this->makeConfig('alt');
+
+        $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
+
+        $pipeline = $this->makePipeline();
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            static function (LlmConfiguration $config): string {
+                if ($config->getIdentifier() === 'primary') {
+                    throw new ProviderResponseException('rate limited', 429);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+    }
+
+    #[Test]
+    public function doesNotRetryOn4xxResponseOtherThan429(): void
+    {
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $alt     = $this->makeConfig('alt');
+        $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+        $err        = new ProviderResponseException('unauthorized', 401);
+
+        $caught = $this->captureException(
+            ProviderResponseException::class,
+            function () use ($pipeline, $primary, $err, &$calls): never {
+                $pipeline->run(
+                    ProviderCallContext::for(ProviderOperation::Chat),
+                    $primary,
+                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                        $calls[] = $config->getIdentifier();
+
+                        throw $err;
+                    },
+                );
+            },
+        );
+
+        self::assertSame($err, $caught);
+        self::assertSame(['primary'], $calls);
+    }
+
+    #[Test]
+    public function doesNotRetryOnUnsupportedFeature(): void
+    {
+        $primary    = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+        $err        = new UnsupportedFeatureException('nope', 1);
+
+        $caught = $this->captureException(
+            UnsupportedFeatureException::class,
+            function () use ($pipeline, $primary, $err, &$calls): never {
+                $pipeline->run(
+                    ProviderCallContext::for(ProviderOperation::Chat),
+                    $primary,
+                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                        $calls[] = $config->getIdentifier();
+
+                        throw $err;
+                    },
+                );
+            },
+        );
+
+        self::assertSame($err, $caught);
+        self::assertSame(['primary'], $calls);
+    }
+
+    #[Test]
+    public function doesNotRetryOnConfigurationException(): void
+    {
+        $primary    = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+        $err        = new ProviderConfigurationException('missing key', 1);
+
+        $caught = $this->captureException(
+            ProviderConfigurationException::class,
+            function () use ($pipeline, $primary, $err, &$calls): never {
+                $pipeline->run(
+                    ProviderCallContext::for(ProviderOperation::Chat),
+                    $primary,
+                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                        $calls[] = $config->getIdentifier();
+
+                        throw $err;
+                    },
+                );
+            },
+        );
+
+        self::assertSame($err, $caught);
+        self::assertSame(['primary'], $calls);
+    }
+
+    #[Test]
+    public function walksEntireChainUntilOneSucceeds(): void
+    {
+        $primary = $this->makeConfig('p', new FallbackChain(['a', 'b', 'c']));
+        $a       = $this->makeConfig('a');
+        $b       = $this->makeConfig('b');
+        $c       = $this->makeConfig('c');
+
+        $this->repositoryStub->method('findOneByIdentifier')
+            ->willReturnMap([
+                ['a', $a],
+                ['b', $b],
+                ['c', $c],
+            ]);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if (\in_array($config->getIdentifier(), ['p', 'a', 'b'], true)) {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame(['p', 'a', 'b', 'c'], $calls);
+    }
+
+    #[Test]
+    public function throwsExhaustedWhenEveryAttemptFails(): void
+    {
+        $primary = $this->makeConfig('p', new FallbackChain(['a', 'b']));
+        $a       = $this->makeConfig('a');
+        $b       = $this->makeConfig('b');
+
+        $this->repositoryStub->method('findOneByIdentifier')
+            ->willReturnMap([
+                ['a', $a],
+                ['b', $b],
+            ]);
+
+        $pipeline = $this->makePipeline();
+
+        $exhausted = $this->captureException(
+            FallbackChainExhaustedException::class,
+            fn() => $pipeline->run(
+                ProviderCallContext::for(ProviderOperation::Chat),
+                $primary,
+                static function (): never {
+                    throw new ProviderConnectionException('down', 0);
+                },
+            ),
+        );
+
+        self::assertSame(['p', 'a', 'b'], $exhausted->getAttemptedConfigurations());
+        self::assertCount(3, $exhausted->getAttemptErrors());
+        self::assertInstanceOf(ProviderConnectionException::class, $exhausted->getPrevious());
+    }
+
+    #[Test]
+    public function skipsMissingFallbackConfigurations(): void
+    {
+        $primary = $this->makeConfig('p', new FallbackChain(['missing', 'b']));
+        $b       = $this->makeConfig('b');
+
+        $this->repositoryStub->method('findOneByIdentifier')
+            ->willReturnMap([
+                ['missing', null],
+                ['b', $b],
+            ]);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if ($config->getIdentifier() === 'p') {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame(['p', 'b'], $calls);
+    }
+
+    #[Test]
+    public function skipsInactiveFallbackConfigurations(): void
+    {
+        $primary  = $this->makeConfig('p', new FallbackChain(['inactive', 'b']));
+        $inactive = $this->makeConfig('inactive', active: false);
+        $b        = $this->makeConfig('b');
+
+        $this->repositoryStub->method('findOneByIdentifier')
+            ->willReturnMap([
+                ['inactive', $inactive],
+                ['b', $b],
+            ]);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if ($config->getIdentifier() === 'p') {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame(['p', 'b'], $calls);
+    }
+
+    #[Test]
+    public function rethrowsPrimaryErrorWhenChainContainsOnlyTheprimary(): void
+    {
+        $primary    = $this->makeConfig('p', new FallbackChain(['p']));
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+        $err        = new ProviderConnectionException('down', 0);
+
+        $caught = $this->captureException(
+            ProviderConnectionException::class,
+            function () use ($pipeline, $primary, $err, &$calls): never {
+                $pipeline->run(
+                    ProviderCallContext::for(ProviderOperation::Chat),
+                    $primary,
+                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                        $calls[] = $config->getIdentifier();
+
+                        throw $err;
+                    },
+                );
+            },
+        );
+
+        self::assertSame($err, $caught);
+        self::assertSame(['p'], $calls, 'Primary should be the only attempt');
+    }
+
+    #[Test]
+    public function ignoresPrimaryIdentifierAppearingInOwnChain(): void
+    {
+        $primary = $this->makeConfig('p', new FallbackChain(['p', 'b']));
+        $b       = $this->makeConfig('b');
+
+        $this->repositoryStub->method('findOneByIdentifier')
+            ->willReturnMap([
+                ['p', $primary],
+                ['b', $b],
+            ]);
+
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if ($config->getIdentifier() === 'p') {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame(['p', 'b'], $calls);
+    }
+
+    #[Test]
+    public function nonProviderExceptionIsNotRetryable(): void
+    {
+        $primary    = $this->makeConfig('p', new FallbackChain(['a']));
+        $pipeline = $this->makePipeline();
+        $calls      = [];
+        $err        = new RuntimeException('unexpected');
+
+        $caught = $this->captureException(
+            RuntimeException::class,
+            function () use ($pipeline, $primary, $err, &$calls): never {
+                $pipeline->run(
+                    ProviderCallContext::for(ProviderOperation::Chat),
+                    $primary,
+                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                        $calls[] = $config->getIdentifier();
+
+                        throw $err;
+                    },
+                );
+            },
+        );
+
+        self::assertSame($err, $caught);
+        self::assertSame(['p'], $calls);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function makeMiddleware(): FallbackMiddleware
+    {
+        return new FallbackMiddleware($this->repositoryStub, new NullLogger());
+    }
+
+    private function makePipeline(): MiddlewarePipeline
+    {
+        return new MiddlewarePipeline([$this->makeMiddleware()]);
+    }
+
+    private function makeConfig(
+        string $identifier,
+        ?FallbackChain $chain = null,
+        bool $active = true,
+    ): LlmConfiguration {
+        $config = new LlmConfiguration();
+        $config->setIdentifier($identifier);
+        $config->setIsActive($active);
+        if ($chain !== null) {
+            $config->setFallbackChainDTO($chain);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @template T of Throwable
+     *
+     * @param class-string<T>   $expected
+     * @param callable(): mixed $action
+     *
+     * @return T
+     */
+    private function captureException(string $expected, callable $action): Throwable
+    {
+        try {
+            $action();
+        } catch (Throwable $caught) {
+            self::assertInstanceOf($expected, $caught);
+
+            return $caught;
+        }
+
+        self::fail(\sprintf('Expected %s was not thrown', $expected));
+    }
+}


### PR DESCRIPTION
## Summary

Second step of the ADR-026 follow-up chain. Implements `ProviderMiddlewareInterface` (landed in #137) with the behaviour currently provided by `FallbackChainExecutor`: walks the primary `LlmConfiguration`'s fallback chain on retryable provider failure.

No breaking change. `FallbackChainExecutor` stays in place; its callers (`LlmServiceManager::runWithFallback()`) keep working unchanged. The executor gets removed in the **feature-service-wiring PR** (ADR follow-up #5) once every call path goes through the pipeline.

## Behaviour (parity with FallbackChainExecutor)

| Case | Behaviour |
|---|---|
| Primary succeeds | Return its result. |
| Primary throws `ProviderConnectionException` | Walk fallback chain. |
| Primary throws `ProviderResponseException` w/ HTTP 429 | Walk fallback chain (different provider might not be throttled). |
| Primary throws anything else | Bubble immediately — fallback can't fix misconfiguration, unsupported features, 4xx. |
| Empty fallback chain | Skip the walk logic entirely; the primary's error bubbles. |
| Chain contains only the primary's own identifier | Rethrow the primary's error verbatim; do **not** wrap one attempt as "every configuration failed". |
| Self-reference inside longer chain (`['p', 'b']` on primary `p`) | Filter the primary out, try `b`. |
| Fallback identifier not found in repo | Skip, log, try next. |
| Fallback record is inactive | Skip, log, try next. |
| Every attempt exhausted | Throw `FallbackChainExhaustedException::fromAttempts()` carrying all attempts. |

Log entries additionally carry `operation` (from `ProviderCallContext::operation`) and `correlationId` so sinks can group per call.

## What's new vs the executor

The semantic behaviour is identical. The only interface-level changes:
- `handle(ProviderCallContext, LlmConfiguration, callable $next)` instead of `execute(LlmConfiguration, callable $execute)`.
- `$next()` is the pipeline continuation, not a raw provider call — so stacking `FallbackMiddleware` + `BudgetMiddleware` + `UsageMiddleware` (future PRs) composes correctly.
- Logs include operation + correlation id.

## Streaming caveat

`ProviderOperation::Stream` should not be routed through this middleware: once chunks have been emitted to the caller a provider swap is impossible. Documented in the class docblock; not enforced programmatically since consumers build the pipeline and pick which middleware to compose. The feature-service-wiring PR will set up different pipelines per operation where this matters.

## Tests

14 unit tests in `Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php` mirror the behavioural matrix of the legacy `FallbackChainExecutorTest`. Exercised through `MiddlewarePipeline::run()` rather than calling `handle()` directly, which:

- validates the middleware integrates with the pipeline end-to-end,
- uses the pipeline's templated `@return T` so PHPStan level 10 can infer never-returning terminals correctly.

Full local verification on PHP 8.4: 3127 unit tests · PHPStan level 10 · PHP-CS-Fixer dry-run — all green.

## Follow-ups (per ADR-026)

- [ ] BudgetMiddleware — call `BudgetService::check()` before `$next`.
- [ ] UsageMiddleware — route response through `UsageTrackerService::trackUsage()` after `$next`.
- [ ] CacheMiddleware — opt-in by `ProviderOperation`.
- [ ] Feature-service wiring — every `Service/Feature/*` builds its terminal + invokes the pipeline. This is the step that finally deletes `FallbackChainExecutor`.

## Test plan
- [ ] CI green
- [ ] Sanity: the behavioural table above matches what `FallbackChainExecutor` already does for you