### PR TITLE
refactor(task): extract TaskInputResolver from TaskController (slice 13b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `TcaSchemaFactory` dependencies; it now injects the three reader
   interfaces. Behaviour is unchanged. This is slice 13a of the
   `TaskController` split (ADR-027).
+- `TaskController` no longer carries the input-source dispatch logic.
+  The `getInputData()` / `getSyslogData()` / `getTableData()` private
+  helpers move into a new `Service/Task/TaskInputResolver` (with
+  `TaskInputResolverInterface`). The resolver owns the `Task::INPUT_*`
+  match plus the per-source formatting (timestamp + type-label
+  localisation for syslog rows, "no table configured" / "read failed"
+  placeholders for the table source) and delegates the actual data
+  fetching to the slice-13a reader services. The controller's
+  `getInputData()` becomes a single delegation; the `SystemLogReader`
+  and `DeprecationLogReader` are no longer injected directly into the
+  controller (the resolver owns them). Behaviour is unchanged. Slice
+  13b of the `TaskController` split (ADR-027).
 - Specialized translators register via the new `#[AsTranslator]` marker
   attribute, mirroring the `#[AsLlmProvider]` pattern used for LLM
   providers. The attribute carries no fields — translator identifier

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -22,9 +22,8 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
-use Netresearch\NrLlm\Service\Task\DeprecationLogReaderInterface;
 use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
-use Netresearch\NrLlm\Service\Task\SystemLogReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -78,8 +77,7 @@ final class TaskController extends ActionController
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly RecordTableReaderInterface $recordTableReader,
-        private readonly SystemLogReaderInterface $systemLogReader,
-        private readonly DeprecationLogReaderInterface $deprecationLogReader,
+        private readonly TaskInputResolverInterface $taskInputResolver,
     ) {}
 
     /**
@@ -675,73 +673,7 @@ final class TaskController extends ActionController
      */
     private function getInputData(Task $task): string
     {
-        return match ($task->getInputType()) {
-            Task::INPUT_SYSLOG => $this->getSyslogData($task),
-            Task::INPUT_DEPRECATION_LOG => $this->deprecationLogReader->readTail(),
-            Task::INPUT_TABLE => $this->getTableData($task),
-            default => '',
-        };
-    }
-
-    /**
-     * Get system log data.
-     */
-    private function getSyslogData(Task $task): string
-    {
-        $config = $task->getInputSourceArray();
-        $limit = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : 50;
-        $errorOnly = isset($config['error_only']) ? (bool)$config['error_only'] : true;
-
-        $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
-
-        $output = [];
-        foreach ($rows as $row) {
-            $tstamp = isset($row['tstamp']) && is_numeric($row['tstamp']) ? (int)$row['tstamp'] : 0;
-            $typeValue = isset($row['type']) && is_numeric($row['type']) ? (int)$row['type'] : 0;
-            $errorValue = isset($row['error']) && is_numeric($row['error']) ? (int)$row['error'] : 0;
-            $details = isset($row['details']) && is_scalar($row['details']) ? (string)$row['details'] : '';
-
-            $time = date('Y-m-d H:i:s', $tstamp);
-            $type = match ($typeValue) {
-                1 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.db', 'NrLlm') ?? 'DB',
-                2 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.file', 'NrLlm') ?? 'FILE',
-                3 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.cache', 'NrLlm') ?? 'CACHE',
-                4 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.extension', 'NrLlm') ?? 'EXTENSION',
-                5 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.error', 'NrLlm') ?? 'ERROR',
-                254 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.setting', 'NrLlm') ?? 'SETTING',
-                255 => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.login', 'NrLlm') ?? 'LOGIN',
-                default => LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.type.other', 'NrLlm') ?? 'OTHER',
-            };
-            $error = $errorValue > 0 ? (LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.errorMarker', 'NrLlm') ?? '[ERROR]') : '';
-            $output[] = "[{$time}] [{$type}] {$error} {$details}";
-        }
-
-        return implode("\n", $output);
-    }
-
-    /**
-     * Get data from a database table.
-     */
-    private function getTableData(Task $task): string
-    {
-        $config = $task->getInputSourceArray();
-        $table = isset($config['table']) && is_scalar($config['table']) ? (string)$config['table'] : '';
-        $limit = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : 50;
-
-        if ($table === '') {
-            return LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.notConfigured', 'NrLlm') ?? 'No table configured.';
-        }
-
-        try {
-            $rows = $this->recordTableReader->fetchAll($table, $limit);
-        } catch (Throwable $e) {
-            return sprintf(
-                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.readError', 'NrLlm') ?? 'Error reading table: %s',
-                $e->getMessage(),
-            );
-        }
-
-        return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
+        return $this->taskInputResolver->resolve($task);
     }
 
     /**

--- a/Classes/Service/Task/TaskInputResolver.php
+++ b/Classes/Service/Task/TaskInputResolver.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Netresearch\NrLlm\Domain\Model\Task;
+use Throwable;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Resolves a `Task`'s configured input source into the input string
+ * passed to the LLM.
+ *
+ * Owns the dispatch over `Task::INPUT_*` plus the per-source
+ * formatting (timestamp + type-label localisation for syslog rows,
+ * "no table configured" / "read failed" placeholders for the table
+ * source). Delegates the actual data fetching to the slice-13a
+ * reader services so the resolver itself stays free of
+ * `ConnectionPool` / filesystem coupling.
+ *
+ * Behaviour matches the pre-13b `TaskController::getInputData()`
+ * private helper exactly — this slice is a pure refactor.
+ */
+final readonly class TaskInputResolver implements TaskInputResolverInterface
+{
+    private const SYSLOG_DEFAULT_LIMIT = 50;
+    private const TABLE_DEFAULT_LIMIT = 50;
+
+    public function __construct(
+        private SystemLogReaderInterface $systemLogReader,
+        private DeprecationLogReaderInterface $deprecationLogReader,
+        private RecordTableReaderInterface $recordTableReader,
+    ) {}
+
+    public function resolve(Task $task): string
+    {
+        return match ($task->getInputType()) {
+            Task::INPUT_SYSLOG          => $this->resolveSyslog($task),
+            Task::INPUT_DEPRECATION_LOG => $this->deprecationLogReader->readTail(),
+            Task::INPUT_TABLE           => $this->resolveTable($task),
+            default                     => '',
+        };
+    }
+
+    private function resolveSyslog(Task $task): string
+    {
+        $config    = $task->getInputSourceArray();
+        $limit     = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : self::SYSLOG_DEFAULT_LIMIT;
+        $errorOnly = isset($config['error_only']) ? (bool)$config['error_only'] : true;
+
+        $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
+
+        $output = [];
+        foreach ($rows as $row) {
+            $tstamp     = isset($row['tstamp']) && is_numeric($row['tstamp']) ? (int)$row['tstamp'] : 0;
+            $typeValue  = isset($row['type']) && is_numeric($row['type']) ? (int)$row['type'] : 0;
+            $errorValue = isset($row['error']) && is_numeric($row['error']) ? (int)$row['error'] : 0;
+            $details    = isset($row['details']) && is_scalar($row['details']) ? (string)$row['details'] : '';
+
+            $time  = date('Y-m-d H:i:s', $tstamp);
+            $type  = $this->translateSyslogType($typeValue);
+            $error = $errorValue > 0
+                ? (LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.errorMarker', 'NrLlm') ?? '[ERROR]')
+                : '';
+
+            $output[] = "[{$time}] [{$type}] {$error} {$details}";
+        }
+
+        return implode("\n", $output);
+    }
+
+    private function translateSyslogType(int $typeValue): string
+    {
+        $key = match ($typeValue) {
+            1       => 'task.syslog.type.db',
+            2       => 'task.syslog.type.file',
+            3       => 'task.syslog.type.cache',
+            4       => 'task.syslog.type.extension',
+            5       => 'task.syslog.type.error',
+            254     => 'task.syslog.type.setting',
+            255     => 'task.syslog.type.login',
+            default => 'task.syslog.type.other',
+        };
+
+        $fallback = match ($typeValue) {
+            1       => 'DB',
+            2       => 'FILE',
+            3       => 'CACHE',
+            4       => 'EXTENSION',
+            5       => 'ERROR',
+            254     => 'SETTING',
+            255     => 'LOGIN',
+            default => 'OTHER',
+        };
+
+        return LocalizationUtility::translate(
+            'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:' . $key,
+            'NrLlm',
+        ) ?? $fallback;
+    }
+
+    private function resolveTable(Task $task): string
+    {
+        $config = $task->getInputSourceArray();
+        $table  = isset($config['table']) && is_scalar($config['table']) ? (string)$config['table'] : '';
+        $limit  = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : self::TABLE_DEFAULT_LIMIT;
+
+        if ($table === '') {
+            return LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.notConfigured',
+                'NrLlm',
+            ) ?? 'No table configured.';
+        }
+
+        try {
+            $rows = $this->recordTableReader->fetchAll($table, $limit);
+        } catch (Throwable $e) {
+            return sprintf(
+                LocalizationUtility::translate(
+                    'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.readError',
+                    'NrLlm',
+                ) ?? 'Error reading table: %s',
+                $e->getMessage(),
+            );
+        }
+
+        return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
+    }
+}

--- a/Classes/Service/Task/TaskInputResolver.php
+++ b/Classes/Service/Task/TaskInputResolver.php
@@ -54,7 +54,17 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
         $limit     = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : self::SYSLOG_DEFAULT_LIMIT;
         $errorOnly = isset($config['error_only']) ? (bool)$config['error_only'] : true;
 
-        $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
+        try {
+            $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
+        } catch (Throwable $e) {
+            return sprintf(
+                LocalizationUtility::translate(
+                    'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.readError',
+                    'NrLlm',
+                ) ?? 'Error reading sys_log: %s',
+                $e->getMessage(),
+            );
+        }
 
         $output = [];
         foreach ($rows as $row) {

--- a/Classes/Service/Task/TaskInputResolverInterface.php
+++ b/Classes/Service/Task/TaskInputResolverInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Netresearch\NrLlm\Domain\Model\Task;
+
+/**
+ * Resolves a `Task`'s `input_type` configuration into the actual
+ * input string that gets fed to the LLM.
+ *
+ * Concrete implementation: `TaskInputResolver`. The interface exists so
+ * the slice 13c `TaskExecutionService` can be unit-tested without
+ * standing up the full reader chain (and so future input sources can
+ * be wired in via decorator without touching every call site).
+ *
+ * Behaviour mirrors the controller's pre-13b `getInputData()` private
+ * helper: returns the input string for known input types, or the
+ * empty string for unknown / static types.
+ */
+interface TaskInputResolverInterface
+{
+    /**
+     * Resolve the configured input source for the given task.
+     *
+     * Returns a localised placeholder string when the source is
+     * misconfigured or unreadable (matches the pre-13b behaviour);
+     * never throws.
+     */
+    public function resolve(Task $task): string;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -151,6 +151,9 @@ services:
   Netresearch\NrLlm\Service\Task\DeprecationLogReaderInterface:
     alias: Netresearch\NrLlm\Service\Task\DeprecationLogReader
 
+  Netresearch\NrLlm\Service\Task\TaskInputResolverInterface:
+    alias: Netresearch\NrLlm\Service\Task\TaskInputResolver
+
   # ========================================
   # Translation Registry
   # ========================================

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -342,6 +342,10 @@
                 <source>Error reading table: %s</source>
                 <target>Fehler beim Lesen der Tabelle: %s</target>
             </trans-unit>
+            <trans-unit id="task.syslog.readError">
+                <source>Error reading sys_log: %s</source>
+                <target>Fehler beim Lesen des sys_log: %s</target>
+            </trans-unit>
 
             <!-- Configuration controller -->
             <trans-unit id="configuration.notConfigured">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -260,6 +260,9 @@
             <trans-unit id="task.table.readError">
                 <source>Error reading table: %s</source>
             </trans-unit>
+            <trans-unit id="task.syslog.readError">
+                <source>Error reading sys_log: %s</source>
+            </trans-unit>
 
             <!-- Configuration controller -->
             <trans-unit id="configuration.notConfigured">

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -15,10 +15,10 @@ use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -59,17 +59,17 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
         $llmServiceManager = $this->get(LlmServiceManagerInterface::class);
         self::assertInstanceOf(LlmServiceManagerInterface::class, $llmServiceManager);
 
-        $connectionPool = $this->get(ConnectionPool::class);
-        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $recordTableReader = $this->get(RecordTableReaderInterface::class);
+        self::assertInstanceOf(RecordTableReaderInterface::class, $recordTableReader);
 
-        $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
-        self::assertInstanceOf(TcaSchemaFactory::class, $tcaSchemaFactory);
+        $taskInputResolver = $this->get(TaskInputResolverInterface::class);
+        self::assertInstanceOf(TaskInputResolverInterface::class, $taskInputResolver);
 
         return $this->createControllerWithReflection(TaskController::class, [
-            'taskRepository' => $this->taskRepository,
+            'taskRepository'    => $this->taskRepository,
             'llmServiceManager' => $llmServiceManager,
-            'connectionPool' => $connectionPool,
-            'tcaSchemaFactory' => $tcaSchemaFactory,
+            'recordTableReader' => $recordTableReader,
+            'taskInputResolver' => $taskInputResolver,
         ]);
     }
 

--- a/Tests/Functional/Controller/Backend/TaskControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskControllerTest.php
@@ -13,12 +13,13 @@ use GuzzleHttp\Psr7\ServerRequest;
 use Netresearch\NrLlm\Controller\Backend\TaskController;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 /**
@@ -53,11 +54,11 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
         $llmServiceManager = $this->get(LlmServiceManagerInterface::class);
         self::assertInstanceOf(LlmServiceManagerInterface::class, $llmServiceManager);
 
-        $connectionPool = $this->get(ConnectionPool::class);
-        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $recordTableReader = $this->get(RecordTableReaderInterface::class);
+        self::assertInstanceOf(RecordTableReaderInterface::class, $recordTableReader);
 
-        $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
-        self::assertInstanceOf(TcaSchemaFactory::class, $tcaSchemaFactory);
+        $taskInputResolver = $this->get(TaskInputResolverInterface::class);
+        self::assertInstanceOf(TaskInputResolverInterface::class, $taskInputResolver);
 
         $persistenceManager = $this->get(PersistenceManagerInterface::class);
         self::assertInstanceOf(PersistenceManagerInterface::class, $persistenceManager);
@@ -67,8 +68,8 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
         $this->controller = $this->createControllerWithDependencies(
             $taskRepository,
             $llmServiceManager,
-            $connectionPool,
-            $tcaSchemaFactory,
+            $recordTableReader,
+            $taskInputResolver,
         );
     }
 
@@ -79,8 +80,8 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
     private function createControllerWithDependencies(
         TaskRepository $taskRepository,
         LlmServiceManagerInterface $llmServiceManager,
-        ConnectionPool $connectionPool,
-        TcaSchemaFactory $tcaSchemaFactory,
+        RecordTableReaderInterface $recordTableReader,
+        TaskInputResolverInterface $taskInputResolver,
     ): TaskController {
         $reflection = new ReflectionClass(TaskController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
@@ -88,8 +89,8 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
         // Set only the properties needed for AJAX actions
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'llmServiceManager', $llmServiceManager);
-        $this->setPrivateProperty($controller, 'connectionPool', $connectionPool);
-        $this->setPrivateProperty($controller, 'tcaSchemaFactory', $tcaSchemaFactory);
+        $this->setPrivateProperty($controller, 'recordTableReader', $recordTableReader);
+        $this->setPrivateProperty($controller, 'taskInputResolver', $taskInputResolver);
 
         return $controller;
     }


### PR DESCRIPTION
## Summary

Second implementation slice of [ADR-027](https://github.com/netresearch/t3x-nr-llm/pull/170). Moves the input-source dispatch logic — the `Task::INPUT_*` match plus the per-source formatting that the [slice-13a](https://github.com/netresearch/t3x-nr-llm/pull/171) readers don't own — out of `TaskController` into a new `final readonly` resolver under `Classes/Service/Task/`.

Not auto-merging; awaiting review.

## What

### `TaskInputResolver` (+ interface)

- Single public method `resolve(Task $task): string`.
- Owns the `match` over `Task::INPUT_SYSLOG`, `Task::INPUT_DEPRECATION_LOG`, `Task::INPUT_TABLE` and the default empty-string fallback.
- Per-source private methods `resolveSyslog()` and `resolveTable()` carry the formatting that previously sat inline on the controller:
  - syslog timestamp + type-label localisation (`task.syslog.type.db` etc., with `'DB'` / `'FILE'` / ... fallbacks when XLIFF lookup fails),
  - "no table configured" placeholder,
  - "Error reading table: <message>" formatting on `RecordTableReader` failures.
- Collaborators: the slice-13a reader services (`SystemLogReaderInterface`, `DeprecationLogReaderInterface`, `RecordTableReaderInterface`). The resolver itself never touches `ConnectionPool` or the filesystem.
- New `translateSyslogType()` private helper consolidates the type-label match — fewer chances of the labels and the fallback strings drifting out of sync.

### `TaskController` changes

- Constructor: gains `TaskInputResolverInterface`, drops the direct `SystemLogReaderInterface` + `DeprecationLogReaderInterface` dependencies (the resolver owns them now). `RecordTableReaderInterface` stays — `fetchRecordsAction`, `loadRecordDataAction`, and `listTablesAction` (all picker AJAX endpoints) still call it directly.
- `getInputData()` private helper shrinks to a single `$this->taskInputResolver->resolve($task)` delegation; the `getSyslogData()` and `getTableData()` private helpers are **deleted**.

### DI alias

\`\`\`yaml
Netresearch\NrLlm\Service\Task\TaskInputResolverInterface:
  alias: Netresearch\NrLlm\Service\Task\TaskInputResolver
\`\`\`

(Slice 13a's lesson re-applied: Symfony's autoconfigure does not auto-alias interface→implementation; the alias is required for the resolver to be injected via interface typehint.)

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3224) | all green |
| Container compile (`.Build/bin/typo3 list`) | clean — TYPO3 CMS 14.1.1 boots |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Rector dry-run clean
- [x] Unit tests pass (3224 / 3224)
- [x] Container compile clean on TYPO3 14.1.1
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Functional / E2E tests still pass (no behavioural change expected — the resolver is byte-for-byte equivalent to the pre-13b private helpers)

## What's next per ADR-027

- **Slice 13c**: `TaskExecutionService` extraction.
- **Slice 13d**: typed `Response/*` DTOs replacing the 16 raw `JsonResponse([…])` literals.
- **Slice 13e**: split into per-pathway controllers + route updates.

## Related

- ADR: [ADR-027 — Split TaskController](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr027SplitTaskController.rst)
- Slice 13a: #171 (merged)