### PR TITLE
chore: address Copilot review backlog on PRs #138-142

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@v1.3.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag to republish (e.g. "v1.2.3")'
+        description: 'Git tag to republish (e.g. "v1.2.3"). Must be an existing tag on this repo; typo will fail after Checkout.'
         required: true
         type: string
       target:
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
   republish:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@v1.3.1
     permissions:
       contents: read
     with:

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -44,7 +44,8 @@ use Netresearch\NrLlm\Service\BudgetService;
  * With Budget outside Fallback the pre-flight check runs exactly once
  * per user-initiated call, not once per fallback attempt. Consumers
  * that want to charge each retry separately should register a custom
- * pipeline order; the default ordering follows this ADR.
+ * pipeline order; the default ordering is defined by ADR-026 (the
+ * middleware pipeline itself), with the rule set documented there.
  *
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -28,8 +28,23 @@ use Netresearch\NrLlm\Service\BudgetService;
  *    check" (CLI, scheduler, unauthenticated callers; see ADR-025 rule 1).
  *  - `BudgetMiddleware::METADATA_PLANNED_COST` : float, the expected
  *    cost of the call in the configured currency. 0.0 / absent means
- *    "precheck request count only"; real cost can still be accounted
- *    for post-call by the UsageMiddleware.
+ *    "I do not know the cost yet — evaluate only the non-cost limits
+ *    (request count, token totals from existing usage rows)"; the
+ *    cost-per-day bucket still blocks a request when prior usage has
+ *    already exceeded the configured ceiling. Real cost for this call
+ *    is accounted post-flight by the UsageMiddleware.
+ *
+ * Pipeline ordering:
+ *
+ *   BudgetMiddleware         <-- outermost of the retry/usage layers
+ *     FallbackMiddleware     <-- may swap the configuration and retry
+ *       UsageMiddleware      <-- records what actually ran
+ *         <terminal>
+ *
+ * With Budget outside Fallback the pre-flight check runs exactly once
+ * per user-initiated call, not once per fallback attempt. Consumers
+ * that want to charge each retry separately should register a custom
+ * pipeline order; the default ordering follows this ADR.
  *
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.
@@ -76,13 +91,6 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
     {
         $value = $context->metadata[$key] ?? null;
 
-        if (\is_float($value)) {
-            return $value;
-        }
-        if (\is_int($value)) {
-            return (float)$value;
-        }
-
-        return 0.0;
+        return (\is_float($value) || \is_int($value)) ? (float)$value : 0.0;
     }
 }

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -108,6 +108,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
                     'LLM fallback configuration not found, skipping',
                     [
                         'configuration' => $identifier,
+                        'operation'     => $context->operation->value,
                         'correlationId' => $context->correlationId,
                     ],
                 );
@@ -118,6 +119,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
                     'LLM fallback configuration is inactive, skipping',
                     [
                         'configuration' => $identifier,
+                        'operation'     => $context->operation->value,
                         'correlationId' => $context->correlationId,
                     ],
                 );

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -84,7 +84,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             return;
         }
 
-        /** @var array{tokens?: int, cost?: float} $metrics */
+        /** @var array{tokens: int, cost?: float} $metrics */
         $metrics = [
             'tokens' => $usage->totalTokens,
         ];

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -142,30 +142,6 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         );
     }
 
-    #[Test]
-    public function ignoresNonIntOrNonPositiveTtl(): void
-    {
-        $this->cache->method('get')->willReturn(null);
-        $this->cache->expects(self::once())
-            ->method('set')
-            ->with('key', ['x' => 1], 3600, []);
-
-        $context = new ProviderCallContext(
-            operation: ProviderOperation::Embedding,
-            correlationId: 'test',
-            metadata: [
-                CacheMiddleware::METADATA_CACHE_KEY => 'key',
-                CacheMiddleware::METADATA_CACHE_TTL => 0,   // ignored
-            ],
-        );
-
-        $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
-        );
-    }
-
     /**
      * Non-integer / non-positive TTL values all fall back to the default.
      * PHP's loose-typing conventions make it easy for a consumer to pass

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -50,12 +51,15 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
     public function passesThroughWhenCacheKeyIsEmptyString(): void
     {
         $this->cache->expects(self::never())->method('get');
+        $this->cache->expects(self::never())->method('set');
 
-        $this->pipeline()->run(
+        $result = $this->pipeline()->run(
             context: $this->context(key: ''),
             configuration: $this->configuration(),
             terminal: static fn(LlmConfiguration $c): string => 'ran',
         );
+
+        self::assertSame('ran', $result);
     }
 
     #[Test]
@@ -90,7 +94,7 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         $result         = $this->pipeline()->run(
             context: $this->context(key: 'embed:abc'),
             configuration: $this->configuration(),
-            terminal: static function () use (&$terminalCalled): array {
+            terminal: static function (LlmConfiguration $c) use (&$terminalCalled): array {
                 $terminalCalled = true;
 
                 return ['vector' => [0.9]];
@@ -152,6 +156,55 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
             metadata: [
                 CacheMiddleware::METADATA_CACHE_KEY => 'key',
                 CacheMiddleware::METADATA_CACHE_TTL => 0,   // ignored
+            ],
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+    }
+
+    /**
+     * Non-integer / non-positive TTL values all fall back to the default.
+     * PHP's loose-typing conventions make it easy for a consumer to pass
+     * a numeric string (`'3600'`), a float (`1.5`), a boolean (`true` — 1
+     * under int-coercion), or any other shape through an options bag; the
+     * middleware must treat every non-strict-int-positive value as "use
+     * the default", never silently coercing.
+     *
+     * @return array<string, array{0: mixed}>
+     */
+    public static function nonIntegerOrNonPositiveTtlProvider(): array
+    {
+        return [
+            'zero (explicit ignore)' => [0],
+            'negative'               => [-1],
+            'numeric string'         => ['3600'],
+            'float'                  => [1.5],
+            'bool true'              => [true],
+            'bool false'             => [false],
+            'null'                   => [null],
+            'array'                  => [[3600]],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('nonIntegerOrNonPositiveTtlProvider')]
+    public function nonIntegerOrNonPositiveTtlFallsBackToDefault(mixed $ttl): void
+    {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects(self::once())
+            ->method('set')
+            ->with('key', ['x' => 1], 3600, []);
+
+        $context = new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'test',
+            metadata: [
+                CacheMiddleware::METADATA_CACHE_KEY => 'key',
+                CacheMiddleware::METADATA_CACHE_TTL => $ttl,
             ],
         );
 

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -79,7 +79,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             fn() => $pipeline->run(
                 ProviderCallContext::for(ProviderOperation::Chat),
                 $primary,
-                static function () use ($err): never {
+                static function (LlmConfiguration $c) use ($err): never {
                     throw $err;
                 },
             ),
@@ -280,7 +280,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             fn() => $pipeline->run(
                 ProviderCallContext::for(ProviderOperation::Chat),
                 $primary,
-                static function (): never {
+                static function (LlmConfiguration $c): never {
                     throw new ProviderConnectionException('down', 0);
                 },
             ),
@@ -357,7 +357,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function rethrowsPrimaryErrorWhenChainContainsOnlyTheprimary(): void
+    public function rethrowsPrimaryErrorWhenChainContainsOnlyThePrimary(): void
     {
         $primary    = $this->makeConfig('p', new FallbackChain(['p']));
         $pipeline = $this->makePipeline();


### PR DESCRIPTION
Consolidates the 16 unresolved Copilot review threads on the merged middleware-pipeline PRs (#138 through #142). My earlier merges skipped resolving threads; this PR closes that debt. Follow-up is to also resolve the threads post-hoc with pointers to this PR.

## Scope by source PR

### #138 FallbackMiddleware — 5 threads

- **Log consistency (×2)**: "fallback not found" and "fallback inactive" log lines now carry `operation` alongside `correlationId`, matching the other log lines in the middleware. A single grep now groups all entries for one call.
- **Test typo**: `rethrowsPrimaryErrorWhenChainContainsOnlyTheprimary` → `…OnlyThePrimary`.
- **Test-terminal signatures (×2)**: closures gained an `LlmConfiguration` parameter to match the `callable(LlmConfiguration): mixed` contract. PHP accepts extras silently, so this is contract-shape clarity, not a runtime fix.

### #139 BudgetMiddleware — 3 threads

- **Docblock correction**: `METADATA_PLANNED_COST` now documents that `0.0 / absent` still evaluates non-cost limits (request count, token totals); only the pay-per-call cost bucket is skipped. Added "Pipeline ordering" section so custom-pipeline builders know Budget belongs outside Fallback.
- **`readFloat()` simplification**: collapsed to a single expression per Gemini's suggestion. Same behaviour, three lines instead of eight.

### #141 UsageMiddleware — 3 threads

- **Phpdoc tightening**: `@var array{tokens?: int, cost?: float}` → `array{tokens: int, cost?: float}` (tokens is unconditionally set).
- The "named args in `with()`" concern was stale — calls use positional arguments. Thread will be closed with an explanation.
- The "array return coverage" concern was already addressed in PR #152 (`arrayPayloadMissingUsageKeyIsSkipped`). Thread will be closed with a pointer there.

### #142 CacheMiddleware — 4 threads

- **`get()` semantics** — our `CacheManagerInterface::get()` is typed `?array` and normalises the TYPO3 cache-frontend `false` to `null` at `CacheManager.php:56`. Concern doesn't apply to our interface. Thread will be closed with the code pointer.
- **TTL coercion**: replaced the single-case `0`-only test with data-provider test `nonIntegerOrNonPositiveTtlFallsBackToDefault` covering eight shapes (zero, negative, numeric string, float, bool, null, array).
- **Pass-through contract**: `passesThroughWhenCacheKeyIsEmptyString` now asserts the return value AND that `set()` is never called, matching `passesThroughWhenNoCacheKeyOnContext`'s shape.
- **Terminal signature**: `returnsCachedValueAndSkipsTerminalOnHit`'s terminal closure now takes `LlmConfiguration`.

### #140 release-typo3-extension orchestrator — 3 threads

- **Pin immutability**: `.github/workflows/release.yml` and `republish.yml` now pin `netresearch/typo3-ci-workflows` to `@v1.3.1` instead of `@main`. Upstream changes become opt-in via tag bump instead of silent surprise mid-release.
- **Input hint**: `republish.yml`'s `tag` description now warns that the tag must already exist — best GitHub's dispatch form allows without a custom pre-check.

## Verification

```
✓ PHPStan level 10 (338 files, 0 errors)
✓ Unit tests (3165 tests, 0 failures)
✓ PHP-CS-Fixer clean
✓ Rector clean
```

## Signed-off-by

Sebastian Mendel <sebastian.mendel@netresearch.de>