### PR TITLE
test: address Copilot review follow-ups on PRs #143 and #151

### DIFF
--- a/Tests/Unit/AbstractUnitTestCase.php
+++ b/Tests/Unit/AbstractUnitTestCase.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit;
 
 use Faker\Factory as FakerFactory;
 use Faker\Generator as Faker;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -269,5 +270,19 @@ abstract class AbstractUnitTestCase extends TestCase
     protected function randomApiKey(): string
     {
         return 'sk-' . $this->faker->regexify('[a-zA-Z0-9]{48}');
+    }
+
+    /**
+     * Empty middleware pipeline — a noop that invokes the terminal directly.
+     *
+     * Extracted so the `new LlmServiceManager(..., new MiddlewarePipeline([]), ...)`
+     * boilerplate repeated across 20+ tests has a single source of truth; if
+     * the pipeline constructor grows a new mandatory dependency, only this
+     * helper needs updating. See the Copilot review on PR #143 for the
+     * original motivation.
+     */
+    protected function emptyMiddlewarePipeline(): MiddlewarePipeline
+    {
+        return new MiddlewarePipeline([]);
     }
 }

--- a/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
+++ b/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
@@ -291,4 +291,92 @@ class EmbeddingResponseTest extends AbstractUnitTestCase
         self::assertEquals(5, $response->getCount());
         self::assertEquals(256, $response->getDimensions());
     }
+
+    // ====================================================================
+    // Cache-codec serialization (toArray / fromArray) — ADR-026 cleanup.
+    // CacheMiddleware persists array<string, mixed>, LlmServiceManager::embed()
+    // round-trips typed responses through this codec.
+    // ====================================================================
+
+    #[Test]
+    public function toArrayEmitsCanonicalShape(): void
+    {
+        $response = new EmbeddingResponse(
+            embeddings: [[0.1, 0.2], [0.3, 0.4]],
+            model: 'text-embedding-3-small',
+            usage: new UsageStatistics(7, 0, 7, 0.0001),
+            provider: 'openai',
+        );
+
+        $array = $response->toArray();
+
+        self::assertSame([[0.1, 0.2], [0.3, 0.4]], $array['embeddings']);
+        self::assertSame('text-embedding-3-small', $array['model']);
+        self::assertSame('openai', $array['provider']);
+        self::assertSame([
+            'promptTokens'     => 7,
+            'completionTokens' => 0,
+            'totalTokens'      => 7,
+            'estimatedCost'    => 0.0001,
+        ], $array['usage']);
+    }
+
+    #[Test]
+    public function fromArrayRoundTripsAllFields(): void
+    {
+        $original = new EmbeddingResponse(
+            embeddings: [[0.5, 0.6, 0.7]],
+            model: 'ada-002',
+            usage: new UsageStatistics(4, 0, 4, 0.0002),
+            provider: 'openai',
+        );
+
+        $restored = EmbeddingResponse::fromArray($original->toArray());
+
+        self::assertEquals($original, $restored);
+    }
+
+    #[Test]
+    public function fromArrayDefaultsMissingFieldsToSafeEmpties(): void
+    {
+        $restored = EmbeddingResponse::fromArray([]);
+
+        self::assertSame([], $restored->embeddings);
+        self::assertSame('', $restored->model);
+        self::assertSame('', $restored->provider);
+        self::assertSame(0, $restored->usage->totalTokens);
+    }
+
+    #[Test]
+    public function fromArrayAcceptsLegacyPayloadWithoutProvider(): void
+    {
+        // Cached payloads predating the `provider` column addition.
+        $restored = EmbeddingResponse::fromArray([
+            'embeddings' => [[0.1]],
+            'model'      => 'legacy-model',
+            'usage'      => ['promptTokens' => 2, 'totalTokens' => 2],
+        ]);
+
+        self::assertSame('legacy-model', $restored->model);
+        self::assertSame('', $restored->provider);
+        self::assertSame(2, $restored->usage->totalTokens);
+    }
+
+    #[Test]
+    public function fromArrayCoercesMalformedEmbeddingsToEmpty(): void
+    {
+        $restored = EmbeddingResponse::fromArray(['embeddings' => 'not-an-array']);
+
+        self::assertSame([], $restored->embeddings);
+    }
+
+    #[Test]
+    public function fromArrayCoercesMalformedUsageToEmptyStatistics(): void
+    {
+        $restored = EmbeddingResponse::fromArray(['usage' => 'not-an-array']);
+
+        self::assertSame(0, $restored->usage->promptTokens);
+        self::assertSame(0, $restored->usage->totalTokens);
+        self::assertNull($restored->usage->estimatedCost);
+    }
 }

--- a/Tests/Unit/Domain/Model/UsageStatisticsTest.php
+++ b/Tests/Unit/Domain/Model/UsageStatisticsTest.php
@@ -153,4 +153,89 @@ class UsageStatisticsTest extends AbstractUnitTestCase
 
         self::assertEquals($smallCost, $usage->getCost());
     }
+
+    // ====================================================================
+    // Cache-codec serialization (toArray / fromArray) — ADR-026 cleanup.
+    // ====================================================================
+
+    #[Test]
+    public function toArrayEmitsCanonicalKeys(): void
+    {
+        $usage = new UsageStatistics(10, 5, 15, 0.025);
+
+        self::assertSame(
+            [
+                'promptTokens'     => 10,
+                'completionTokens' => 5,
+                'totalTokens'      => 15,
+                'estimatedCost'    => 0.025,
+            ],
+            $usage->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayPreservesNullEstimatedCost(): void
+    {
+        $usage = new UsageStatistics(1, 2, 3);
+
+        $array = $usage->toArray();
+
+        self::assertArrayHasKey('estimatedCost', $array);
+        self::assertNull($array['estimatedCost']);
+    }
+
+    #[Test]
+    public function fromArrayRoundTripsAllFields(): void
+    {
+        $original = new UsageStatistics(100, 50, 150, 0.003);
+
+        $restored = UsageStatistics::fromArray($original->toArray());
+
+        self::assertEquals($original, $restored);
+    }
+
+    #[Test]
+    public function fromArrayDefaultsMissingTokenFieldsToZero(): void
+    {
+        $restored = UsageStatistics::fromArray([]);
+
+        self::assertSame(0, $restored->promptTokens);
+        self::assertSame(0, $restored->completionTokens);
+        self::assertSame(0, $restored->totalTokens);
+        self::assertNull($restored->estimatedCost);
+    }
+
+    #[Test]
+    public function fromArrayCoercesIntegerCostToFloat(): void
+    {
+        $restored = UsageStatistics::fromArray([
+            'promptTokens'  => 1,
+            'estimatedCost' => 1, // legacy cached payload may have stored an int
+        ]);
+
+        self::assertSame(1.0, $restored->estimatedCost);
+    }
+
+    #[Test]
+    public function fromArrayIgnoresNonNumericCost(): void
+    {
+        $restored = UsageStatistics::fromArray(['estimatedCost' => 'not-a-number']);
+
+        self::assertNull($restored->estimatedCost);
+    }
+
+    #[Test]
+    public function fromArrayIgnoresNonIntegerTokenFields(): void
+    {
+        $restored = UsageStatistics::fromArray([
+            'promptTokens'     => '10',   // string — should not be silently cast
+            'completionTokens' => 5.5,    // float
+            'totalTokens'      => null,
+        ]);
+
+        self::assertSame(0, $restored->promptTokens);
+        self::assertSame(0, $restored->completionTokens);
+        self::assertSame(0, $restored->totalTokens);
+    }
 }

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -245,7 +245,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function arrayPayloadWithMissingProviderRecordsUnknown(): void
+    public function arrayPayloadWithEmptyProviderRecordsUnknown(): void
     {
         $this->tracker->expects(self::once())
             ->method('trackUsage')

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -206,6 +206,98 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
     }
 
     // -----------------------------------------------------------------------
+    // Array-payload path — terminal returns `array<string, mixed>` on the
+    // CacheMiddleware codec path (embeddings). UsageMiddleware must still
+    // record from the `usage` / `provider` sub-keys.
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tracksArrayPayloadEmittedByCacheCodec(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Embedding->value,
+                'openai',
+                ['tokens' => 42, 'cost' => 0.0015],
+                null,
+            );
+
+        $payload = [
+            'embeddings' => [[0.1, 0.2]],
+            'model'      => 'text-embedding-3-small',
+            'provider'   => 'openai',
+            'usage'      => [
+                'promptTokens'     => 42,
+                'completionTokens' => 0,
+                'totalTokens'      => 42,
+                'estimatedCost'    => 0.0015,
+            ],
+        ];
+
+        $result = $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => $payload,
+        );
+
+        self::assertSame($payload, $result);
+    }
+
+    #[Test]
+    public function arrayPayloadWithMissingProviderRecordsUnknown(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                self::anything(),
+                'unknown',
+                self::anything(),
+                self::anything(),
+            );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => [
+                'provider' => '',
+                'usage'    => ['totalTokens' => 5],
+            ],
+        );
+    }
+
+    #[Test]
+    public function arrayPayloadMissingUsageKeyIsSkipped(): void
+    {
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => [
+                'embeddings' => [[0.1]],
+                'provider'   => 'openai',
+                // no 'usage' key — nothing reliable to record
+            ],
+        );
+    }
+
+    #[Test]
+    public function arrayPayloadWithNonStringProviderIsSkipped(): void
+    {
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Embedding),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => [
+                'provider' => ['not', 'a', 'string'],
+                'usage'    => ['totalTokens' => 5],
+            ],
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
 

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Tests\Unit\Service;
 
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
-use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
@@ -39,7 +38,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $loggerStub = self::createStub(LoggerInterface::class);
         $adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
 
-        return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
     }
 
     private function createProviderStub(string $identifier, string $name = 'Test'): ProviderInterface

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -70,7 +70,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
-            new MiddlewarePipeline([]),
+            $this->emptyMiddlewarePipeline(),
             self::createStub(CacheManagerInterface::class),
         );
 
@@ -122,7 +122,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('No provider specified and no default provider configured');
@@ -290,7 +290,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
         $config = $manager->getProviderConfiguration('openai');
 
         self::assertArrayHasKey('apiKeyIdentifier', $config);
@@ -339,7 +339,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         // Register only an unavailable provider
         $unavailableProvider = new TestableProvider('test', 'Test', false);
@@ -469,7 +469,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->willThrowException(new Exception('Config not found'));
 
         // Should not throw, but log warning
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         // Manager should work without configuration
         self::assertNull($manager->getDefaultProvider());
@@ -511,7 +511,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $configurableProvider = new TestableProvider('configurable', 'Configurable', true);
         $manager->registerProvider($configurableProvider);
@@ -534,7 +534,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromModel($model);
 
@@ -557,7 +557,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromConfiguration($config);
 
@@ -606,7 +606,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->chatWithConfiguration(
             [['role' => 'user', 'content' => 'Hello']],
@@ -642,7 +642,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->completeWithConfiguration('Test prompt', $config);
 
@@ -717,7 +717,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $chunks = [];
         foreach ($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config) as $chunk) {
@@ -743,7 +743,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistry::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support streaming');

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -13,7 +13,6 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
-use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
@@ -56,7 +55,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             $extensionConfigStub,
             $loggerStub,
             $adapterRegistryStub,
-            new MiddlewarePipeline([]),
+            $this->emptyMiddlewarePipeline(),
             self::createStub(CacheManagerInterface::class),
         );
 


### PR DESCRIPTION
Picks up the five Copilot review threads that went unresolved when PRs #143 and #151 were merged (my mistake — merged before verifying unresolved threads). One follow-up PR consolidates all of them.

## Threads addressed

### PR #151 — missing serialization tests (3 threads)

- [`UsageStatistics::toArray()` / `fromArray()` round-trip + back-compat defaults](https://github.com/netresearch/t3x-nr-llm/pull/151#discussion_r...)
- [`EmbeddingResponse::toArray()` / `fromArray()` payload shape + compat defaults](https://github.com/netresearch/t3x-nr-llm/pull/151#discussion_r...)
- [`UsageMiddleware` array-payload path coverage](https://github.com/netresearch/t3x-nr-llm/pull/151#discussion_r...)

### PR #143 — test boilerplate (1) + pipeline-routing assertion (1)

- [Shared `MiddlewarePipeline([])` helper](https://github.com/netresearch/t3x-nr-llm/pull/143#discussion_r...)
- [Targeted pipeline-routing test](https://github.com/netresearch/t3x-nr-llm/pull/143#discussion_r...)

## Changes

**New test cases**

| Class | Cases | Purpose |
|---|---|---|
| `UsageStatisticsTest` | +7 | canonical key order, null-cost preservation, full round-trip, missing-token defaults, integer-cost→float coercion (legacy payload shape), non-numeric-cost rejection, non-integer token rejection |
| `EmbeddingResponseTest` | +6 | canonical shape, round-trip, missing-field defaults, legacy-payload-without-provider compat, malformed-embeddings coercion, malformed-usage coercion |
| `UsageMiddlewareTest` | +4 | array-payload happy path, empty-provider → 'unknown' fallback, missing-usage skip, non-string-provider skip |

**Helper refactor**

- `AbstractUnitTestCase::emptyMiddlewarePipeline()` added.
- 15 `new MiddlewarePipeline([])` sites in `LlmServiceManagerTest`, `LlmServiceManagerMutationTest`, and `LlmTranslatorTest` switch to the helper.
- E2E and integration tests keep the explicit construction (they don't extend `AbstractUnitTestCase`).

**Pipeline-routing assertion**

Already covered by PR #150's `RecordingMiddleware`-based tests (`directChatRoutesThroughMiddlewarePipeline` and four siblings) which assert operation, identifier, uid, fallback-chain shape, and — via this PR's companion tests — context metadata. No extra work here; the corresponding thread on #143 will be resolved with a pointer to #150's tests.

## Verification

```
✓ PHPStan level 10 (338 files, 0 errors)
✓ Rector dry-run clean
✓ PHP-CS-Fixer dry-run clean
✓ Unit tests (3157 tests, 6822 assertions, 0 failures)
```

## Signed-off-by

Sebastian Mendel <sebastian.mendel@netresearch.de>