### PR TITLE
feat(provider): add BudgetMiddleware for pre-flight spend checks

### DIFF
--- a/Classes/Exception/BudgetExceededException.php
+++ b/Classes/Exception/BudgetExceededException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when BudgetMiddleware denies a provider call.
+ *
+ * Carries the full BudgetCheckResult so consumers (controllers, logs,
+ * flash messages) can surface which bucket tripped, the current usage,
+ * and the limit without re-running the check.
+ */
+final class BudgetExceededException extends RuntimeException
+{
+    public function __construct(
+        public readonly BudgetCheckResult $result,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($result->reason, 0, $previous);
+    }
+}

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Service\BudgetService;
+
+/**
+ * Pre-flight budget check middleware (ADR-025).
+ *
+ * Reads the target backend user id and the planned cost from the
+ * ProviderCallContext metadata and asks BudgetService whether the call
+ * is allowed. On denial the call is short-circuited with a typed
+ * BudgetExceededException carrying the full BudgetCheckResult so
+ * controllers / log sinks can report exactly which bucket tripped.
+ *
+ * Metadata keys consumed (callers put them on the context):
+ *  - `BudgetMiddleware::METADATA_BE_USER_UID` : int, the backend user
+ *    whose budget is checked. 0 / absent / non-int means "skip the
+ *    check" (CLI, scheduler, unauthenticated callers; see ADR-025 rule 1).
+ *  - `BudgetMiddleware::METADATA_PLANNED_COST` : float, the expected
+ *    cost of the call in the configured currency. 0.0 / absent means
+ *    "precheck request count only"; real cost can still be accounted
+ *    for post-call by the UsageMiddleware.
+ *
+ * No side effects. The budget record is not incremented here — that is
+ * the job of UsageMiddleware after the call succeeds.
+ */
+final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
+{
+    public const METADATA_BE_USER_UID  = 'beUserUid';
+    public const METADATA_PLANNED_COST = 'plannedCost';
+
+    public function __construct(
+        private BudgetService $budgetService,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     *
+     * @throws BudgetExceededException when the pre-flight check denies the call
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $beUserUid   = $this->readInt($context, self::METADATA_BE_USER_UID);
+        $plannedCost = $this->readFloat($context, self::METADATA_PLANNED_COST);
+
+        $result = $this->budgetService->check($beUserUid, $plannedCost);
+
+        if (!$result->allowed) {
+            throw new BudgetExceededException($result);
+        }
+
+        return $next($configuration);
+    }
+
+    private function readInt(ProviderCallContext $context, string $key): int
+    {
+        $value = $context->metadata[$key] ?? null;
+
+        return \is_int($value) ? $value : 0;
+    }
+
+    private function readFloat(ProviderCallContext $context, string $key): float
+    {
+        $value = $context->metadata[$key] ?? null;
+
+        if (\is_float($value)) {
+            return $value;
+        }
+        if (\is_int($value)) {
+            return (float)$value;
+        }
+
+        return 0.0;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\BudgetService;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(BudgetMiddleware::class)]
+#[CoversClass(BudgetExceededException::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class BudgetMiddlewareTest extends AbstractUnitTestCase
+{
+    private BudgetService&MockObject $budgetService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->budgetService = $this->createMock(BudgetService::class);
+    }
+
+    #[Test]
+    public function callsNextWhenBudgetCheckAllows(): void
+    {
+        $this->budgetService->method('check')
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $called = false;
+        $result = $this->pipeline()->run(
+            context: $this->contextFor(beUserUid: 42, plannedCost: 0.5),
+            configuration: $this->configuration(),
+            terminal: static function (LlmConfiguration $c) use (&$called): string {
+                $called = true;
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertTrue($called, 'Terminal must run when budget check allows.');
+    }
+
+    #[Test]
+    public function throwsBudgetExceededExceptionWhenDenied(): void
+    {
+        $denial = BudgetCheckResult::denied(
+            exceededLimit: BudgetCheckResult::LIMIT_DAILY_COST,
+            currentUsage: 9.5,
+            limit: 10.0,
+        );
+        $this->budgetService->method('check')->willReturn($denial);
+
+        $terminalWasCalled = false;
+
+        try {
+            $this->pipeline()->run(
+                context: $this->contextFor(beUserUid: 42, plannedCost: 1.0),
+                configuration: $this->configuration(),
+                terminal: static function () use (&$terminalWasCalled): string {
+                    $terminalWasCalled = true;
+
+                    return 'should-never-run';
+                },
+            );
+            self::fail('Expected BudgetExceededException.');
+        } catch (BudgetExceededException $e) {
+            self::assertSame($denial, $e->result);
+            self::assertSame(BudgetCheckResult::LIMIT_DAILY_COST, $e->result->exceededLimit);
+            self::assertSame($denial->reason, $e->getMessage());
+            self::assertFalse($terminalWasCalled, 'Terminal must not run after denial.');
+        }
+    }
+
+    #[Test]
+    public function passesUidZeroWhenMetadataAbsent(): void
+    {
+        $this->budgetService->expects(self::once())
+            ->method('check')
+            ->with(0, 0.0)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ok',
+        );
+    }
+
+    #[Test]
+    public function coercesIntegerPlannedCostToFloat(): void
+    {
+        $this->budgetService->expects(self::once())
+            ->method('check')
+            ->with(7, 3.0)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $this->pipeline()->run(
+            context: $this->contextFor(beUserUid: 7, plannedCost: 3), // int, not float
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ok',
+        );
+    }
+
+    #[Test]
+    public function ignoresNonNumericMetadataSilently(): void
+    {
+        // Non-int for uid and non-numeric for cost must fall back to
+        // 0 / 0.0 rather than cast surprisingly.
+        $this->budgetService->expects(self::once())
+            ->method('check')
+            ->with(0, 0.0)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $context = new ProviderCallContext(
+            operation: ProviderOperation::Chat,
+            correlationId: 'test',
+            metadata: [
+                BudgetMiddleware::METADATA_BE_USER_UID  => 'not-an-int',
+                BudgetMiddleware::METADATA_PLANNED_COST => 'not-a-number',
+            ],
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ok',
+        );
+    }
+
+    #[Test]
+    public function passesNegativeUidThroughToService(): void
+    {
+        // Per ADR-025 rule 1 BudgetService itself treats uid <= 0 as
+        // "allowed / unauthenticated". The middleware does not pre-filter;
+        // it forwards whatever was on the metadata so the service keeps
+        // ownership of that policy.
+        $this->budgetService->expects(self::once())
+            ->method('check')
+            ->with(-1, 0.0)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $this->pipeline()->run(
+            context: $this->contextFor(beUserUid: -1, plannedCost: 0.0),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ok',
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function pipeline(): MiddlewarePipeline
+    {
+        return new MiddlewarePipeline([new BudgetMiddleware($this->budgetService)]);
+    }
+
+    /**
+     * @param int|float|string $plannedCost accepts int to exercise the
+     *                                      int->float coercion path
+     */
+    private function contextFor(int $beUserUid, int|float|string $plannedCost): ProviderCallContext
+    {
+        return new ProviderCallContext(
+            operation: ProviderOperation::Chat,
+            correlationId: 'test',
+            metadata: [
+                BudgetMiddleware::METADATA_BE_USER_UID  => $beUserUid,
+                BudgetMiddleware::METADATA_PLANNED_COST => $plannedCost,
+            ],
+        );
+    }
+
+    private function configuration(): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier('primary');
+
+        return $config;
+    }
+}


### PR DESCRIPTION
## Summary

Third step of the ADR-026 follow-up chain. Wires `BudgetService::check()` (ADR-025) into the pipeline so per-user spending limits are enforced before a provider call is dispatched. Stops every feature service from having to remember the check itself.

## Behaviour

On entry the middleware reads two keys from `ProviderCallContext::metadata`:

| Key | Type | Default | Meaning |
|---|---|---|---|
| `BudgetMiddleware::METADATA_BE_USER_UID` | `int` | `0` | Backend user whose budget to evaluate. `0` / absent / non-int = skip the check (CLI, scheduler, unauthenticated callers; ADR-025 rule 1). |
| `BudgetMiddleware::METADATA_PLANNED_COST` | `float` | `0.0` | Expected cost of the call. Integers are coerced to float. `0.0` still validates request-count and token-count limits. |

Flow:

1. Read the two keys (defensive — wrong types fall back to safe zeros rather than casting).
2. Call `BudgetService::check($beUserUid, $plannedCost)`.
3. Allowed → delegate to `$next($configuration)` and return.
4. Denied → throw typed `BudgetExceededException` carrying the full `BudgetCheckResult` so controllers / log sinks can report exactly which bucket tripped (daily requests / daily tokens / daily cost / monthly requests / monthly tokens / monthly cost) without re-running the check.

No side effects. The budget record is not incremented — that is the job of the upcoming `UsageMiddleware` after a successful call.

## Design notes

- The middleware does **not** pre-filter `uid <= 0` itself; it forwards whatever was on the metadata so that **`BudgetService`** remains the single authoritative owner of the "allowed if uid <= 0" policy (ADR-025 rule 1). If that policy changes, one file changes.
- Metadata extraction is deliberately strict about types — a wrong payload falls back to zeros rather than casting so an accidentally mis-typed value never charges a random user.
- New `BudgetExceededException` lives under `Classes/Exception/` matching the existing domain-exception pattern (AccessDeniedException, ConfigurationNotFoundException, …). `final`, readonly `BudgetCheckResult` property, message sourced from the result's `reason` field.

## Tests

6 unit tests, routed through `MiddlewarePipeline::run()`:

- Allowed result → terminal runs, value returned
- Denied result → `BudgetExceededException` thrown, result attached, terminal not invoked
- Missing metadata → defaults to `uid=0` / `cost=0.0`
- Integer planned-cost coerced to float
- Non-numeric metadata silently falls back to zeros
- Negative uid forwarded verbatim (policy stays in `BudgetService`)

Full local verification on PHP 8.4: **3133 unit tests** · PHPStan level 10 · PHP-CS-Fixer dry-run — all green.

## Follow-ups (per ADR-026)

- [ ] **UsageMiddleware** — route response through `UsageTrackerService::trackUsage()` after `$next`. This is the counterpart that actually records the cost.
- [ ] CacheMiddleware — opt-in by `ProviderOperation`.
- [ ] Feature-service wiring — every `Service/Feature/*` builds its terminal + invokes the pipeline. Finally deletes `FallbackChainExecutor`.

## Test plan
- [ ] CI green
- [ ] Confirm the metadata-key convention (`beUserUid` / `plannedCost`) matches what feature services will set once we wire them in