### PR TITLE
feat(provider): route direct LlmServiceManager methods through pipeline (ADR-026 FU-5)

### DIFF
--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -152,10 +152,13 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new ChatOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
 
-        return $provider->chatCompletion($messages, $optionsArray);
+        return $this->runThroughPipeline(
+            $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
+            ProviderOperation::Chat,
+            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($messages, $optionsArray),
+        );
     }
 
     /**
@@ -166,10 +169,13 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new ChatOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
 
-        return $provider->complete($prompt, $optionsArray);
+        return $this->runThroughPipeline(
+            $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
+            ProviderOperation::Completion,
+            fn(): CompletionResponse => $this->getProvider($providerKey)->complete($prompt, $optionsArray),
+        );
     }
 
     /**
@@ -182,17 +188,23 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new EmbeddingOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
 
-        if (!$provider->supportsFeature('embeddings')) {
-            throw new UnsupportedFeatureException(
-                sprintf('Provider "%s" does not support embeddings', $provider->getIdentifier()),
-                8701213030,
-            );
-        }
+        return $this->runThroughPipeline(
+            $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
+            ProviderOperation::Embedding,
+            function () use ($input, $optionsArray, $providerKey): EmbeddingResponse {
+                $provider = $this->getProvider($providerKey);
+                if (!$provider->supportsFeature('embeddings')) {
+                    throw new UnsupportedFeatureException(
+                        sprintf('Provider "%s" does not support embeddings', $provider->getIdentifier()),
+                        8701213030,
+                    );
+                }
 
-        return $provider->embeddings($input, $optionsArray);
+                return $provider->embeddings($input, $optionsArray);
+            },
+        );
     }
 
     /**
@@ -205,17 +217,23 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new VisionOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
 
-        if (!$provider instanceof VisionCapableInterface) {
-            throw new UnsupportedFeatureException(
-                sprintf('Provider "%s" does not support vision', $provider->getIdentifier()),
-                5549344501,
-            );
-        }
+        return $this->runThroughPipeline(
+            $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
+            ProviderOperation::Vision,
+            function () use ($content, $optionsArray, $providerKey): VisionResponse {
+                $provider = $this->getProvider($providerKey);
+                if (!$provider instanceof VisionCapableInterface) {
+                    throw new UnsupportedFeatureException(
+                        sprintf('Provider "%s" does not support vision', $provider->getIdentifier()),
+                        5549344501,
+                    );
+                }
 
-        return $provider->analyzeImage($content, $optionsArray);
+                return $provider->analyzeImage($content, $optionsArray);
+            },
+        );
     }
 
     /**
@@ -254,17 +272,23 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new ToolOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
 
-        if (!$provider instanceof ToolCapableInterface) {
-            throw new UnsupportedFeatureException(
-                sprintf('Provider "%s" does not support tool calling', $provider->getIdentifier()),
-                9324699785,
-            );
-        }
+        return $this->runThroughPipeline(
+            $this->synthesizeTransientConfiguration(ProviderOperation::Tools, $providerKey),
+            ProviderOperation::Tools,
+            function () use ($messages, $tools, $optionsArray, $providerKey): CompletionResponse {
+                $provider = $this->getProvider($providerKey);
+                if (!$provider instanceof ToolCapableInterface) {
+                    throw new UnsupportedFeatureException(
+                        sprintf('Provider "%s" does not support tool calling', $provider->getIdentifier()),
+                        9324699785,
+                    );
+                }
 
-        return $provider->chatCompletionWithTools($messages, $tools, $optionsArray);
+                return $provider->chatCompletionWithTools($messages, $tools, $optionsArray);
+            },
+        );
     }
 
     /**
@@ -403,6 +427,37 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             $configuration,
             $terminal,
         );
+    }
+
+    /**
+     * Build a transient LlmConfiguration for direct (ad-hoc) provider calls.
+     *
+     * Direct API methods — `chat()`, `complete()`, `embed()`, `vision()`,
+     * `chatWithTools()` — do not carry an LlmConfiguration entity, but the
+     * pipeline's interface requires one. The synthesized instance is
+     * unpersisted (no uid, never written), carries an empty fallback chain
+     * (so FallbackMiddleware passes through) and has a human-readable
+     * identifier so log / trace labels can distinguish ad-hoc traffic from
+     * configuration-backed calls.
+     *
+     * Middleware that needs more context (beUserUid for BudgetMiddleware,
+     * cache keys for CacheMiddleware, etc.) reads it from the
+     * ProviderCallContext metadata — not from the configuration.
+     */
+    private function synthesizeTransientConfiguration(
+        ProviderOperation $operation,
+        ?string $providerKey,
+    ): LlmConfiguration {
+        $identifier = sprintf(
+            'ad-hoc:%s:%s',
+            $operation->value,
+            $providerKey ?? ($this->defaultProvider ?? 'default'),
+        );
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier($identifier);
+
+        return $configuration;
     }
 
     /**

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -6,7 +6,7 @@
 ADR-026: Provider Middleware Pipeline
 ==========================================
 
-:Status: Proposed
+:Status: Accepted
 :Date: 2026-04
 :Authors: Netresearch DTT GmbH
 
@@ -139,12 +139,56 @@ the test matrix keeps green end-to-end:
 4. **CacheMiddleware** — opt-in per operation via
    :php:`ProviderOperation`. Embedding lookups start going through it;
    the branch currently inside :php:`EmbeddingService` comes out.
-5. **Feature-service wiring** — every :php:`Service/Feature/*` builds
-   its terminal callable and invokes the pipeline, inheriting every
-   middleware registered above without writing any glue.
+5. **Direct-method wiring (centralised)** — every direct API method on
+   :php:`LlmServiceManager` (``chat``, ``complete``, ``embed``,
+   ``vision``, ``chatWithTools``) builds its terminal callable and
+   invokes the pipeline via a synthesised transient
+   :php:`LlmConfiguration`. Because every feature service
+   (:php:`CompletionService`, :php:`EmbeddingService`,
+   :php:`TranslationService`, :php:`VisionService`) delegates to these
+   methods, feature-service traffic inherits the full middleware stack
+   without each service owning its own pipeline glue.
+
+   The transient configuration is unpersisted (no uid), carries an
+   empty fallback chain (so :php:`FallbackMiddleware` passes through
+   verbatim), and uses a human-readable ``ad-hoc:<operation>:<provider>``
+   identifier so log / trace labels distinguish direct traffic from
+   configuration-backed calls. Middleware that needs more context
+   (``beUserUid`` for :php:`BudgetMiddleware`, cache keys for
+   :php:`CacheMiddleware`) reads it from the
+   :php:`ProviderCallContext` metadata, not from the configuration.
+
+   Streaming (:php:`streamChat` / :php:`streamChatWithConfiguration`)
+   deliberately stays out of the pipeline per the ADR's original scope:
+   once the first chunk has been emitted, we cannot swap providers
+   mid-stream, and most middleware assume a single terminal result.
+
+   **Why the centralised form rather than "every feature service owns
+   glue":** the ADR's problem statement explicitly identifies direct
+   calls as the bug ("``chat()``, ``complete()``, ``embed()``,
+   ``vision()`` — bypass [the fallback executor] entirely, which
+   silently splits retry semantics"). Wiring feature services only
+   would have left direct :php:`LlmServiceManager` callers still
+   bypassing the pipeline. Centralising on :php:`LlmServiceManager`
+   fixes both in one step and keeps feature services free of pipeline
+   concerns.
 
 Each follow-up is scoped to a single concern and keeps the codebase
 shippable after every step.
+
+Remaining cleanup
+-----------------
+
+:php:`EmbeddingService::embedFull()` still contains an inline cache
+branch from before the middleware landed. The branch is harmless —
+:php:`CacheMiddleware` is opt-in via :php:`ProviderCallContext`
+metadata keys, and the direct-call pipeline does not currently set
+them — but it is dead duplication. Removing it requires (a) adding
+``toArray()`` / ``fromArray()`` helpers to the typed response objects
+so :php:`CacheMiddleware` (which persists ``array<string, mixed>``)
+can store / restore them, and (b) plumbing the cache key from
+:php:`EmbeddingOptions` through :php:`LlmServiceManager::embed()` onto
+the context metadata. Tracked separately; does not block this step.
 
 .. _adr-026-alternatives:
 

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -828,7 +828,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
      * and (optionally) a non-default TestableProvider. Separate setup from the
      * default subject so ad-hoc tests can inspect a specific middleware stack.
      *
-     * @param list<\Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface> $middleware
+     * @param list<ProviderMiddlewareInterface> $middleware
      */
     private function buildManagerWithMiddleware(
         array $middleware,

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -26,6 +26,9 @@ use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -744,6 +747,150 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         foreach ($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config) as $chunk) {
             // Should throw before yielding
         }
+    }
+
+    // ====================================================================
+    // Middleware pipeline wiring for direct (ad-hoc) calls — ADR-026 FU-5
+    // ====================================================================
+
+    #[Test]
+    public function directChatRoutesThroughMiddlewarePipeline(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertCount(1, $spy->calls);
+        self::assertSame(ProviderOperation::Chat, $spy->calls[0]['operation']);
+        self::assertTrue($spy->calls[0]['fallbackChainEmpty'], 'Ad-hoc call has empty fallback chain');
+        self::assertNull($spy->calls[0]['uid'], 'Synthesized configuration is unpersisted (uid = null)');
+        self::assertStringStartsWith('ad-hoc:chat:', $spy->calls[0]['identifier']);
+    }
+
+    #[Test]
+    public function directCompleteRoutesThroughMiddlewarePipeline(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->complete('prompt');
+
+        self::assertCount(1, $spy->calls);
+        self::assertSame(ProviderOperation::Completion, $spy->calls[0]['operation']);
+    }
+
+    #[Test]
+    public function directEmbedRoutesThroughMiddlewarePipeline(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->embed('text');
+
+        self::assertCount(1, $spy->calls);
+        self::assertSame(ProviderOperation::Embedding, $spy->calls[0]['operation']);
+    }
+
+    #[Test]
+    public function directVisionRoutesThroughMiddlewarePipeline(): void
+    {
+        $spy      = new RecordingMiddleware();
+        $provider = new TestableVisionProvider();
+        $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
+
+        $manager->vision([
+            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.test/i.png']],
+        ]);
+
+        self::assertCount(1, $spy->calls);
+        self::assertSame(ProviderOperation::Vision, $spy->calls[0]['operation']);
+    }
+
+    #[Test]
+    public function directChatWithToolsRoutesThroughMiddlewarePipeline(): void
+    {
+        $spy      = new RecordingMiddleware();
+        $provider = new TestableToolProvider();
+        $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
+
+        $manager->chatWithTools(
+            [['role' => 'user', 'content' => 'hi']],
+            [['type' => 'function', 'function' => ['name' => 'noop', 'description' => '', 'parameters' => []]]],
+        );
+
+        self::assertCount(1, $spy->calls);
+        self::assertSame(ProviderOperation::Tools, $spy->calls[0]['operation']);
+    }
+
+    /**
+     * Build a fresh LlmServiceManager pre-configured with the given middleware
+     * and (optionally) a non-default TestableProvider. Separate setup from the
+     * default subject so ad-hoc tests can inspect a specific middleware stack.
+     *
+     * @param list<\Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface> $middleware
+     */
+    private function buildManagerWithMiddleware(
+        array $middleware,
+        ?TestableProvider $provider = null,
+    ): LlmServiceManager {
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            new MiddlewarePipeline($middleware),
+        );
+        $testProvider = $provider ?? new TestableProvider();
+        $testProvider->setNextResponse(new CompletionResponse(
+            content: 'stub',
+            model: 'stub',
+            usage: new UsageStatistics(1, 1, 2),
+            finishReason: 'stop',
+            provider: $testProvider->getIdentifier(),
+        ));
+        $testProvider->setNextEmbeddingResponse(new EmbeddingResponse(
+            embeddings: [[0.1, 0.2]],
+            model: 'stub',
+            usage: new UsageStatistics(1, 0, 1),
+            provider: $testProvider->getIdentifier(),
+        ));
+        if ($testProvider instanceof TestableVisionProvider) {
+            $testProvider->setNextVisionResponse(new VisionResponse(
+                description: 'stub',
+                model: 'stub',
+                usage: new UsageStatistics(1, 1, 2),
+                provider: $testProvider->getIdentifier(),
+            ));
+        }
+        $manager->registerProvider($testProvider);
+        $manager->setDefaultProvider($testProvider->getIdentifier());
+
+        return $manager;
+    }
+}
+
+/**
+ * Middleware that captures every invocation's configuration + operation for
+ * assertions without wrapping or transforming behaviour.
+ */
+final class RecordingMiddleware implements ProviderMiddlewareInterface
+{
+    /** @var list<array{operation: ProviderOperation, identifier: string, fallbackChainEmpty: bool, uid: ?int}> */
+    public array $calls = [];
+
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $this->calls[] = [
+            'operation'          => $context->operation,
+            'identifier'         => $configuration->getIdentifier(),
+            'fallbackChainEmpty' => $configuration->getFallbackChainDTO()->isEmpty(),
+            'uid'                => $configuration->getUid(),
+        ];
+
+        return $next($configuration);
     }
 }
 


### PR DESCRIPTION
Closes the final follow-up from [ADR-026](Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst).

## Problem

Before this PR:

- `chat()`, `complete()`, `embed()`, `vision()`, `chatWithTools()` on `LlmServiceManager` went straight to the provider, **bypassing every middleware** in the pipeline.
- Feature services (`CompletionService`, `EmbeddingService`, `TranslationService`, `VisionService`) delegate to those direct methods, so **no feature-service traffic inherited** fallback, budget, usage, or cache middleware.

Exactly the "silently splits retry semantics" problem ADR-026 called out in its problem statement.

## Fix

Each direct method synthesises a transient **unpersisted** `LlmConfiguration` (empty fallback chain, null uid, `ad-hoc:<operation>:<provider>` identifier) and calls `runThroughPipeline()`.

Feature services are **untouched** — they inherit the pipeline transparently via the existing `$llmManager->chat/embed/vision()` call sites. No test rewrites in the feature-service layer.

## Middleware behaviour on ad-hoc calls

| Middleware | Behaviour |
|---|---|
| `FallbackMiddleware` | Early-returns on empty chain (unchanged path) |
| `BudgetMiddleware` | Skips when no `beUserUid` metadata is set |
| `UsageMiddleware` | Records with `configurationUid=null` (existing `$uid > 0` guard handles this) |
| `CacheMiddleware` | No-op unless caller sets cache metadata |

`streamChat` / `streamChatWithConfiguration` remain intentionally outside the pipeline — once chunks have been yielded, providers cannot be swapped mid-stream and most middleware assume a single terminal result.

## Why centralised on `LlmServiceManager` rather than per-feature-service

The ADR originally said "every Service/Feature/\* builds its terminal callable." Wiring only feature services would have left direct `LlmServiceManager` callers still bypassing the pipeline — the exact bug the ADR identified. Centralising on `LlmServiceManager` fixes both in one step and keeps feature services free of pipeline concerns. ADR-026 FU-5 has been rewritten to describe the shipped architecture.

## Tests

`LlmServiceManagerTest` gets 5 new cases using a `RecordingMiddleware` spy:

- `directChatRoutesThroughMiddlewarePipeline` — verifies `ProviderOperation::Chat`, empty fallback chain, null uid, `ad-hoc:chat:` identifier prefix
- `directCompleteRoutesThroughMiddlewarePipeline`
- `directEmbedRoutesThroughMiddlewarePipeline`
- `directVisionRoutesThroughMiddlewarePipeline`
- `directChatWithToolsRoutesThroughMiddlewarePipeline`

## Verification

```
✓ PHPStan level 10 (337 files, 0 errors)
✓ Unit tests (3141 tests, 6780 assertions, 0 failures)
```

## ADR-026

- Status flipped **Proposed → Accepted**
- FU-5 rewritten to describe the centralised `LlmServiceManager` approach actually shipped
- **Remaining cleanup** section added: the inline cache branch inside `EmbeddingService::embedFull()` is harmless duplication for now (`CacheMiddleware` is opt-in via metadata) but should come out once typed responses grow `toArray/fromArray` helpers and `LlmServiceManager::embed()` plumbs cache keys onto the context. Out of scope here — separate PR.

## Signed-off-by

Sebastian Mendel <sebastian.mendel@netresearch.de>