### PR TITLE
refactor: REC #6 — deprecate LlmConfiguration string options API (slice 16e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecated
 
+- `LlmConfiguration::getOptions(): string` and `setOptions(string)` are
+  deprecated since 0.8.0 in favour of the typed
+  `getOptionsArray(): array<string, mixed>` /
+  `setOptionsArray(array<string, mixed>)` accessors. The `options`
+  field carries provider-specific extras beyond the typed entity
+  columns (`temperature`, `maxTokens`, `topP`, `frequencyPenalty`,
+  `presencePenalty`, `systemPrompt`, …) — its shape is open-ended by
+  design and varies per provider, so REC #6 stops at the array-typed
+  surface rather than introducing a typed DTO that would impose
+  false structure. The legacy raw-JSON methods remain for Extbase
+  property mapping (the framework hydrates the entity through this
+  getter / setter pair) and will not be removed before a major
+  version bump. REC #6 slice 16e.
 - `LlmConfiguration::getModelSelectionCriteria(): string` and
   `setModelSelectionCriteria(string)` are deprecated since 0.8.0 in
   favour of the typed `getModelSelectionCriteriaDTO(): ModelSelectionCriteria` /

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -261,6 +261,21 @@ class LlmConfiguration extends AbstractEntity
         return self::DEFAULT_TIMEOUT;
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `getOptionsArray()` (returns `array<string, mixed>`).
+     *             The `options` field carries provider-specific extras
+     *             beyond the typed entity columns
+     *             (`temperature` / `maxTokens` / `topP` / etc.) — its
+     *             shape is open-ended by design and varies per
+     *             provider, so REC #6 stops at the array-typed
+     *             surface rather than introducing a typed DTO that
+     *             would impose false structure. The raw-JSON accessor
+     *             is retained for Extbase property mapping (the
+     *             framework hydrates the entity through this getter /
+     *             setter pair) and will not be removed before a major
+     *             version bump.
+     */
     public function getOptions(): string
     {
         return $this->options;
@@ -478,6 +493,14 @@ class LlmConfiguration extends AbstractEntity
         $this->timeout = max(0, $timeout);
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `setOptionsArray(array<string, mixed>)` so the
+     *             persisted JSON is produced by `json_encode()` rather
+     *             than passed in as an arbitrary string. The raw-JSON
+     *             setter is retained for Extbase property mapping and
+     *             will not be removed before a major version bump.
+     */
     public function setOptions(string $options): void
     {
         $this->options = $options;


### PR DESCRIPTION
## Summary

Fifth slice of **REC #6**. Deprecate the raw-JSON `LlmConfiguration::getOptions(): string` / `setOptions(string)` accessors in favour of the typed `getOptionsArray()` / `setOptionsArray()` pair.

## Design decision (Option B from the slice plan)

**No typed DTO for this field.** Unlike `fallbackChain` / `modelSelectionCriteria` which have well-known shapes, the `options` field carries provider-specific extras beyond the typed entity columns (`temperature`, `maxTokens`, `topP`, `frequencyPenalty`, `presencePenalty`, `systemPrompt`, …). Its shape is open-ended by design and varies per provider — defining a `ConfigurationOptions` DTO would either:

- force every key to be optional `mixed` (no real typing benefit), or
- impose false structure that would reject legitimate provider-specific keys.

The existing `array<string, mixed>` surface IS the application-level type and it's correct for an open extension bucket.

## Why so small

Project-wide grep confirms zero production callers of the raw-string variants. All production code already uses `getOptionsArray()` / `setOptionsArray()` / `toOptionsArray()`. The only legacy callers are tests that explicitly exercise the legacy string surface (`LlmConfigurationRepositoryTest:297` asserts `setOptions('')` semantics; fuzzy tests in `Tests/Fuzzy/` exercise raw-JSON input fuzz) — all left untouched per slice convention.

## What changed

- `LlmConfiguration::getOptions(): string` — `@deprecated since 0.8.0` with redirect to `getOptionsArray()`. Docblock explains why we stop at the array-typed surface (open-ended provider extras) rather than introducing a DTO.
- `LlmConfiguration::setOptions(string)` — `@deprecated since 0.8.0` with redirect to `setOptionsArray()`. Docblock notes the raw-JSON setter is retained for Extbase property mapping.

## REC #6 slice progress

- [x] **16a (#179)** — `CapabilitySet` DTO + `Model` typed accessors.
- [x] **16b (#180)** — `Model` caller migration + 8 deprecation markers.
- [x] **16c (#181)** — `LlmConfiguration::fallbackChain` deprecation.
- [x] **16d (#182)** — `LlmConfiguration::modelSelectionCriteria` deprecation.
- [x] **16e (this PR)** — `LlmConfiguration::options` deprecation (Option B — no DTO).
- [ ] **16f** — new `ProviderOptions` typed DTO for `Provider::\$options` (currently raw string with no decoder per the audit). This one likely needs Option A (introduce DTO) because there's no existing array-typed surface — `Provider` only has `getOptions(): string`.

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3320 tests / 7205 assertions** all green (unchanged — docs-only commit)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR
- [ ] Bot review threads addressed