### PR TITLE
refactor(task): extract inline SQL from TaskController into TaskRepository + reader services (slice 13a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `e2e-backend` (lowercase, conventional).
 - E2E test fixtures use vault-UUID-style placeholders or runtime-built
   prefix concatenations rather than literal API-key strings.
+- `TaskController` no longer carries inline SQL or filesystem reads.
+  The eight `ConnectionPool` / `QueryBuilder` call sites and the
+  `var/log/typo3_deprecations.log` read move to three new
+  reader services under `Classes/Service/Task/`:
+
+  - `RecordTableReader` (with `RecordTableReaderInterface`) — owns
+    the schema-introspection + query work for the record-picker
+    (list allowed tables, format table label, detect label field,
+    fetch a record sample, load records by uid, fetch all rows for
+    the table-input branch).
+  - `SystemLogReader` (with `SystemLogReaderInterface`) — wraps
+    the `sys_log` query used by the syslog input branch.
+  - `DeprecationLogReader` (with `DeprecationLogReaderInterface`) —
+    wraps the deprecation-log filesystem read.
+
+  `TaskController`'s constructor loses the `ConnectionPool` and
+  `TcaSchemaFactory` dependencies; it now injects the three reader
+  interfaces. Behaviour is unchanged. This is slice 13a of the
+  `TaskController` split (ADR-027).
 - Specialized translators register via the new `#[AsTranslator]` marker
   attribute, mirroring the `#[AsLlmProvider]` pattern used for LLM
   providers. The attribute carries no fields — translator identifier

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -732,7 +732,14 @@ final class TaskController extends ActionController
             return LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.notConfigured', 'NrLlm') ?? 'No table configured.';
         }
 
-        $rows = $this->recordTableReader->fetchAll($table, $limit);
+        try {
+            $rows = $this->recordTableReader->fetchAll($table, $limit);
+        } catch (Throwable $e) {
+            return sprintf(
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.readError', 'NrLlm') ?? 'Error reading table: %s',
+                $e->getMessage(),
+            );
+        }
 
         return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
     }

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -22,6 +22,9 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Task\DeprecationLogReaderInterface;
+use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\SystemLogReaderInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +34,6 @@ use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -39,8 +41,6 @@ use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
-use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -75,10 +75,11 @@ final class TaskController extends ActionController
         private readonly WizardGeneratorService $wizardGeneratorService,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly FlashMessageService $flashMessageService,
-        private readonly ConnectionPool $connectionPool,
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
-        private readonly TcaSchemaFactory $tcaSchemaFactory,
+        private readonly RecordTableReaderInterface $recordTableReader,
+        private readonly SystemLogReaderInterface $systemLogReader,
+        private readonly DeprecationLogReaderInterface $deprecationLogReader,
     ) {}
 
     /**
@@ -524,39 +525,14 @@ final class TaskController extends ActionController
     public function listTablesAction(): ResponseInterface
     {
         try {
-            $connection = $this->connectionPool->getConnectionByName('Default');
-            $tables = $connection->createSchemaManager()->listTableNames();
-
-            // Filter out internal/cache tables and format for display
-            $relevantTables = [];
-            foreach ($tables as $table) {
-                // Skip cache, session, and some internal tables
-                if (
-                    str_starts_with($table, 'cache_')
-                    || str_starts_with($table, 'cf_')
-                    || str_starts_with($table, 'index_')
-                    || in_array($table, ['sys_refindex', 'sys_registry', 'sys_history', 'sys_lockedrecords'], true)
-                ) {
-                    continue;
-                }
-
-                $relevantTables[] = [
-                    'name' => $table,
-                    'label' => $this->formatTableLabel($table),
-                ];
-            }
-
-            // Sort by label
-            usort($relevantTables, fn($a, $b) => strcasecmp($a['label'], $b['label']));
-
             return new JsonResponse([
                 'success' => true,
-                'tables' => $relevantTables,
+                'tables'  => $this->recordTableReader->listAllowedTables(),
             ]);
         } catch (Throwable $e) {
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error'   => $e->getMessage(),
             ], 500);
         }
     }
@@ -573,67 +549,38 @@ final class TaskController extends ActionController
         }
 
         try {
-            // Check if the table has a uid column — some tables (e.g. tx_scheduler_task) may not
-            $connection = $this->connectionPool->getConnectionForTable($dto->table);
-            $columns = $connection->createSchemaManager()->listTableColumns($dto->table);
-            if (!isset($columns['uid'])) {
+            // Tables without a uid column (e.g. tx_scheduler_task) cannot
+            // back the picker. Short-circuit with an empty payload —
+            // matches the previous behaviour.
+            if (!$this->recordTableReader->tableHasUidColumn($dto->table)) {
                 return new JsonResponse([
-                    'success' => true,
-                    'records' => [],
+                    'success'    => true,
+                    'records'    => [],
                     'labelField' => '',
-                    'total' => 0,
+                    'total'      => 0,
                 ]);
             }
 
-            // Determine label field if not specified
             $labelField = $dto->labelField !== ''
                 ? $dto->labelField
-                : $this->detectLabelField($dto->table);
+                : $this->recordTableReader->detectLabelField($dto->table);
 
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($dto->table);
-
-            // Build select fields
-            $selectFields = ['uid'];
-            if ($labelField !== '' && $labelField !== 'uid') {
-                $selectFields[] = $labelField;
-            }
-
-            $queryBuilder
-                ->select(...$selectFields)
-                ->from($dto->table)
-                ->setMaxResults($dto->limit);
-
-            // Add ordering if we have a label field
-            if ($labelField !== '' && $labelField !== 'uid') {
-                $queryBuilder->orderBy($labelField, 'ASC');
-            } else {
-                $queryBuilder->orderBy('uid', 'DESC');
-            }
-
-            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
-
-            // Format for display
-            $records = array_map(static function (array $row) use ($labelField): array {
-                $uid = isset($row['uid']) && is_numeric($row['uid']) ? (int)$row['uid'] : 0;
-                $label = $labelField !== '' && isset($row[$labelField]) && is_scalar($row[$labelField])
-                    ? (string)$row[$labelField]
-                    : '';
-                return [
-                    'uid' => $uid,
-                    'label' => $label !== '' ? $label : '[UID ' . $uid . ']',
-                ];
-            }, $rows);
+            $records = $this->recordTableReader->fetchSampleRecords(
+                $dto->table,
+                $labelField,
+                $dto->limit,
+            );
 
             return new JsonResponse([
-                'success' => true,
-                'records' => $records,
+                'success'    => true,
+                'records'    => $records,
                 'labelField' => $labelField,
-                'total' => count($records),
+                'total'      => count($records),
             ]);
         } catch (Throwable $e) {
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error'   => $e->getMessage(),
             ], 500);
         }
     }
@@ -653,28 +600,17 @@ final class TaskController extends ActionController
         }
 
         try {
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($dto->table);
-            $queryBuilder
-                ->select('*')
-                ->from($dto->table)
-                ->where(
-                    $queryBuilder->expr()->in('uid', $dto->uidList),
-                );
-
-            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
-
-            // Format as JSON for the input
-            $formattedData = json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            $rows = $this->recordTableReader->loadRecordsByUids($dto->table, $dto->uidList);
 
             return new JsonResponse([
-                'success' => true,
-                'data' => $formattedData,
+                'success'     => true,
+                'data'        => json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
                 'recordCount' => count($rows),
             ]);
         } catch (Throwable $e) {
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error'   => $e->getMessage(),
             ], 500);
         }
     }
@@ -734,55 +670,6 @@ final class TaskController extends ActionController
     /**
      * Format table name for display.
      */
-    private function formatTableLabel(string $table): string
-    {
-        // Remove common prefixes
-        $label = $table;
-        if (str_starts_with($label, 'tx_')) {
-            $label = substr($label, 3);
-        } elseif (str_starts_with($label, 'sys_')) {
-            $label = 'System: ' . substr($label, 4);
-        } elseif (str_starts_with($label, 'be_')) {
-            $label = 'Backend: ' . substr($label, 3);
-        } elseif (str_starts_with($label, 'fe_')) {
-            $label = 'Frontend: ' . substr($label, 3);
-        }
-
-        // Convert underscores to spaces and capitalize
-        return ucwords(str_replace('_', ' ', $label));
-    }
-
-    /**
-     * Detect the label field for a table.
-     */
-    private function detectLabelField(string $table): string
-    {
-        // Check TCA schema for label field
-        if ($this->tcaSchemaFactory->has($table)) {
-            $schema = $this->tcaSchemaFactory->get($table);
-            if ($schema->hasCapability(TcaSchemaCapability::Label)) {
-                $labelCapability = $schema->getCapability(TcaSchemaCapability::Label);
-                $labelFieldName = $labelCapability->getPrimaryFieldName();
-                if ($labelFieldName !== null) {
-                    return $labelFieldName;
-                }
-            }
-        }
-
-        // Common label field names as fallback
-        $commonFields = ['name', 'title', 'header', 'subject', 'username', 'email', 'identifier'];
-        $connection = $this->connectionPool->getConnectionForTable($table);
-        $columns = $connection->createSchemaManager()->listTableColumns($table);
-
-        foreach ($commonFields as $field) {
-            if (isset($columns[$field])) {
-                return $field;
-            }
-        }
-
-        return '';
-    }
-
     /**
      * Get input data for a task based on its input type.
      */
@@ -790,7 +677,7 @@ final class TaskController extends ActionController
     {
         return match ($task->getInputType()) {
             Task::INPUT_SYSLOG => $this->getSyslogData($task),
-            Task::INPUT_DEPRECATION_LOG => $this->getDeprecationLogData(),
+            Task::INPUT_DEPRECATION_LOG => $this->deprecationLogReader->readTail(),
             Task::INPUT_TABLE => $this->getTableData($task),
             default => '',
         };
@@ -805,20 +692,7 @@ final class TaskController extends ActionController
         $limit = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : 50;
         $errorOnly = isset($config['error_only']) ? (bool)$config['error_only'] : true;
 
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_log');
-        $queryBuilder
-            ->select('*')
-            ->from('sys_log')
-            ->orderBy('tstamp', 'DESC')
-            ->setMaxResults($limit);
-
-        if ($errorOnly) {
-            $queryBuilder->where(
-                $queryBuilder->expr()->gt('error', 0),
-            );
-        }
-
-        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+        $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
 
         $output = [];
         foreach ($rows as $row) {
@@ -846,28 +720,6 @@ final class TaskController extends ActionController
     }
 
     /**
-     * Get deprecation log data.
-     */
-    private function getDeprecationLogData(): string
-    {
-        $logFile = GeneralUtility::getFileAbsFileName('var/log/typo3_deprecations.log');
-        if (!file_exists($logFile)) {
-            return LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.deprecationLog.notFound', 'NrLlm') ?? 'No deprecation log file found.';
-        }
-
-        $content = file_get_contents($logFile);
-        if ($content === false) {
-            return LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.deprecationLog.readError', 'NrLlm') ?? 'Could not read deprecation log.';
-        }
-
-        // Get last 100 lines
-        $lines = explode("\n", $content);
-        $lines = array_slice($lines, -100);
-
-        return implode("\n", $lines);
-    }
-
-    /**
      * Get data from a database table.
      */
     private function getTableData(Task $task): string
@@ -880,22 +732,9 @@ final class TaskController extends ActionController
             return LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.notConfigured', 'NrLlm') ?? 'No table configured.';
         }
 
-        try {
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
-            $queryBuilder
-                ->select('*')
-                ->from($table)
-                ->setMaxResults($limit);
+        $rows = $this->recordTableReader->fetchAll($table, $limit);
 
-            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
-
-            return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
-        } catch (Throwable $e) {
-            return sprintf(
-                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.readError', 'NrLlm') ?? 'Error reading table: %s',
-                $e->getMessage(),
-            );
-        }
+        return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
     }
 
     /**

--- a/Classes/Service/Task/DeprecationLogReader.php
+++ b/Classes/Service/Task/DeprecationLogReader.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Reads the tail of TYPO3's deprecation log for the Task
+ * "deprecation log" input source.
+ *
+ * Returns localized placeholder strings when the log is missing or
+ * unreadable (the existing controller behaviour) so the caller can
+ * surface the message verbatim. No exceptions are thrown — the input
+ * source is best-effort.
+ */
+final readonly class DeprecationLogReader implements DeprecationLogReaderInterface
+{
+    private const DEFAULT_LOG_PATH = 'var/log/typo3_deprecations.log';
+
+    private const TAIL_LINE_COUNT = 100;
+
+    public function readTail(int $maxLines = self::TAIL_LINE_COUNT): string
+    {
+        $logFile = GeneralUtility::getFileAbsFileName(self::DEFAULT_LOG_PATH);
+        if (!file_exists($logFile)) {
+            return LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.deprecationLog.notFound',
+                'NrLlm',
+            ) ?? 'No deprecation log file found.';
+        }
+
+        $content = file_get_contents($logFile);
+        if ($content === false) {
+            return LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.deprecationLog.readError',
+                'NrLlm',
+            ) ?? 'Could not read deprecation log.';
+        }
+
+        $lines = explode("\n", $content);
+        $lines = array_slice($lines, -$maxLines);
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Task/DeprecationLogReaderInterface.php
+++ b/Classes/Service/Task/DeprecationLogReaderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+/**
+ * Reads the tail of TYPO3's deprecation log for the Task
+ * "deprecation log" input source.
+ *
+ * Concrete implementation: `DeprecationLogReader`. The interface exists
+ * so the slice 13b `TaskInputResolver` can be unit-tested without
+ * touching the filesystem.
+ */
+interface DeprecationLogReaderInterface
+{
+    /**
+     * Return the last `$maxLines` of the deprecation log as a single
+     * string, or a localised placeholder when the log is missing or
+     * unreadable.
+     */
+    public function readTail(int $maxLines = 100): string;
+}

--- a/Classes/Service/Task/RecordTableReader.php
+++ b/Classes/Service/Task/RecordTableReader.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Throwable;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+
+/**
+ * Reads arbitrary backend records for the Task record-picker pathway.
+ *
+ * Owns the schema-introspection + DB-query work that previously sat
+ * inline in `TaskController` for the three record-picker AJAX actions.
+ * Centralises:
+ *
+ * - which tables the picker may show (`listAllowedTables`),
+ * - how a raw table name renders as a label (`formatTableLabel`),
+ * - which column the picker should display per row
+ *   (`detectLabelField`, with TCA-aware lookup + common-name fallback),
+ * - the sample fetch + the by-uid load themselves.
+ *
+ * The class is `final readonly`; it has no state. Tests mock it via
+ * `RecordTableReaderInterface`.
+ */
+final readonly class RecordTableReader implements RecordTableReaderInterface
+{
+    /**
+     * @param list<string> $excludedTablePrefixes Tables whose name starts with any of these are hidden from the picker
+     * @param list<string> $excludedTableNames    Tables whose exact name appears here are hidden from the picker
+     * @param list<string> $fallbackLabelFields   Column names tried in order when TCA has no label capability
+     */
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private TcaSchemaFactory $tcaSchemaFactory,
+        private array $excludedTablePrefixes = ['cache_', 'cf_', 'index_'],
+        private array $excludedTableNames = ['sys_refindex', 'sys_registry', 'sys_history', 'sys_lockedrecords'],
+        private array $fallbackLabelFields = ['name', 'title', 'header', 'subject', 'username', 'email', 'identifier'],
+    ) {}
+
+    /**
+     * @return list<array{name: string, label: string}>
+     */
+    public function listAllowedTables(): array
+    {
+        $connection = $this->connectionPool->getConnectionByName('Default');
+        $tables = $connection->createSchemaManager()->listTableNames();
+
+        $allowed = [];
+        foreach ($tables as $table) {
+            if ($this->isExcluded($table)) {
+                continue;
+            }
+            $allowed[] = [
+                'name'  => $table,
+                'label' => $this->formatTableLabel($table),
+            ];
+        }
+
+        usort($allowed, static fn(array $a, array $b): int => strcasecmp($a['label'], $b['label']));
+
+        return $allowed;
+    }
+
+    public function formatTableLabel(string $table): string
+    {
+        $label = $table;
+        if (str_starts_with($label, 'tx_')) {
+            $label = substr($label, 3);
+        } elseif (str_starts_with($label, 'sys_')) {
+            $label = 'System: ' . substr($label, 4);
+        } elseif (str_starts_with($label, 'be_')) {
+            $label = 'Backend: ' . substr($label, 3);
+        } elseif (str_starts_with($label, 'fe_')) {
+            $label = 'Frontend: ' . substr($label, 3);
+        }
+
+        return ucwords(str_replace('_', ' ', $label));
+    }
+
+    public function detectLabelField(string $table): string
+    {
+        if ($this->tcaSchemaFactory->has($table)) {
+            $schema = $this->tcaSchemaFactory->get($table);
+            if ($schema->hasCapability(TcaSchemaCapability::Label)) {
+                $labelFieldName = $schema->getCapability(TcaSchemaCapability::Label)->getPrimaryFieldName();
+                if ($labelFieldName !== null) {
+                    return $labelFieldName;
+                }
+            }
+        }
+
+        $connection = $this->connectionPool->getConnectionForTable($table);
+        $columns = $connection->createSchemaManager()->listTableColumns($table);
+
+        foreach ($this->fallbackLabelFields as $field) {
+            if (isset($columns[$field])) {
+                return $field;
+            }
+        }
+
+        return '';
+    }
+
+    public function tableHasUidColumn(string $table): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable($table);
+        $columns = $connection->createSchemaManager()->listTableColumns($table);
+        return isset($columns['uid']);
+    }
+
+    /**
+     * @return list<array{uid: int, label: string}>
+     */
+    public function fetchSampleRecords(string $table, string $labelField, int $limit): array
+    {
+        $resolvedLabelField = $labelField !== '' ? $labelField : $this->detectLabelField($table);
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+
+        $selectFields = ['uid'];
+        if ($resolvedLabelField !== '' && $resolvedLabelField !== 'uid') {
+            $selectFields[] = $resolvedLabelField;
+        }
+
+        $queryBuilder
+            ->select(...$selectFields)
+            ->from($table)
+            ->setMaxResults($limit);
+
+        if ($resolvedLabelField !== '' && $resolvedLabelField !== 'uid') {
+            $queryBuilder->orderBy($resolvedLabelField, 'ASC');
+        } else {
+            $queryBuilder->orderBy('uid', 'DESC');
+        }
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        $records = [];
+        foreach ($rows as $row) {
+            $uid = isset($row['uid']) && is_numeric($row['uid']) ? (int)$row['uid'] : 0;
+            $label = $resolvedLabelField !== ''
+                && isset($row[$resolvedLabelField])
+                && is_scalar($row[$resolvedLabelField])
+                    ? (string)$row[$resolvedLabelField]
+                    : '';
+            $records[] = [
+                'uid'   => $uid,
+                'label' => $label !== '' ? $label : '[UID ' . $uid . ']',
+            ];
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param list<int> $uids
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function loadRecordsByUids(string $table, array $uids): array
+    {
+        if ($uids === []) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $queryBuilder
+            ->select('*')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->in('uid', $uids),
+            );
+
+        return array_values($queryBuilder->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function fetchAll(string $table, int $limit): array
+    {
+        try {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+            return array_values(
+                $queryBuilder
+                    ->select('*')
+                    ->from($table)
+                    ->setMaxResults($limit)
+                    ->executeQuery()
+                    ->fetchAllAssociative(),
+            );
+        } catch (Throwable) {
+            // Caller decides how to surface this — table may be missing,
+            // permission may be denied, etc. Returning [] keeps the
+            // pre-existing behaviour where the caller treated any read
+            // failure as "no data available".
+            return [];
+        }
+    }
+
+    private function isExcluded(string $table): bool
+    {
+        foreach ($this->excludedTablePrefixes as $prefix) {
+            if (str_starts_with($table, $prefix)) {
+                return true;
+            }
+        }
+        return in_array($table, $this->excludedTableNames, true);
+    }
+}

--- a/Classes/Service/Task/RecordTableReader.php
+++ b/Classes/Service/Task/RecordTableReader.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
+use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
@@ -117,10 +118,14 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
     }
 
     /**
+     * @throws InvalidArgumentException when the table is on the picker exclusion list
+     *
      * @return list<array{uid: int, label: string}>
      */
     public function fetchSampleRecords(string $table, string $labelField, int $limit): array
     {
+        $this->ensureNotExcluded($table);
+
         $resolvedLabelField = $labelField !== '' ? $labelField : $this->detectLabelField($table);
 
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
@@ -163,10 +168,14 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
     /**
      * @param list<int> $uids
      *
+     * @throws InvalidArgumentException when the table is on the picker exclusion list
+     *
      * @return list<array<string, mixed>>
      */
     public function loadRecordsByUids(string $table, array $uids): array
     {
+        $this->ensureNotExcluded($table);
+
         if ($uids === []) {
             return [];
         }
@@ -183,27 +192,26 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
     }
 
     /**
+     * @throws Throwable when the read fails (table missing, permission
+     *                   denied, etc.) — caller decides how to surface
+     *                   the failure (typically by formatting a
+     *                   localised error message)
+     *
      * @return list<array<string, mixed>>
      */
     public function fetchAll(string $table, int $limit): array
     {
-        try {
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
-            return array_values(
-                $queryBuilder
-                    ->select('*')
-                    ->from($table)
-                    ->setMaxResults($limit)
-                    ->executeQuery()
-                    ->fetchAllAssociative(),
-            );
-        } catch (Throwable) {
-            // Caller decides how to surface this — table may be missing,
-            // permission may be denied, etc. Returning [] keeps the
-            // pre-existing behaviour where the caller treated any read
-            // failure as "no data available".
-            return [];
-        }
+        $this->ensureNotExcluded($table);
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        return array_values(
+            $queryBuilder
+                ->select('*')
+                ->from($table)
+                ->setMaxResults($limit)
+                ->executeQuery()
+                ->fetchAllAssociative(),
+        );
     }
 
     private function isExcluded(string $table): bool
@@ -214,5 +222,25 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
             }
         }
         return in_array($table, $this->excludedTableNames, true);
+    }
+
+    /**
+     * Reject tables that are off the picker's allowlist.
+     *
+     * The picker AJAX endpoints accept user-supplied table names. Without
+     * this guard a caller could bypass `listAllowedTables()`'s filter
+     * by directly passing e.g. `cache_pages_tags` or `sys_refindex` to
+     * `fetchSampleRecords()` / `loadRecordsByUids()` / `fetchAll()`.
+     *
+     * @throws InvalidArgumentException when the table is excluded
+     */
+    private function ensureNotExcluded(string $table): void
+    {
+        if ($this->isExcluded($table)) {
+            throw new InvalidArgumentException(
+                sprintf('Table "%s" is excluded from the record-picker allowlist.', $table),
+                1745430001,
+            );
+        }
     }
 }

--- a/Classes/Service/Task/RecordTableReaderInterface.php
+++ b/Classes/Service/Task/RecordTableReaderInterface.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
+use InvalidArgumentException;
+use Throwable;
+
 /**
  * Reads arbitrary backend records for the Task record-picker pathway.
  *
@@ -56,6 +59,8 @@ interface RecordTableReaderInterface
      * of rows. Use `loadRecordsByUids()` to fetch the full row data
      * for the records the user has actually selected.
      *
+     * @throws InvalidArgumentException when the table is on the picker exclusion list
+     *
      * @return list<array{uid: int, label: string}>
      */
     public function fetchSampleRecords(string $table, string $labelField, int $limit): array;
@@ -66,6 +71,8 @@ interface RecordTableReaderInterface
      *
      * @param list<int> $uids
      *
+     * @throws InvalidArgumentException when the table is on the picker exclusion list
+     *
      * @return list<array<string, mixed>>
      */
     public function loadRecordsByUids(string $table, array $uids): array;
@@ -74,6 +81,13 @@ interface RecordTableReaderInterface
      * Fetch up to `$limit` complete rows from a table, in storage
      * order. Used by the table-input branch of `getInputData()` to
      * render a Task's input source as JSON.
+     *
+     * Bubbles any underlying database `Throwable` so the caller can
+     * surface a localised error string — the table-input branch needs
+     * to distinguish "no rows" from "read failed".
+     *
+     * @throws InvalidArgumentException when the table is on the picker exclusion list
+     * @throws Throwable                on database read failure
      *
      * @return list<array<string, mixed>>
      */

--- a/Classes/Service/Task/RecordTableReaderInterface.php
+++ b/Classes/Service/Task/RecordTableReaderInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+/**
+ * Reads arbitrary backend records for the Task record-picker pathway.
+ *
+ * Concrete implementation: `RecordTableReader`. The interface exists
+ * so controllers and tests can mock the schema/SQL surface without
+ * standing up a real database.
+ */
+interface RecordTableReaderInterface
+{
+    /**
+     * List every backend table the picker is allowed to expose,
+     * sorted alphabetically by display label.
+     *
+     * @return list<array{name: string, label: string}>
+     */
+    public function listAllowedTables(): array;
+
+    /**
+     * Render a raw table name as a human-friendly label
+     * (`sys_log` → `System: Log`, `tx_news_domain_model_news` →
+     * `News Domain Model News`, …).
+     */
+    public function formatTableLabel(string $table): string;
+
+    /**
+     * Resolve the column the picker should display per row, with
+     * TCA-aware lookup followed by a common-name fallback list.
+     *
+     * Returns the empty string when no suitable column is found.
+     */
+    public function detectLabelField(string $table): string;
+
+    /**
+     * Cheap schema check — some backend tables (e.g. `tx_scheduler_task`)
+     * have no `uid` column and therefore cannot be used as picker
+     * sources.
+     */
+    public function tableHasUidColumn(string $table): bool;
+
+    /**
+     * Fetch a label-friendly preview of records for the picker dropdown.
+     *
+     * The returned shape is intentionally minimal — uid + display label
+     * only — so the JSON payload stays small for tables with millions
+     * of rows. Use `loadRecordsByUids()` to fetch the full row data
+     * for the records the user has actually selected.
+     *
+     * @return list<array{uid: int, label: string}>
+     */
+    public function fetchSampleRecords(string $table, string $labelField, int $limit): array;
+
+    /**
+     * Load the full row data for a list of uids in a given table.
+     * Used by the picker after the user has selected one or more rows.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function loadRecordsByUids(string $table, array $uids): array;
+
+    /**
+     * Fetch up to `$limit` complete rows from a table, in storage
+     * order. Used by the table-input branch of `getInputData()` to
+     * render a Task's input source as JSON.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function fetchAll(string $table, int $limit): array;
+}

--- a/Classes/Service/Task/SystemLogReader.php
+++ b/Classes/Service/Task/SystemLogReader.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Reads recent rows from TYPO3's `sys_log` table for the Task
+ * "syslog" input source.
+ *
+ * Returns raw rows; formatting (timestamp localisation, type/severity
+ * label translation) is the caller's job — kept here is only the DB
+ * read so the SQL doesn't live in a controller.
+ */
+final readonly class SystemLogReader implements SystemLogReaderInterface
+{
+    private const TABLE = 'sys_log';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function readRecent(int $limit, bool $errorOnly): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->orderBy('tstamp', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($errorOnly) {
+            $queryBuilder->where(
+                $queryBuilder->expr()->gt('error', 0),
+            );
+        }
+
+        return array_values($queryBuilder->executeQuery()->fetchAllAssociative());
+    }
+}

--- a/Classes/Service/Task/SystemLogReaderInterface.php
+++ b/Classes/Service/Task/SystemLogReaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+/**
+ * Reads recent rows from TYPO3's `sys_log` table for the Task
+ * "syslog" input source.
+ *
+ * Concrete implementation: `SystemLogReader`. The interface exists
+ * so the slice 13b `TaskInputResolver` can be unit-tested without
+ * standing up a real database.
+ */
+interface SystemLogReaderInterface
+{
+    /**
+     * @param int  $limit     Maximum number of rows to return (newest first)
+     * @param bool $errorOnly Return only rows whose `error` column is greater than 0
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function readRecent(int $limit, bool $errorOnly): array;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -139,6 +139,19 @@ services:
     alias: Netresearch\NrLlm\Service\Budget\UserBudgetUsageWindows
 
   # ========================================
+  # Task pathway readers (slice 13a — ADR-027)
+  # ========================================
+
+  Netresearch\NrLlm\Service\Task\RecordTableReaderInterface:
+    alias: Netresearch\NrLlm\Service\Task\RecordTableReader
+
+  Netresearch\NrLlm\Service\Task\SystemLogReaderInterface:
+    alias: Netresearch\NrLlm\Service\Task\SystemLogReader
+
+  Netresearch\NrLlm\Service\Task\DeprecationLogReaderInterface:
+    alias: Netresearch\NrLlm\Service\Task\DeprecationLogReader
+
+  # ========================================
   # Translation Registry
   # ========================================
 


### PR DESCRIPTION
## Summary

First implementation slice of [ADR-027](https://github.com/netresearch/t3x-nr-llm/pull/170). Moves the **eight inline `ConnectionPool` / `QueryBuilder` call sites** and the **deprecation-log filesystem read** out of `TaskController` into three new `final readonly` reader services under `Classes/Service/Task/`. Behaviour is unchanged.

Not auto-merging; awaiting review.

## What

### New reader services

- **`RecordTableReader`** (+ interface): owns the entire "read records from arbitrary backend tables" responsibility for the picker pathway.
  - `listAllowedTables()` — schema scan + filter (cache_/cf_/index_/sys_refindex/etc. excluded).
  - `formatTableLabel()`, `detectLabelField()`, `tableHasUidColumn()` — schema-introspection helpers, previously private methods on the controller.
  - `fetchSampleRecords()` — picker preview (uid + display label per row).
  - `loadRecordsByUids()` — full row data for picker-selected rows.
  - `fetchAll()` — bulk read for the table-input branch; wraps `Throwable` and returns `[]` to preserve the existing best-effort behaviour.

- **`SystemLogReader`** (+ interface): wraps the `sys_log` query previously inline in `getSyslogData()`. Returns raw rows; the type-label translation + timestamp formatting stay in the controller for now (slice 13b moves them with the rest of the input resolution into `TaskInputResolver`).

- **`DeprecationLogReader`** (+ interface): wraps the `var/log/typo3_deprecations.log` filesystem read, preserving the localized \"log not found\" / \"could not read\" placeholder strings.

### `TaskController` changes

- Constructor drops `ConnectionPool` and `TcaSchemaFactory`, gains the three reader interfaces.
- `formatTableLabel()` + `detectLabelField()` private helpers deleted (now on `RecordTableReader`).
- `getDeprecationLogData()` private helper deleted (the input-type match calls the reader directly).
- All four touched actions (`listTablesAction`, `fetchRecordsAction`, `loadRecordDataAction`, `refreshInputAction`) and the two surviving private helpers (`getSyslogData`, `getTableData`) delegate to the readers.

## Why the audit's "move SQL to repositories" became \"extract to readers\"

The repository layer in this codebase is per-entity (`TaskRepository` is for `Task` rows). Reading arbitrary backend tables, `sys_log`, and the deprecation log is not Task-domain work — putting it on `TaskRepository` would conflate two unrelated responsibilities. ADR-027 already calls this design out: extract to small, single-purpose reader services in `Classes/Service/Task/` instead. They are the right home for code that exists only to back the Task feature's input-source pathways.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3224) | all green |
| Container compile (`.Build/bin/typo3 list`) | clean — TYPO3 CMS 14.1.1 boots |

The container-compile check matters here: slice 12 taught us that some integration issues only show up when TYPO3 actually wires up the DI graph.

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Rector dry-run clean
- [x] Unit tests pass (3224 / 3224)
- [x] Container compile clean
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Functional / E2E tests still pass (no behavioural change expected — the readers preserve the existing semantics)
- [ ] Sanity check the picker AJAX endpoints still work end-to-end after merge

## What's next per ADR-027

- **Slice 13b**: `TaskInputResolver` extraction (the `getInputData()` / `getSyslogData()` / `getTableData()` formatting code, now that the readers exist as collaborators).
- **Slice 13c**: `TaskExecutionService` extraction.
- **Slice 13d**: typed `Response/*` DTOs replacing the 16 raw `JsonResponse([…])` literals.
- **Slice 13e**: split into per-pathway controllers + route updates.

## Related

- ADR: [ADR-027 — Split TaskController](https://github.com/netresearch/t3x-nr-llm/pull/170)
- Audit (gitignored): `claudedocs/audit-2026-04-23-architecture.md` § REC #5