### PR TITLE
feat(domain)!: remove legacy Model::CAPABILITY_* constants (REC #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,7 +273,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### BREAKING
 
-- The following classes are now `final` (and `final readonly` where applicable)
+- The eight `Model::CAPABILITY_*` legacy public class constants
+  (`CAPABILITY_CHAT`, `CAPABILITY_COMPLETION`, `CAPABILITY_EMBEDDINGS`,
+  `CAPABILITY_VISION`, `CAPABILITY_STREAMING`, `CAPABILITY_TOOLS`,
+  `CAPABILITY_JSON_MODE`, `CAPABILITY_AUDIO`) have been REMOVED. They
+  have been marked `@deprecated` since the introduction of the
+  `Domain\Enum\ModelCapability` backed enum, and the architecture
+  audit (REC #10) flagged the parallel-truths state as a structural
+  debt to clear. Downstream consumers must migrate references to the
+  enum value: `Model::CAPABILITY_CHAT` → `ModelCapability::CHAT->value`
+  (or pass the enum directly anywhere that accepts
+  `string|ModelCapability` — e.g. `CapabilitySet::has()`,
+  `with()`, `without()`). The `Model::getAllCapabilities()` static
+  helper (used by `ModelController` to populate the BE list view's
+  capability label dropdown) is unchanged — it is keyed on the enum
+  values, not on the removed constants. REC #10. (and `final readonly` where applicable)
   and can no longer be subclassed by downstream extensions: the four leaf
   provider exceptions (`ProviderConfigurationException`,
   `ProviderConnectionException`, `ProviderResponseException`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,7 +287,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `with()`, `without()`). The `Model::getAllCapabilities()` static
   helper (used by `ModelController` to populate the BE list view's
   capability label dropdown) is unchanged — it is keyed on the enum
-  values, not on the removed constants. REC #10. (and `final readonly` where applicable)
+  values, not on the removed constants. REC #10.
+- The following classes are now `final` (and `final readonly` where applicable)
   and can no longer be subclassed by downstream extensions: the four leaf
   provider exceptions (`ProviderConfigurationException`,
   `ProviderConnectionException`, `ProviderResponseException`,

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -21,27 +21,6 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 class Model extends AbstractEntity
 {
-    /**
-     * Capability constants.
-     *
-     * @deprecated Use ModelCapability enum instead
-     */
-    public const CAPABILITY_CHAT = 'chat';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_COMPLETION = 'completion';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_EMBEDDINGS = 'embeddings';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_VISION = 'vision';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_STREAMING = 'streaming';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_TOOLS = 'tools';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_JSON_MODE = 'json_mode';
-    /** @deprecated Use ModelCapability enum instead */
-    public const CAPABILITY_AUDIO = 'audio';
-
     protected string $identifier = '';
     protected string $name = '';
     protected string $description = '';

--- a/Tests/Unit/Domain/Model/ModelTest.php
+++ b/Tests/Unit/Domain/Model/ModelTest.php
@@ -79,9 +79,9 @@ final class ModelTest extends TestCase
         $model = new Model();
         $model->setCapabilities('chat,vision,tools');
 
-        self::assertTrue($model->hasCapability(Model::CAPABILITY_CHAT));
-        self::assertTrue($model->hasCapability(Model::CAPABILITY_VISION));
-        self::assertTrue($model->hasCapability(Model::CAPABILITY_TOOLS));
+        self::assertTrue($model->hasCapability(ModelCapability::CHAT->value));
+        self::assertTrue($model->hasCapability(ModelCapability::VISION->value));
+        self::assertTrue($model->hasCapability(ModelCapability::TOOLS->value));
     }
 
     #[Test]
@@ -90,8 +90,8 @@ final class ModelTest extends TestCase
         $model = new Model();
         $model->setCapabilities('chat,vision');
 
-        self::assertFalse($model->hasCapability(Model::CAPABILITY_TOOLS));
-        self::assertFalse($model->hasCapability(Model::CAPABILITY_EMBEDDINGS));
+        self::assertFalse($model->hasCapability(ModelCapability::TOOLS->value));
+        self::assertFalse($model->hasCapability(ModelCapability::EMBEDDINGS->value));
     }
 
     #[Test]
@@ -143,22 +143,26 @@ final class ModelTest extends TestCase
     }
 
     // ========================================
-    // Capability constants tests
+    // Capability label map (UI helper used by ModelController)
     // ========================================
 
     #[Test]
     public function getAllCapabilitiesReturnsExpectedCapabilities(): void
     {
+        // After REC #10 the legacy `Model::CAPABILITY_*` constants are
+        // gone; the source of truth is the `ModelCapability` enum.
+        // `getAllCapabilities()` stays as a UI label-map helper used
+        // by `ModelController` and is keyed on the enum values.
         $capabilities = Model::getAllCapabilities();
 
-        self::assertArrayHasKey(Model::CAPABILITY_CHAT, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_COMPLETION, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_EMBEDDINGS, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_VISION, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_STREAMING, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_TOOLS, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_JSON_MODE, $capabilities);
-        self::assertArrayHasKey(Model::CAPABILITY_AUDIO, $capabilities);
+        self::assertArrayHasKey(ModelCapability::CHAT->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::COMPLETION->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::EMBEDDINGS->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::VISION->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::STREAMING->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::TOOLS->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::JSON_MODE->value, $capabilities);
+        self::assertArrayHasKey(ModelCapability::AUDIO->value, $capabilities);
     }
 
     // ========================================


### PR DESCRIPTION
## Summary

**Closes REC #10** of the architecture audit ("Remove legacy string constants once enums are the single source of truth"). Removes the eight `Model::CAPABILITY_*` legacy public class constants that the audit explicitly flagged as "marked deprecated but not removed — two parallel truths for every enum value".

The `Domain\Enum\ModelCapability` backed enum has been the documented source of truth since the typed-value-object work; the constants were marked `@deprecated Use ModelCapability enum instead` at that point. This slice executes the deletion the deprecation promised.

## Migration scope

Project-wide grep (`grep -rn "Model::CAPABILITY_" Classes/ Tests/`) turned up only **8 test sites** in `ModelTest.php`. Production code already used the enum exclusively. Migrated each test site:

```
Model::CAPABILITY_CHAT → ModelCapability::CHAT->value
```

## What's NOT removed

`Model::getAllCapabilities()` is **unchanged**. It is not a "constant" per the audit's REC #10 wording — it is a UI label-map helper used by `ModelController::indexAction()` to populate the backend list view's capability-filter dropdown. It already keys on the enum values internally and the audit doesn't flag it.

## ⚠️ BREAKING

Downstream consumers that referenced the public constants directly need to migrate:

| Removed | Replacement |
|---|---|
| `Model::CAPABILITY_CHAT` | `ModelCapability::CHAT->value` |
| `Model::CAPABILITY_COMPLETION` | `ModelCapability::COMPLETION->value` |
| `Model::CAPABILITY_EMBEDDINGS` | `ModelCapability::EMBEDDINGS->value` |
| `Model::CAPABILITY_VISION` | `ModelCapability::VISION->value` |
| `Model::CAPABILITY_STREAMING` | `ModelCapability::STREAMING->value` |
| `Model::CAPABILITY_TOOLS` | `ModelCapability::TOOLS->value` |
| `Model::CAPABILITY_JSON_MODE` | `ModelCapability::JSON_MODE->value` |
| `Model::CAPABILITY_AUDIO` | `ModelCapability::AUDIO->value` |

Or pass the enum directly anywhere that accepts `string|ModelCapability` (e.g. `CapabilitySet::has()` / `with()` / `without()` from REC #6).

The breaking-change risk is acceptable on a 0.x version (precedent: slice 14's `final` class additions also broke downstream subclassing).

## Audit progress

- [x] **REC #5** — `TaskController` split (slices 13a-e, earlier).
- [x] **REC #8** — typed `ProviderResponseException` (slice 14, #176).
- [x] **REC #4** — auto budget pre-flight in feature services (slices 15a-b, #177 + #178).
- [x] **REC #6** — domain entity JSON/CSV strings → typed DTOs (slices 16a-f, #179 + #180 + #181 + #182 + #183 + #184).
- [x] **REC #10 (this PR)** — remove legacy `Model::CAPABILITY_*` constants.
- [ ] **REC #7** — extract `AbstractSpecializedService` + HTTP pipeline (slice 18+, multi-file refactor across 5 specialized services). Last item in user-confirmed order.

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3320 tests / 7205 assertions** all green (unchanged)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR (PHP 8.2–8.5 × TYPO3 13.4 / 14.0)
- [ ] Bot review threads addressed