### PR TITLE
feat(provider): add UsageMiddleware for post-call usage accounting

### DIFF
--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+
+/**
+ * Records usage to tx_nrllm_service_usage after a successful provider call.
+ *
+ * Counterpart of BudgetMiddleware. Budget is a pre-flight gate; this
+ * middleware is the post-flight recorder that feeds the same table
+ * BudgetService aggregates from, so the two stay consistent without a
+ * second source of truth.
+ *
+ * Recognised response types:
+ *  - CompletionResponse
+ *  - EmbeddingResponse
+ *  - VisionResponse
+ *
+ * All three carry a typed UsageStatistics + provider identifier. Any
+ * other return value (streaming Generator, translation result, raw
+ * string, plain array) is silently skipped — there is nothing reliable
+ * to record for those shapes from this position in the pipeline.
+ *
+ * Pipeline ordering recommendation:
+ *
+ *   BudgetMiddleware         <-- outermost; pre-flight denial
+ *     FallbackMiddleware     <-- swaps LlmConfiguration on retryable failure
+ *       UsageMiddleware      <-- inner; sees the config that actually ran
+ *         <terminal provider call>
+ *
+ * With this order the $configuration parameter reaching UsageMiddleware
+ * is the one FallbackMiddleware actually dispatched (the fallback, if
+ * any swap happened) — so the recorded configuration_uid reflects
+ * reality, not the primary that failed. The response's $provider field
+ * is used when present; otherwise the middleware records 'unknown'.
+ *
+ * The middleware never runs when $next throws: failed calls are not
+ * tracked here. If failure-rate telemetry is needed later, a dedicated
+ * middleware can wrap and record regardless of outcome.
+ */
+final readonly class UsageMiddleware implements ProviderMiddlewareInterface
+{
+    public function __construct(
+        private UsageTrackerServiceInterface $usageTracker,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $result = $next($configuration);
+
+        $this->track($context, $configuration, $result);
+
+        return $result;
+    }
+
+    private function track(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        mixed $result,
+    ): void {
+        if (
+            !$result instanceof CompletionResponse
+            && !$result instanceof EmbeddingResponse
+            && !$result instanceof VisionResponse
+        ) {
+            return;
+        }
+
+        $usage = $result->usage;
+
+        /** @var array{tokens?: int, cost?: float} $metrics */
+        $metrics = [
+            'tokens' => $usage->totalTokens,
+        ];
+        if ($usage->estimatedCost !== null) {
+            $metrics['cost'] = $usage->estimatedCost;
+        }
+
+        $provider = $result->provider !== '' ? $result->provider : 'unknown';
+
+        $configUid = $configuration->getUid();
+        $uid       = ($configUid !== null && $configUid > 0) ? $configUid : null;
+
+        $this->usageTracker->trackUsage(
+            serviceType: $context->operation->value,
+            provider: $provider,
+            metrics: $metrics,
+            configurationUid: $uid,
+        );
+    }
+}

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionProperty;
+use RuntimeException;
+
+#[CoversClass(UsageMiddleware::class)]
+final class UsageMiddlewareTest extends AbstractUnitTestCase
+{
+    private UsageTrackerServiceInterface&MockObject $tracker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tracker = $this->createMock(UsageTrackerServiceInterface::class);
+    }
+
+    #[Test]
+    public function tracksCompletionResponseWithTokensAndCost(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                serviceType: ProviderOperation::Chat->value,
+                provider: 'openai',
+                metrics: ['tokens' => 150, 'cost' => 0.0012],
+                configurationUid: 7,
+            );
+
+        $response = new CompletionResponse(
+            content: 'hi',
+            model: 'gpt-4o-mini',
+            usage: new UsageStatistics(100, 50, 150, 0.0012),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $result = $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(uid: 7),
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+        );
+
+        self::assertSame($response, $result);
+    }
+
+    #[Test]
+    public function tracksEmbeddingResponseWithOperationAsServiceType(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Embedding->value,
+                'claude',
+                ['tokens' => 42],
+                null,
+            );
+
+        $response = new EmbeddingResponse(
+            embeddings: [[0.1, 0.2]],
+            model: 'claude-embed',
+            usage: new UsageStatistics(42, 0, 42),  // no cost
+            provider: 'claude',
+        );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration(), // uid = null (not persisted)
+            terminal: static fn(LlmConfiguration $c): EmbeddingResponse => $response,
+        );
+    }
+
+    #[Test]
+    public function tracksVisionResponse(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Vision->value,
+                'gemini',
+                ['tokens' => 300, 'cost' => 0.003],
+                12,
+            );
+
+        $response = new VisionResponse(
+            description: 'a cat',
+            model: 'gemini-vision',
+            usage: new UsageStatistics(200, 100, 300, 0.003),
+            provider: 'gemini',
+        );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Vision),
+            configuration: $this->configuration(uid: 12),
+            terminal: static fn(LlmConfiguration $c): VisionResponse => $response,
+        );
+    }
+
+    #[Test]
+    public function usesUnknownProviderWhenResponseLacksOne(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Chat->value,
+                'unknown',
+                ['tokens' => 10],
+                null,
+            );
+
+        $response = new CompletionResponse(
+            content: 'x',
+            model: 'm',
+            usage: new UsageStatistics(5, 5, 10),
+            // $provider defaults to ''
+        );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+        );
+    }
+
+    #[Test]
+    public function skipsUnknownResultTypes(): void
+    {
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $result = $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'raw-string-response',
+        );
+
+        self::assertSame('raw-string-response', $result);
+    }
+
+    #[Test]
+    public function doesNotTrackWhenTerminalThrows(): void
+    {
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(),
+            terminal: static function (LlmConfiguration $c): never {
+                throw new RuntimeException('boom');
+            },
+        );
+    }
+
+    #[Test]
+    public function recordsConfigurationUidNullWhenUidIsZero(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                null,
+            );
+
+        // Force uid = 0 via reflection (the public getter maps null -> int | null,
+        // but a just-loaded entity from the repo can have getUid() === 0 in
+        // unusual bootstrapping cases; the middleware must treat it as null).
+        $config = $this->configuration();
+        $this->setUid($config, 0);
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $config,
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+                content: 'x',
+                model: 'm',
+                usage: new UsageStatistics(1, 1, 2),
+                provider: 'p',
+            ),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function pipeline(): MiddlewarePipeline
+    {
+        return new MiddlewarePipeline([new UsageMiddleware($this->tracker)]);
+    }
+
+    private function configuration(?int $uid = null): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier('primary');
+        if ($uid !== null) {
+            $this->setUid($config, $uid);
+        }
+
+        return $config;
+    }
+
+    private function setUid(LlmConfiguration $config, int $uid): void
+    {
+        $prop = new ReflectionProperty($config, 'uid');
+        $prop->setValue($config, $uid);
+    }
+}


### PR DESCRIPTION
## Summary

Fourth step of the ADR-026 follow-up chain. Counterpart to `BudgetMiddleware` — records the actual usage of a successful provider call into `tx_nrllm_service_usage`, which is exactly the table `BudgetService::check()` aggregates from. Closes the loop so per-user limits are enforced against real usage without a second source of truth.

## Recognised response shapes

| Response type | Tracked |
|---|---|
| `CompletionResponse` | yes (tokens + cost + provider) |
| `EmbeddingResponse` | yes (tokens + cost + provider) |
| `VisionResponse` | yes (tokens + cost + provider) |
| `Generator` (streaming) | skipped — usage not known until stream is consumed |
| `TranslationResult` / raw string / array | skipped — no reliable shape from this position |

If failure-rate or streaming-completion telemetry is needed later, it belongs in a dedicated middleware that wraps the generator or records regardless of outcome.

## Recorded dimensions

Pass-through to `UsageTrackerServiceInterface::trackUsage()`:

| Arg | Source |
|---|---|
| `serviceType` | `ProviderOperation->value` (`chat` / `embed` / `vision` / ...) |
| `provider` | `$response->provider` or `'unknown'` if empty |
| `metrics` | `['tokens' => totalTokens]` + `'cost' => estimatedCost` if present |
| `configurationUid` | `$configuration->getUid()` when non-null and positive, else `null` |

`be_user` is picked up by `UsageTrackerService` from TYPO3 context internally, matching how the specialized services currently track — no metadata key needed on the middleware side.

## Design notes

- **Failed calls are not recorded.** The middleware only runs after `$next` returns; if the terminal throws, the exception propagates and no row is written. This keeps `tx_nrllm_service_usage` a billable-usage source of truth rather than a failure log.
- **Pipeline ordering (see ADR-026 and class docblock):**
  ```
  BudgetMiddleware      <-- outer: pre-flight denial
    FallbackMiddleware  <-- middle: swaps config on retryable failure
      UsageMiddleware   <-- inner: sees the config that actually ran
        <terminal>
  ```
  With this order the `$configuration` parameter reaching `UsageMiddleware` is whichever one `FallbackMiddleware` actually dispatched, so the recorded `configurationUid` reflects the config that succeeded, not the primary that failed.
- **Uid normalisation**: `getUid()` can return `null` (unpersisted) or `0` in unusual bootstrap cases. Both are normalised to `null` on the tracker call, matching how TYPO3 surfaces "no uid".

## Tests

7 unit tests routed through `MiddlewarePipeline::run()`:

- Completion / Embedding / Vision responses recorded with operation value as serviceType, response provider, tokens + cost metrics
- Response with empty provider records `'unknown'`
- Non-typed results (plain string / array) silently skipped
- Terminal throw → tracker not called, exception propagates (via `expectException`)
- Zero uid normalised to null `configurationUid`

Full local verification on PHP 8.4: **3140 unit tests** · PHPStan level 10 · PHP-CS-Fixer dry-run — all green.

## Follow-ups (per ADR-026)

- [ ] **CacheMiddleware** — opt-in by `ProviderOperation`; starts with embeddings (deterministic, high-value).
- [ ] **Feature-service wiring** — every `Service/Feature/*` builds its terminal + invokes the pipeline. Sets the canonical middleware order above. Finally deletes `FallbackChainExecutor`.

## Test plan
- [ ] CI green
- [ ] Confirm `ProviderOperation::value` strings match the reporting convention you want on usage rows (`chat`, `embed`, `vision`) — or whether you'd prefer a single `'llm'` umbrella