### PR TITLE
fix: address automated-assessment findings (branding, testsuite, Makefile)

### DIFF
--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -15,10 +15,10 @@
          requireCoverageMetadata="false"
 >
     <testsuites>
-        <testsuite name="Functional tests">
+        <testsuite name="functional">
             <directory>../Tests/Functional/</directory>
         </testsuite>
-        <testsuite name="E2E Backend tests">
+        <testsuite name="e2e-backend">
             <directory>../Tests/E2E/Backend/</directory>
         </testsuite>
     </testsuites>

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 RUNTESTS := Build/Scripts/runTests.sh
 
-.PHONY: help up start down restart install install-all sync seed seed-tasks ollama test test-unit test-integration test-functional test-fuzzy test-e2e coverage mutation cgl cgl-fix phpstan rector rector-fix docs clean ci ci-full
+.PHONY: help up start down restart install install-all sync seed seed-tasks ollama test test-unit test-integration test-func test-fuzzy test-e2e coverage mutation cgl cgl-fix phpstan rector rector-fix docs clean ci ci-full
 
 # Default target
 help:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 -include .Build/vendor/netresearch/typo3-ci-workflows/Makefile.include
 
+RUNTESTS := Build/Scripts/runTests.sh
+
 .PHONY: help up start down restart install install-all sync seed seed-tasks ollama test test-unit test-integration test-functional test-fuzzy test-e2e coverage mutation cgl cgl-fix phpstan rector rector-fix docs clean ci ci-full
 
 # Default target
@@ -94,47 +96,49 @@ ollama:
 	@echo "🤖 Ollama Status:"
 	@ddev ollama list || echo "   Model not yet pulled. Run: ddev ollama pull"
 
-# Testing targets
+# Testing targets (use runTests.sh Docker runner exclusively)
 test:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/phpunit -c Build/phpunit.xml --testsuite unit,integration,fuzzy"
+	$(RUNTESTS) -s unit
+	$(RUNTESTS) -s integration
+	$(RUNTESTS) -s fuzzy
 
 test-unit:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/phpunit -c Build/phpunit.xml --testsuite unit"
+	$(RUNTESTS) -s unit
 
 test-integration:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/phpunit -c Build/phpunit.xml --testsuite integration"
+	$(RUNTESTS) -s integration
 
 test-func:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/phpunit -c Build/FunctionalTests.xml"
+	$(RUNTESTS) -s functional
 
 test-fuzzy:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/phpunit -c Build/phpunit.xml --testsuite fuzzy"
+	$(RUNTESTS) -s fuzzy
 
 test-e2e:
-	cd Tests/E2E/Playwright && npm run test
+	$(RUNTESTS) -s e2e
 
 coverage:
-	ddev exec "cd /var/www/nr_llm && XDEBUG_MODE=coverage .Build/bin/phpunit -c Build/phpunit.xml --coverage-html .Build/coverage"
-	@echo "Coverage report: .Build/coverage/index.html"
+	$(RUNTESTS) -s unitCoverage
+	@echo "Coverage report: .Build/coverage/html-unit/index.html"
 
 mutation:
-	ddev exec "cd /var/www/nr_llm && .Build/bin/infection --configuration=infection.json.dist --threads=4 --show-mutations --no-progress"
+	$(RUNTESTS) -s mutation
 
 # Quality targets
 cgl: ## Check code style (dry-run)
-	composer ci:test:php:cgl
+	$(RUNTESTS) -s cgl -n
 
 cgl-fix: ## Fix code style
-	composer ci:cgl
+	$(RUNTESTS) -s cgl
 
 phpstan: ## Run PHPStan static analysis
-	composer ci:test:php:phpstan
+	$(RUNTESTS) -s phpstan
 
 rector: ## Run Rector dry-run
-	composer ci:test:php:rector
+	$(RUNTESTS) -s rector -n
 
 rector-fix:
-	composer rector
+	$(RUNTESTS) -s rector
 
 ci: cgl phpstan test-unit test-integration test-fuzzy
 	@echo "All CI checks passed"

--- a/Resources/Public/Icons/Extension.svg
+++ b/Resources/Public/Icons/Extension.svg
@@ -2,7 +2,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 300">
     <defs>
         <style>
-            .nr-frame{fill:#2999a4;}
+            .nr-frame{fill:#2F99A4;}
             .nr-letter{fill:#595a62;}
         </style>
     </defs>


### PR DESCRIPTION
## Summary

Fixes three verified findings from `/automated-assessment`:

- **NB-02** (error): `Resources/Public/Icons/Extension.svg` used `#2999a4` (typo — middle digit `9`) instead of the official Netresearch brand teal `#2F99A4`.
- **TT-05** (error): `Build/FunctionalTests.xml` testsuites were named `"Functional tests"` / `"E2E Backend tests"`. Renamed to conventional lowercase keys `functional` / `e2e-backend` — matches `runTests.sh -s functional` and the typo3-testing skill's expected pattern.
- **TT-58** (error): `Makefile` test/quality targets invoked `ddev exec "... phpunit ..."` directly. Rewired all targets to use `Build/Scripts/runTests.sh -s <suite>` — honours the project AGENTS.md rule "ALWAYS use `Build/Scripts/runTests.sh`, never phpunit directly" and gives consistent PHP-version / Xdebug behaviour.

## Not in this PR (deliberate)

- **TT-71** (captainhook at root): `composer.json` sets `extra.captainhook.config: Build/captainhook.json` — this is the official captainhook-plugin pattern and works correctly. The skill checkpoint is being updated upstream to honour this config path.
- **ER-01/02, ER-19/20/21** (missing `.github/workflows/security.yml`, `codeql.yml`, `scorecard.yml`, `dependency-review.yml`): these are all already wired as jobs inside `.github/workflows/ci.yml` calling the netresearch org reusable workflows. The enterprise-readiness skill is being updated upstream to detect reusable-workflow job calls.
- **GH-24** (`pull_request_target` trigger): the upstream `netresearch/.github/.github/workflows/auto-merge-deps.yml` explicitly uses `pull_request:` + `workflow_call:`. The github-project skill checkpoint is being updated upstream.
- Glob/parser false-positives (PM-07/08, TT-135, DC-01) — tracked in separate skill-runner PRs.

## Test plan

- [ ] CI green on this PR
- [ ] `make test-unit` / `make phpstan` / `make cgl` still work locally (now via runTests.sh)
- [ ] Extension icon renders correctly with fixed brand color in TYPO3 backend