### PR TITLE
chore: address PR #160 + #161 review backlog (list contracts, vision regex, test coverage)

### DIFF
--- a/Classes/Domain/ValueObject/VisionContent.php
+++ b/Classes/Domain/ValueObject/VisionContent.php
@@ -157,9 +157,16 @@ final readonly class VisionContent implements JsonSerializable
 
         if ($type === self::TYPE_IMAGE_URL) {
             $imageUrl = $data['image_url'] ?? null;
-            $detail   = is_array($imageUrl) && isset($imageUrl['detail']) && is_string($imageUrl['detail'])
-                ? $imageUrl['detail']
-                : null;
+            $detail   = null;
+            if (\is_array($imageUrl) && \array_key_exists('detail', $imageUrl)) {
+                if (!\is_string($imageUrl['detail'])) {
+                    throw new InvalidArgumentException(
+                        'VisionContent image_url.detail must be a string when present.',
+                        1745420004,
+                    );
+                }
+                $detail = $imageUrl['detail'];
+            }
 
             return new self(
                 type: self::TYPE_IMAGE_URL,

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -301,9 +301,16 @@ final class ClaudeProvider extends AbstractProvider implements
             }
 
             $imageUrl = $item->imageUrl ?? '';
-            // Handle base64 data URLs
+            // Handle base64 data URLs.
+            // analyzeImage() is image-only — skip data URIs whose MIME type
+            // isn't `image/*` rather than forwarding malformed Claude requests
+            // (e.g. `data:application/pdf;base64,...`). Non-image documents
+            // belong on the document path, not vision.
             if (str_starts_with($imageUrl, 'data:')) {
-                if (preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1) {
+                if (
+                    preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1
+                    && str_starts_with($matches[1], 'image/')
+                ) {
                     $claudeContent[] = [
                         'type' => 'image',
                         'source' => [

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -303,15 +303,16 @@ final class ClaudeProvider extends AbstractProvider implements
             $imageUrl = $item->imageUrl ?? '';
             // Handle base64 data URLs
             if (str_starts_with($imageUrl, 'data:')) {
-                preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
-                $claudeContent[] = [
-                    'type' => 'image',
-                    'source' => [
-                        'type'       => 'base64',
-                        'media_type' => $matches[1] ?? 'image/jpeg',
-                        'data'       => $matches[2] ?? '',
-                    ],
-                ];
+                if (preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1) {
+                    $claudeContent[] = [
+                        'type' => 'image',
+                        'source' => [
+                            'type'       => 'base64',
+                            'media_type' => $matches[1],
+                            'data'       => $matches[2],
+                        ],
+                    ];
+                }
             } else {
                 // For URLs, Claude accepts either url or base64 source.
                 $claudeContent[] = [

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -305,8 +305,14 @@ final class GeminiProvider extends AbstractProvider implements
             }
 
             $imageUrl = $item->imageUrl ?? '';
+            // analyzeImage() is image-only — skip data URIs whose MIME type
+            // isn't `image/*` so non-image documents (e.g. `data:application/pdf`)
+            // never reach the vision endpoint.
             if (str_starts_with($imageUrl, 'data:')) {
-                if (preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1) {
+                if (
+                    preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1
+                    && str_starts_with($matches[1], 'image/')
+                ) {
                     $parts[] = [
                         'inlineData' => [
                             'mimeType' => $matches[1],

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -294,10 +294,9 @@ final class GeminiProvider extends AbstractProvider implements
         $parts = [];
         foreach ($content as $item) {
             if ($item->isText()) {
-                $text = $item->text ?? '';
-                if ($text !== '') {
-                    $parts[] = ['text' => $text];
-                }
+                // VisionContent::__construct enforces non-empty text for TYPE_TEXT,
+                // so $item->text is guaranteed to be a non-empty string here.
+                $parts[] = ['text' => $item->text];
                 continue;
             }
 
@@ -307,13 +306,14 @@ final class GeminiProvider extends AbstractProvider implements
 
             $imageUrl = $item->imageUrl ?? '';
             if (str_starts_with($imageUrl, 'data:')) {
-                preg_match('/^data:(image\/\w+);base64,(.+)$/', $imageUrl, $matches);
-                $parts[] = [
-                    'inlineData' => [
-                        'mimeType' => $matches[1] ?? 'image/jpeg',
-                        'data'     => $matches[2] ?? '',
-                    ],
-                ];
+                if (preg_match('/^data:([^;]+);base64,(.+)$/', $imageUrl, $matches) === 1) {
+                    $parts[] = [
+                        'inlineData' => [
+                            'mimeType' => $matches[1],
+                            'data'     => $matches[2],
+                        ],
+                    ];
+                }
             } else {
                 $parts[] = [
                     'fileData' => [

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -251,7 +251,7 @@ final class OpenAiProvider extends AbstractProvider implements
         $messages = [
             [
                 'role' => 'user',
-                'content' => array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content),
+                'content' => array_values(array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content)),
             ],
         ];
 

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -456,7 +456,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $messages = [
             [
                 'role' => 'user',
-                'content' => array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content),
+                'content' => array_values(array_map(static fn(VisionContent $vc): array => $vc->toArray(), $content)),
             ],
         ];
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -532,7 +532,9 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 }
 
                 if (
-                    array_keys($message) === ['role', 'content']
+                    count($message) === 2
+                    && array_key_exists('role', $message)
+                    && array_key_exists('content', $message)
                     && is_string($message['role'])
                     && is_string($message['content'])
                 ) {

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -270,11 +270,11 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
-        $normalisedContent = array_map(
+        $normalisedContent = array_values(array_map(
             static fn(VisionContent|array $item): VisionContent
                 => $item instanceof VisionContent ? $item : VisionContent::fromArray($item),
             $content,
-        );
+        ));
 
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
@@ -340,10 +340,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         unset($optionsArray['provider']);
 
         $normalisedMessages = $this->normaliseMessages($messages);
-        $normalisedTools    = array_map(
+        $normalisedTools    = array_values(array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
             $tools,
-        );
+        ));
 
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Tools, $providerKey),
@@ -525,7 +525,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     private function normaliseMessages(array $messages): array
     {
-        return array_map(
+        return array_values(array_map(
             static function (ChatMessage|array $message): ChatMessage|array {
                 if ($message instanceof ChatMessage) {
                     return $message;
@@ -542,7 +542,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 return $message;
             },
             $messages,
-        );
+        ));
     }
 
     /**

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -603,20 +603,22 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $capabilities = [];
         foreach ($providers as $provider) {
             $models = $this->modelRepository->findByProvider($provider);
-            $capabilities[$provider->getIdentifier()] = [
-                'provider' => $provider->getName(),
-                'adapterType' => $provider->getAdapterType(),
-                'modelCount' => $models->count(),
-                'models' => [],
-            ];
 
+            $modelEntries = [];
             foreach ($models as $model) {
-                $capabilities[$provider->getIdentifier()]['models'][] = [
+                $modelEntries[] = [
                     'name' => $model->getName(),
                     'modelId' => $model->getModelId(),
                     'contextLength' => $model->getContextLength(),
                 ];
             }
+
+            $capabilities[$provider->getIdentifier()] = [
+                'provider' => $provider->getName(),
+                'adapterType' => $provider->getAdapterType(),
+                'modelCount' => $models->count(),
+                'models' => $modelEntries,
+            ];
         }
 
         // Each provider should have retrievable capabilities

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -471,6 +471,14 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
         self::assertSame('echo', $result->toolCalls[0]->name);
+
+        // The provider must have received typed ToolSpec instances — otherwise
+        // LlmServiceManager forwarded the legacy array shape unchanged and
+        // the normalisation contract is broken.
+        self::assertCount(1, $toolProvider->capturedTools);
+        self::assertInstanceOf(ToolSpec::class, $toolProvider->capturedTools[0]);
+        self::assertSame('echo', $toolProvider->capturedTools[0]->name);
+        self::assertSame('echoes input', $toolProvider->capturedTools[0]->description);
     }
 
     #[Test]
@@ -1149,6 +1157,9 @@ class TestableStreamingProvider extends TestableProvider implements StreamingCap
  */
 class TestableToolProvider extends TestableProvider implements ToolCapableInterface
 {
+    /** @var list<ToolSpec> */
+    public array $capturedTools = [];
+
     public function __construct()
     {
         parent::__construct('openai-tools', 'OpenAI Tools', true);
@@ -1156,9 +1167,10 @@ class TestableToolProvider extends TestableProvider implements ToolCapableInterf
 
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
-        // Return response with tool calls from parent
-        $response = $this->chatCompletion($messages, $options);
-        return $response;
+        // Capture so tests can assert that LlmServiceManager normalised
+        // legacy array fixtures into typed ToolSpec instances before forwarding.
+        $this->capturedTools = $tools;
+        return $this->chatCompletion($messages, $options);
     }
 
     public function supportsTools(): bool


### PR DESCRIPTION
## Summary

Addresses **all 12** unresolved review threads on the already-merged DTO/VO slice PRs (#160 backlog cleanup + #161 vision migration). No new feature work.

> **Note:** I am NOT enabling auto-merge on this PR — per the user's directive, reviews land first, then we merge.

## Findings addressed

### List-contract violations (gemini + copilot, 5 threads)

`array_map()` preserves input keys. Public-API entry points promised `list<T>` but never reindexed, so an associative or sparse caller fixture leaked through as a JSON object on the wire. Wrapped every normalisation in `array_values(...)`:

- `LlmServiceManager::vision()` content list (PR #161 thread)
- `LlmServiceManager::chatWithTools()` tools list (PR #160 thread, gemini + copilot)
- `LlmServiceManager::normaliseMessages()` (slice 7 follow-up, same class of issue)
- `OpenAiProvider::analyzeImage()` `messages[0].content` (PR #161 thread)
- `OpenRouterProvider::analyzeImage()` `messages[0].content` (PR #161 thread)

### Data-URI regex robustness (gemini, 2 threads)

The vision `analyzeImage()` paths in `ClaudeProvider` and `GeminiProvider` matched `^data:(image\/\w+);base64,(.+)$` and used `?? 'image/jpeg'` / `?? ''` fallbacks. Result: a data URI carrying `charset` or any non-`image/*` mime type silently produced a malformed API request. Aligned both with the canonical `^data:([^;]+);base64,(.+)$` regex used elsewhere in those providers, and made the content block only append on a successful match — malformed URIs are now skipped cleanly.

### Redundant Gemini empty-text branch (copilot, 1 thread)

`VisionContent::__construct()` enforces non-empty text for `TYPE_TEXT` (code 1745420002). The defensive `if ($text !== '')` and `?? ''` fallback in `GeminiProvider::analyzeImage()` were dead code. Replaced with a direct `$parts[] = ['text' => \$item->text];` call and a comment pointing to the VO invariant.

### `VisionContent::fromArray()` strict detail validation (copilot, 1 thread)

A present-but-non-string `image_url.detail` was silently coerced to `null`, bypassing the constructor's existing detail validation. Now throws `InvalidArgumentException` 1745420004 (same code as the existing detail-value rejection) — matches the no-silent-coercion policy used for `type` / `text`.

### `chatWithToolsAcceptsLegacyArrayShapedToolFixtures` test (copilot, 1 thread)

The test passed even when `LlmServiceManager` forwarded the legacy array shape unchanged because `TestableToolProvider::chatCompletionWithTools()` ignored its `\$tools` parameter. Now captures the incoming tools on the provider and asserts that the entries are typed `ToolSpec` instances with the expected name/description — the test would fail if normalisation broke.

### Already-resolved (gemini, 1 thread)

The `is_array` / `is_string` leading-backslash comment on `VisionContent.php:160` is moot: that line was already rewritten as part of this PR's strict-detail handling and now uses fully-qualified globals (`\is_array`, `\array_key_exists`, `\is_string`).

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Unit tests pass (3219 / 3219)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Strengthened test asserts the failure path: removing `array_values(array_map(...))` around tool normalisation should break the new captured-tools assertion

## Related

- Closes outstanding review backlog on #160 (5 threads) and #161 (7 threads)