### PR TITLE
feat(domain): extract MessageRole enum from ChatMessage

### DIFF
--- a/Classes/Domain/Enum/MessageRole.php
+++ b/Classes/Domain/Enum/MessageRole.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * Role of a message in a chat conversation.
+ *
+ * Mirrors the role values understood by every supported LLM provider.
+ * Backed by the same lower-case string each provider expects on the wire,
+ * so the enum value is what gets serialised — no separate translation
+ * table needed.
+ *
+ * Replaces the previous `ChatMessage::VALID_ROLES` const array. Existing
+ * string call sites (`new ChatMessage('user', ...)`) keep working because
+ * `ChatMessage` accepts `string|MessageRole` and normalises through this
+ * enum at construction time.
+ */
+enum MessageRole: string
+{
+    case System    = 'system';
+    case User      = 'user';
+    case Assistant = 'assistant';
+    case Tool      = 'tool';
+
+    /**
+     * Get all role values as a flat list of strings.
+     *
+     * Useful for error messages, validators, and serialisation paths
+     * that still operate on strings.
+     *
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn(self $case): string => $case->value,
+            self::cases(),
+        );
+    }
+
+    /**
+     * Test whether a string is a recognised role.
+     */
+    public static function isValid(string $value): bool
+    {
+        return self::tryFrom($value) !== null;
+    }
+
+    /**
+     * Try to create from a string; returns `null` on unknown values.
+     *
+     * Provided alongside the built-in `tryFrom()` to match the project's
+     * convention (see ModelCapability, ModelSelectionMode).
+     */
+    public static function tryFromString(string $value): ?self
+    {
+        return self::tryFrom($value);
+    }
+}

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -11,31 +11,61 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 
 use InvalidArgumentException;
 use JsonSerializable;
+use Netresearch\NrLlm\Domain\Enum\MessageRole;
 
 /**
  * Value Object representing a chat message.
  *
  * Immutable representation of a message in a chat conversation,
- * consisting of a role (system, user, assistant) and content.
+ * consisting of a role (system, user, assistant, tool) and content.
+ *
+ * The constructor accepts either the `MessageRole` enum or a raw string;
+ * unknown strings are rejected with the same `InvalidArgumentException`
+ * code as before this class moved to the enum so downstream catches stay
+ * stable. The public `string $role` field is preserved for back-compat —
+ * it is sourced from the enum's value, so the two cannot drift. New
+ * code is encouraged to read `getRole(): MessageRole` instead of the
+ * string field.
  */
 final readonly class ChatMessage implements JsonSerializable
 {
-    private const VALID_ROLES = ['system', 'user', 'assistant', 'tool'];
+    public string $role;
 
     /**
-     * @param string $role    The message role (system, user, assistant, tool)
-     * @param string $content The message content
+     * @param string|MessageRole $role Either a backed enum value or its
+     *                                 string equivalent — the legacy
+     *                                 string form is preserved so
+     *                                 existing call sites do not need
+     *                                 to migrate immediately.
      */
     public function __construct(
-        public string $role,
+        string|MessageRole $role,
         public string $content,
     ) {
-        if (!in_array($this->role, self::VALID_ROLES, true)) {
+        $resolved = $role instanceof MessageRole ? $role : MessageRole::tryFrom($role);
+        if ($resolved === null) {
             throw new InvalidArgumentException(
-                sprintf('Invalid role "%s". Valid roles: %s', $this->role, implode(', ', self::VALID_ROLES)),
+                sprintf(
+                    'Invalid role "%s". Valid roles: %s',
+                    is_string($role) ? $role : $role->value,
+                    implode(', ', MessageRole::values()),
+                ),
                 1736502001,
             );
         }
+        $this->role = $resolved->value;
+    }
+
+    /**
+     * Get the message role as the typed enum.
+     *
+     * Prefer this over reading the `$role` string field in new code —
+     * the enum gives `match` exhaustiveness and prevents typos.
+     */
+    public function getRole(): MessageRole
+    {
+        // Cannot return null: the constructor already validated the value.
+        return MessageRole::from($this->role);
     }
 
     /**
@@ -43,7 +73,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function system(string $content): self
     {
-        return new self('system', $content);
+        return new self(MessageRole::System, $content);
     }
 
     /**
@@ -51,7 +81,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function user(string $content): self
     {
-        return new self('user', $content);
+        return new self(MessageRole::User, $content);
     }
 
     /**
@@ -59,7 +89,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function assistant(string $content): self
     {
-        return new self('assistant', $content);
+        return new self(MessageRole::Assistant, $content);
     }
 
     /**
@@ -67,7 +97,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function tool(string $content): self
     {
-        return new self('tool', $content);
+        return new self(MessageRole::Tool, $content);
     }
 
     /**
@@ -109,7 +139,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isSystem(): bool
     {
-        return $this->role === 'system';
+        return $this->role === MessageRole::System->value;
     }
 
     /**
@@ -117,7 +147,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isUser(): bool
     {
-        return $this->role === 'user';
+        return $this->role === MessageRole::User->value;
     }
 
     /**
@@ -125,7 +155,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isAssistant(): bool
     {
-        return $this->role === 'assistant';
+        return $this->role === MessageRole::Assistant->value;
     }
 
     /**
@@ -133,16 +163,20 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isTool(): bool
     {
-        return $this->role === 'tool';
+        return $this->role === MessageRole::Tool->value;
     }
 
     /**
      * Get valid roles.
      *
+     * Retained for back-compat with callers that consume the string list.
+     * New code should call `MessageRole::values()` (or `MessageRole::cases()`)
+     * directly.
+     *
      * @return list<string>
      */
     public static function getValidRoles(): array
     {
-        return self::VALID_ROLES;
+        return MessageRole::values();
     }
 }

--- a/Tests/Unit/Domain/Enum/MessageRoleTest.php
+++ b/Tests/Unit/Domain/Enum/MessageRoleTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\MessageRole;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageRole::class)]
+final class MessageRoleTest extends TestCase
+{
+    #[Test]
+    public function valuesListsEveryWireString(): void
+    {
+        self::assertSame(
+            ['system', 'user', 'assistant', 'tool'],
+            MessageRole::values(),
+        );
+    }
+
+    #[Test]
+    public function isValidReturnsTrueForKnownRoles(): void
+    {
+        self::assertTrue(MessageRole::isValid('system'));
+        self::assertTrue(MessageRole::isValid('user'));
+        self::assertTrue(MessageRole::isValid('assistant'));
+        self::assertTrue(MessageRole::isValid('tool'));
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForUnknownStrings(): void
+    {
+        self::assertFalse(MessageRole::isValid(''));
+        self::assertFalse(MessageRole::isValid('USER'));
+        self::assertFalse(MessageRole::isValid('moderator'));
+        self::assertFalse(MessageRole::isValid('user '));
+    }
+
+    #[Test]
+    public function tryFromStringMatchesBuiltInTryFrom(): void
+    {
+        self::assertSame(MessageRole::User, MessageRole::tryFromString('user'));
+        self::assertNull(MessageRole::tryFromString('moderator'));
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
+++ b/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
 
 use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\Enum\MessageRole;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(ChatMessage::class)]
+#[CoversClass(MessageRole::class)]
 class ChatMessageTest extends AbstractUnitTestCase
 {
     // ──────────────────────────────────────────────
@@ -87,6 +89,26 @@ class ChatMessageTest extends AbstractUnitTestCase
         $message = new ChatMessage('user', '');
 
         self::assertSame('', $message->content);
+    }
+
+    #[Test]
+    public function constructorAcceptsMessageRoleEnumDirectly(): void
+    {
+        $content = $this->faker->sentence();
+
+        $message = new ChatMessage(MessageRole::Assistant, $content);
+
+        self::assertSame('assistant', $message->role);
+        self::assertSame(MessageRole::Assistant, $message->getRole());
+        self::assertSame($content, $message->content);
+    }
+
+    #[Test]
+    public function getRoleReturnsTypedEnumForStringConstruction(): void
+    {
+        $message = new ChatMessage('tool', 'output');
+
+        self::assertSame(MessageRole::Tool, $message->getRole());
     }
 
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

First slice of **audit recommendation #2** (DTO/VO promotion — "ChatMessage VO is a zombie + array-everywhere"). Replaces the `const VALID_ROLES` string array inside `ChatMessage` with a typed enum that follows the convention already established by `ModelCapability`, `ModelSelectionMode`, and the rest of `Domain/Enum/`.

**Internal-only change, no behaviour drift.** No provider, service, or controller file is touched. `ChatMessage` is the only call site, and it preserves both its public `string $role` field and the legacy string constructor signature. Existing tests keep passing without modification.

## What changes

| File | Change |
|---|---|
| `Classes/Domain/Enum/MessageRole.php` | **New** — backed enum with cases `System`, `User`, `Assistant`, `Tool`. `values()`, `isValid(string)`, `tryFromString(string)` mirror the existing convention. |
| `Classes/Domain/ValueObject/ChatMessage.php` | Constructor now accepts `string\|MessageRole`. Validation routed through `MessageRole::tryFrom()`. Same `InvalidArgumentException` with code `1736502001` on unknown roles so downstream catches stay stable. New `getRole(): MessageRole` accessor. The public `string $role` field is preserved and is now sourced from the enum value, so the two cannot drift. `is*()` predicates compare against `MessageRole::*->value`. `getValidRoles()` delegates to `MessageRole::values()`. |

## What does NOT change

- Public `string $role` field still exists.
- All four factory methods (`system`, `user`, `assistant`, `tool`) keep their signatures.
- All four `is*()` predicates keep their signatures.
- `fromArray()` / `toArray()` / `jsonSerialize()` unchanged.
- `getValidRoles()` keeps its `list<string>` return type.
- Exception type and code unchanged on invalid input.

## Why this slice first

The audit's #2 finding lists `ChatMessage` as a zombie — the VO exists but is never used in production. This slice does **not** start using it; it just gets the enum primitive in place so subsequent slices (ToolSpec / ToolCall / VisionContent VOs and the eventual `ProviderInterface` signature migration) can lean on it. Each future slice is reviewable in isolation and won't bundle in an "extract enum" sub-task on top of its own scope.

## Verification

- Full suite on PHP 8.4: **3168 unit tests** · PHPStan level 10 · PHP-CS-Fixer dry-run — all green
- New `MessageRoleTest` covers `values()`, `isValid()`, `tryFromString()`
- `ChatMessageTest` keeps every existing string scenario + adds two cases for the enum-passing constructor and `getRole(): MessageRole`

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | **Done** (PRs #137-#143 + follow-ups #150 #151) |
| **2** | **ChatMessage VO + array-everywhere** | **Slice 1 (this PR)** |
| 3 | Unify provider/translator registration, lock registry | Pending |
| 4 | Feature services consume budget+usage via pipeline | Done as part of #1 |
| 5 | Split TaskController, typed response DTOs everywhere | Pending |
| 6 | Promote domain-entity JSON strings to DTOs | Pending |
| 7 | Extract AbstractSpecializedService + HTTP pipeline | Pending |
| 8 | Enrich exception taxonomy | Pending |
| 9 | Add interfaces for feature/supporting services | Pending |
| 10 | Remove legacy string constants | Partial — this PR removes `ChatMessage::VALID_ROLES` |

## Test plan
- [ ] CI green
- [ ] Spot-check the back-compat: existing `new ChatMessage('user', ...)` call sites in tests still work without changes