### PR TITLE
feat(provider): add CacheMiddleware for array-payload cache short-circuit

### DIFF
--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+
+/**
+ * Array-payload cache middleware.
+ *
+ * Sits between the caller and a provider call to skip the call entirely
+ * when the same request has been answered before. Opt-in per call: the
+ * middleware does nothing unless the caller supplies a cache key via
+ * ProviderCallContext metadata. This keeps non-deterministic operations
+ * (stateful chat, vision) untouched even when this middleware is
+ * registered in the pipeline.
+ *
+ * Caller responsibilities (usually a feature service):
+ *  1. Compute a stable cache key from the provider id + operation +
+ *     inputs + relevant options. Put it on the context metadata under
+ *     `CacheMiddleware::METADATA_CACHE_KEY`. Absent / empty = skip.
+ *  2. Optionally put a TTL (`METADATA_CACHE_TTL`, int seconds) and
+ *     cache tags (`METADATA_CACHE_TAGS`, list<string>) on the context
+ *     so the store call is parameterised correctly.
+ *  3. Wrap the terminal so it returns an `array<string, mixed>`, which
+ *     is the shape CacheManager stores. Non-array return values are
+ *     never written to cache — the middleware quietly passes them
+ *     through on miss so callers who do not opt in to serialisation
+ *     are not surprised by empty cache slots.
+ *
+ * Why array-only
+ * --------------
+ * The TYPO3 cache framework (via CacheManager here) persists arrays,
+ * not arbitrary objects. Typed response objects
+ * (CompletionResponse / EmbeddingResponse / VisionResponse) therefore
+ * live at the feature-service boundary: the feature service wraps the
+ * provider call so the terminal returns `$response->toArray()`, then
+ * reconstructs the typed response from whatever the pipeline returns
+ * (cached array or freshly-computed array). Keeping the middleware
+ * opinion-free on response shape is what lets it work for any future
+ * operation without a per-type codec.
+ *
+ * Pipeline ordering recommendation
+ * --------------------------------
+ * Outer of Fallback (so a cache hit skips even the fallback attempt)
+ * and outer of Budget (so a free cache hit is not counted against a
+ * user's budget):
+ *
+ *   CacheMiddleware          <-- outermost; short-circuits on hit
+ *     BudgetMiddleware       <-- pre-flight only on miss
+ *       FallbackMiddleware   <-- swaps config on retryable failure
+ *         UsageMiddleware    <-- records the call that actually ran
+ *           <terminal>
+ *
+ * Callers who want cache accounting (count hits against budget / usage)
+ * should put Cache *inside* those layers — it is a pipeline-assembly
+ * choice, not a property of this middleware.
+ */
+final readonly class CacheMiddleware implements ProviderMiddlewareInterface
+{
+    public const METADATA_CACHE_KEY  = 'cacheKey';
+    public const METADATA_CACHE_TTL  = 'cacheTtl';
+    public const METADATA_CACHE_TAGS = 'cacheTags';
+
+    private const DEFAULT_TTL_SECONDS = 3600;
+
+    public function __construct(
+        private CacheManagerInterface $cache,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $key = $this->readKey($context);
+        if ($key === null) {
+            return $next($configuration);
+        }
+
+        $cached = $this->cache->get($key);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $result = $next($configuration);
+
+        if (\is_array($result)) {
+            /** @var array<string, mixed> $result */
+            $this->cache->set(
+                $key,
+                $result,
+                $this->readTtl($context),
+                $this->readTags($context),
+            );
+        }
+
+        return $result;
+    }
+
+    private function readKey(ProviderCallContext $context): ?string
+    {
+        $value = $context->metadata[self::METADATA_CACHE_KEY] ?? null;
+        if (!\is_string($value) || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function readTtl(ProviderCallContext $context): int
+    {
+        $value = $context->metadata[self::METADATA_CACHE_TTL] ?? null;
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        return self::DEFAULT_TTL_SECONDS;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function readTags(ProviderCallContext $context): array
+    {
+        $value = $context->metadata[self::METADATA_CACHE_TAGS] ?? null;
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($value as $tag) {
+            if (\is_string($tag) && $tag !== '') {
+                $tags[] = $tag;
+            }
+        }
+
+        return $tags;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(CacheMiddleware::class)]
+final class CacheMiddlewareTest extends AbstractUnitTestCase
+{
+    private CacheManagerInterface&MockObject $cache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cache = $this->createMock(CacheManagerInterface::class);
+    }
+
+    #[Test]
+    public function passesThroughWhenNoCacheKeyOnContext(): void
+    {
+        $this->cache->expects(self::never())->method('get');
+        $this->cache->expects(self::never())->method('set');
+
+        $result = $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ran',
+        );
+
+        self::assertSame('ran', $result);
+    }
+
+    #[Test]
+    public function passesThroughWhenCacheKeyIsEmptyString(): void
+    {
+        $this->cache->expects(self::never())->method('get');
+
+        $this->pipeline()->run(
+            context: $this->context(key: ''),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'ran',
+        );
+    }
+
+    #[Test]
+    public function passesThroughWhenCacheKeyIsNonString(): void
+    {
+        $this->cache->expects(self::never())->method('get');
+
+        $context = new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'test',
+            metadata: [CacheMiddleware::METADATA_CACHE_KEY => 42],
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['stored' => false],
+        );
+    }
+
+    #[Test]
+    public function returnsCachedValueAndSkipsTerminalOnHit(): void
+    {
+        $cached = ['vector' => [0.1, 0.2, 0.3]];
+        $this->cache->expects(self::once())
+            ->method('get')
+            ->with('embed:abc')
+            ->willReturn($cached);
+        $this->cache->expects(self::never())->method('set');
+
+        $terminalCalled = false;
+        $result         = $this->pipeline()->run(
+            context: $this->context(key: 'embed:abc'),
+            configuration: $this->configuration(),
+            terminal: static function () use (&$terminalCalled): array {
+                $terminalCalled = true;
+
+                return ['vector' => [0.9]];
+            },
+        );
+
+        self::assertSame($cached, $result);
+        self::assertFalse($terminalCalled, 'Terminal must not run on cache hit.');
+    }
+
+    #[Test]
+    public function storesArrayResultOnMiss(): void
+    {
+        $produced = ['vector' => [0.4, 0.5]];
+
+        $this->cache->expects(self::once())
+            ->method('get')
+            ->with('embed:new')
+            ->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('embed:new', $produced, 3600, []);
+
+        $result = $this->pipeline()->run(
+            context: $this->context(key: 'embed:new'),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => $produced,
+        );
+
+        self::assertSame($produced, $result);
+    }
+
+    #[Test]
+    public function usesCustomTtlFromMetadata(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('key', ['x' => 1], 86400, []);
+
+        $this->pipeline()->run(
+            context: $this->context(key: 'key', ttl: 86400),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+    }
+
+    #[Test]
+    public function ignoresNonIntOrNonPositiveTtl(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('key', ['x' => 1], 3600, []);
+
+        $context = new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'test',
+            metadata: [
+                CacheMiddleware::METADATA_CACHE_KEY => 'key',
+                CacheMiddleware::METADATA_CACHE_TTL => 0,   // ignored
+            ],
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+    }
+
+    #[Test]
+    public function passesCacheTagsThroughToSet(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('key', ['x' => 1], 3600, ['nr_llm_embed', 'user_42']);
+
+        $this->pipeline()->run(
+            context: $this->context(key: 'key', tags: ['nr_llm_embed', 'user_42']),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+    }
+
+    #[Test]
+    public function filtersNonStringAndEmptyTags(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('key', ['x' => 1], 3600, ['good']);
+
+        $context = new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'test',
+            metadata: [
+                CacheMiddleware::METADATA_CACHE_KEY  => 'key',
+                CacheMiddleware::METADATA_CACHE_TAGS => ['good', '', 42, null, false],
+            ],
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+    }
+
+    #[Test]
+    public function doesNotStoreNonArrayResult(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::never())->method('set');
+
+        $result = $this->pipeline()->run(
+            context: $this->context(key: 'key'),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): string => 'not-an-array',
+        );
+
+        self::assertSame('not-an-array', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function pipeline(): MiddlewarePipeline
+    {
+        return new MiddlewarePipeline([new CacheMiddleware($this->cache)]);
+    }
+
+    /**
+     * @param array<int, string>|null $tags
+     */
+    private function context(string $key, ?int $ttl = null, ?array $tags = null): ProviderCallContext
+    {
+        $metadata = [CacheMiddleware::METADATA_CACHE_KEY => $key];
+        if ($ttl !== null) {
+            $metadata[CacheMiddleware::METADATA_CACHE_TTL] = $ttl;
+        }
+        if ($tags !== null) {
+            $metadata[CacheMiddleware::METADATA_CACHE_TAGS] = $tags;
+        }
+
+        return new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'test',
+            metadata: $metadata,
+        );
+    }
+
+    private function configuration(): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier('primary');
+
+        return $config;
+    }
+}


### PR DESCRIPTION
## Summary

Fifth step of the ADR-026 follow-up chain. Sits between the caller and a provider call to skip the call entirely when the same request has been answered before. **Opt-in per call** via `ProviderCallContext` metadata — non-deterministic operations (stateful chat, vision) stay untouched even when the middleware is registered in the pipeline.

This is the last middleware before the final **feature-service-wiring** PR that switches `LlmServiceManager` over and finally deletes `FallbackChainExecutor`.

## Caller contract

| Key | Type | Default | Meaning |
|---|---|---|---|
| `CacheMiddleware::METADATA_CACHE_KEY` | `string` | — | Stable key from provider + operation + inputs + relevant options. Absent / empty / non-string = skip. |
| `CacheMiddleware::METADATA_CACHE_TTL` | `int` (seconds) | `3600` | Positive ints only. Non-positive / non-int falls back to default. |
| `CacheMiddleware::METADATA_CACHE_TAGS` | `list<string>` | `[]` | Non-string / empty entries filtered out. |

The caller is expected to wrap its terminal so it returns `array<string, mixed>` — that's the shape `CacheManager` stores. Non-array return values pass through on miss and are **not** written to cache. The middleware quietly no-ops on writes it cannot materialise, so callers who have not yet opted in to serialisation are not surprised.

## Why array-only

TYPO3's `CacheManager` persists arrays, not arbitrary objects. Two paths were considered:

1. **Teach the middleware every typed response** (`CompletionResponse` / `EmbeddingResponse` / `VisionResponse` / …). Couples the middleware to the response hierarchy; every new response requires a codec here.
2. **Keep the middleware opinion-free on shape.** Typed responses live at the feature-service boundary: the feature service wraps the provider call so the terminal returns `$response->toArray()`, then reconstructs the typed response from whatever the pipeline returned. One middleware, works for any future operation.

(2) wins — the middleware stays ~80 LOC and its contract doesn't drift as the domain grows.

## Pipeline ordering (documented in the class)

```
CacheMiddleware          ← outermost; short-circuits on hit
  BudgetMiddleware       ← pre-flight only on miss
    FallbackMiddleware   ← swaps config on retryable failure
      UsageMiddleware    ← records the call that actually ran
        <terminal provider call>
```

Rationale: a cache hit should skip fallback *and* budget, because a free cached response shouldn't be billed against a user's budget. Callers who want cache hits accounted for can reorder — it's a pipeline-assembly choice, not a property of this middleware.

## Tests

10 unit tests via `MiddlewarePipeline::run()`:

- Pass-through when no / empty / non-string key
- Hit returns cached value, terminal not called
- Miss stores result with default 3600 TTL + no tags
- Custom TTL honoured
- Non-positive / non-int TTL falls back to default
- Tag list propagated end-to-end
- Non-string / empty tags filtered out of the final tag list
- Non-array result on miss: returned verbatim, **not** written to cache

Full local verification on PHP 8.4: **3150 unit tests** · PHPStan level 10 · PHP-CS-Fixer dry-run — all green.

## ADR-026 progress

| # | Step | Status |
|---|---|---|
| 0 | Middleware infrastructure | Merged (#137) |
| 1 | FallbackMiddleware | Merged (#138) |
| 2 | BudgetMiddleware | Merged (#139) |
| 3 | UsageMiddleware | Merged (#141) |
| **4** | **CacheMiddleware** | **This PR** |
| 5 | Feature-service wiring | Next — switches LlmServiceManager and deletes FallbackChainExecutor |

## Test plan
- [ ] CI green
- [ ] Sanity-check the documented pipeline order (cache outermost) matches how you want billable usage accounted