### PR TITLE
fix(template): migrate Bootstrap 4 form-group → Bootstrap 5 mb-3 (TC-130)

### DIFF
--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -20,7 +20,7 @@
                     </div>
                     <div class="card-body">
                         <form id="testForm">
-                            <div class="form-group">
+                            <div class="mb-3">
                                 <label for="provider">Provider</label>
                                 <select id="provider" name="provider" class="form-control">
                                     <f:for each="{providers}" as="provider">
@@ -29,7 +29,7 @@
                                 </select>
                             </div>
 
-                            <div class="form-group mt-3">
+                            <div class="mb-3">
                                 <label for="prompt">Prompt</label>
                                 <textarea id="prompt" name="prompt" class="form-control" rows="4">Hello, please respond with a brief greeting to test the connection.</textarea>
                             </div>

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -21,8 +21,8 @@
                     <div class="card-body">
                         <form id="testForm">
                             <div class="mb-3">
-                                <label for="provider">Provider</label>
-                                <select id="provider" name="provider" class="form-control">
+                                <label for="provider" class="form-label">Provider</label>
+                                <select id="provider" name="provider" class="form-select">
                                     <f:for each="{providers}" as="provider">
                                         <option value="{provider.identifier}">{provider.name}</option>
                                     </f:for>
@@ -30,7 +30,7 @@
                             </div>
 
                             <div class="mb-3">
-                                <label for="prompt">Prompt</label>
+                                <label for="prompt" class="form-label">Prompt</label>
                                 <textarea id="prompt" name="prompt" class="form-control" rows="4">Hello, please respond with a brief greeting to test the connection.</textarea>
                             </div>
 
@@ -88,7 +88,7 @@
 
                         <div id="loadingIndicator" style="display: none;">
                             <div class="spinner-border text-primary" role="status">
-                                <span class="sr-only">Loading...</span>
+                                <span class="visually-hidden">Loading...</span>
                             </div>
                             <span class="ms-2">Sending request...</span>
                         </div>


### PR DESCRIPTION
## Summary

Follow-on to PR #147. After typo3-conformance-skill PR #56 unblocked the previously-silent TC-100 / TC-130 anti-pattern checks (\`type: not_regex\` was being silently skipped because the runner only recognises \`type: regex_not\`), TC-130 surfaced two remaining Bootstrap 4 \`form-group\` usages in \`Backend/Test.html\`.

\`form-group\` was Bootstrap 4's wrapper utility with built-in margin. Bootstrap 5 dropped the class — replace with the equivalent margin utility \`mb-3\` to match BS5 conventions.

## Out of scope

- **TC-100** (TCA \`'eval' => 'trim'\` → \`'trim' => true\` column option) — deferred to a separate migration PR. Touches TCA which warrants careful testing across the v13/v14 matrix.

## Test plan

- [ ] CI green
- [x] Visual: backend Test page renders with correct spacing under Bootstrap 5