### PR TITLE
refactor: extract BudgetServiceInterface, lock BudgetService final readonly, isolate DB aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead. The Symfony alias
   `ProviderAdapterRegistryInterface → ProviderAdapterRegistry` is wired
   in `Configuration/Services.yaml` so existing autowiring keeps working.
+- `BudgetService` is now `final readonly` and implements the new
+  `BudgetServiceInterface`. The DB-aggregation step previously embedded
+  in the service's `aggregateWindowUsage()` method moved to a separate
+  collaborator: `Service/Budget/UserBudgetUsageWindows` implementing
+  `BudgetUsageWindowsInterface`. `BudgetService::__construct()` now
+  takes `(UserBudgetRepository, BudgetUsageWindowsInterface)` rather
+  than `(UserBudgetRepository, ConnectionPool)`. Symfony aliases
+  `BudgetServiceInterface → BudgetService` and
+  `BudgetUsageWindowsInterface → UserBudgetUsageWindows` keep autowiring
+  transparent for callers that injected via `BudgetService`. Direct
+  instantiation (rare) needs the new constructor signature.
 
 ## [0.7.0] - 2026-04-22
 

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -11,7 +11,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
-use Netresearch\NrLlm\Service\BudgetService;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 
 /**
  * Pre-flight budget check middleware (ADR-025).
@@ -56,7 +56,7 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
     public const METADATA_PLANNED_COST = 'plannedCost';
 
     public function __construct(
-        private BudgetService $budgetService,
+        private BudgetServiceInterface $budgetService,
     ) {}
 
     /**

--- a/Classes/Service/Budget/BudgetUsageWindowsInterface.php
+++ b/Classes/Service/Budget/BudgetUsageWindowsInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Budget;
+
+/**
+ * Aggregates per-backend-user AI usage across daily and monthly windows.
+ *
+ * `BudgetService::check()` reads two roll-ups (current day, current month)
+ * from `tx_nrllm_service_usage` to decide whether the next call would
+ * push the user past their cap. Extracting the aggregation behind this
+ * interface lets `BudgetService` be `final readonly` while tests still
+ * substitute the DB read with a canned response.
+ */
+interface BudgetUsageWindowsInterface
+{
+    /**
+     * Aggregate per-user usage for the daily AND monthly windows in a
+     * single DB roundtrip.
+     *
+     * Pass `null` for a window when its limit is not configured — the
+     * implementation MUST return a zeroed bucket for that window so the
+     * caller does not have to special-case missing data.
+     *
+     * @return array{
+     *   daily: array{requests: int, tokens: int, cost: float},
+     *   monthly: array{requests: int, tokens: int, cost: float}
+     * }
+     */
+    public function aggregate(
+        int $beUserUid,
+        ?int $dailyFromTimestamp,
+        ?int $monthlyFromTimestamp,
+        int $toTimestamp,
+    ): array;
+}

--- a/Classes/Service/Budget/UserBudgetUsageWindows.php
+++ b/Classes/Service/Budget/UserBudgetUsageWindows.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Budget;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * SQL-backed implementation of `BudgetUsageWindowsInterface`.
+ *
+ * Reads `tx_nrllm_service_usage` (the per-user/per-day rollup written by
+ * `UsageMiddleware`) and returns daily + monthly totals in one roundtrip
+ * via conditional SUM() expressions.
+ */
+final readonly class UserBudgetUsageWindows implements BudgetUsageWindowsInterface
+{
+    private const USAGE_TABLE = 'tx_nrllm_service_usage';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function aggregate(
+        int $beUserUid,
+        ?int $dailyFromTimestamp,
+        ?int $monthlyFromTimestamp,
+        int $toTimestamp,
+    ): array {
+        $empty = ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        if ($dailyFromTimestamp === null && $monthlyFromTimestamp === null) {
+            return ['daily' => $empty, 'monthly' => $empty];
+        }
+
+        // The lower bound for the SQL WHERE: monthly is always the wider
+        // window, so if it's set we use that; otherwise fall back to the
+        // daily bound.
+        $lowerBound = $monthlyFromTimestamp ?? $dailyFromTimestamp;
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::USAGE_TABLE);
+        $dailyFromParam = $queryBuilder->createNamedParameter($dailyFromTimestamp ?? PHP_INT_MAX);
+        $monthlyFromParam = $queryBuilder->createNamedParameter($monthlyFromTimestamp ?? PHP_INT_MAX);
+
+        $row = $queryBuilder
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS daily_requests', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS daily_tokens', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS daily_cost', $dailyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS monthly_requests', $monthlyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS monthly_tokens', $monthlyFromParam))
+            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS monthly_cost', $monthlyFromParam))
+            ->from(self::USAGE_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('be_user', $queryBuilder->createNamedParameter($beUserUid)),
+                $queryBuilder->expr()->gte('request_date', $queryBuilder->createNamedParameter($lowerBound)),
+                $queryBuilder->expr()->lte('request_date', $queryBuilder->createNamedParameter($toTimestamp)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($row)) {
+            return ['daily' => $empty, 'monthly' => $empty];
+        }
+
+        return [
+            'daily' => [
+                'requests' => is_numeric($row['daily_requests'] ?? null) ? (int)$row['daily_requests'] : 0,
+                'tokens' => is_numeric($row['daily_tokens'] ?? null) ? (int)$row['daily_tokens'] : 0,
+                'cost' => is_numeric($row['daily_cost'] ?? null) ? (float)$row['daily_cost'] : 0.0,
+            ],
+            'monthly' => [
+                'requests' => is_numeric($row['monthly_requests'] ?? null) ? (int)$row['monthly_requests'] : 0,
+                'tokens' => is_numeric($row['monthly_tokens'] ?? null) ? (int)$row['monthly_tokens'] : 0,
+                'cost' => is_numeric($row['monthly_cost'] ?? null) ? (float)$row['monthly_cost'] : 0.0,
+            ],
+        ];
+    }
+}

--- a/Classes/Service/BudgetService.php
+++ b/Classes/Service/BudgetService.php
@@ -12,7 +12,7 @@ namespace Netresearch\NrLlm\Service;
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
-use TYPO3\CMS\Core\Database\ConnectionPool;
+use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 
 /**
  * Enforces per-backend-user daily and monthly AI spending ceilings.
@@ -35,26 +35,13 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  * Like CapabilityPermissionService, this ships the primitive; wiring the
  * check into individual feature services is a deliberate follow-up.
  */
-class BudgetService
+final readonly class BudgetService implements BudgetServiceInterface
 {
-    private const USAGE_TABLE = 'tx_nrllm_service_usage';
-
     public function __construct(
-        private readonly UserBudgetRepository $repository,
-        private readonly ConnectionPool $connectionPool,
+        private UserBudgetRepository $repository,
+        private BudgetUsageWindowsInterface $usageWindows,
     ) {}
 
-    /**
-     * Pre-flight check: is the user allowed to make a request whose
-     * expected cost is $plannedCost?
-     *
-     * Resolution:
-     *   1. No budget record -> allowed (admin hasn't capped this user)
-     *   2. Budget is inactive -> allowed (admin muted the cap)
-     *   3. Budget has no limits set -> allowed
-     *   4. Otherwise check current-day and current-month buckets in order.
-     *      The first bucket to exceed its limit wins and is reported back.
-     */
     public function check(int $beUserUid, float $plannedCost = 0.0): BudgetCheckResult
     {
         if ($beUserUid <= 0) {
@@ -81,11 +68,7 @@ class BudgetService
         $dayStart = $now->setTime(0, 0, 0)->getTimestamp();
         $monthStart = $now->modify('first day of this month')->setTime(0, 0, 0)->getTimestamp();
 
-        // ONE DB roundtrip covering both windows. When only one window is
-        // configured the other aggregate is cheap (the row count is tiny
-        // since tx_nrllm_service_usage is already a per-user/per-day
-        // rollup, not a per-request log).
-        $windows = $this->aggregateWindowUsage(
+        $windows = $this->usageWindows->aggregate(
             $beUserUid,
             $hasDailyLimits ? $dayStart : null,
             $hasMonthlyLimits ? $monthStart : null,
@@ -161,68 +144,5 @@ class BudgetService
             );
         }
         return BudgetCheckResult::allowed();
-    }
-
-    /**
-     * Aggregate per-user usage for the daily AND monthly windows in a
-     * single DB roundtrip, using conditional SUM() expressions. Protected
-     * so tests can stub out the DB layer without mocking the QueryBuilder
-     * chain. `null` for a window means "limit not configured" — the
-     * matching aggregate is returned as a zeroed bucket.
-     *
-     * @return array{daily: array{requests: int, tokens: int, cost: float}, monthly: array{requests: int, tokens: int, cost: float}}
-     */
-    protected function aggregateWindowUsage(
-        int $beUserUid,
-        ?int $dailyFromTimestamp,
-        ?int $monthlyFromTimestamp,
-        int $toTimestamp,
-    ): array {
-        $empty = ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
-        if ($dailyFromTimestamp === null && $monthlyFromTimestamp === null) {
-            return ['daily' => $empty, 'monthly' => $empty];
-        }
-
-        // The lower bound for the SQL WHERE: monthly is always the wider
-        // window, so if it's set we use that; otherwise fall back to the
-        // daily bound.
-        $lowerBound = $monthlyFromTimestamp ?? $dailyFromTimestamp;
-
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::USAGE_TABLE);
-        $dailyFromParam = $queryBuilder->createNamedParameter($dailyFromTimestamp ?? PHP_INT_MAX);
-        $monthlyFromParam = $queryBuilder->createNamedParameter($monthlyFromTimestamp ?? PHP_INT_MAX);
-
-        $row = $queryBuilder
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS daily_requests', $dailyFromParam))
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS daily_tokens', $dailyFromParam))
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS daily_cost', $dailyFromParam))
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN request_count ELSE 0 END) AS monthly_requests', $monthlyFromParam))
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN tokens_used ELSE 0 END) AS monthly_tokens', $monthlyFromParam))
-            ->addSelectLiteral(sprintf('SUM(CASE WHEN request_date >= %s THEN estimated_cost ELSE 0 END) AS monthly_cost', $monthlyFromParam))
-            ->from(self::USAGE_TABLE)
-            ->where(
-                $queryBuilder->expr()->eq('be_user', $queryBuilder->createNamedParameter($beUserUid)),
-                $queryBuilder->expr()->gte('request_date', $queryBuilder->createNamedParameter($lowerBound)),
-                $queryBuilder->expr()->lte('request_date', $queryBuilder->createNamedParameter($toTimestamp)),
-            )
-            ->executeQuery()
-            ->fetchAssociative();
-
-        if (!is_array($row)) {
-            return ['daily' => $empty, 'monthly' => $empty];
-        }
-
-        return [
-            'daily' => [
-                'requests' => is_numeric($row['daily_requests'] ?? null) ? (int)$row['daily_requests'] : 0,
-                'tokens' => is_numeric($row['daily_tokens'] ?? null) ? (int)$row['daily_tokens'] : 0,
-                'cost' => is_numeric($row['daily_cost'] ?? null) ? (float)$row['daily_cost'] : 0.0,
-            ],
-            'monthly' => [
-                'requests' => is_numeric($row['monthly_requests'] ?? null) ? (int)$row['monthly_requests'] : 0,
-                'tokens' => is_numeric($row['monthly_tokens'] ?? null) ? (int)$row['monthly_tokens'] : 0,
-                'cost' => is_numeric($row['monthly_cost'] ?? null) ? (float)$row['monthly_cost'] : 0.0,
-            ],
-        ];
     }
 }

--- a/Classes/Service/BudgetServiceInterface.php
+++ b/Classes/Service/BudgetServiceInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+
+/**
+ * Public surface of the per-backend-user AI budget gate.
+ *
+ * Consumers (middleware, feature services, tests) should depend on this
+ * interface rather than the concrete `BudgetService` so the
+ * implementation can be substituted without inheritance.
+ */
+interface BudgetServiceInterface
+{
+    /**
+     * Pre-flight check: is the user allowed to make a request whose
+     * expected cost is `$plannedCost`?
+     *
+     * Returns `BudgetCheckResult::allowed()` when there is no budget
+     * record, the budget is inactive, no limits are set, or every
+     * configured limit (current-day and current-month) is still under
+     * its cap. Otherwise returns `BudgetCheckResult::denied(...)`
+     * naming the first bucket that would overflow.
+     */
+    public function check(int $beUserUid, float $plannedCost = 0.0): BudgetCheckResult;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -127,6 +127,13 @@ services:
   Netresearch\NrLlm\Service\BudgetService:
     public: true
 
+  Netresearch\NrLlm\Service\BudgetServiceInterface:
+    alias: Netresearch\NrLlm\Service\BudgetService
+    public: true
+
+  Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface:
+    alias: Netresearch\NrLlm\Service\Budget\UserBudgetUsageWindows
+
   # ========================================
   # Translation Registry
   # ========================================

--- a/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
@@ -16,7 +16,7 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
-use Netresearch\NrLlm\Service\BudgetService;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,12 +28,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[AllowMockObjectsWithoutExpectations]
 final class BudgetMiddlewareTest extends AbstractUnitTestCase
 {
-    private BudgetService&MockObject $budgetService;
+    private BudgetServiceInterface&MockObject $budgetService;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->budgetService = $this->createMock(BudgetService::class);
+        $this->budgetService = $this->createMock(BudgetServiceInterface::class);
     }
 
     #[Test]

--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -12,24 +12,23 @@ namespace Netresearch\NrLlm\Tests\Unit\Service;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
+use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 use Netresearch\NrLlm\Service\BudgetService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 
 #[CoversClass(BudgetService::class)]
 class BudgetServiceTest extends AbstractUnitTestCase
 {
     private UserBudgetRepository&Stub $repositoryStub;
-    private ConnectionPool&Stub $connectionPoolStub;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->repositoryStub = self::createStub(UserBudgetRepository::class);
-        $this->connectionPoolStub = self::createStub(ConnectionPool::class);
     }
 
     #[Test]
@@ -225,41 +224,36 @@ class BudgetServiceTest extends AbstractUnitTestCase
         $budget = $this->makeBudget(dailyRequests: 100, monthlyRequests: 100);
         $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
 
-        $service = new class ($this->repositoryStub, $this->connectionPoolStub) extends BudgetService {
-            public int $callCount = 0;
-
-            public ?int $capturedDailyFrom = null;
-
-            public ?int $capturedMonthlyFrom = null;
-
-            /**
-             * @return array{daily: array{requests: int, tokens: int, cost: float}, monthly: array{requests: int, tokens: int, cost: float}}
-             */
-            protected function aggregateWindowUsage(
+        /** @var BudgetUsageWindowsInterface&MockObject $usageWindows */
+        $usageWindows = $this->createMock(BudgetUsageWindowsInterface::class);
+        $capturedDailyFrom = null;
+        $capturedMonthlyFrom = null;
+        $usageWindows->expects(self::once())
+            ->method('aggregate')
+            ->willReturnCallback(static function (
                 int $beUserUid,
                 ?int $dailyFromTimestamp,
                 ?int $monthlyFromTimestamp,
                 int $toTimestamp,
-            ): array {
-                $this->callCount++;
-                $this->capturedDailyFrom = $dailyFromTimestamp;
-                $this->capturedMonthlyFrom = $monthlyFromTimestamp;
+            ) use (&$capturedDailyFrom, &$capturedMonthlyFrom): array {
+                $capturedDailyFrom = $dailyFromTimestamp;
+                $capturedMonthlyFrom = $monthlyFromTimestamp;
                 return [
                     'daily' => ['requests' => 3, 'tokens' => 0, 'cost' => 0.0],
                     'monthly' => ['requests' => 50, 'tokens' => 0, 'cost' => 0.0],
                 ];
-            }
-        };
+            });
+
+        $service = new BudgetService($this->repositoryStub, $usageWindows);
 
         $result = $service->check(42);
 
         self::assertTrue($result->allowed);
-        self::assertSame(1, $service->callCount, 'Should make exactly one DB aggregation call');
-        self::assertNotNull($service->capturedDailyFrom, 'Daily window should be requested');
-        self::assertNotNull($service->capturedMonthlyFrom, 'Monthly window should be requested');
+        self::assertNotNull($capturedDailyFrom, 'Daily window should be requested');
+        self::assertNotNull($capturedMonthlyFrom, 'Monthly window should be requested');
         self::assertLessThan(
-            $service->capturedDailyFrom,
-            $service->capturedMonthlyFrom,
+            $capturedDailyFrom,
+            $capturedMonthlyFrom,
             'Monthly start must precede daily start',
         );
     }
@@ -293,34 +287,13 @@ class BudgetServiceTest extends AbstractUnitTestCase
      */
     private function makeService(array $daily = null, array $monthly = null): BudgetService
     {
-        $dailyWindow = $daily ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
-        $monthlyWindow = $monthly ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
-        return new class ($this->repositoryStub, $this->connectionPoolStub, $dailyWindow, $monthlyWindow) extends BudgetService {
-            /**
-             * @param array{requests: int, tokens: int, cost: float} $fakeDaily
-             * @param array{requests: int, tokens: int, cost: float} $fakeMonthly
-             */
-            public function __construct(
-                UserBudgetRepository $repository,
-                ConnectionPool $connectionPool,
-                private readonly array $fakeDaily,
-                private readonly array $fakeMonthly,
-            ) {
-                parent::__construct($repository, $connectionPool);
-            }
+        $usageWindows = self::createStub(BudgetUsageWindowsInterface::class);
+        $usageWindows->method('aggregate')->willReturn([
+            'daily' => $daily ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
+            'monthly' => $monthly ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
+        ]);
 
-            protected function aggregateWindowUsage(
-                int $beUserUid,
-                ?int $dailyFromTimestamp,
-                ?int $monthlyFromTimestamp,
-                int $toTimestamp,
-            ): array {
-                return [
-                    'daily' => $this->fakeDaily,
-                    'monthly' => $this->fakeMonthly,
-                ];
-            }
-        };
+        return new BudgetService($this->repositoryStub, $usageWindows);
     }
 
     private function makeBudget(


### PR DESCRIPTION
## Summary

Slice 11 — completes the audit's \"Final classes\" row at **10/10** and addresses the last service the audit explicitly listed as needing locking. Not auto-merging; awaiting review.

## Architectural change (the interesting bit)

`BudgetServiceTest` previously mocked `aggregateWindowUsage()` via anonymous classes that extended `BudgetService` — incompatible with `final`. Rather than making the production class non-extension-friendly, the SQL aggregation moves out of the service into its own collaborator:

- **New** `Classes/Service/Budget/BudgetUsageWindowsInterface.php` — contract for \"give me daily + monthly usage rollups\".
- **New** `Classes/Service/Budget/UserBudgetUsageWindows.php` — `final readonly` SQL implementation; the conditional-SUM single-roundtrip query that lived in `BudgetService::aggregateWindowUsage()` moves here verbatim.
- `BudgetService::__construct()` now takes `(UserBudgetRepository, BudgetUsageWindowsInterface)` instead of `(UserBudgetRepository, ConnectionPool)`. Smaller, focused on budget evaluation only.

## Lock + interface

- **New** `Classes/Service/BudgetServiceInterface.php` — single public method `check()`.
- `BudgetService` is now **`final readonly`** and implements the interface.
- `BudgetMiddleware` constructor typehint updated to the interface.
- `Configuration/Services.yaml` aliases:
  - `BudgetServiceInterface → BudgetService`
  - `BudgetUsageWindowsInterface → UserBudgetUsageWindows`

## Test refactor

- `BudgetServiceTest::makeService()` now stubs `BudgetUsageWindowsInterface` — no more anonymous subclasses.
- The \"single aggregation call\" test uses a `MockObject` with `willReturnCallback()` to capture the daily/monthly timestamp arguments. Same assertions: exactly one DB roundtrip, monthly window starts before daily.
- `BudgetMiddlewareTest` mocks the new interface instead of the concrete class.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3219) | all green |

## Audit scoreboard delta

| Axis | Before | After |
|---|---|---|
| **Final classes** | **9/10** | **10/10** ✓ — only the deliberately-non-final `ProviderException` base remains, and that's correct (it parents the leaf exception classes) |
| DI wiring | 7/10 | 7/10 (TranslatorRegistry asymmetry still pending — separate slice) |
| Architecture | 7/10 | 7/10 |

## CHANGELOG

Added a `BudgetService` entry under `[Unreleased] § BREAKING` noting the constructor-signature change for direct instantiators (autowired consumers are unaffected via the new aliases).

## Note on PR ordering

This branch is based on the same `main` as #167; if #167 lands first there will be a small CHANGELOG / Services.yaml merge conflict. I'll rebase as needed.

## Follow-up

- Slice 12: TranslatorRegistry interface check (REC #3 closure — verify the existing `TranslatorRegistryInterface` is still aligned, decide on tagged-iterator vs compiler-pass-attribute unification).
- After 12: REC #5 (split TaskController) — needs an ADR first; will pause and ask.
- Then REC #6 (domain JSON → DTOs), REC #7 (specialized HTTP pipeline), REC #8 (exception taxonomy), REC #10 (legacy enum constants).