### PR TITLE
refactor(task): extract TaskExecutionService from TaskController (slice 13c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `DeprecationLogReader` are no longer injected directly into the
   controller (the resolver owns them). Behaviour is unchanged. Slice
   13b of the `TaskController` split (ADR-027).
+- `TaskController::executeAction()` no longer carries the LLM
+  orchestration logic. Prompt building, configuration lookup, and
+  dispatch to `LlmServiceManager` move into a new
+  `Service/Task/TaskExecutionService` (with
+  `TaskExecutionServiceInterface`). The service returns a typed
+  `TaskExecutionResult` (`content`, `model`, `outputFormat`, `usage`)
+  rather than a `CompletionResponse` so future Task-specific fields
+  can attach without leaking into the LLM abstraction. The controller
+  loses its direct `LlmServiceManagerInterface` injection (the service
+  owns it now); the new service is the natural seam for the future
+  REC #4 budget pre-flight, with the hook point documented in the
+  service's class docblock. Behaviour is unchanged. Slice 13c of the
+  `TaskController` split (ADR-027).
 - Specialized translators register via the new `#[AsTranslator]` marker
   attribute, mirroring the `#[AsLlmProvider]` pattern used for LLM
   providers. The attribute carries no fields — translator identifier

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -20,9 +20,8 @@ use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
-use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
-use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -70,7 +69,7 @@ final class TaskController extends ActionController
         private readonly TaskRepository $taskRepository,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly ModelRepository $modelRepository,
-        private readonly LlmServiceManagerInterface $llmServiceManager,
+        private readonly TaskExecutionServiceInterface $taskExecutionService,
         private readonly WizardGeneratorService $wizardGeneratorService,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly FlashMessageService $flashMessageService,
@@ -483,38 +482,27 @@ final class TaskController extends ActionController
         }
 
         try {
-            // Build the prompt with input
-            $prompt = $task->buildPrompt(['input' => $dto->input]);
-
-            // Get configuration (lazy-loaded by Extbase)
-            $configuration = $task->getConfiguration();
-
-            // Execute the prompt
-            if ($configuration !== null) {
-                $response = $this->llmServiceManager->completeWithConfiguration($prompt, $configuration);
-            } else {
-                $response = $this->llmServiceManager->complete($prompt, new ChatOptions());
-            }
-
-            return new JsonResponse([
-                'success' => true,
-                'content' => $response->content,
-                'model' => $response->model,
-                'outputFormat' => $task->getOutputFormat(),
-                'usage' => [
-                    'promptTokens' => $response->usage->promptTokens,
-                    'completionTokens' => $response->usage->completionTokens,
-                    'totalTokens' => $response->usage->totalTokens,
-                ],
-            ]);
+            $result = $this->taskExecutionService->execute($task, $dto->input);
         } catch (Throwable $e) {
             // Return 200 with success:false so JavaScript can read the error message
             // HTTP 500 causes TYPO3's AjaxRequest to throw before parsing the JSON
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error'   => $e->getMessage(),
             ]);
         }
+
+        return new JsonResponse([
+            'success'      => true,
+            'content'      => $result->content,
+            'model'        => $result->model,
+            'outputFormat' => $result->outputFormat,
+            'usage'        => [
+                'promptTokens'     => $result->usage->promptTokens,
+                'completionTokens' => $result->usage->completionTokens,
+                'totalTokens'      => $result->usage->totalTokens,
+            ],
+        ]);
     }
 
     /**

--- a/Classes/Service/Task/TaskExecutionResult.php
+++ b/Classes/Service/Task/TaskExecutionResult.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+
+/**
+ * Result of running a Task through the LLM.
+ *
+ * Owned by `TaskExecutionService::execute()`. Carries everything the
+ * frontend needs to render the result (the LLM-produced content, the
+ * model that produced it, the Task's preferred output format for
+ * client-side rendering, and the usage statistics so the
+ * cost / quota indicators stay in sync). Wrapping the raw
+ * `CompletionResponse` lets us add Task-specific fields (currently
+ * just `outputFormat`) without leaking that concept into the LLM
+ * abstraction.
+ */
+final readonly class TaskExecutionResult
+{
+    public function __construct(
+        public string $content,
+        public string $model,
+        public string $outputFormat,
+        public UsageStatistics $usage,
+    ) {}
+}

--- a/Classes/Service/Task/TaskExecutionService.php
+++ b/Classes/Service/Task/TaskExecutionService.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+
+/**
+ * Orchestrates running a `Task` through the LLM.
+ *
+ * Owns the steps that previously sat inline in
+ * `TaskController::executeAction()`: build the prompt with the user
+ * input, route through the task's `LlmConfiguration` if one is set
+ * (otherwise fall back to the global default chat options), and
+ * package the response as a typed `TaskExecutionResult`.
+ *
+ * **REC #4 (audit) hook point.** The future automatic budget pre-flight
+ * + usage tracking will plug in here — the natural sequence is:
+ *
+ *   1. read the calling backend user uid from the controller call
+ *      (will need a small signature extension, e.g. an
+ *      `ExecutionContext` argument carrying `beUserUid` and any
+ *      planned-cost estimate);
+ *   2. ask `BudgetServiceInterface::check()` whether the call is
+ *      allowed and short-circuit with a typed exception on denial;
+ *   3. let the existing pipeline middleware (`UsageMiddleware`,
+ *      `BudgetMiddleware`) handle the rest via `LlmServiceManager`.
+ *
+ * Slice 13c intentionally keeps this surface lean — the controller
+ * still passes `(Task, string $input)` and the service still proxies
+ * to the manager directly. REC #4 will land in a follow-up.
+ */
+final readonly class TaskExecutionService implements TaskExecutionServiceInterface
+{
+    public function __construct(
+        private LlmServiceManagerInterface $llmServiceManager,
+    ) {}
+
+    public function execute(Task $task, string $input): TaskExecutionResult
+    {
+        $prompt = $task->buildPrompt(['input' => $input]);
+
+        $configuration = $task->getConfiguration();
+        $response = $configuration !== null
+            ? $this->llmServiceManager->completeWithConfiguration($prompt, $configuration)
+            : $this->llmServiceManager->complete($prompt, new ChatOptions());
+
+        return new TaskExecutionResult(
+            content: $response->content,
+            model: $response->model,
+            outputFormat: $task->getOutputFormat(),
+            usage: $response->usage,
+        );
+    }
+}

--- a/Classes/Service/Task/TaskExecutionServiceInterface.php
+++ b/Classes/Service/Task/TaskExecutionServiceInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Task;
+
+use Netresearch\NrLlm\Domain\Model\Task;
+use Throwable;
+
+/**
+ * Orchestrates running a `Task` through the LLM.
+ *
+ * Concrete implementation: `TaskExecutionService`. The interface exists
+ * so the future per-pathway controllers (slice 13e) can mock execution
+ * in unit tests, and so the future REC #4 budget pre-flight middleware
+ * can wrap a decorator around this seam without changing call sites.
+ */
+interface TaskExecutionServiceInterface
+{
+    /**
+     * Run a task with the given user input.
+     *
+     * The caller (controller) is responsible for verifying the task
+     * exists and is active before delegating here — the service
+     * trusts its argument.
+     *
+     * @throws Throwable on prompt-build / LLM failure (caller surfaces
+     *                   the message)
+     */
+    public function execute(Task $task, string $input): TaskExecutionResult;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -154,6 +154,9 @@ services:
   Netresearch\NrLlm\Service\Task\TaskInputResolverInterface:
     alias: Netresearch\NrLlm\Service\Task\TaskInputResolver
 
+  Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface:
+    alias: Netresearch\NrLlm\Service\Task\TaskExecutionService
+
   # ========================================
   # Translation Registry
   # ========================================

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -14,8 +14,8 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
-use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -56,8 +56,8 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
 
     private function createController(): TaskController
     {
-        $llmServiceManager = $this->get(LlmServiceManagerInterface::class);
-        self::assertInstanceOf(LlmServiceManagerInterface::class, $llmServiceManager);
+        $taskExecutionService = $this->get(TaskExecutionServiceInterface::class);
+        self::assertInstanceOf(TaskExecutionServiceInterface::class, $taskExecutionService);
 
         $recordTableReader = $this->get(RecordTableReaderInterface::class);
         self::assertInstanceOf(RecordTableReaderInterface::class, $recordTableReader);
@@ -66,10 +66,10 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
         self::assertInstanceOf(TaskInputResolverInterface::class, $taskInputResolver);
 
         return $this->createControllerWithReflection(TaskController::class, [
-            'taskRepository'    => $this->taskRepository,
-            'llmServiceManager' => $llmServiceManager,
-            'recordTableReader' => $recordTableReader,
-            'taskInputResolver' => $taskInputResolver,
+            'taskRepository'       => $this->taskRepository,
+            'taskExecutionService' => $taskExecutionService,
+            'recordTableReader'    => $recordTableReader,
+            'taskInputResolver'    => $taskInputResolver,
         ]);
     }
 

--- a/Tests/Functional/Controller/Backend/TaskControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskControllerTest.php
@@ -12,8 +12,8 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 use GuzzleHttp\Psr7\ServerRequest;
 use Netresearch\NrLlm\Controller\Backend\TaskController;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
-use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -51,8 +51,8 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
         self::assertInstanceOf(TaskRepository::class, $taskRepository);
         $this->taskRepository = $taskRepository;
 
-        $llmServiceManager = $this->get(LlmServiceManagerInterface::class);
-        self::assertInstanceOf(LlmServiceManagerInterface::class, $llmServiceManager);
+        $taskExecutionService = $this->get(TaskExecutionServiceInterface::class);
+        self::assertInstanceOf(TaskExecutionServiceInterface::class, $taskExecutionService);
 
         $recordTableReader = $this->get(RecordTableReaderInterface::class);
         self::assertInstanceOf(RecordTableReaderInterface::class, $recordTableReader);
@@ -67,7 +67,7 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
         // This bypasses initializeAction() which requires Extbase request context
         $this->controller = $this->createControllerWithDependencies(
             $taskRepository,
-            $llmServiceManager,
+            $taskExecutionService,
             $recordTableReader,
             $taskInputResolver,
         );
@@ -79,7 +79,7 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
      */
     private function createControllerWithDependencies(
         TaskRepository $taskRepository,
-        LlmServiceManagerInterface $llmServiceManager,
+        TaskExecutionServiceInterface $taskExecutionService,
         RecordTableReaderInterface $recordTableReader,
         TaskInputResolverInterface $taskInputResolver,
     ): TaskController {
@@ -88,7 +88,7 @@ final class TaskControllerTest extends AbstractFunctionalTestCase
 
         // Set only the properties needed for AJAX actions
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
-        $this->setPrivateProperty($controller, 'llmServiceManager', $llmServiceManager);
+        $this->setPrivateProperty($controller, 'taskExecutionService', $taskExecutionService);
         $this->setPrivateProperty($controller, 'recordTableReader', $recordTableReader);
         $this->setPrivateProperty($controller, 'taskInputResolver', $taskInputResolver);
 


### PR DESCRIPTION
## Summary

Third implementation slice of [ADR-027](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr027SplitTaskController.rst). Moves the LLM orchestration out of \`TaskController::executeAction()\` into a new \`final readonly\` service plus a typed result DTO. Behaviour unchanged.

Not auto-merging; awaiting review.

## What

### \`TaskExecutionResult\` (new typed DTO)

\`final readonly\` carrying \`content\`, \`model\`, \`outputFormat\`, \`usage\` (typed \`UsageStatistics\`). Wrapping the \`CompletionResponse\` rather than returning it directly lets future Task-specific fields attach without leaking that concept into the LLM abstraction layer.

### \`TaskExecutionService\` (+ interface)

Single public method \`execute(Task \$task, string \$input): TaskExecutionResult\`. Owns:

- the prompt build via \`Task::buildPrompt(['input' => \$input])\`,
- the \`\$task->getConfiguration() !== null ? completeWithConfiguration : complete\` dispatch,
- the response wrap into \`TaskExecutionResult\`.

The service trusts that the caller has already verified the task exists and is active — the controller still does the 404/400 check before delegating. The service docblock **explicitly marks itself as the future REC #4 budget pre-flight hook point**: the natural sequence (read \`beUserUid\` from an \`ExecutionContext\` arg → \`BudgetServiceInterface::check()\` → short-circuit on denial) is documented but NOT implemented in this slice.

### \`TaskController\` changes

- Constructor: gains \`TaskExecutionServiceInterface\`, **drops \`LlmServiceManagerInterface\`** (no other action used it). The three reader interfaces remain.
- \`executeAction()\` shrinks from a ~45-line block to: parse DTO, check task exists/active, delegate, shape JSON. The \`Throwable\` catch returns \`success:false\` (HTTP 200) to keep AjaxRequest semantics — unchanged.

### Test fixtures

\`Tests/Functional/Controller/Backend/TaskControllerTest\` and \`Tests/E2E/Backend/TaskExecutionE2ETest\` now reflect-inject \`TaskExecutionServiceInterface\` instead of \`LlmServiceManagerInterface\`. Both still resolve through the container.

### DI alias

\`\`\`yaml
Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface:
  alias: Netresearch\NrLlm\Service\Task\TaskExecutionService
\`\`\`

(Slice 13a's lesson re-applied — Symfony's autoconfigure does not auto-alias interface→implementation.)

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3224) | all green |
| Container compile (\`.Build/bin/typo3 list\`) | clean — TYPO3 CMS 14.1.1 boots |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Rector dry-run clean
- [x] Unit tests pass (3224 / 3224)
- [x] Container compile clean
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Functional / E2E tests still pass

## What's next per ADR-027

- **Slice 13d**: typed \`Response/*\` DTOs replacing the 16 raw \`JsonResponse([…])\` literals.
- **Slice 13e**: split into per-pathway controllers + route updates.

**REC #4** (auto budget + usage in feature services) lands as a separate slice after the controller split is complete — \`TaskExecutionService\` is the seam.

## Related

- ADR: [ADR-027](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr027SplitTaskController.rst)
- Slice 13a (#171), Slice 13b (#172) — both merged