### PR TITLE
feat(provider): migrate ProviderInterface chat methods to typed ChatMessage list

### DIFF
--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -109,11 +110,17 @@ final class ClaudeProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $converted = $this->convertMessagesForClaude($messages);
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
@@ -173,12 +180,18 @@ final class ClaudeProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $converted = $this->convertMessagesForClaude($messages);
 
         // Convert OpenAI-shaped ToolSpec into Claude's `input_schema` format.
@@ -387,13 +400,19 @@ final class ClaudeProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $converted = $this->convertMessagesForClaude($messages);
 
         $payload = [
@@ -464,6 +483,9 @@ final class ClaudeProvider extends AbstractProvider implements
      *
      * Handles system message extraction, tool result messages (role='tool'),
      * assistant messages with tool_calls, and multimodal content arrays.
+     *
+     * Receives the already-flattened OpenAI-style array shapes produced by
+     * `ChatMessage::toArray()` at the public entry points.
      *
      * @param array<int, array<string, mixed>> $messages
      *
@@ -546,7 +568,7 @@ final class ClaudeProvider extends AbstractProvider implements
             }
 
             // Plain text message: pass through
-            $filteredMessages[] = $message;
+            $filteredMessages[] = $msgArray;
         }
 
         // Flush remaining tool results

--- a/Classes/Provider/Contract/ProviderInterface.php
+++ b/Classes/Provider/Contract/ProviderInterface.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Provider\Contract;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 
 interface ProviderInterface
@@ -32,8 +33,14 @@ interface ProviderInterface
     public function supportsFeature(string|ModelCapability $feature): bool;
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * `LlmServiceManager` normalises every entry to a `ChatMessage` before
+     * forwarding the call. Implementations called directly (e.g. from tests
+     * or one-off scripts) may also receive legacy `['role' => ..., 'content'
+     * => ...]` array fixtures; each implementation is responsible for
+     * normalising mixed input via `ChatMessage::fromArray()`.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse;
 

--- a/Classes/Provider/Contract/StreamingCapableInterface.php
+++ b/Classes/Provider/Contract/StreamingCapableInterface.php
@@ -10,12 +10,18 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Contract;
 
 use Generator;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 
 interface StreamingCapableInterface
 {
     /**
-     * @param array<int, array{role: string, content: string}> $messages
-     * @param array<string, mixed>                             $options
+     * `LlmServiceManager` normalises every entry to a `ChatMessage` before
+     * forwarding the call. Implementations called directly may also receive
+     * legacy `['role' => ..., 'content' => ...]` array fixtures and are
+     * responsible for normalising mixed input via `ChatMessage::fromArray()`.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -10,18 +10,21 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Contract;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 
 interface ToolCapableInterface
 {
     /**
-     * Implementations may assume every `$tools` entry is a `ToolSpec` —
-     * `LlmServiceManager::chatWithTools()` normalises any legacy
-     * array-shaped fixture via `ToolSpec::fromArray()` before forwarding.
+     * `LlmServiceManager::chatWithTools()` normalises every `$messages`
+     * entry to a `ChatMessage` and every `$tools` entry to a `ToolSpec`
+     * before forwarding. Implementations called directly may also receive
+     * legacy array fixtures and are responsible for normalising mixed
+     * input via `ChatMessage::fromArray()` / `ToolSpec::fromArray()`.
      *
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse;
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -83,11 +84,17 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
         $geminiContents = $this->convertToGeminiFormat($messages);
 
@@ -142,12 +149,18 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
         $geminiContents = $this->convertToGeminiFormat($messages);
 
@@ -386,13 +399,19 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
         $geminiContents = $this->convertToGeminiFormat($messages);
 
@@ -466,7 +485,7 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
+     * @param list<ChatMessage|array<string, mixed>> $messages
      *
      * @return array{contents: array<int, array<string, mixed>>, systemInstruction?: array<string, mixed>}
      */

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -13,6 +13,7 @@ use Generator;
 use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
@@ -99,11 +100,17 @@ final class GroqProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -152,12 +159,18 @@ final class GroqProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -212,13 +225,19 @@ final class GroqProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $payload = [
             'model' => $this->getString($options, 'model', $this->getDefaultModel()),
             'messages' => $messages,

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -14,6 +14,7 @@ use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
@@ -91,11 +92,17 @@ final class MistralProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -138,12 +145,18 @@ final class MistralProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -237,13 +250,19 @@ final class MistralProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $payload = [
             'model' => $this->getString($options, 'model', $this->getDefaultModel()),
             'messages' => $messages,

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -14,6 +14,7 @@ use JsonException;
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Throwable;
@@ -104,11 +105,17 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         /** @var array<string, mixed> $payloadOptions */
@@ -187,13 +194,19 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         /** @var array<string, mixed> $payloadOptions */

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -90,11 +91,17 @@ final class OpenAiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -130,12 +137,18 @@ final class OpenAiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [
@@ -295,13 +308,19 @@ final class OpenAiProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         $payload = [

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -243,11 +244,17 @@ final class OpenRouterProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->selectModel($options);
 
         $payload = [
@@ -319,12 +326,18 @@ final class OpenRouterProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param list<ToolSpec>                   $tools
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
      */
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->selectModel($options);
 
         $payload = [
@@ -507,13 +520,19 @@ final class OpenRouterProvider extends AbstractProvider implements
     }
 
     /**
-     * @param array<int, array<string, mixed>> $messages
-     * @param array<string, mixed>             $options
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
         $model = $this->selectModel($options);
 
         $payload = [

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -149,7 +150,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Send a chat completion request.
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped messages are accepted for back-compat and
+     * normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      */
     public function chat(array $messages, ?ChatOptions $options = null): CompletionResponse
     {
@@ -158,10 +162,12 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
+        $normalisedMessages = $this->normaliseMessages($messages);
+
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
-            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($messages, $optionsArray),
+            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($normalisedMessages, $optionsArray),
         );
     }
 
@@ -290,7 +296,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Stream a chat completion response.
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped messages are accepted for back-compat and
+     * normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      *
      * @return Generator<int, string, mixed, void>
      */
@@ -309,20 +318,19 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        return $provider->streamChatCompletion($messages, $optionsArray);
+        return $provider->streamChatCompletion($this->normaliseMessages($messages), $optionsArray);
     }
 
     /**
      * Chat completion with tool calling.
      *
-     * Accepts either typed `ToolSpec` instances or legacy array fixtures
-     * (`{type: 'function', function: {name, description, parameters}}`)
-     * for back-compat — array entries are normalised via
-     * `ToolSpec::fromArray()` so the downstream provider always receives
-     * `list<ToolSpec>` and never has to defend against mixed input.
+     * Accepts both typed `ChatMessage` / `ToolSpec` instances and legacy
+     * array fixtures for back-compat — each non-typed entry is routed
+     * through the matching `fromArray()` factory so the downstream
+     * provider always receives `list<ChatMessage>` + `list<ToolSpec>`.
      *
-     * @param array<int, array{role: string, content: string}> $messages
-     * @param list<ToolSpec|array<string, mixed>>              $tools
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
     {
@@ -331,7 +339,8 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
-        $normalisedTools = array_map(
+        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedTools    = array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
             $tools,
         );
@@ -339,7 +348,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Tools, $providerKey),
             ProviderOperation::Tools,
-            function () use ($messages, $normalisedTools, $optionsArray, $providerKey): CompletionResponse {
+            function () use ($normalisedMessages, $normalisedTools, $optionsArray, $providerKey): CompletionResponse {
                 $provider = $this->getProvider($providerKey);
                 if (!$provider instanceof ToolCapableInterface) {
                     throw new UnsupportedFeatureException(
@@ -348,7 +357,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->chatCompletionWithTools($messages, $normalisedTools, $optionsArray);
+                return $provider->chatCompletionWithTools($normalisedMessages, $normalisedTools, $optionsArray);
             },
         );
     }
@@ -429,18 +438,23 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * on the primary (network, 5xx, 429) transparently re-run the request
      * against each fallback configuration in order.
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped messages are accepted for back-compat and
+     * normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      */
     public function chatWithConfiguration(array $messages, LlmConfiguration $configuration): CompletionResponse
     {
+        $normalisedMessages = $this->normaliseMessages($messages);
+
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Chat,
-            function (LlmConfiguration $config) use ($messages): CompletionResponse {
+            function (LlmConfiguration $config) use ($normalisedMessages): CompletionResponse {
                 $adapter = $this->getAdapterFromConfiguration($config);
                 $options = $config->toOptionsArray();
                 unset($options['provider']);
-                return $adapter->chatCompletion($messages, $options);
+                return $adapter->chatCompletion($normalisedMessages, $options);
             },
         );
     }
@@ -492,6 +506,27 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
+     * Normalise a public-API messages list into `list<ChatMessage>`.
+     *
+     * Legacy array fixtures (`['role' => '...', 'content' => '...']`) are
+     * routed through `ChatMessage::fromArray()` so providers downstream
+     * always receive typed instances and never have to defend against
+     * mixed input. Pre-typed entries pass through verbatim.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     *
+     * @return list<ChatMessage>
+     */
+    private function normaliseMessages(array $messages): array
+    {
+        return array_map(
+            static fn(ChatMessage|array $message): ChatMessage
+                => $message instanceof ChatMessage ? $message : ChatMessage::fromArray($message),
+            $messages,
+        );
+    }
+
+    /**
      * Build a transient LlmConfiguration for direct (ad-hoc) provider calls.
      *
      * Direct API methods — `chat()`, `complete()`, `embed()`, `vision()`,
@@ -529,7 +564,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * chunk has been yielded to the caller we cannot swap providers mid-stream.
      * Use chatWithConfiguration() if fallback protection is required.
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped messages are accepted for back-compat and
+     * normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      *
      * @return Generator<int, string, mixed, void>
      */
@@ -548,7 +586,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        return $adapter->streamChatCompletion($messages, $options);
+        return $adapter->streamChatCompletion($this->normaliseMessages($messages), $options);
     }
 
     /**

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -50,7 +51,10 @@ interface LlmServiceManagerInterface
     public function getDefaultProvider(): ?string;
 
     /**
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped message fixtures are accepted for back-compat
+     * and normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      */
     public function chat(array $messages, ?ChatOptions $options = null): CompletionResponse;
 
@@ -64,14 +68,20 @@ interface LlmServiceManagerInterface
     /**
      * Chat using a specific LLM configuration (database-backed provider resolution).
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped message fixtures are accepted for back-compat
+     * and normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      */
     public function chatWithConfiguration(array $messages, LlmConfiguration $configuration): CompletionResponse;
 
     /**
      * Stream chat completion using a specific LLM configuration.
      *
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped message fixtures are accepted for back-compat
+     * and normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      *
      * @return Generator<int, string, mixed, void>
      */
@@ -92,18 +102,22 @@ interface LlmServiceManagerInterface
     public function vision(array $content, ?VisionOptions $options = null): VisionResponse;
 
     /**
-     * @param array<int, array{role: string, content: string}> $messages
+     * Legacy array-shaped message fixtures are accepted for back-compat
+     * and normalised via `ChatMessage::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
      *
      * @return Generator<int, string, mixed, void>
      */
     public function streamChat(array $messages, ?ChatOptions $options = null): Generator;
 
     /**
-     * Legacy array-shaped tool fixtures are accepted for back-compat
-     * and normalised via `ToolSpec::fromArray()` before dispatch.
+     * Legacy array-shaped message and tool fixtures are accepted for
+     * back-compat and normalised via `ChatMessage::fromArray()` /
+     * `ToolSpec::fromArray()` before dispatch.
      *
-     * @param array<int, array{role: string, content: string}> $messages
-     * @param list<ToolSpec|array<string, mixed>>              $tools
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse;
 

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\AbstractProvider;
@@ -630,7 +631,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $mockAdapter->expects(self::once())
             ->method('chatCompletion')
             ->with(
-                [['role' => 'user', 'content' => 'Hello']],
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
                 ['temperature' => 0.7],  // provider key should be removed
             )
             ->willReturn($expectedResponse);


### PR DESCRIPTION
## Summary

Promote `ProviderInterface::chatCompletion`, `StreamingCapableInterface::streamChatCompletion`, and `ToolCapableInterface::chatCompletionWithTools` from raw `array<int, array<string, mixed>>` to `list<ChatMessage|array<string, mixed>>`. The public API (`LlmServiceManager`) eagerly normalises every entry to a typed `ChatMessage` via `fromArray()`, so middleware and downstream provider code paths only ever see VOs. Provider implementations remain tolerant of legacy array fixtures so direct callers (unit tests, ad-hoc scripts) keep working without churn.

This is **slice 7** of audit recommendation #2 (DTO/VO promotion), continuing the strategy proven on `ToolSpec` (#157) and `VisionContent` (#161): typed-first contract, factory-normalised legacy entries.

## Why

`ChatMessage` was introduced in slice 1 (#155) but only consumed at the `LlmServiceManager` boundary. The audit (`claudedocs/audit-2026-04-23-architecture.md`, REC-2) flagged the provider contract as the next surface so middleware no longer has to defend against `array{role, content}` shapes. With this slice the canonical message representation reaches the provider seam — the next steps (tool messages, multimodal content, message-history persistence) build on a typed boundary.

## Changes

### Provider contracts
- `Classes/Provider/Contract/ProviderInterface.php`
- `Classes/Provider/Contract/StreamingCapableInterface.php`
- `Classes/Provider/Contract/ToolCapableInterface.php`

PHPDoc updated to `list<ChatMessage|array<string, mixed>>` with explicit normalisation contract for direct callers (\"`LlmServiceManager` normalises every entry to a `ChatMessage` before forwarding...\").

### Provider implementations (all 7)
- `OpenAiProvider`, `ClaudeProvider`, `GeminiProvider`, `GroqProvider`, `MistralProvider`, `OllamaProvider`, `OpenRouterProvider`

Every `chatCompletion` / `streamChatCompletion` / `chatCompletionWithTools` entry point now starts with:

\`\`\`php
\$messages = array_map(
    static fn (ChatMessage|array \$m): array
        => \$m instanceof ChatMessage ? \$m->toArray() : \$m,
    \$messages,
);
\`\`\`

The existing OpenAI-shape conversion logic (multimodal blocks, tool result accumulation, system-message extraction in Claude) operates on the flattened array shape unchanged.

### LlmServiceManager
- New private `normaliseMessages(array \$messages): array` helper.
- Called from `chat()`, `streamChat()`, `chatWithTools()`, `chatWithConfiguration()`, and `streamChatWithConfiguration()` so the middleware pipeline always operates on typed messages.
- `LlmServiceManagerInterface` PHPDocs updated for the five methods that take messages, mirroring the existing back-compat note pattern from `chatWithTools` / `vision`.

### Tests
- `Tests/Unit/Service/LlmServiceManagerTest::chatWithConfigurationUsesAdapter` — adapter expectation updated to match the new normalisation behaviour (adapter receives typed `ChatMessage` entries).

### ClaudeProvider docfix
- `convertMessagesForClaude` PHPDoc corrected to reflect the already-flattened array shapes it now receives at the call site.
- The \"plain text passthrough\" branch was pushing the original loop variable; switched to the `asArray` result so the return type strictly matches the declared `array<int, array<string, mixed>>`.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Unit tests pass (3219 / 3219)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] No regression in tests calling provider methods directly with array fixtures (back-compat shim verified by existing test suite)

## Follow-up

Slice 8 will surface `ChatMessage` in the public-API entry points (e.g. accept-only signatures on a future `LlmServiceManagerInterface::chatTyped()`) once consumer migrations elsewhere in the project (nr-content-suggestions, nr-translation-llm) have caught up.