### PR TITLE
feat(provider): migrate VisionCapableInterface input to typed VisionContent list

### DIFF
--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -265,47 +266,48 @@ final class ClaudeProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $content
-     * @param array<string, mixed>             $options
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
      */
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
-        // Convert content array to Claude's vision format
+        // Convert each VisionContent into Claude's vision-block format.
         $claudeContent = [];
 
         foreach ($content as $item) {
-            $itemArray = $this->asArray($item);
-            $itemType = $this->getString($itemArray, 'type');
-
-            if ($itemType === 'text') {
+            if ($item->isText()) {
                 $claudeContent[] = [
                     'type' => 'text',
-                    'text' => $this->getString($itemArray, 'text'),
+                    'text' => $item->text ?? '',
                 ];
-            } elseif ($itemType === 'image_url') {
-                $imageUrl = $this->getNestedString($itemArray, 'image_url.url');
+                continue;
+            }
 
-                // Handle base64 data URLs
-                if (str_starts_with($imageUrl, 'data:')) {
-                    preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
-                    $claudeContent[] = [
-                        'type' => 'image',
-                        'source' => [
-                            'type' => 'base64',
-                            'media_type' => $matches[1] ?? 'image/jpeg',
-                            'data' => $matches[2] ?? '',
-                        ],
-                    ];
-                } else {
-                    // For URLs, Claude requires base64 encoding
-                    $claudeContent[] = [
-                        'type' => 'image',
-                        'source' => [
-                            'type' => 'url',
-                            'url' => $imageUrl,
-                        ],
-                    ];
-                }
+            if (!$item->isImage()) {
+                continue;
+            }
+
+            $imageUrl = $item->imageUrl ?? '';
+            // Handle base64 data URLs
+            if (str_starts_with($imageUrl, 'data:')) {
+                preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
+                $claudeContent[] = [
+                    'type' => 'image',
+                    'source' => [
+                        'type'       => 'base64',
+                        'media_type' => $matches[1] ?? 'image/jpeg',
+                        'data'       => $matches[2] ?? '',
+                    ],
+                ];
+            } else {
+                // For URLs, Claude accepts either url or base64 source.
+                $claudeContent[] = [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'url',
+                        'url'  => $imageUrl,
+                    ],
+                ];
             }
         }
 

--- a/Classes/Provider/Contract/VisionCapableInterface.php
+++ b/Classes/Provider/Contract/VisionCapableInterface.php
@@ -10,12 +10,17 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Contract;
 
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 
 interface VisionCapableInterface
 {
     /**
-     * @param array<int, array{type: string, image_url?: array{url: string}, text?: string}> $content
-     * @param array<string, mixed>                                                           $options
+     * Implementations may assume every `$content` entry is a `VisionContent` —
+     * `LlmServiceManager::vision()` normalises any legacy array fixture
+     * via `VisionContent::fromArray()` before forwarding the call.
+     *
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
      */
     public function analyzeImage(array $content, array $options = []): VisionResponse;
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -270,8 +271,8 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $content
-     * @param array<string, mixed>             $options
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
      */
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
@@ -279,33 +280,34 @@ final class GeminiProvider extends AbstractProvider implements
 
         $parts = [];
         foreach ($content as $item) {
-            $itemArray = $this->asArray($item);
-            $itemType = $this->getString($itemArray, 'type');
-
-            if ($itemType === 'text') {
-                $text = $this->getString($itemArray, 'text');
+            if ($item->isText()) {
+                $text = $item->text ?? '';
                 if ($text !== '') {
                     $parts[] = ['text' => $text];
                 }
-            } elseif ($itemType === 'image_url') {
-                $imageUrl = $this->getNestedString($itemArray, 'image_url.url');
+                continue;
+            }
 
-                if (str_starts_with($imageUrl, 'data:')) {
-                    preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
-                    $parts[] = [
-                        'inlineData' => [
-                            'mimeType' => $matches[1] ?? 'image/jpeg',
-                            'data' => $matches[2] ?? '',
-                        ],
-                    ];
-                } else {
-                    $parts[] = [
-                        'fileData' => [
-                            'mimeType' => 'image/jpeg',
-                            'fileUri' => $imageUrl,
-                        ],
-                    ];
-                }
+            if (!$item->isImage()) {
+                continue;
+            }
+
+            $imageUrl = $item->imageUrl ?? '';
+            if (str_starts_with($imageUrl, 'data:')) {
+                preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
+                $parts[] = [
+                    'inlineData' => [
+                        'mimeType' => $matches[1] ?? 'image/jpeg',
+                        'data'     => $matches[2] ?? '',
+                    ],
+                ];
+            } else {
+                $parts[] = [
+                    'fileData' => [
+                        'mimeType' => 'image/jpeg',
+                        'fileUri'  => $imageUrl,
+                    ],
+                ];
             }
         }
 

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -229,15 +230,15 @@ final class OpenAiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $content
-     * @param array<string, mixed>             $options
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
      */
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
         $messages = [
             [
                 'role' => 'user',
-                'content' => $content,
+                'content' => array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content),
             ],
         ];
 

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -431,8 +432,8 @@ final class OpenRouterProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $content
-     * @param array<string, mixed>             $options
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
      */
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
@@ -442,7 +443,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $messages = [
             [
                 'role' => 'user',
-                'content' => $content,
+                'content' => array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content),
             ],
         ];
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
@@ -248,7 +249,13 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Analyze an image with vision capabilities.
      *
-     * @param array<int, array{type: string, image_url?: array{url: string}, text?: string}> $content
+     * Accepts either typed `VisionContent` instances or legacy array
+     * fixtures (`{type: 'text'|'image_url', ...}`) for back-compat —
+     * array entries are normalised via `VisionContent::fromArray()` so
+     * the downstream provider always receives `list<VisionContent>` and
+     * never has to defend against mixed input.
+     *
+     * @param list<VisionContent|array<string, mixed>> $content
      */
     public function vision(array $content, ?VisionOptions $options = null): VisionResponse
     {
@@ -257,10 +264,16 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
+        $normalisedContent = array_map(
+            static fn(VisionContent|array $item): VisionContent
+                => $item instanceof VisionContent ? $item : VisionContent::fromArray($item),
+            $content,
+        );
+
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
             ProviderOperation::Vision,
-            function () use ($content, $optionsArray, $providerKey): VisionResponse {
+            function () use ($normalisedContent, $optionsArray, $providerKey): VisionResponse {
                 $provider = $this->getProvider($providerKey);
                 if (!$provider instanceof VisionCapableInterface) {
                     throw new UnsupportedFeatureException(
@@ -269,7 +282,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->analyzeImage($content, $optionsArray);
+                return $provider->analyzeImage($normalisedContent, $optionsArray);
             },
         );
     }

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
@@ -82,7 +83,11 @@ interface LlmServiceManagerInterface
     public function embed(string|array $input, ?EmbeddingOptions $options = null): EmbeddingResponse;
 
     /**
-     * @param array<int, array{type: string, image_url?: array{url: string}, text?: string}> $content
+     * Legacy array-shaped vision-content fixtures are accepted for
+     * back-compat and normalised via `VisionContent::fromArray()`
+     * before dispatch.
+     *
+     * @param list<VisionContent|array<string, mixed>> $content
      */
     public function vision(array $content, ?VisionOptions $options = null): VisionResponse;
 

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
@@ -498,8 +499,8 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function analyzeImageReturnsVisionResponse(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'Describe this image'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.png']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this image']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.png']]),
         ];
 
         $apiResponse = [
@@ -526,8 +527,8 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function analyzeImageHandlesBase64DataUrl(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'What is this?'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQSkZJRg==']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQSkZJRg==']]),
         ];
 
         $apiResponse = [
@@ -552,7 +553,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     #[Test]
     public function analyzeImageWithSystemPrompt(): void
     {
-        $content = [['type' => 'text', 'text' => 'Describe']];
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'Describe'])];
         $options = ['system_prompt' => 'Be concise'];
 
         $apiResponse = [
@@ -761,7 +762,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     #[Test]
     public function analyzeImageHandlesMultipleContentBlocks(): void
     {
-        $content = [['type' => 'text', 'text' => 'Describe']];
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'Describe'])];
 
         $apiResponse = [
             'id' => 'msg_test',
@@ -788,7 +789,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     #[Test]
     public function analyzeImageWithExplicitModel(): void
     {
-        $content = [['type' => 'text', 'text' => 'What is this?']];
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?'])];
         $options = ['model' => 'claude-opus-4-5-20251124'];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -421,8 +422,8 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
 
         $content = [
-            ['type' => 'text', 'text' => 'Describe this image'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQSkZJRg==']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this image']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQSkZJRg==']]),
         ];
 
         $apiResponse = [
@@ -780,8 +781,8 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
 
         $content = [
-            ['type' => 'text', 'text' => 'Describe this'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']]),
         ];
 
         $apiResponse = [
@@ -816,8 +817,8 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
 
         $content = [
-            ['type' => 'text', 'text' => 'What is this?'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,iVBORw0KGgo=']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,iVBORw0KGgo=']]),
         ];
 
         $apiResponse = [
@@ -847,13 +848,19 @@ class GeminiProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function analyzeImageWithEmptyText(): void
+    public function analyzeImageWithImageOnlyContent(): void
     {
+        // Pre-VisionContent migration this test passed an empty-text item
+        // alongside the image and asserted Gemini silently dropped it. The
+        // typed VO now rejects empty-text payloads at construction (covered
+        // by VisionContentTest::constructorRejectsEmptyTextPayload), so the
+        // scenario degenerates into "image-only content also works" — that
+        // path remains worth exercising on Gemini, where the previous code
+        // had a defensive `if ($text !== '')` branch.
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
 
         $content = [
-            ['type' => 'text', 'text' => ''],
-            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQ']],
+            VisionContent::imageUrl('data:image/jpeg;base64,/9j/4AAQ'),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
@@ -485,8 +486,8 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     public function analyzeImageReturnsVisionResponse(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'What is in this image?'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is in this image?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']]),
         ];
 
         $apiResponse = [
@@ -516,8 +517,8 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     public function analyzeImageWithSystemPrompt(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'Describe this'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,abc123']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,abc123']]),
         ];
 
         $apiResponse = [
@@ -1136,8 +1137,8 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     public function analyzeImageWithCustomModel(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'What is this?'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/img.jpg']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/img.jpg']]),
         ];
 
         $apiResponse = [

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -615,8 +616,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     public function analyzeImageReturnsVisionResponse(): void
     {
         $content = [
-            ['type' => 'text', 'text' => 'Describe this image'],
-            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.png']],
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this image']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.png']]),
         ];
 
         $apiResponse = [
@@ -645,7 +646,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     #[Test]
     public function analyzeImageWithSystemPrompt(): void
     {
-        $content = [['type' => 'text', 'text' => 'What is this?']];
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?'])];
         $options = ['system_prompt' => 'You are a helpful assistant'];
 
         $apiResponse = [
@@ -1260,7 +1261,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                 $this->createJsonResponseMock($visionResponse),
             );
 
-        $content = [['type' => 'text', 'text' => 'Describe this']];
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this'])];
         $result = $this->subject->analyzeImage($content);
 
         self::assertInstanceOf(VisionResponse::class, $result);


### PR DESCRIPTION
## Summary

**Sixth slice of audit recommendation #2** — the vision-side counterpart to #158. Switches the public vision contract from `array<int, array{type: string, image_url?: array{url: string}, text?: string}>` to `list<VisionContent>` (the VO landed in #159 and was extended with the `detail` field in #160).

Same back-compat protocol as #158: callers passing array fixtures continue to work because `LlmServiceManager::vision()` normalises each non-`VisionContent` entry through `VisionContent::fromArray()` before dispatch.

## Provider side

| Provider | Wire conversion |
|---|---|
| OpenAi, OpenRouter | `messages[0].content => array_map(fn (VisionContent $vc) => $vc->toArray(), $content)` — pass-through providers, one-line addition |
| **Claude** | Per-item `if/elseif ('type')` collapses into `$item->isText()` / `$item->isImage()` predicates with `$item->text` / `$item->imageUrl` reads. Data-URL parsing branch unchanged. **~12 LOC simplified.** |
| **Gemini** | Same simplification — typed-field reads instead of `getString($item, 'type')` + `getNestedString($item, 'image_url.url')`. **~14 LOC simplified.** |

## Service side

- `LlmServiceManager::vision()` accepts `list<VisionContent | array<string, mixed>>`. Legacy array entries are routed through `VisionContent::fromArray()` before forwarding.
- `LlmServiceManagerInterface::vision()` PHPDoc mirrors the union type and documents the normalisation.
- `VisionService` feature class unchanged — it already passes `$content` straight through, which now flows through the normalisation layer transparently.

## Test side

29 array-shaped fixtures across the 4 vision-provider tests migrated to `VisionContent::fromArray(...)` wrappers. **Targeted migration:** only `$content = [...]` assignments that flow into an `analyzeImage()` call were rewrapped. Claude API response mocks (which share the same `{type: 'text'}` shape but mean a different thing — they're assistant-side response blocks) stayed untouched. First pass with a broader regex caught 42 false positives in `ClaudeProviderTest`; reverted and used a paren-aware Python script that scopes to `$content = [...]` literals followed by `analyzeImage($content)` calls within ~80 lines.

`GeminiProviderTest::analyzeImageWithEmptyText` renamed to `analyzeImageWithImageOnlyContent`. The original asserted Gemini silently dropped empty-text items — that scenario is no longer reachable because the typed VO rejects empty-text payloads at construction (covered by `VisionContentTest`). The test is repurposed to assert the image-only path still works (the previous code had a defensive `if ($text !== '')` branch worth keeping coverage on).

## Compatibility / migration guide

| Caller type | What to change |
|---|---|
| Callers via `LlmServiceManager::vision()` | Nothing — the manager normalises legacy fixtures |
| Callers bypassing the manager (calling `analyzeImage()` directly) | Pass `list<VisionContent>`, e.g. `VisionContent::text($prompt)` + `VisionContent::imageUrl($url, $detail)` |
| Implementers of `VisionCapableInterface` | Read `$item->isText()` / `$item->isImage()` / `$item->text` / `$item->imageUrl` (or `$item->toArray()` for OpenAI wire shape) instead of nested-array unpacking |

## Verification

- Full suite on PHP 8.4: **3219 unit tests** · PHPStan level 10 clean · PHP-CS-Fixer dry-run clean
- The 25 `VisionContent` test cases from #159 + #160 protected the wire-shape round trips used by the migrated fixtures
- Diff stat: **+133 / −94** — net +39 LOC; the Claude / Gemini per-item simplifications paid for the 4 normalisation sites + manager normalisation

## Audit progress

| # | Recommendation | Status |
|---|---|---|
| 1 | Provider middleware pipeline | Done |
| **2** | **ChatMessage VO + array-everywhere** | Slices 1-5 merged · **slice 6 (this PR)** |
| 4 | Feature services consume budget+usage | Done as part of #1 |

## Follow-ups still on slice 2

- The big one: **`ProviderInterface::chatCompletion(array $messages, ...)` → `list<ChatMessage>`**. Largest breaking change of the whole #2 effort — touches 1 interface + all 7 providers + `LlmServiceManager::chat()/complete()/stream*()/streamWithConfiguration` + most provider tests + integration tests. **Will pause and confirm scope before this slice.**
- Promote `ChatMessage` factories in feature services (additive helpers; only useful after the chat-completion slice).

## Test plan
- [ ] CI green
- [ ] Spot-check the Claude/Gemini per-item simplifications — they were the two providers with non-trivial vision-block conversion logic