### PR TITLE
feat(domain): add VisionContent value object

### DIFF
--- a/Classes/Domain/ValueObject/VisionContent.php
+++ b/Classes/Domain/ValueObject/VisionContent.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+/**
+ * Value Object describing one item in a vision-request content list.
+ *
+ * Mirrors the discriminated-union shape every supported provider expects:
+ * a vision call's `content` is a list whose items are either a text
+ * fragment or an image reference (URL or `data:` URI). Two factories
+ * cover those two kinds; `fromArray()` accepts the wire shape verbatim;
+ * `toArray()` emits it back.
+ *
+ * Replaces the
+ * `array<int, array{type: string, image_url?: array{url: string}, text?: string}>`
+ * shape currently used by
+ * :php:`LlmServiceManager::vision()` /
+ * :php:`VisionCapableInterface::analyzeImage()`. The provider migration
+ * lands in a follow-up slice; this VO is purely additive so callers
+ * can opt in early.
+ */
+final readonly class VisionContent implements JsonSerializable
+{
+    public const TYPE_TEXT      = 'text';
+    public const TYPE_IMAGE_URL = 'image_url';
+
+    /**
+     * @var list<string> recognised discriminator values, mirroring the
+     *                   wire format of every supported provider
+     */
+    public const KNOWN_TYPES = [self::TYPE_TEXT, self::TYPE_IMAGE_URL];
+
+    /**
+     * @param string      $type     one of the `TYPE_*` constants
+     * @param string|null $text     text payload when `$type === TYPE_TEXT`,
+     *                              `null` otherwise
+     * @param string|null $imageUrl URL or `data:` URI when
+     *                              `$type === TYPE_IMAGE_URL`, `null`
+     *                              otherwise
+     */
+    public function __construct(
+        public string $type,
+        public ?string $text = null,
+        public ?string $imageUrl = null,
+    ) {
+        if (!\in_array($this->type, self::KNOWN_TYPES, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid VisionContent type "%s". Valid types: %s',
+                    $this->type,
+                    implode(', ', self::KNOWN_TYPES),
+                ),
+                1745420001,
+            );
+        }
+        if ($this->type === self::TYPE_TEXT && ($this->text === null || $this->text === '')) {
+            throw new InvalidArgumentException(
+                'VisionContent of type "text" requires a non-empty text payload.',
+                1745420002,
+            );
+        }
+        if ($this->type === self::TYPE_IMAGE_URL && ($this->imageUrl === null || $this->imageUrl === '')) {
+            throw new InvalidArgumentException(
+                'VisionContent of type "image_url" requires a non-empty URL.',
+                1745420003,
+            );
+        }
+    }
+
+    /**
+     * Create a text fragment.
+     */
+    public static function text(string $text): self
+    {
+        return new self(type: self::TYPE_TEXT, text: $text);
+    }
+
+    /**
+     * Create an image reference.
+     *
+     * `$url` may be a remote URL or a `data:image/...;base64,...` URI;
+     * the VO does not validate the URL form because every provider
+     * accepts both transparently.
+     */
+    public static function imageUrl(string $url): self
+    {
+        return new self(type: self::TYPE_IMAGE_URL, imageUrl: $url);
+    }
+
+    /**
+     * Reconstruct from the provider wire shape.
+     *
+     * @param array{type?: string, text?: string, image_url?: array{url?: string}|string} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $type = $data['type'] ?? '';
+        if (!\is_string($type)) {
+            $type = '';
+        }
+
+        if ($type === self::TYPE_TEXT) {
+            $text = $data['text'] ?? '';
+
+            return new self(
+                type: self::TYPE_TEXT,
+                text: \is_string($text) ? $text : '',
+            );
+        }
+
+        if ($type === self::TYPE_IMAGE_URL) {
+            return new self(
+                type: self::TYPE_IMAGE_URL,
+                imageUrl: self::extractImageUrl($data['image_url'] ?? null),
+            );
+        }
+
+        // Unknown / missing type: let the constructor's invariant guard
+        // emit the canonical error so the rejection message matches the
+        // direct-construction path.
+        return new self(type: $type);
+    }
+
+    /**
+     * Serialise to the wire shape every supported provider accepts.
+     * Idempotent: `VisionContent::fromArray($vc->toArray()) == $vc`.
+     *
+     * @return array{type: string, text?: string, image_url?: array{url: string}}
+     */
+    public function toArray(): array
+    {
+        if ($this->type === self::TYPE_TEXT) {
+            return [
+                'type' => self::TYPE_TEXT,
+                'text' => $this->text ?? '',
+            ];
+        }
+
+        return [
+            'type' => self::TYPE_IMAGE_URL,
+            'image_url' => ['url' => $this->imageUrl ?? ''],
+        ];
+    }
+
+    /**
+     * @return array{type: string, text?: string, image_url?: array{url: string}}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function isText(): bool
+    {
+        return $this->type === self::TYPE_TEXT;
+    }
+
+    public function isImage(): bool
+    {
+        return $this->type === self::TYPE_IMAGE_URL;
+    }
+
+    /**
+     * Pull a URL string out of either the canonical
+     * `{image_url: {url: '...'}}` shape or the legacy flat
+     * `{image_url: '...'}` form some integrations still emit.
+     */
+    private static function extractImageUrl(mixed $raw): string
+    {
+        if (\is_string($raw)) {
+            return $raw;
+        }
+        if (\is_array($raw)) {
+            $url = $raw['url'] ?? '';
+
+            return \is_string($url) ? $url : '';
+        }
+
+        return '';
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/VisionContentTest.php
+++ b/Tests/Unit/Domain/ValueObject/VisionContentTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(VisionContent::class)]
+final class VisionContentTest extends TestCase
+{
+    #[Test]
+    public function textFactoryProducesTextContent(): void
+    {
+        $vc = VisionContent::text('describe this image');
+
+        self::assertSame(VisionContent::TYPE_TEXT, $vc->type);
+        self::assertSame('describe this image', $vc->text);
+        self::assertNull($vc->imageUrl);
+        self::assertTrue($vc->isText());
+        self::assertFalse($vc->isImage());
+    }
+
+    #[Test]
+    public function imageUrlFactoryProducesImageContent(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/cat.jpg');
+
+        self::assertSame(VisionContent::TYPE_IMAGE_URL, $vc->type);
+        self::assertNull($vc->text);
+        self::assertSame('https://example.com/cat.jpg', $vc->imageUrl);
+        self::assertTrue($vc->isImage());
+        self::assertFalse($vc->isText());
+    }
+
+    #[Test]
+    public function imageUrlAcceptsDataUri(): void
+    {
+        $dataUri = 'data:image/png;base64,iVBORw0KGgo=';
+
+        $vc = VisionContent::imageUrl($dataUri);
+
+        self::assertSame($dataUri, $vc->imageUrl);
+    }
+
+    #[Test]
+    public function constructorRejectsUnknownType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420001);
+
+        new VisionContent(type: 'video', text: 'x');
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyTextPayload(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420002);
+
+        new VisionContent(type: VisionContent::TYPE_TEXT, text: '');
+    }
+
+    #[Test]
+    public function constructorRejectsMissingTextPayload(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420002);
+
+        new VisionContent(type: VisionContent::TYPE_TEXT);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyImageUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420003);
+
+        new VisionContent(type: VisionContent::TYPE_IMAGE_URL, imageUrl: '');
+    }
+
+    #[Test]
+    public function constructorRejectsMissingImageUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420003);
+
+        new VisionContent(type: VisionContent::TYPE_IMAGE_URL);
+    }
+
+    #[Test]
+    public function fromArrayReadsTextWireShape(): void
+    {
+        $vc = VisionContent::fromArray([
+            'type' => 'text',
+            'text' => 'caption this',
+        ]);
+
+        self::assertSame(VisionContent::TYPE_TEXT, $vc->type);
+        self::assertSame('caption this', $vc->text);
+    }
+
+    #[Test]
+    public function fromArrayReadsCanonicalImageUrlWireShape(): void
+    {
+        $vc = VisionContent::fromArray([
+            'type'      => 'image_url',
+            'image_url' => ['url' => 'https://example.com/x.png'],
+        ]);
+
+        self::assertSame(VisionContent::TYPE_IMAGE_URL, $vc->type);
+        self::assertSame('https://example.com/x.png', $vc->imageUrl);
+    }
+
+    #[Test]
+    public function fromArrayAcceptsLegacyFlatImageUrlShape(): void
+    {
+        // Some integrations emit `image_url: '<url>'` without the
+        // `{url: ...}` envelope. The factory normalises it.
+        $vc = VisionContent::fromArray([
+            'type'      => 'image_url',
+            'image_url' => 'https://example.com/y.png',
+        ]);
+
+        self::assertSame('https://example.com/y.png', $vc->imageUrl);
+    }
+
+    #[Test]
+    public function fromArrayPropagatesEmptyTextThroughInvariant(): void
+    {
+        // Defensive: if a misbehaving provider sends `{type:'text', text:''}`,
+        // the factory must not silently produce an empty-string item — the
+        // constructor invariant catches it.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420002);
+
+        VisionContent::fromArray(['type' => 'text', 'text' => '']);
+    }
+
+    #[Test]
+    public function toArrayProducesIdempotentTextShape(): void
+    {
+        $vc = VisionContent::text('hello');
+
+        self::assertSame(['type' => 'text', 'text' => 'hello'], $vc->toArray());
+    }
+
+    #[Test]
+    public function toArrayProducesIdempotentImageShape(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/z.png');
+
+        self::assertSame(
+            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/z.png']],
+            $vc->toArray(),
+        );
+    }
+
+    #[Test]
+    public function fromArrayAndToArrayRoundTripText(): void
+    {
+        $shape = ['type' => 'text', 'text' => 'roundtrip'];
+
+        self::assertSame($shape, VisionContent::fromArray($shape)->toArray());
+    }
+
+    #[Test]
+    public function fromArrayAndToArrayRoundTripImage(): void
+    {
+        $shape = ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/r.png']];
+
+        self::assertSame($shape, VisionContent::fromArray($shape)->toArray());
+    }
+
+    #[Test]
+    public function jsonSerializeMatchesToArray(): void
+    {
+        $vc = VisionContent::text('hi');
+
+        self::assertSame($vc->toArray(), $vc->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## Summary

**Fifth slice of audit recommendation #2.** Adds the missing value object for vision-request content items — the discriminated-union shape every supported provider expects in the `content` list of a vision call.

**Internal-only, purely additive.** No provider, no `VisionCapableInterface`, no `LlmServiceManager` is touched. The VO sits alongside the existing array shape ready for the next slice to migrate the wire signatures (same pattern as #156).

## Background

`LlmServiceManager::vision()` and `VisionCapableInterface::analyzeImage()` currently take

```
array<int, array{type: string, image_url?: array{url: string}, text?: string}>
```

This is the discriminated union OpenAI / Anthropic / Gemini all align on:

```php
[
    ['type' => 'text', 'text' => 'describe this'],
    ['type' => 'image_url', 'image_url' => ['url' => 'https://...']],
]
```

`VisionContent` models this cleanly with two factories — `text()` and `imageUrl()` — plus `fromArray()` / `toArray()` for wire-shape interchange.

## API

```php
VisionContent::text('caption this');                        // text fragment
VisionContent::imageUrl('https://example.com/cat.jpg');     // remote URL
VisionContent::imageUrl('data:image/png;base64,…');         // data: URI also fine

VisionContent::fromArray($wireShape);                       // strict factory
$vc->toArray();                                             // back to wire
$vc->jsonSerialize();                                       // matches toArray()

$vc->isText();   // bool predicate
$vc->isImage();  // bool predicate
```

`fromArray()` accepts both the canonical `image_url: {url: '…'}` envelope **and** the legacy flat `image_url: '<url>'` form some integrations emit, so the factory normalises both into a single shape.

Constructor invariants enforce a known type and a non-empty payload for the discriminator's matching field, with fixed exception codes (`1745420001-003`) so downstream catches stay stable across slices.

## Tests

17 unit tests in `VisionContentTest`:

- Both factories (`text` + `imageUrl`)
- `imageUrl` accepts `data:` URIs verbatim
- Constructor rejects unknown type, empty/missing text payload, empty/missing imageUrl
- `fromArray` reads canonical and legacy flat `image_url` shapes
- `fromArray` propagates empty text through the constructor invariant rather than producing an empty-string item silently
- `toArray` idempotence + round-trip for both kinds
- `jsonSerialize` matches `toArray`

Full suite on PHP 8.4: **3209 unit tests green**, PHPStan level 10 clean, PHP-CS-Fixer applied.

Diff is purely additive: 2 new files, no existing file touched.

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | Done |
| **2** | **ChatMessage VO + array-everywhere** | Slices 1-4 merged · **slice 5 (this PR)** |
| 4 | Feature services consume budget+usage | Done as part of #1 |

## Follow-up slices for #2

- Migrate `VisionCapableInterface::analyzeImage($content, …)` and `LlmServiceManager::vision($content, …)` from `array<int, array{…}>` to `list<VisionContent>`. Public API change, **same pause-and-confirm protocol** as #157 / #158.
- Promote `ChatMessage` from zombie to canonical message representation in feature services (additive helpers).
- The big one: `ProviderInterface::chatCompletion(array $messages, …)` → `list<ChatMessage>`. Largest breaking change of the whole #2 effort. Pause-and-confirm before.

## Test plan
- [ ] CI green
- [ ] Sanity-check the legacy flat `image_url: '<url>'` handling — that's the variant that catches integrations that didn't read OpenAI's docs carefully