### PR TITLE
refactor: extract ProviderAdapterRegistryInterface and lock the registry final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`Service/ModelSelectionService`, `Service/PromptTemplateService`).
   Downstream consumers that extended any of these classes should switch to
   composition or open an issue if a documented extension point is needed.
-  The base `ProviderException` and `ProviderAdapterRegistry` remain
-  non-final pending interface extraction.
+  The base `ProviderException` is the only deliberately non-final class
+  remaining (it parents the leaf exceptions); `LlmConfigurationService` and
+  `BudgetService` are still non-final pending the same interface-extract
+  pattern applied to the registry below.
 - `ProviderAdapterRegistry` is now `final` and implements the new
   `ProviderAdapterRegistryInterface`. Downstream consumers that
   constructor-injected the concrete class should typehint the interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   composition or open an issue if a documented extension point is needed.
   The base `ProviderException` and `ProviderAdapterRegistry` remain
   non-final pending interface extraction.
+- `ProviderAdapterRegistry` is now `final` and implements the new
+  `ProviderAdapterRegistryInterface`. Downstream consumers that
+  constructor-injected the concrete class should typehint the interface
+  instead. The Symfony alias
+  `ProviderAdapterRegistryInterface → ProviderAdapterRegistry` is wired
+  in `Configuration/Services.yaml` so existing autowiring keeps working.
 
 ## [0.7.0] - 2026-04-22
 

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -17,7 +17,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -58,7 +58,7 @@ final class ConfigurationController extends ActionController
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly ModelRepository $modelRepository,
         private readonly LlmServiceManagerInterface $llmServiceManager,
-        private readonly ProviderAdapterRegistry $providerAdapterRegistry,
+        private readonly ProviderAdapterRegistryInterface $providerAdapterRegistry,
         private readonly WizardGeneratorService $wizardGeneratorService,
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -17,7 +17,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -57,7 +57,7 @@ final class ModelController extends ActionController
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
-        private readonly ProviderAdapterRegistry $providerAdapterRegistry,
+        private readonly ProviderAdapterRegistryInterface $providerAdapterRegistry,
         private readonly ModelDiscoveryInterface $modelDiscovery,
         private readonly TestPromptResolverInterface $testPromptResolver,
     ) {}

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -14,7 +14,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -47,7 +47,7 @@ final class ProviderController extends ActionController
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly IconFactory $iconFactory,
         private readonly ProviderRepository $providerRepository,
-        private readonly ProviderAdapterRegistry $providerAdapterRegistry,
+        private readonly ProviderAdapterRegistryInterface $providerAdapterRegistry,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Core\SingletonInterface;
  * This registry bridges database Provider entities with PHP adapter implementations.
  * It creates and configures adapter instances on demand based on provider settings.
  */
-class ProviderAdapterRegistry implements SingletonInterface
+final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface, SingletonInterface
 {
     /**
      * Mapping of adapter types to provider class names.

--- a/Classes/Provider/ProviderAdapterRegistryInterface.php
+++ b/Classes/Provider/ProviderAdapterRegistryInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider;
+
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+
+/**
+ * Public surface of the provider-adapter registry.
+ *
+ * Consumers (controllers, the manager, tests) should depend on this
+ * interface rather than the concrete `ProviderAdapterRegistry` so the
+ * implementation can be substituted without inheritance.
+ */
+interface ProviderAdapterRegistryInterface
+{
+    /**
+     * Register a custom adapter class for an adapter type.
+     *
+     * @param class-string<AbstractProvider> $adapterClass The adapter class name
+     *
+     * @throws ProviderConfigurationException when the class does not extend AbstractProvider
+     */
+    public function registerAdapter(string $adapterType, string $adapterClass): void;
+
+    /**
+     * Get an adapter class for the given adapter type.
+     *
+     * Falls back to OpenAI-compatible for unknown types.
+     *
+     * @return class-string<AbstractProvider>
+     */
+    public function getAdapterClass(string $adapterType): string;
+
+    /**
+     * Check if an adapter type is supported (built-in or custom).
+     */
+    public function hasAdapter(string $adapterType): bool;
+
+    /**
+     * Get all registered adapter types.
+     *
+     * @return array<string, string> Adapter type to human-readable name
+     */
+    public function getRegisteredAdapters(): array;
+
+    /**
+     * Create a configured adapter instance from a Provider entity.
+     *
+     * @param bool $useCache Whether to reuse cached instances for persisted providers
+     */
+    public function createAdapterFromProvider(Provider $provider, bool $useCache = true): ProviderInterface;
+
+    /**
+     * Create a configured adapter instance from a Model entity.
+     *
+     * Convenience wrapper that extracts the provider and overrides the
+     * adapter's default model with the model's `modelId`.
+     *
+     * @param bool $useCache Whether to reuse cached instances for persisted providers
+     *
+     * @throws ProviderConfigurationException when the model has no associated provider
+     */
+    public function createAdapterFromModel(Model $model, bool $useCache = true): ProviderInterface;
+
+    /**
+     * Clear the adapter cache.
+     *
+     * Pass a `$providerUid` to evict only that provider's cached adapter,
+     * or `null` to clear the entire cache.
+     */
+    public function clearCache(?int $providerUid = null): void;
+
+    /**
+     * Test a provider connection.
+     *
+     * Sanitises any secrets that might appear in upstream error messages
+     * before returning them.
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testProviderConnection(Provider $provider): array;
+}

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -29,7 +29,7 @@ use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
@@ -51,7 +51,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function __construct(
         private readonly ExtensionConfiguration $extensionConfiguration,
         private readonly LoggerInterface $logger,
-        private readonly ProviderAdapterRegistry $adapterRegistry,
+        private readonly ProviderAdapterRegistryInterface $adapterRegistry,
         private readonly MiddlewarePipeline $pipeline,
         private readonly CacheManagerInterface $cacheManager,
     ) {
@@ -613,7 +613,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /**
      * Get provider adapter registry.
      */
-    public function getAdapterRegistry(): ProviderAdapterRegistry
+    public function getAdapterRegistry(): ProviderAdapterRegistryInterface
     {
         return $this->adapterRegistry;
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -69,6 +69,10 @@ services:
   Netresearch\NrLlm\Provider\ProviderAdapterRegistry:
     public: true
 
+  Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface:
+    alias: Netresearch\NrLlm\Provider\ProviderAdapterRegistry
+    public: true
+
   # ========================================
   # Feature Services (PUBLIC)
   # ========================================

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -13,7 +13,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
@@ -60,7 +60,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -108,7 +108,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['claude' => ['apiKeyIdentifier' => '019650a0-1234-7abc-8def-0123456789ab']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -154,7 +154,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -211,7 +211,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -265,7 +265,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -311,7 +311,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -374,7 +374,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             ],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($openAiProvider);
         $serviceManager->registerProvider($claudeProvider);

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -12,7 +12,7 @@ namespace Netresearch\NrLlm\Tests\E2E;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
@@ -54,7 +54,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -88,7 +88,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         // Mock cache manager returning cached embeddings with full structure
@@ -172,7 +172,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
@@ -239,7 +239,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
-        $adapterRegistry = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
         $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -14,7 +14,7 @@ use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -38,7 +38,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
 {
     private LlmServiceManager $subject;
     private ExtensionConfiguration&MockObject $extensionConfigStub;
-    private ProviderAdapterRegistry&Stub $adapterRegistryStub;
+    private ProviderAdapterRegistryInterface&Stub $adapterRegistryStub;
 
     protected function setUp(): void
     {
@@ -61,7 +61,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
                 ],
             ]);
 
-        $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
+        $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
         $this->subject = new LlmServiceManager(
             $this->extensionConfigStub,

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -18,7 +18,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -43,7 +43,7 @@ final class ConfigurationControllerTest extends TestCase
     private LlmConfigurationRepository&MockObject $configurationRepository;
     private LlmConfigurationService&MockObject $configurationService;
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
-    private ProviderAdapterRegistry&MockObject $providerAdapterRegistry;
+    private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ModelRepository&MockObject $modelRepository;
     private TestPromptResolverInterface&MockObject $testPromptResolver;
     private ConfigurationController $subject;
@@ -55,7 +55,7 @@ final class ConfigurationControllerTest extends TestCase
         $this->configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $this->configurationService = $this->createMock(LlmConfigurationService::class);
         $this->llmServiceManager = $this->createMock(LlmServiceManagerInterface::class);
-        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistry::class);
+        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
         $this->modelRepository = $this->createMock(ModelRepository::class);
         $this->testPromptResolver = $this->createMock(TestPromptResolverInterface::class);
         $this->testPromptResolver->method('resolve')->willReturn('Hello, test prompt');

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -17,7 +17,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -45,7 +45,7 @@ final class ModelControllerTest extends TestCase
     private ModelRepository&MockObject $modelRepository;
     private ProviderRepository&MockObject $providerRepository;
     private PersistenceManagerInterface&MockObject $persistenceManager;
-    private ProviderAdapterRegistry&MockObject $providerAdapterRegistry;
+    private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ModelDiscoveryInterface&MockObject $modelDiscovery;
     private TestPromptResolverInterface&MockObject $testPromptResolver;
     private ModelController $subject;
@@ -57,7 +57,7 @@ final class ModelControllerTest extends TestCase
         $this->modelRepository = $this->createMock(ModelRepository::class);
         $this->providerRepository = $this->createMock(ProviderRepository::class);
         $this->persistenceManager = $this->createMock(PersistenceManagerInterface::class);
-        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistry::class);
+        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
         $this->modelDiscovery = $this->createMock(ModelDiscoveryInterface::class);
         $this->testPromptResolver = $this->createMock(TestPromptResolverInterface::class);
         $this->testPromptResolver->method('resolve')->willReturn('Hello, test prompt');

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -12,7 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
 use Netresearch\NrLlm\Controller\Backend\ProviderController;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -34,7 +34,7 @@ final class ProviderControllerTest extends TestCase
 {
     private ProviderRepository&MockObject $providerRepository;
     private PersistenceManagerInterface&MockObject $persistenceManager;
-    private ProviderAdapterRegistry&MockObject $providerAdapterRegistry;
+    private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ProviderController $subject;
 
     protected function setUp(): void
@@ -42,7 +42,7 @@ final class ProviderControllerTest extends TestCase
         parent::setUp();
 
         $this->providerRepository = $this->createMock(ProviderRepository::class);
-        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistry::class);
+        $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
         $this->persistenceManager = $this->createMock(PersistenceManagerInterface::class);
 
         // Create controller using reflection to inject only required dependencies

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -11,7 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service;
 
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -36,7 +36,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
             ->willReturn($config);
 
         $loggerStub = self::createStub(LoggerInterface::class);
-        $adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
         return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
     }

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -33,7 +33,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -51,7 +51,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     private LlmServiceManager $subject;
     private ExtensionConfiguration $extensionConfigStub;
     private LoggerInterface $loggerStub;
-    private ProviderAdapterRegistry $adapterRegistryStub;
+    private ProviderAdapterRegistryInterface $adapterRegistryStub;
     private TestableProvider $provider;
 
     protected function setUp(): void
@@ -67,7 +67,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ]);
 
         $this->loggerStub = self::createStub(LoggerInterface::class);
-        $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
+        $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
         $this->subject = new LlmServiceManager(
             $this->extensionConfigStub,
@@ -569,7 +569,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $model = self::createStub(Model::class);
         $mockAdapter = self::createStub(ProviderInterface::class);
 
-        $registryMock = $this->createMock(ProviderAdapterRegistry::class);
+        $registryMock = $this->createMock(ProviderAdapterRegistryInterface::class);
         $registryMock->expects(self::once())
             ->method('createAdapterFromModel')
             ->with($model)
@@ -592,7 +592,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         $mockAdapter = self::createStub(ProviderInterface::class);
 
-        $registryMock = $this->createMock(ProviderAdapterRegistry::class);
+        $registryMock = $this->createMock(ProviderAdapterRegistryInterface::class);
         $registryMock->expects(self::once())
             ->method('createAdapterFromModel')
             ->with($model)
@@ -644,7 +644,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             )
             ->willReturn($expectedResponse);
 
-        $registryMock = self::createStub(ProviderAdapterRegistry::class);
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
         $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
@@ -680,7 +680,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with('Test prompt', ['temperature' => 0.5])
             ->willReturn($expectedResponse);
 
-        $registryMock = self::createStub(ProviderAdapterRegistry::class);
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
         $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
@@ -755,7 +755,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             }
         };
 
-        $registryMock = self::createStub(ProviderAdapterRegistry::class);
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
         $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
@@ -781,7 +781,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $mockAdapter = self::createStub(ProviderInterface::class);
         $mockAdapter->method('getIdentifier')->willReturn('non-streaming');
 
-        $registryMock = self::createStub(ProviderAdapterRegistry::class);
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
         $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -13,7 +13,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
-use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
@@ -49,7 +49,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             ]);
 
         $loggerStub = self::createStub(LoggerInterface::class);
-        $adapterRegistryStub = self::createStub(ProviderAdapterRegistry::class);
+        $adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
         $this->llmManager = new LlmServiceManager(
             $extensionConfigStub,


### PR DESCRIPTION
## Summary

Slice 9 — completes REC #3 second half (\"unify provider/translator registration on a single pattern and lock the registry\") from `claudedocs/audit-2026-04-23-architecture.md`. Not enabling auto-merge; awaiting review.

## What

- **New** `Classes/Provider/ProviderAdapterRegistryInterface.php` — exposes the registry's full public surface (`registerAdapter`, `getAdapterClass`, `hasAdapter`, `getRegisteredAdapters`, `createAdapterFromProvider`, `createAdapterFromModel`, `clearCache`, `testProviderConnection`).
- `ProviderAdapterRegistry` now implements that interface and is marked **`final`** — downstream extensions can no longer subclass it.
- `Configuration/Services.yaml` aliases `ProviderAdapterRegistryInterface → ProviderAdapterRegistry`, mirroring the existing pattern used for `LlmServiceManagerInterface`, `CacheManagerInterface`, `UsageTrackerServiceInterface`, `TranslatorRegistryInterface`, and `ModelDiscoveryInterface`. Autowiring keeps working without any consumer-side change.
- Constructor injections at the **4 production call sites** now typehint the interface: `ProviderController`, `ConfigurationController`, `ModelController`, `LlmServiceManager`. `LlmServiceManager::getAdapterRegistry()` return type updated likewise.
- Test mocks migrated from `createMock(ProviderAdapterRegistry::class)` → `createMock(ProviderAdapterRegistryInterface::class)` across **9 test files**. Concrete-class imports dropped where no longer needed.
- The two test files that genuinely cover the implementation itself — `Tests/Unit/Provider/ProviderAdapterRegistryTest`, `Tests/Functional/Provider/ProviderConnectionTest` — deliberately keep the concrete reference.

## Why

The audit explicitly called out `ProviderAdapterRegistry` as \"non-final but should be\" with the caveat that locking it required first solving the test-mocking problem (PHPUnit can't `createMock` a `final` class). Extracting the interface solves both at once:

- Tests now mock the interface — final concrete is fine.
- Downstream extensions needing to swap registry behaviour implement the interface rather than extending the concrete.

PR #165 deliberately left this class non-final because the same-PR refactor would have made review harder; isolating it here keeps each slice reviewable.

## CHANGELOG

Updated the existing `[Unreleased] § BREAKING` entry to note the registry final + interface migration. The breakage is limited to consumers that typehinted the concrete class directly — the new Symfony alias keeps autowiring transparent.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Rector dry-run clean
- [x] Unit tests pass (3219 / 3219)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Sweep for downstream consumers (`nr-content-suggestions`, `nr-translation-llm`) that might typehint the concrete class — none expected, but worth a check before merge

## Audit scoreboard delta

| Axis | Before | After |
|---|---|---|
| Final classes | 8/10 | 9/10 (only `LlmConfigurationService` and `BudgetService` left, plus the deliberately-non-final `ProviderException` base) |
| DI wiring | 6/10 | 7/10 (registry asymmetry partially resolved — interface now exists; tagged-iterator unification is the remaining piece) |

## Follow-up

- Same pattern for `LlmConfigurationService` (2 test files using `createMock`) — natural next slice.
- `BudgetService` needs a different approach: `BudgetServiceTest` uses anonymous classes extending the service for unit-level isolation. Either extract an interface and migrate the doubles to PHPUnit mocks, or accept that this service stays non-final for testability.