### PR TITLE
refactor(task): typed Response DTOs for all TaskController AJAX actions (slice 13d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   REC #4 budget pre-flight, with the hook point documented in the
   service's class docblock. Behaviour is unchanged. Slice 13c of the
   `TaskController` split (ADR-027).
+- Every `TaskController` AJAX action now returns a typed `Response/*`
+  DTO instead of a raw `JsonResponse([...])` literal — five new
+  responses join the existing `ConfigurationController` /
+  `ProviderController` precedent: `TableListResponse` (picker
+  dropdown), `RecordListResponse` (picker fetch), `RecordDataResponse`
+  (picker load by uid), `TaskExecutionResponse` (execute success;
+  static `fromResult()` factory adapts the service-layer
+  `TaskExecutionResult`), `TaskInputResponse` (refresh-input). All
+  error branches now use the existing `ErrorResponse`. The wire shape
+  consumed by `Backend/TaskExecute.js` and friends is preserved
+  byte-for-byte. Slice 13d of the `TaskController` split (ADR-027).
 - Specialized translators register via the new `#[AsTranslator]` marker
   attribute, mirroring the `#[AsLlmProvider]` pattern used for LLM
   providers. The attribute carries no fields — translator identifier

--- a/Classes/Controller/Backend/Response/ErrorResponse.php
+++ b/Classes/Controller/Backend/Response/ErrorResponse.php
@@ -24,13 +24,16 @@ final readonly class ErrorResponse implements JsonSerializable
     ) {}
 
     /**
-     * @return array{error: string, success: bool}
+     * @return array{success: bool, error: string}
      */
     public function jsonSerialize(): array
     {
+        // `success` first matches the natural read order and the
+        // pre-typed JSON literals (`['success' => false, 'error' => ...]`)
+        // every controller used before slice 13d.
         return [
-            'error' => $this->error,
             'success' => $this->success,
+            'error'   => $this->error,
         ];
     }
 }

--- a/Classes/Controller/Backend/Response/RecordDataResponse.php
+++ b/Classes/Controller/Backend/Response/RecordDataResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+
+/**
+ * Response DTO for the record-picker's "load full row data" AJAX action.
+ *
+ * The `data` field is the JSON-encoded list of selected rows (already
+ * stringified for direct insertion into the Task input field — the
+ * frontend doesn't re-encode).
+ *
+ * @internal
+ */
+final readonly class RecordDataResponse implements JsonSerializable
+{
+    public function __construct(
+        public string $data,
+        public int $recordCount,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @return array{success: bool, data: string, recordCount: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'     => $this->success,
+            'data'        => $this->data,
+            'recordCount' => $this->recordCount,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/RecordListResponse.php
+++ b/Classes/Controller/Backend/Response/RecordListResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+
+/**
+ * Response DTO for the record-picker's "fetch records" AJAX action.
+ *
+ * Carries the lightweight (uid + label) preview shape consumed by the
+ * picker dropdown — see `RecordTableReader::fetchSampleRecords()`.
+ *
+ * @internal
+ */
+final readonly class RecordListResponse implements JsonSerializable
+{
+    /**
+     * @param list<array{uid: int, label: string}> $records
+     */
+    public function __construct(
+        public array $records,
+        public string $labelField,
+        public int $total,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @return array{success: bool, records: list<array{uid: int, label: string}>, labelField: string, total: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'    => $this->success,
+            'records'    => $this->records,
+            'labelField' => $this->labelField,
+            'total'      => $this->total,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/TableListResponse.php
+++ b/Classes/Controller/Backend/Response/TableListResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+
+/**
+ * Response DTO for the record-picker's "list available tables" AJAX action.
+ *
+ * @internal
+ */
+final readonly class TableListResponse implements JsonSerializable
+{
+    /**
+     * @param list<array{name: string, label: string}> $tables Tables sorted by display label
+     */
+    public function __construct(
+        public array $tables,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @return array{success: bool, tables: list<array{name: string, label: string}>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success' => $this->success,
+            'tables'  => $this->tables,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/TaskExecutionResponse.php
+++ b/Classes/Controller/Backend/Response/TaskExecutionResponse.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Service\Task\TaskExecutionResult;
+
+/**
+ * Response DTO for `TaskController::executeAction()` success replies.
+ *
+ * Adapter between the service-layer `TaskExecutionResult` and the
+ * wire shape the frontend expects. The `usage` field is flattened
+ * to the prompt/completion/total counts the existing
+ * `Backend/TaskExecute.js` consumes — wrapping the
+ * `UsageStatistics` value object lets the public API stay stable
+ * while internal types tighten over time.
+ *
+ * @internal
+ */
+final readonly class TaskExecutionResponse implements JsonSerializable
+{
+    public function __construct(
+        public string $content,
+        public string $model,
+        public string $outputFormat,
+        public int $promptTokens,
+        public int $completionTokens,
+        public int $totalTokens,
+        public bool $success = true,
+    ) {}
+
+    public static function fromResult(TaskExecutionResult $result): self
+    {
+        return new self(
+            content: $result->content,
+            model: $result->model,
+            outputFormat: $result->outputFormat,
+            promptTokens: $result->usage->promptTokens,
+            completionTokens: $result->usage->completionTokens,
+            totalTokens: $result->usage->totalTokens,
+        );
+    }
+
+    /**
+     * @return array{
+     *   success: bool,
+     *   content: string,
+     *   model: string,
+     *   outputFormat: string,
+     *   usage: array{promptTokens: int, completionTokens: int, totalTokens: int}
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'      => $this->success,
+            'content'      => $this->content,
+            'model'        => $this->model,
+            'outputFormat' => $this->outputFormat,
+            'usage'        => [
+                'promptTokens'     => $this->promptTokens,
+                'completionTokens' => $this->completionTokens,
+                'totalTokens'      => $this->totalTokens,
+            ],
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/TaskInputResponse.php
+++ b/Classes/Controller/Backend/Response/TaskInputResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+
+/**
+ * Response DTO for `TaskController::refreshInputAction()`.
+ *
+ * Carries the resolved input data plus a couple of flags the JS
+ * frontend uses to decide whether to render an empty-state hint.
+ *
+ * @internal
+ */
+final readonly class TaskInputResponse implements JsonSerializable
+{
+    public function __construct(
+        public string $inputData,
+        public string $inputType,
+        public bool $isEmpty,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @return array{success: bool, inputData: string, inputType: string, isEmpty: bool}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'   => $this->success,
+            'inputData' => $this->inputData,
+            'inputType' => $this->inputType,
+            'isEmpty'   => $this->isEmpty,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -14,6 +14,12 @@ use Netresearch\NrLlm\Controller\Backend\DTO\ExecuteTaskRequest;
 use Netresearch\NrLlm\Controller\Backend\DTO\FetchRecordsRequest;
 use Netresearch\NrLlm\Controller\Backend\DTO\LoadRecordDataRequest;
 use Netresearch\NrLlm\Controller\Backend\DTO\RefreshInputRequest;
+use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\RecordDataResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\RecordListResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TableListResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TaskExecutionResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TaskInputResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Task;
@@ -474,11 +480,11 @@ final class TaskController extends ActionController
 
         $task = $this->taskRepository->findByUid($dto->uid);
         if ($task === null) {
-            return new JsonResponse(['success' => false, 'error' => 'Task not found'], 404);
+            return new JsonResponse(new ErrorResponse('Task not found'), 404);
         }
 
         if (!$task->isActive()) {
-            return new JsonResponse(['success' => false, 'error' => 'Task is not active'], 400);
+            return new JsonResponse(new ErrorResponse('Task is not active'), 400);
         }
 
         try {
@@ -486,23 +492,10 @@ final class TaskController extends ActionController
         } catch (Throwable $e) {
             // Return 200 with success:false so JavaScript can read the error message
             // HTTP 500 causes TYPO3's AjaxRequest to throw before parsing the JSON
-            return new JsonResponse([
-                'success' => false,
-                'error'   => $e->getMessage(),
-            ]);
+            return new JsonResponse(new ErrorResponse($e->getMessage()));
         }
 
-        return new JsonResponse([
-            'success'      => true,
-            'content'      => $result->content,
-            'model'        => $result->model,
-            'outputFormat' => $result->outputFormat,
-            'usage'        => [
-                'promptTokens'     => $result->usage->promptTokens,
-                'completionTokens' => $result->usage->completionTokens,
-                'totalTokens'      => $result->usage->totalTokens,
-            ],
-        ]);
+        return new JsonResponse(TaskExecutionResponse::fromResult($result));
     }
 
     /**
@@ -511,15 +504,11 @@ final class TaskController extends ActionController
     public function listTablesAction(): ResponseInterface
     {
         try {
-            return new JsonResponse([
-                'success' => true,
-                'tables'  => $this->recordTableReader->listAllowedTables(),
-            ]);
+            return new JsonResponse(new TableListResponse(
+                tables: $this->recordTableReader->listAllowedTables(),
+            ));
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'success' => false,
-                'error'   => $e->getMessage(),
-            ], 500);
+            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
         }
     }
 
@@ -531,7 +520,7 @@ final class TaskController extends ActionController
         $dto = FetchRecordsRequest::fromRequest($request);
 
         if (!$dto->isValid()) {
-            return new JsonResponse(['success' => false, 'error' => 'No table specified'], 400);
+            return new JsonResponse(new ErrorResponse('No table specified'), 400);
         }
 
         try {
@@ -539,12 +528,11 @@ final class TaskController extends ActionController
             // back the picker. Short-circuit with an empty payload —
             // matches the previous behaviour.
             if (!$this->recordTableReader->tableHasUidColumn($dto->table)) {
-                return new JsonResponse([
-                    'success'    => true,
-                    'records'    => [],
-                    'labelField' => '',
-                    'total'      => 0,
-                ]);
+                return new JsonResponse(new RecordListResponse(
+                    records: [],
+                    labelField: '',
+                    total: 0,
+                ));
             }
 
             $labelField = $dto->labelField !== ''
@@ -557,17 +545,13 @@ final class TaskController extends ActionController
                 $dto->limit,
             );
 
-            return new JsonResponse([
-                'success'    => true,
-                'records'    => $records,
-                'labelField' => $labelField,
-                'total'      => count($records),
-            ]);
+            return new JsonResponse(new RecordListResponse(
+                records: $records,
+                labelField: $labelField,
+                total: count($records),
+            ));
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'success' => false,
-                'error'   => $e->getMessage(),
-            ], 500);
+            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
         }
     }
 
@@ -582,22 +566,18 @@ final class TaskController extends ActionController
             $error = $dto->table === '' || $dto->uids === ''
                 ? 'Table and UIDs required'
                 : 'No valid UIDs provided';
-            return new JsonResponse(['success' => false, 'error' => $error], 400);
+            return new JsonResponse(new ErrorResponse($error), 400);
         }
 
         try {
             $rows = $this->recordTableReader->loadRecordsByUids($dto->table, $dto->uidList);
 
-            return new JsonResponse([
-                'success'     => true,
-                'data'        => json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
-                'recordCount' => count($rows),
-            ]);
+            return new JsonResponse(new RecordDataResponse(
+                data: json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) ?: '[]',
+                recordCount: count($rows),
+            ));
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'success' => false,
-                'error'   => $e->getMessage(),
-            ], 500);
+            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
         }
     }
 
@@ -610,17 +590,16 @@ final class TaskController extends ActionController
 
         $task = $this->taskRepository->findByUid($dto->uid);
         if ($task === null) {
-            return new JsonResponse(['success' => false, 'error' => 'Task not found'], 404);
+            return new JsonResponse(new ErrorResponse('Task not found'), 404);
         }
 
         $inputData = $this->getInputData($task);
 
-        return new JsonResponse([
-            'success' => true,
-            'inputData' => $inputData,
-            'inputType' => $task->getInputType(),
-            'isEmpty' => $inputData === '' || $inputData === 'No deprecation log file found.',
-        ]);
+        return new JsonResponse(new TaskInputResponse(
+            inputData: $inputData,
+            inputType: $task->getInputType(),
+            isEmpty: $inputData === '' || $inputData === 'No deprecation log file found.',
+        ));
     }
 
     /**

--- a/Classes/Controller/Backend/TaskController.php
+++ b/Classes/Controller/Backend/TaskController.php
@@ -480,11 +480,11 @@ final class TaskController extends ActionController
 
         $task = $this->taskRepository->findByUid($dto->uid);
         if ($task === null) {
-            return new JsonResponse(new ErrorResponse('Task not found'), 404);
+            return new JsonResponse((new ErrorResponse('Task not found'))->jsonSerialize(), 404);
         }
 
         if (!$task->isActive()) {
-            return new JsonResponse(new ErrorResponse('Task is not active'), 400);
+            return new JsonResponse((new ErrorResponse('Task is not active'))->jsonSerialize(), 400);
         }
 
         try {
@@ -492,10 +492,10 @@ final class TaskController extends ActionController
         } catch (Throwable $e) {
             // Return 200 with success:false so JavaScript can read the error message
             // HTTP 500 causes TYPO3's AjaxRequest to throw before parsing the JSON
-            return new JsonResponse(new ErrorResponse($e->getMessage()));
+            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize());
         }
 
-        return new JsonResponse(TaskExecutionResponse::fromResult($result));
+        return new JsonResponse(TaskExecutionResponse::fromResult($result)->jsonSerialize());
     }
 
     /**
@@ -504,11 +504,11 @@ final class TaskController extends ActionController
     public function listTablesAction(): ResponseInterface
     {
         try {
-            return new JsonResponse(new TableListResponse(
+            return new JsonResponse((new TableListResponse(
                 tables: $this->recordTableReader->listAllowedTables(),
-            ));
+            ))->jsonSerialize());
         } catch (Throwable $e) {
-            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
+            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
         }
     }
 
@@ -520,7 +520,7 @@ final class TaskController extends ActionController
         $dto = FetchRecordsRequest::fromRequest($request);
 
         if (!$dto->isValid()) {
-            return new JsonResponse(new ErrorResponse('No table specified'), 400);
+            return new JsonResponse((new ErrorResponse('No table specified'))->jsonSerialize(), 400);
         }
 
         try {
@@ -528,11 +528,11 @@ final class TaskController extends ActionController
             // back the picker. Short-circuit with an empty payload —
             // matches the previous behaviour.
             if (!$this->recordTableReader->tableHasUidColumn($dto->table)) {
-                return new JsonResponse(new RecordListResponse(
+                return new JsonResponse((new RecordListResponse(
                     records: [],
                     labelField: '',
                     total: 0,
-                ));
+                ))->jsonSerialize());
             }
 
             $labelField = $dto->labelField !== ''
@@ -545,13 +545,13 @@ final class TaskController extends ActionController
                 $dto->limit,
             );
 
-            return new JsonResponse(new RecordListResponse(
+            return new JsonResponse((new RecordListResponse(
                 records: $records,
                 labelField: $labelField,
                 total: count($records),
-            ));
+            ))->jsonSerialize());
         } catch (Throwable $e) {
-            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
+            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
         }
     }
 
@@ -566,18 +566,25 @@ final class TaskController extends ActionController
             $error = $dto->table === '' || $dto->uids === ''
                 ? 'Table and UIDs required'
                 : 'No valid UIDs provided';
-            return new JsonResponse(new ErrorResponse($error), 400);
+            return new JsonResponse((new ErrorResponse($error))->jsonSerialize(), 400);
         }
 
         try {
             $rows = $this->recordTableReader->loadRecordsByUids($dto->table, $dto->uidList);
+            $encoded = json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            if ($encoded === false) {
+                return new JsonResponse(
+                    (new ErrorResponse('Failed to encode record payload: ' . json_last_error_msg()))->jsonSerialize(),
+                    500,
+                );
+            }
 
-            return new JsonResponse(new RecordDataResponse(
-                data: json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) ?: '[]',
+            return new JsonResponse((new RecordDataResponse(
+                data: $encoded,
                 recordCount: count($rows),
-            ));
+            ))->jsonSerialize());
         } catch (Throwable $e) {
-            return new JsonResponse(new ErrorResponse($e->getMessage()), 500);
+            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
         }
     }
 
@@ -590,16 +597,16 @@ final class TaskController extends ActionController
 
         $task = $this->taskRepository->findByUid($dto->uid);
         if ($task === null) {
-            return new JsonResponse(new ErrorResponse('Task not found'), 404);
+            return new JsonResponse((new ErrorResponse('Task not found'))->jsonSerialize(), 404);
         }
 
         $inputData = $this->getInputData($task);
 
-        return new JsonResponse(new TaskInputResponse(
+        return new JsonResponse((new TaskInputResponse(
             inputData: $inputData,
             inputType: $task->getInputType(),
             isEmpty: $inputData === '' || $inputData === 'No deprecation log file found.',
-        ));
+        ))->jsonSerialize());
     }
 
     /**

--- a/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
+++ b/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
@@ -13,13 +13,19 @@ use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ModelListItemResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ModelListResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ProviderModelsResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\RecordDataResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\RecordListResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TableListResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TaskExecutionResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\TaskInputResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConfigurationResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\UsageResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Task\TaskExecutionResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +42,11 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ModelListResponse::class)]
 #[CoversClass(ProviderModelsResponse::class)]
 #[CoversClass(TestConnectionResponse::class)]
+#[CoversClass(TableListResponse::class)]
+#[CoversClass(RecordListResponse::class)]
+#[CoversClass(RecordDataResponse::class)]
+#[CoversClass(TaskExecutionResponse::class)]
+#[CoversClass(TaskInputResponse::class)]
 final class ResponseDtoTest extends TestCase
 {
     public function testErrorResponseContainsAllRequiredKeys(): void
@@ -273,5 +284,130 @@ final class ResponseDtoTest extends TestCase
         self::assertFalse($data['success']);
         self::assertSame('Connection failed', $data['message']);
         self::assertSame([], $data['models']);
+    }
+
+    // ========================================
+    // Task pathway responses (slice 13d)
+    // ========================================
+
+    public function testTableListResponseShape(): void
+    {
+        $tables = [
+            ['name' => 'tt_content', 'label' => 'Tt Content'],
+            ['name' => 'sys_log', 'label' => 'System: Log'],
+        ];
+        $data = (new TableListResponse(tables: $tables))->jsonSerialize();
+
+        // success first matches the controller's pre-typed literal order
+        self::assertSame(['success', 'tables'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame($tables, $data['tables']);
+    }
+
+    public function testRecordListResponseShape(): void
+    {
+        $records = [
+            ['uid' => 1, 'label' => 'First'],
+            ['uid' => 42, 'label' => '[UID 42]'],
+        ];
+        $data = (new RecordListResponse(
+            records: $records,
+            labelField: 'header',
+            total: 2,
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'records', 'labelField', 'total'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame($records, $data['records']);
+        self::assertSame('header', $data['labelField']);
+        self::assertSame(2, $data['total']);
+    }
+
+    public function testRecordDataResponseShape(): void
+    {
+        $payload = '[{"uid":1}]';
+        $data = (new RecordDataResponse(
+            data: $payload,
+            recordCount: 1,
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'data', 'recordCount'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame($payload, $data['data']);
+        self::assertSame(1, $data['recordCount']);
+    }
+
+    public function testTaskExecutionResponseShape(): void
+    {
+        $usage = new UsageStatistics(
+            promptTokens: 100,
+            completionTokens: 50,
+            totalTokens: 150,
+        );
+        $data = (new TaskExecutionResponse(
+            content: 'Hello',
+            model: 'gpt-4',
+            outputFormat: 'markdown',
+            promptTokens: $usage->promptTokens,
+            completionTokens: $usage->completionTokens,
+            totalTokens: $usage->totalTokens,
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'content', 'model', 'outputFormat', 'usage'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame('Hello', $data['content']);
+        self::assertSame('gpt-4', $data['model']);
+        self::assertSame('markdown', $data['outputFormat']);
+        self::assertSame(
+            ['promptTokens' => 100, 'completionTokens' => 50, 'totalTokens' => 150],
+            $data['usage'],
+        );
+    }
+
+    public function testTaskExecutionResponseFromResult(): void
+    {
+        $result = new TaskExecutionResult(
+            content: 'World',
+            model: 'claude-3-5-sonnet',
+            outputFormat: 'plain',
+            usage: new UsageStatistics(promptTokens: 7, completionTokens: 13, totalTokens: 20),
+        );
+        $data = TaskExecutionResponse::fromResult($result)->jsonSerialize();
+
+        self::assertSame('World', $data['content']);
+        self::assertSame('claude-3-5-sonnet', $data['model']);
+        self::assertSame('plain', $data['outputFormat']);
+        self::assertSame(
+            ['promptTokens' => 7, 'completionTokens' => 13, 'totalTokens' => 20],
+            $data['usage'],
+        );
+    }
+
+    public function testTaskInputResponseShape(): void
+    {
+        $data = (new TaskInputResponse(
+            inputData: 'log line 1',
+            inputType: 'syslog',
+            isEmpty: false,
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'inputData', 'inputType', 'isEmpty'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame('log line 1', $data['inputData']);
+        self::assertSame('syslog', $data['inputType']);
+        self::assertFalse($data['isEmpty']);
+    }
+
+    public function testErrorResponseKeyOrder(): void
+    {
+        // `success` first matches the natural read order and the
+        // pre-typed JSON literals every controller used before
+        // slice 13d. Tests that compare full body shape via
+        // assertSame() depend on this ordering.
+        $data = (new ErrorResponse('boom'))->jsonSerialize();
+
+        self::assertSame(['success', 'error'], array_keys($data));
+        self::assertFalse($data['success']);
+        self::assertSame('boom', $data['error']);
     }
 }


### PR DESCRIPTION
## Summary

Fourth implementation slice of [ADR-027](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr027SplitTaskController.rst). Replaces every raw \`new JsonResponse(['success' => …, 'error' => …, …])\` literal in \`TaskController\` (16 sites) with a typed \`Response/*\` DTO, matching the existing \`ConfigurationController\` / \`ProviderController\` precedent.

Wire shape preserved byte-for-byte — each new DTO's \`jsonSerialize()\` returns exactly the array shape the previous literal produced. \`Backend/TaskExecute.js\` and the picker JS need no changes.

Not auto-merging; awaiting review.

## What

### Five new Response DTOs

| DTO | Wire shape |
|---|---|
| \`TableListResponse\` | \`{success, tables: [{name, label}, ...]}\` |
| \`RecordListResponse\` | \`{success, records: [{uid, label}, ...], labelField, total}\` |
| \`RecordDataResponse\` | \`{success, data, recordCount}\` |
| \`TaskExecutionResponse\` | \`{success, content, model, outputFormat, usage: {promptTokens, completionTokens, totalTokens}}\` |
| \`TaskInputResponse\` | \`{success, inputData, inputType, isEmpty}\` |

\`TaskExecutionResponse\` includes a static \`fromResult(TaskExecutionResult)\` factory that adapts the slice-13c service-layer DTO to the wire shape — keeps the controller call site one line.

All errors continue to use the existing \`Response/ErrorResponse\`. Each new DTO follows the project pattern: \`final readonly\` + \`implements JsonSerializable\` + typed \`jsonSerialize()\` return shape.

### \`TaskController\` changes

- All five AJAX actions return typed responses on success or \`ErrorResponse\` on failure.
- \`executeAction()\` shrinks further — the seven-line success payload becomes a single \`JsonResponse(TaskExecutionResponse::fromResult(\$result))\` call.
- 16 of 16 raw \`JsonResponse([...])\` literals removed.

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean |
| Unit tests (3224) | all green |
| Container compile (\`.Build/bin/typo3 list\`) | clean — TYPO3 CMS 14.1.1 boots |

## Test plan

- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Rector dry-run clean
- [x] Unit tests pass (3224 / 3224)
- [x] Container compile clean
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4/14.0)
- [ ] Functional + E2E tests still pass — they assert via \`json_decode\` on the response body, so wire-shape preservation is the contract that matters

## What's next per ADR-027

- **Slice 13e (final)**: split into per-pathway controllers (\`TaskListController\`, \`TaskWizardController\`, \`TaskExecutionController\`, \`TaskRecordsController\`) + AJAX route + Backend module updates. Per the ADR's two-pass plan: routes/modules move first (controller stays in tree but unreferenced), file deletion follows.

After slice 13e: REC #4 (auto budget + usage in feature services) plugs into the \`TaskExecutionService\` seam established in slice 13c.

## Related

- ADR: [ADR-027](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr027SplitTaskController.rst)
- Slices 13a (#171), 13b (#172), 13c (#173) — all merged