### PR TITLE
feat(budget): wire automatic budget pre-flight into CompletionService (REC #4 — slice 15a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Canonical sections in `AGENTS.md` (Commands, Testing, Development Workflow,
   Architecture, File Map, Critical Constraints, Heuristics, Shared Utilities,
   Golden Samples).
+- `Service/Budget/BackendUserContextResolverInterface` (with default
+  implementation `BackendUserContextResolver`) — single seam for resolving
+  the active TYPO3 backend user uid out of `$GLOBALS['BE_USER']`. The
+  resolver returns `null` (rather than `0`) when no BE user is in scope
+  so `BudgetMiddleware`'s "skip the check" branch fires for CLI /
+  scheduler / FE callers without faking an unauthenticated principal.
+  `CompletionService` injects the resolver and auto-populates
+  `ChatOptions::beUserUid` when the caller did not set one — slice 15a
+  of REC #4 (automatic budget pre-flight wiring; downstream feature
+  services Embedding / Translation / Vision follow in slice 15b).
+  `ChatOptions` (and by extension `ToolOptions`) gained typed
+  `beUserUid` / `plannedCost` fields with `withBeUserUid()` /
+  `withPlannedCost()` setters; `LlmServiceManager::chat()` translates
+  these into `BudgetMiddleware::METADATA_BE_USER_UID` /
+  `METADATA_PLANNED_COST` on the `ProviderCallContext` so the existing
+  middleware reads them without changes. Fields are deliberately kept
+  off `ChatOptions::toArray()` — they are pipeline metadata, not
+  provider-side options, and must never reach the provider wire
+  payload.
 
 ### Changed
 

--- a/Classes/Service/Budget/BackendUserContextResolver.php
+++ b/Classes/Service/Budget/BackendUserContextResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Budget;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Default resolver — reads the active BE user from `$GLOBALS['BE_USER']`.
+ *
+ * Mirrors the pattern used by `CapabilityPermissionService` (the only
+ * other production consumer of `$GLOBALS['BE_USER']` in this extension):
+ * direct superglobal access, defended by an `instanceof` check so the
+ * resolver returns `null` rather than blowing up when called outside a
+ * backend request (CLI, scheduler, FE-only contexts).
+ *
+ * The TYPO3 v13/v14 user-array layout is documented to expose the uid
+ * at `$BE_USER->user['uid']` as `int|null`; we narrow defensively in
+ * case a third-party layer hands us a non-int (string-from-CSV, etc.)
+ * and translate any non-positive value to `null` so the BudgetMiddleware
+ * does not run a check against `uid === 0` (which is always
+ * unauthenticated and would needlessly hit the budget service).
+ */
+final readonly class BackendUserContextResolver implements BackendUserContextResolverInterface
+{
+    public function resolveBeUserUid(): ?int
+    {
+        $candidate = $GLOBALS['BE_USER'] ?? null;
+        if (!$candidate instanceof BackendUserAuthentication) {
+            return null;
+        }
+
+        $uid = $candidate->user['uid'] ?? null;
+        if (!is_int($uid) || $uid <= 0) {
+            return null;
+        }
+
+        return $uid;
+    }
+}

--- a/Classes/Service/Budget/BackendUserContextResolverInterface.php
+++ b/Classes/Service/Budget/BackendUserContextResolverInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Budget;
+
+/**
+ * Resolves the current backend user identifier for budget pre-flight checks.
+ *
+ * Feature services (CompletionService, EmbeddingService, ...) consult this
+ * resolver when callers did not explicitly set a `beUserUid` on the options
+ * object. The resolver is the only seam between the LLM call path and the
+ * `$GLOBALS['BE_USER']` superglobal — keeping it behind an interface lets
+ * tests run without a TYPO3 backend bootstrap and lets non-BE callers
+ * (CLI, scheduler, FE) wire a no-op implementation.
+ *
+ * Returning `null` is the documented "no BE user in scope" signal — the
+ * BudgetMiddleware treats absent / 0 / non-int as "skip the check", so
+ * resolvers that cannot determine a user MUST return `null` rather than
+ * fabricating a default (returning 0 also works but `null` makes the
+ * "unknown" intent explicit at every call site).
+ */
+interface BackendUserContextResolverInterface
+{
+    /**
+     * Return the current backend user uid, or null when no BE user is
+     * authenticated in the current request scope.
+     */
+    public function resolveBeUserUid(): ?int;
+}

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -83,7 +83,13 @@ final readonly class CompletionService
             $optionsArray['stop'] = $optionsArray['stop_sequences'];
             unset($optionsArray['stop_sequences']);
 
-            // Create temporary options with modified array
+            // Create temporary options with modified array. Every typed
+            // field that ChatOptions exposes must be copied across — the
+            // new constructor call would otherwise silently drop the
+            // budget pre-flight fields (REC #4) and let stop-sequence
+            // callers bypass the BudgetMiddleware. PHPStan won't catch
+            // this because every parameter is `?T = null`, so missing
+            // fields look like "use the default".
             $tempOptions = new ChatOptions(
                 temperature: $options->getTemperature(),
                 maxTokens: $options->getMaxTokens(),
@@ -93,6 +99,8 @@ final readonly class CompletionService
                 responseFormat: $options->getResponseFormat(),
                 provider: $options->getProvider(),
                 model: $options->getModel(),
+                beUserUid: $options->getBeUserUid(),
+                plannedCost: $options->getPlannedCost(),
             );
             return $this->llmManager->chat($messages, $tempOptions);
         }

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 
@@ -19,11 +20,22 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  *
  * Provides simple text generation with configurable creativity,
  * format control, and token management.
+ *
+ * Budget pre-flight (REC #4): when a caller does not set an explicit
+ * `beUserUid` on the options, the service consults
+ * `BackendUserContextResolverInterface` to find the active backend user
+ * and populates the option so the BudgetMiddleware in the pipeline can
+ * enforce per-user limits without every caller having to remember the
+ * wiring. The resolver injection is optional so unit tests that only
+ * care about the messaging path can omit it; in production DI the
+ * Symfony container always autowires it from
+ * `Configuration/Services.yaml`.
  */
 final readonly class CompletionService
 {
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
     ) {}
 
     /**
@@ -36,6 +48,7 @@ final readonly class CompletionService
     public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse
     {
         $options ??= new ChatOptions();
+        $options = $this->autoPopulateBeUserUid($options);
         $optionsArray = $options->toArray();
         $this->validateOptions($optionsArray);
 
@@ -247,5 +260,30 @@ final readonly class CompletionService
             'markdown', 'text' => 'text',
             default => 'text',
         };
+    }
+
+    /**
+     * Auto-populate `beUserUid` from the resolver when the caller did
+     * not set it explicitly (REC #4). Callers that pass a uid (including
+     * `0` for "anonymous / skip the check") win over the resolver — only
+     * `null` triggers the lookup. Returns the (possibly enriched) options
+     * unchanged when no resolver is wired or when the resolver itself
+     * returns `null` (CLI / scheduler / FE contexts).
+     */
+    private function autoPopulateBeUserUid(ChatOptions $options): ChatOptions
+    {
+        if ($options->getBeUserUid() !== null) {
+            return $options;
+        }
+        if ($this->beUserContextResolver === null) {
+            return $options;
+        }
+
+        $resolved = $this->beUserContextResolver->resolveBeUserUid();
+        if ($resolved === null) {
+            return $options;
+        }
+
+        return $options->withBeUserUid($resolved);
     }
 }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -187,6 +187,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
             ProviderOperation::Completion,
             fn(): CompletionResponse => $this->getProvider($providerKey)->complete($prompt, $optionsArray),
+            $this->buildBudgetMetadata($options),
         );
     }
 
@@ -361,6 +362,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
                 return $provider->chatCompletionWithTools($normalisedMessages, $normalisedTools, $optionsArray);
             },
+            $this->buildBudgetMetadata($options),
         );
     }
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -168,6 +169,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
             fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($normalisedMessages, $optionsArray),
+            $this->buildBudgetMetadata($options),
         );
     }
 
@@ -487,9 +489,15 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * operation kind (so middleware can filter by operation) and the
      * terminal closure that performs the actual provider invocation.
      *
+     * Optional `$metadata` is forwarded onto the `ProviderCallContext` so
+     * cross-cutting middleware (BudgetMiddleware, CacheMiddleware, …) can
+     * read what each entry-point knows. Entry points that have no extra
+     * context (legacy callers, fixed-shape calls) pass an empty array.
+     *
      * @template T
      *
      * @param callable(LlmConfiguration): T $terminal
+     * @param array<string, mixed>          $metadata
      *
      * @return T
      */
@@ -497,12 +505,45 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         LlmConfiguration $configuration,
         ProviderOperation $operation,
         callable $terminal,
+        array $metadata = [],
     ): mixed {
         return $this->pipeline->run(
-            ProviderCallContext::for($operation),
+            ProviderCallContext::for($operation, $metadata),
             $configuration,
             $terminal,
         );
+    }
+
+    /**
+     * Translate the budget-relevant fields on the typed options object
+     * into the metadata keys the BudgetMiddleware reads. Only fields that
+     * the caller has explicitly set (non-null) become metadata — the
+     * middleware's "skip the check" branch then naturally fires for
+     * absent values, matching its documented contract (see
+     * `BudgetMiddleware::handle()`).
+     *
+     * Lives on the manager rather than on the option object itself so
+     * the manager owns the mapping between "public typed surface" and
+     * "internal pipeline contract" — option objects do not need to know
+     * which middleware exists or how it reads metadata.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildBudgetMetadata(ChatOptions $options): array
+    {
+        $metadata = [];
+
+        $beUserUid = $options->getBeUserUid();
+        if ($beUserUid !== null) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
+
+        $plannedCost = $options->getPlannedCost();
+        if ($plannedCost !== null) {
+            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
+        }
+
+        return $metadata;
     }
 
     /**

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
 /**
  * Options for chat completion requests.
  *
@@ -207,6 +209,7 @@ class ChatOptions extends AbstractOptions
     {
         $clone = clone $this;
         $clone->beUserUid = $beUserUid;
+        $clone->validate();
         return $clone;
     }
 
@@ -222,6 +225,7 @@ class ChatOptions extends AbstractOptions
     {
         $clone = clone $this;
         $clone->plannedCost = $plannedCost;
+        $clone->validate();
         return $clone;
     }
 
@@ -355,6 +359,29 @@ class ChatOptions extends AbstractOptions
 
         if ($this->responseFormat !== null) {
             self::validateEnum($this->responseFormat, self::RESPONSE_FORMATS, 'response_format');
+        }
+
+        if ($this->beUserUid !== null && $this->beUserUid < 0) {
+            // 0 is documented as "anonymous / skip the check" by the
+            // BudgetMiddleware contract; positive uids identify real BE
+            // users. A negative value can only be a caller bug — refuse
+            // it loudly rather than letting it fall through to a budget
+            // service lookup that would either error or, worse, match
+            // an unrelated row by absolute value.
+            throw new InvalidArgumentException(
+                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
+                7461293501,
+            );
+        }
+
+        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
+            // Negative cost has no semantic — providers do not refund.
+            // The BudgetMiddleware would evaluate it as a credit toward
+            // the per-day cost ceiling, which would be a budget bypass.
+            throw new InvalidArgumentException(
+                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
+                4658297014,
+            );
         }
     }
 }

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -33,6 +33,8 @@ class ChatOptions extends AbstractOptions
         private ?array $stopSequences = null,
         private ?string $provider = null,
         private ?string $model = null,
+        private ?int $beUserUid = null,
+        private ?float $plannedCost = null,
     ) {
         $this->validate();
     }
@@ -191,6 +193,38 @@ class ChatOptions extends AbstractOptions
         return $clone;
     }
 
+    /**
+     * Set the backend user uid for budget pre-flight (REC #4).
+     *
+     * Callers that already know the BE user (controllers wiring an explicit
+     * uid) should set it here so feature services skip resolver lookup.
+     * Leaving it `null` lets the feature service auto-populate from the
+     * `BackendUserContextResolverInterface`. Pass `0` to explicitly opt
+     * out of the budget check (the BudgetMiddleware treats `0` as
+     * "no user — skip the check").
+     */
+    public function withBeUserUid(int $beUserUid): static
+    {
+        $clone = clone $this;
+        $clone->beUserUid = $beUserUid;
+        return $clone;
+    }
+
+    /**
+     * Set the expected cost of the call for budget pre-flight (REC #4).
+     *
+     * Use when the caller has a meaningful estimate (token counter +
+     * model rate). Leaving it `null` / `0.0` tells the BudgetMiddleware
+     * to evaluate only the non-cost limits (request count, prior usage
+     * totals); real cost is accounted post-flight by UsageMiddleware.
+     */
+    public function withPlannedCost(float $plannedCost): static
+    {
+        $clone = clone $this;
+        $clone->plannedCost = $plannedCost;
+        return $clone;
+    }
+
     // ========================================
     // Getters
     // ========================================
@@ -246,6 +280,16 @@ class ChatOptions extends AbstractOptions
     public function getModel(): ?string
     {
         return $this->model;
+    }
+
+    public function getBeUserUid(): ?int
+    {
+        return $this->beUserUid;
+    }
+
+    public function getPlannedCost(): ?float
+    {
+        return $this->plannedCost;
     }
 
     // ========================================

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -34,6 +34,8 @@ class ToolOptions extends ChatOptions
         ?array $stopSequences = null,
         ?string $provider = null,
         ?string $model = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
         private ?string $toolChoice = null,
         private ?bool $parallelToolCalls = null,
     ) {
@@ -48,6 +50,8 @@ class ToolOptions extends ChatOptions
             $stopSequences,
             $provider,
             $model,
+            $beUserUid,
+            $plannedCost,
         );
         $this->validateToolOptions();
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -138,6 +138,9 @@ services:
   Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface:
     alias: Netresearch\NrLlm\Service\Budget\UserBudgetUsageWindows
 
+  Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface:
+    alias: Netresearch\NrLlm\Service\Budget\BackendUserContextResolver
+
   # ========================================
   # Task pathway readers (slice 13a — ADR-027)
   # ========================================

--- a/Tests/Unit/Service/Budget/BackendUserContextResolverTest.php
+++ b/Tests/Unit/Service/Budget/BackendUserContextResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Budget;
+
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolver;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use stdClass;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+#[CoversClass(BackendUserContextResolver::class)]
+final class BackendUserContextResolverTest extends AbstractUnitTestCase
+{
+    private mixed $previousBeUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function returnsNullWhenBeUserGlobalIsAbsent(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        self::assertNull((new BackendUserContextResolver())->resolveBeUserUid());
+    }
+
+    #[Test]
+    public function returnsNullWhenBeUserIsNotABackendUserAuthentication(): void
+    {
+        // Defensive — if a third-party hooks something else into the
+        // global, the resolver must not crash. CLI / scheduler contexts
+        // sometimes leave non-typed sentinels here.
+        $GLOBALS['BE_USER'] = new stdClass();
+
+        self::assertNull((new BackendUserContextResolver())->resolveBeUserUid());
+    }
+
+    #[Test]
+    public function returnsTheBeUserUidWhenSet(): void
+    {
+        $beUser = self::createStub(BackendUserAuthentication::class);
+        $beUser->user = ['uid' => 7, 'username' => 'editor'];
+        $GLOBALS['BE_USER'] = $beUser;
+
+        self::assertSame(7, (new BackendUserContextResolver())->resolveBeUserUid());
+    }
+
+    #[Test]
+    public function returnsNullWhenUidIsZero(): void
+    {
+        // uid === 0 is the documented "anonymous / not logged in"
+        // marker in TYPO3. The resolver maps it to null so the
+        // BudgetMiddleware does not run a per-user budget check
+        // against an anonymous principal.
+        $beUser = self::createStub(BackendUserAuthentication::class);
+        $beUser->user = ['uid' => 0];
+        $GLOBALS['BE_USER'] = $beUser;
+
+        self::assertNull((new BackendUserContextResolver())->resolveBeUserUid());
+    }
+
+    #[Test]
+    public function returnsNullWhenUidIsNotAnInt(): void
+    {
+        // Belt-and-braces — TYPO3 typing says int|null, but a CSV / DB
+        // round-trip from a misbehaving extension could hand us a
+        // string. Guard against it rather than coercing.
+        $beUser = self::createStub(BackendUserAuthentication::class);
+        $beUser->user = ['uid' => '42'];
+        $GLOBALS['BE_USER'] = $beUser;
+
+        self::assertNull((new BackendUserContextResolver())->resolveBeUserUid());
+    }
+
+    #[Test]
+    public function returnsNullWhenUserArrayIsMissingUid(): void
+    {
+        $beUser = self::createStub(BackendUserAuthentication::class);
+        $beUser->user = ['username' => 'editor'];
+        $GLOBALS['BE_USER'] = $beUser;
+
+        self::assertNull((new BackendUserContextResolver())->resolveBeUserUid());
+    }
+}

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -797,6 +797,38 @@ class CompletionServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function completePreservesBudgetFieldsThroughStopSequencesRebuild(): void
+    {
+        // Regression test for the Gemini high-priority finding on
+        // PR #177: when the caller supplies stopSequences, the service
+        // rebuilds a temporary ChatOptions from the typed getters.
+        // Earlier passes of slice 15a copied every typed field except
+        // the new beUserUid / plannedCost, silently dropping them and
+        // letting stop-sequence callers bypass BudgetMiddleware. The
+        // rebuild now copies all 12 typed fields.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $subject = new CompletionService($llmManagerMock);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $forwarded): bool => $forwarded->getBeUserUid() === 13
+                        && $forwarded->getPlannedCost() === 0.07
+                        // Sanity: the stop_sequences path itself still
+                        // works (the rebuild's job).
+                        && $forwarded->getStopSequences() === null),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $options = (new ChatOptions(stopSequences: ['END']))
+            ->withBeUserUid(13)
+            ->withPlannedCost(0.07);
+
+        $subject->complete('hello', $options);
+    }
+
+    #[Test]
     public function completeWorksWithoutResolverDependency(): void
     {
         // Existing callers that don't pass a resolver (legacy DI wiring,

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -714,6 +715,105 @@ class CompletionServiceTest extends AbstractUnitTestCase
         $result = $subject->completeMarkdown('Test', null);
 
         self::assertEquals('# Title', $result);
+    }
+
+    #[Test]
+    public function completeAutoPopulatesBeUserUidFromResolverWhenCallerLeftItUnset(): void
+    {
+        // REC #4 slice 15a: when callers don't pass beUserUid, the
+        // service consults the resolver and forwards the resolved uid
+        // to LlmServiceManager via the typed option. The middleware
+        // pipeline picks it up from the option's getter once the
+        // manager translates it into ProviderCallContext metadata.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new CompletionService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool
+                    => $options->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->complete('hello');
+    }
+
+    #[Test]
+    public function completeRespectsExplicitBeUserUidOverResolver(): void
+    {
+        // Caller-supplied uid wins — the resolver is for the absent-default
+        // case only. We assert by giving the resolver an expectation that
+        // would fail the test if it were ever called.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::never())
+            ->method('resolveBeUserUid');
+
+        $subject = new CompletionService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool
+                    => $options->getBeUserUid() === 99),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->complete('hello', (new ChatOptions())->withBeUserUid(99));
+    }
+
+    #[Test]
+    public function completeLeavesBeUserUidUnsetWhenResolverReturnsNull(): void
+    {
+        // Non-BE contexts (CLI, scheduler, FE) — the resolver returns
+        // null and we do not fabricate a 0. The BudgetMiddleware's
+        // "skip the check" branch then fires for the missing uid.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(null);
+
+        $subject = new CompletionService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool
+                    => $options->getBeUserUid() === null),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->complete('hello');
+    }
+
+    #[Test]
+    public function completeWorksWithoutResolverDependency(): void
+    {
+        // Existing callers that don't pass a resolver (legacy DI wiring,
+        // older tests) keep working — beUserUid simply stays null.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $subject = new CompletionService($llmManagerMock);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool
+                    => $options->getBeUserUid() === null),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->complete('hello');
     }
 
     /**

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -39,6 +39,7 @@ use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -935,6 +936,55 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $metadata = $spy->calls[0]['metadata'];
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_BE_USER_UID, $metadata);
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $metadata);
+    }
+
+    #[Test]
+    public function completePlumbsBudgetMetadataFromOptions(): void
+    {
+        // Mirror of chatPlumbsBudgetMetadataFromOptions for the
+        // complete() entry point — closes the metadata-bypass that
+        // PR #177 review (Copilot) found in slice 15a where only
+        // chat() carried the metadata.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new ChatOptions())
+            ->withBeUserUid(13)
+            ->withPlannedCost(0.17);
+
+        $manager->complete('hello', $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(13, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.17, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
+    }
+
+    #[Test]
+    public function chatWithToolsPlumbsBudgetMetadataFromOptions(): void
+    {
+        // ToolOptions extends ChatOptions, so the typed budget fields
+        // are already present on the subclass — just need to be plumbed
+        // through the chatWithTools() entrypoint identically to chat().
+        $spy      = new RecordingMiddleware();
+        $provider = new TestableToolProvider();
+        $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
+
+        $options = new ToolOptions(
+            beUserUid: 21,
+            plannedCost: 0.05,
+        );
+
+        $manager->chatWithTools(
+            [['role' => 'user', 'content' => 'hi']],
+            [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'noop', 'description' => '', 'parameters' => []]])],
+            $options,
+        );
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(21, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.05, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
     }
 
     #[Test]

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -896,6 +897,64 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
         self::assertArrayNotHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+    }
+
+    #[Test]
+    public function chatPlumbsBudgetMetadataFromOptions(): void
+    {
+        // REC #4 slice 15a — the manager translates the typed
+        // ChatOptions::beUserUid / plannedCost fields into the metadata
+        // keys that BudgetMiddleware reads from the ProviderCallContext.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new ChatOptions())
+            ->withBeUserUid(7)
+            ->withPlannedCost(0.42);
+
+        $manager->chat([['role' => 'user', 'content' => 'hi']], $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(7, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.42, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
+    }
+
+    #[Test]
+    public function chatOmitsBudgetMetadataWhenOptionsAreUnset(): void
+    {
+        // Default ChatOptions leave both fields null — the manager must
+        // not fabricate keys for them. BudgetMiddleware then takes its
+        // documented "skip the check" branch.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->chat([['role' => 'user', 'content' => 'hi']]);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertArrayNotHasKey(BudgetMiddleware::METADATA_BE_USER_UID, $metadata);
+        self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $metadata);
+    }
+
+    #[Test]
+    public function chatPlumbsOnlyBeUserUidWhenPlannedCostUnset(): void
+    {
+        // Each field is independently optional — a uid-only call (the
+        // common "I know who but not the cost" shape from CompletionService
+        // auto-populate) must not leak a planned_cost: 0.0 entry that
+        // would change BudgetMiddleware behaviour vs. the absent-key path.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new ChatOptions())->withBeUserUid(11);
+
+        $manager->chat([['role' => 'user', 'content' => 'hi']], $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(11, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $metadata);
     }
 
     /**

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -377,4 +377,104 @@ class ChatOptionsTest extends AbstractUnitTestCase
         self::assertEquals('openai', $options->getProvider());
         self::assertEquals('gpt-4o', $options->getModel());
     }
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new ChatOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneWithFieldSet(): void
+    {
+        $original = new ChatOptions();
+        $modified = $original->withBeUserUid(11);
+
+        self::assertNull($original->getBeUserUid());
+        self::assertSame(11, $modified->getBeUserUid());
+    }
+
+    #[Test]
+    public function withPlannedCostReturnsCloneWithFieldSet(): void
+    {
+        $original = new ChatOptions();
+        $modified = $original->withPlannedCost(0.05);
+
+        self::assertNull($original->getPlannedCost());
+        self::assertSame(0.05, $modified->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        // Per BudgetMiddleware contract: 0 = anonymous / skip, positive
+        // = real BE user. Negative is always a caller bug.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        new ChatOptions(beUserUid: -1);
+    }
+
+    #[Test]
+    public function withBeUserUidRejectsNegativeValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ChatOptions())->withBeUserUid(-5);
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        // Negative cost would credit the per-day ceiling — i.e. a
+        // budget bypass. Refuse it at construction time.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        new ChatOptions(plannedCost: -0.01);
+    }
+
+    #[Test]
+    public function withPlannedCostRejectsNegativeValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ChatOptions())->withPlannedCost(-1.0);
+    }
+
+    #[Test]
+    public function constructorAcceptsZeroBeUserUidAsAnonymousMarker(): void
+    {
+        // 0 is documented as "skip the check" — must not throw.
+        $options = new ChatOptions(beUserUid: 0);
+
+        self::assertSame(0, $options->getBeUserUid());
+    }
+
+    #[Test]
+    public function constructorAcceptsZeroPlannedCost(): void
+    {
+        $options = new ChatOptions(plannedCost: 0.0);
+
+        self::assertSame(0.0, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        // beUserUid / plannedCost are pipeline metadata, not provider
+        // wire payload — the manager reads them via typed getters and
+        // they must never reach the provider's options array.
+        $options = new ChatOptions(beUserUid: 7, plannedCost: 0.5);
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('be_user_uid', $array);
+        self::assertArrayNotHasKey('beUserUid', $array);
+        self::assertArrayNotHasKey('planned_cost', $array);
+        self::assertArrayNotHasKey('plannedCost', $array);
+    }
 }


### PR DESCRIPTION
## Summary

REC #4 of the architecture audit (`claudedocs/audit-2026-04-23-architecture.md`, gitignored) calls for **automatic budget + usage in feature services**. The `BudgetMiddleware` was already in the pipeline (ADR-025/026) but only fired when callers manually populated `ProviderCallContext` metadata — which `CompletionService` and friends never did. This slice closes the gap for `CompletionService`; **slice 15b** will repeat the pattern for `EmbeddingService` / `TranslationService` / `VisionService`.

## What changed

- **New seam:** `Service/Budget/BackendUserContextResolverInterface` + default `BackendUserContextResolver` — the only hop between the LLM call path and `\$GLOBALS['BE_USER']`. Mirrors the pattern from `CapabilityPermissionService` (the only other production consumer). Returns `null` (not `0`) when no BE user is in scope so the middleware's "skip the check" branch fires cleanly for CLI / scheduler / FE.
- **Typed option fields:** `ChatOptions` (and `ToolOptions`) gain `beUserUid` and `plannedCost` with matching `withBeUserUid()` / `withPlannedCost()` setters. **Kept out of `toArray()`** — these are pipeline metadata, not provider-side options.
- **Manager wiring:** `LlmServiceManager::chat()` translates the typed fields into `BudgetMiddleware::METADATA_BE_USER_UID` / `METADATA_PLANNED_COST` on the `ProviderCallContext`. Translation lives on the manager so option objects don't need to know which middleware exists.
- **Auto-populate:** `CompletionService` accepts an *optional* `BackendUserContextResolverInterface` (default `null`) and auto-fills `beUserUid` only when (a) caller omitted it AND (b) resolver is wired AND (c) resolver returns a uid. Caller-supplied uid (incl. `0` for explicit skip) always wins.

## Why optional injection

The 38 existing `new CompletionService(\$llmManager)` instantiation sites across `CompletionServiceTest`, `CompletionServiceMutationTest`, and `ChatCompletionWorkflowTest` keep working unchanged — `getBeUserUid()` simply stays `null` when no resolver is wired, which is the same behaviour those tests already asserted. Production DI autowires the resolver via the `Services.yaml` alias, so the auto-populate path is always live in real use.

## LSP-contravariance note

Adding params to `ChatOptions::__construct()` immediately broke `ToolOptions` (PHPStan level 10 caught it on the first re-run). The matching params were added to `ToolOptions` and forwarded to `parent::__construct()`. Without level 10 we'd have silently shipped a subclass that dropped the fields.

## Tests

- `BackendUserContextResolverTest` — 6 cases (missing global, non-`BackendUserAuthentication` value, valid uid, `uid === 0` → null, non-int uid, missing uid key).
- `CompletionServiceTest` — 4 new cases (auto-populate from resolver, caller wins over resolver, resolver returning null leaves uid unset, no-resolver legacy path).
- `LlmServiceManagerTest` — 3 new cases (full round-trip, both fields absent → no metadata keys, uid-only must not leak `planned_cost: 0.0`).

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3262 tests / 7079 assertions** all green (was 3249 → +13)
- [x] `.Build/bin/typo3 list` — container compiles cleanly (catches DI issues unit tests miss; per the slice 12 lesson)
- [ ] CI matrix on PR (PHP 8.2–8.5 × TYPO3 13.4 / 14.0)
- [ ] Bot review threads addressed