### PR TITLE
feat(domain): migrate CompletionResponse::$toolCalls to typed ToolCall[]

### DIFF
--- a/Classes/Domain/Model/CompletionResponse.php
+++ b/Classes/Domain/Model/CompletionResponse.php
@@ -9,14 +9,18 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+
 /**
  * Response object for text completion requests.
  */
 final readonly class CompletionResponse
 {
     /**
-     * @param array<int, array<string, mixed>>|null $toolCalls
-     * @param array<string, mixed>|null             $metadata
+     * @param list<ToolCall>|null       $toolCalls Typed tool invocations the
+     *                                             model emitted; `null` when
+     *                                             no tools were invoked.
+     * @param array<string, mixed>|null $metadata
      */
     public function __construct(
         public string $content,

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -222,14 +223,11 @@ final class ClaudeProvider extends AbstractProvider implements
             } elseif ($blockType === 'thinking') {
                 $nativeThinkingBlocks[] = $this->getString($blockArray, 'thinking');
             } elseif ($blockType === 'tool_use') {
-                $toolCalls[] = [
-                    'id' => $this->getString($blockArray, 'id'),
-                    'type' => 'function',
-                    'function' => [
-                        'name' => $this->getString($blockArray, 'name'),
-                        'arguments' => $this->getArray($blockArray, 'input'),
-                    ],
-                ];
+                $toolCalls[] = ToolCall::function(
+                    id: $this->getString($blockArray, 'id'),
+                    name: $this->getString($blockArray, 'name'),
+                    arguments: $this->getArray($blockArray, 'input'),
+                );
             }
         }
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -196,14 +197,11 @@ final class GeminiProvider extends AbstractProvider implements
 
             $functionCall = $this->getArray($partArray, 'functionCall');
             if ($functionCall !== []) {
-                $toolCalls[] = [
-                    'id' => 'call_' . uniqid(),
-                    'type' => 'function',
-                    'function' => [
-                        'name' => $this->getString($functionCall, 'name'),
-                        'arguments' => $this->getArray($functionCall, 'args'),
-                    ],
-                ];
+                $toolCalls[] = ToolCall::function(
+                    id: 'call_' . uniqid(),
+                    name: $this->getString($functionCall, 'name'),
+                    arguments: $this->getArray($functionCall, 'args'),
+                );
             }
         }
 

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -13,6 +13,7 @@ use Generator;
 use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
@@ -182,24 +183,12 @@ final class GroqProvider extends AbstractProvider implements
         $message = $this->getArray($choice, 'message');
         $usage = $this->getArray($response, 'usage');
 
-        $toolCalls = null;
+        $toolCalls    = null;
         $rawToolCalls = $this->getArray($message, 'tool_calls');
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $tcArray = $this->asArray($tc);
-                $function = $this->getArray($tcArray, 'function');
-                $arguments = $this->getString($function, 'arguments');
-                $decodedArgs = json_decode($arguments, true);
-
-                $toolCalls[] = [
-                    'id' => $this->getString($tcArray, 'id'),
-                    'type' => $this->getString($tcArray, 'type'),
-                    'function' => [
-                        'name' => $this->getString($function, 'name'),
-                        'arguments' => is_array($decodedArgs) ? $decodedArgs : [],
-                    ],
-                ];
+                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
             }
         }
 

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -14,6 +14,7 @@ use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 
@@ -163,24 +164,12 @@ final class MistralProvider extends AbstractProvider implements
         $message = $this->getArray($choice, 'message');
         $usage = $this->getArray($response, 'usage');
 
-        $toolCalls = null;
+        $toolCalls    = null;
         $rawToolCalls = $this->getArray($message, 'tool_calls');
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $tcArray = $this->asArray($tc);
-                $function = $this->getArray($tcArray, 'function');
-                $arguments = $this->getString($function, 'arguments');
-                $decodedArgs = json_decode($arguments, true);
-
-                $toolCalls[] = [
-                    'id' => $this->getString($tcArray, 'id'),
-                    'type' => $this->getString($tcArray, 'type'),
-                    'function' => [
-                        'name' => $this->getString($function, 'name'),
-                        'arguments' => is_array($decodedArgs) ? $decodedArgs : [],
-                    ],
-                ];
+                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
             }
         }
 

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -154,24 +155,12 @@ final class OpenAiProvider extends AbstractProvider implements
         $message = $this->getArray($choice, 'message');
         $usage = $this->getArray($response, 'usage');
 
-        $toolCalls = null;
+        $toolCalls    = null;
         $rawToolCalls = $this->getArray($message, 'tool_calls');
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $tcArray = $this->asArray($tc);
-                $function = $this->getArray($tcArray, 'function');
-                $arguments = $this->getString($function, 'arguments');
-                $decodedArgs = json_decode($arguments, true);
-
-                $toolCalls[] = [
-                    'id' => $this->getString($tcArray, 'id'),
-                    'type' => $this->getString($tcArray, 'type'),
-                    'function' => [
-                        'name' => $this->getString($function, 'name'),
-                        'arguments' => is_array($decodedArgs) ? $decodedArgs : [],
-                    ],
-                ];
+                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
             }
         }
 

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -351,24 +352,12 @@ final class OpenRouterProvider extends AbstractProvider implements
         $message = $this->getArray($choice, 'message');
         $usage = $this->getArray($response, 'usage');
 
-        $toolCalls = null;
+        $toolCalls    = null;
         $rawToolCalls = $this->getArray($message, 'tool_calls');
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $tcArray = $this->asArray($tc);
-                $function = $this->getArray($tcArray, 'function');
-                $arguments = $this->getString($function, 'arguments');
-                $decodedArgs = json_decode($arguments, true);
-
-                $toolCalls[] = [
-                    'id' => $this->getString($tcArray, 'id'),
-                    'type' => $this->getString($tcArray, 'type'),
-                    'function' => [
-                        'name' => $this->getString($function, 'name'),
-                        'arguments' => is_array($decodedArgs) ? $decodedArgs : [],
-                    ],
-                ];
+                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
             }
         }
 

--- a/Tests/Unit/Domain/Model/CompletionResponseTest.php
+++ b/Tests/Unit/Domain/Model/CompletionResponseTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -22,9 +23,9 @@ class CompletionResponseTest extends AbstractUnitTestCase
     #[Test]
     public function constructorSetsAllProperties(): void
     {
-        $usage = new UsageStatistics(100, 50, 150);
-        $toolCalls = [['id' => 'call_1', 'type' => 'function']];
-        $metadata = ['id' => 'chatcmpl-123'];
+        $usage     = new UsageStatistics(100, 50, 150);
+        $toolCalls = [ToolCall::function('call_1', 'fn', [])];
+        $metadata  = ['id' => 'chatcmpl-123'];
 
         $response = new CompletionResponse(
             content: 'Hello, world!',
@@ -285,9 +286,9 @@ class CompletionResponseTest extends AbstractUnitTestCase
     public function multipleToolCallsAreStored(): void
     {
         $toolCalls = [
-            ['id' => 'call_1', 'function' => ['name' => 'func1']],
-            ['id' => 'call_2', 'function' => ['name' => 'func2']],
-            ['id' => 'call_3', 'function' => ['name' => 'func3']],
+            ToolCall::function('call_1', 'func1', []),
+            ToolCall::function('call_2', 'func2', []),
+            ToolCall::function('call_3', 'func3', []),
         ];
 
         $response = new CompletionResponse(
@@ -300,6 +301,6 @@ class CompletionResponseTest extends AbstractUnitTestCase
 
         self::assertNotNull($response->toolCalls);
         self::assertCount(3, $response->toolCalls);
-        self::assertEquals('call_2', $response->toolCalls[1]['id']);
+        self::assertSame('call_2', $response->toolCalls[1]->id);
     }
 }

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -350,10 +350,9 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'San Francisco'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'San Francisco'], $toolCall->arguments);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -386,10 +386,9 @@ class GeminiProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, string>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'London'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'London'], $toolCall->arguments);
     }
 
     #[Test]
@@ -770,9 +769,8 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $result = $subject->chatCompletionWithTools($messages, $tools);
 
         self::assertNotNull($result->toolCalls);
-        /** @var array{function: array{name: string}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
+        self::assertEquals('get_weather', $toolCall->name);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -271,10 +271,9 @@ class GroqProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, string>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'London'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'London'], $toolCall->arguments);
     }
 
     #[Test]
@@ -510,9 +509,8 @@ class GroqProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         // Invalid JSON should result in empty array for arguments
-        /** @var array{function: array{arguments: array<mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals([], $toolCall['function']['arguments']);
+        self::assertEquals([], $toolCall->arguments);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -271,10 +271,9 @@ class MistralProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, string>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'Paris'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'Paris'], $toolCall->arguments);
     }
 
     #[Test]
@@ -553,9 +552,8 @@ class MistralProviderTest extends AbstractUnitTestCase
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
         // Invalid JSON should return empty array for arguments
-        /** @var array{function: array{arguments: array<mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals([], $toolCall['function']['arguments']);
+        self::assertEquals([], $toolCall->arguments);
     }
 
     // ==================== Streaming tests ====================

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -443,10 +443,9 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'Tokyo'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'Tokyo'], $toolCall->arguments);
     }
 
     #[Test]
@@ -947,10 +946,9 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $result = $this->subject->chatCompletionWithTools($messages, $tools);
 
         self::assertNotNull($result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
         // Invalid JSON arguments should fall back to empty array
-        self::assertEquals([], $toolCall['function']['arguments']);
+        self::assertEquals([], $toolCall->arguments);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -521,10 +521,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
-        /** @var array{function: array{name: string, arguments: array<string, mixed>}} $toolCall */
         $toolCall = $result->toolCalls[0];
-        self::assertEquals('get_weather', $toolCall['function']['name']);
-        self::assertEquals(['location' => 'San Francisco'], $toolCall['function']['arguments']);
+        self::assertEquals('get_weather', $toolCall->name);
+        self::assertEquals(['location' => 'San Francisco'], $toolCall->arguments);
     }
 
     #[Test]

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
@@ -423,7 +424,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             finishReason: 'tool_calls',
             provider: 'openai',
             toolCalls: [
-                ['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'get_weather', 'arguments' => []]],
+                ToolCall::function('call_1', 'get_weather', []),
             ],
         ));
         $this->subject->registerProvider($toolProvider);


### PR DESCRIPTION
## Summary

**Third slice of audit recommendation #2.** Replaces `CompletionResponse::$toolCalls` from `array<int, array<string, mixed>>|null` to typed `?list<ToolCall>` (the VO landed in #156). All six providers that emit tool calls migrate in lockstep — the legacy unpack-and-rebuild boilerplate **collapses by ~50 LOC** across the provider suite.

## Provider-side: net **−72 LOC** of array juggling

Before (repeated identically in OpenAi / OpenRouter / Mistral / Groq):

```php
$toolCalls[] = [
    'id'   => $this->getString($tcArray, 'id'),
    'type' => $this->getString($tcArray, 'type'),
    'function' => [
        'name'      => $this->getString($function, 'name'),
        'arguments' => is_array($decodedArgs) ? $decodedArgs : [],
    ],
];
```

After:

```php
$toolCalls[] = ToolCall::fromArray($this->asArray($tc));
```

`ToolCall::fromArray()` already handles both wire variants (JSON-string and already-decoded arguments), so providers no longer have to know which shape they got.

Gemini and Claude build the call inline mid-block-loop; both switched to `ToolCall::function(id, name, arguments)` for a clean factory call.

## Domain side

- `CompletionResponse::$toolCalls` PHPDoc switched from `array<int, array<string, mixed>>|null` to `list<ToolCall>|null`.
- `hasToolCalls()` unchanged — null + empty check works identically on the typed list.
- Constructor signature unchanged: `?array $toolCalls`. Type narrowing happens via PHPDoc + PHPStan.

## Test side

- **All six provider tests** + `CompletionResponseTest` + `LlmServiceManagerTest` migrated from `$toolCall['function']['name']` / `['arguments']` array access to `$toolCall->name` / `->arguments` property access.
- Stale `/** @var array{function: …} $toolCall */` doc comments removed — PHPStan now infers the type from `CompletionResponse`.
- `CompletionResponseTest` and `LlmServiceManagerTest` fixtures use `ToolCall::function(...)` instead of nested arrays.

## Compatibility

This is a **public-facing data-shape change** on `$toolCalls` — the read type goes from array to object. The only readers in the codebase are tests; no controllers or feature services touch the field directly. Third-party consumers reading `$response->toolCalls[0]['id']` need to migrate to `$response->toolCalls[0]->id` (or call `->toArray()` on the `ToolCall` for the legacy shape).

The constructor remains `?array $toolCalls` — passing legacy raw arrays still type-checks at the language level; it just won't be a valid `list<ToolCall>` and will fail the moment you try to read `$tc->name`. PHPStan catches this immediately.

## Verification

- Full suite on PHP 8.4: **3192 unit tests** · PHPStan level 10 clean · PHP-CS-Fixer dry-run clean
- The 14 `ToolCallTest` cases from PR #156 protected the refactor — every variant of the wire shape was already exercised before this PR

## Diff stat

```
 15 files changed, 56 insertions(+), 108 deletions(-)
```

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | Done |
| **2** | **ChatMessage VO + array-everywhere** | Slice 1 #155 + slice 2 #156 + **slice 3 (this PR)** |
| 4 | Feature services consume budget+usage | Done as part of #1 |
| 10 | Remove legacy string constants | Partial — slice 1 + this PR remove more array shapes |

## Follow-ups still on slice 2

- **`ToolCapableInterface::chatCompletionWithTools($tools, ...)`** — switch input from `array<int, array{...}>` to `list<ToolSpec>`. Public API change. **Will pause and confirm before this slice.**
- `ProviderInterface::chatCompletion(array $messages, ...)` → `list<ChatMessage>`. Largest breaking change of the whole #2 effort — same pause-and-confirm.
- `VisionContent` VO for `analyzeImage()`'s array-of-arrays.
- Promote `ChatMessage` from zombie to canonical message representation in feature services.

## Test plan
- [ ] CI green
- [ ] Spot-check the converted Gemini / Claude call sites — they were the two odd ones that didn't follow OpenAi's pattern