### PR TITLE
chore: address PR #162 Copilot review (preserve rich message shapes)

### DIFF
--- a/Classes/Provider/Contract/ProviderInterface.php
+++ b/Classes/Provider/Contract/ProviderInterface.php
@@ -33,11 +33,15 @@ interface ProviderInterface
     public function supportsFeature(string|ModelCapability $feature): bool;
 
     /**
-     * `LlmServiceManager` normalises every entry to a `ChatMessage` before
-     * forwarding the call. Implementations called directly (e.g. from tests
-     * or one-off scripts) may also receive legacy `['role' => ..., 'content'
-     * => ...]` array fixtures; each implementation is responsible for
-     * normalising mixed input via `ChatMessage::fromArray()`.
+     * `LlmServiceManager` may forward simple `{role, content}` fixtures as
+     * typed `ChatMessage` instances, but richer provider-specific shapes
+     * (tool result messages, multimodal content) are passed through as
+     * arrays so their additional fields survive. Implementations called
+     * directly (e.g. from tests or one-off scripts) may also receive
+     * legacy `['role' => ..., 'content' => ...]` array fixtures.
+     * Implementations should therefore normalise mixed input by converting
+     * `ChatMessage` entries via `toArray()` and leaving array fixtures
+     * untouched.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $options

--- a/Classes/Provider/Contract/StreamingCapableInterface.php
+++ b/Classes/Provider/Contract/StreamingCapableInterface.php
@@ -15,10 +15,12 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 interface StreamingCapableInterface
 {
     /**
-     * `LlmServiceManager` normalises every entry to a `ChatMessage` before
-     * forwarding the call. Implementations called directly may also receive
-     * legacy `['role' => ..., 'content' => ...]` array fixtures and are
-     * responsible for normalising mixed input via `ChatMessage::fromArray()`.
+     * `LlmServiceManager` may forward simple `{role, content}` fixtures as
+     * typed `ChatMessage` instances; richer provider-specific shapes are
+     * passed through as arrays. Implementations called directly may also
+     * receive legacy array fixtures. Implementations should therefore
+     * normalise mixed input by converting `ChatMessage` entries via
+     * `toArray()` and leaving array fixtures untouched.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $options

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -16,11 +16,13 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 interface ToolCapableInterface
 {
     /**
-     * `LlmServiceManager::chatWithTools()` normalises every `$messages`
-     * entry to a `ChatMessage` and every `$tools` entry to a `ToolSpec`
-     * before forwarding. Implementations called directly may also receive
-     * legacy array fixtures and are responsible for normalising mixed
-     * input via `ChatMessage::fromArray()` / `ToolSpec::fromArray()`.
+     * `LlmServiceManager::chatWithTools()` always normalises every `$tools`
+     * entry to a typed `ToolSpec` before forwarding (legacy array tool
+     * fixtures are accepted at the public API only, never reach this layer).
+     * Messages may arrive as a mix of typed `ChatMessage` and richer
+     * provider-specific arrays (tool result shapes, multimodal content) so
+     * implementations should normalise messages by converting `ChatMessage`
+     * entries via `toArray()` and leaving array fixtures untouched.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param list<ToolSpec>                         $tools

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -506,22 +506,41 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
-     * Normalise a public-API messages list into `list<ChatMessage>`.
+     * Normalise a public-API messages list for forwarding to providers.
      *
-     * Legacy array fixtures (`['role' => '...', 'content' => '...']`) are
-     * routed through `ChatMessage::fromArray()` so providers downstream
-     * always receive typed instances and never have to defend against
-     * mixed input. Pre-typed entries pass through verbatim.
+     * Simple legacy fixtures matching the `ChatMessage` shape (`{role: string,
+     * content: string}` only) are routed through `ChatMessage::fromArray()`
+     * so providers downstream see typed VOs whenever the sender used the
+     * documented shape. Richer provider-specific arrays carrying
+     * `tool_call_id`, `tool_calls`, `name`, or multimodal `content` arrays
+     * are passed through unchanged so their additional fields survive the
+     * round-trip — `ChatMessage` does not currently model those shapes and
+     * eagerly running them through `fromArray()` would silently drop the
+     * extra keys (and break `ClaudeProvider::convertMessagesForClaude()` for
+     * tool-result and multimodal messages).
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      *
-     * @return list<ChatMessage>
+     * @return list<ChatMessage|array<string, mixed>>
      */
     private function normaliseMessages(array $messages): array
     {
         return array_map(
-            static fn(ChatMessage|array $message): ChatMessage
-                => $message instanceof ChatMessage ? $message : ChatMessage::fromArray($message),
+            static function (ChatMessage|array $message): ChatMessage|array {
+                if ($message instanceof ChatMessage) {
+                    return $message;
+                }
+
+                if (
+                    array_keys($message) === ['role', 'content']
+                    && is_string($message['role'])
+                    && is_string($message['content'])
+                ) {
+                    return ChatMessage::fromArray($message);
+                }
+
+                return $message;
+            },
             $messages,
         );
     }


### PR DESCRIPTION
## Summary

Address all 4 Copilot review comments from PR #162 (typed `ChatMessage` list migration).

### Fix 1: real regression — `normaliseMessages()` dropped tool / multimodal data

Slice 7 routed every non-`ChatMessage` entry unconditionally through `ChatMessage::fromArray()`. But `ChatMessage` only models `{role, content}` — so tool-result fixtures (with `tool_call_id`), assistant fixtures with `tool_calls`, and multimodal fixtures with array `content` payloads silently lost their extra fields when forwarded to providers via `chat()`, `streamChat()`, `chatWithTools()`, `chatWithConfiguration()`, or `streamChatWithConfiguration()`. `ClaudeProvider::convertMessagesForClaude()` reads exactly those fields, so the round-trip was actually broken.

`normaliseMessages()` now only wraps fixtures whose keys are exactly `['role', 'content']` with string values — richer arrays pass through unchanged. Return type widens to `list<ChatMessage|array<string, mixed>>`; downstream providers (which already accept the union after slice 7) handle both transparently.

### Fix 2-4: contract docblocks described the wrong normalisation direction

`ProviderInterface::chatCompletion`, `StreamingCapableInterface::streamChatCompletion`, and `ToolCapableInterface::chatCompletionWithTools` previously read as \"implementations should normalise via `ChatMessage::fromArray()`\". But every provider in the repo actually does the opposite — converts `ChatMessage` entries via `toArray()` and leaves array fixtures untouched, because the downstream conversion logic in each provider operates on OpenAI-shaped arrays.

Docblocks rewritten to describe the actual contract. `ToolCapableInterface` additionally clarifies that `$tools` always arrives as `list<ToolSpec>` at this layer (legacy tool arrays are normalised in `LlmServiceManager::chatWithTools()` and never reach the provider).

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Unit tests pass (3219 / 3219)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)

## Related
- Addresses Copilot review on #162