### PR TITLE
fix(ddev): correct vhost routing and drop nr-vault bind-mount

### DIFF
--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -1,60 +1,14 @@
 ServerName nr-llm.ddev.site
 
 # ============================================================================
-# Main site - Landing page at /var/www/html
-# ============================================================================
-<VirtualHost *:80>
-    RewriteEngine On
-    RewriteCond %{HTTP:X-Forwarded-Proto} =https
-    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
-    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
-
-    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
-
-    ServerAdmin webmaster@localhost
-    DocumentRoot /var/www/html
-    <Directory "/var/www/html/">
-        AllowOverride All
-        Require all granted
-    </Directory>
-
-    ErrorLog /dev/stdout
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
-    Alias "/phpstatus" "/var/www/phpstatus.php"
-</VirtualHost>
-
-<VirtualHost *:443>
-    SSLEngine on
-    SSLCertificateFile /etc/ssl/certs/master.crt
-    SSLCertificateKeyFile /etc/ssl/certs/master.key
-
-    RewriteEngine On
-    RewriteCond %{HTTP:X-Forwarded-Proto} =https
-    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
-    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
-
-    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
-
-    ServerAdmin webmaster@localhost
-    DocumentRoot /var/www/html
-    <Directory "/var/www/html/">
-        AllowOverride All
-        Require all granted
-    </Directory>
-
-    ErrorLog /dev/stdout
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
-    Alias "/phpstatus" "/var/www/phpstatus.php"
-</VirtualHost>
-
-# ============================================================================
 # Documentation - docs.nr-llm.ddev.site
+# (must be before the default vhost so Apache matches it first)
 # ============================================================================
 <VirtualHost *:80>
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
+    ServerName docs.nr-llm.ddev.site
     DocumentRoot /var/www/nr_llm/Documentation-GENERATED-temp
-    ServerAlias docs.nr-llm.ddev.site
 
     <Directory "/var/www/nr_llm/Documentation-GENERATED-temp/">
         AllowOverride All
@@ -73,8 +27,8 @@ ServerName nr-llm.ddev.site
 
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
+    ServerName docs.nr-llm.ddev.site
     DocumentRoot /var/www/nr_llm/Documentation-GENERATED-temp
-    ServerAlias docs.nr-llm.ddev.site
 
     <Directory "/var/www/nr_llm/Documentation-GENERATED-temp/">
         AllowOverride All
@@ -97,8 +51,8 @@ ServerName nr-llm.ddev.site
 
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
+    ServerName v14.nr-llm.ddev.site
     DocumentRoot /var/www/html/v14/public
-    ServerAlias v14.nr-llm.ddev.site
 
     <Directory "/var/www/html/v14/">
         AllowOverride All
@@ -122,10 +76,59 @@ ServerName nr-llm.ddev.site
 
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
+    ServerName v14.nr-llm.ddev.site
     DocumentRoot /var/www/html/v14/public
-    ServerAlias v14.nr-llm.ddev.site
 
     <Directory "/var/www/html/v14/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+# ============================================================================
+# Main site - Landing page at /var/www/html (default/fallback)
+# ============================================================================
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    ServerName nr-llm.ddev.site
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    ServerName nr-llm.ddev.site
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html/">
         AllowOverride All
         Require all granted
     </Directory>

--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -5,6 +5,11 @@ ServerName nr-llm.ddev.site
 # (must be before the default vhost so Apache matches it first)
 # ============================================================================
 <VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
     ServerName docs.nr-llm.ddev.site
@@ -17,6 +22,7 @@ ServerName nr-llm.ddev.site
     </Directory>
 
     ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
     Alias "/phpstatus" "/var/www/phpstatus.php"
 </VirtualHost>
 
@@ -25,6 +31,11 @@ ServerName nr-llm.ddev.site
     SSLCertificateFile /etc/ssl/certs/master.crt
     SSLCertificateKeyFile /etc/ssl/certs/master.key
 
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
     ServerName docs.nr-llm.ddev.site
@@ -37,6 +48,7 @@ ServerName nr-llm.ddev.site
     </Directory>
 
     ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
     Alias "/phpstatus" "/var/www/phpstatus.php"
 </VirtualHost>
 
@@ -54,7 +66,7 @@ ServerName nr-llm.ddev.site
     ServerName v14.nr-llm.ddev.site
     DocumentRoot /var/www/html/v14/public
 
-    <Directory "/var/www/html/v14/">
+    <Directory "/var/www/html/v14/public/">
         AllowOverride All
         Require all granted
     </Directory>
@@ -79,7 +91,7 @@ ServerName nr-llm.ddev.site
     ServerName v14.nr-llm.ddev.site
     DocumentRoot /var/www/html/v14/public
 
-    <Directory "/var/www/html/v14/">
+    <Directory "/var/www/html/v14/public/">
         AllowOverride All
         Require all granted
     </Directory>

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -35,8 +35,10 @@ composer config --unset platform.php
 
 # Add extension repositories and install
 echo "Adding nr_llm extension..."
-composer config repositories.nr_vault path "/var/www/nr-vault"
 composer config repositories.nr_llm path "$EXTENSION_PATH"
+# Opt-in: to debug against a local nr-vault checkout, create a
+# .ddev/docker-compose.nrvault.yaml override that bind-mounts the
+# source to /var/www/nr-vault, then add a path repo here yourself.
 composer require netresearch/nr-llm:@dev --no-interaction --no-progress
 
 # Add dev dependencies

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -37,8 +37,11 @@ composer config --unset platform.php
 echo "Adding nr_llm extension..."
 composer config repositories.nr_llm path "$EXTENSION_PATH"
 # Opt-in: to debug against a local nr-vault checkout, create a
-# .ddev/docker-compose.nrvault.yaml override that bind-mounts the
-# source to /var/www/nr-vault, then add a path repo here yourself.
+# local-only .ddev/docker-compose.nrvault.yaml override that
+# bind-mounts the source to /var/www/nr-vault, then add a path repo
+# here yourself. Keep that override untracked (for example, add
+# .ddev/docker-compose.nrvault.yaml to .git/info/exclude before
+# creating it) to avoid accidentally committing local settings.
 composer require netresearch/nr-llm:@dev --no-interaction --no-progress
 
 # Add dev dependencies

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -39,8 +39,10 @@ composer config minimum-stability dev
 composer config prefer-stable true
 composer config repositories.nr_llm path "$EXTENSION_PATH"
 # Opt-in: to debug against a local nr-vault checkout, create a
-# .ddev/docker-compose.nrvault.yaml override that bind-mounts the
-# source to /var/www/nr-vault, then add a path repo here yourself.
+# local-only .ddev/docker-compose.nrvault.yaml override that bind-mounts
+# the source to /var/www/nr-vault, then add a path repo here yourself.
+# Keep that override untracked (for example via .git/info/exclude) so it
+# is not accidentally committed.
 composer require netresearch/nr-llm:@dev --no-interaction --no-progress
 
 # Add dev dependencies

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -37,8 +37,10 @@ composer config --unset platform.php
 echo "🔌 Adding nr_llm extension..."
 composer config minimum-stability dev
 composer config prefer-stable true
-composer config repositories.nr_vault path "/var/www/nr-vault"
 composer config repositories.nr_llm path "$EXTENSION_PATH"
+# Opt-in: to debug against a local nr-vault checkout, create a
+# .ddev/docker-compose.nrvault.yaml override that bind-mounts the
+# source to /var/www/nr-vault, then add a path repo here yourself.
 composer require netresearch/nr-llm:@dev --no-interaction --no-progress
 
 # Add dev dependencies

--- a/.ddev/docker-compose.web.yaml
+++ b/.ddev/docker-compose.web.yaml
@@ -25,11 +25,6 @@ services:
               source: ../
               target: /var/www/nr_llm
               consistency: cached
-            # nr-vault dependency (path repository)
-            - type: bind
-              source: ../../nr-vault
-              target: /var/www/nr-vault
-              consistency: cached
             # TYPO3 v14 installation volume
             - v14-data:/var/www/html/v14
 volumes:

--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -15,11 +15,11 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
-use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
+use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;

--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
@@ -66,6 +67,14 @@ return RectorConfig::configure()
         // Skip readonly for test properties that are set in setUp() - causes PHPStan errors
         ReadOnlyPropertyRector::class => [
             __DIR__ . '/../../Tests/Integration/Provider/OpenAiProviderIntegrationTest.php',
+        ],
+        // AddErrorCodeToExceptionRector assumes the standard \Throwable
+        // ($message, $code, $previous) signature. Custom exceptions whose
+        // constructor expects ($context, ?Throwable $previous) instead must
+        // be skipped, otherwise Rector injects an int where a Throwable is
+        // required.
+        AddErrorCodeToExceptionRector::class => [
+            __DIR__ . '/../../Classes/Provider/Middleware/BudgetMiddleware.php',
         ],
         // Skip Fuzzy tests - Eris\Generator namespace functions conflict with auto-imports
         __DIR__ . '/../../Tests/Fuzzy/',

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -59,7 +59,7 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
         $result = $this->budgetService->check($beUserUid, $plannedCost);
 
         if (!$result->allowed) {
-            throw new BudgetExceededException($result, 3554497632);
+            throw new BudgetExceededException($result);
         }
 
         return $next($configuration);

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -59,7 +59,7 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
         $result = $this->budgetService->check($beUserUid, $plannedCost);
 
         if (!$result->allowed) {
-            throw new BudgetExceededException($result);
+            throw new BudgetExceededException($result, 3554497632);
         }
 
         return $next($configuration);

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -43,10 +43,10 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->tracker->expects(self::once())
             ->method('trackUsage')
             ->with(
-                serviceType: ProviderOperation::Chat->value,
-                provider: 'openai',
-                metrics: ['tokens' => 150, 'cost' => 0.0012],
-                configurationUid: 7,
+                ProviderOperation::Chat->value,
+                'openai',
+                ['tokens' => 150, 'cost' => 0.0012],
+                7,
             );
 
         $response = new CompletionResponse(
@@ -170,7 +170,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             context: ProviderCallContext::for(ProviderOperation::Chat),
             configuration: $this->configuration(),
             terminal: static function (LlmConfiguration $c): never {
-                throw new RuntimeException('boom');
+                throw new RuntimeException('boom', 1504818594);
             },
         );
     }


### PR DESCRIPTION
## Description

Two independent DDEV fixes surfaced while reorganising the local layout.

**1. Apache vhost ordering (`48fb467`)**

`docs.nr-llm.ddev.site` and `v14.nr-llm.ddev.site` were falling back to the landing-page vhost because that vhost was declared first with a broad `ServerName` and the other hostnames were only `ServerAlias` entries on it. Apache picks the first matching vhost when names overlap, so the aliases never won.

- Move the docs vhost to the top of the file with an explicit `ServerName docs.nr-llm.ddev.site`.
- Give the v14 vhost its own `ServerName` (not just an alias).
- Leave the landing-page vhost last as the default fallback.

**2. Install `netresearch/nr-vault` from composer, not via bind-mount (`ba5d539`)**

`install-v13` / `install-v14` registered a composer path repository pointing at `/var/www/nr-vault`, which was a bind-mount of `~/projects/nr-vault` from the host. That turned a normal composer dependency into a local source link and silently required every contributor to have an `nr-vault` checkout in a specific relative location — otherwise DDEV startup failed or the install script wired composer up against a missing path.

- Drop the `nr-vault` bind-mount from `.ddev/docker-compose.web.yaml`.
- Drop the `composer config repositories.nr_vault path ...` line from both install scripts.
- Composer now installs `netresearch/nr-vault` from the registry per the version constraint already in `composer.json` (`^0.4.0 || ^0.5.0`).

For the rare case of debugging against a local `nr-vault` working copy, a short opt-in comment in each install script explains how to re-enable the link via a `.ddev/docker-compose.nrvault.yaml` override plus a manual path-repo config — no longer the default.

## Related Issue

n/a — local DDEV hygiene, no tracking ticket.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — docs/v14 vhost routing
- [x] Refactoring (no functional changes on the happy path) — nr-vault via composer

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run \`composer ci\` and all checks pass — DDEV-only changes; no PHP/JS touched.
- [ ] I have added tests that prove my fix/feature works — infrastructure/config, not covered by the test suite.
- [ ] I have updated the documentation accordingly — no docs reference the removed bind-mount.
- [x] My changes generate no new warnings

## Manual verification

- `ddev restart` succeeds with both changes applied.
- `curl -sk -o /dev/null -w "%{http_code}" https://nr-llm.ddev.site` → 200
- `curl -sk -o /dev/null -w "%{http_code}" https://docs.nr-llm.ddev.site` → 200
- `ddev exec ls /var/www/nr-vault` → no such file (bind-mount correctly gone)
- `v14.nr-llm.ddev.site` needs `ddev install-v14` to rebuild the v14 TYPO3 install, then will resolve via the new vhost order.