### PR TITLE
chore: address review backlog on PRs #155-#159

### DIFF
--- a/Classes/Domain/Enum/MessageRole.php
+++ b/Classes/Domain/Enum/MessageRole.php
@@ -24,10 +24,10 @@ namespace Netresearch\NrLlm\Domain\Enum;
  */
 enum MessageRole: string
 {
-    case System    = 'system';
-    case User      = 'user';
-    case Assistant = 'assistant';
-    case Tool      = 'tool';
+    case SYSTEM    = 'system';
+    case USER      = 'user';
+    case ASSISTANT = 'assistant';
+    case TOOL      = 'tool';
 
     /**
      * Get all role values as a flat list of strings.

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -73,7 +73,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function system(string $content): self
     {
-        return new self(MessageRole::System, $content);
+        return new self(MessageRole::SYSTEM, $content);
     }
 
     /**
@@ -81,7 +81,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function user(string $content): self
     {
-        return new self(MessageRole::User, $content);
+        return new self(MessageRole::USER, $content);
     }
 
     /**
@@ -89,7 +89,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function assistant(string $content): self
     {
-        return new self(MessageRole::Assistant, $content);
+        return new self(MessageRole::ASSISTANT, $content);
     }
 
     /**
@@ -97,7 +97,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public static function tool(string $content): self
     {
-        return new self(MessageRole::Tool, $content);
+        return new self(MessageRole::TOOL, $content);
     }
 
     /**
@@ -139,7 +139,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isSystem(): bool
     {
-        return $this->role === MessageRole::System->value;
+        return $this->role === MessageRole::SYSTEM->value;
     }
 
     /**
@@ -147,7 +147,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isUser(): bool
     {
-        return $this->role === MessageRole::User->value;
+        return $this->role === MessageRole::USER->value;
     }
 
     /**
@@ -155,7 +155,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isAssistant(): bool
     {
-        return $this->role === MessageRole::Assistant->value;
+        return $this->role === MessageRole::ASSISTANT->value;
     }
 
     /**
@@ -163,7 +163,7 @@ final readonly class ChatMessage implements JsonSerializable
      */
     public function isTool(): bool
     {
-        return $this->role === MessageRole::Tool->value;
+        return $this->role === MessageRole::TOOL->value;
     }
 
     /**

--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -96,9 +96,9 @@ final readonly class ToolSpec implements JsonSerializable
      */
     public static function fromArray(array $data): self
     {
-        if (!isset($data['function'])) {
+        if (!isset($data['function']) || !\is_array($data['function'])) {
             throw new InvalidArgumentException(
-                'ToolSpec array missing required "function" key.',
+                'ToolSpec array requires a "function" key with an array value.',
                 1745410003,
             );
         }

--- a/Classes/Domain/ValueObject/VisionContent.php
+++ b/Classes/Domain/ValueObject/VisionContent.php
@@ -34,11 +34,22 @@ final readonly class VisionContent implements JsonSerializable
     public const TYPE_TEXT      = 'text';
     public const TYPE_IMAGE_URL = 'image_url';
 
+    public const DETAIL_LOW  = 'low';
+    public const DETAIL_HIGH = 'high';
+    public const DETAIL_AUTO = 'auto';
+
     /**
      * @var list<string> recognised discriminator values, mirroring the
      *                   wire format of every supported provider
      */
     public const KNOWN_TYPES = [self::TYPE_TEXT, self::TYPE_IMAGE_URL];
+
+    /**
+     * @var list<string> recognised values for the OpenAI `image_url.detail`
+     *                   knob; provider-specific use only — Claude / Gemini
+     *                   ignore it
+     */
+    public const KNOWN_DETAILS = [self::DETAIL_LOW, self::DETAIL_HIGH, self::DETAIL_AUTO];
 
     /**
      * @param string      $type     one of the `TYPE_*` constants
@@ -47,11 +58,18 @@ final readonly class VisionContent implements JsonSerializable
      * @param string|null $imageUrl URL or `data:` URI when
      *                              `$type === TYPE_IMAGE_URL`, `null`
      *                              otherwise
+     * @param string|null $detail   OpenAI image-detail level (`low` /
+     *                              `high` / `auto`); only meaningful with
+     *                              `TYPE_IMAGE_URL`. Other providers
+     *                              ignore it but the field is preserved
+     *                              through `toArray()` for round-trip
+     *                              fidelity.
      */
     public function __construct(
         public string $type,
         public ?string $text = null,
         public ?string $imageUrl = null,
+        public ?string $detail = null,
     ) {
         if (!\in_array($this->type, self::KNOWN_TYPES, true)) {
             throw new InvalidArgumentException(
@@ -75,6 +93,22 @@ final readonly class VisionContent implements JsonSerializable
                 1745420003,
             );
         }
+        if ($this->detail !== null && !\in_array($this->detail, self::KNOWN_DETAILS, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid VisionContent detail "%s". Valid values: %s',
+                    $this->detail,
+                    implode(', ', self::KNOWN_DETAILS),
+                ),
+                1745420004,
+            );
+        }
+        if ($this->detail !== null && $this->type !== self::TYPE_IMAGE_URL) {
+            throw new InvalidArgumentException(
+                'VisionContent detail can only be set on image_url items.',
+                1745420005,
+            );
+        }
     }
 
     /**
@@ -91,10 +125,13 @@ final readonly class VisionContent implements JsonSerializable
      * `$url` may be a remote URL or a `data:image/...;base64,...` URI;
      * the VO does not validate the URL form because every provider
      * accepts both transparently.
+     *
+     * `$detail` is OpenAI-specific (`low` / `high` / `auto`); other
+     * providers silently ignore it. Use one of the `DETAIL_*` constants.
      */
-    public static function imageUrl(string $url): self
+    public static function imageUrl(string $url, ?string $detail = null): self
     {
-        return new self(type: self::TYPE_IMAGE_URL, imageUrl: $url);
+        return new self(type: self::TYPE_IMAGE_URL, imageUrl: $url, detail: $detail);
     }
 
     /**
@@ -119,9 +156,15 @@ final readonly class VisionContent implements JsonSerializable
         }
 
         if ($type === self::TYPE_IMAGE_URL) {
+            $imageUrl = $data['image_url'] ?? null;
+            $detail   = is_array($imageUrl) && isset($imageUrl['detail']) && is_string($imageUrl['detail'])
+                ? $imageUrl['detail']
+                : null;
+
             return new self(
                 type: self::TYPE_IMAGE_URL,
-                imageUrl: self::extractImageUrl($data['image_url'] ?? null),
+                imageUrl: self::extractImageUrl($imageUrl),
+                detail: $detail,
             );
         }
 
@@ -135,7 +178,7 @@ final readonly class VisionContent implements JsonSerializable
      * Serialise to the wire shape every supported provider accepts.
      * Idempotent: `VisionContent::fromArray($vc->toArray()) == $vc`.
      *
-     * @return array{type: string, text?: string, image_url?: array{url: string}}
+     * @return array{type: string, text?: string, image_url?: array{url: string, detail?: string}}
      */
     public function toArray(): array
     {
@@ -146,14 +189,19 @@ final readonly class VisionContent implements JsonSerializable
             ];
         }
 
+        $imageUrl = ['url' => $this->imageUrl ?? ''];
+        if ($this->detail !== null) {
+            $imageUrl['detail'] = $this->detail;
+        }
+
         return [
-            'type' => self::TYPE_IMAGE_URL,
-            'image_url' => ['url' => $this->imageUrl ?? ''],
+            'type'      => self::TYPE_IMAGE_URL,
+            'image_url' => $imageUrl,
         ];
     }
 
     /**
-     * @return array{type: string, text?: string, image_url?: array{url: string}}
+     * @return array{type: string, text?: string, image_url?: array{url: string, detail?: string}}
      */
     public function jsonSerialize(): array
     {

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -15,18 +15,12 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 interface ToolCapableInterface
 {
     /**
+     * Implementations may assume every `$tools` entry is a `ToolSpec` —
+     * `LlmServiceManager::chatWithTools()` normalises any legacy
+     * array-shaped fixture via `ToolSpec::fromArray()` before forwarding.
+     *
      * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools    Typed tool declarations
-     *                                                   the model is allowed to
-     *                                                   invoke. Provider
-     *                                                   implementations are
-     *                                                   responsible for any
-     *                                                   per-vendor wire-format
-     *                                                   conversion (most call
-     *                                                   `$spec->toArray()` for
-     *                                                   the OpenAI shape; Claude
-     *                                                   / Gemini read the typed
-     *                                                   fields directly).
+     * @param list<ToolSpec>                   $tools
      * @param array<string, mixed>             $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse;

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -302,8 +302,14 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Chat completion with tool calling.
      *
+     * Accepts either typed `ToolSpec` instances or legacy array fixtures
+     * (`{type: 'function', function: {name, description, parameters}}`)
+     * for back-compat — array entries are normalised via
+     * `ToolSpec::fromArray()` so the downstream provider always receives
+     * `list<ToolSpec>` and never has to defend against mixed input.
+     *
      * @param array<int, array{role: string, content: string}> $messages
-     * @param list<ToolSpec>                                   $tools
+     * @param list<ToolSpec|array<string, mixed>>              $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
     {
@@ -312,10 +318,15 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
+        $normalisedTools = array_map(
+            static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
+            $tools,
+        );
+
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Tools, $providerKey),
             ProviderOperation::Tools,
-            function () use ($messages, $tools, $optionsArray, $providerKey): CompletionResponse {
+            function () use ($messages, $normalisedTools, $optionsArray, $providerKey): CompletionResponse {
                 $provider = $this->getProvider($providerKey);
                 if (!$provider instanceof ToolCapableInterface) {
                     throw new UnsupportedFeatureException(
@@ -324,7 +335,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->chatCompletionWithTools($messages, $tools, $optionsArray);
+                return $provider->chatCompletionWithTools($messages, $normalisedTools, $optionsArray);
             },
         );
     }

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -94,8 +94,11 @@ interface LlmServiceManagerInterface
     public function streamChat(array $messages, ?ChatOptions $options = null): Generator;
 
     /**
+     * Legacy array-shaped tool fixtures are accepted for back-compat
+     * and normalised via `ToolSpec::fromArray()` before dispatch.
+     *
      * @param array<int, array{role: string, content: string}> $messages
-     * @param list<ToolSpec>                                    $tools
+     * @param list<ToolSpec|array<string, mixed>>              $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse;
 

--- a/Tests/Unit/Domain/Enum/MessageRoleTest.php
+++ b/Tests/Unit/Domain/Enum/MessageRoleTest.php
@@ -47,7 +47,7 @@ final class MessageRoleTest extends TestCase
     #[Test]
     public function tryFromStringMatchesBuiltInTryFrom(): void
     {
-        self::assertSame(MessageRole::User, MessageRole::tryFromString('user'));
+        self::assertSame(MessageRole::USER, MessageRole::tryFromString('user'));
         self::assertNull(MessageRole::tryFromString('moderator'));
     }
 }

--- a/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
+++ b/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
@@ -96,10 +96,10 @@ class ChatMessageTest extends AbstractUnitTestCase
     {
         $content = $this->faker->sentence();
 
-        $message = new ChatMessage(MessageRole::Assistant, $content);
+        $message = new ChatMessage(MessageRole::ASSISTANT, $content);
 
         self::assertSame('assistant', $message->role);
-        self::assertSame(MessageRole::Assistant, $message->getRole());
+        self::assertSame(MessageRole::ASSISTANT, $message->getRole());
         self::assertSame($content, $message->content);
     }
 
@@ -108,7 +108,7 @@ class ChatMessageTest extends AbstractUnitTestCase
     {
         $message = new ChatMessage('tool', 'output');
 
-        self::assertSame(MessageRole::Tool, $message->getRole());
+        self::assertSame(MessageRole::TOOL, $message->getRole());
     }
 
     // ──────────────────────────────────────────────

--- a/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
@@ -111,6 +111,18 @@ final class ToolSpecTest extends TestCase
     }
 
     #[Test]
+    public function fromArrayThrowsWhenFunctionKeyIsNotAnArray(): void
+    {
+        // Defensive: a malformed payload could send a string / null / object.
+        // The factory must reject before reaching offset access on $function.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745410003);
+
+        /** @phpstan-ignore-next-line argument.type intentional malformed input */
+        ToolSpec::fromArray(['type' => 'function', 'function' => 'not-an-array']);
+    }
+
+    #[Test]
     public function fromArrayThrowsWhenFunctionNameMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/Tests/Unit/Domain/ValueObject/VisionContentTest.php
+++ b/Tests/Unit/Domain/ValueObject/VisionContentTest.php
@@ -188,4 +188,96 @@ final class VisionContentTest extends TestCase
 
         self::assertSame($vc->toArray(), $vc->jsonSerialize());
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // detail field (OpenAI image_url.detail = low|high|auto)
+    // ──────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function imageUrlFactoryCarriesOptionalDetail(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/a.png', VisionContent::DETAIL_HIGH);
+
+        self::assertSame(VisionContent::DETAIL_HIGH, $vc->detail);
+    }
+
+    #[Test]
+    public function detailDefaultsToNull(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/a.png');
+
+        self::assertNull($vc->detail);
+    }
+
+    #[Test]
+    public function constructorRejectsUnknownDetailValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420004);
+
+        new VisionContent(
+            type: VisionContent::TYPE_IMAGE_URL,
+            imageUrl: 'https://example.com/a.png',
+            detail: 'extra-high',
+        );
+    }
+
+    #[Test]
+    public function constructorRejectsDetailOnTextItem(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745420005);
+
+        new VisionContent(
+            type: VisionContent::TYPE_TEXT,
+            text: 'caption',
+            detail: VisionContent::DETAIL_HIGH,
+        );
+    }
+
+    #[Test]
+    public function fromArrayReadsDetailFromImageUrlEnvelope(): void
+    {
+        $vc = VisionContent::fromArray([
+            'type'      => 'image_url',
+            'image_url' => ['url' => 'https://example.com/x.png', 'detail' => 'low'],
+        ]);
+
+        self::assertSame(VisionContent::DETAIL_LOW, $vc->detail);
+    }
+
+    #[Test]
+    public function toArrayIncludesDetailWhenSet(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/a.png', VisionContent::DETAIL_AUTO);
+
+        self::assertSame(
+            [
+                'type'      => 'image_url',
+                'image_url' => ['url' => 'https://example.com/a.png', 'detail' => 'auto'],
+            ],
+            $vc->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayOmitsDetailWhenNull(): void
+    {
+        $vc = VisionContent::imageUrl('https://example.com/a.png');
+
+        $arr = $vc->toArray();
+
+        self::assertArrayNotHasKey('detail', $arr['image_url'] ?? []);
+    }
+
+    #[Test]
+    public function fromArrayAndToArrayRoundTripImageWithDetail(): void
+    {
+        $shape = [
+            'type'      => 'image_url',
+            'image_url' => ['url' => 'https://example.com/r.png', 'detail' => 'high'],
+        ];
+
+        self::assertSame($shape, VisionContent::fromArray($shape)->toArray());
+    }
 }

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -443,6 +443,36 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatWithToolsAcceptsLegacyArrayShapedToolFixtures(): void
+    {
+        // Back-compat path: callers passing the pre-#158 array fixture
+        // shape are normalised via ToolSpec::fromArray() inside
+        // chatWithTools(). The provider sees only ToolSpec instances.
+        $toolProvider = new TestableToolProvider();
+        $toolProvider->setNextResponse(new CompletionResponse(
+            content: '',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(5, 5, 10),
+            finishReason: 'tool_calls',
+            provider: 'openai',
+            toolCalls: [ToolCall::function('call_1', 'echo', [])],
+        ));
+        $this->subject->registerProvider($toolProvider);
+        $this->subject->setDefaultProvider('openai-tools');
+
+        $messages    = [['role' => 'user', 'content' => 'echo back']];
+        $legacyTools = [
+            ['type' => 'function', 'function' => ['name' => 'echo', 'description' => 'echoes input', 'parameters' => []]],
+        ];
+
+        $result = $this->subject->chatWithTools($messages, $legacyTools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('echo', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function chatWithToolsThrowsWhenProviderDoesNotSupportTools(): void
     {
         $this->expectException(UnsupportedFeatureException::class);


### PR DESCRIPTION
## Summary

Five concrete review-backlog fixes on the audit-recommendation-#2 series (PRs #155-#159), bundled into one chore PR mirroring the [`a1cf52b`](../commit/a1cf52b) pattern. After this lands I'll reply + resolve every linked thread referencing this commit/PR.

## Fixes

### #155 — `MessageRole` case naming (gemini-code-assist)

Renames the cases from TitleCase (`System / User / Assistant / Tool`) to ALL_CAPS (`SYSTEM / USER / ASSISTANT / TOOL`) to match the existing `Domain/Enum/` convention (`ModelCapability::CHAT`, `ModelSelectionMode::FIXED`, …). Updates the four `ChatMessage` factories, the four `is*()` predicates, and the two test files. The wire string values are unchanged — only PHP-side identifiers move.

### #156 — `ToolSpec::fromArray()` non-array `function` guard (Copilot, gemini)

Hardens `ToolSpec::fromArray()` against the case where `$data['function']` is provided but is not an array (string, null, object). Previously that would `TypeError` on `$function['name']` access; now the same `InvalidArgumentException(1745410003)` already used for missing-key fires. Reuses the existing exception code so downstream catches stay stable. New test covers the non-array variant.

### #158 — `ToolSpec` normalisation at the public entry point (Copilot, 7 threads)

Six providers' `chatCompletionWithTools()` callsites used `array_map(static fn (ToolSpec $spec) => ...)` while the runtime signature stayed `array $tools` — a legacy array fixture would `TypeError` on the closure dispatch. Fixes by normalising at the public entry point:

- `LlmServiceManager::chatWithTools()` now accepts `list<ToolSpec | array<string, mixed>>` and routes each non-`ToolSpec` entry through `ToolSpec::fromArray()` before dispatch.
- Providers downstream see only `ToolSpec` instances and stay unchanged — the contract is documented on `ToolCapableInterface`.
- New test `chatWithToolsAcceptsLegacyArrayShapedToolFixtures()` proves the back-compat path round-trips through to the `TestableToolProvider`.

### #158 — `ToolCapableInterface` verbose PHPDoc trimmed (gemini)

Drops the implementation guidance from the interface contract; replaces with a one-line note that `LlmServiceManager::chatWithTools()` already normalises legacy fixtures so implementations can assume `list<ToolSpec>`.

### #159 — `VisionContent` missing `detail` field (gemini, 4 threads)

Adds the OpenAI `image_url.detail` knob (`low / high / auto`) to `VisionContent`:

- Constructor accepts `?string $detail = null` with new invariants (`1745420004` invalid value, `1745420005` `detail` on a `text` item — preserves the no-silent-coercion principle).
- `imageUrl()` factory takes the optional second argument.
- `fromArray()` extracts the field from the `image_url` envelope.
- `toArray()` includes `detail` when set, omits it otherwise — so round-trips with-and-without are both stable.
- **8 new tests** covering factory, invariants, wire-shape extraction, omission semantics, and round-trip.

Other providers (Claude, Gemini) ignore `detail` on the wire; the field is preserved through `toArray()` for round-trip fidelity but has no effect when the host provider doesn't recognise it. **Closes the functional gap blocking migration of `VisionService::analyzeImageFull` to the typed VO** — without `detail`, the migration would have lost OpenAI's image-quality control.

## Verification

- Full suite on PHP 8.4: **3219 unit tests** (10 new) · PHPStan level 10 clean · PHP-CS-Fixer applied
- Diff stat: **+230 / −40** (mostly tests + the new VisionContent tests cluster)

## Threads to resolve after this lands

| PR | Threads | Resolved by |
|---|---|---|
| #155 | 1 | MessageRole rename |
| #156 | 2 | ToolSpec is_array guard |
| #157 | 1 | reply only — array_values defensive note (no functional gap) |
| #158 | 8 | normalisation + interface PHPDoc trim + new test |
| #159 | 4 | VisionContent detail field |

Total: 16 threads across 5 merged PRs.

## Test plan
- [ ] CI green
- [ ] Spot-check the back-compat assertion: a third-party caller passing the pre-#158 array fixture to `LlmServiceManager::chatWithTools()` continues to work