### PR TITLE
feat(domain): add ToolSpec and ToolCall value objects

### DIFF
--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+/**
+ * Value Object representing a single tool invocation the model emitted.
+ *
+ * Pairs with :php:`ToolSpec` — the caller declares specs, the model
+ * answers with calls. Each call carries the provider-issued correlation
+ * id (so a follow-up `tool` role message can reference it), the name of
+ * the spec being invoked, and the arguments the model chose, parsed
+ * into an associative array.
+ *
+ * Replaces the nested associative-array shape currently produced by
+ * :php:`OpenAiProvider::chatCompletion()` (`Classes/Provider/OpenAiProvider.php:157-175`)
+ * and stored on :php:`CompletionResponse::$toolCalls` as
+ * `array<int, array<string, mixed>>`. The legacy array shape is
+ * preserved verbatim by `toArray()` so the migration of providers and
+ * `CompletionResponse` can land in a follow-up slice without
+ * disturbing this data model.
+ */
+final readonly class ToolCall implements JsonSerializable
+{
+    /** @see ToolSpec::TYPE_FUNCTION */
+    public const TYPE_FUNCTION = 'function';
+
+    /**
+     * @param string               $id        Provider-issued identifier; the
+     *                                        caller echoes this back when it
+     *                                        sends the tool's result.
+     * @param string               $name      Name of the `ToolSpec` this call
+     *                                        targets.
+     * @param array<string, mixed> $arguments Parsed JSON-decoded argument map.
+     *                                        Empty array when the model
+     *                                        produced an empty / malformed
+     *                                        argument string.
+     * @param string               $type      Tool kind; only `function`
+     *                                        currently exists on the wire.
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public array $arguments,
+        public string $type = self::TYPE_FUNCTION,
+    ) {
+        if ($this->id === '') {
+            throw new InvalidArgumentException(
+                'ToolCall id must not be empty.',
+                1745411001,
+            );
+        }
+        if ($this->name === '') {
+            throw new InvalidArgumentException(
+                'ToolCall name must not be empty.',
+                1745411002,
+            );
+        }
+        if ($this->type === '') {
+            throw new InvalidArgumentException(
+                'ToolCall type must not be empty.',
+                1745411003,
+            );
+        }
+    }
+
+    /**
+     * Reconstruct from the OpenAI / Anthropic-aligned wire shape.
+     *
+     * Accepts the on-the-wire variant where `function.arguments` is a
+     * JSON string (what every provider actually returns) AND the
+     * already-decoded variant where it is a map (what the legacy
+     * extractor in OpenAiProvider currently produces). The input
+     * variation is what makes calling code today so noisy — this
+     * factory normalises it once.
+     *
+     * @param array{
+     *     id?: string,
+     *     type?: string,
+     *     function?: array{
+     *         name?: string,
+     *         arguments?: string|array<string, mixed>,
+     *     },
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $function = $data['function'] ?? [];
+        if (!\is_array($function)) {
+            $function = [];
+        }
+
+        $rawArgs   = $function['arguments'] ?? [];
+        $arguments = self::normaliseArguments($rawArgs);
+
+        $id   = $data['id'] ?? '';
+        $name = $function['name'] ?? '';
+        $type = $data['type'] ?? self::TYPE_FUNCTION;
+
+        return new self(
+            id: \is_string($id) ? $id : '',
+            name: \is_string($name) ? $name : '',
+            arguments: $arguments,
+            type: \is_string($type) && $type !== '' ? $type : self::TYPE_FUNCTION,
+        );
+    }
+
+    /**
+     * Convenience factory mirroring `ToolSpec::function()`.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    public static function function(string $id, string $name, array $arguments): self
+    {
+        return new self(
+            id: $id,
+            name: $name,
+            arguments: $arguments,
+            type: self::TYPE_FUNCTION,
+        );
+    }
+
+    /**
+     * Serialise to the array shape `OpenAiProvider` currently emits.
+     * Idempotent against `fromArray()` for either input variant of
+     * `function.arguments`.
+     *
+     * @return array{
+     *     id: string,
+     *     type: string,
+     *     function: array{
+     *         name: string,
+     *         arguments: array<string, mixed>,
+     *     }
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'   => $this->id,
+            'type' => $this->type,
+            'function' => [
+                'name'      => $this->name,
+                'arguments' => $this->arguments,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     type: string,
+     *     function: array{
+     *         name: string,
+     *         arguments: array<string, mixed>,
+     *     }
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Decode a wire-shape `arguments` value into a plain array.
+     *
+     * @return array<string, mixed>
+     */
+    private static function normaliseArguments(mixed $raw): array
+    {
+        if (\is_array($raw)) {
+            /** @var array<string, mixed> $raw */
+            return $raw;
+        }
+        if (\is_string($raw) && $raw !== '') {
+            $decoded = \json_decode($raw, true);
+            if (\is_array($decoded)) {
+                /** @var array<string, mixed> $decoded */
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+}

--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+/**
+ * Value Object describing a tool the model is allowed to call.
+ *
+ * Mirrors the OpenAI / Anthropic / Gemini "function-calling" contract:
+ * a typed declaration consisting of a machine name, a free-form
+ * human-readable description, and a JSON-Schema parameter object the
+ * model fills in. The single supported tool kind is `function`,
+ * matching every provider that currently implements
+ * :php:`ToolCapableInterface`.
+ *
+ * Currently a leaf node: the `parameters` field is intentionally a
+ * plain `array<string, mixed>` because JSON Schema is unbounded and
+ * not worth modelling once again — every provider passes it through
+ * verbatim. If a future audit slice picks up parameter validation, a
+ * dedicated VO can wrap this property without touching call sites.
+ *
+ * Pairs with :php:`ToolCall` on the response side: callers declare
+ * `ToolSpec` instances; the model returns `ToolCall` instances pointing
+ * back at one of those specs by name.
+ */
+final readonly class ToolSpec implements JsonSerializable
+{
+    /**
+     * The single tool kind every supported provider recognises.
+     *
+     * Kept as a const rather than an enum because no other variants
+     * exist and adding one is a provider-level change anyway.
+     */
+    public const TYPE_FUNCTION = 'function';
+
+    /**
+     * @param array<string, mixed> $parameters JSON-Schema-shaped parameter
+     *                                         description; passed verbatim
+     *                                         to the provider.
+     */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public array $parameters,
+        public string $type = self::TYPE_FUNCTION,
+    ) {
+        if ($this->name === '') {
+            throw new InvalidArgumentException(
+                'ToolSpec name must not be empty.',
+                1745410001,
+            );
+        }
+        if ($this->type === '') {
+            throw new InvalidArgumentException(
+                'ToolSpec type must not be empty.',
+                1745410002,
+            );
+        }
+    }
+
+    /**
+     * Convenience factory for the dominant `function` kind.
+     *
+     * @param array<string, mixed> $parameters
+     */
+    public static function function(string $name, string $description, array $parameters): self
+    {
+        return new self(
+            name: $name,
+            description: $description,
+            parameters: $parameters,
+            type: self::TYPE_FUNCTION,
+        );
+    }
+
+    /**
+     * Reconstruct from the provider wire shape.
+     *
+     * @param array{
+     *     type?: string,
+     *     function: array{
+     *         name: string,
+     *         description?: string,
+     *         parameters?: array<string, mixed>,
+     *     }
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['function'])) {
+            throw new InvalidArgumentException(
+                'ToolSpec array missing required "function" key.',
+                1745410003,
+            );
+        }
+        $function = $data['function'];
+        if (!isset($function['name']) || !\is_string($function['name'])) {
+            throw new InvalidArgumentException(
+                'ToolSpec function.name must be a non-empty string.',
+                1745410004,
+            );
+        }
+
+        $description = $function['description'] ?? '';
+        $parameters  = $function['parameters'] ?? [];
+        $type        = $data['type'] ?? self::TYPE_FUNCTION;
+
+        return new self(
+            name: $function['name'],
+            description: \is_string($description) ? $description : '',
+            parameters: \is_array($parameters) ? $parameters : [],
+            type: \is_string($type) && $type !== '' ? $type : self::TYPE_FUNCTION,
+        );
+    }
+
+    /**
+     * Serialise to the array shape every provider currently expects on
+     * the wire. Idempotent: `ToolSpec::fromArray($spec->toArray()) ==
+     * $spec`.
+     *
+     * @return array{
+     *     type: string,
+     *     function: array{
+     *         name: string,
+     *         description: string,
+     *         parameters: array<string, mixed>,
+     *     }
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'function' => [
+                'name'        => $this->name,
+                'description' => $this->description,
+                'parameters'  => $this->parameters,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     function: array{
+     *         name: string,
+     *         description: string,
+     *         parameters: array<string, mixed>,
+     *     }
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/ToolCallTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolCallTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolCall::class)]
+final class ToolCallTest extends TestCase
+{
+    #[Test]
+    public function constructorAcceptsValidInputs(): void
+    {
+        $call = new ToolCall(
+            id: 'call_abc',
+            name: 'get_weather',
+            arguments: ['city' => 'Berlin'],
+        );
+
+        self::assertSame('call_abc', $call->id);
+        self::assertSame('get_weather', $call->name);
+        self::assertSame(['city' => 'Berlin'], $call->arguments);
+        self::assertSame(ToolCall::TYPE_FUNCTION, $call->type);
+    }
+
+    #[Test]
+    public function functionFactoryDefaultsTypeToFunction(): void
+    {
+        $call = ToolCall::function('id1', 'fn', ['a' => 1]);
+
+        self::assertSame(ToolCall::TYPE_FUNCTION, $call->type);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745411001);
+
+        new ToolCall(id: '', name: 'fn', arguments: []);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745411002);
+
+        new ToolCall(id: 'id', name: '', arguments: []);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745411003);
+
+        new ToolCall(id: 'id', name: 'fn', arguments: [], type: '');
+    }
+
+    #[Test]
+    public function fromArrayDecodesJsonStringArguments(): void
+    {
+        $wire = [
+            'id'   => 'call_abc',
+            'type' => 'function',
+            'function' => [
+                'name'      => 'get_weather',
+                'arguments' => '{"city":"Berlin","unit":"celsius"}',
+            ],
+        ];
+
+        $call = ToolCall::fromArray($wire);
+
+        self::assertSame('call_abc', $call->id);
+        self::assertSame('get_weather', $call->name);
+        self::assertSame(['city' => 'Berlin', 'unit' => 'celsius'], $call->arguments);
+    }
+
+    #[Test]
+    public function fromArrayAcceptsAlreadyDecodedArrayArguments(): void
+    {
+        // OpenAiProvider's legacy extractor produces this shape after
+        // `json_decode`. The factory must accept it without re-decoding.
+        $alreadyDecoded = [
+            'id'   => 'call_abc',
+            'type' => 'function',
+            'function' => [
+                'name'      => 'fn',
+                'arguments' => ['x' => 1, 'y' => 2],
+            ],
+        ];
+
+        $call = ToolCall::fromArray($alreadyDecoded);
+
+        self::assertSame(['x' => 1, 'y' => 2], $call->arguments);
+    }
+
+    #[Test]
+    public function fromArrayProducesEmptyArgumentsForMissingOrMalformed(): void
+    {
+        $cases = [
+            'missing arguments' => [
+                'id' => 'a', 'function' => ['name' => 'fn'],
+            ],
+            'empty string arguments' => [
+                'id' => 'a', 'function' => ['name' => 'fn', 'arguments' => ''],
+            ],
+            'malformed json arguments' => [
+                'id' => 'a', 'function' => ['name' => 'fn', 'arguments' => 'not-json'],
+            ],
+            'json scalar arguments' => [
+                'id' => 'a', 'function' => ['name' => 'fn', 'arguments' => '"just-a-string"'],
+            ],
+        ];
+
+        foreach ($cases as $label => $wire) {
+            /** @phpstan-ignore-next-line argument.type fixture intentionally varies */
+            $call = ToolCall::fromArray($wire);
+            self::assertSame([], $call->arguments, $label);
+        }
+    }
+
+    #[Test]
+    public function fromArrayDefaultsTypeToFunctionWhenAbsent(): void
+    {
+        $call = ToolCall::fromArray([
+            'id' => 'id1',
+            'function' => ['name' => 'fn'],
+        ]);
+
+        self::assertSame(ToolCall::TYPE_FUNCTION, $call->type);
+    }
+
+    #[Test]
+    public function fromArrayPropagatesEmptyIdAndNameToConstructor(): void
+    {
+        // Defensive: the wire shape can legitimately omit fields when a
+        // provider misbehaves. The constructor's invariant guards still
+        // catch this — the factory does not silently default to dummy
+        // values.
+        $this->expectException(InvalidArgumentException::class);
+
+        ToolCall::fromArray([]);
+    }
+
+    #[Test]
+    public function toArrayProducesLegacyOpenAiShape(): void
+    {
+        $call = ToolCall::function('call_abc', 'get_weather', ['city' => 'Berlin']);
+
+        self::assertSame(
+            [
+                'id'   => 'call_abc',
+                'type' => 'function',
+                'function' => [
+                    'name'      => 'get_weather',
+                    'arguments' => ['city' => 'Berlin'],
+                ],
+            ],
+            $call->toArray(),
+        );
+    }
+
+    #[Test]
+    public function fromArrayWithJsonStringArgumentsAndToArrayRoundTrip(): void
+    {
+        $wire = [
+            'id'   => 'call_abc',
+            'type' => 'function',
+            'function' => [
+                'name'      => 'get_weather',
+                'arguments' => '{"city":"Berlin"}',
+            ],
+        ];
+
+        $expected = [
+            'id'   => 'call_abc',
+            'type' => 'function',
+            'function' => [
+                'name'      => 'get_weather',
+                'arguments' => ['city' => 'Berlin'],
+            ],
+        ];
+
+        self::assertSame($expected, ToolCall::fromArray($wire)->toArray());
+    }
+
+    #[Test]
+    public function jsonSerializeMatchesToArray(): void
+    {
+        $call = ToolCall::function('id1', 'fn', ['a' => 1]);
+
+        self::assertSame($call->toArray(), $call->jsonSerialize());
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolSpec::class)]
+final class ToolSpecTest extends TestCase
+{
+    private const PARAMS = [
+        'type'       => 'object',
+        'properties' => [
+            'city' => ['type' => 'string'],
+        ],
+        'required' => ['city'],
+    ];
+
+    #[Test]
+    public function constructorAcceptsValidInputs(): void
+    {
+        $spec = new ToolSpec(
+            name: 'get_weather',
+            description: 'Get the weather for a city',
+            parameters: self::PARAMS,
+        );
+
+        self::assertSame('get_weather', $spec->name);
+        self::assertSame('Get the weather for a city', $spec->description);
+        self::assertSame(self::PARAMS, $spec->parameters);
+        self::assertSame(ToolSpec::TYPE_FUNCTION, $spec->type);
+    }
+
+    #[Test]
+    public function functionFactoryDefaultsTypeToFunction(): void
+    {
+        $spec = ToolSpec::function('get_weather', '...', self::PARAMS);
+
+        self::assertSame(ToolSpec::TYPE_FUNCTION, $spec->type);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745410001);
+
+        new ToolSpec(name: '', description: 'd', parameters: []);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745410002);
+
+        new ToolSpec(name: 'n', description: 'd', parameters: [], type: '');
+    }
+
+    #[Test]
+    public function fromArrayReadsWireShape(): void
+    {
+        $wire = [
+            'type'     => 'function',
+            'function' => [
+                'name'        => 'get_weather',
+                'description' => 'Weather lookup',
+                'parameters'  => self::PARAMS,
+            ],
+        ];
+
+        $spec = ToolSpec::fromArray($wire);
+
+        self::assertSame('get_weather', $spec->name);
+        self::assertSame('Weather lookup', $spec->description);
+        self::assertSame(self::PARAMS, $spec->parameters);
+        self::assertSame('function', $spec->type);
+    }
+
+    #[Test]
+    public function fromArrayDefaultsMissingDescriptionAndParameters(): void
+    {
+        $spec = ToolSpec::fromArray([
+            'function' => ['name' => 'noop'],
+        ]);
+
+        self::assertSame('noop', $spec->name);
+        self::assertSame('', $spec->description);
+        self::assertSame([], $spec->parameters);
+        self::assertSame(ToolSpec::TYPE_FUNCTION, $spec->type);
+    }
+
+    #[Test]
+    public function fromArrayThrowsWhenFunctionKeyMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745410003);
+
+        /** @phpstan-ignore-next-line argument.type intentional malformed input */
+        ToolSpec::fromArray(['type' => 'function']);
+    }
+
+    #[Test]
+    public function fromArrayThrowsWhenFunctionNameMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745410004);
+
+        /** @phpstan-ignore-next-line argument.type intentional malformed input */
+        ToolSpec::fromArray(['function' => ['description' => 'no name']]);
+    }
+
+    #[Test]
+    public function toArrayProducesIdempotentWireShape(): void
+    {
+        $spec = ToolSpec::function('get_weather', 'Get weather', self::PARAMS);
+
+        self::assertSame(
+            [
+                'type'     => 'function',
+                'function' => [
+                    'name'        => 'get_weather',
+                    'description' => 'Get weather',
+                    'parameters'  => self::PARAMS,
+                ],
+            ],
+            $spec->toArray(),
+        );
+    }
+
+    #[Test]
+    public function fromArrayAndToArrayRoundTrip(): void
+    {
+        $wire = [
+            'type'     => 'function',
+            'function' => [
+                'name'        => 'get_weather',
+                'description' => 'Get weather',
+                'parameters'  => self::PARAMS,
+            ],
+        ];
+
+        self::assertSame($wire, ToolSpec::fromArray($wire)->toArray());
+    }
+
+    #[Test]
+    public function jsonSerializeMatchesToArray(): void
+    {
+        $spec = ToolSpec::function('a', 'b', ['type' => 'object']);
+
+        self::assertSame($spec->toArray(), $spec->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## Summary

**Second slice of audit recommendation #2.** Adds the two missing value objects on the function-calling path:

- **`ToolSpec`** — caller-side declaration of a tool the model is allowed to invoke. Mirrors the OpenAI / Anthropic / Gemini wire shape (name, description, JSON-Schema parameters).
- **`ToolCall`** — response-side representation of a single tool invocation the model emitted. Replaces the nested `array<string, mixed>` shape currently produced by `OpenAiProvider::chatCompletion()` (`Classes/Provider/OpenAiProvider.php:157-175`) and stored on `CompletionResponse::$toolCalls` as `array<int, array<string, mixed>>`.

**Internal-only change. Purely additive.** No provider, no `ProviderInterface`/`ToolCapableInterface`, no `CompletionResponse` is touched. The two VOs sit alongside the existing array shapes ready for the next slice to migrate the wire signatures.

## Why this is the next-most-impactful slice of #2

The audit's tour de force was `OpenAiProvider.php:157-175` — 20 lines of nested array un-packing that no other layer in the extension can sanely reuse, and that has to be reproduced in the other six providers. `ToolCall::fromArray()` is the one normalising factory that collapses every variant of that array dance into a single call. Once it lands, the follow-up slice that replaces the array shape in `CompletionResponse` and `ToolCapableInterface` becomes a mechanical 7-provider rewrite where each diff is small enough to review on its own.

## Notable design choices

- **`ToolCall::fromArray()` accepts both `function.arguments` variants.** On the wire it's a JSON string; the legacy OpenAI extractor however hands us an already-decoded map. The factory normalises both to `array<string, mixed>` so callers stop having to know which path they're on. Empty / non-string / malformed JSON degrade to `[]` rather than throwing — matching the legacy code's permissive behaviour.
- **Validation invariants enforce non-empty id / name / type at construction**, with fixed exception codes (`1745410001-004` for `ToolSpec`, `1745411001-003` for `ToolCall`) so downstream catches stay stable across the migration slices.
- **`toArray()` reproduces the legacy OpenAi-style shape verbatim**, so the follow-up slice that migrates `CompletionResponse::$toolCalls` to `?list<ToolCall>` produces zero wire-format diff.
- **JSON Schema kept as `array<string, mixed>`.** Modelling JSON Schema as a VO is unbounded and not worth doing twice in the project; the parameters map is already passed through every provider verbatim.
- **`function` const, not enum.** Only one tool kind exists today; adding another is a provider-level change anyway. Constants keep the surface flat without locking in a future enum we'd have to expand on.

## Verification

- Full suite on PHP 8.4: **3192 unit tests** · PHPStan level 10 clean · PHP-CS-Fixer dry-run clean
- **`ToolSpecTest`**: 10 tests covering constructor invariants, factory, wire-shape round-trip, missing-key error paths, JSON serialization
- **`ToolCallTest`**: 14 tests covering both `function.arguments` shapes (JSON string + already-decoded), empty / malformed argument variants, type defaulting, missing-id/name propagation through `fromArray`, JSON serialization

Diff is purely additive: 4 new files, no existing file touched.

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | Done |
| **2** | **ChatMessage VO + array-everywhere** | Slice 1 (#155) merged · **slice 2 (this PR)** |
| 4 | Feature services consume budget+usage | Done as part of #1 |

## Follow-up slices for #2

- Promote `ChatMessage` from zombie to canonical message representation; switch the four `ChatMessage::*()` factories to be the recommended path.
- **Migrate `CompletionResponse::$toolCalls` from `array<int, array>` → `?list<ToolCall>`.** Internal — only one writer (`OpenAiProvider`) and read sites are mostly tests.
- Migrate `ToolCapableInterface::chatCompletionWithTools($tools, ...)` from `array<...>` → `list<ToolSpec>`. **Breaking** — I'll pause and confirm scope before this one.
- `VisionContent` VO for the array-of-arrays in `ProviderInterface::analyzeImage()`.
- Eventually: `ProviderInterface::chatCompletion(array $messages, ...)` → `list<ChatMessage>`. Also breaking.

## Test plan
- [ ] CI green
- [ ] Sanity-check the `ToolCall::fromArray()` JSON-string handling against your real-world OpenAI traces — that's the variant that matters in production