### PR TITLE
feat(exception): enrich ProviderResponseException with typed httpStatus / responseBody / endpoint (REC #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   REC #4 budget pre-flight, with the hook point documented in the
   service's class docblock. Behaviour is unchanged. Slice 13c of the
   `TaskController` split (ADR-027).
+- `ProviderResponseException` carries typed `httpStatus`,
+  `responseBody`, and `endpoint` properties so callers can branch on
+  the actual HTTP semantics rather than re-parsing the message string.
+  Both production call sites (`AbstractProvider::sendRequest()` for
+  4xx responses and `OpenRouterProvider::handleOpenRouterError()` for
+  the catch-all branch) populate the new fields. The previous
+  constructor signature `(string $message, int $code = 0, ?Throwable
+  $previous = null)` is preserved so existing callers passing the
+  HTTP status as the second arg keep working — `httpStatus` defaults
+  to that value when the named arg is not supplied. Demonstrated the
+  new pattern in `ConfigurationController::testConfigurationAction()`,
+  which now catches `ProviderResponseException` ahead of the generic
+  `Throwable` and surfaces the upstream HTTP status as the AJAX
+  response status (was always 500). REC #8 from the audit.
 - `TaskController` is split into four per-pathway controllers,
   closing REC #5 and the entire ADR-027 work:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,15 +72,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `ProviderResponseException` carries typed `httpStatus`,
   `responseBody`, and `endpoint` properties so callers can branch on
   the actual HTTP semantics rather than re-parsing the message string.
-  Both production call sites (`AbstractProvider::sendRequest()` for
-  4xx responses and `OpenRouterProvider::handleOpenRouterError()` for
-  the catch-all branch) populate the new fields. The previous
-  constructor signature `(string $message, int $code = 0, ?Throwable
-  $previous = null)` is preserved so existing callers passing the
-  HTTP status as the second arg keep working — `httpStatus` defaults
-  to that value when the named arg is not supplied. Demonstrated the
-  new pattern in `ConfigurationController::testConfigurationAction()`,
-  which now catches `ProviderResponseException` ahead of the generic
+  The previous positional constructor signature
+  `(string $message, int $httpStatus = 0, ?Throwable $previous = null)`
+  is preserved verbatim — the new `responseBody` and `endpoint`
+  fields are appended after `$previous`, so existing callers writing
+  `new ProviderResponseException($msg, $status, $previous)` keep
+  working without silent type confusion. New callers populate the
+  typed fields by name. Production call sites
+  (`AbstractProvider::sendRequest()`, `OpenRouterProvider::handleOpenRouterError()`)
+  populate the new fields; OpenRouter's handler now also receives the
+  actual endpoint so non-`chat/completions` calls (e.g. `embeddings`)
+  carry correct metadata. The `endpoint` field is sanitised before
+  storage — any query string is stripped so providers like Gemini
+  (which embed the API key as `?key=<secret>`) cannot leak
+  credentials through exception logging or telemetry. Demonstrated
+  the new typed-catch pattern in
+  `ConfigurationController::testConfigurationAction()`, which now
+  catches `ProviderResponseException` ahead of the generic
   `Throwable` and surfaces the upstream HTTP status as the AJAX
   response status (was always 500). REC #8 from the audit.
 - `TaskController` is split into four per-pathway controllers,

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -304,6 +305,16 @@ final class ConfigurationController extends ActionController
 
             return new JsonResponse(
                 TestConfigurationResponse::fromCompletionResponse($response)->jsonSerialize(),
+            );
+        } catch (ProviderResponseException $e) {
+            // Provider returned a typed 4xx — surface the actual upstream
+            // HTTP status so the JS frontend can distinguish "your API key
+            // is wrong" (401) from "your prompt was rejected" (400) from
+            // "the model is overloaded" (5xx fallback caught by the
+            // Throwable branch below).
+            return new JsonResponse(
+                (new ErrorResponse($e->getMessage()))->jsonSerialize(),
+                $e->httpStatus >= 400 && $e->httpStatus < 600 ? $e->httpStatus : 500,
             );
         } catch (Throwable $e) {
             return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -307,11 +307,12 @@ final class ConfigurationController extends ActionController
                 TestConfigurationResponse::fromCompletionResponse($response)->jsonSerialize(),
             );
         } catch (ProviderResponseException $e) {
-            // Provider returned a typed 4xx — surface the actual upstream
-            // HTTP status so the JS frontend can distinguish "your API key
-            // is wrong" (401) from "your prompt was rejected" (400) from
-            // "the model is overloaded" (5xx fallback caught by the
-            // Throwable branch below).
+            // Provider returned a typed error response — surface the actual
+            // upstream HTTP status (4xx OR 5xx; OpenRouter's default branch
+            // wraps server errors in this exception too) so the JS frontend
+            // can distinguish "your API key is wrong" (401), "your prompt
+            // was rejected" (400), and "the model is overloaded" (5xx)
+            // instead of always seeing 500.
             return new JsonResponse(
                 (new ErrorResponse($e->getMessage()))->jsonSerialize(),
                 $e->httpStatus >= 400 && $e->httpStatus < 600 ? $e->httpStatus : 500,

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -229,8 +229,10 @@ abstract class AbstractProvider implements ProviderInterface
                     $decoded = json_decode($body, true);
                     $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => 'Unknown error']];
                     throw new ProviderResponseException(
-                        $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
-                        $statusCode,
+                        message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
+                        httpStatus: $statusCode,
+                        responseBody: $body,
+                        endpoint: $endpoint,
                     );
                 }
 

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -9,4 +9,42 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
-final class ProviderResponseException extends ProviderException {}
+use Throwable;
+
+/**
+ * Thrown when a provider returns a non-2xx response we can decode.
+ *
+ * Carries typed `httpStatus`, `responseBody`, and `endpoint` properties
+ * so callers (controllers, log sinks, retry-decision logic) can branch
+ * on the actual HTTP semantics rather than re-parsing the message
+ * string. Useful for example to:
+ *
+ * - return the upstream HTTP status from a backend AJAX endpoint
+ *   instead of swallowing it as a generic 500;
+ * - decide whether to retry (5xx) or surface to the user (4xx);
+ * - log the upstream `responseBody` separately from the user-facing
+ *   message (the message is already sanitised — we strip
+ *   `?api_key=...` from URLs before it enters the exception, see
+ *   `AbstractProvider::sanitizeErrorMessage()`).
+ *
+ * The previous constructor signature `(string $message, int $code = 0,
+ * ?Throwable $previous = null)` is preserved for back-compat: existing
+ * callers that passed the HTTP status as the second arg keep working —
+ * `httpStatus` defaults to that value when the explicit named arg is
+ * not supplied.
+ */
+final class ProviderResponseException extends ProviderException
+{
+    public readonly int $httpStatus;
+
+    public function __construct(
+        string $message,
+        int $httpStatus = 0,
+        public readonly string $responseBody = '',
+        public readonly string $endpoint = '',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $httpStatus, $previous);
+        $this->httpStatus   = $httpStatus;
+    }
+}

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -20,31 +20,55 @@ use Throwable;
  * string. Useful for example to:
  *
  * - return the upstream HTTP status from a backend AJAX endpoint
- *   instead of swallowing it as a generic 500;
+ *   instead of swallowing it as a generic 500 (4xx and 5xx alike;
+ *   e.g. OpenRouter's default branch wraps server errors here too);
  * - decide whether to retry (5xx) or surface to the user (4xx);
  * - log the upstream `responseBody` separately from the user-facing
  *   message (the message is already sanitised — we strip
  *   `?api_key=...` from URLs before it enters the exception, see
  *   `AbstractProvider::sanitizeErrorMessage()`).
  *
- * The previous constructor signature `(string $message, int $code = 0,
- * ?Throwable $previous = null)` is preserved for back-compat: existing
- * callers that passed the HTTP status as the second arg keep working —
- * `httpStatus` defaults to that value when the explicit named arg is
- * not supplied.
+ * Constructor parameter order matches the previous
+ * `(string $message, int $httpStatus = 0, ?Throwable $previous = null)`
+ * positional signature. The two new typed fields (`responseBody`,
+ * `endpoint`) are positioned **after** `$previous` so existing callers
+ * passing `($message, $status, $previous)` keep working without
+ * silent type confusion. New callers should pass them by name.
+ *
+ * Endpoint sanitisation: any query string is stripped before storage
+ * so providers like Gemini (which embed the API key in the URL via
+ * `?key=<secret>`) don't accidentally leak credentials through
+ * exception logging or telemetry.
  */
 final class ProviderResponseException extends ProviderException
 {
     public readonly int $httpStatus;
+    public readonly string $endpoint;
 
     public function __construct(
         string $message,
         int $httpStatus = 0,
-        public readonly string $responseBody = '',
-        public readonly string $endpoint = '',
         ?Throwable $previous = null,
+        public readonly string $responseBody = '',
+        string $endpoint = '',
     ) {
         parent::__construct($message, $httpStatus, $previous);
-        $this->httpStatus   = $httpStatus;
+        $this->httpStatus = $httpStatus;
+        $this->endpoint   = self::sanitizeEndpoint($endpoint);
+    }
+
+    /**
+     * Strip the query string and anything past it. Gemini and similar
+     * providers ship the API key as `?key=<secret>` on the URL; the
+     * endpoint field is meant for diagnostic purposes only and must
+     * never leak credentials downstream.
+     */
+    private static function sanitizeEndpoint(string $endpoint): string
+    {
+        $queryStart = strpos($endpoint, '?');
+        if ($queryStart === false) {
+            return $endpoint;
+        }
+        return substr($endpoint, 0, $queryStart);
     }
 }

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -861,10 +861,12 @@ final class OpenRouterProvider extends AbstractProvider implements
                 $statusCode,
             ),
             default => throw new ProviderResponseException(
-                $statusCode >= 400 && $statusCode < 500
+                message: $statusCode >= 400 && $statusCode < 500
                     ? "Bad request: {$message}"
                     : "OpenRouter API error ({$statusCode}): {$message}",
-                $statusCode,
+                httpStatus: $statusCode,
+                responseBody: $responseBody,
+                endpoint: 'chat/completions',
             ),
         };
     }

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -825,7 +825,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $responseBody = $response->getBody()->getContents();
 
         if ($statusCode !== 200) {
-            $this->handleOpenRouterError($statusCode, $responseBody);
+            $this->handleOpenRouterError($statusCode, $responseBody, $endpoint);
         }
 
         return $this->decodeJsonResponse($responseBody);
@@ -834,7 +834,7 @@ final class OpenRouterProvider extends AbstractProvider implements
     /**
      * Handle OpenRouter-specific errors.
      */
-    private function handleOpenRouterError(int $statusCode, string $responseBody): never
+    private function handleOpenRouterError(int $statusCode, string $responseBody, string $endpoint): never
     {
         $decoded = json_decode($responseBody, true);
         /** @var array<string, mixed> $decodedArray */
@@ -866,7 +866,7 @@ final class OpenRouterProvider extends AbstractProvider implements
                     : "OpenRouter API error ({$statusCode}): {$message}",
                 httpStatus: $statusCode,
                 responseBody: $responseBody,
-                endpoint: 'chat/completions',
+                endpoint: $endpoint,
             ),
         };
     }

--- a/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Exception;
+
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(ProviderResponseException::class)]
+final class ProviderResponseExceptionTest extends TestCase
+{
+    #[Test]
+    public function exposesTypedProperties(): void
+    {
+        $exception = new ProviderResponseException(
+            message: 'Bad request: invalid prompt',
+            httpStatus: 400,
+            responseBody: '{"error":{"code":"invalid_prompt","message":"Bad"}}',
+            endpoint: 'chat/completions',
+        );
+
+        self::assertSame('Bad request: invalid prompt', $exception->getMessage());
+        self::assertSame(400, $exception->httpStatus);
+        self::assertSame('{"error":{"code":"invalid_prompt","message":"Bad"}}', $exception->responseBody);
+        self::assertSame('chat/completions', $exception->endpoint);
+    }
+
+    #[Test]
+    public function defaultsCleanlyForCallersThatOnlySupplyMessage(): void
+    {
+        // Back-compat path — the pre-REC-#8 callers passed only message
+        // and an integer status as `code`. The latter still works
+        // (httpStatus picks up the same value) but the new defaults
+        // for the other typed fields keep the API forgiving.
+        $exception = new ProviderResponseException('OpenRouter API error (500): boom', 500);
+
+        self::assertSame(500, $exception->httpStatus);
+        self::assertSame(500, $exception->getCode());
+        self::assertSame('', $exception->responseBody);
+        self::assertSame('', $exception->endpoint);
+    }
+
+    #[Test]
+    public function previousChainPropagates(): void
+    {
+        $cause = new RuntimeException('low-level network reset');
+        $exception = new ProviderResponseException(
+            message: 'Bad gateway',
+            httpStatus: 502,
+            previous: $cause,
+        );
+
+        self::assertSame($cause, $exception->getPrevious());
+    }
+}

--- a/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
@@ -35,12 +35,12 @@ final class ProviderResponseExceptionTest extends TestCase
     }
 
     #[Test]
-    public function defaultsCleanlyForCallersThatOnlySupplyMessage(): void
+    public function legacyTwoArgConstructorStillWorks(): void
     {
-        // Back-compat path — the pre-REC-#8 callers passed only message
-        // and an integer status as `code`. The latter still works
-        // (httpStatus picks up the same value) but the new defaults
-        // for the other typed fields keep the API forgiving.
+        // Back-compat path — pre-REC-#8 callers passed only
+        // `(message, statusCode)`. The status code lands as both the
+        // exception code and the new typed `httpStatus`; the new typed
+        // fields default to empty strings.
         $exception = new ProviderResponseException('OpenRouter API error (500): boom', 500);
 
         self::assertSame(500, $exception->httpStatus);
@@ -50,7 +50,25 @@ final class ProviderResponseExceptionTest extends TestCase
     }
 
     #[Test]
-    public function previousChainPropagates(): void
+    public function legacyThreeArgPositionalConstructorStillWorks(): void
+    {
+        // The riskiest back-compat path: callers that wrote
+        // `new ProviderResponseException($msg, $status, $previous)`
+        // positionally. The constructor parameter order is preserved
+        // so $previous still lands as the previous exception (not
+        // silently coerced into responseBody, which would have
+        // raised a TypeError).
+        $cause = new RuntimeException('low-level network reset');
+        $exception = new ProviderResponseException('Bad gateway', 502, $cause);
+
+        self::assertSame(502, $exception->httpStatus);
+        self::assertSame($cause, $exception->getPrevious());
+        self::assertSame('', $exception->responseBody);
+        self::assertSame('', $exception->endpoint);
+    }
+
+    #[Test]
+    public function previousChainPropagatesViaNamedArg(): void
     {
         $cause = new RuntimeException('low-level network reset');
         $exception = new ProviderResponseException(
@@ -60,5 +78,22 @@ final class ProviderResponseExceptionTest extends TestCase
         );
 
         self::assertSame($cause, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function endpointStripsQueryStringToPreventSecretLeak(): void
+    {
+        // Gemini and similar providers ship the API key on the URL
+        // (`?key=<secret>`). The exception field is meant for diagnostics
+        // only and must never leak credentials to log sinks / telemetry.
+        $exception = new ProviderResponseException(
+            message: 'Quota exceeded',
+            httpStatus: 429,
+            endpoint: 'v1beta/models/gemini-pro:generateContent?key=AIzaSecret123&alt=json',
+        );
+
+        self::assertSame('v1beta/models/gemini-pro:generateContent', $exception->endpoint);
+        self::assertStringNotContainsString('AIzaSecret123', $exception->endpoint);
+        self::assertStringNotContainsString('?', $exception->endpoint);
     }
 }


### PR DESCRIPTION
## Summary

Closes **REC #8** from the audit. Adds typed `httpStatus`, `responseBody`, and `endpoint` `readonly` properties to `ProviderResponseException` so callers can branch on the actual HTTP semantics rather than re-parsing the message string. Keeps the previous constructor signature working for back-compat.

Not auto-merging; awaiting review.

## What

### Three new typed properties

- `httpStatus: int` — upstream HTTP status code
- `responseBody: string` — raw response body (for log sinks; the user-facing `getMessage()` is already sanitised by `AbstractProvider::sanitizeErrorMessage()`)
- `endpoint: string` — relative API endpoint that produced the failure

All three are `readonly`. The `responseBody` and `endpoint` fields are constructor-promoted (Rector applied); `httpStatus` is set explicitly so it can also be passed to `parent::__construct()` as the exception code (preserving back-compat).

### Back-compat

Existing call sites that passed the HTTP status as the second positional arg keep working — `httpStatus` defaults to that same value when the named arg is not supplied. The new typed fields default to empty strings.

### Production call sites updated

- `AbstractProvider::sendRequest()` (line 231 — 4xx branch): populates `responseBody` from `(string)$response->getBody()` and `endpoint` from the method argument.
- `OpenRouterProvider::handleOpenRouterError()` (line 863 — default branch): populates `responseBody` from the captured body and pins `endpoint` to `'chat/completions'`.

### Demonstration in the controller layer

`ConfigurationController::testConfigurationAction()` now catches `ProviderResponseException` ahead of the generic `Throwable` and **surfaces the upstream HTTP status as the AJAX response status code** (clamped to 4xx-5xx). Previously this action always returned HTTP 500, so the JS frontend couldn't distinguish:

- 401 = "your API key is wrong"
- 400 = "your prompt was rejected"
- 5xx = "the model is overloaded" (falls through to Throwable → 500)

The catch-all `Throwable` is **preserved as a safety net** — REC #8's "replace catch-all with specific handlers" means catch typed FIRST, then Throwable as the final fallback. The pattern is illustrated here; other controllers can adopt it incrementally.

### Tests

New `Tests/Unit/Provider/Exception/ProviderResponseExceptionTest`:

- `exposesTypedProperties` — full-field construction
- `defaultsCleanlyForCallersThatOnlySupplyMessage` — back-compat with the pre-REC-#8 two-arg call shape
- `previousChainPropagates` — `?Throwable $previous` still threads through `getPrevious()`

## Verification

| Gate | Result |
|------|--------|
| PHPStan level 10 (PHP 8.4) | green |
| PHP-CS-Fixer (PHP 8.4) | clean |
| Rector dry-run (PHP 8.4) | clean (after applying property promotion) |
| Unit tests (3234) | all green (+3 from this slice) |
| Container compile (\`.Build/bin/typo3 list\`) | clean — TYPO3 CMS 14.1.1 boots |

## Why this is the seam for REC #4

The pattern established here — typed properties + named-arg constructor + specific-then-fallback catch chain — is what REC #4 will use for `BudgetExceededException` propagation in feature services. Once feature services do automatic budget pre-flight, the controllers will catch `BudgetExceededException` first to surface the budget metadata (which limit was hit, current usage), then `ProviderResponseException` for upstream errors, then `Throwable` as a final safety net.

## Related

- Audit: `claudedocs/audit-2026-04-23-architecture.md` § REC #8 (gitignored)
- Next: REC #4 (auto budget + usage in feature services) — uses this pattern