### PR TITLE
refactor: REC #6 — deprecate Provider string options API (slice 16f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecated
 
+- `Provider::getOptions(): string` and `setOptions(string)` are
+  deprecated since 0.8.0 in favour of the typed
+  `getOptionsArray(): array<string, mixed>` /
+  `setOptionsArray(array<string, mixed>)` accessors. Same rationale
+  as the parallel `LlmConfiguration` deprecation in slice 16e — the
+  `options` field carries provider-adapter-specific extras beyond
+  the typed entity columns (`apiKey`, `endpoint`, `timeout`,
+  `maxRetries`) and its shape is open-ended by design, so REC #6
+  stops at the array-typed surface rather than introducing a typed
+  DTO. The legacy raw-JSON methods remain for Extbase property
+  mapping and will not be removed before a major version bump.
+  REC #6 slice 16f — closes REC #6.
 - `LlmConfiguration::getOptions(): string` and `setOptions(string)` are
   deprecated since 0.8.0 in favour of the typed
   `getOptionsArray(): array<string, mixed>` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `setOptionsArray(array<string, mixed>)` accessors. Same rationale
   as the parallel `LlmConfiguration` deprecation in slice 16e — the
   `options` field carries provider-adapter-specific extras beyond
-  the typed entity columns (`apiKey`, `endpoint`, `timeout`,
-  `maxRetries`) and its shape is open-ended by design, so REC #6
-  stops at the array-typed surface rather than introducing a typed
-  DTO. The legacy raw-JSON methods remain for Extbase property
-  mapping and will not be removed before a major version bump.
-  REC #6 slice 16f — closes REC #6.
+  the typed `Provider` entity columns and its shape is open-ended
+  by design, so REC #6 stops at the array-typed surface rather
+  than introducing a typed DTO. The legacy raw-JSON methods remain
+  for Extbase property mapping and will not be removed before a
+  major version bump. REC #6 slice 16f — closes REC #6.
 - `LlmConfiguration::getOptions(): string` and `setOptions(string)` are
   deprecated since 0.8.0 in favour of the typed
   `getOptionsArray(): array<string, mixed>` /

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -160,6 +160,20 @@ class Provider extends AbstractEntity
         return $this->maxRetries;
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `getOptionsArray()` (returns `array<string, mixed>`).
+     *             The `options` field carries provider-specific extras
+     *             beyond the typed entity columns (`apiKey`, `endpoint`,
+     *             `timeout`, `maxRetries`) — its shape is open-ended by
+     *             design and varies per adapter, so REC #6 stops at the
+     *             array-typed surface rather than introducing a typed
+     *             DTO that would impose false structure. The raw-JSON
+     *             accessor is retained for Extbase property mapping
+     *             (the framework hydrates the entity through this
+     *             getter / setter pair) and will not be removed before
+     *             a major version bump.
+     */
     public function getOptions(): string
     {
         return $this->options;
@@ -317,6 +331,14 @@ class Provider extends AbstractEntity
         $this->maxRetries = max(0, $maxRetries);
     }
 
+    /**
+     * @deprecated since 0.8.0 — application code should use the typed
+     *             `setOptionsArray(array<string, mixed>)` so the
+     *             persisted JSON is produced by `json_encode()` rather
+     *             than passed in as an arbitrary string. The raw-JSON
+     *             setter is retained for Extbase property mapping and
+     *             will not be removed before a major version bump.
+     */
     public function setOptions(string $options): void
     {
         $this->options = $options;

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -163,16 +163,15 @@ class Provider extends AbstractEntity
     /**
      * @deprecated since 0.8.0 — application code should use the typed
      *             `getOptionsArray()` (returns `array<string, mixed>`).
-     *             The `options` field carries provider-specific extras
-     *             beyond the typed entity columns (`apiKey`, `endpoint`,
-     *             `timeout`, `maxRetries`) — its shape is open-ended by
-     *             design and varies per adapter, so REC #6 stops at the
-     *             array-typed surface rather than introducing a typed
-     *             DTO that would impose false structure. The raw-JSON
-     *             accessor is retained for Extbase property mapping
-     *             (the framework hydrates the entity through this
-     *             getter / setter pair) and will not be removed before
-     *             a major version bump.
+     *             The `options` field carries provider-adapter-specific
+     *             extras beyond the typed entity columns; its shape is
+     *             open-ended by design and varies per adapter, so
+     *             REC #6 stops at the array-typed surface rather than
+     *             introducing a typed DTO that would impose false
+     *             structure. The raw-JSON accessor is retained for
+     *             Extbase property mapping (the framework hydrates the
+     *             entity through this getter / setter pair) and will
+     *             not be removed before a major version bump.
      */
     public function getOptions(): string
     {


### PR DESCRIPTION
## Summary

Sixth and final slice of **REC #6**. Deprecate the raw-JSON `Provider::getOptions(): string` / `setOptions(string)` accessors in favour of the typed `getOptionsArray()` / `setOptionsArray()` pair. **Closes REC #6.**

## Audit footnote

The audit's wording on REC #6 said `Provider.options` is "raw string with no decoder", but `getOptionsArray()` / `setOptionsArray()` actually already exist on the entity (`Provider.php:173`, `Provider.php:330`) and are used by every production caller. The structural concern the audit raised is real (raw-string was the wrong application surface), but the array-typed surface that solves it is already in place — same as slice 16e for `LlmConfiguration::options`.

## Design decision (Option B again)

Same as slice 16e: **no typed DTO**. The `options` field carries provider-adapter-specific extras beyond the typed entity columns (`apiKey`, `endpoint`, `timeout`, `maxRetries`). Defining a `ProviderOptions` DTO would either:

- force every key to be optional `mixed` (no real typing benefit), or
- impose false structure that would reject legitimate provider-specific keys.

The existing `array<string, mixed>` surface IS the application-level type.

## REC #6 progress (closed)

- [x] **16a (#179)** — `CapabilitySet` DTO + `Model` typed accessors.
- [x] **16b (#180)** — `Model` caller migration + 8 deprecation markers.
- [x] **16c (#181)** — `LlmConfiguration::fallbackChain` deprecation.
- [x] **16d (#182)** — `LlmConfiguration::modelSelectionCriteria` deprecation.
- [x] **16e (#183)** — `LlmConfiguration::options` deprecation (Option B — no DTO).
- [x] **16f (this PR)** — `Provider::options` deprecation (Option B — no DTO). **Closes REC #6.**

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3320 tests / 7205 assertions** all green (unchanged — docs-only commit)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR
- [ ] Bot review threads addressed