### PR TITLE
feat(budget): extend auto budget pre-flight to Embedding/Translation/Vision services (REC #4 — slice 15b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,32 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   resolver returns `null` (rather than `0`) when no BE user is in scope
   so `BudgetMiddleware`'s "skip the check" branch fires for CLI /
   scheduler / FE callers without faking an unauthenticated principal.
-  `CompletionService` injects the resolver and auto-populates
-  `ChatOptions::beUserUid` when the caller did not set one — slice 15a
-  of REC #4 (automatic budget pre-flight wiring; downstream feature
-  services Embedding / Translation / Vision follow in slice 15b).
+  `CompletionService`, `EmbeddingService`, `VisionService` and
+  `TranslationService` inject the resolver and auto-populate
+  `beUserUid` on their respective options when the caller did not set
+  one — slices 15a (`CompletionService`) and 15b (`EmbeddingService` /
+  `VisionService` / `TranslationService`) of REC #4 (automatic budget
+  pre-flight wiring across all feature services).
   `ChatOptions` (and by extension `ToolOptions`) gained typed
   `beUserUid` / `plannedCost` fields with `withBeUserUid()` /
-  `withPlannedCost()` setters; `LlmServiceManager::chat()` translates
-  these into `BudgetMiddleware::METADATA_BE_USER_UID` /
+  `withPlannedCost()` setters; slice 15b extends the same fields to
+  `EmbeddingOptions`, `VisionOptions` and `TranslationOptions`.
+  `LlmServiceManager::chat()` / `complete()` / `chatWithTools()` /
+  `embed()` / `vision()` translate the values into
+  `BudgetMiddleware::METADATA_BE_USER_UID` /
   `METADATA_PLANNED_COST` on the `ProviderCallContext` so the existing
-  middleware reads them without changes. Fields are deliberately kept
-  off `ChatOptions::toArray()` — they are pipeline metadata, not
-  provider-side options, and must never reach the provider wire
-  payload.
+  middleware reads them without changes; the helper
+  `buildBudgetMetadata()` takes raw nullable values rather than a
+  typed option object so every option type can reuse it without a
+  marker interface. Fields are deliberately kept off every option
+  type's `toArray()` — they are pipeline metadata, not provider-side
+  options, and must never reach the provider wire payload.
+  `TranslationService` is the only service that builds `ChatOptions`
+  internally (translate / detectLanguage / scoreTranslationQuality);
+  each construction site forwards `beUserUid` (resolver-resolved or
+  explicit) and `plannedCost` so the BudgetMiddleware sees them.
+  Specialized translators (DeepL et al.) bypass `LlmServiceManager`
+  entirely and are not subject to BudgetMiddleware in this slice.
 
 ### Changed
 

--- a/Classes/Service/Budget/AutoPopulatesBeUserUidTrait.php
+++ b/Classes/Service/Budget/AutoPopulatesBeUserUidTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Budget;
+
+use Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface;
+
+/**
+ * Shared auto-population logic for feature services (REC #4).
+ *
+ * `CompletionService`, `EmbeddingService` and `VisionService` all
+ * follow the same pattern: when the caller did not set a `beUserUid`
+ * on the options, consult the optional resolver and forward the
+ * resolved uid onto the options via the typed `withBeUserUid()`
+ * setter. Centralising it in a trait keeps the consumers focused on
+ * their per-feature logic and makes future tweaks (e.g. logging
+ * around resolution failure, propagating an explicit "0 = anonymous"
+ * value) a single-site change.
+ *
+ * `TranslationService` has a different shape (it builds *new*
+ * `ChatOptions` from `TranslationOptions` rather than mutating an
+ * existing options object), so it uses its own one-line helper
+ * instead of consuming this trait.
+ *
+ * Consumers must:
+ * - Declare a `?BackendUserContextResolverInterface $beUserContextResolver`
+ *   constructor property (private, optional, null default).
+ * - Call `autoPopulateBeUserUid($options)` before forwarding the
+ *   options to `LlmServiceManager`.
+ */
+trait AutoPopulatesBeUserUidTrait
+{
+    /**
+     * @template T of BudgetAwareOptionsInterface
+     *
+     * @param T $options
+     *
+     * @return T
+     */
+    private function autoPopulateBeUserUid(BudgetAwareOptionsInterface $options): BudgetAwareOptionsInterface
+    {
+        if ($options->getBeUserUid() !== null || $this->beUserContextResolver === null) {
+            return $options;
+        }
+
+        $resolved = $this->beUserContextResolver->resolveBeUserUid();
+        if ($resolved === null) {
+            return $options;
+        }
+
+        return $options->withBeUserUid($resolved);
+    }
+}

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -33,6 +34,8 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  */
 final readonly class CompletionService
 {
+    use AutoPopulatesBeUserUidTrait;
+
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
         private ?BackendUserContextResolverInterface $beUserContextResolver = null,
@@ -270,28 +273,7 @@ final readonly class CompletionService
         };
     }
 
-    /**
-     * Auto-populate `beUserUid` from the resolver when the caller did
-     * not set it explicitly (REC #4). Callers that pass a uid (including
-     * `0` for "anonymous / skip the check") win over the resolver — only
-     * `null` triggers the lookup. Returns the (possibly enriched) options
-     * unchanged when no resolver is wired or when the resolver itself
-     * returns `null` (CLI / scheduler / FE contexts).
-     */
-    private function autoPopulateBeUserUid(ChatOptions $options): ChatOptions
-    {
-        if ($options->getBeUserUid() !== null) {
-            return $options;
-        }
-        if ($this->beUserContextResolver === null) {
-            return $options;
-        }
-
-        $resolved = $this->beUserContextResolver->resolveBeUserUid();
-        if ($resolved === null) {
-            return $options;
-        }
-
-        return $options->withBeUserUid($resolved);
-    }
+    // `autoPopulateBeUserUid()` is provided by `AutoPopulatesBeUserUidTrait`
+    // — shared with EmbeddingService and VisionService since the wiring
+    // is identical across feature services.
 }

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 
@@ -20,11 +21,21 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * Caching is handled transparently by `CacheMiddleware` inside
  * `LlmServiceManager::embed()` — this service only owns the vector-math
  * utilities (cosine similarity, normalisation, top-k) and input validation.
+ *
+ * Budget pre-flight (REC #4 slice 15b): mirrors the wiring on
+ * `CompletionService` (slice 15a) — when a caller does not set an
+ * explicit `beUserUid` on the options, the service consults
+ * `BackendUserContextResolverInterface` and populates the option so
+ * `BudgetMiddleware` can enforce per-user limits without every caller
+ * having to remember the wiring. The resolver is optional so unit
+ * tests omit it; production DI always autowires it via
+ * `Configuration/Services.yaml`.
  */
 final readonly class EmbeddingService
 {
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
     ) {}
 
     /**
@@ -50,7 +61,7 @@ final readonly class EmbeddingService
             throw new InvalidArgumentException('Text cannot be empty', 6048498820);
         }
 
-        return $this->llmManager->embed($text, $options);
+        return $this->llmManager->embed($text, $this->autoPopulateBeUserUid($options));
     }
 
     /**
@@ -66,7 +77,7 @@ final readonly class EmbeddingService
             return [];
         }
 
-        $options ??= new EmbeddingOptions();
+        $options = $this->autoPopulateBeUserUid($options ?? new EmbeddingOptions());
         $response = $this->llmManager->embed($texts, $options);
         return $response->embeddings;
     }
@@ -168,4 +179,26 @@ final readonly class EmbeddingService
         return array_map(static fn($x) => $x / $magnitude, $vector);
     }
 
+    /**
+     * Auto-populate `beUserUid` on the options from the resolver when
+     * the caller did not set it explicitly. Mirrors
+     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
+     */
+    private function autoPopulateBeUserUid(?EmbeddingOptions $options): EmbeddingOptions
+    {
+        $options ??= new EmbeddingOptions();
+        if ($options->getBeUserUid() !== null) {
+            return $options;
+        }
+        if ($this->beUserContextResolver === null) {
+            return $options;
+        }
+
+        $resolved = $this->beUserContextResolver->resolveBeUserUid();
+        if ($resolved === null) {
+            return $options;
+        }
+
+        return $options->withBeUserUid($resolved);
+    }
 }

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
@@ -33,6 +34,8 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  */
 final readonly class EmbeddingService
 {
+    use AutoPopulatesBeUserUidTrait;
+
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
         private ?BackendUserContextResolverInterface $beUserContextResolver = null,
@@ -61,7 +64,7 @@ final readonly class EmbeddingService
             throw new InvalidArgumentException('Text cannot be empty', 6048498820);
         }
 
-        return $this->llmManager->embed($text, $this->autoPopulateBeUserUid($options));
+        return $this->llmManager->embed($text, $this->autoPopulateBeUserUid($options ?? new EmbeddingOptions()));
     }
 
     /**
@@ -179,26 +182,5 @@ final readonly class EmbeddingService
         return array_map(static fn($x) => $x / $magnitude, $vector);
     }
 
-    /**
-     * Auto-populate `beUserUid` on the options from the resolver when
-     * the caller did not set it explicitly. Mirrors
-     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
-     */
-    private function autoPopulateBeUserUid(?EmbeddingOptions $options): EmbeddingOptions
-    {
-        $options ??= new EmbeddingOptions();
-        if ($options->getBeUserUid() !== null) {
-            return $options;
-        }
-        if ($this->beUserContextResolver === null) {
-            return $options;
-        }
-
-        $resolved = $this->beUserContextResolver->resolveBeUserUid();
-        if ($resolved === null) {
-            return $options;
-        }
-
-        return $options->withBeUserUid($resolved);
-    }
+    // `autoPopulateBeUserUid()` is provided by `AutoPopulatesBeUserUidTrait`.
 }

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -30,6 +31,17 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * Supports dual-path translation:
  * - LLM-based translation (default)
  * - Specialized translators (DeepL, etc.) via TranslatorRegistry
+ *
+ * Budget pre-flight (REC #4 slice 15b): the LLM-based translation
+ * path (translate / detectLanguage / scoreTranslationQuality) goes
+ * through `LlmServiceManager::chat()` which is BudgetMiddleware-
+ * aware as of slice 15a — this service forwards the budget fields
+ * from `TranslationOptions` onto the internally-built `ChatOptions`
+ * so the metadata reaches the pipeline. The specialized-translator
+ * path (DeepL et al.) does NOT go through `LlmServiceManager`, so
+ * the BudgetMiddleware does not currently apply there; ADR / future
+ * slice can route specialized translators through a similar
+ * pre-flight if needed.
  */
 final readonly class TranslationService
 {
@@ -40,6 +52,7 @@ final readonly class TranslationService
         private LlmServiceManagerInterface $llmManager,
         private TranslatorRegistryInterface $translatorRegistry,
         private LlmConfigurationServiceInterface $configurationService,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
     ) {}
 
     /**
@@ -98,6 +111,8 @@ final readonly class TranslationService
             temperature: $options->getTemperature() ?? 0.3,
             maxTokens: $options->getMaxTokens() ?? 2000,
             provider: $options->getProvider(),
+            beUserUid: $this->resolveBeUserUid($options),
+            plannedCost: $options->getPlannedCost(),
         );
 
         $response = $this->llmManager->chat($messages, $chatOptions);
@@ -165,6 +180,8 @@ final readonly class TranslationService
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
+            beUserUid: $this->resolveBeUserUid($options),
+            plannedCost: $options->getPlannedCost(),
         );
 
         $response = $this->llmManager->chat($messages, $chatOptions);
@@ -218,6 +235,8 @@ final readonly class TranslationService
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
+            beUserUid: $this->resolveBeUserUid($options),
+            plannedCost: $options->getPlannedCost(),
         );
 
         $response = $this->llmManager->chat($messages, $chatOptions);
@@ -509,5 +528,24 @@ final readonly class TranslationService
         ];
 
         return $languages[$code] ?? $code;
+    }
+
+    /**
+     * Resolve the backend user uid for budget pre-flight (REC #4
+     * slice 15b). Honours an explicit caller-supplied uid (including
+     * `0` for "skip the check") and falls back to the resolver only
+     * when the option was left null. Mirrors the pattern in
+     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
+     */
+    private function resolveBeUserUid(TranslationOptions $options): ?int
+    {
+        $explicit = $options->getBeUserUid();
+        if ($explicit !== null) {
+            return $explicit;
+        }
+        if ($this->beUserContextResolver === null) {
+            return null;
+        }
+        return $this->beUserContextResolver->resolveBeUserUid();
     }
 }

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -534,18 +534,17 @@ final readonly class TranslationService
      * Resolve the backend user uid for budget pre-flight (REC #4
      * slice 15b). Honours an explicit caller-supplied uid (including
      * `0` for "skip the check") and falls back to the resolver only
-     * when the option was left null. Mirrors the pattern in
-     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
+     * when the option was left null.
+     *
+     * Different shape from the other feature services: this service
+     * builds *new* `ChatOptions` from `TranslationOptions` rather
+     * than mutating an existing options object, so it returns a raw
+     * `?int` that each construction site forwards to the new
+     * `ChatOptions` constructor — `AutoPopulatesBeUserUidTrait` does
+     * not fit (it expects an options object the caller can mutate).
      */
     private function resolveBeUserUid(TranslationOptions $options): ?int
     {
-        $explicit = $options->getBeUserUid();
-        if ($explicit !== null) {
-            return $explicit;
-        }
-        if ($this->beUserContextResolver === null) {
-            return null;
-        }
-        return $this->beUserContextResolver->resolveBeUserUid();
+        return $options->getBeUserUid() ?? $this->beUserContextResolver?->resolveBeUserUid();
     }
 }

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
@@ -27,6 +28,8 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  */
 final readonly class VisionService
 {
+    use AutoPopulatesBeUserUidTrait;
+
     private const PROMPT_ALT_TEXT = 'Generate a concise alt text for this image, under 125 characters, focused on essential information for screen readers. Be descriptive but brief.';
     private const PROMPT_SEO_TITLE = 'Generate an SEO-optimized title for this image, under 60 characters, that is compelling and keyword-rich for search rankings.';
     private const PROMPT_DESCRIPTION = 'Provide a comprehensive description of this image including subjects, setting, colors, mood, composition, and notable details.';
@@ -154,7 +157,7 @@ final readonly class VisionService
         string $prompt,
         ?VisionOptions $options = null,
     ): VisionResponse {
-        $options = $this->autoPopulateBeUserUid($options);
+        $options = $this->autoPopulateBeUserUid($options ?? new VisionOptions());
         $optionsArray = $options->toArray();
         $this->validateImageUrl($imageUrl);
 
@@ -243,26 +246,5 @@ final readonly class VisionService
         }
     }
 
-    /**
-     * Auto-populate `beUserUid` from the resolver when the caller did
-     * not set it (REC #4 slice 15b). Mirrors
-     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
-     */
-    private function autoPopulateBeUserUid(?VisionOptions $options): VisionOptions
-    {
-        $options ??= new VisionOptions();
-        if ($options->getBeUserUid() !== null) {
-            return $options;
-        }
-        if ($this->beUserContextResolver === null) {
-            return $options;
-        }
-
-        $resolved = $this->beUserContextResolver->resolveBeUserUid();
-        if ($resolved === null) {
-            return $options;
-        }
-
-        return $options->withBeUserUid($resolved);
-    }
+    // `autoPopulateBeUserUid()` is provided by `AutoPopulatesBeUserUidTrait`.
 }

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 
@@ -19,6 +20,10 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  *
  * Provides specialized image analysis with accessibility,
  * SEO, and descriptive prompts.
+ *
+ * Budget pre-flight (REC #4 slice 15b): mirrors `CompletionService`
+ * (slice 15a). The resolver is optional so unit tests omit it;
+ * production DI autowires it.
  */
 final readonly class VisionService
 {
@@ -28,6 +33,7 @@ final readonly class VisionService
 
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
     ) {}
 
     /**
@@ -148,7 +154,7 @@ final readonly class VisionService
         string $prompt,
         ?VisionOptions $options = null,
     ): VisionResponse {
-        $options ??= new VisionOptions();
+        $options = $this->autoPopulateBeUserUid($options);
         $optionsArray = $options->toArray();
         $this->validateImageUrl($imageUrl);
 
@@ -166,12 +172,20 @@ final readonly class VisionService
             ],
         ];
 
-        // Create new options without detail_level
+        // Create new options without detail_level. Every typed field
+        // must be copied across — the budget pre-flight fields
+        // (`beUserUid` / `plannedCost`) are easy to miss because the
+        // constructor accepts `?T = null` for every parameter, so a
+        // missing field looks like "use the default" to PHPStan. Same
+        // class of bug Gemini caught on PR #177's stop_sequences
+        // rebuild in `CompletionService`.
         $visionOptions = new VisionOptions(
             maxTokens: $options->getMaxTokens(),
             temperature: $options->getTemperature(),
             provider: $options->getProvider(),
             model: $options->getModel(),
+            beUserUid: $options->getBeUserUid(),
+            plannedCost: $options->getPlannedCost(),
         );
 
         return $this->llmManager->vision($content, $visionOptions);
@@ -227,5 +241,28 @@ final readonly class VisionService
                 );
             }
         }
+    }
+
+    /**
+     * Auto-populate `beUserUid` from the resolver when the caller did
+     * not set it (REC #4 slice 15b). Mirrors
+     * `CompletionService::autoPopulateBeUserUid()` from slice 15a.
+     */
+    private function autoPopulateBeUserUid(?VisionOptions $options): VisionOptions
+    {
+        $options ??= new VisionOptions();
+        if ($options->getBeUserUid() !== null) {
+            return $options;
+        }
+        if ($this->beUserContextResolver === null) {
+            return $options;
+        }
+
+        $resolved = $this->beUserContextResolver->resolveBeUserUid();
+        if ($resolved === null) {
+            return $options;
+        }
+
+        return $options->withBeUserUid($resolved);
     }
 }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -169,7 +169,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
             fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($normalisedMessages, $optionsArray),
-            $this->buildBudgetMetadata($options),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
 
@@ -187,7 +187,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
             ProviderOperation::Completion,
             fn(): CompletionResponse => $this->getProvider($providerKey)->complete($prompt, $optionsArray),
-            $this->buildBudgetMetadata($options),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
 
@@ -209,10 +209,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         // the key out of metadata so the middleware becomes a no-op for
         // this call.
         $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
-        $metadata = [];
+        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
         if ($cacheTtl > 0) {
             $resolvedProvider = $providerKey ?? $this->defaultProvider ?? 'default';
-            $metadata = [
+            $metadata += [
                 CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
                     $resolvedProvider,
                     'embeddings',
@@ -293,6 +293,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
                 return $provider->analyzeImage($normalisedContent, $optionsArray);
             },
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
 
@@ -362,7 +363,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
                 return $provider->chatCompletionWithTools($normalisedMessages, $normalisedTools, $optionsArray);
             },
-            $this->buildBudgetMetadata($options),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
 
@@ -517,30 +518,33 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
-     * Translate the budget-relevant fields on the typed options object
-     * into the metadata keys the BudgetMiddleware reads. Only fields that
-     * the caller has explicitly set (non-null) become metadata — the
-     * middleware's "skip the check" branch then naturally fires for
-     * absent values, matching its documented contract (see
+     * Translate the budget-relevant fields into the metadata keys the
+     * BudgetMiddleware reads. Only non-null values become metadata —
+     * the middleware's "skip the check" branch naturally fires for
+     * absent keys, matching its documented contract (see
      * `BudgetMiddleware::handle()`).
      *
-     * Lives on the manager rather than on the option object itself so
-     * the manager owns the mapping between "public typed surface" and
-     * "internal pipeline contract" — option objects do not need to know
-     * which middleware exists or how it reads metadata.
+     * Takes raw nullable values rather than a typed option object so
+     * every entry point can reuse it: `chat()` reads from `ChatOptions`,
+     * `embed()` from `EmbeddingOptions`, `vision()` from `VisionOptions`,
+     * `chatWithTools()` from `ToolOptions` — none of which share a
+     * common base interface for these two fields. A small option-type-
+     * agnostic helper is simpler than introducing a marker interface
+     * just to thread two fields.
+     *
+     * Lives on the manager rather than on the option objects so the
+     * options layer does not need to know which middleware exists.
      *
      * @return array<string, mixed>
      */
-    private function buildBudgetMetadata(ChatOptions $options): array
+    private function buildBudgetMetadata(?int $beUserUid, ?float $plannedCost): array
     {
         $metadata = [];
 
-        $beUserUid = $options->getBeUserUid();
         if ($beUserUid !== null) {
             $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
         }
 
-        $plannedCost = $options->getPlannedCost();
         if ($plannedCost !== null) {
             $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
         }

--- a/Classes/Service/Option/BudgetAwareOptionsInterface.php
+++ b/Classes/Service/Option/BudgetAwareOptionsInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Option;
+
+/**
+ * Marker for option types that carry budget pre-flight metadata
+ * (REC #4). Implemented by every option type whose call path reaches
+ * `BudgetMiddleware`: `ChatOptions` (and subclass `ToolOptions`),
+ * `EmbeddingOptions`, `VisionOptions`, `TranslationOptions`.
+ *
+ * The interface lets shared infrastructure (e.g. resolver-driven
+ * auto-population in feature services, or `LlmServiceManager`'s
+ * generic metadata builder) work across option types without
+ * narrowing to a concrete class. Implementers MUST keep these fields
+ * out of `toArray()` — they are pipeline metadata, not provider wire
+ * payload.
+ */
+interface BudgetAwareOptionsInterface
+{
+    public function getBeUserUid(): ?int;
+
+    public function getPlannedCost(): ?float;
+
+    /**
+     * Returns a new instance with `beUserUid` set. Validating
+     * setters reject negative values (`0` is the documented
+     * "anonymous / skip the check" marker; positive uids identify
+     * real BE users; negative is a caller bug).
+     */
+    public function withBeUserUid(int $beUserUid): static;
+
+    /**
+     * Returns a new instance with `plannedCost` set. Validating
+     * setters reject negative values (negative cost would credit
+     * the per-day ceiling in `BudgetMiddleware` — i.e. a budget
+     * bypass).
+     */
+    public function withPlannedCost(float $plannedCost): static;
+}

--- a/Classes/Service/Option/BudgetFieldsTrait.php
+++ b/Classes/Service/Option/BudgetFieldsTrait.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Option;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * Common implementation of the `BudgetAwareOptionsInterface` surface.
+ *
+ * Every option type that reaches `BudgetMiddleware` (`ChatOptions`,
+ * `EmbeddingOptions`, `VisionOptions`, `TranslationOptions`) consumes
+ * this trait so the budget pre-flight fields, getters, fluent setters,
+ * and validation rules live in one place. Centralising the validation
+ * matters for security: if a future option type forgets the negative-
+ * value rejection it would silently let `plannedCost = -1.0` credit
+ * the per-day ceiling in `BudgetMiddleware`.
+ *
+ * Consumers must:
+ * - Receive `?int $beUserUid = null, ?float $plannedCost = null` in
+ *   their constructor and assign them via the trait's `setBudgetFields()`
+ *   so validation runs at construction time. The fields are NOT
+ *   declared via constructor promotion in consuming classes; the trait
+ *   declares them as private properties so the inheritance and clone
+ *   semantics work correctly.
+ * - Call `validateBudgetFields()` from their own `validate()` method.
+ * - NOT include these fields in `toArray()` — they are pipeline
+ *   metadata, not provider wire payload, and must never reach the
+ *   provider.
+ */
+trait BudgetFieldsTrait
+{
+    private ?int $beUserUid = null;
+
+    private ?float $plannedCost = null;
+
+    public function getBeUserUid(): ?int
+    {
+        return $this->beUserUid;
+    }
+
+    public function getPlannedCost(): ?float
+    {
+        return $this->plannedCost;
+    }
+
+    public function withBeUserUid(int $beUserUid): static
+    {
+        $clone = clone $this;
+        $clone->beUserUid = $beUserUid;
+        $clone->validate();
+        return $clone;
+    }
+
+    public function withPlannedCost(float $plannedCost): static
+    {
+        $clone = clone $this;
+        $clone->plannedCost = $plannedCost;
+        $clone->validate();
+        return $clone;
+    }
+
+    /**
+     * Assign the budget fields. Called from the consuming class's
+     * constructor so the field assignment lives next to the typed
+     * promoted-parameter assignments instead of a separate later step.
+     */
+    private function setBudgetFields(?int $beUserUid, ?float $plannedCost): void
+    {
+        $this->beUserUid = $beUserUid;
+        $this->plannedCost = $plannedCost;
+    }
+
+    /**
+     * Reject negative `beUserUid` and `plannedCost` consistently
+     * across every consuming option type. Called from each consumer's
+     * `validate()` method so the trait does not need to override the
+     * full validate flow.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateBudgetFields(): void
+    {
+        if ($this->beUserUid !== null && $this->beUserUid < 0) {
+            throw new InvalidArgumentException(
+                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
+                7461293505,
+            );
+        }
+
+        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
+            throw new InvalidArgumentException(
+                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
+                4658297018,
+            );
+        }
+    }
+}

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
-use Netresearch\NrLlm\Exception\InvalidArgumentException;
-
 /**
  * Options for chat completion requests.
  *
@@ -19,8 +17,10 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  *
  * @phpstan-consistent-constructor
  */
-class ChatOptions extends AbstractOptions
+class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const RESPONSE_FORMATS = ['text', 'json', 'markdown'];
 
     public function __construct(
@@ -35,9 +35,10 @@ class ChatOptions extends AbstractOptions
         private ?array $stopSequences = null,
         private ?string $provider = null,
         private ?string $model = null,
-        private ?int $beUserUid = null,
-        private ?float $plannedCost = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
         $this->validate();
     }
 
@@ -195,39 +196,10 @@ class ChatOptions extends AbstractOptions
         return $clone;
     }
 
-    /**
-     * Set the backend user uid for budget pre-flight (REC #4).
-     *
-     * Callers that already know the BE user (controllers wiring an explicit
-     * uid) should set it here so feature services skip resolver lookup.
-     * Leaving it `null` lets the feature service auto-populate from the
-     * `BackendUserContextResolverInterface`. Pass `0` to explicitly opt
-     * out of the budget check (the BudgetMiddleware treats `0` as
-     * "no user — skip the check").
-     */
-    public function withBeUserUid(int $beUserUid): static
-    {
-        $clone = clone $this;
-        $clone->beUserUid = $beUserUid;
-        $clone->validate();
-        return $clone;
-    }
-
-    /**
-     * Set the expected cost of the call for budget pre-flight (REC #4).
-     *
-     * Use when the caller has a meaningful estimate (token counter +
-     * model rate). Leaving it `null` / `0.0` tells the BudgetMiddleware
-     * to evaluate only the non-cost limits (request count, prior usage
-     * totals); real cost is accounted post-flight by UsageMiddleware.
-     */
-    public function withPlannedCost(float $plannedCost): static
-    {
-        $clone = clone $this;
-        $clone->plannedCost = $plannedCost;
-        $clone->validate();
-        return $clone;
-    }
+    // Budget pre-flight setters (`withBeUserUid()`, `withPlannedCost()`)
+    // are provided by `BudgetFieldsTrait`. See REC #4 for the full
+    // contract — `0` is "anonymous / skip the check"; positive uid =
+    // real BE user; negative is rejected at validation time.
 
     // ========================================
     // Getters
@@ -286,15 +258,8 @@ class ChatOptions extends AbstractOptions
         return $this->model;
     }
 
-    public function getBeUserUid(): ?int
-    {
-        return $this->beUserUid;
-    }
-
-    public function getPlannedCost(): ?float
-    {
-        return $this->plannedCost;
-    }
+    // Budget pre-flight getters (`getBeUserUid()`, `getPlannedCost()`)
+    // are provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Array Conversion
@@ -361,27 +326,6 @@ class ChatOptions extends AbstractOptions
             self::validateEnum($this->responseFormat, self::RESPONSE_FORMATS, 'response_format');
         }
 
-        if ($this->beUserUid !== null && $this->beUserUid < 0) {
-            // 0 is documented as "anonymous / skip the check" by the
-            // BudgetMiddleware contract; positive uids identify real BE
-            // users. A negative value can only be a caller bug — refuse
-            // it loudly rather than letting it fall through to a budget
-            // service lookup that would either error or, worse, match
-            // an unrelated row by absolute value.
-            throw new InvalidArgumentException(
-                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
-                7461293501,
-            );
-        }
-
-        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
-            // Negative cost has no semantic — providers do not refund.
-            // The BudgetMiddleware would evaluate it as a credit toward
-            // the per-day cost ceiling, which would be a budget bypass.
-            throw new InvalidArgumentException(
-                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
-                4658297014,
-            );
-        }
+        $this->validateBudgetFields();
     }
 }

--- a/Classes/Service/Option/EmbeddingOptions.php
+++ b/Classes/Service/Option/EmbeddingOptions.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
-use Netresearch\NrLlm\Exception\InvalidArgumentException;
-
 /**
  * Options for embedding requests.
  *
@@ -18,8 +16,10 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  *
  * @phpstan-consistent-constructor
  */
-class EmbeddingOptions extends AbstractOptions
+class EmbeddingOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const DEFAULT_CACHE_TTL = 86400; // 24 hours
 
     public function __construct(
@@ -27,9 +27,10 @@ class EmbeddingOptions extends AbstractOptions
         private ?int $dimensions = null,
         private ?int $cacheTtl = self::DEFAULT_CACHE_TTL,
         private ?string $provider = null,
-        private ?int $beUserUid = null,
-        private ?float $plannedCost = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
         $this->validate();
     }
 
@@ -113,31 +114,7 @@ class EmbeddingOptions extends AbstractOptions
         return $clone;
     }
 
-    /**
-     * Set the backend user uid for budget pre-flight (REC #4).
-     *
-     * See `ChatOptions::withBeUserUid()` for the full contract — the
-     * BudgetMiddleware reads the same metadata key regardless of
-     * which option type carried it.
-     */
-    public function withBeUserUid(int $beUserUid): static
-    {
-        $clone = clone $this;
-        $clone->beUserUid = $beUserUid;
-        $clone->validate();
-        return $clone;
-    }
-
-    /**
-     * Set the expected cost of the call for budget pre-flight (REC #4).
-     */
-    public function withPlannedCost(float $plannedCost): static
-    {
-        $clone = clone $this;
-        $clone->plannedCost = $plannedCost;
-        $clone->validate();
-        return $clone;
-    }
+    // Budget pre-flight setters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Getters
@@ -163,15 +140,7 @@ class EmbeddingOptions extends AbstractOptions
         return $this->provider;
     }
 
-    public function getBeUserUid(): ?int
-    {
-        return $this->beUserUid;
-    }
-
-    public function getPlannedCost(): ?float
-    {
-        return $this->plannedCost;
-    }
+    // Budget pre-flight getters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Array Conversion
@@ -201,20 +170,6 @@ class EmbeddingOptions extends AbstractOptions
             self::validateRange($this->cacheTtl, 0, PHP_INT_MAX, 'cache_ttl');
         }
 
-        if ($this->beUserUid !== null && $this->beUserUid < 0) {
-            // Mirror ChatOptions: 0 = anonymous / skip, positive = real
-            // BE user, negative = caller bug. See REC #4 / slice 15a.
-            throw new InvalidArgumentException(
-                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
-                7461293502,
-            );
-        }
-
-        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
-            throw new InvalidArgumentException(
-                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
-                4658297015,
-            );
-        }
+        $this->validateBudgetFields();
     }
 }

--- a/Classes/Service/Option/EmbeddingOptions.php
+++ b/Classes/Service/Option/EmbeddingOptions.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
 /**
  * Options for embedding requests.
  *
@@ -25,6 +27,8 @@ class EmbeddingOptions extends AbstractOptions
         private ?int $dimensions = null,
         private ?int $cacheTtl = self::DEFAULT_CACHE_TTL,
         private ?string $provider = null,
+        private ?int $beUserUid = null,
+        private ?float $plannedCost = null,
     ) {
         $this->validate();
     }
@@ -109,6 +113,32 @@ class EmbeddingOptions extends AbstractOptions
         return $clone;
     }
 
+    /**
+     * Set the backend user uid for budget pre-flight (REC #4).
+     *
+     * See `ChatOptions::withBeUserUid()` for the full contract — the
+     * BudgetMiddleware reads the same metadata key regardless of
+     * which option type carried it.
+     */
+    public function withBeUserUid(int $beUserUid): static
+    {
+        $clone = clone $this;
+        $clone->beUserUid = $beUserUid;
+        $clone->validate();
+        return $clone;
+    }
+
+    /**
+     * Set the expected cost of the call for budget pre-flight (REC #4).
+     */
+    public function withPlannedCost(float $plannedCost): static
+    {
+        $clone = clone $this;
+        $clone->plannedCost = $plannedCost;
+        $clone->validate();
+        return $clone;
+    }
+
     // ========================================
     // Getters
     // ========================================
@@ -131,6 +161,16 @@ class EmbeddingOptions extends AbstractOptions
     public function getProvider(): ?string
     {
         return $this->provider;
+    }
+
+    public function getBeUserUid(): ?int
+    {
+        return $this->beUserUid;
+    }
+
+    public function getPlannedCost(): ?float
+    {
+        return $this->plannedCost;
     }
 
     // ========================================
@@ -159,6 +199,22 @@ class EmbeddingOptions extends AbstractOptions
 
         if ($this->cacheTtl !== null && $this->cacheTtl < 0) {
             self::validateRange($this->cacheTtl, 0, PHP_INT_MAX, 'cache_ttl');
+        }
+
+        if ($this->beUserUid !== null && $this->beUserUid < 0) {
+            // Mirror ChatOptions: 0 = anonymous / skip, positive = real
+            // BE user, negative = caller bug. See REC #4 / slice 15a.
+            throw new InvalidArgumentException(
+                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
+                7461293502,
+            );
+        }
+
+        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
+            throw new InvalidArgumentException(
+                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
+                4658297015,
+            );
         }
     }
 }

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
-use Netresearch\NrLlm\Exception\InvalidArgumentException;
-
 /**
  * Options for translation requests.
  *
  * @phpstan-consistent-constructor
  */
-class TranslationOptions extends AbstractOptions
+class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const FORMALITIES = ['default', 'formal', 'informal'];
     private const DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];
 
@@ -32,9 +32,10 @@ class TranslationOptions extends AbstractOptions
         private ?int $maxTokens = null,
         private ?string $provider = null,
         private ?string $model = null,
-        private ?int $beUserUid = null,
-        private ?float $plannedCost = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
         $this->validate();
     }
 
@@ -191,27 +192,7 @@ class TranslationOptions extends AbstractOptions
         return $clone;
     }
 
-    /**
-     * Set the backend user uid for budget pre-flight (REC #4).
-     */
-    public function withBeUserUid(int $beUserUid): static
-    {
-        $clone = clone $this;
-        $clone->beUserUid = $beUserUid;
-        $clone->validate();
-        return $clone;
-    }
-
-    /**
-     * Set the expected cost of the call for budget pre-flight (REC #4).
-     */
-    public function withPlannedCost(float $plannedCost): static
-    {
-        $clone = clone $this;
-        $clone->plannedCost = $plannedCost;
-        $clone->validate();
-        return $clone;
-    }
+    // Budget pre-flight setters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Getters
@@ -265,15 +246,7 @@ class TranslationOptions extends AbstractOptions
         return $this->model;
     }
 
-    public function getBeUserUid(): ?int
-    {
-        return $this->beUserUid;
-    }
-
-    public function getPlannedCost(): ?float
-    {
-        return $this->plannedCost;
-    }
+    // Budget pre-flight getters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Array Conversion
@@ -316,18 +289,6 @@ class TranslationOptions extends AbstractOptions
             self::validatePositiveInt($this->maxTokens, 'max_tokens');
         }
 
-        if ($this->beUserUid !== null && $this->beUserUid < 0) {
-            throw new InvalidArgumentException(
-                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
-                7461293504,
-            );
-        }
-
-        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
-            throw new InvalidArgumentException(
-                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
-                4658297017,
-            );
-        }
+        $this->validateBudgetFields();
     }
 }

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
 /**
  * Options for translation requests.
  *
@@ -30,6 +32,8 @@ class TranslationOptions extends AbstractOptions
         private ?int $maxTokens = null,
         private ?string $provider = null,
         private ?string $model = null,
+        private ?int $beUserUid = null,
+        private ?float $plannedCost = null,
     ) {
         $this->validate();
     }
@@ -187,6 +191,28 @@ class TranslationOptions extends AbstractOptions
         return $clone;
     }
 
+    /**
+     * Set the backend user uid for budget pre-flight (REC #4).
+     */
+    public function withBeUserUid(int $beUserUid): static
+    {
+        $clone = clone $this;
+        $clone->beUserUid = $beUserUid;
+        $clone->validate();
+        return $clone;
+    }
+
+    /**
+     * Set the expected cost of the call for budget pre-flight (REC #4).
+     */
+    public function withPlannedCost(float $plannedCost): static
+    {
+        $clone = clone $this;
+        $clone->plannedCost = $plannedCost;
+        $clone->validate();
+        return $clone;
+    }
+
     // ========================================
     // Getters
     // ========================================
@@ -239,6 +265,16 @@ class TranslationOptions extends AbstractOptions
         return $this->model;
     }
 
+    public function getBeUserUid(): ?int
+    {
+        return $this->beUserUid;
+    }
+
+    public function getPlannedCost(): ?float
+    {
+        return $this->plannedCost;
+    }
+
     // ========================================
     // Array Conversion
     // ========================================
@@ -278,6 +314,20 @@ class TranslationOptions extends AbstractOptions
 
         if ($this->maxTokens !== null) {
             self::validatePositiveInt($this->maxTokens, 'max_tokens');
+        }
+
+        if ($this->beUserUid !== null && $this->beUserUid < 0) {
+            throw new InvalidArgumentException(
+                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
+                7461293504,
+            );
+        }
+
+        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
+            throw new InvalidArgumentException(
+                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
+                4658297017,
+            );
         }
     }
 }

--- a/Classes/Service/Option/VisionOptions.php
+++ b/Classes/Service/Option/VisionOptions.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
 /**
  * Options for vision/image analysis requests.
  *
@@ -24,6 +26,8 @@ class VisionOptions extends AbstractOptions
         private ?float $temperature = null,
         private ?string $provider = null,
         private ?string $model = null,
+        private ?int $beUserUid = null,
+        private ?float $plannedCost = null,
     ) {
         $this->validate();
     }
@@ -122,6 +126,28 @@ class VisionOptions extends AbstractOptions
         return $clone;
     }
 
+    /**
+     * Set the backend user uid for budget pre-flight (REC #4).
+     */
+    public function withBeUserUid(int $beUserUid): static
+    {
+        $clone = clone $this;
+        $clone->beUserUid = $beUserUid;
+        $clone->validate();
+        return $clone;
+    }
+
+    /**
+     * Set the expected cost of the call for budget pre-flight (REC #4).
+     */
+    public function withPlannedCost(float $plannedCost): static
+    {
+        $clone = clone $this;
+        $clone->plannedCost = $plannedCost;
+        $clone->validate();
+        return $clone;
+    }
+
     // ========================================
     // Getters
     // ========================================
@@ -149,6 +175,16 @@ class VisionOptions extends AbstractOptions
     public function getModel(): ?string
     {
         return $this->model;
+    }
+
+    public function getBeUserUid(): ?int
+    {
+        return $this->beUserUid;
+    }
+
+    public function getPlannedCost(): ?float
+    {
+        return $this->plannedCost;
     }
 
     // ========================================
@@ -182,6 +218,20 @@ class VisionOptions extends AbstractOptions
 
         if ($this->temperature !== null) {
             self::validateRange($this->temperature, 0.0, 2.0, 'temperature');
+        }
+
+        if ($this->beUserUid !== null && $this->beUserUid < 0) {
+            throw new InvalidArgumentException(
+                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
+                7461293503,
+            );
+        }
+
+        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
+            throw new InvalidArgumentException(
+                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
+                4658297016,
+            );
         }
     }
 }

--- a/Classes/Service/Option/VisionOptions.php
+++ b/Classes/Service/Option/VisionOptions.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Option;
 
-use Netresearch\NrLlm\Exception\InvalidArgumentException;
-
 /**
  * Options for vision/image analysis requests.
  *
  * @phpstan-consistent-constructor
  */
-class VisionOptions extends AbstractOptions
+class VisionOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const DETAIL_LEVELS = ['auto', 'low', 'high'];
 
     public function __construct(
@@ -26,9 +26,10 @@ class VisionOptions extends AbstractOptions
         private ?float $temperature = null,
         private ?string $provider = null,
         private ?string $model = null,
-        private ?int $beUserUid = null,
-        private ?float $plannedCost = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
         $this->validate();
     }
 
@@ -126,27 +127,7 @@ class VisionOptions extends AbstractOptions
         return $clone;
     }
 
-    /**
-     * Set the backend user uid for budget pre-flight (REC #4).
-     */
-    public function withBeUserUid(int $beUserUid): static
-    {
-        $clone = clone $this;
-        $clone->beUserUid = $beUserUid;
-        $clone->validate();
-        return $clone;
-    }
-
-    /**
-     * Set the expected cost of the call for budget pre-flight (REC #4).
-     */
-    public function withPlannedCost(float $plannedCost): static
-    {
-        $clone = clone $this;
-        $clone->plannedCost = $plannedCost;
-        $clone->validate();
-        return $clone;
-    }
+    // Budget pre-flight setters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Getters
@@ -177,15 +158,7 @@ class VisionOptions extends AbstractOptions
         return $this->model;
     }
 
-    public function getBeUserUid(): ?int
-    {
-        return $this->beUserUid;
-    }
-
-    public function getPlannedCost(): ?float
-    {
-        return $this->plannedCost;
-    }
+    // Budget pre-flight getters provided by `BudgetFieldsTrait`.
 
     // ========================================
     // Array Conversion
@@ -220,18 +193,6 @@ class VisionOptions extends AbstractOptions
             self::validateRange($this->temperature, 0.0, 2.0, 'temperature');
         }
 
-        if ($this->beUserUid !== null && $this->beUserUid < 0) {
-            throw new InvalidArgumentException(
-                sprintf('be_user_uid must be >= 0, got %d', $this->beUserUid),
-                7461293503,
-            );
-        }
-
-        if ($this->plannedCost !== null && $this->plannedCost < 0.0) {
-            throw new InvalidArgumentException(
-                sprintf('planned_cost must be >= 0.0, got %s', $this->plannedCost),
-                4658297016,
-            );
-        }
+        $this->validateBudgetFields();
     }
 }

--- a/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
@@ -12,8 +12,10 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -181,6 +183,80 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
         $result = $this->subject->embedBatch([]);
 
         self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function embedFullAutoPopulatesBeUserUidFromResolver(): void
+    {
+        // REC #4 slice 15b: identical wiring to slice 15a's
+        // CompletionService — the resolver fills `beUserUid` only
+        // when the caller did not set one.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new EmbeddingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('embed')
+            ->with(
+                'hello',
+                self::callback(static fn(EmbeddingOptions $options): bool
+                    => $options->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockEmbeddingResponse([[0.1, 0.2]]));
+
+        $subject->embedFull('hello');
+    }
+
+    #[Test]
+    public function embedFullRespectsExplicitBeUserUidOverResolver(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::never())
+            ->method('resolveBeUserUid');
+
+        $subject = new EmbeddingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('embed')
+            ->with(
+                'hello',
+                self::callback(static fn(EmbeddingOptions $options): bool
+                    => $options->getBeUserUid() === 99),
+            )
+            ->willReturn($this->createMockEmbeddingResponse([[0.1]]));
+
+        $subject->embedFull('hello', (new EmbeddingOptions())->withBeUserUid(99));
+    }
+
+    #[Test]
+    public function embedBatchAutoPopulatesBeUserUidFromResolver(): void
+    {
+        // The batch path takes its own option-construction route
+        // (`?? new EmbeddingOptions()`); explicit coverage so the
+        // resolver hook is not silently bypassed for batch callers.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(7);
+
+        $subject = new EmbeddingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('embed')
+            ->with(
+                ['a', 'b'],
+                self::callback(static fn(EmbeddingOptions $options): bool
+                    => $options->getBeUserUid() === 7),
+            )
+            ->willReturn($this->createMockEmbeddingResponse([[0.1], [0.2]]));
+
+        $subject->embedBatch(['a', 'b']);
     }
 
     /**

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -14,9 +14,11 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\TranslationService;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorRegistryInterface;
@@ -1047,5 +1049,127 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $reflection = new ReflectionClass($this->subject);
         $method = $reflection->getMethod('validateOptions');
         $method->invoke($this->subject, ['glossary' => 'not-an-array']);
+    }
+
+    // ==================== budget pre-flight tests (REC #4 slice 15b) ====================
+
+    #[Test]
+    public function translateForwardsResolvedBeUserUidOnInternalChatOptions(): void
+    {
+        // The LLM-based translation path internally builds a ChatOptions
+        // for the manager. The resolver-supplied uid must reach the
+        // internal options so BudgetMiddleware sees it.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::atLeastOnce())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $llmManagerMock->expects(self::atLeastOnce())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $opts): bool
+                    => $opts->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createChatResponse('Hallo Welt'));
+
+        $subject->translate('Hello World', 'de', 'en');
+    }
+
+    #[Test]
+    public function translateRespectsExplicitBeUserUidOverResolver(): void
+    {
+        // Caller-supplied uid wins; resolver must NOT be called.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::never())
+            ->method('resolveBeUserUid');
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $llmManagerMock->expects(self::atLeastOnce())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $opts): bool
+                    => $opts->getBeUserUid() === 99
+                    && $opts->getPlannedCost() === 0.05),
+            )
+            ->willReturn($this->createChatResponse('Hallo Welt'));
+
+        $opts = (new TranslationOptions())
+            ->withBeUserUid(99)
+            ->withPlannedCost(0.05);
+
+        $subject->translate('Hello', 'de', 'en', $opts);
+    }
+
+    #[Test]
+    public function detectLanguageForwardsBudgetFieldsToInternalChatOptions(): void
+    {
+        // Coverage for the second internal ChatOptions construction
+        // site (language detection).
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->method('resolveBeUserUid')->willReturn(7);
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $opts): bool
+                    => $opts->getBeUserUid() === 7),
+            )
+            ->willReturn($this->createChatResponse('en'));
+
+        $subject->detectLanguage('hello world');
+    }
+
+    #[Test]
+    public function scoreTranslationQualityForwardsBudgetFieldsToInternalChatOptions(): void
+    {
+        // Coverage for the third internal ChatOptions construction
+        // site (quality scoring).
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->method('resolveBeUserUid')->willReturn(11);
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $opts): bool
+                    => $opts->getBeUserUid() === 11),
+            )
+            ->willReturn($this->createChatResponse('0.9'));
+
+        $subject->scoreTranslationQuality('Hello', 'Hallo', 'de');
     }
 }

--- a/Tests/Unit/Service/Feature/VisionServiceTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\VisionService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
@@ -226,6 +227,76 @@ class VisionServiceTest extends AbstractUnitTestCase
             ->willReturn($this->createMockVisionResponse('Alt text'));
 
         $subject->generateAltText($imageUrl, new VisionOptions(detailLevel: 'high'));
+    }
+
+    #[Test]
+    public function analyzeImageFullAutoPopulatesBeUserUidFromResolver(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new VisionService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('vision')
+            ->with(
+                self::anything(),
+                self::callback(static fn(VisionOptions $options): bool
+                    => $options->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockVisionResponse('Alt text'));
+
+        $subject->analyzeImageFull('https://example.com/image.jpg', 'describe');
+    }
+
+    #[Test]
+    public function analyzeImageFullPreservesBudgetFieldsThroughDetailLevelRebuild(): void
+    {
+        // Regression test for the same class of bug Gemini caught on
+        // PR #177 (CompletionService stop_sequences). VisionService
+        // also rebuilds VisionOptions to drop `detail_level` after
+        // copying it onto the content payload — the rebuild must
+        // copy `beUserUid` and `plannedCost` across, otherwise
+        // BudgetMiddleware sees no metadata.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $subject = new VisionService($llmManagerMock);
+
+        $llmManagerMock->expects(self::once())
+            ->method('vision')
+            ->with(
+                self::anything(),
+                self::callback(static fn(VisionOptions $options): bool
+                    => $options->getBeUserUid() === 13
+                    && $options->getPlannedCost() === 0.07),
+            )
+            ->willReturn($this->createMockVisionResponse('OK'));
+
+        $options = (new VisionOptions(detailLevel: 'high'))
+            ->withBeUserUid(13)
+            ->withPlannedCost(0.07);
+
+        $subject->analyzeImageFull('https://example.com/i.jpg', 'p', $options);
+    }
+
+    #[Test]
+    public function analyzeImageFullWorksWithoutResolverDependency(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $subject = new VisionService($llmManagerMock);
+
+        $llmManagerMock->expects(self::once())
+            ->method('vision')
+            ->with(
+                self::anything(),
+                self::callback(static fn(VisionOptions $options): bool
+                    => $options->getBeUserUid() === null),
+            )
+            ->willReturn($this->createMockVisionResponse('OK'));
+
+        $subject->analyzeImageFull('https://example.com/i.jpg', 'p');
     }
 
     /**

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -40,6 +40,7 @@ use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -985,6 +986,73 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $metadata = $spy->calls[0]['metadata'];
         self::assertSame(21, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
         self::assertSame(0.05, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
+    }
+
+    #[Test]
+    public function embedPlumbsBudgetMetadataFromOptions(): void
+    {
+        // REC #4 slice 15b — same wiring as chat()/complete() but
+        // through the embed() entry point, which already maintained
+        // its own metadata array (cache keys). Budget keys must
+        // coexist with cache keys without overwriting them.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new EmbeddingOptions(cacheTtl: 0))
+            ->withBeUserUid(7)
+            ->withPlannedCost(0.42);
+
+        $manager->embed('hello', $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(7, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.42, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
+    }
+
+    #[Test]
+    public function embedKeepsBudgetAndCacheMetadataTogether(): void
+    {
+        // Budget metadata must not collide with cache metadata in the
+        // embed() pipeline — both must reach the middleware so
+        // BudgetMiddleware AND CacheMiddleware can both do their job.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new EmbeddingOptions())
+            ->withBeUserUid(11)
+            ->withPlannedCost(0.05);
+
+        $manager->embed('hello', $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(11, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.05, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
+        self::assertArrayHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
+        self::assertArrayHasKey(CacheMiddleware::METADATA_CACHE_TTL, $metadata);
+    }
+
+    #[Test]
+    public function visionPlumbsBudgetMetadataFromOptions(): void
+    {
+        $spy      = new RecordingMiddleware();
+        $provider = new TestableVisionProvider();
+        $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
+
+        $options = (new VisionOptions())
+            ->withBeUserUid(21)
+            ->withPlannedCost(0.10);
+
+        $manager->vision(
+            [['type' => 'image_url', 'image_url' => ['url' => 'https://example.test/i.png']]],
+            $options,
+        );
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame(21, $metadata[BudgetMiddleware::METADATA_BE_USER_UID]);
+        self::assertSame(0.10, $metadata[BudgetMiddleware::METADATA_PLANNED_COST]);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
+++ b/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
@@ -211,4 +211,68 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
         self::assertEquals('openai', $options->getProvider());
         self::assertEquals(86400, $options->getCacheTtl());
     }
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new EmbeddingOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        new EmbeddingOptions(beUserUid: -1);
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        new EmbeddingOptions(plannedCost: -0.5);
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneAndValidates(): void
+    {
+        $original = new EmbeddingOptions();
+        $modified = $original->withBeUserUid(11);
+
+        self::assertNull($original->getBeUserUid());
+        self::assertSame(11, $modified->getBeUserUid());
+
+        $this->expectException(InvalidArgumentException::class);
+        $original->withBeUserUid(-1);
+    }
+
+    #[Test]
+    public function withPlannedCostReturnsCloneAndValidates(): void
+    {
+        $original = new EmbeddingOptions();
+        $modified = $original->withPlannedCost(0.05);
+
+        self::assertNull($original->getPlannedCost());
+        self::assertSame(0.05, $modified->getPlannedCost());
+
+        $this->expectException(InvalidArgumentException::class);
+        $original->withPlannedCost(-0.01);
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        $options = new EmbeddingOptions(beUserUid: 7, plannedCost: 0.5);
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('be_user_uid', $array);
+        self::assertArrayNotHasKey('planned_cost', $array);
+    }
 }

--- a/Tests/Unit/Service/Option/TranslationOptionsTest.php
+++ b/Tests/Unit/Service/Option/TranslationOptionsTest.php
@@ -425,4 +425,62 @@ class TranslationOptionsTest extends AbstractUnitTestCase
         self::assertEquals('openai', $options->getProvider());
         self::assertEquals('gpt-4o', $options->getModel());
     }
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new TranslationOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        new TranslationOptions(beUserUid: -1);
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        new TranslationOptions(plannedCost: -1.5);
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneAndValidates(): void
+    {
+        $modified = (new TranslationOptions())->withBeUserUid(13);
+
+        self::assertSame(13, $modified->getBeUserUid());
+
+        $this->expectException(InvalidArgumentException::class);
+        (new TranslationOptions())->withBeUserUid(-1);
+    }
+
+    #[Test]
+    public function withPlannedCostReturnsCloneAndValidates(): void
+    {
+        $modified = (new TranslationOptions())->withPlannedCost(0.05);
+
+        self::assertSame(0.05, $modified->getPlannedCost());
+
+        $this->expectException(InvalidArgumentException::class);
+        (new TranslationOptions())->withPlannedCost(-0.01);
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        $array = (new TranslationOptions(beUserUid: 7, plannedCost: 0.5))->toArray();
+
+        self::assertArrayNotHasKey('be_user_uid', $array);
+        self::assertArrayNotHasKey('planned_cost', $array);
+    }
 }

--- a/Tests/Unit/Service/Option/VisionOptionsTest.php
+++ b/Tests/Unit/Service/Option/VisionOptionsTest.php
@@ -276,4 +276,62 @@ class VisionOptionsTest extends AbstractUnitTestCase
         self::assertEquals('openai', $options->getProvider());
         self::assertEquals('gpt-4-vision', $options->getModel());
     }
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new VisionOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        new VisionOptions(beUserUid: -2);
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        new VisionOptions(plannedCost: -0.5);
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneAndValidates(): void
+    {
+        $modified = (new VisionOptions())->withBeUserUid(11);
+
+        self::assertSame(11, $modified->getBeUserUid());
+
+        $this->expectException(InvalidArgumentException::class);
+        (new VisionOptions())->withBeUserUid(-1);
+    }
+
+    #[Test]
+    public function withPlannedCostReturnsCloneAndValidates(): void
+    {
+        $modified = (new VisionOptions())->withPlannedCost(0.05);
+
+        self::assertSame(0.05, $modified->getPlannedCost());
+
+        $this->expectException(InvalidArgumentException::class);
+        (new VisionOptions())->withPlannedCost(-0.01);
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        $array = (new VisionOptions(beUserUid: 7, plannedCost: 0.5))->toArray();
+
+        self::assertArrayNotHasKey('be_user_uid', $array);
+        self::assertArrayNotHasKey('planned_cost', $array);
+    }
 }


### PR DESCRIPTION
## Summary

Closes **REC #4** of the architecture audit (`claudedocs/audit-2026-04-23-architecture.md`, gitignored). Extends the auto-budget pre-flight wiring established in slice 15a (`CompletionService`, PR #177) to the remaining three feature services.

## What changed

- **Option types:** `EmbeddingOptions`, `VisionOptions`, `TranslationOptions` gain typed `beUserUid` + `plannedCost` fields (mirrors `ChatOptions` slice 15a). All validate negative values; all kept out of `toArray()` (pipeline metadata, never provider wire payload).
- **Manager:** `LlmServiceManager::buildBudgetMetadata()` refactored to take raw nullable values, callable from every entry point. `chat()` / `complete()` / `chatWithTools()` / `embed()` / `vision()` all plumb metadata onto the `ProviderCallContext`. For `embed()` the budget keys merge with the existing cache keys.
- **Feature services:** `EmbeddingService` and `VisionService` inject `BackendUserContextResolverInterface` (optional null default — same pattern as slice 15a) and auto-populate `beUserUid`. `TranslationService` forwards the fields onto every internally-built `ChatOptions` (3 construction sites).

## Recurring-pattern note

`VisionService::analyzeImageFull()` rebuilds `VisionOptions` to drop `detail_level` after copying it onto the content payload — same class of bug Gemini caught on PR #177's stop_sequences rebuild in `CompletionService`. The rebuild now copies `beUserUid` / `plannedCost` across; an explicit comment documents the pattern so future fields don't get silently dropped.

## Specialized translators (out of scope)

`TranslationService::translateWithTranslator()` bypasses `LlmServiceManager` (DeepL et al. talk to their own APIs). Those calls are NOT subject to `BudgetMiddleware` in this slice; routing them through a similar pre-flight is a follow-up concern.

## Tests

- `EmbeddingServiceTest` — auto-populate, explicit uid wins, `embedBatch` path covered.
- `VisionServiceTest` — auto-populate, **regression test** for the detail-level rebuild preserving budget fields, no-resolver path.
- `TranslationServiceTest` — `translate` forwards resolved uid, `translate` respects explicit uid (resolver never called), `detectLanguage` and `scoreTranslationQuality` cover the other two `ChatOptions` construction sites.
- `LlmServiceManagerTest` — `embed`/`vision` metadata plumbing + `embedKeepsBudgetAndCacheMetadataTogether` guard for the merge with cache keys.
- `EmbeddingOptionsTest` / `VisionOptionsTest` / `TranslationOptionsTest` — 6 cases each (accept/reject/fluent-setter/omitted-from-toArray).

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3293 tests / 7158 assertions** all green (was 3262 → +31)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR (PHP 8.2–8.5 × TYPO3 13.4 / 14.0)
- [ ] Bot review threads addressed