### PR TITLE
refactor: REC #6 — typed ModelSelectionCriteria accessors + deprecate legacy string API (slice 16d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecated
 
+- `LlmConfiguration::getModelSelectionCriteria(): string` and
+  `setModelSelectionCriteria(string)` are deprecated since 0.8.0 in
+  favour of the typed `getModelSelectionCriteriaDTO(): ModelSelectionCriteria` /
+  `setModelSelectionCriteriaDTO(ModelSelectionCriteria)` accessors
+  (the typed `ModelSelectionCriteria` DTO has lived in
+  `Classes/Domain/DTO/` for a while and is the documented
+  application-level surface). The legacy methods remain for Extbase
+  property mapping (the framework hydrates the entity through this
+  getter / setter pair) and will not be removed before a major
+  version bump. Production callers that consume the array shape
+  (`ModelSelectionService::executeForConfiguration()` via
+  `getModelSelectionCriteriaArray()`) are NOT migrated in this slice
+  — `findMatchingModel(array $criteria)` keeps its array signature
+  for now; a future slice can adopt the typed DTO end-to-end. REC #6
+  slice 16d.
 - `LlmConfiguration::getFallbackChain(): string` and
   `setFallbackChain(string)` are deprecated since 0.8.0 in favour of
   the typed `getFallbackChainDTO(): FallbackChain` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   property mapping (the framework hydrates the entity through this
   getter / setter pair) and will not be removed before a major
   version bump. Production callers that consume the array shape
-  (`ModelSelectionService::executeForConfiguration()` via
+  (`ModelSelectionService::resolveModel()` via
   `getModelSelectionCriteriaArray()`) are NOT migrated in this slice
   — `findMatchingModel(array $criteria)` keeps its array signature
   for now; a future slice can adopt the typed DTO end-to-end. REC #6

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -131,6 +131,15 @@ class LlmConfiguration extends AbstractEntity
         return ModelSelectionMode::tryFrom($this->modelSelectionMode);
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `getModelSelectionCriteriaDTO()` (returns a
+     *             `ModelSelectionCriteria` value object). The raw-JSON
+     *             accessor is retained for Extbase property mapping (the
+     *             framework hydrates the entity through this getter /
+     *             setter pair) and will not be removed before a major
+     *             version bump.
+     */
     public function getModelSelectionCriteria(): string
     {
         return $this->modelSelectionCriteria;
@@ -398,6 +407,14 @@ class LlmConfiguration extends AbstractEntity
         $this->modelSelectionMode = $modelSelectionMode;
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `setModelSelectionCriteriaDTO()` so the persisted JSON
+     *             is produced by the DTO's own serialiser rather than
+     *             passed in as an arbitrary string. The raw-JSON setter
+     *             is retained for Extbase property mapping and will not
+     *             be removed before a major version bump.
+     */
     public function setModelSelectionCriteria(string $modelSelectionCriteria): void
     {
         $this->modelSelectionCriteria = $modelSelectionCriteria;


### PR DESCRIPTION
## Summary

Fourth slice of **REC #6**. Mirror of slice 16c (#181) for the second JSON-string field on `LlmConfiguration`. Mark the raw-JSON `getModelSelectionCriteria(): string` / `setModelSelectionCriteria(string)` accessors `@deprecated since 0.8.0` in favour of the typed `getModelSelectionCriteriaDTO()` / `setModelSelectionCriteriaDTO()` pair.

## Why so small

Project-wide grep:
```
grep -rn "getModelSelectionCriteria()\|setModelSelectionCriteria("
```

Zero production callers of the raw-string accessors. The only callers in the entire codebase are inside `LlmConfiguration` itself (unchanged) and one unit test asserting the legacy string surface explicitly (`LlmConfigurationTest:425` — left untouched per slice 16b convention).

## What's intentionally not migrated

Production callers DO use the *array* shape (`getModelSelectionCriteriaArray()` / `setModelSelectionCriteriaArray()`) — `ModelSelectionService::executeForConfiguration()` reads the array and forwards it into `findMatchingModel(array $criteria)`. Migrating that path to the typed DTO end-to-end requires changing `findMatchingModel`'s signature, which is a separate concern. Out of scope for this slice; the CHANGELOG calls it out as a future slice.

## What changed

- `LlmConfiguration::getModelSelectionCriteria(): string` — `@deprecated since 0.8.0` with redirect to `getModelSelectionCriteriaDTO()`. Docblock matches slice 16c style (generic class reference, no method enumeration, no private-method leakage).
- `LlmConfiguration::setModelSelectionCriteria(string)` — `@deprecated since 0.8.0` with redirect to `setModelSelectionCriteriaDTO(ModelSelectionCriteria)`.

## REC #6 slice progress

- [x] **16a (#179)** — `CapabilitySet` DTO + `Model` typed accessors.
- [x] **16b (#180)** — `Model` caller migration + 8 deprecation markers.
- [x] **16c (#181)** — `LlmConfiguration::fallbackChain` deprecation.
- [x] **16d (this PR)** — `LlmConfiguration::modelSelectionCriteria` deprecation.
- [ ] **16e** — `LlmConfiguration::options` deprecation. There's no typed DTO yet — slice will introduce one (`ConfigurationOptions` or similar) before deprecating the raw-string accessors.
- [ ] **16f** — new `ProviderOptions` typed DTO for `Provider::\$options` (currently raw string with no decoder).

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3320 tests / 7205 assertions** all green (unchanged — docs-only commit)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR
- [ ] Bot review threads addressed