### PR TITLE
feat(embedding): move cache into CacheMiddleware (ADR-026 cleanup)

### DIFF
--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -30,6 +30,53 @@ final readonly class EmbeddingResponse
     ) {}
 
     /**
+     * Serialize to an array shape suitable for cache storage.
+     *
+     * Paired with `fromArray()` so `CacheMiddleware` (which stores
+     * `array<string, mixed>`) can round-trip an `EmbeddingResponse`
+     * through a TYPO3 cache frontend without a per-type codec.
+     *
+     * @return array{embeddings: array<int, array<int, float>>, model: string, usage: array{promptTokens: int, completionTokens: int, totalTokens: int, estimatedCost: ?float}, provider: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'embeddings' => $this->embeddings,
+            'model'      => $this->model,
+            'usage'      => $this->usage->toArray(),
+            'provider'   => $this->provider,
+        ];
+    }
+
+    /**
+     * Restore from a previously serialized array shape. Missing fields fall
+     * back to safe empty defaults so cached payloads from an older shape still
+     * load.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $embeddings = $data['embeddings'] ?? [];
+        if (!\is_array($embeddings)) {
+            $embeddings = [];
+        }
+
+        /** @var array<int, array<int, float>> $embeddings */
+        $usageData = $data['usage'] ?? [];
+        if (!\is_array($usageData)) {
+            $usageData = [];
+        }
+
+        return new self(
+            embeddings: $embeddings,
+            model: \is_string($data['model'] ?? null) ? $data['model'] : '',
+            usage: UsageStatistics::fromArray($usageData),
+            provider: \is_string($data['provider'] ?? null) ? $data['provider'] : '',
+        );
+    }
+
+    /**
      * Get the first embedding vector (for single input).
      *
      * @return array<int, float>

--- a/Classes/Domain/Model/UsageStatistics.php
+++ b/Classes/Domain/Model/UsageStatistics.php
@@ -52,4 +52,39 @@ final readonly class UsageStatistics
             $estimatedCost,
         );
     }
+
+    /**
+     * Serialize to an array shape suitable for cache storage.
+     *
+     * @return array{promptTokens: int, completionTokens: int, totalTokens: int, estimatedCost: ?float}
+     */
+    public function toArray(): array
+    {
+        return [
+            'promptTokens'     => $this->promptTokens,
+            'completionTokens' => $this->completionTokens,
+            'totalTokens'      => $this->totalTokens,
+            'estimatedCost'    => $this->estimatedCost,
+        ];
+    }
+
+    /**
+     * Restore from a previously serialized array shape.
+     *
+     * Fields default to 0 / null when absent so cached payloads from older
+     * versions (before estimatedCost was added, for example) still load.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $estimatedCost = $data['estimatedCost'] ?? null;
+
+        return new self(
+            promptTokens: \is_int($data['promptTokens'] ?? null) ? $data['promptTokens'] : 0,
+            completionTokens: \is_int($data['completionTokens'] ?? null) ? $data['completionTokens'] : 0,
+            totalTokens: \is_int($data['totalTokens'] ?? null) ? $data['totalTokens'] : 0,
+            estimatedCost: \is_float($estimatedCost) || \is_int($estimatedCost) ? (float)$estimatedCost : null,
+        );
+    }
 }

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 
@@ -23,15 +24,17 @@ use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
  * BudgetService aggregates from, so the two stay consistent without a
  * second source of truth.
  *
- * Recognised response types:
- *  - CompletionResponse
- *  - EmbeddingResponse
- *  - VisionResponse
+ * Recognised response shapes:
+ *  - CompletionResponse / EmbeddingResponse / VisionResponse (typed path)
+ *  - `array{usage: array, provider: string, ...}` (array payload emitted by
+ *    feature services that opt in to CacheMiddleware — CacheMiddleware
+ *    stores `array<string, mixed>`, so the terminal is wrapped with a
+ *    `$response->toArray()` codec. UsageMiddleware sees the array on both
+ *    cache-hit and cache-miss paths and records consistently either way.)
  *
- * All three carry a typed UsageStatistics + provider identifier. Any
- * other return value (streaming Generator, translation result, raw
- * string, plain array) is silently skipped — there is nothing reliable
- * to record for those shapes from this position in the pipeline.
+ * Streaming Generator, translation result, raw string, plain array without
+ * `usage` / `provider` — silently skipped. Nothing reliable to record for
+ * those shapes from this position in the pipeline.
  *
  * Pipeline ordering recommendation:
  *
@@ -76,15 +79,10 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         LlmConfiguration $configuration,
         mixed $result,
     ): void {
-        if (
-            !$result instanceof CompletionResponse
-            && !$result instanceof EmbeddingResponse
-            && !$result instanceof VisionResponse
-        ) {
+        [$usage, $provider] = $this->extractUsage($result);
+        if ($usage === null) {
             return;
         }
-
-        $usage = $result->usage;
 
         /** @var array{tokens?: int, cost?: float} $metrics */
         $metrics = [
@@ -94,16 +92,51 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             $metrics['cost'] = $usage->estimatedCost;
         }
 
-        $provider = $result->provider !== '' ? $result->provider : 'unknown';
-
         $configUid = $configuration->getUid();
         $uid       = ($configUid !== null && $configUid > 0) ? $configUid : null;
 
         $this->usageTracker->trackUsage(
             serviceType: $context->operation->value,
-            provider: $provider,
+            provider: $provider !== '' ? $provider : 'unknown',
             metrics: $metrics,
             configurationUid: $uid,
         );
+    }
+
+    /**
+     * Extract `(usage, provider)` from whatever the terminal returned.
+     *
+     * Typed responses (common path) expose both fields directly. Array
+     * payloads (CacheMiddleware codec shape) carry the same information
+     * under `usage` / `provider` keys — the middleware reconstructs a
+     * `UsageStatistics` from those so recording happens identically on
+     * both paths. Unrecognised shapes return `[null, '']` so the
+     * middleware silently skips.
+     *
+     * @return array{0: ?UsageStatistics, 1: string}
+     */
+    private function extractUsage(mixed $result): array
+    {
+        if (
+            $result instanceof CompletionResponse
+            || $result instanceof EmbeddingResponse
+            || $result instanceof VisionResponse
+        ) {
+            return [$result->usage, $result->provider];
+        }
+
+        if (
+            \is_array($result)
+            && isset($result['usage'], $result['provider'])
+            && \is_array($result['usage'])
+            && \is_string($result['provider'])
+        ) {
+            /** @var array<string, mixed> $usageData */
+            $usageData = $result['usage'];
+
+            return [UsageStatistics::fromArray($usageData), $result['provider']];
+        }
+
+        return [null, ''];
     }
 }

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -10,31 +10,25 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
-use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
-use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 
 /**
  * High-level service for text embeddings and similarity calculations.
  *
- * Provides text-to-vector conversion with caching and
- * similarity calculation utilities.
+ * Caching is handled transparently by `CacheMiddleware` inside
+ * `LlmServiceManager::embed()` — this service only owns the vector-math
+ * utilities (cosine similarity, normalisation, top-k) and input validation.
  */
 class EmbeddingService
 {
-    private const DEFAULT_CACHE_TTL = 86400; // 24 hours (embeddings are deterministic)
-
     public function __construct(
         private readonly LlmServiceManagerInterface $llmManager,
-        private readonly CacheManagerInterface $cacheManager,
     ) {}
 
     /**
      * Generate embedding vector for text.
-     *
-     * Embeddings are deterministic and aggressively cached.
      *
      * @param string $text Text to embed
      *
@@ -42,8 +36,7 @@ class EmbeddingService
      */
     public function embed(string $text, ?EmbeddingOptions $options = null): array
     {
-        $response = $this->embedFull($text, $options);
-        return $response->getVector();
+        return $this->embedFull($text, $options)->getVector();
     }
 
     /**
@@ -53,54 +46,11 @@ class EmbeddingService
      */
     public function embedFull(string $text, ?EmbeddingOptions $options = null): EmbeddingResponse
     {
-        $options ??= new EmbeddingOptions();
-        $optionsArray = $options->toArray();
-
-        if (empty($text)) {
+        if ($text === '') {
             throw new InvalidArgumentException('Text cannot be empty', 6048498820);
         }
 
-        $model = is_string($optionsArray['model'] ?? null) ? $optionsArray['model'] : 'default';
-        $provider = is_string($optionsArray['provider'] ?? null) ? $optionsArray['provider'] : 'openai';
-        $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : self::DEFAULT_CACHE_TTL;
-
-        // Check cache
-        $cached = $this->cacheManager->getCachedEmbeddings($provider, $text, $optionsArray);
-        if ($cached !== null) {
-            /** @var array{embeddings: array<int, array<int, float>>, model: string, usage?: array{promptTokens?: int, totalTokens?: int}} $cached */
-            $usageData = $cached['usage'] ?? [];
-            return new EmbeddingResponse(
-                embeddings: $cached['embeddings'],
-                model: $cached['model'],
-                usage: new UsageStatistics(
-                    promptTokens: $usageData['promptTokens'] ?? 0,
-                    completionTokens: 0,
-                    totalTokens: $usageData['totalTokens'] ?? 0,
-                ),
-                provider: $provider,
-            );
-        }
-
-        // Execute embedding request
-        $response = $this->llmManager->embed($text, $options);
-
-        // Cache the result
-        $this->cacheManager->cacheEmbeddings(
-            $provider,
-            $text,
-            $optionsArray,
-            [
-                'embeddings' => $response->embeddings,
-                'model' => $response->model,
-                'usage' => [
-                    'promptTokens' => $response->usage->promptTokens,
-                    'totalTokens' => $response->usage->totalTokens,
-                ],
-            ],
-            $cacheTtl,
-        );
-
-        return $response;
+        return $this->llmManager->embed($text, $options);
     }
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -22,6 +22,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -49,6 +50,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         private readonly LoggerInterface $logger,
         private readonly ProviderAdapterRegistry $adapterRegistry,
         private readonly MiddlewarePipeline $pipeline,
+        private readonly CacheManagerInterface $cacheManager,
     ) {
         $this->loadConfiguration();
     }
@@ -190,10 +192,36 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
-        return $this->runThroughPipeline(
+        // Cache metadata: CacheMiddleware short-circuits when it sees a key.
+        // Callers pass cache_ttl: 0 (via EmbeddingOptions::noCache()) to
+        // disable caching for ephemeral content — we honour that by leaving
+        // the key out of metadata so the middleware becomes a no-op for
+        // this call.
+        $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
+        $metadata = [];
+        if ($cacheTtl > 0) {
+            $resolvedProvider = $providerKey ?? $this->defaultProvider ?? 'default';
+            $metadata = [
+                CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
+                    $resolvedProvider,
+                    'embeddings',
+                    ['input' => $input, 'options' => $optionsArray],
+                ),
+                CacheMiddleware::METADATA_CACHE_TTL  => $cacheTtl,
+                CacheMiddleware::METADATA_CACHE_TAGS => [
+                    'nrllm_embeddings',
+                    'nrllm_provider_' . $resolvedProvider,
+                ],
+            ];
+        }
+
+        // Terminal returns an array-shaped payload so CacheMiddleware (which
+        // persists `array<string, mixed>`) can round-trip through the TYPO3
+        // cache frontend. The typed response is reconstructed at this layer.
+        $raw = $this->pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Embedding, $metadata),
             $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
-            ProviderOperation::Embedding,
-            function () use ($input, $optionsArray, $providerKey): EmbeddingResponse {
+            function () use ($input, $optionsArray, $providerKey): array {
                 $provider = $this->getProvider($providerKey);
                 if (!$provider->supportsFeature('embeddings')) {
                     throw new UnsupportedFeatureException(
@@ -202,9 +230,18 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->embeddings($input, $optionsArray);
+                return $provider->embeddings($input, $optionsArray)->toArray();
             },
         );
+
+        if (!is_array($raw)) {
+            throw new ProviderException(
+                'Embedding pipeline returned non-array payload — expected array<string, mixed>',
+                2746395810,
+            );
+        }
+
+        return EmbeddingResponse::fromArray($raw);
     }
 
     /**

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -176,19 +176,35 @@ the test matrix keeps green end-to-end:
 Each follow-up is scoped to a single concern and keeps the codebase
 shippable after every step.
 
-Remaining cleanup
------------------
+Embedding cache migration — done
+--------------------------------
 
-:php:`EmbeddingService::embedFull()` still contains an inline cache
-branch from before the middleware landed. The branch is harmless —
-:php:`CacheMiddleware` is opt-in via :php:`ProviderCallContext`
-metadata keys, and the direct-call pipeline does not currently set
-them — but it is dead duplication. Removing it requires (a) adding
-``toArray()`` / ``fromArray()`` helpers to the typed response objects
-so :php:`CacheMiddleware` (which persists ``array<string, mixed>``)
-can store / restore them, and (b) plumbing the cache key from
-:php:`EmbeddingOptions` through :php:`LlmServiceManager::embed()` onto
-the context metadata. Tracked separately; does not block this step.
+The inline cache branch that used to live in :php:`EmbeddingService::embedFull()`
+has been moved behind :php:`CacheMiddleware`:
+
+* :php:`EmbeddingResponse` and :php:`UsageStatistics` grew ``toArray()``
+  / ``fromArray()`` helpers so the typed response can round-trip through
+  :php:`CacheMiddleware` (which persists ``array<string, mixed>`` via
+  the TYPO3 cache frontend).
+* :php:`LlmServiceManager::embed()` derives a stable cache key via
+  :php:`CacheManagerInterface::generateCacheKey()` (same hash shape the
+  old inline branch produced, so existing cache entries stay valid) and
+  places it on the :php:`ProviderCallContext` metadata under
+  :php:`CacheMiddleware::METADATA_CACHE_KEY`. ``cache_ttl == 0``
+  (:php:`EmbeddingOptions::noCache()`) omits the key so the middleware
+  is a no-op — consistent with the old ``cacheTtl`` semantics.
+* The terminal now returns ``$response->toArray()``; the manager
+  reconstructs the typed :php:`EmbeddingResponse` via
+  :php:`EmbeddingResponse::fromArray` before returning to the caller.
+  Public method signature is unchanged.
+* :php:`UsageMiddleware` learned to also recognise the array-payload
+  shape (``['usage' => [...], 'provider' => '...']``) so usage
+  accounting stays consistent whether the pipeline produced a typed
+  response (other operations) or an array (embeddings via
+  :php:`CacheMiddleware`).
+* :php:`EmbeddingService` no longer depends on
+  :php:`CacheManagerInterface`; it is a pure vector-math façade on top
+  of :php:`LlmServiceManager::embed()`.
 
 .. _adr-026-alternatives:
 

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -60,7 +61,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -108,7 +109,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -154,7 +155,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
@@ -211,7 +212,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
@@ -265,7 +266,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -311,7 +312,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -374,7 +375,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($openAiProvider);
         $serviceManager->registerProvider($claudeProvider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -55,7 +55,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -66,7 +66,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
         $cacheManager->method('cacheEmbeddings')->willReturn('cache-key');
 
-        $embeddingService = new EmbeddingService($serviceManager, $cacheManager);
+        $embeddingService = new EmbeddingService($serviceManager);
 
         // Act
         $result = $embeddingService->embedFull('Test text for embedding');
@@ -89,7 +89,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         // Mock cache manager returning cached embeddings with full structure
         $cachedData = [
@@ -107,7 +107,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $cacheManager->method('getCachedEmbeddings')
             ->willReturn($cachedData);
 
-        $embeddingService = new EmbeddingService($serviceManager, $cacheManager);
+        $embeddingService = new EmbeddingService($serviceManager);
 
         // Act - Should hit cache, not make HTTP request
         $result = $embeddingService->embedFull('Cached text');
@@ -173,7 +173,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -183,7 +183,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
         $cacheManager->method('cacheEmbeddings')->willReturn('cache-key');
 
-        $embeddingService = new EmbeddingService($serviceManager, $cacheManager);
+        $embeddingService = new EmbeddingService($serviceManager);
 
         // Act: Batch embedding
         $result = $embeddingService->embedBatch([
@@ -240,7 +240,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]));
+        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -250,7 +250,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
         $cacheManager->method('cacheEmbeddings')->willReturn('cache-key');
 
-        $embeddingService = new EmbeddingService($serviceManager, $cacheManager);
+        $embeddingService = new EmbeddingService($serviceManager);
 
         // Act: Get embedding vectors (not full responses)
         $vector1 = $embeddingService->embed('Hello world');

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Tests\Integration\AbstractIntegrationTestCase;
@@ -67,6 +68,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
             new NullLogger(),
             $this->adapterRegistryStub,
             new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
         );
     }
 
@@ -258,7 +260,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
             'providers' => [],
         ]);
 
-        $manager = new LlmServiceManager($configMock, new NullLogger(), $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($configMock, new NullLogger(), $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('No provider specified and no default provider configured');

--- a/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
@@ -12,7 +12,6 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
-use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
@@ -50,8 +49,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarReturnsEmptyArrayForEmptyCandidates(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $result = $service->findMostSimilar([0.1, 0.2, 0.3], [], 5);
 
@@ -62,8 +60,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarReturnsLimitedResults(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0, 0.0];
         $candidates = [
@@ -82,8 +79,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarSortsByDescendingSimilarity(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0];
         $candidates = [
@@ -103,8 +99,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function pairwiseSimilaritiesHasDiagonalOfOnes(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vectors = [
             [1.0, 0.0, 0.0],
@@ -124,8 +119,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function pairwiseSimilaritiesIsSymmetric(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vectors = [
             [1.0, 0.5],
@@ -142,8 +136,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function normalizeReturnsZeroVectorForZeroInput(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $zeroVector = [0.0, 0.0, 0.0];
         $result = $service->normalize($zeroVector);
@@ -155,8 +148,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function normalizeCreatesUnitLengthVector(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vector = [3.0, 4.0]; // Magnitude = 5.0
         $result = $service->normalize($vector);
@@ -170,8 +162,6 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     #[Test]
     public function embedFullWithOptionsUsesProvidedOptions(): void
     {
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $cacheStub->method('getCachedEmbeddings')->willReturn(null);
 
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
@@ -179,7 +169,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
             ->method('embed')
             ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
 
-        $service = new EmbeddingService($llmManagerMock, $cacheStub);
+        $service = new EmbeddingService($llmManagerMock);
         $options = new EmbeddingOptions(model: 'text-embedding-3-large');
 
         $result = $service->embedFull('test text', $options);
@@ -190,8 +180,6 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     #[Test]
     public function embedFullCreatesDefaultOptionsWhenNull(): void
     {
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $cacheStub->method('getCachedEmbeddings')->willReturn(null);
 
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
@@ -199,7 +187,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
             ->method('embed')
             ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
 
-        $service = new EmbeddingService($llmManagerMock, $cacheStub);
+        $service = new EmbeddingService($llmManagerMock);
 
         // Pass null options
         $result = $service->embedFull('test text', null);
@@ -211,8 +199,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function embedFullThrowsOnEmptyText(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Text cannot be empty');
@@ -223,7 +210,6 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     #[Test]
     public function embedBatchCreatesDefaultOptionsWhenNull(): void
     {
-        $cacheStub = self::createStub(CacheManagerInterface::class);
 
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
@@ -231,82 +217,16 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
             ->method('embed')
             ->willReturn($this->createMockEmbeddingResponse([[0.1], [0.2]]));
 
-        $service = new EmbeddingService($llmManagerMock, $cacheStub);
+        $service = new EmbeddingService($llmManagerMock);
 
         $result = $service->embedBatch(['text1', 'text2'], null);
 
         self::assertCount(2, $result);
     }
 
-    #[Test]
-    public function embedFullCachesResultAfterApiCall(): void
-    {
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock->method('getCachedEmbeddings')->willReturn(null);
-        $cacheMock
-            ->expects(self::once())
-            ->method('cacheEmbeddings');
-
-        $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $llmManagerStub
-            ->method('embed')
-            ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
-
-        $service = new EmbeddingService($llmManagerStub, $cacheMock);
-        $service->embedFull('test text');
-    }
-
-    #[Test]
-    public function embedFullUsesDefaultCacheTtlOf24Hours(): void
-    {
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock->method('getCachedEmbeddings')->willReturn(null);
-        $cacheMock
-            ->expects(self::once())
-            ->method('cacheEmbeddings')
-            ->with(
-                self::anything(),
-                self::anything(),
-                self::anything(),
-                self::anything(),
-                86400, // 24 hours
-            );
-
-        $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $llmManagerStub
-            ->method('embed')
-            ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
-
-        $service = new EmbeddingService($llmManagerStub, $cacheMock);
-        $service->embedFull('test text');
-    }
-
-    #[Test]
-    public function embedFullReturnsCachedResponseWhenAvailable(): void
-    {
-        $cachedData = [
-            'embeddings' => [[0.5, 0.6]],
-            'model' => 'cached-model',
-            'usage' => ['promptTokens' => 10, 'totalTokens' => 10],
-        ];
-
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock
-            ->expects(self::once())
-            ->method('getCachedEmbeddings')
-            ->willReturn($cachedData);
-
-        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
-        $llmManagerMock
-            ->expects(self::never())
-            ->method('embed');
-
-        $service = new EmbeddingService($llmManagerMock, $cacheMock);
-        $result = $service->embedFull('test text');
-
-        self::assertEquals([[0.5, 0.6]], $result->embeddings);
-        self::assertEquals('cached-model', $result->model);
-    }
+    // embedding cache behaviour is now owned by `CacheMiddleware` inside
+    // `LlmServiceManager::embed()`; coverage lives in
+    // `LlmServiceManagerTest` and `CacheMiddlewareTest`.
 
     /**
      * @param array<int, float> $vectorA
@@ -317,8 +237,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function cosineSimilarityHandlesEdgeCases(array $vectorA, array $vectorB, float $expected): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $result = $service->cosineSimilarity($vectorA, $vectorB);
 
@@ -342,8 +261,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function pairwiseSimilaritiesCreatesCorrectDimensions(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vectors = [
             [1.0, 0.0],
@@ -364,8 +282,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarUsesDefaultTopKOfFive(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0];
         $candidates = [
@@ -388,8 +305,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarReturnsAllWhenCandidatesLessThanTopK(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0];
         $candidates = [
@@ -407,8 +323,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarReturnsCorrectIndices(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0];
         $candidates = [
@@ -427,8 +342,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function normalizePreservesDirection(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vector = [3.0, 4.0];
         $result = $service->normalize($vector);
@@ -442,8 +356,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function normalizeHandlesNegativeValues(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vector = [-3.0, 4.0];
         $result = $service->normalize($vector);
@@ -461,8 +374,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function pairwiseSimilaritiesReturnsEmptyForEmptyInput(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $result = $service->pairwiseSimilarities([]);
 
@@ -473,8 +385,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function pairwiseSimilaritiesHandlesSingleVector(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $vectors = [[1.0, 0.0, 0.0]];
 
@@ -489,46 +400,21 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function embedBatchReturnsEmptyArrayForEmptyInput(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $result = $service->embedBatch([]);
 
         self::assertEmpty($result);
     }
 
-    #[Test]
-    public function embedFullReturnsCachedUsageStatisticsWithDefaults(): void
-    {
-        // Test that cached embeddings with missing usage stats use defaults
-        $cachedData = [
-            'embeddings' => [[0.5, 0.6]],
-            'model' => 'cached-model',
-            'usage' => [], // Empty usage - should use defaults
-        ];
-
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock
-            ->expects(self::once())
-            ->method('getCachedEmbeddings')
-            ->willReturn($cachedData);
-
-        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
-
-        $service = new EmbeddingService($llmManagerMock, $cacheMock);
-        $result = $service->embedFull('test text');
-
-        // Should default to 0 when not in cache
-        self::assertEquals(0, $result->usage->promptTokens);
-        self::assertEquals(0, $result->usage->totalTokens);
-    }
+    // cached-usage-default handling moved to `EmbeddingResponse::fromArray`,
+    // covered by response-serialization tests.
 
     #[Test]
     public function pairwiseSimilaritiesOffDiagonalCalculatesCorrectly(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         // Orthogonal unit vectors
         $vectors = [
@@ -547,8 +433,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
     public function findMostSimilarWithTopKOfOne(): void
     {
         $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $service = new EmbeddingService($llmManagerStub, $cacheStub);
+        $service = new EmbeddingService($llmManagerStub);
 
         $queryVector = [1.0, 0.0];
         $candidates = [

--- a/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
@@ -12,7 +12,6 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
-use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -24,14 +23,12 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
 {
     private EmbeddingService $subject;
     private LlmServiceManagerInterface $llmManagerStub;
-    private CacheManagerInterface $cacheStub;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $this->cacheStub = self::createStub(CacheManagerInterface::class);
-        $this->subject = new EmbeddingService($this->llmManagerStub, $this->cacheStub);
+        $this->subject = new EmbeddingService($this->llmManagerStub);
     }
 
     #[Test]
@@ -40,63 +37,32 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
         $text = 'Test text';
         $expectedVector = [0.1, 0.2, 0.3];
 
-        $cacheStub = self::createStub(CacheManagerInterface::class);
-        $cacheStub->method('getCachedEmbeddings')->willReturn(null);
-
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
             ->expects(self::once())
             ->method('embed')
             ->willReturn($this->createMockEmbeddingResponse([$expectedVector]));
 
-        $subject = new EmbeddingService($llmManagerMock, $cacheStub);
+        $subject = new EmbeddingService($llmManagerMock);
         $result = $subject->embed($text);
 
         self::assertEquals($expectedVector, $result);
     }
 
     #[Test]
-    public function embedUsesCachedResult(): void
+    public function embedDelegatesToLlmServiceManager(): void
     {
-        $text = 'Cached text';
-        $cachedVector = [0.5, 0.6, 0.7];
-
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock
-            ->expects(self::once())
-            ->method('getCachedEmbeddings')
-            ->willReturn([
-                'embeddings' => [$cachedVector],
-                'model' => 'text-embedding-3-small',
-                'usage' => ['promptTokens' => 5, 'totalTokens' => 5],
-            ]);
-
+        // Caching is now handled transparently by CacheMiddleware inside
+        // LlmServiceManager::embed() — the feature service just forwards.
+        // See ADR-026 for the pipeline architecture.
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
-            ->expects(self::never())
-            ->method('embed');
+            ->expects(self::once())
+            ->method('embed')
+            ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
 
-        $subject = new EmbeddingService($llmManagerMock, $cacheMock);
-        $result = $subject->embed($text);
-
-        self::assertEquals($cachedVector, $result);
-    }
-
-    #[Test]
-    public function embedStoresResultInCache(): void
-    {
-        $text = 'New text';
-        $vector = [0.1, 0.2];
-
-        $cacheMock = $this->createMock(CacheManagerInterface::class);
-        $cacheMock->method('getCachedEmbeddings')->willReturn(null);
-        $cacheMock->expects(self::once())->method('cacheEmbeddings');
-
-        $llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
-        $llmManagerStub->method('embed')->willReturn($this->createMockEmbeddingResponse([$vector]));
-
-        $subject = new EmbeddingService($llmManagerStub, $cacheMock);
-        $subject->embed($text);
+        $subject = new EmbeddingService($llmManagerMock);
+        $subject->embed('Text');
     }
 
     #[Test]
@@ -111,7 +77,7 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
             ->method('embed')
             ->willReturn($this->createMockEmbeddingResponse($vectors));
 
-        $subject = new EmbeddingService($llmManagerMock, $this->cacheStub);
+        $subject = new EmbeddingService($llmManagerMock);
         $results = $subject->embedBatch($texts);
 
         self::assertCount(3, $results);

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -38,7 +39,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $loggerStub = self::createStub(LoggerInterface::class);
         $adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
 
-        return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, new MiddlewarePipeline([]));
+        return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
     }
 
     private function createProviderStub(string $identifier, string $name = 'Test'): ProviderInterface

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -30,6 +30,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -68,6 +69,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             $this->loggerStub,
             $this->adapterRegistryStub,
             new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
         );
 
         // Create and register a testable provider
@@ -118,7 +120,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('No provider specified and no default provider configured');
@@ -286,7 +288,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $config = $manager->getProviderConfiguration('openai');
 
         self::assertArrayHasKey('apiKeyIdentifier', $config);
@@ -335,7 +337,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         // Register only an unavailable provider
         $unavailableProvider = new TestableProvider('test', 'Test', false);
@@ -465,7 +467,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->willThrowException(new Exception('Config not found'));
 
         // Should not throw, but log warning
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         // Manager should work without configuration
         self::assertNull($manager->getDefaultProvider());
@@ -507,7 +509,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $configurableProvider = new TestableProvider('configurable', 'Configurable', true);
         $manager->registerProvider($configurableProvider);
@@ -530,7 +532,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromModel($model);
 
@@ -553,7 +555,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromConfiguration($config);
 
@@ -602,7 +604,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->chatWithConfiguration(
             [['role' => 'user', 'content' => 'Hello']],
@@ -638,7 +640,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->completeWithConfiguration('Test prompt', $config);
 
@@ -713,7 +715,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $chunks = [];
         foreach ($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config) as $chunk) {
@@ -739,7 +741,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support streaming');
@@ -823,6 +825,36 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertSame(ProviderOperation::Tools, $spy->calls[0]['operation']);
     }
 
+    #[Test]
+    public function embedPlumbsCacheMetadataWhenTtlPositive(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        // EmbeddingOptions defaults to cacheTtl = 86400, so cache metadata
+        // should be set on the ProviderCallContext the middleware sees.
+        $manager->embed('text');
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertArrayHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+        self::assertArrayHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_TTL, $metadata);
+        self::assertSame(86400, $metadata[\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_TTL]);
+    }
+
+    #[Test]
+    public function embedOmitsCacheMetadataWhenTtlZero(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->embed('text', \Netresearch\NrLlm\Service\Option\EmbeddingOptions::noCache());
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertArrayNotHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+    }
+
     /**
      * Build a fresh LlmServiceManager pre-configured with the given middleware
      * and (optionally) a non-default TestableProvider. Separate setup from the
@@ -839,6 +871,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             $this->loggerStub,
             $this->adapterRegistryStub,
             new MiddlewarePipeline($middleware),
+            self::createStub(CacheManagerInterface::class),
         );
         $testProvider = $provider ?? new TestableProvider();
         $testProvider->setNextResponse(new CompletionResponse(
@@ -875,7 +908,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
  */
 final class RecordingMiddleware implements ProviderMiddlewareInterface
 {
-    /** @var list<array{operation: ProviderOperation, identifier: string, fallbackChainEmpty: bool, uid: ?int}> */
+    /** @var list<array{operation: ProviderOperation, identifier: string, fallbackChainEmpty: bool, uid: ?int, metadata: array<string, mixed>}> */
     public array $calls = [];
 
     public function handle(
@@ -888,6 +921,7 @@ final class RecordingMiddleware implements ProviderMiddlewareInterface
             'identifier'         => $configuration->getIdentifier(),
             'fallbackChainEmpty' => $configuration->getFallbackChainDTO()->isEmpty(),
             'uid'                => $configuration->getUid(),
+            'metadata'           => $context->metadata,
         ];
 
         return $next($configuration);

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
@@ -33,6 +34,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -837,9 +839,9 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
-        self::assertArrayHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_KEY, $metadata);
-        self::assertArrayHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_TTL, $metadata);
-        self::assertSame(86400, $metadata[\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_TTL]);
+        self::assertArrayHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+        self::assertArrayHasKey(CacheMiddleware::METADATA_CACHE_TTL, $metadata);
+        self::assertSame(86400, $metadata[CacheMiddleware::METADATA_CACHE_TTL]);
     }
 
     #[Test]
@@ -848,11 +850,11 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->embed('text', \Netresearch\NrLlm\Service\Option\EmbeddingOptions::noCache());
+        $manager->embed('text', EmbeddingOptions::noCache());
 
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
-        self::assertArrayNotHasKey(\Netresearch\NrLlm\Provider\Middleware\CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+        self::assertArrayNotHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
     }
 
     /**

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
@@ -56,6 +57,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             $loggerStub,
             $adapterRegistryStub,
             new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
         );
 
         $this->provider = new TranslatorTestProvider();


### PR DESCRIPTION
Finishes the last item tracked under [ADR-026](Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst): the inline embedding cache branch that lived in `EmbeddingService::embedFull()` is now owned by `CacheMiddleware` inside `LlmServiceManager::embed()`.

## Before / after

| Before | After |
|---|---|
| `EmbeddingService` held its own cache branch with `getCachedEmbeddings` / `cacheEmbeddings` calls. | `EmbeddingService` is a pure vector-math façade; no cache dependency. |
| `CacheMiddleware` was wired into the pipeline but never activated (no metadata key). | `LlmServiceManager::embed()` sets the cache metadata on the call context; `CacheMiddleware` short-circuits on hit. |
| Usage middleware never saw cached embeddings — unified accounting drifted. | `UsageMiddleware` recognises the array-payload shape and records both cache-hit and cache-miss paths consistently. |

## Changes

### Domain
- **`EmbeddingResponse` + `UsageStatistics`** — new `toArray` / `fromArray` helpers so typed responses round-trip through `CacheMiddleware` (which persists `array<string, mixed>` via the TYPO3 cache frontend).

### Pipeline
- **`LlmServiceManager::embed()`** — derives a stable cache key via `CacheManagerInterface::generateCacheKey()` (same hash shape the old branch produced, so existing cache entries stay valid). Places it on the `ProviderCallContext` metadata under `CacheMiddleware::METADATA_CACHE_KEY`. `cache_ttl == 0` (via `EmbeddingOptions::noCache()`) omits the key — consistent with the old `cacheTtl` semantics.
- Terminal returns `$response->toArray()`; manager reconstructs typed `EmbeddingResponse` via `fromArray`. Public method signature unchanged.

### Middleware
- **`UsageMiddleware`** — learned the array-payload shape. When terminal returns `['usage' => [...], 'provider' => '...']` (CacheMiddleware codec path), usage accounting works the same as for typed responses.

### Feature services
- **`EmbeddingService`** — dropped `CacheManagerInterface` constructor dependency. Now a pure vector-math façade on top of `LlmServiceManager::embed()`.

## Tests

- **New**: `embedPlumbsCacheMetadataWhenTtlPositive`, `embedOmitsCacheMetadataWhenTtlZero` in `LlmServiceManagerTest`. `RecordingMiddleware` now captures context metadata.
- **Dropped**: 4 cache-behaviour tests from `EmbeddingServiceTest` / `EmbeddingServiceMutationTest` — behaviour moved to `CacheMiddleware` + `LlmServiceManager`.
- **Updated**: all `new LlmServiceManager(...)` call sites across unit, integration, and E2E tests pass a `CacheManagerInterface` stub.

## Verification

```
✓ PHPStan level 10 (338 files, 0 errors)
✓ Unit tests (3138 tests, 0 failures)
```

## Cache compatibility

Cache entries written before this PR remain valid because `CacheManager::generateCacheKey('provider', 'embeddings', ['input' => ..., 'options' => ...])` produces the exact same hash `EmbeddingService::embedFull()` used to produce via the `cacheEmbeddings()` wrapper. Nothing to invalidate on upgrade.

## ADR-026

"Remaining cleanup" section replaced with "Embedding cache migration — done" listing all five sub-changes for future-me.

## Signed-off-by

Sebastian Mendel <sebastian.mendel@netresearch.de>