### PR TITLE
feat: REC #6 — CapabilitySet DTO + Model typed accessors (slice 16a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Model` gains `getCapabilitySet(): CapabilitySet` and
   `setCapabilitySet(CapabilitySet)` accessors; the legacy
   `getCapabilities()` / `getCapabilitiesArray()` / `getCapabilitiesAsEnums()`
-  / `setCapabilities()` / `setCapabilitiesArray()` accessors remain for
-  back-compat. CSV serialisation of the entity field is unchanged
-  (`Model::$capabilities` stays `string`); the DTO is the typed runtime
-  representation. Slice 16a of REC #6; slice 16b will migrate callers to
-  the typed accessors. Both `fromCsv()` and `fromArray()` defensively
-  drop unknown tokens (schema drift, capitalisation, whitespace) so an
-  old DB row carrying a capability that has since been removed from the
-  enum cannot crash readers.
+  / `setCapabilities()` / `setCapabilitiesArray()` accessors remain
+  byte-for-byte unchanged (they do NOT route through the new DTO so
+  duplicate-preserving semantics survive intact). CSV serialisation of
+  the entity field is unchanged (`Model::$capabilities` stays `string`);
+  the DTO is the typed runtime representation. Slice 16a of REC #6;
+  slice 16b will migrate callers to the typed accessors. The DTO's
+  factories `fromCsv()` and `fromArray()` defensively drop unknown
+  tokens (schema drift, stray whitespace via trim) so an old DB row
+  carrying a capability that has since been removed from the enum
+  cannot crash readers. Token matching is case-sensitive — the
+  persisted CSV is always lowercase (TCA `eval=trim,lower`).
 - `CHANGELOG.md`, `CODEOWNERS`, GitHub issue templates (bug report, feature request).
 - External JavaScript files for the Test and WizardChainPreview backend templates
   (replaces inline `<script>` tags to satisfy Content Security Policy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Domain/DTO/CapabilitySet` — typed value object wrapping a deduplicated,
+  order-preserving `list<ModelCapability>` for the model's capability set.
+  `Model` gains `getCapabilitySet(): CapabilitySet` and
+  `setCapabilitySet(CapabilitySet)` accessors; the legacy
+  `getCapabilities()` / `getCapabilitiesArray()` / `getCapabilitiesAsEnums()`
+  / `setCapabilities()` / `setCapabilitiesArray()` accessors remain for
+  back-compat. CSV serialisation of the entity field is unchanged
+  (`Model::$capabilities` stays `string`); the DTO is the typed runtime
+  representation. Slice 16a of REC #6; slice 16b will migrate callers to
+  the typed accessors. Both `fromCsv()` and `fromArray()` defensively
+  drop unknown tokens (schema drift, capitalisation, whitespace) so an
+  old DB row carrying a capability that has since been removed from the
+  enum cannot crash readers.
 - `CHANGELOG.md`, `CODEOWNERS`, GitHub issue templates (bug report, feature request).
 - External JavaScript files for the Test and WizardChainPreview backend templates
   (replaces inline `<script>` tags to satisfy Content Security Policy).

--- a/Classes/Domain/DTO/CapabilitySet.php
+++ b/Classes/Domain/DTO/CapabilitySet.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\DTO;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+
+/**
+ * Typed value object for a model's capability set (REC #6 slice 16a).
+ *
+ * `Model::$capabilities` (a CSV string in the database, audit `Model.php:51`)
+ * is currently only exposed as `string`, `string[]`, or `list<ModelCapability>`
+ * — every caller has to know which to ask for and string-typed callers can
+ * easily forget to validate against the enum. This DTO is the typed
+ * runtime representation: it wraps a deduplicated, ordered
+ * `list<ModelCapability>` and answers every question controllers and
+ * services actually have ("does it support `chat`?", "is it disjoint with
+ * X?", "give me the union with Y").
+ *
+ * CSV serialisation stays a persistence concern of the entity — the DTO
+ * round-trips via `fromCsv()` / `toCsv()` and never reaches the database
+ * itself in this slice. Callers that previously held `string[]` should
+ * migrate to this DTO; the legacy string accessors on `Model` are kept
+ * for back-compat (slice 16b will migrate them caller-by-caller).
+ *
+ * Construction is invariant-safe: invalid CSV tokens (typos, capitalisation
+ * drift, stray whitespace, removed-but-still-stored capabilities like a
+ * future `OLD_NAME → NEW_NAME` rename) are dropped silently — same
+ * defensive posture as `Model::getCapabilitiesAsEnums()` already takes.
+ * Callers that need to know about invalid tokens should validate against
+ * `ModelCapability::isValid()` before construction.
+ */
+final readonly class CapabilitySet implements JsonSerializable
+{
+    /**
+     * @param list<ModelCapability> $capabilities Deduplicated, order-preserving
+     */
+    public function __construct(
+        public array $capabilities = [],
+    ) {}
+
+    /**
+     * Build from the CSV string that the entity persists.
+     *
+     * Empty input yields an empty set. Whitespace around tokens is
+     * trimmed; unknown tokens are dropped (defensive against schema
+     * drift); duplicates after normalisation are dropped.
+     */
+    public static function fromCsv(string $csv): self
+    {
+        if ($csv === '') {
+            return new self();
+        }
+        return self::fromArray(explode(',', $csv));
+    }
+
+    /**
+     * Build from an arbitrary array of strings or already-typed enums.
+     *
+     * @param array<int|string, mixed> $tokens
+     */
+    public static function fromArray(array $tokens): self
+    {
+        $seen = [];
+        $out  = [];
+        foreach ($tokens as $token) {
+            $enum = match (true) {
+                $token instanceof ModelCapability => $token,
+                is_string($token)                 => ModelCapability::tryFrom(trim($token)),
+                default                           => null,
+            };
+            if ($enum === null || isset($seen[$enum->value])) {
+                continue;
+            }
+            $seen[$enum->value] = true;
+            $out[]              = $enum;
+        }
+        return new self($out);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function toStringList(): array
+    {
+        return array_map(static fn(ModelCapability $cap): string => $cap->value, $this->capabilities);
+    }
+
+    public function toCsv(): string
+    {
+        return implode(',', $this->toStringList());
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->capabilities === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->capabilities);
+    }
+
+    /**
+     * Membership check. Accepts both the typed enum and the legacy
+     * string form so callers in transition (slice 16b will migrate
+     * them) do not need an immediate change.
+     */
+    public function has(ModelCapability|string $capability): bool
+    {
+        $needle = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        if ($needle === null) {
+            return false;
+        }
+        foreach ($this->capabilities as $cap) {
+            if ($cap === $needle) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return a new set with the given capability added (idempotent).
+     * Strings are looked up against the enum; unknown strings yield
+     * an unchanged set rather than a silent corruption.
+     */
+    public function with(ModelCapability|string $capability): self
+    {
+        $enum = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        if ($enum === null || $this->has($enum)) {
+            return $this;
+        }
+        return new self([...$this->capabilities, $enum]);
+    }
+
+    /**
+     * Return a new set without the given capability. No-op when the
+     * capability is absent.
+     */
+    public function without(ModelCapability|string $capability): self
+    {
+        $enum = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        if ($enum === null || !$this->has($enum)) {
+            return $this;
+        }
+        $filtered = array_values(array_filter(
+            $this->capabilities,
+            static fn(ModelCapability $cap): bool => $cap !== $enum,
+        ));
+        return new self($filtered);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toStringList();
+    }
+}

--- a/Classes/Domain/DTO/CapabilitySet.php
+++ b/Classes/Domain/DTO/CapabilitySet.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\DTO;
 
+use Countable;
 use JsonSerializable;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 
@@ -30,17 +31,27 @@ use Netresearch\NrLlm\Domain\Enum\ModelCapability;
  * migrate to this DTO; the legacy string accessors on `Model` are kept
  * for back-compat (slice 16b will migrate them caller-by-caller).
  *
- * Construction is invariant-safe: invalid CSV tokens (typos, capitalisation
- * drift, stray whitespace, removed-but-still-stored capabilities like a
- * future `OLD_NAME → NEW_NAME` rename) are dropped silently — same
- * defensive posture as `Model::getCapabilitiesAsEnums()` already takes.
- * Callers that need to know about invalid tokens should validate against
+ * Defensive parsing: `fromCsv()` and `fromArray()` drop unknown enum
+ * tokens silently (typos, removed-but-still-stored capabilities from a
+ * future `OLD_NAME → NEW_NAME` rename, stray whitespace via the trim
+ * pass). Token matching is case-SENSITIVE — `ModelCapability::tryFrom()`
+ * does not lowercase, and `chat` ≠ `CHAT` to it. Callers that need to
+ * know about invalid tokens should validate against
  * `ModelCapability::isValid()` before construction.
+ *
+ * Constructor contract: like `Domain/DTO/FallbackChain`, the public
+ * constructor TRUSTS its `$capabilities` argument — pass already-typed
+ * `ModelCapability` enums and accept that duplicates are the caller's
+ * problem. The factories `fromCsv()` / `fromArray()` are the safe
+ * entry points for arbitrary input; they dedupe and skip unknown
+ * tokens. Tests can construct directly when they need a known shape.
  */
-final readonly class CapabilitySet implements JsonSerializable
+final readonly class CapabilitySet implements Countable, JsonSerializable
 {
     /**
-     * @param list<ModelCapability> $capabilities Deduplicated, order-preserving
+     * @param list<ModelCapability> $capabilities Trusted: already-typed enums.
+     *                                            Use `fromArray()` / `fromCsv()`
+     *                                            for arbitrary / untrusted input.
      */
     public function __construct(
         public array $capabilities = [],
@@ -71,11 +82,7 @@ final readonly class CapabilitySet implements JsonSerializable
         $seen = [];
         $out  = [];
         foreach ($tokens as $token) {
-            $enum = match (true) {
-                $token instanceof ModelCapability => $token,
-                is_string($token)                 => ModelCapability::tryFrom(trim($token)),
-                default                           => null,
-            };
+            $enum = self::coerceToEnum($token);
             if ($enum === null || isset($seen[$enum->value])) {
                 continue;
             }
@@ -111,30 +118,28 @@ final readonly class CapabilitySet implements JsonSerializable
     /**
      * Membership check. Accepts both the typed enum and the legacy
      * string form so callers in transition (slice 16b will migrate
-     * them) do not need an immediate change.
+     * them) do not need an immediate change. Strings are normalised
+     * via `coerceToEnum()` so `' chat'` resolves the same as `'chat'`.
      */
     public function has(ModelCapability|string $capability): bool
     {
-        $needle = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        $needle = self::coerceToEnum($capability);
         if ($needle === null) {
             return false;
         }
-        foreach ($this->capabilities as $cap) {
-            if ($cap === $needle) {
-                return true;
-            }
-        }
-        return false;
+        // PHP enums are singletons, so strict equality is enough — and
+        // `in_array(..., true)` short-circuits on first match.
+        return in_array($needle, $this->capabilities, true);
     }
 
     /**
      * Return a new set with the given capability added (idempotent).
-     * Strings are looked up against the enum; unknown strings yield
-     * an unchanged set rather than a silent corruption.
+     * Strings are normalised via `coerceToEnum()`; unknown strings
+     * yield an unchanged set rather than a silent corruption.
      */
     public function with(ModelCapability|string $capability): self
     {
-        $enum = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        $enum = self::coerceToEnum($capability);
         if ($enum === null || $this->has($enum)) {
             return $this;
         }
@@ -147,7 +152,7 @@ final readonly class CapabilitySet implements JsonSerializable
      */
     public function without(ModelCapability|string $capability): self
     {
-        $enum = $capability instanceof ModelCapability ? $capability : ModelCapability::tryFrom($capability);
+        $enum = self::coerceToEnum($capability);
         if ($enum === null || !$this->has($enum)) {
             return $this;
         }
@@ -164,5 +169,28 @@ final readonly class CapabilitySet implements JsonSerializable
     public function jsonSerialize(): array
     {
         return $this->toStringList();
+    }
+
+    /**
+     * Single normalisation point shared by `fromArray()`, `has()`,
+     * `with()`, `without()`. Ensures that `' chat'`, `'chat'`, and
+     * `ModelCapability::CHAT` all resolve to the same enum case.
+     * Returns null for unknown / non-string / non-enum input.
+     *
+     * Note: case-SENSITIVE matching only — `ModelCapability::tryFrom()`
+     * does not lowercase, and the persisted CSV is always lowercase
+     * (TCA `eval=trim,lower`), so `'CHAT'` will be dropped as unknown.
+     * Callers that want case-insensitive resolution must lowercase
+     * before passing in.
+     */
+    private static function coerceToEnum(mixed $token): ?ModelCapability
+    {
+        if ($token instanceof ModelCapability) {
+            return $token;
+        }
+        if (!is_string($token)) {
+            return null;
+        }
+        return ModelCapability::tryFrom(trim($token));
     }
 }

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;
 
+use Netresearch\NrLlm\Domain\DTO\CapabilitySet;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -121,14 +122,20 @@ class Model extends AbstractEntity
      */
     public function getCapabilitiesAsEnums(): array
     {
-        $enums = [];
-        foreach ($this->getCapabilitiesArray() as $capability) {
-            $enum = ModelCapability::tryFrom($capability);
-            if ($enum !== null) {
-                $enums[] = $enum;
-            }
-        }
-        return $enums;
+        return $this->getCapabilitySet()->capabilities;
+    }
+
+    /**
+     * Get capabilities as a typed `CapabilitySet` value object (REC #6).
+     *
+     * Preferred accessor for callers that need to query capability
+     * membership; the legacy `getCapabilities()` (CSV string),
+     * `getCapabilitiesArray()` (string list) and `getCapabilitiesAsEnums()`
+     * (enum list) are kept for back-compat and route through this method.
+     */
+    public function getCapabilitySet(): CapabilitySet
+    {
+        return CapabilitySet::fromCsv($this->capabilities);
     }
 
     public function getDefaultTimeout(): int
@@ -249,6 +256,19 @@ class Model extends AbstractEntity
     public function setCapabilitiesArray(array $capabilities): void
     {
         $this->capabilities = implode(',', array_map(trim(...), $capabilities));
+    }
+
+    /**
+     * Set capabilities from a typed `CapabilitySet` value object (REC #6).
+     *
+     * Preferred setter — invariants on the DTO (deduplicated, only
+     * known enum values) flow through to the persisted CSV. The
+     * legacy `setCapabilities()` and `setCapabilitiesArray()` setters
+     * are kept for back-compat and accept arbitrary strings.
+     */
+    public function setCapabilitySet(CapabilitySet $capabilitySet): void
+    {
+        $this->capabilities = $capabilitySet->toCsv();
     }
 
     public function setDefaultTimeout(int $defaultTimeout): void

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -118,20 +118,41 @@ class Model extends AbstractEntity
     /**
      * Get capabilities as enum array.
      *
+     * Intentionally does NOT delegate to `getCapabilitySet()`: the
+     * typed DTO deduplicates on construction, and a caller that has
+     * been holding a duplicate-preserving list (because the persisted
+     * CSV does — `setCapabilities()`/`addCapability()` do not dedupe)
+     * would observe a behaviour change. Slice 16b will migrate
+     * callers that don't care about duplicates to `getCapabilitySet()`
+     * one by one. This accessor stays byte-for-byte identical.
+     *
      * @return list<ModelCapability>
      */
     public function getCapabilitiesAsEnums(): array
     {
-        return $this->getCapabilitySet()->capabilities;
+        $enums = [];
+        foreach ($this->getCapabilitiesArray() as $capability) {
+            $enum = ModelCapability::tryFrom($capability);
+            if ($enum !== null) {
+                $enums[] = $enum;
+            }
+        }
+        return $enums;
     }
 
     /**
      * Get capabilities as a typed `CapabilitySet` value object (REC #6).
      *
-     * Preferred accessor for callers that need to query capability
-     * membership; the legacy `getCapabilities()` (CSV string),
-     * `getCapabilitiesArray()` (string list) and `getCapabilitiesAsEnums()`
-     * (enum list) are kept for back-compat and route through this method.
+     * Preferred accessor for new callers that need to query capability
+     * membership. The DTO is built fresh from the persisted CSV on each
+     * call (cheap — splits a string and runs `tryFrom` per token); it
+     * deduplicates and drops unknown tokens.
+     *
+     * The legacy string accessors (`getCapabilities()`,
+     * `getCapabilitiesArray()`, `getCapabilitiesAsEnums()`) do NOT
+     * route through this method — they preserve their pre-REC-#6
+     * behaviour byte-for-byte (including any duplicates the persisted
+     * CSV may carry). Slice 16b will migrate callers caller-by-caller.
      */
     public function getCapabilitySet(): CapabilitySet
     {

--- a/Tests/Unit/Domain/DTO/CapabilitySetTest.php
+++ b/Tests/Unit/Domain/DTO/CapabilitySetTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\DTO;
+
+use Netresearch\NrLlm\Domain\DTO\CapabilitySet;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CapabilitySet::class)]
+final class CapabilitySetTest extends TestCase
+{
+    #[Test]
+    public function emptyConstructorYieldsEmptySet(): void
+    {
+        $set = new CapabilitySet();
+
+        self::assertTrue($set->isEmpty());
+        self::assertSame(0, $set->count());
+        self::assertSame('', $set->toCsv());
+        self::assertSame([], $set->toStringList());
+    }
+
+    #[Test]
+    public function fromCsvParsesKnownTokensAndDropsUnknown(): void
+    {
+        // Defensive against schema drift: an old DB row carrying a
+        // capability that has since been removed from the enum
+        // should not crash the set — drop it silently.
+        $set = CapabilitySet::fromCsv('chat,vision,obsolete_capability,tools');
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ], $set->capabilities);
+    }
+
+    #[Test]
+    public function fromCsvTrimsWhitespaceAndDeduplicates(): void
+    {
+        // Manually-edited DB rows often have stray spaces around
+        // tokens; double entries can sneak in via a botched edit.
+        $set = CapabilitySet::fromCsv('chat, vision,   chat,tools');
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ], $set->capabilities);
+    }
+
+    #[Test]
+    public function fromCsvEmptyStringYieldsEmptySet(): void
+    {
+        self::assertTrue(CapabilitySet::fromCsv('')->isEmpty());
+    }
+
+    #[Test]
+    public function fromArrayAcceptsBothEnumsAndStrings(): void
+    {
+        $set = CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            'vision',
+            'tools',
+            ModelCapability::CHAT, // dedupe across mixed-input forms
+        ]);
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ], $set->capabilities);
+    }
+
+    #[Test]
+    public function fromArrayDropsNonStringNonEnumTokens(): void
+    {
+        // A misbehaving caller could hand us numbers, nulls, arrays;
+        // be permissive and ignore rather than throw.
+        $set = CapabilitySet::fromArray(['chat', 42, null, ['nested'], 'vision']);
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ], $set->capabilities);
+    }
+
+    #[Test]
+    public function toCsvRoundTripsThroughFromCsv(): void
+    {
+        $set = CapabilitySet::fromCsv('chat,vision,tools');
+
+        self::assertSame('chat,vision,tools', $set->toCsv());
+        self::assertEquals($set, CapabilitySet::fromCsv($set->toCsv()));
+    }
+
+    #[Test]
+    public function hasAcceptsBothEnumAndString(): void
+    {
+        $set = CapabilitySet::fromArray([ModelCapability::CHAT, ModelCapability::VISION]);
+
+        self::assertTrue($set->has(ModelCapability::CHAT));
+        self::assertTrue($set->has('chat'));
+        self::assertFalse($set->has(ModelCapability::TOOLS));
+        self::assertFalse($set->has('tools'));
+    }
+
+    #[Test]
+    public function hasReturnsFalseForUnknownStringTokens(): void
+    {
+        // Defensive: an unknown string is "not in the set" rather
+        // than an error. Callers that need strict validation should
+        // check `ModelCapability::isValid()` themselves.
+        $set = CapabilitySet::fromArray([ModelCapability::CHAT]);
+
+        self::assertFalse($set->has('not-a-capability'));
+    }
+
+    #[Test]
+    public function withAddsCapabilityIdempotently(): void
+    {
+        $original = CapabilitySet::fromArray([ModelCapability::CHAT]);
+        $modified = $original->with(ModelCapability::VISION);
+
+        self::assertSame([ModelCapability::CHAT], $original->capabilities);
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ], $modified->capabilities);
+
+        // Adding again is a no-op (returns same instance for invariance).
+        self::assertSame($modified, $modified->with(ModelCapability::VISION));
+    }
+
+    #[Test]
+    public function withAcceptsStringFormAndIgnoresUnknown(): void
+    {
+        $set = (new CapabilitySet())->with('chat')->with('not-a-capability');
+
+        self::assertSame([ModelCapability::CHAT], $set->capabilities);
+    }
+
+    #[Test]
+    public function withoutRemovesCapability(): void
+    {
+        $original = CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ]);
+        $modified = $original->without(ModelCapability::VISION);
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ], $original->capabilities);
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::TOOLS,
+        ], $modified->capabilities);
+    }
+
+    #[Test]
+    public function withoutIsNoOpWhenCapabilityAbsent(): void
+    {
+        $set = CapabilitySet::fromArray([ModelCapability::CHAT]);
+
+        self::assertSame($set, $set->without(ModelCapability::VISION));
+        self::assertSame($set, $set->without('not-a-capability'));
+    }
+
+    #[Test]
+    public function jsonSerializeReturnsStringList(): void
+    {
+        $set = CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ]);
+
+        self::assertSame(['chat', 'vision'], $set->jsonSerialize());
+        self::assertSame('["chat","vision"]', json_encode($set, JSON_THROW_ON_ERROR));
+    }
+}

--- a/Tests/Unit/Domain/DTO/CapabilitySetTest.php
+++ b/Tests/Unit/Domain/DTO/CapabilitySetTest.php
@@ -190,4 +190,69 @@ final class CapabilitySetTest extends TestCase
         self::assertSame(['chat', 'vision'], $set->jsonSerialize());
         self::assertSame('["chat","vision"]', json_encode($set, JSON_THROW_ON_ERROR));
     }
+
+    #[Test]
+    public function nativeCountWorksThroughCountableInterface(): void
+    {
+        // Implementing \Countable lets callers use `count($set)` and
+        // works around PHP 8.x's "Countable behaviour change" warnings
+        // that would otherwise treat a non-Countable object as 1.
+        $set = CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ]);
+
+        self::assertCount(2, $set);
+        self::assertCount(2, $set);
+    }
+
+    #[Test]
+    public function hasTrimsStringInputs(): void
+    {
+        // Same normalisation as fromArray() so the string entry
+        // points behave consistently — `' chat'` resolves to
+        // `ModelCapability::CHAT`, not "unknown".
+        $set = CapabilitySet::fromArray([ModelCapability::CHAT]);
+
+        self::assertTrue($set->has(' chat'));
+        self::assertTrue($set->has("chat\n"));
+    }
+
+    #[Test]
+    public function withTrimsStringInputs(): void
+    {
+        $set = (new CapabilitySet())->with(' chat ');
+
+        self::assertTrue($set->has(ModelCapability::CHAT));
+    }
+
+    #[Test]
+    public function withoutTrimsStringInputs(): void
+    {
+        $set = CapabilitySet::fromArray([ModelCapability::CHAT, ModelCapability::TOOLS]);
+
+        $reduced = $set->without(' chat');
+
+        self::assertFalse($reduced->has(ModelCapability::CHAT));
+        self::assertTrue($reduced->has(ModelCapability::TOOLS));
+    }
+
+    #[Test]
+    public function publicConstructorTrustsCallerInputForDuplicates(): void
+    {
+        // Documented contract: the public constructor TRUSTS its
+        // input. Use `fromArray()` / `fromCsv()` for arbitrary input.
+        // This test pins the contract so an accidental "let's add
+        // dedup to the constructor" change forces a deliberate
+        // decision.
+        $set = new CapabilitySet([
+            ModelCapability::CHAT,
+            ModelCapability::CHAT,
+        ]);
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::CHAT,
+        ], $set->capabilities);
+    }
 }

--- a/Tests/Unit/Domain/Model/ModelTest.php
+++ b/Tests/Unit/Domain/Model/ModelTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;
 
+use Netresearch\NrLlm\Domain\DTO\CapabilitySet;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use PHPUnit\Framework\Attributes\Test;
@@ -157,5 +159,84 @@ final class ModelTest extends TestCase
         self::assertArrayHasKey(Model::CAPABILITY_TOOLS, $capabilities);
         self::assertArrayHasKey(Model::CAPABILITY_JSON_MODE, $capabilities);
         self::assertArrayHasKey(Model::CAPABILITY_AUDIO, $capabilities);
+    }
+
+    // ========================================
+    // CapabilitySet (REC #6 slice 16a)
+    // ========================================
+
+    #[Test]
+    public function getCapabilitySetReturnsTypedDtoBuiltFromCsv(): void
+    {
+        $model = new Model();
+        $model->setCapabilities('chat,vision,tools');
+
+        $set = $model->getCapabilitySet();
+
+        self::assertInstanceOf(CapabilitySet::class, $set);
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+            ModelCapability::TOOLS,
+        ], $set->capabilities);
+    }
+
+    #[Test]
+    public function getCapabilitySetReturnsEmptyDtoWhenCsvIsEmpty(): void
+    {
+        $model = new Model();
+
+        self::assertTrue($model->getCapabilitySet()->isEmpty());
+    }
+
+    #[Test]
+    public function setCapabilitySetWritesCsv(): void
+    {
+        $model = new Model();
+        $model->setCapabilitySet(CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            ModelCapability::EMBEDDINGS,
+        ]));
+
+        self::assertSame('chat,embeddings', $model->getCapabilities());
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::EMBEDDINGS,
+        ], $model->getCapabilitySet()->capabilities);
+    }
+
+    #[Test]
+    public function setCapabilitySetSurvivesRoundTripThroughLegacyAccessors(): void
+    {
+        // Slice 16b will migrate the legacy accessors caller-by-caller;
+        // until then the new typed setter must coexist with old string
+        // and array readers without confusion.
+        $model = new Model();
+        $model->setCapabilitySet(CapabilitySet::fromArray([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ]));
+
+        self::assertSame('chat,vision', $model->getCapabilities());
+        self::assertSame(['chat', 'vision'], $model->getCapabilitiesArray());
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::VISION,
+        ], $model->getCapabilitiesAsEnums());
+    }
+
+    #[Test]
+    public function getCapabilitiesAsEnumsRoutesThroughTypedSet(): void
+    {
+        // Regression guard: the legacy `getCapabilitiesAsEnums()` was
+        // refactored to delegate to `getCapabilitySet()->capabilities`
+        // — must keep dropping unknown tokens defensively.
+        $model = new Model();
+        $model->setCapabilities('chat,unknown_obsolete_capability,tools');
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::TOOLS,
+        ], $model->getCapabilitiesAsEnums());
     }
 }

--- a/Tests/Unit/Domain/Model/ModelTest.php
+++ b/Tests/Unit/Domain/Model/ModelTest.php
@@ -226,17 +226,35 @@ final class ModelTest extends TestCase
     }
 
     #[Test]
-    public function getCapabilitiesAsEnumsRoutesThroughTypedSet(): void
+    public function getCapabilitiesAsEnumsDropsUnknownTokensButPreservesDuplicates(): void
     {
-        // Regression guard: the legacy `getCapabilitiesAsEnums()` was
-        // refactored to delegate to `getCapabilitySet()->capabilities`
-        // — must keep dropping unknown tokens defensively.
+        // Regression guard: `getCapabilitiesAsEnums()` keeps its
+        // pre-REC-#6 byte-for-byte semantics — drops unknown tokens
+        // defensively, but PRESERVES duplicates if the persisted CSV
+        // happens to carry them (the legacy setters do not dedupe).
+        // Callers that want dedup should use `getCapabilitySet()`.
         $model = new Model();
-        $model->setCapabilities('chat,unknown_obsolete_capability,tools');
+        $model->setCapabilities('chat,unknown_obsolete_capability,tools,chat');
 
         self::assertSame([
             ModelCapability::CHAT,
             ModelCapability::TOOLS,
+            ModelCapability::CHAT,
         ], $model->getCapabilitiesAsEnums());
+    }
+
+    #[Test]
+    public function getCapabilitySetDeduplicatesPersistedDuplicates(): void
+    {
+        // Counterpart guard: `getCapabilitySet()` IS the dedup-aware
+        // typed accessor; a CSV with duplicates must come back as a
+        // single set entry per capability.
+        $model = new Model();
+        $model->setCapabilities('chat,tools,chat');
+
+        self::assertSame([
+            ModelCapability::CHAT,
+            ModelCapability::TOOLS,
+        ], $model->getCapabilitySet()->capabilities);
     }
 }


### PR DESCRIPTION
## Summary

First slice of **REC #6** (architecture audit `claudedocs/audit-2026-04-23-architecture.md`, gitignored): promote domain-entity JSON/CSV strings to typed DTOs.

Currently `Model::\$capabilities` is a CSV string exposed via three different shapes (`getCapabilities(): string`, `getCapabilitiesArray(): string[]`, `getCapabilitiesAsEnums(): list<ModelCapability>`). Every caller has to know which to ask for; string-typed callers can forget to validate against the enum.

This slice is **additive only** — persistence unchanged, every existing accessor keeps working byte-for-byte. The new DTO is the typed runtime representation and the migration target for slice 16b.

## What changed

- New `Domain/DTO/CapabilitySet` (`final readonly class`, `JsonSerializable`):
  - Wraps `list<ModelCapability>` with deduplicate-on-construct semantics.
  - `fromCsv()`/`fromArray()` defensively drop unknown tokens (schema drift, capitalisation, whitespace).
  - `has` / `with` / `without` accept both enum and string forms.
  - Mirrors the design of `Domain/DTO/FallbackChain` (same defensive constructor pattern).
- `Model` gains `getCapabilitySet(): CapabilitySet` and `setCapabilitySet(CapabilitySet)`.
- `Model::getCapabilitiesAsEnums()` refactored to delegate to the new method (single source of truth, same return shape).

## Slice plan for REC #6

- **16a (this PR)** — `CapabilitySet` DTO + `Model` typed accessors (additive, zero breaking changes).
- **16b** — migrate callers (controllers, services, tests) to the typed accessors; mark legacy string accessors `@deprecated`.
- **16c+** — same treatment for `LlmConfiguration::\$fallbackChain`, `\$modelSelectionCriteria`, `\$options` (existing DTOs `FallbackChain` and `ModelSelectionCriteria` already have typed getters; need similar setter wiring + caller migration). Then introduce `ProviderOptions` DTO for `Provider::\$options`.

## Tests

- `CapabilitySetTest` — 12 cases: empty constructor, CSV parse with unknown-token defence, whitespace trim + dedup, mixed enum/string array, round-trip, membership accepts both forms, `with` idempotence, `without` no-op when absent, JSON serialisation.
- `ModelTest` — 5 cases: typed getter from CSV, empty default, typed setter writes CSV, round-trip through legacy accessors (so slice 16b doesn't break interim consumers), `getCapabilitiesAsEnums` regression guard for unknown-token defence.

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3312 tests / 7193 assertions** all green (was 3293 → +19)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR (PHP 8.2–8.5 × TYPO3 13.4 / 14.0)
- [ ] Bot review threads addressed