### PR TITLE
feat(provider): migrate ToolCapableInterface input to typed ToolSpec list

### DIFF
--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -172,24 +173,19 @@ final class ClaudeProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
         $converted = $this->convertMessagesForClaude($messages);
 
-        // Convert OpenAI tool format to Claude format
-        $claudeTools = [];
-        foreach ($tools as $tool) {
-            $toolArray = $this->asArray($tool);
-            $function = $this->getArray($toolArray, 'function');
-            $claudeTools[] = [
-                'name' => $this->getString($function, 'name'),
-                'description' => $this->getString($function, 'description'),
-                'input_schema' => $this->getArray($function, 'parameters'),
-            ];
-        }
+        // Convert OpenAI-shaped ToolSpec into Claude's `input_schema` format.
+        $claudeTools = array_map(static fn(ToolSpec $spec): array => [
+            'name'         => $spec->name,
+            'description'  => $spec->description,
+            'input_schema' => $spec->parameters,
+        ], $tools);
 
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -10,13 +10,24 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Contract;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 
 interface ToolCapableInterface
 {
     /**
-     * @param array<int, array<string, mixed>>                                                                                      $messages
-     * @param array<int, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}> $tools
-     * @param array<string, mixed>                                                                                                  $options
+     * @param array<int, array<string, mixed>> $messages
+     * @param list<ToolSpec>                   $tools    Typed tool declarations
+     *                                                   the model is allowed to
+     *                                                   invoke. Provider
+     *                                                   implementations are
+     *                                                   responsible for any
+     *                                                   per-vendor wire-format
+     *                                                   conversion (most call
+     *                                                   `$spec->toArray()` for
+     *                                                   the OpenAI shape; Claude
+     *                                                   / Gemini read the typed
+     *                                                   fields directly).
+     * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse;
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -141,7 +142,7 @@ final class GeminiProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -149,17 +150,13 @@ final class GeminiProvider extends AbstractProvider implements
         $model = $this->getString($options, 'model', $this->getDefaultModel());
         $geminiContents = $this->convertToGeminiFormat($messages);
 
-        // Convert OpenAI tool format to Gemini format
+        // Convert OpenAI-shaped ToolSpec into Gemini's `functionDeclarations` format.
         $geminiTools = [
-            'functionDeclarations' => array_map(function (array $tool): array {
-                $toolArray = $this->asArray($tool);
-                $function = $this->getArray($toolArray, 'function');
-                return [
-                    'name' => $this->getString($function, 'name'),
-                    'description' => $this->getString($function, 'description'),
-                    'parameters' => $this->getArray($function, 'parameters'),
-                ];
-            }, $tools),
+            'functionDeclarations' => array_map(static fn(ToolSpec $spec): array => [
+                'name'        => $spec->name,
+                'description' => $spec->description,
+                'parameters'  => $spec->parameters,
+            ], $tools),
         ];
 
         $payload = [

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -14,6 +14,7 @@ use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
@@ -152,7 +153,7 @@ final class GroqProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -162,7 +163,7 @@ final class GroqProvider extends AbstractProvider implements
         $payload = [
             'model' => $model,
             'messages' => $messages,
-            'tools' => $tools,
+            'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 
@@ -138,7 +139,7 @@ final class MistralProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -148,7 +149,7 @@ final class MistralProvider extends AbstractProvider implements
         $payload = [
             'model' => $model,
             'messages' => $messages,
-            'tools' => $tools,
+            'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -129,7 +130,7 @@ final class OpenAiProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -139,7 +140,7 @@ final class OpenAiProvider extends AbstractProvider implements
         $payload = [
             'model' => $model,
             'messages' => $messages,
-            'tools' => $tools,
+            'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
             'max_completion_tokens' => $this->getInt($options, 'max_tokens', 4096),
             ...$this->buildSamplingParams($model, $options),
         ];

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -318,7 +319,7 @@ final class OpenRouterProvider extends AbstractProvider implements
 
     /**
      * @param array<int, array<string, mixed>> $messages
-     * @param array<int, array<string, mixed>> $tools
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -328,7 +329,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $payload = [
             'model' => $model,
             'messages' => $messages,
-            'tools' => $tools,
+            'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -301,8 +302,8 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Chat completion with tool calling.
      *
-     * @param array<int, array{role: string, content: string}>                                                                      $messages
-     * @param array<int, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}> $tools
+     * @param array<int, array{role: string, content: string}> $messages
+     * @param list<ToolSpec>                                   $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
     {

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
@@ -93,8 +94,8 @@ interface LlmServiceManagerInterface
     public function streamChat(array $messages, ?ChatOptions $options = null): Generator;
 
     /**
-     * @param array<int, array{role: string, content: string}>                                                                      $messages
-     * @param array<int, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}> $tools
+     * @param array<int, array{role: string, content: string}> $messages
+     * @param list<ToolSpec>                                    $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse;
 

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
@@ -311,7 +312,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'What is the weather?']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -321,7 +322,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
                         'properties' => ['location' => ['type' => 'string']],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -359,7 +360,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function chatCompletionWithToolsHandlesToolChoice(): void
     {
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
         $options = ['tool_choice' => 'auto'];
 
         $apiResponse = [
@@ -388,7 +389,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
             ['role' => 'system', 'content' => 'You are helpful'],
             ['role' => 'user', 'content' => 'test'],
         ];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
 
         $apiResponse = [
             'id' => 'msg_test',
@@ -413,7 +414,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function chatCompletionWithToolsMixedContentBlocks(): void
     {
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
 
         $apiResponse = [
             'id' => 'msg_test',
@@ -448,7 +449,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function chatCompletionWithToolsMapsDifferentToolChoices(mixed $toolChoice): void
     {
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
         $options = ['tool_choice' => $toolChoice];
 
         $apiResponse = [
@@ -900,7 +901,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function chatCompletionWithToolsExtractsThinking(): void
     {
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
 
         $apiResponse = [
             'id' => 'msg_test',
@@ -976,14 +977,14 @@ class ClaudeProviderTest extends AbstractUnitTestCase
             ],
         ];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'describe_image',
                     'description' => 'Describe an image',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1101,7 +1102,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -1111,7 +1112,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
                         'properties' => ['location' => ['type' => 'string']],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1161,14 +1162,14 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
                     'description' => 'Get weather',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1217,10 +1218,10 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => ['type' => 'object']],
-            ],
+            ]),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -338,7 +339,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -350,7 +351,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
                         ],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -671,14 +672,14 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
                     'description' => 'Get current weather',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -728,14 +729,14 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
                     'description' => 'Get weather',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1250,7 +1251,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -1260,7 +1261,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
                         'properties' => ['location' => ['type' => 'string']],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1317,14 +1318,14 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
                     'description' => 'Get weather',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -1380,14 +1381,14 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
                     'description' => 'Get weather',
                     'parameters' => ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Provider\GroqProvider;
@@ -215,7 +216,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -227,7 +228,7 @@ class GroqProviderTest extends AbstractUnitTestCase
                         ],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -360,14 +361,14 @@ class GroqProviderTest extends AbstractUnitTestCase
 
         $messages = [['role' => 'user', 'content' => 'Test']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'test_function',
                     'description' => 'A test function',
                     'parameters' => ['type' => 'object', 'properties' => []],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -491,14 +492,14 @@ class GroqProviderTest extends AbstractUnitTestCase
             ->willReturn($this->createJsonResponseMock($apiResponse));
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_data',
                     'description' => 'Get data',
                     'parameters' => ['type' => 'object'],
                 ],
-            ],
+            ]),
         ];
 
         $result = $subject->chatCompletionWithTools(

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\MistralProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -215,7 +216,7 @@ class MistralProviderTest extends AbstractUnitTestCase
         ];
 
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -227,7 +228,7 @@ class MistralProviderTest extends AbstractUnitTestCase
                         ],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -413,14 +414,14 @@ class MistralProviderTest extends AbstractUnitTestCase
 
         $messages = [['role' => 'user', 'content' => 'Test']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'test_function',
                     'description' => 'A test function',
                     'parameters' => ['type' => 'object', 'properties' => []],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -504,14 +505,14 @@ class MistralProviderTest extends AbstractUnitTestCase
 
         $messages = [['role' => 'user', 'content' => 'Test']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'test_function',
                     'description' => 'Test',
                     'parameters' => ['type' => 'object', 'properties' => []],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
@@ -397,7 +398,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'What is the weather?']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -407,7 +408,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
                         'properties' => ['location' => ['type' => 'string']],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -453,10 +454,10 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'Get weather']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => ['name' => 'get_weather', 'parameters' => []],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -880,7 +881,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'Hello']];
         $tools = [
-            ['type' => 'function', 'function' => ['name' => 'test', 'parameters' => []]],
+            ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'parameters' => []]]),
         ];
 
         // Response has no tool_calls key at all (not even empty)
@@ -912,7 +913,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'Get weather']];
         $tools = [
-            ['type' => 'function', 'function' => ['name' => 'get_weather', 'parameters' => []]],
+            ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', 'parameters' => []]]),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -471,7 +472,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     {
         $messages = [['role' => 'user', 'content' => 'What is the weather?']];
         $tools = [
-            [
+            ToolSpec::fromArray([
                 'type' => 'function',
                 'function' => [
                     'name' => 'get_weather',
@@ -483,7 +484,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                         ],
                     ],
                 ],
-            ],
+            ]),
         ];
 
         $apiResponse = [
@@ -530,7 +531,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     public function chatCompletionWithToolsHandlesToolChoice(): void
     {
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test']]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test']])];
         $options = ['tool_choice' => 'auto'];
 
         $apiResponse = [
@@ -1169,7 +1170,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $provider = $this->createProviderWithConfig(['autoFallback' => false]);
 
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test']]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test']])];
 
         $apiResponse = [
             'id' => 'gen-test',

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
@@ -432,7 +433,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         $messages = [['role' => 'user', 'content' => 'What is the weather?']];
         $tools = [
-            ['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => []]],
+            ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => []]]),
         ];
 
         $result = $this->subject->chatWithTools($messages, $tools);
@@ -448,7 +449,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $this->expectExceptionMessage('does not support tool calling');
 
         $messages = [['role' => 'user', 'content' => 'test']];
-        $tools = [['type' => 'function', 'function' => ['name' => 'test', 'description' => 'test', 'parameters' => []]]];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'test', 'parameters' => []]])];
 
         $this->subject->chatWithTools($messages, $tools);
     }
@@ -821,7 +822,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         $manager->chatWithTools(
             [['role' => 'user', 'content' => 'hi']],
-            [['type' => 'function', 'function' => ['name' => 'noop', 'description' => '', 'parameters' => []]]],
+            [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'noop', 'description' => '', 'parameters' => []]])],
         );
 
         self::assertCount(1, $spy->calls);


### PR DESCRIPTION
## Summary

**Fourth slice of audit recommendation #2** — the input-side counterpart to #157. Switches the public function-calling contract from `array<int, array{type, function: {name, description, parameters}}>` to `list<ToolSpec>` (the VO landed in #156).

This is a **public API change**, called out in advance per my earlier commitment to pause on signature breaks.

## What changes

### `ToolCapableInterface` (the breaking surface)

```diff
- /** @param array<int, array{type, function: {name, description, parameters}}> $tools */
+ /** @param list<ToolSpec> $tools */
  public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse;
```

The runtime `array $tools` parameter type stays — language-level back-compat at the call boundary. PHPStan catches misuse statically.

### `LlmServiceManager::chatWithTools()` and `LlmServiceManagerInterface::chatWithTools()`

Same PHPDoc switch. Same back-compat at runtime.

### Provider implementations

| Provider | Wire conversion |
|---|---|
| OpenAi, OpenRouter, Mistral, Groq | `'tools' => array_map(fn (ToolSpec $s) => $s->toArray(), $tools)` — one-line addition at the payload site |
| **Claude** | The per-tool unpacking loop **collapses into an `array_map`** reading `$spec->name / description / parameters` directly. **~5 LOC deleted.** |
| **Gemini** | Same simplification — `array_map` with typed-field reads building Gemini's `functionDeclarations` shape. **~5 LOC deleted.** |

### Test side

**32 array-shaped tool fixtures across 7 test files** migrated to `ToolSpec::fromArray([...])` wrappers — preserves the existing fixture data verbatim, just routes it through the typed VO at construction. The `ToolSpec::fromArray()` factory was specifically built in #156 for this migration path.

## Compatibility / migration guide for downstream

Third-party implementers or callers of `ToolCapableInterface::chatCompletionWithTools` / `LlmServiceManager::chatWithTools` must update:

**Callers** — pass `list<ToolSpec>` instead of `array<int, array{...}>`:

```diff
- $tools = [
-     ['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => '...', 'parameters' => [...]]],
- ];
+ $tools = [ToolSpec::function(name: 'get_weather', description: '...', parameters: [...])];
+ // or, one-liner migration of existing array fixtures:
+ $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', ...]])];
```

**Implementers** of `ToolCapableInterface` (custom providers) — read typed fields instead of unpacking arrays:

```diff
- $name        = $this->getString($this->getArray($toolArray, 'function'), 'name');
- $parameters  = $this->getArray($this->getArray($toolArray, 'function'), 'parameters');
+ $name        = $spec->name;
+ $parameters  = $spec->parameters;
```

Or, for OpenAI-shaped wire output, just `$spec->toArray()`.

## Verification

- Full suite on PHP 8.4: **3192 unit tests** · PHPStan level 10 clean · PHP-CS-Fixer dry-run clean
- The 10 `ToolSpec` test cases from #156 protected the wire-shape round trip used by the migrated fixtures
- Diff stat: **+107 / −90** — net +17 LOC; the Claude / Gemini collapses paid for the per-payload `array_map` additions everywhere else

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | Done |
| **2** | **ChatMessage VO + array-everywhere** | Slice 1 #155 + slice 2 #156 + slice 3 #157 + **slice 4 (this PR)** |
| 4 | Feature services consume budget+usage | Done as part of #1 |

## Follow-ups still on slice 2

- `VisionContent` VO for `ProviderInterface::analyzeImage()`'s array-of-arrays. **Additive**, no breaking change — same shape as #156.
- Promote `ChatMessage` from zombie to canonical message representation in feature services (additive helpers).
- `ProviderInterface::chatCompletion(array $messages, ...)` → `list<ChatMessage>`. Largest breaking change of the whole #2 effort. **Will pause and confirm before this slice** — same protocol as this PR.

## Test plan
- [ ] CI green
- [ ] Confirm the migration guide above maps cleanly to anything in the downstream Netresearch suite that consumes `chatWithTools`