### PR TITLE
refactor: lock leaf provider exceptions and Feature/supporting services as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Resources/Public/Icons/Extension.svg` brand colour corrected to the official
   Netresearch teal `#2F99A4` (was `#2999a4` typo).
 
+### BREAKING
+
+- The following classes are now `final` (and `final readonly` where applicable)
+  and can no longer be subclassed by downstream extensions: the four leaf
+  provider exceptions (`ProviderConfigurationException`,
+  `ProviderConnectionException`, `ProviderResponseException`,
+  `UnsupportedFeatureException`); the four feature services
+  (`Service/Feature/CompletionService`, `EmbeddingService`,
+  `TranslationService`, `VisionService`); the two supporting services
+  (`Service/ModelSelectionService`, `Service/PromptTemplateService`).
+  Downstream consumers that extended any of these classes should switch to
+  composition or open an issue if a documented extension point is needed.
+  The base `ProviderException` and `ProviderAdapterRegistry` remain
+  non-final pending interface extraction.
+
 ## [0.7.0] - 2026-04-22
 
 Initial public release. See git history for prior commits.

--- a/Classes/Provider/Exception/ProviderConfigurationException.php
+++ b/Classes/Provider/Exception/ProviderConfigurationException.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
-class ProviderConfigurationException extends ProviderException {}
+final class ProviderConfigurationException extends ProviderException {}

--- a/Classes/Provider/Exception/ProviderConnectionException.php
+++ b/Classes/Provider/Exception/ProviderConnectionException.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
-class ProviderConnectionException extends ProviderException {}
+final class ProviderConnectionException extends ProviderException {}

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
-class ProviderResponseException extends ProviderException {}
+final class ProviderResponseException extends ProviderException {}

--- a/Classes/Provider/Exception/UnsupportedFeatureException.php
+++ b/Classes/Provider/Exception/UnsupportedFeatureException.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
-class UnsupportedFeatureException extends ProviderException {}
+final class UnsupportedFeatureException extends ProviderException {}

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -20,7 +20,7 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  * Provides simple text generation with configurable creativity,
  * format control, and token management.
  */
-class CompletionService
+final class CompletionService
 {
     public function __construct(
         private readonly LlmServiceManagerInterface $llmManager,

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -20,10 +20,10 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  * Provides simple text generation with configurable creativity,
  * format control, and token management.
  */
-final class CompletionService
+final readonly class CompletionService
 {
     public function __construct(
-        private readonly LlmServiceManagerInterface $llmManager,
+        private LlmServiceManagerInterface $llmManager,
     ) {}
 
     /**

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -21,10 +21,10 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * `LlmServiceManager::embed()` — this service only owns the vector-math
  * utilities (cosine similarity, normalisation, top-k) and input validation.
  */
-final class EmbeddingService
+final readonly class EmbeddingService
 {
     public function __construct(
-        private readonly LlmServiceManagerInterface $llmManager,
+        private LlmServiceManagerInterface $llmManager,
     ) {}
 
     /**

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -21,7 +21,7 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * `LlmServiceManager::embed()` — this service only owns the vector-math
  * utilities (cosine similarity, normalisation, top-k) and input validation.
  */
-class EmbeddingService
+final class EmbeddingService
 {
     public function __construct(
         private readonly LlmServiceManagerInterface $llmManager,

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -31,7 +31,7 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * - LLM-based translation (default)
  * - Specialized translators (DeepL, etc.) via TranslatorRegistry
  */
-class TranslationService
+final class TranslationService
 {
     private const SUPPORTED_FORMALITIES = ['default', 'formal', 'informal'];
     private const SUPPORTED_DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -31,15 +31,15 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * - LLM-based translation (default)
  * - Specialized translators (DeepL, etc.) via TranslatorRegistry
  */
-final class TranslationService
+final readonly class TranslationService
 {
     private const SUPPORTED_FORMALITIES = ['default', 'formal', 'informal'];
     private const SUPPORTED_DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];
 
     public function __construct(
-        private readonly LlmServiceManagerInterface $llmManager,
-        private readonly TranslatorRegistryInterface $translatorRegistry,
-        private readonly LlmConfigurationService $configurationService,
+        private LlmServiceManagerInterface $llmManager,
+        private TranslatorRegistryInterface $translatorRegistry,
+        private LlmConfigurationService $configurationService,
     ) {}
 
     /**

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -20,7 +20,7 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * Provides specialized image analysis with accessibility,
  * SEO, and descriptive prompts.
  */
-class VisionService
+final class VisionService
 {
     private const PROMPT_ALT_TEXT = 'Generate a concise alt text for this image, under 125 characters, focused on essential information for screen readers. Be descriptive but brief.';
     private const PROMPT_SEO_TITLE = 'Generate an SEO-optimized title for this image, under 60 characters, that is compelling and keyword-rich for search rankings.';

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -20,14 +20,14 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * Provides specialized image analysis with accessibility,
  * SEO, and descriptive prompts.
  */
-final class VisionService
+final readonly class VisionService
 {
     private const PROMPT_ALT_TEXT = 'Generate a concise alt text for this image, under 125 characters, focused on essential information for screen readers. Be descriptive but brief.';
     private const PROMPT_SEO_TITLE = 'Generate an SEO-optimized title for this image, under 60 characters, that is compelling and keyword-rich for search rankings.';
     private const PROMPT_DESCRIPTION = 'Provide a comprehensive description of this image including subjects, setting, colors, mood, composition, and notable details.';
 
     public function __construct(
-        private readonly LlmServiceManagerInterface $llmManager,
+        private LlmServiceManagerInterface $llmManager,
     ) {}
 
     /**

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -22,10 +22,10 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
  * - Minimum context length requirements
  * - Cost constraints and preferences
  */
-final class ModelSelectionService
+final readonly class ModelSelectionService
 {
     public function __construct(
-        private readonly ModelRepository $modelRepository,
+        private ModelRepository $modelRepository,
     ) {}
 
     /**

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -22,7 +22,7 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
  * - Minimum context length requirements
  * - Cost constraints and preferences
  */
-class ModelSelectionService
+final class ModelSelectionService
 {
     public function __construct(
         private readonly ModelRepository $modelRepository,

--- a/Classes/Service/PromptTemplateService.php
+++ b/Classes/Service/PromptTemplateService.php
@@ -21,10 +21,10 @@ use Netresearch\NrLlm\Exception\PromptTemplateNotFoundException;
  * Handles template loading, variable substitution, versioning,
  * and performance tracking.
  */
-final class PromptTemplateService
+final readonly class PromptTemplateService
 {
     public function __construct(
-        private readonly PromptTemplateRepository $repository,
+        private PromptTemplateRepository $repository,
     ) {}
 
     /**

--- a/Classes/Service/PromptTemplateService.php
+++ b/Classes/Service/PromptTemplateService.php
@@ -21,7 +21,7 @@ use Netresearch\NrLlm\Exception\PromptTemplateNotFoundException;
  * Handles template loading, variable substitution, versioning,
  * and performance tracking.
  */
-class PromptTemplateService
+final class PromptTemplateService
 {
     public function __construct(
         private readonly PromptTemplateRepository $repository,

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -603,20 +603,22 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $capabilities = [];
         foreach ($providers as $provider) {
             $models = $this->modelRepository->findByProvider($provider);
-            $capabilities[$provider->getIdentifier()] = [
-                'provider' => $provider->getName(),
-                'adapterType' => $provider->getAdapterType(),
-                'modelCount' => $models->count(),
-                'models' => [],
-            ];
 
+            $modelEntries = [];
             foreach ($models as $model) {
-                $capabilities[$provider->getIdentifier()]['models'][] = [
+                $modelEntries[] = [
                     'name' => $model->getName(),
                     'modelId' => $model->getModelId(),
                     'contextLength' => $model->getContextLength(),
                 ];
             }
+
+            $capabilities[$provider->getIdentifier()] = [
+                'provider' => $provider->getName(),
+                'adapterType' => $provider->getAdapterType(),
+                'modelCount' => $models->count(),
+                'models' => $modelEntries,
+            ];
         }
 
         // Each provider should have retrievable capabilities


### PR DESCRIPTION
## Summary

Slice 8 of the architecture audit (`claudedocs/audit-2026-04-23-architecture.md`, Recommendations § \"Final classes\"). Marks 10 classes as `final` where there is no extension or mocking dependency. **Not enabling auto-merge** — waiting for review.

## Why this slice now

The registry / middleware / VO migrations have stabilised the surface. Locking these leaves declares non-extension as a contract, satisfies the audit finding without churn, and unblocks the audit's REC #3 second half (\"unify provider/translator registration on a single pattern and lock the registry\") which needs the registry pattern settled before any further inheritance can sneak in.

## Locked

### Provider exceptions (4 leaves)
- `ProviderConfigurationException`
- `ProviderConnectionException`
- `ProviderResponseException`
- `UnsupportedFeatureException`

The base `ProviderException` stays non-final by design — it is the parent of these four leaves plus the already-`final` `FallbackChainExhaustedException`.

### Feature services (4)
- `Service/Feature/CompletionService`
- `Service/Feature/EmbeddingService`
- `Service/Feature/TranslationService`
- `Service/Feature/VisionService`

None are subclassed anywhere. Heuristics in the AGENTS.md already require new feature services to live alongside these (one directory per feature) rather than extend.

### Supporting services (2)
- `Service/ModelSelectionService`
- `Service/PromptTemplateService`

## Deliberately left non-final (follow-up scope)

| Class | Reason | Follow-up |
|---|---|---|
| `ProviderAdapterRegistry` | Mocked via PHPUnit `createMock` / `createStub` across 9 test files | Extract `ProviderAdapterRegistryInterface` first, then lock — fits the audit's REC #3 \"unify provider/translator registration\" slice |
| `LlmConfigurationService` | Same `createMock` pattern in 2 test files | Extract interface, then lock |
| `BudgetService` | `BudgetServiceTest` extends it via anonymous test doubles | Either extract interface or replace anonymous doubles with PHPUnit mocks |
| `ProviderException` (base) | Parent of the 4 leaves above | Stays non-final by design |

## Already final (no change needed)

Identified during scoping — the audit listed these but they were already migrated to `final readonly`:

- `CapabilityPermissionService`
- `TestPromptResolverService`
- `UsageTrackerService`
- `WizardGeneratorService`

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Unit tests pass (3219 / 3219)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Spot-check that no downstream consumer of `nr-llm` (e.g. `nr-content-suggestions`, `nr-translation-llm`) extends any of the locked classes — none expected, but worth a sweep before merge

## Audit scoreboard delta

| Axis | Before | After |
|---|---|---|
| Final classes | 7/10 | 8/10 (still pending registry interface-extract) |