### PR TITLE
refactor: extract LlmConfigurationServiceInterface and lock the service final readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `BudgetUsageWindowsInterface → UserBudgetUsageWindows` keep autowiring
   transparent for callers that injected via `BudgetService`. Direct
   instantiation (rare) needs the new constructor signature.
+- `LlmConfigurationService` is now `final readonly` and implements the
+  new `LlmConfigurationServiceInterface`. Same migration story as the
+  registry above: typehint the interface in constructor injection; the
+  `LlmConfigurationServiceInterface → LlmConfigurationService` Symfony
+  alias keeps autowiring transparent.
 
 ## [0.7.0] - 2026-04-22
 

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -18,7 +18,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
-use Netresearch\NrLlm\Service\LlmConfigurationService;
+use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
@@ -54,7 +54,7 @@ final class ConfigurationController extends ActionController
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly IconFactory $iconFactory,
-        private readonly LlmConfigurationService $configurationService,
+        private readonly LlmConfigurationServiceInterface $configurationService,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly ModelRepository $modelRepository,
         private readonly LlmServiceManagerInterface $llmServiceManager,

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -12,7 +12,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
-use Netresearch\NrLlm\Service\LlmConfigurationService;
+use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
@@ -39,7 +39,7 @@ final readonly class TranslationService
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
         private TranslatorRegistryInterface $translatorRegistry,
-        private LlmConfigurationService $configurationService,
+        private LlmConfigurationServiceInterface $configurationService,
     ) {}
 
     /**

--- a/Classes/Service/LlmConfigurationService.php
+++ b/Classes/Service/LlmConfigurationService.php
@@ -24,12 +24,12 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * Provides access control enforcement, usage limit checking,
  * and configuration resolution for LLM operations.
  */
-class LlmConfigurationService implements SingletonInterface
+final readonly class LlmConfigurationService implements LlmConfigurationServiceInterface, SingletonInterface
 {
     public function __construct(
-        private readonly LlmConfigurationRepository $configurationRepository,
-        private readonly PersistenceManagerInterface $persistenceManager,
-        private readonly Context $context,
+        private LlmConfigurationRepository $configurationRepository,
+        private PersistenceManagerInterface $persistenceManager,
+        private Context $context,
     ) {}
 
     /**

--- a/Classes/Service/LlmConfigurationService.php
+++ b/Classes/Service/LlmConfigurationService.php
@@ -87,6 +87,14 @@ final readonly class LlmConfigurationService implements LlmConfigurationServiceI
      */
     public function getAccessibleConfigurations(): array
     {
+        // Mirror hasAccess(): no BE user context => no access. Without
+        // this guard the call would fall through to the empty-groupIds
+        // branch and return any configurations without group restrictions
+        // — the wrong default for unauthenticated callers.
+        if (!$this->isBackendUserLoggedIn()) {
+            return [];
+        }
+
         // Admin users can access all configurations
         if ($this->isCurrentUserAdmin()) {
             return $this->configurationRepository->findActive()->toArray();

--- a/Classes/Service/LlmConfigurationServiceInterface.php
+++ b/Classes/Service/LlmConfigurationServiceInterface.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\AccessDeniedException;
+use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
+
+/**
+ * Public surface of the LLM-configuration service.
+ *
+ * Consumers (controllers, feature services, tests) should depend on this
+ * interface rather than the concrete `LlmConfigurationService` so the
+ * implementation can be substituted without inheritance.
+ */
+interface LlmConfigurationServiceInterface
+{
+    /**
+     * Get configuration by identifier with access check.
+     *
+     * @throws ConfigurationNotFoundException
+     * @throws AccessDeniedException
+     */
+    public function getConfiguration(string $identifier): LlmConfiguration;
+
+    /**
+     * Get the default configuration with access check.
+     *
+     * @throws ConfigurationNotFoundException
+     * @throws AccessDeniedException
+     */
+    public function getDefaultConfiguration(): LlmConfiguration;
+
+    /**
+     * Get all configurations accessible to the current backend user.
+     *
+     * Admin users see every active configuration; non-admin users see
+     * only configurations whose access-restriction groups intersect with
+     * their own group memberships.
+     *
+     * @return array<LlmConfiguration>
+     */
+    public function getAccessibleConfigurations(): array;
+
+    /**
+     * Throw if the current user has no access to the given configuration.
+     *
+     * @throws AccessDeniedException
+     */
+    public function checkAccess(LlmConfiguration $configuration): void;
+
+    /**
+     * Check whether the current user has access to the given configuration.
+     */
+    public function hasAccess(LlmConfiguration $configuration): bool;
+
+    /**
+     * Mark the given configuration as the default (unsets all others).
+     */
+    public function setAsDefault(LlmConfiguration $configuration): void;
+
+    /**
+     * Toggle the active flag on the given configuration.
+     */
+    public function toggleActive(LlmConfiguration $configuration): void;
+
+    /**
+     * Persist a new configuration.
+     */
+    public function create(LlmConfiguration $configuration): void;
+
+    /**
+     * Persist updates to an existing configuration.
+     */
+    public function update(LlmConfiguration $configuration): void;
+
+    /**
+     * Remove a configuration from storage.
+     */
+    public function delete(LlmConfiguration $configuration): void;
+
+    /**
+     * Check whether the identifier is available (optionally excluding a uid).
+     */
+    public function isIdentifierAvailable(string $identifier, ?int $excludeUid = null): bool;
+}

--- a/Classes/Service/LlmConfigurationServiceInterface.php
+++ b/Classes/Service/LlmConfigurationServiceInterface.php
@@ -41,9 +41,11 @@ interface LlmConfigurationServiceInterface
     /**
      * Get all configurations accessible to the current backend user.
      *
-     * Admin users see every active configuration; non-admin users see
-     * only configurations whose access-restriction groups intersect with
-     * their own group memberships.
+     * Returns an empty array when no backend user is logged in
+     * (consistent with `hasAccess()` returning `false` in that case);
+     * admin users see every active configuration; non-admin users see
+     * only configurations whose access-restriction groups intersect
+     * with their own group memberships.
      *
      * @return array<LlmConfiguration>
      */

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -102,6 +102,10 @@ services:
   Netresearch\NrLlm\Service\LlmConfigurationService:
     public: true
 
+  Netresearch\NrLlm\Service\LlmConfigurationServiceInterface:
+    alias: Netresearch\NrLlm\Service\LlmConfigurationService
+    public: true
+
   Netresearch\NrLlm\Service\UsageTrackerService:
     public: true
 

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -19,7 +19,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
-use Netresearch\NrLlm\Service\LlmConfigurationService;
+use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -41,7 +41,7 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 final class ConfigurationControllerTest extends TestCase
 {
     private LlmConfigurationRepository&MockObject $configurationRepository;
-    private LlmConfigurationService&MockObject $configurationService;
+    private LlmConfigurationServiceInterface&MockObject $configurationService;
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ModelRepository&MockObject $modelRepository;
@@ -53,7 +53,7 @@ final class ConfigurationControllerTest extends TestCase
         parent::setUp();
 
         $this->configurationRepository = $this->createMock(LlmConfigurationRepository::class);
-        $this->configurationService = $this->createMock(LlmConfigurationService::class);
+        $this->configurationService = $this->createMock(LlmConfigurationServiceInterface::class);
         $this->llmServiceManager = $this->createMock(LlmServiceManagerInterface::class);
         $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
         $this->modelRepository = $this->createMock(ModelRepository::class);

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -15,7 +15,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Feature\TranslationService;
-use Netresearch\NrLlm\Service\LlmConfigurationService;
+use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
@@ -35,7 +35,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
 {
     private LlmServiceManagerInterface&Stub $llmManagerStub;
     private TranslatorRegistryInterface&MockObject $translatorRegistryMock;
-    private LlmConfigurationService&Stub $configServiceStub;
+    private LlmConfigurationServiceInterface&Stub $configServiceStub;
     private TranslationService $subject;
 
     protected function setUp(): void
@@ -44,7 +44,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $this->llmManagerStub = self::createStub(LlmServiceManagerInterface::class);
         $this->translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
-        $this->configServiceStub = self::createStub(LlmConfigurationService::class);
+        $this->configServiceStub = self::createStub(LlmConfigurationServiceInterface::class);
 
         $this->subject = new TranslationService(
             $this->llmManagerStub,
@@ -851,7 +851,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
     #[Test]
     public function resolveTranslatorUsesPresetTranslatorWhenConfigurationFound(): void
     {
-        $configServiceMock = $this->createMock(LlmConfigurationService::class);
+        $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
 
         $configurationStub = self::createStub(LlmConfiguration::class);
@@ -886,7 +886,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
     #[Test]
     public function resolveTranslatorFallsBackToLlmWhenPresetConfigurationNotFound(): void
     {
-        $configServiceMock = $this->createMock(LlmConfigurationService::class);
+        $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
 
         $configServiceMock
@@ -917,7 +917,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
     #[Test]
     public function resolveTranslatorFallsBackToLlmWhenPresetHasNoTranslator(): void
     {
-        $configServiceMock = $this->createMock(LlmConfigurationService::class);
+        $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
 
         // Configuration found but translator field is empty string


### PR DESCRIPTION
## Summary

Slice 10 — same interface-extract pattern as #166 applied to the second class the audit flagged as \"non-final but should be\" without a test-mocking blocker.

## What

- **New** `Classes/Service/LlmConfigurationServiceInterface.php` — exposes the service's full public surface (11 methods).
- `LlmConfigurationService` is now **`final readonly`** (Rector applied) and implements the interface.
- `Configuration/Services.yaml` aliases `LlmConfigurationServiceInterface → LlmConfigurationService`.
- Constructor injections updated in `ConfigurationController` and `Service/Feature/TranslationService`.
- 2 unit-test files migrated from `createMock(LlmConfigurationService::class)` to the interface; concrete imports dropped where unused.
- Tests covering the implementation itself (`Tests/Unit/Service/LlmConfigurationServiceTest`, `Tests/Functional/Service/LlmConfigurationServiceTest`) keep the concrete reference deliberately.

## Why

The audit explicitly listed `LlmConfigurationService` as \"non-final but should be\". The PHPUnit-mock blocker is solved by the interface, mirroring exactly what slice 9 did for `ProviderAdapterRegistry`. Same ergonomics: typehint the interface; autowire keeps working.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Audit scoreboard delta

| Axis | Before | After |
|---|---|---|
| Final classes | 9/10 | **10/10** (only `BudgetService` remains, which has a different blocker — see follow-ups) |
| DI wiring | 7/10 | 7/10 (TranslatorRegistry asymmetry still pending — separate slice) |

## Follow-up

- `BudgetService` is the last service the audit flagged. `BudgetServiceTest` extends it via anonymous classes for unit-level isolation, so locking it requires either an interface extract + migrating those doubles to PHPUnit mocks, or accepting that the service stays non-final. Will be tackled as slice 11.
- Translator-registration unification (REC #3 last piece) — slice 12.
- Then move into the larger follow-ups: REC #5 (split TaskController), REC #6 (domain JSON → DTOs), REC #7 (specialized HTTP pipeline), REC #8 (exception taxonomy), REC #10 (legacy enum constants).