### PR TITLE
refactor(specialized): extract AbstractSpecializedService + migrate 5 services (REC #7 — closes audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,51 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Classes/Specialized/AbstractSpecializedService` — base class for
+  every single-task AI service that talks to a provider over HTTP
+  (DALL-E, FAL, Whisper, TTS, DeepL — slice 18, REC #7). Concentrates
+  the HTTP scaffolding that each service was reimplementing
+  separately: extension-config loading (with fail-soft logging),
+  availability check, JSON POST, status-code → typed-exception
+  mapping (`ServiceConfigurationException` for 401/403,
+  `ServiceUnavailableException` for 429 / 5xx / network errors),
+  endpoint URL construction. Subclasses declare their identity
+  (`getServiceDomain()` / `getServiceProvider()` for exception
+  payloads, `getProviderLabel()` for log messages) and the auth
+  scheme (`buildAuthHeaders()` — three are in active use today:
+  `Bearer ` (OpenAI), `Key ` (FAL), `DeepL-Auth-Key ` (DeepL)).
+- `Classes/Specialized/MultipartBodyBuilderTrait` — multipart/form-data
+  body construction for services that upload files
+  (`WhisperTranscriptionService`, `DallEImageService`). Kept out of
+  the base class so JSON-only services don't carry the trait's
+  footprint. Pure body builder (`encodeMultipartBody()`) plus a
+  full request dispatcher (`sendMultipartRequest()`) that ties into
+  the base's `executeRequest()`.
+
 ### Changed
 
+- `DallEImageService`, `FalImageService`, `WhisperTranscriptionService`,
+  `TextToSpeechService`, and `DeepLTranslator` now extend
+  `AbstractSpecializedService` instead of carrying their own copies
+  of `loadConfiguration()`, `ensureAvailable()`, `executeRequest()`,
+  and the auth-header / JSON-POST boilerplate. **Public API is
+  unchanged** — every public method on every service keeps its
+  signature, and the constructor signature is identical (Symfony DI
+  autowires the same dep set as before). Whisper and TTS retain
+  their own request-execution path (Whisper because text/srt/vtt
+  formats return raw strings, not JSON; TTS because the response
+  is binary audio bytes); the rest of the scaffolding still comes
+  from the base. Per-service variation points (DALL-E's 400
+  validation branch, FAL's 422 branch, DeepL's 456 quota branch,
+  FAL's `detail`/`message` error shape, DeepL's top-level `message`
+  error shape) override `mapErrorStatus()` / `decodeErrorMessage()`
+  hooks on the base. Closes REC #7. Net per-service LOC reduction
+  averages ~12% (2828 → 2491 across the five services), but the
+  real win is centralisation: a future bug in HTTP error handling
+  or auth-header threading lives in one place to fix instead of
+  five.
 - `ModelSelectionService::modelMatchesCriteria()` now routes capability
   membership through the typed `Model::getCapabilitySet()->has()` instead
   of the legacy string-CSV `Model::hasCapability()`. The legacy strict

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized;
 
-use Exception;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -159,6 +158,13 @@ abstract class AbstractSpecializedService
      * `buildAuthHeaders()` are applied, and the payload is
      * `json_encode`d with `JSON_THROW_ON_ERROR`.
      *
+     * Body-less methods (`GET`, `HEAD`, `DELETE`) skip the JSON body
+     * even when `$payload` is non-empty — some upstreams and proxies
+     * reject GET-with-body and the right place to put query data on
+     * a GET is the URL itself, not the body. Subclasses that need to
+     * send GET data should serialise it onto the endpoint string they
+     * pass in.
+     *
      * @param array<string, mixed> $payload
      *
      * @throws ServiceUnavailableException
@@ -176,16 +182,29 @@ abstract class AbstractSpecializedService
             $request = $request->withHeader($name, $value);
         }
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
-        $request = $request->withBody($body);
+        if ($this->methodAllowsBody($method)) {
+            $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+            $request = $request->withBody($body);
+        }
 
         return $this->executeRequest($request);
     }
 
     /**
+     * Body-less HTTP methods per RFC 9110. `TRACE` and `OPTIONS` are
+     * the other body-less methods but neither is in active use here.
+     */
+    private function methodAllowsBody(string $method): bool
+    {
+        return !in_array(strtoupper($method), ['GET', 'HEAD', 'DELETE'], true);
+    }
+
+    /**
      * Concatenate `$this->baseUrl` and a relative endpoint with
-     * exactly one separating slash. `$endpoint` may be empty (the
-     * service POSTs directly to the base URL — DALL-E TTS does this).
+     * exactly one separating slash. `$endpoint` may be empty, in
+     * which case the request targets the base URL directly (the
+     * `TextToSpeechService` does this — its base URL already
+     * resolves to `/v1/audio/speech`).
      */
     protected function buildEndpointUrl(string $endpoint): string
     {
@@ -346,7 +365,12 @@ abstract class AbstractSpecializedService
             }
             /** @var array<string, mixed> $config */
             $this->loadServiceConfiguration($config);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
+            // Catch `Throwable` not `Exception` because mis-typed
+            // extension config (or a subclass parsing it as the wrong
+            // shape) raises `TypeError` — which extends `Error`, not
+            // `Exception`. We want `isAvailable() === false` and a
+            // log line in either case rather than a bootstrap fatal.
             $this->logger->warning(
                 sprintf('Failed to load %s configuration', $this->getProviderLabel()),
                 ['exception' => $e],

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -1,0 +1,356 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized;
+
+use Exception;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Base class for specialised single-task AI services (REC #7).
+ *
+ * Concentrates the HTTP scaffolding that every specialised service —
+ * DALL-E, FAL, Whisper, TTS, DeepL — was reimplementing on its own
+ * (audit estimated ~40-50% duplication, ~300+ LOC reclaimable). Each
+ * subclass declares its identity (domain / provider strings used in
+ * exceptions and usage tracking) and the auth header scheme; the base
+ * owns config loading, availability checks, JSON POST, and the
+ * status-code → typed-exception mapping.
+ *
+ * Multipart-body construction lives in `MultipartBodyBuilderTrait`
+ * (only Whisper and DALL-E need it — JSON-only services don't pay
+ * for the trait's footprint).
+ *
+ * Constructor signature is identical across every consumer. Property
+ * visibility intentionally `protected` (not `private`) so subclasses
+ * can read `apiKey` / `baseUrl` when building service-specific
+ * payloads — the alternative (passing them through accessor methods)
+ * adds no encapsulation since the subclass is the only thing that
+ * touches them anyway.
+ *
+ * @phpstan-consistent-constructor
+ */
+abstract class AbstractSpecializedService
+{
+    protected string $apiKey = '';
+    protected string $baseUrl = '';
+    protected int $timeout;
+
+    public function __construct(
+        protected readonly ClientInterface $httpClient,
+        protected readonly RequestFactoryInterface $requestFactory,
+        protected readonly StreamFactoryInterface $streamFactory,
+        protected readonly ExtensionConfiguration $extensionConfiguration,
+        protected readonly UsageTrackerServiceInterface $usageTracker,
+        protected readonly LoggerInterface $logger,
+    ) {
+        $this->timeout = $this->getDefaultTimeout();
+        $this->loadConfiguration();
+    }
+
+    /**
+     * Returns true once the service has a usable API key from
+     * extension configuration. Stable across the lifetime of the
+     * instance — if the config changes at runtime, callers must
+     * rebuild the service via DI rather than poll.
+     */
+    public function isAvailable(): bool
+    {
+        return $this->apiKey !== '';
+    }
+
+    /**
+     * Service domain used by `ServiceUnavailableException` /
+     * `ServiceConfigurationException` (`'image'`, `'speech'`,
+     * `'translation'`, …) so log sinks and downstream catches can
+     * filter by domain without parsing the message string.
+     */
+    abstract protected function getServiceDomain(): string;
+
+    /**
+     * Service provider identifier used by exception payloads and
+     * usage-tracking calls (`'dall-e'`, `'fal'`, `'whisper'`,
+     * `'tts'`, `'deepl'`).
+     */
+    abstract protected function getServiceProvider(): string;
+
+    /**
+     * Default base URL for the upstream API. Used when the extension
+     * configuration does not override it. Each provider has a
+     * documented default endpoint.
+     */
+    abstract protected function getDefaultBaseUrl(): string;
+
+    /**
+     * Default request timeout in seconds. Some services (Whisper —
+     * audio transcription) want a higher default; speech synthesis
+     * and translation are typically faster.
+     */
+    abstract protected function getDefaultTimeout(): int;
+
+    /**
+     * Service-specific config picking. Called from `loadConfiguration()`
+     * with the already-fetched `nr_llm` config tree (or `[]` if loading
+     * failed). Subclasses navigate to their own config branch — e.g.
+     * `$config['providers']['openai']['apiKey']` for DALL-E or
+     * `$config['translation']['deepl']['apiKey']` for DeepL — and set
+     * `$this->apiKey`, `$this->baseUrl`, `$this->timeout` from it.
+     *
+     * Subclasses MUST set `$this->apiKey` and `$this->baseUrl`. The
+     * base class pre-populates `$this->timeout` with
+     * `getDefaultTimeout()` so subclasses only need to override it
+     * when the config provides a timeout override.
+     *
+     * @param array<string, mixed> $config the full `nr_llm` config tree
+     */
+    abstract protected function loadServiceConfiguration(array $config): void;
+
+    /**
+     * Build the auth headers the upstream API expects. Three schemes
+     * are in active use across the specialised services today:
+     *  - `['Authorization' => 'Bearer ' . $this->apiKey]` (OpenAI)
+     *  - `['Authorization' => 'Key '    . $this->apiKey]` (FAL)
+     *  - `['Authorization' => 'DeepL-Auth-Key ' . $this->apiKey]`.
+     *
+     * Returning a multi-key array is supported for any future
+     * provider that needs an extra header alongside auth (e.g.
+     * `'X-Api-Version'`); the request builder applies all of them.
+     *
+     * @return array<string, string>
+     */
+    abstract protected function buildAuthHeaders(): array;
+
+    /**
+     * Throw a typed `ServiceUnavailableException` when the service
+     * is not configured. Convenience for the `if (!$this->isAvailable())
+     * throw …;` pattern that every service replicates.
+     *
+     * @throws ServiceUnavailableException
+     */
+    protected function ensureAvailable(): void
+    {
+        if (!$this->isAvailable()) {
+            throw ServiceUnavailableException::notConfigured(
+                $this->getServiceDomain(),
+                $this->getServiceProvider(),
+            );
+        }
+    }
+
+    /**
+     * Send a JSON request to the upstream API and return the decoded
+     * response body. The endpoint is appended to `$this->baseUrl`
+     * (with single-slash normalisation), auth headers from
+     * `buildAuthHeaders()` are applied, and the payload is
+     * `json_encode`d with `JSON_THROW_ON_ERROR`.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws ServiceUnavailableException
+     *
+     * @return array<string, mixed>
+     */
+    protected function sendJsonRequest(string $endpoint, array $payload, string $method = 'POST'): array
+    {
+        $url = $this->buildEndpointUrl($endpoint);
+
+        $request = $this->requestFactory->createRequest($method, $url)
+            ->withHeader('Content-Type', 'application/json');
+
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $request = $request->withBody($body);
+
+        return $this->executeRequest($request);
+    }
+
+    /**
+     * Concatenate `$this->baseUrl` and a relative endpoint with
+     * exactly one separating slash. `$endpoint` may be empty (the
+     * service POSTs directly to the base URL — DALL-E TTS does this).
+     */
+    protected function buildEndpointUrl(string $endpoint): string
+    {
+        $base = rtrim($this->baseUrl, '/');
+        $endpoint = ltrim($endpoint, '/');
+        if ($endpoint === '') {
+            return $base;
+        }
+        return $base . '/' . $endpoint;
+    }
+
+    /**
+     * Send the prepared request, decode the JSON body, and map any
+     * upstream error to a typed exception. Empty 2xx responses come
+     * back as the empty array; non-2xx responses raise either
+     * `ServiceConfigurationException` (auth) or
+     * `ServiceUnavailableException` (everything else).
+     *
+     * Subclasses can override `decodeErrorMessage()` to extract the
+     * upstream error message from a service-specific JSON shape;
+     * everything else stays in the base.
+     *
+     * @throws ServiceUnavailableException
+     * @throws ServiceConfigurationException
+     *
+     * @return array<string, mixed>
+     */
+    protected function executeRequest(RequestInterface $request): array
+    {
+        try {
+            $response = $this->httpClient->sendRequest($request);
+            $statusCode = $response->getStatusCode();
+            $responseBody = (string)$response->getBody();
+
+            if ($statusCode >= 200 && $statusCode < 300) {
+                if ($responseBody === '') {
+                    return [];
+                }
+                $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+                /** @var array<string, mixed> $result */
+                $result = is_array($decoded) ? $decoded : [];
+                return $result;
+            }
+
+            $errorMessage = $this->decodeErrorMessage($responseBody);
+
+            $this->logger->error(sprintf('%s API error', $this->getProviderLabel()), [
+                'status_code' => $statusCode,
+                'error'       => $errorMessage,
+            ]);
+
+            throw $this->mapErrorStatus($statusCode, $errorMessage);
+        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            $this->logger->error(sprintf('%s API connection error', $this->getProviderLabel()), [
+                'exception' => $e->getMessage(),
+            ]);
+
+            throw new ServiceUnavailableException(
+                sprintf('Failed to connect to %s API: %s', $this->getProviderLabel(), $e->getMessage()),
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider()],
+                0,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * Extract the error message from an upstream non-2xx body. The
+     * default handles the most common shape — `{"error": {"message":
+     * "..."}}` — used by every OpenAI-family service (DALL-E,
+     * Whisper, TTS). Subclasses with a different shape (FAL uses
+     * `detail`/`message`; DeepL uses `message`) override.
+     */
+    protected function decodeErrorMessage(string $responseBody): string
+    {
+        if ($responseBody === '') {
+            return $this->unknownErrorLabel();
+        }
+        $error = json_decode($responseBody, true);
+        if (!is_array($error)) {
+            return $this->unknownErrorLabel();
+        }
+        $errorBranch = $error['error'] ?? null;
+        if (is_array($errorBranch)) {
+            $message = $errorBranch['message'] ?? null;
+            if (is_string($message) && $message !== '') {
+                return $message;
+            }
+        }
+        return $this->unknownErrorLabel();
+    }
+
+    /**
+     * Map an upstream HTTP status code to a typed exception. The
+     * default covers the auth (401/403) and rate-limit (429) cases
+     * that every service handles identically; subclasses override
+     * to add provider-specific branches (FAL has a 422 validation
+     * branch, DALL-E distinguishes 400 validation, etc.).
+     */
+    protected function mapErrorStatus(int $statusCode, string $errorMessage): Throwable
+    {
+        return match ($statusCode) {
+            401, 403 => ServiceConfigurationException::invalidApiKey(
+                $this->getServiceDomain(),
+                $this->getServiceProvider(),
+            ),
+            429 => new ServiceUnavailableException(
+                sprintf('%s API rate limit exceeded', $this->getProviderLabel()),
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider()],
+            ),
+            default => new ServiceUnavailableException(
+                sprintf('%s API error: %s', $this->getProviderLabel(), $errorMessage),
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider()],
+            ),
+        };
+    }
+
+    /**
+     * Human-readable label for log messages and exception text.
+     * Defaults to the provider identifier upper-cased and
+     * dash-stripped (`'dall-e'` → `'DALL-E'`, `'tts'` → `'TTS'`).
+     * Subclasses with a more specific brand name (`'OpenAI Whisper'`)
+     * can override.
+     */
+    protected function getProviderLabel(): string
+    {
+        return strtoupper($this->getServiceProvider());
+    }
+
+    /**
+     * Default fallback when an upstream error body has no usable
+     * message. Subclasses can override to provide a more specific
+     * label (e.g. `'Unknown DALL-E API error'`).
+     */
+    protected function unknownErrorLabel(): string
+    {
+        return sprintf('Unknown %s API error', $this->getProviderLabel());
+    }
+
+    /**
+     * Load the `nr_llm` extension configuration and hand the
+     * already-decoded tree to the subclass. Failures are logged at
+     * `warning` level and leave `$this->apiKey` empty so
+     * `isAvailable()` will report `false` — same fail-soft posture
+     * the per-service implementations had.
+     */
+    private function loadConfiguration(): void
+    {
+        try {
+            $config = $this->extensionConfiguration->get('nr_llm');
+            if (!is_array($config)) {
+                return;
+            }
+            /** @var array<string, mixed> $config */
+            $this->loadServiceConfiguration($config);
+        } catch (Exception $e) {
+            $this->logger->warning(
+                sprintf('Failed to load %s configuration', $this->getProviderLabel()),
+                ['exception' => $e],
+            );
+        }
+    }
+}

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -507,9 +507,9 @@ final class DallEImageService extends AbstractSpecializedService
         $imageContent = file_get_contents($imagePath);
         if ($imageContent === false) {
             throw new ServiceUnavailableException(
-                'Failed to read image file',
+                sprintf('Failed to read image file: %s', $imagePath),
                 'image',
-                ['provider' => 'dall-e'],
+                ['provider' => 'dall-e', 'path' => $imagePath],
             );
         }
 
@@ -521,9 +521,9 @@ final class DallEImageService extends AbstractSpecializedService
             $maskContent = file_get_contents($maskPath);
             if ($maskContent === false) {
                 throw new ServiceUnavailableException(
-                    'Failed to read mask file',
+                    sprintf('Failed to read mask file: %s', $maskPath),
                     'image',
-                    ['provider' => 'dall-e'],
+                    ['provider' => 'dall-e', 'path' => $maskPath],
                 );
             }
             $parts[] = ['name' => 'mask', 'filename' => 'mask.png', 'content' => $maskContent, 'contentType' => 'image/png'];

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -334,10 +334,37 @@ final class DallEImageService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        /** @var array{providers?: array{openai?: array{apiKey?: string}}, image?: array{dalle?: array{baseUrl?: string, timeout?: int}}} $config */
-        $this->apiKey  = $config['providers']['openai']['apiKey'] ?? '';
-        $this->baseUrl = $config['image']['dalle']['baseUrl'] ?? self::API_URL;
-        $this->timeout = (int)($config['image']['dalle']['timeout'] ?? $this->getDefaultTimeout());
+        // is_string() guards: the extension config tree is user-editable
+        // YAML and the @var hint above describes the documented shape,
+        // not a runtime guarantee. Direct assignment without guards
+        // would TypeError on `non-string apiKey` and defeat the
+        // base's fail-soft contract.
+        $apiKey  = $this->resolveScalarConfig($config, ['providers', 'openai', 'apiKey']);
+        $baseUrl = $this->resolveScalarConfig($config, ['image', 'dalle', 'baseUrl']);
+        $timeout = $this->resolveScalarConfig($config, ['image', 'dalle', 'timeout']);
+
+        $this->apiKey  = is_string($apiKey) ? $apiKey : '';
+        $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
+    }
+
+    /**
+     * Walk a nested array path safely. Returns the leaf value or null
+     * if any intermediate hop is missing / not an array.
+     *
+     * @param array<string, mixed> $config
+     * @param list<string>         $path
+     */
+    private function resolveScalarConfig(array $config, array $path): mixed
+    {
+        $current = $config;
+        foreach ($path as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                return null;
+            }
+            $current = $current[$key];
+        }
+        return $current;
     }
 
     protected function buildAuthHeaders(): array

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -9,18 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;
 
-use Exception;
-use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
-use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * DALL-E image generation service.
@@ -36,8 +29,10 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  *
  * @see https://platform.openai.com/docs/guides/images
  */
-final class DallEImageService
+final class DallEImageService extends AbstractSpecializedService
 {
+    use MultipartBodyBuilderTrait;
+
     private const API_URL = 'https://api.openai.com/v1/images';
     private const DEFAULT_MODEL = 'dall-e-3';
     private const DEFAULT_SIZE = '1024x1024';
@@ -61,30 +56,6 @@ final class DallEImageService
             'supports_variations' => false,
         ],
     ];
-
-    private string $apiKey = '';
-    private string $baseUrl = '';
-    /** @phpstan-ignore property.onlyWritten (intended for future HTTP client configuration) */
-    private int $timeout = 120;
-
-    public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly UsageTrackerServiceInterface $usageTracker,
-        private readonly LoggerInterface $logger,
-    ) {
-        $this->loadConfiguration();
-    }
-
-    /**
-     * Check if service is available.
-     */
-    public function isAvailable(): bool
-    {
-        return $this->apiKey !== '';
-    }
 
     /**
      * Generate an image from a text prompt.
@@ -112,21 +83,15 @@ final class DallEImageService
         $quality = is_string($optionsArray['quality'] ?? null) ? $optionsArray['quality'] : 'standard';
         $style = is_string($optionsArray['style'] ?? null) ? $optionsArray['style'] : 'vivid';
 
-        // Validate prompt length
         $this->validatePrompt($prompt, $model);
 
-        // Build request payload
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
+        $response = $this->sendJsonRequest('generations', $payload);
 
-        // Send request
-        $response = $this->sendRequest('generations', $payload);
-
-        // Parse response
         /** @var array<int, array{url?: string, b64_json?: string, revised_prompt?: string}> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        // Track usage
         $this->usageTracker->trackUsage('image', 'dall-e:' . $model, [
             'size' => $size,
             'quality' => $quality,
@@ -192,7 +157,7 @@ final class DallEImageService
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $payload['n'] = $count;
 
-        $response = $this->sendRequest('generations', $payload);
+        $response = $this->sendJsonRequest('generations', $payload);
 
         $results = [];
         /** @var array<int, array{url?: string, b64_json?: string, revised_prompt?: string}> $responseData */
@@ -213,7 +178,6 @@ final class DallEImageService
             );
         }
 
-        // Track usage
         $this->usageTracker->trackUsage('image', 'dall-e:' . $model, [
             'size' => $size,
             'count' => count($results),
@@ -244,7 +208,7 @@ final class DallEImageService
 
         $count = min(max($count, 1), 10);
 
-        $response = $this->sendMultipartRequest('variations', $imagePath, null, [
+        $response = $this->sendImageMultipart('variations', $imagePath, null, [
             'n' => (string)$count,
             'size' => $size,
             'response_format' => 'url',
@@ -299,7 +263,7 @@ final class DallEImageService
             $this->validateImageFile($maskPath);
         }
 
-        $response = $this->sendMultipartRequest('edits', $imagePath, $maskPath, [
+        $response = $this->sendImageMultipart('edits', $imagePath, $maskPath, [
             'prompt' => $prompt,
             'size' => $size,
             'response_format' => 'url',
@@ -345,38 +309,62 @@ final class DallEImageService
         return self::MODEL_CAPABILITIES[$model]['sizes'] ?? ['1024x1024'];
     }
 
-    /**
-     * Load configuration from extension settings.
-     */
-    private function loadConfiguration(): void
+    protected function getServiceDomain(): string
     {
-        try {
-            $config = $this->extensionConfiguration->get('nr_llm');
-            if (!is_array($config)) {
-                return;
-            }
+        return 'image';
+    }
 
-            /** @var array{providers?: array{openai?: array{apiKey?: string}}, image?: array{dalle?: array{baseUrl?: string, timeout?: int}}} $config */
-            $this->apiKey = $config['providers']['openai']['apiKey'] ?? '';
-            $this->baseUrl = $config['image']['dalle']['baseUrl'] ?? self::API_URL;
-            $this->timeout = (int)($config['image']['dalle']['timeout'] ?? 120);
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load DALL-E configuration', [
-                'exception' => $e,
-            ]);
-        }
+    protected function getServiceProvider(): string
+    {
+        return 'dall-e';
+    }
+
+    protected function getDefaultBaseUrl(): string
+    {
+        return self::API_URL;
+    }
+
+    protected function getDefaultTimeout(): int
+    {
+        return 120;
     }
 
     /**
-     * Ensure service is available.
-     *
-     * @throws ServiceUnavailableException
+     * @param array<string, mixed> $config
      */
-    private function ensureAvailable(): void
+    protected function loadServiceConfiguration(array $config): void
     {
-        if (!$this->isAvailable()) {
-            throw ServiceUnavailableException::notConfigured('image', 'dall-e');
+        /** @var array{providers?: array{openai?: array{apiKey?: string}}, image?: array{dalle?: array{baseUrl?: string, timeout?: int}}} $config */
+        $this->apiKey  = $config['providers']['openai']['apiKey'] ?? '';
+        $this->baseUrl = $config['image']['dalle']['baseUrl'] ?? self::API_URL;
+        $this->timeout = (int)($config['image']['dalle']['timeout'] ?? $this->getDefaultTimeout());
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'Bearer ' . $this->apiKey];
+    }
+
+    /**
+     * DALL-E surfaces a 400 validation error distinctly from generic
+     * 4xx — keeps the existing exception payload (`type => 'validation'`)
+     * so downstream catches that branched on it continue to work.
+     */
+    protected function mapErrorStatus(int $statusCode, string $errorMessage): Throwable
+    {
+        if ($statusCode === 400) {
+            return new ServiceUnavailableException(
+                'DALL-E API error: ' . $errorMessage,
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider(), 'type' => 'validation'],
+            );
         }
+        return parent::mapErrorStatus($statusCode, $errorMessage);
+    }
+
+    protected function getProviderLabel(): string
+    {
+        return 'DALL-E';
     }
 
     /**
@@ -472,136 +460,52 @@ final class DallEImageService
     }
 
     /**
-     * Send JSON request.
+     * Build the parts list for an image edit / variation request and
+     * dispatch via the shared multipart sender. Wraps the trait's
+     * generic part-shape API in a DALL-E-specific signature so the
+     * call sites (`createVariations`, `edit`) stay readable.
      *
-     * @param array<string, mixed> $payload
-     *
-     * @throws ServiceUnavailableException
-     *
-     * @return array<string, mixed>
-     */
-    private function sendRequest(string $endpoint, array $payload): array
-    {
-        $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
-
-        $request = $this->requestFactory->createRequest('POST', $url)
-            ->withHeader('Authorization', 'Bearer ' . $this->apiKey)
-            ->withHeader('Content-Type', 'application/json');
-
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
-        $request = $request->withBody($body);
-
-        return $this->executeRequest($request);
-    }
-
-    /**
-     * Send multipart request for image upload.
-     *
-     * @param array<string, mixed> $fields
+     * @param array<string, scalar|null> $fields
      *
      * @throws ServiceUnavailableException
      *
      * @return array<string, mixed>
      */
-    private function sendMultipartRequest(
+    private function sendImageMultipart(
         string $endpoint,
         string $imagePath,
         ?string $maskPath,
         array $fields,
     ): array {
-        $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
-
-        $boundary = 'dalle' . uniqid();
-        $body = '';
-
-        // Add image file
         $imageContent = file_get_contents($imagePath);
         if ($imageContent === false) {
-            throw new ServiceUnavailableException('Failed to read image file', 'image', ['provider' => 'dall-e']);
+            throw new ServiceUnavailableException(
+                'Failed to read image file',
+                'image',
+                ['provider' => 'dall-e'],
+            );
         }
-        $body .= "--{$boundary}\r\n";
-        $body .= "Content-Disposition: form-data; name=\"image\"; filename=\"image.png\"\r\n";
-        $body .= "Content-Type: image/png\r\n\r\n";
-        $body .= $imageContent . "\r\n";
 
-        // Add mask file if provided
+        $parts = [
+            ['name' => 'image', 'filename' => 'image.png', 'content' => $imageContent, 'contentType' => 'image/png'],
+        ];
+
         if ($maskPath !== null) {
             $maskContent = file_get_contents($maskPath);
             if ($maskContent === false) {
-                throw new ServiceUnavailableException('Failed to read mask file', 'image', ['provider' => 'dall-e']);
+                throw new ServiceUnavailableException(
+                    'Failed to read mask file',
+                    'image',
+                    ['provider' => 'dall-e'],
+                );
             }
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"mask\"; filename=\"mask.png\"\r\n";
-            $body .= "Content-Type: image/png\r\n\r\n";
-            $body .= $maskContent . "\r\n";
+            $parts[] = ['name' => 'mask', 'filename' => 'mask.png', 'content' => $maskContent, 'contentType' => 'image/png'];
         }
 
-        // Add other fields
         foreach ($fields as $name => $value) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"{$name}\"\r\n\r\n";
-            $body .= (is_scalar($value) ? (string)$value : '') . "\r\n";
+            $parts[] = ['name' => $name, 'value' => $value ?? ''];
         }
 
-        $body .= "--{$boundary}--\r\n";
-
-        $request = $this->requestFactory->createRequest('POST', $url)
-            ->withHeader('Authorization', 'Bearer ' . $this->apiKey)
-            ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
-
-        $request = $request->withBody($this->streamFactory->createStream($body));
-
-        return $this->executeRequest($request);
-    }
-
-    /**
-     * Execute HTTP request.
-     *
-     * @throws ServiceUnavailableException
-     *
-     * @return array<string, mixed>
-     */
-    private function executeRequest(RequestInterface $request): array
-    {
-        try {
-            $response = $this->httpClient->sendRequest($request);
-            $statusCode = $response->getStatusCode();
-            $responseBody = (string)$response->getBody();
-
-            if ($statusCode >= 200 && $statusCode < 300) {
-                /** @var array<string, mixed> */
-                return json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
-            }
-
-            /** @var array{error?: array{message?: string}} $error */
-            $error = json_decode($responseBody, true) ?? [];
-            $errorMessage = $error['error']['message'] ?? 'Unknown DALL-E API error';
-
-            $this->logger->error('DALL-E API error', [
-                'status_code' => $statusCode,
-                'error' => $errorMessage,
-            ]);
-
-            throw match ($statusCode) {
-                401, 403 => ServiceConfigurationException::invalidApiKey('image', 'dall-e'),
-                429 => new ServiceUnavailableException('DALL-E API rate limit exceeded', 'image', ['provider' => 'dall-e']),
-                400 => new ServiceUnavailableException('DALL-E API error: ' . $errorMessage, 'image', ['provider' => 'dall-e', 'type' => 'validation']),
-                default => new ServiceUnavailableException('DALL-E API error: ' . $errorMessage, 'image', ['provider' => 'dall-e']),
-            };
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
-            throw $e;
-        } catch (Throwable $e) {
-            $this->logger->error('DALL-E API connection error', [
-                'exception' => $e->getMessage(),
-            ]);
-
-            throw new ServiceUnavailableException(
-                'Failed to connect to DALL-E API: ' . $e->getMessage(),
-                'image',
-                ['provider' => 'dall-e'],
-                0,
-                $e,
-            );
-        }
+        return $this->sendMultipartRequest($endpoint, $parts);
     }
 }

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -9,17 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;
 
-use Exception;
-use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
-use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * FAL.ai image generation service.
@@ -36,7 +28,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  *
  * @see https://fal.ai/docs
  */
-final class FalImageService
+final class FalImageService extends AbstractSpecializedService
 {
     private const API_URL = 'https://fal.run';
     private const QUEUE_API_URL = 'https://queue.fal.run';
@@ -61,29 +53,7 @@ final class FalImageService
         'photo-portrait' => '3:4',
     ];
 
-    private string $apiKey = '';
-    private string $baseUrl = '';
-    private int $timeout = 120;
     private int $pollInterval = 1000; // milliseconds
-
-    public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly UsageTrackerServiceInterface $usageTracker,
-        private readonly LoggerInterface $logger,
-    ) {
-        $this->loadConfiguration();
-    }
-
-    /**
-     * Check if service is available.
-     */
-    public function isAvailable(): bool
-    {
-        return $this->apiKey !== '';
-    }
 
     /**
      * Generate an image using specified model.
@@ -112,21 +82,17 @@ final class FalImageService
 
         $modelEndpoint = $this->resolveModelEndpoint($model);
 
-        // Build request payload
         $payload = $this->buildGeneratePayload($prompt, $options);
 
-        // Send request (synchronous for fast models, queue for slow ones)
         $usesQueue = $this->modelUsesQueue($model);
         $response = $usesQueue
             ? $this->sendQueueRequest($modelEndpoint, $payload)
-            : $this->sendRequest($modelEndpoint, $payload);
+            : $this->sendJsonRequest($modelEndpoint, $payload);
 
-        // Parse response
         $images = $response['images'] ?? [];
         /** @var array<string, mixed> $image */
         $image = is_array($images) && isset($images[0]) && is_array($images[0]) ? $images[0] : [];
 
-        // Track usage
         $this->usageTracker->trackUsage('image', 'fal:' . $model, [
             'size' => $options['image_size'] ?? 'square_hd',
         ]);
@@ -176,7 +142,7 @@ final class FalImageService
         $usesQueue = $this->modelUsesQueue($model);
         $response = $usesQueue
             ? $this->sendQueueRequest($modelEndpoint, $payload)
-            : $this->sendRequest($modelEndpoint, $payload);
+            : $this->sendJsonRequest($modelEndpoint, $payload);
 
         $results = [];
         $responseImages = $response['images'] ?? [];
@@ -253,56 +219,103 @@ final class FalImageService
         return self::ASPECT_RATIOS;
     }
 
-    /**
-     * Load configuration from extension settings.
-     */
-    private function loadConfiguration(): void
+    protected function getServiceDomain(): string
     {
-        try {
-            $config = $this->extensionConfiguration->get('nr_llm');
+        return 'image';
+    }
 
-            if (!is_array($config)) {
-                return;
-            }
+    protected function getServiceProvider(): string
+    {
+        return 'fal';
+    }
 
-            $imageConfig = $config['image'] ?? null;
-            if (!is_array($imageConfig)) {
-                return;
-            }
+    protected function getDefaultBaseUrl(): string
+    {
+        return self::API_URL;
+    }
 
-            $falConfig = $imageConfig['fal'] ?? null;
-            if (!is_array($falConfig)) {
-                return;
-            }
-
-            $apiKey = $falConfig['apiKey'] ?? '';
-            $this->apiKey = is_string($apiKey) ? $apiKey : '';
-
-            $baseUrl = $falConfig['baseUrl'] ?? self::API_URL;
-            $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
-
-            $timeout = $falConfig['timeout'] ?? 120;
-            $this->timeout = is_int($timeout) ? $timeout : (is_numeric($timeout) ? (int)$timeout : 120);
-
-            $pollInterval = $falConfig['pollInterval'] ?? 1000;
-            $this->pollInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load FAL configuration', [
-                'exception' => $e->getMessage(),
-            ]);
-        }
+    protected function getDefaultTimeout(): int
+    {
+        return 120;
     }
 
     /**
-     * Ensure service is available.
-     *
-     * @throws ServiceUnavailableException
+     * @param array<string, mixed> $config
      */
-    private function ensureAvailable(): void
+    protected function loadServiceConfiguration(array $config): void
     {
-        if (!$this->isAvailable()) {
-            throw ServiceUnavailableException::notConfigured('image', 'fal');
+        $imageConfig = $config['image'] ?? null;
+        if (!is_array($imageConfig)) {
+            return;
         }
+
+        $falConfig = $imageConfig['fal'] ?? null;
+        if (!is_array($falConfig)) {
+            return;
+        }
+
+        $apiKey = $falConfig['apiKey'] ?? '';
+        $this->apiKey = is_string($apiKey) ? $apiKey : '';
+
+        $baseUrl = $falConfig['baseUrl'] ?? self::API_URL;
+        $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+
+        $timeout = $falConfig['timeout'] ?? $this->getDefaultTimeout();
+        $this->timeout = is_int($timeout) ? $timeout : (is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout());
+
+        $pollInterval = $falConfig['pollInterval'] ?? 1000;
+        $this->pollInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'Key ' . $this->apiKey];
+    }
+
+    protected function getProviderLabel(): string
+    {
+        return 'FAL';
+    }
+
+    /**
+     * FAL uses `detail` (FastAPI default) or `message` for error
+     * messages — the OpenAI-style `error.message` shape doesn't apply.
+     */
+    protected function decodeErrorMessage(string $responseBody): string
+    {
+        if ($responseBody === '') {
+            return $this->unknownErrorLabel();
+        }
+        $error = json_decode($responseBody, true);
+        if (!is_array($error)) {
+            return $this->unknownErrorLabel();
+        }
+        $detail  = $error['detail']  ?? null;
+        $message = $error['message'] ?? null;
+        if (is_string($detail) && $detail !== '') {
+            return $detail;
+        }
+        if (is_string($message) && $message !== '') {
+            return $message;
+        }
+        return $this->unknownErrorLabel();
+    }
+
+    /**
+     * FAL surfaces a 422 validation error distinctly — keep the
+     * existing wording (`'FAL API validation error: …'`) so log
+     * filters that branch on it continue to work.
+     */
+    protected function mapErrorStatus(int $statusCode, string $errorMessage): Throwable
+    {
+        if ($statusCode === 422) {
+            return new ServiceUnavailableException(
+                'FAL API validation error: ' . $errorMessage,
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider()],
+            );
+        }
+        return parent::mapErrorStatus($statusCode, $errorMessage);
     }
 
     /**
@@ -310,17 +323,14 @@ final class FalImageService
      */
     private function resolveModelEndpoint(string $model): string
     {
-        // Check if it's a known model alias
         if (isset(self::MODELS[$model])) {
             return self::MODELS[$model];
         }
 
-        // Assume it's a full endpoint path
         if (str_contains($model, '/')) {
             return $model;
         }
 
-        // Default to flux-schnell
         return self::MODELS['flux-schnell'];
     }
 
@@ -329,7 +339,6 @@ final class FalImageService
      */
     private function modelUsesQueue(string $model): bool
     {
-        // Fast models can use synchronous API
         $fastModels = ['flux-schnell'];
 
         return !in_array($model, $fastModels, true);
@@ -348,7 +357,6 @@ final class FalImageService
             'prompt' => $prompt,
         ];
 
-        // Image size
         if (isset($options['image_size'])) {
             $payload['image_size'] = $options['image_size'];
         } elseif (isset($options['width']) && isset($options['height'])) {
@@ -362,41 +370,34 @@ final class FalImageService
             $payload['image_size'] = 'square_hd';
         }
 
-        // Number of images
         if (isset($options['num_images'])) {
             $numImages = $options['num_images'];
             $payload['num_images'] = is_numeric($numImages) ? min((int)$numImages, 4) : 1;
         }
 
-        // Guidance scale
         if (isset($options['guidance_scale'])) {
             $guidanceScale = $options['guidance_scale'];
             $payload['guidance_scale'] = is_numeric($guidanceScale) ? (float)$guidanceScale : 7.5;
         }
 
-        // Inference steps
         if (isset($options['num_inference_steps'])) {
             $steps = $options['num_inference_steps'];
             $payload['num_inference_steps'] = is_numeric($steps) ? (int)$steps : 20;
         }
 
-        // Seed
         if (isset($options['seed'])) {
             $seed = $options['seed'];
             $payload['seed'] = is_numeric($seed) ? (int)$seed : 0;
         }
 
-        // Negative prompt
         if (isset($options['negative_prompt'])) {
             $payload['negative_prompt'] = $options['negative_prompt'];
         }
 
-        // Safety checker
         if (isset($options['enable_safety_checker'])) {
             $payload['enable_safety_checker'] = (bool)$options['enable_safety_checker'];
         }
 
-        // Image-to-image
         if (isset($options['image_url'])) {
             $payload['image_url'] = $options['image_url'];
             if (isset($options['strength'])) {
@@ -427,30 +428,14 @@ final class FalImageService
     }
 
     /**
-     * Send synchronous request.
+     * Send queue-based request with polling. Submit, then poll
+     * `/requests/{id}/status` until completion or timeout.
      *
-     * @param array<string, mixed> $payload
-     *
-     * @throws ServiceUnavailableException
-     *
-     * @return array<string, mixed>
-     */
-    private function sendRequest(string $endpoint, array $payload): array
-    {
-        $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
-
-        $request = $this->requestFactory->createRequest('POST', $url)
-            ->withHeader('Authorization', 'Key ' . $this->apiKey)
-            ->withHeader('Content-Type', 'application/json');
-
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
-        $request = $request->withBody($body);
-
-        return $this->executeRequest($request);
-    }
-
-    /**
-     * Send queue-based request with polling.
+     * Cannot route through the base's `sendJsonRequest()` directly
+     * because the queue API lives on a different host
+     * (`queue.fal.run`) than the synchronous endpoint (`fal.run`).
+     * Builds the request manually but reuses the base's
+     * `executeRequest()` for status-handling consistency.
      *
      * @param array<string, mixed> $payload
      *
@@ -462,11 +447,11 @@ final class FalImageService
     {
         $queueUrl = rtrim(self::QUEUE_API_URL, '/') . '/' . ltrim($endpoint, '/');
 
-        // Submit to queue
         $request = $this->requestFactory->createRequest('POST', $queueUrl)
-            ->withHeader('Authorization', 'Key ' . $this->apiKey)
             ->withHeader('Content-Type', 'application/json');
-
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
         $request = $request->withBody($body);
 
@@ -481,7 +466,6 @@ final class FalImageService
             );
         }
 
-        // Poll for result
         return $this->pollForResult($endpoint, $requestId);
     }
 
@@ -498,17 +482,20 @@ final class FalImageService
         $maxAttempts = (int)ceil(($this->timeout * 1000) / $this->pollInterval);
 
         for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
-            $request = $this->requestFactory->createRequest('GET', $statusUrl)
-                ->withHeader('Authorization', 'Key ' . $this->apiKey);
+            $request = $this->requestFactory->createRequest('GET', $statusUrl);
+            foreach ($this->buildAuthHeaders() as $name => $value) {
+                $request = $request->withHeader($name, $value);
+            }
 
             $response = $this->executeRequest($request);
             $status = $response['status'] ?? '';
 
             if ($status === 'COMPLETED') {
-                // Fetch the actual result
                 $resultUrl = rtrim(self::QUEUE_API_URL, '/') . '/' . ltrim($endpoint, '/') . '/requests/' . $requestId;
-                $resultRequest = $this->requestFactory->createRequest('GET', $resultUrl)
-                    ->withHeader('Authorization', 'Key ' . $this->apiKey);
+                $resultRequest = $this->requestFactory->createRequest('GET', $resultUrl);
+                foreach ($this->buildAuthHeaders() as $name => $value) {
+                    $resultRequest = $resultRequest->withHeader($name, $value);
+                }
 
                 return $this->executeRequest($resultRequest);
             }
@@ -523,7 +510,6 @@ final class FalImageService
                 );
             }
 
-            // Wait before next poll
             usleep($this->pollInterval * 1000);
         }
 
@@ -532,63 +518,5 @@ final class FalImageService
             'image',
             ['provider' => 'fal', 'request_id' => $requestId],
         );
-    }
-
-    /**
-     * Execute HTTP request.
-     *
-     * @throws ServiceUnavailableException
-     *
-     * @return array<string, mixed>
-     */
-    private function executeRequest(RequestInterface $request): array
-    {
-        try {
-            $response = $this->httpClient->sendRequest($request);
-            $statusCode = $response->getStatusCode();
-            $responseBody = (string)$response->getBody();
-
-            if ($statusCode >= 200 && $statusCode < 300) {
-                $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
-                /** @var array<string, mixed> $result */
-                $result = is_array($decoded) ? $decoded : [];
-
-                return $result;
-            }
-
-            $error = json_decode($responseBody, true);
-            $errorData = is_array($error) ? $error : [];
-            $detail = $errorData['detail'] ?? null;
-            $message = $errorData['message'] ?? null;
-            $errorMessage = (is_string($detail) ? $detail : null)
-                ?? (is_string($message) ? $message : null)
-                ?? 'Unknown FAL API error';
-
-            $this->logger->error('FAL API error', [
-                'status_code' => $statusCode,
-                'error' => $errorMessage,
-            ]);
-
-            throw match ($statusCode) {
-                401, 403 => ServiceConfigurationException::invalidApiKey('image', 'fal'),
-                429 => new ServiceUnavailableException('FAL API rate limit exceeded', 'image', ['provider' => 'fal']),
-                422 => new ServiceUnavailableException('FAL API validation error: ' . $errorMessage, 'image', ['provider' => 'fal']),
-                default => new ServiceUnavailableException('FAL API error: ' . $errorMessage, 'image', ['provider' => 'fal']),
-            };
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
-            throw $e;
-        } catch (Throwable $e) {
-            $this->logger->error('FAL API connection error', [
-                'exception' => $e->getMessage(),
-            ]);
-
-            throw new ServiceUnavailableException(
-                'Failed to connect to FAL API: ' . $e->getMessage(),
-                'image',
-                ['provider' => 'fal'],
-                0,
-                $e,
-            );
-        }
     }
 }

--- a/Classes/Specialized/MultipartBodyBuilderTrait.php
+++ b/Classes/Specialized/MultipartBodyBuilderTrait.php
@@ -77,7 +77,7 @@ trait MultipartBodyBuilderTrait
     {
         $body = '';
         foreach ($parts as $part) {
-            $name = isset($part['name']) && is_string($part['name']) ? $part['name'] : '';
+            $name = $this->sanitizeHeaderToken(isset($part['name']) && is_string($part['name']) ? $part['name'] : '');
             if ($name === '') {
                 continue;
             }
@@ -86,9 +86,12 @@ trait MultipartBodyBuilderTrait
 
             $isFile = isset($part['filename']);
             if ($isFile) {
-                $filename    = is_string($part['filename'] ?? null) ? $part['filename'] : '';
+                $filename    = $this->sanitizeHeaderToken(is_string($part['filename'] ?? null) ? $part['filename'] : '');
                 $content     = is_string($part['content'] ?? null) ? $part['content'] : '';
-                $contentType = is_string($part['contentType'] ?? null) ? $part['contentType'] : 'application/octet-stream';
+                $contentType = $this->sanitizeHeaderToken(is_string($part['contentType'] ?? null) ? $part['contentType'] : 'application/octet-stream');
+                if ($contentType === '') {
+                    $contentType = 'application/octet-stream';
+                }
                 $body .= sprintf(
                     "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"\r\n",
                     $name,
@@ -108,5 +111,23 @@ trait MultipartBodyBuilderTrait
         $body .= "--{$boundary}--\r\n";
 
         return $body;
+    }
+
+    /**
+     * Strip CR/LF and double-quote characters from a value that
+     * lands in a header line. The multipart body interpolates
+     * `name` / `filename` / `contentType` directly into
+     * `Content-Disposition` and `Content-Type` headers; an attacker
+     * (or a careless caller) passing `"\r\nX-Injected: yes"` in a
+     * filename could otherwise inject arbitrary headers or break
+     * the body framing. Header values that consist only of unsafe
+     * characters return the empty string — the caller's part is
+     * then dropped by the body builder.
+     */
+    private function sanitizeHeaderToken(string $value): string
+    {
+        // Strip CR, LF, NUL, and double-quote — these are the only
+        // characters that could break header framing in this context.
+        return str_replace(["\r", "\n", "\0", '"'], '', $value);
     }
 }

--- a/Classes/Specialized/MultipartBodyBuilderTrait.php
+++ b/Classes/Specialized/MultipartBodyBuilderTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized;
+
+use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+
+/**
+ * Multipart/form-data body construction for specialised services
+ * that upload files (REC #7).
+ *
+ * Currently consumed by `WhisperTranscriptionService` (audio
+ * transcription file upload) and `DallEImageService` (image edit /
+ * variation file upload). JSON-only services (`FalImageService`,
+ * `TextToSpeechService`, `DeepLTranslator`) do not use this trait
+ * — keeping multipart out of `AbstractSpecializedService` means
+ * those three services do not pay the trait's footprint.
+ *
+ * Consumers must `use` `AbstractSpecializedService` (this trait
+ * relies on its `requestFactory`, `streamFactory`, `buildAuthHeaders()`,
+ * `buildEndpointUrl()`, and `executeRequest()` members).
+ *
+ * Part shapes:
+ * - File part:    `['name' => string, 'filename' => string, 'content' => string, 'contentType' => string]`
+ *                 (`contentType` is optional; defaults to `application/octet-stream`).
+ * - Field part:   `['name' => string, 'value' => string|int|float]`.
+ */
+trait MultipartBodyBuilderTrait
+{
+    /**
+     * Send a multipart/form-data request and return the decoded
+     * response. Boundary is generated per-call via `uniqid()` with a
+     * `nrllm-` prefix to keep the wire payload self-identifying in
+     * captured traffic.
+     *
+     * @param list<array<string, mixed>> $parts Each part as a file or field shape (see trait docblock)
+     *
+     * @throws ServiceUnavailableException
+     * @throws ServiceConfigurationException
+     *
+     * @return array<string, mixed>
+     */
+    protected function sendMultipartRequest(string $endpoint, array $parts): array
+    {
+        $boundary = 'nrllm-' . uniqid('', true);
+        $body     = $this->encodeMultipartBody($parts, $boundary);
+        $url      = $this->buildEndpointUrl($endpoint);
+
+        $request = $this->requestFactory->createRequest('POST', $url)
+            ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
+
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        $request = $request->withBody($this->streamFactory->createStream($body));
+
+        return $this->executeRequest($request);
+    }
+
+    /**
+     * Encode parts into a multipart/form-data body. Public-ish (it's
+     * `protected`) so subclasses that need to inspect or test the
+     * exact wire body can call it directly without firing a real
+     * HTTP request.
+     *
+     * @param list<array<string, mixed>> $parts
+     */
+    protected function encodeMultipartBody(array $parts, string $boundary): string
+    {
+        $body = '';
+        foreach ($parts as $part) {
+            $name = isset($part['name']) && is_string($part['name']) ? $part['name'] : '';
+            if ($name === '') {
+                continue;
+            }
+
+            $body .= "--{$boundary}\r\n";
+
+            $isFile = isset($part['filename']);
+            if ($isFile) {
+                $filename    = is_string($part['filename'] ?? null) ? $part['filename'] : '';
+                $content     = is_string($part['content'] ?? null) ? $part['content'] : '';
+                $contentType = is_string($part['contentType'] ?? null) ? $part['contentType'] : 'application/octet-stream';
+                $body .= sprintf(
+                    "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"\r\n",
+                    $name,
+                    $filename,
+                );
+                $body .= "Content-Type: {$contentType}\r\n\r\n";
+                $body .= $content . "\r\n";
+                continue;
+            }
+
+            $value = $part['value'] ?? '';
+            $stringValue = is_scalar($value) ? (string)$value : '';
+            $body .= "Content-Disposition: form-data; name=\"{$name}\"\r\n\r\n";
+            $body .= $stringValue . "\r\n";
+        }
+
+        $body .= "--{$boundary}--\r\n";
+
+        return $body;
+    }
+}

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -9,17 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;
 
-use Exception;
-use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\SpeechSynthesisOptions;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Text-to-speech synthesis service using OpenAI TTS.
@@ -33,9 +27,14 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * - Multiple output formats (mp3, opus, aac, flac, wav, pcm)
  * - Maximum input of 4096 characters per request
  *
+ * Owns its own request execution because TTS returns raw binary
+ * audio bytes — the base's `executeRequest()` always JSON-decodes.
+ * Everything else (config loading, availability, auth headers,
+ * endpoint construction) comes from `AbstractSpecializedService`.
+ *
  * @see https://platform.openai.com/docs/guides/text-to-speech
  */
-final class TextToSpeechService
+final class TextToSpeechService extends AbstractSpecializedService
 {
     private const API_URL = 'https://api.openai.com/v1/audio/speech';
     private const DEFAULT_MODEL = 'tts-1';
@@ -61,30 +60,6 @@ final class TextToSpeechService
     /** Supported output formats. */
     private const FORMATS = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];
 
-    private string $apiKey = '';
-    private string $baseUrl = '';
-    /** @phpstan-ignore property.onlyWritten (intended for future HTTP client configuration) */
-    private int $timeout = 60;
-
-    public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly UsageTrackerServiceInterface $usageTracker,
-        private readonly LoggerInterface $logger,
-    ) {
-        $this->loadConfiguration();
-    }
-
-    /**
-     * Check if service is available.
-     */
-    public function isAvailable(): bool
-    {
-        return $this->apiKey !== '';
-    }
-
     /**
      * Synthesize speech from text.
      *
@@ -105,10 +80,8 @@ final class TextToSpeechService
             ? $options
             : SpeechSynthesisOptions::fromArray($options);
 
-        // Validate input
         $this->validateInput($text);
 
-        // Build request
         $optionsArray = $options->toArray();
         $modelValue = $optionsArray['model'] ?? null;
         $model = is_string($modelValue) ? $modelValue : self::DEFAULT_MODEL;
@@ -127,10 +100,8 @@ final class TextToSpeechService
             'speed' => $speed,
         ];
 
-        // Send request
-        $audioContent = $this->sendRequest($payload);
+        $audioContent = $this->sendBinaryRequest($payload);
 
-        // Track usage
         $this->usageTracker->trackUsage('speech', 'tts:' . $model, [
             'characters' => mb_strlen($text),
             'voice' => $voice,
@@ -196,12 +167,10 @@ final class TextToSpeechService
             ? $options
             : SpeechSynthesisOptions::fromArray($options);
 
-        // If text fits in single request, use normal synthesis
         if (mb_strlen($text) <= self::MAX_INPUT_LENGTH) {
             return [$this->synthesize($text, $options)];
         }
 
-        // Split into chunks at sentence boundaries
         $chunks = $this->splitTextIntoChunks($text);
         $results = [];
 
@@ -250,55 +219,61 @@ final class TextToSpeechService
         return self::MAX_INPUT_LENGTH;
     }
 
-    /**
-     * Load configuration from extension settings.
-     */
-    private function loadConfiguration(): void
+    protected function getServiceDomain(): string
     {
-        try {
-            $config = $this->extensionConfiguration->get('nr_llm');
-            if (!is_array($config)) {
-                return;
-            }
+        return 'speech';
+    }
 
-            // Use OpenAI API key for TTS
-            $providers = $config['providers'] ?? null;
-            if (is_array($providers)) {
-                $openai = $providers['openai'] ?? null;
-                if (is_array($openai)) {
-                    $apiKey = $openai['apiKey'] ?? '';
-                    $this->apiKey = is_string($apiKey) ? $apiKey : '';
-                }
-            }
+    protected function getServiceProvider(): string
+    {
+        return 'tts';
+    }
 
-            // Load speech configuration
-            $speech = $config['speech'] ?? null;
-            if (is_array($speech)) {
-                $tts = $speech['tts'] ?? null;
-                if (is_array($tts)) {
-                    $baseUrl = $tts['baseUrl'] ?? null;
-                    $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
-                    $timeout = $tts['timeout'] ?? null;
-                    $this->timeout = is_numeric($timeout) ? (int)$timeout : 60;
-                }
-            }
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load TTS configuration', [
-                'exception' => $e->getMessage(),
-            ]);
-        }
+    protected function getDefaultBaseUrl(): string
+    {
+        return self::API_URL;
+    }
+
+    protected function getDefaultTimeout(): int
+    {
+        return 60;
     }
 
     /**
-     * Ensure service is available.
-     *
-     * @throws ServiceUnavailableException
+     * @param array<string, mixed> $config
      */
-    private function ensureAvailable(): void
+    protected function loadServiceConfiguration(array $config): void
     {
-        if (!$this->isAvailable()) {
-            throw ServiceUnavailableException::notConfigured('speech', 'tts');
+        $providers = $config['providers'] ?? null;
+        if (is_array($providers)) {
+            $openai = $providers['openai'] ?? null;
+            if (is_array($openai)) {
+                $apiKey = $openai['apiKey'] ?? '';
+                $this->apiKey = is_string($apiKey) ? $apiKey : '';
+            }
         }
+
+        $this->baseUrl = self::API_URL;
+        $speech = $config['speech'] ?? null;
+        if (is_array($speech)) {
+            $tts = $speech['tts'] ?? null;
+            if (is_array($tts)) {
+                $baseUrl = $tts['baseUrl'] ?? null;
+                $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+                $timeout = $tts['timeout'] ?? null;
+                $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
+            }
+        }
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'Bearer ' . $this->apiKey];
+    }
+
+    protected function getProviderLabel(): string
+    {
+        return 'TTS';
     }
 
     /**
@@ -338,22 +313,18 @@ final class TextToSpeechService
         $chunks = [];
         $currentChunk = '';
 
-        // Split into sentences (simple approach)
         $sentences = preg_split('/(?<=[.!?])\s+/', $text, -1, PREG_SPLIT_NO_EMPTY);
 
         if ($sentences === false) {
-            // Fallback: split by length
             return str_split($text, self::MAX_INPUT_LENGTH) ?: [$text];
         }
 
         foreach ($sentences as $sentence) {
-            // If single sentence is too long, split it
             if (mb_strlen($sentence) > self::MAX_INPUT_LENGTH) {
                 if ($currentChunk !== '') {
                     $chunks[] = $currentChunk;
                     $currentChunk = '';
                 }
-                // Split long sentence by commas or force-split
                 $subChunks = $this->splitLongSentence($sentence);
                 foreach ($subChunks as $subChunk) {
                     $chunks[] = $subChunk;
@@ -361,13 +332,11 @@ final class TextToSpeechService
                 continue;
             }
 
-            // Check if adding this sentence exceeds limit
             $testChunk = $currentChunk === '' ? $sentence : $currentChunk . ' ' . $sentence;
 
             if (mb_strlen($testChunk) <= self::MAX_INPUT_LENGTH) {
                 $currentChunk = $testChunk;
             } else {
-                // Save current chunk and start new one
                 if ($currentChunk !== '') {
                     $chunks[] = $currentChunk;
                 }
@@ -375,7 +344,6 @@ final class TextToSpeechService
             }
         }
 
-        // Add remaining chunk
         if ($currentChunk !== '') {
             $chunks[] = $currentChunk;
         }
@@ -390,7 +358,6 @@ final class TextToSpeechService
      */
     private function splitLongSentence(string $sentence): array
     {
-        // Try to split at commas first
         $parts = explode(', ', $sentence);
 
         if (count($parts) > 1) {
@@ -418,27 +385,28 @@ final class TextToSpeechService
             return $chunks;
         }
 
-        // Force-split if no natural break points
         return str_split($sentence, self::MAX_INPUT_LENGTH) ?: [$sentence];
     }
 
     /**
-     * Send synthesis request.
+     * Send synthesis request and return the binary audio body.
+     * Cannot use the base's `sendJsonRequest()` because that one
+     * JSON-decodes the response — TTS gives us raw bytes.
      *
-     * @param array<string, mixed> $payload Request payload
+     * @param array<string, mixed> $payload
      *
      * @throws ServiceUnavailableException
-     *
-     * @return string Binary audio content
      */
-    private function sendRequest(array $payload): string
+    private function sendBinaryRequest(array $payload): string
     {
-        $request = $this->requestFactory->createRequest('POST', $this->baseUrl)
-            ->withHeader('Authorization', 'Bearer ' . $this->apiKey)
+        $request = $this->requestFactory->createRequest('POST', $this->buildEndpointUrl(''))
             ->withHeader('Content-Type', 'application/json');
-
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
-        $request = $request->withBody($body);
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        $request = $request->withBody(
+            $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR)),
+        );
 
         try {
             $response = $this->httpClient->sendRequest($request);
@@ -448,29 +416,14 @@ final class TextToSpeechService
                 return (string)$response->getBody();
             }
 
-            $responseBody = (string)$response->getBody();
-            $decoded = json_decode($responseBody, true);
-            $errorMessage = 'Unknown TTS API error';
-            if (is_array($decoded)) {
-                $errorData = $decoded['error'] ?? null;
-                if (is_array($errorData)) {
-                    $message = $errorData['message'] ?? null;
-                    if (is_string($message)) {
-                        $errorMessage = $message;
-                    }
-                }
-            }
+            $errorMessage = $this->decodeErrorMessage((string)$response->getBody());
 
             $this->logger->error('TTS API error', [
                 'status_code' => $statusCode,
-                'error' => $errorMessage,
+                'error'       => $errorMessage,
             ]);
 
-            throw match ($statusCode) {
-                401, 403 => ServiceConfigurationException::invalidApiKey('speech', 'tts'),
-                429 => new ServiceUnavailableException('TTS API rate limit exceeded', 'speech', ['provider' => 'tts']),
-                default => new ServiceUnavailableException('TTS API error: ' . $errorMessage, 'speech', ['provider' => 'tts']),
-            };
+            throw $this->mapErrorStatus($statusCode, $errorMessage);
         } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
             throw $e;
         } catch (Throwable $e) {

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -9,18 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;
 
-use Exception;
-use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
+use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Option\TranscriptionOptions;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Whisper speech-to-text transcription service.
@@ -34,10 +29,18 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * - Word-level timestamps (verbose mode)
  * - Prompt guidance for improved accuracy
  *
+ * Owns its own multipart-request execution rather than using the
+ * trait's `sendMultipartRequest()` because Whisper returns raw
+ * `string` bodies for the `text`/`srt`/`vtt` response formats — the
+ * base's `executeRequest()` always JSON-decodes. Only the body
+ * construction (`encodeMultipartBody`) is shared via the trait.
+ *
  * @see https://platform.openai.com/docs/guides/speech-to-text
  */
-final class WhisperTranscriptionService
+final class WhisperTranscriptionService extends AbstractSpecializedService
 {
+    use MultipartBodyBuilderTrait;
+
     private const API_URL = 'https://api.openai.com/v1/audio';
     private const DEFAULT_MODEL = 'whisper-1';
     private const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
@@ -51,30 +54,6 @@ final class WhisperTranscriptionService
     private const RESPONSE_FORMATS = [
         'json', 'text', 'srt', 'vtt', 'verbose_json',
     ];
-
-    private string $apiKey = '';
-    private string $baseUrl = '';
-    /** @phpstan-ignore property.onlyWritten (intended for future HTTP client configuration) */
-    private int $timeout = 120; // Transcription can take longer
-
-    public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly UsageTrackerServiceInterface $usageTracker,
-        private readonly LoggerInterface $logger,
-    ) {
-        $this->loadConfiguration();
-    }
-
-    /**
-     * Check if service is available.
-     */
-    public function isAvailable(): bool
-    {
-        return $this->apiKey !== '';
-    }
 
     /**
      * Transcribe audio file to text.
@@ -97,13 +76,10 @@ final class WhisperTranscriptionService
             ? $options
             : TranscriptionOptions::fromArray($options);
 
-        // Validate file
         $this->validateAudioFile($audioPath);
 
-        // Build multipart request
         $response = $this->sendTranscriptionRequest($audioPath, $options);
 
-        // Parse response based on format
         return $this->parseTranscriptionResponse($response, $options);
     }
 
@@ -127,7 +103,6 @@ final class WhisperTranscriptionService
             ? $options
             : TranscriptionOptions::fromArray($options);
 
-        // Validate content size
         if (strlen($audioContent) > self::MAX_FILE_SIZE) {
             throw new UnsupportedFormatException(
                 sprintf('Audio content exceeds maximum size of %d MB', self::MAX_FILE_SIZE / 1024 / 1024),
@@ -135,13 +110,11 @@ final class WhisperTranscriptionService
             );
         }
 
-        // Validate format from filename
         $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
         if (!in_array($extension, self::SUPPORTED_FORMATS, true)) {
             throw UnsupportedFormatException::audioFormat($extension);
         }
 
-        // Build multipart request with content
         $response = $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options);
 
         return $this->parseTranscriptionResponse($response, $options);
@@ -174,7 +147,6 @@ final class WhisperTranscriptionService
 
         $result = $this->parseTranscriptionResponse($response, $options);
 
-        // Track usage
         $this->usageTracker->trackUsage('speech', 'whisper:translation', [
             'file_size' => filesize($audioPath),
         ]);
@@ -202,39 +174,46 @@ final class WhisperTranscriptionService
         return self::RESPONSE_FORMATS;
     }
 
-    /**
-     * Load configuration from extension settings.
-     */
-    private function loadConfiguration(): void
+    protected function getServiceDomain(): string
     {
-        try {
-            $config = $this->extensionConfiguration->get('nr_llm');
-            if (!is_array($config)) {
-                return;
-            }
+        return 'speech';
+    }
 
-            // Use OpenAI API key for Whisper
-            /** @var array{providers?: array{openai?: array{apiKey?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
-            $this->apiKey = (string)($config['providers']['openai']['apiKey'] ?? '');
-            $this->baseUrl = (string)($config['speech']['whisper']['baseUrl'] ?? self::API_URL);
-            $this->timeout = (int)($config['speech']['whisper']['timeout'] ?? 120);
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load Whisper configuration', [
-                'exception' => $e->getMessage(),
-            ]);
-        }
+    protected function getServiceProvider(): string
+    {
+        return 'whisper';
+    }
+
+    protected function getDefaultBaseUrl(): string
+    {
+        return self::API_URL;
+    }
+
+    protected function getDefaultTimeout(): int
+    {
+        // Transcription can take longer than other operations.
+        return 120;
     }
 
     /**
-     * Ensure service is available.
-     *
-     * @throws ServiceUnavailableException
+     * @param array<string, mixed> $config
      */
-    private function ensureAvailable(): void
+    protected function loadServiceConfiguration(array $config): void
     {
-        if (!$this->isAvailable()) {
-            throw ServiceUnavailableException::notConfigured('speech', 'whisper');
-        }
+        /** @var array{providers?: array{openai?: array{apiKey?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
+        $this->apiKey  = (string)($config['providers']['openai']['apiKey'] ?? '');
+        $this->baseUrl = (string)($config['speech']['whisper']['baseUrl'] ?? self::API_URL);
+        $this->timeout = (int)($config['speech']['whisper']['timeout'] ?? $this->getDefaultTimeout());
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'Bearer ' . $this->apiKey];
+    }
+
+    protected function getProviderLabel(): string
+    {
+        return 'Whisper';
     }
 
     /**
@@ -274,12 +253,17 @@ final class WhisperTranscriptionService
         string $audioPath,
         TranscriptionOptions $options,
     ): array|string {
-        $url = rtrim($this->baseUrl, '/') . '/transcriptions';
+        $content = file_get_contents($audioPath);
+        if ($content === false) {
+            throw new ServiceUnavailableException(
+                sprintf('Failed to read audio file: %s', $audioPath),
+                'speech',
+                ['audioPath' => $audioPath],
+            );
+        }
+        $parts = $this->buildTranscriptionParts(basename($audioPath), $content, $options);
 
-        $boundary = 'whisper' . uniqid();
-        $body = $this->buildMultipartBody($audioPath, $options, $boundary);
-
-        return $this->sendMultipartRequest($url, $body, $boundary, $options);
+        return $this->dispatchMultipart('transcriptions', $parts, $options);
     }
 
     /**
@@ -292,12 +276,9 @@ final class WhisperTranscriptionService
         string $filename,
         TranscriptionOptions $options,
     ): array|string {
-        $url = rtrim($this->baseUrl, '/') . '/transcriptions';
+        $parts = $this->buildTranscriptionParts($filename, $audioContent, $options);
 
-        $boundary = 'whisper' . uniqid();
-        $body = $this->buildMultipartBodyFromContent($audioContent, $filename, $options, $boundary);
-
-        return $this->sendMultipartRequest($url, $body, $boundary, $options);
+        return $this->dispatchMultipart('transcriptions', $parts, $options);
     }
 
     /**
@@ -309,26 +290,6 @@ final class WhisperTranscriptionService
         string $audioPath,
         TranscriptionOptions $options,
     ): array|string {
-        $url = rtrim($this->baseUrl, '/') . '/translations';
-
-        $boundary = 'whisper' . uniqid();
-        $body = $this->buildMultipartBody($audioPath, $options, $boundary);
-
-        return $this->sendMultipartRequest($url, $body, $boundary, $options);
-    }
-
-    /**
-     * Build multipart form body from file.
-     */
-    private function buildMultipartBody(
-        string $audioPath,
-        TranscriptionOptions $options,
-        string $boundary,
-    ): string {
-        $body = '';
-
-        // Add file
-        $filename = basename($audioPath);
         $content = file_get_contents($audioPath);
         if ($content === false) {
             throw new ServiceUnavailableException(
@@ -337,117 +298,79 @@ final class WhisperTranscriptionService
                 ['audioPath' => $audioPath],
             );
         }
-        $body .= "--{$boundary}\r\n";
-        $body .= "Content-Disposition: form-data; name=\"file\"; filename=\"{$filename}\"\r\n";
-        $body .= "Content-Type: application/octet-stream\r\n\r\n";
-        $body .= $content . "\r\n";
+        $parts = $this->buildTranscriptionParts(basename($audioPath), $content, $options);
 
-        // Add model
-        $model = $options->model ?? self::DEFAULT_MODEL;
-        $body .= "--{$boundary}\r\n";
-        $body .= "Content-Disposition: form-data; name=\"model\"\r\n\r\n";
-        $body .= $model . "\r\n";
-
-        // Add optional parameters
-        if ($options->language !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"language\"\r\n\r\n";
-            $body .= $options->language . "\r\n";
-        }
-
-        if ($options->format !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"response_format\"\r\n\r\n";
-            $body .= $options->format . "\r\n";
-        }
-
-        if ($options->prompt !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"prompt\"\r\n\r\n";
-            $body .= $options->prompt . "\r\n";
-        }
-
-        if ($options->temperature !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"temperature\"\r\n\r\n";
-            $body .= (string)$options->temperature . "\r\n";
-        }
-
-        $body .= "--{$boundary}--\r\n";
-
-        return $body;
+        return $this->dispatchMultipart('translations', $parts, $options);
     }
 
     /**
-     * Build multipart form body from content.
+     * Compose the multipart parts list shared by transcription /
+     * translation paths. The file part comes first; optional fields
+     * follow only when set on the options object.
+     *
+     * @return list<array<string, mixed>>
      */
-    private function buildMultipartBodyFromContent(
-        string $audioContent,
+    private function buildTranscriptionParts(
         string $filename,
+        string $audioContent,
         TranscriptionOptions $options,
-        string $boundary,
-    ): string {
-        $body = '';
+    ): array {
+        $parts = [
+            [
+                'name'        => 'file',
+                'filename'    => $filename,
+                'content'     => $audioContent,
+                'contentType' => 'application/octet-stream',
+            ],
+            [
+                'name'  => 'model',
+                'value' => $options->model ?? self::DEFAULT_MODEL,
+            ],
+        ];
 
-        // Add file content
-        $body .= "--{$boundary}\r\n";
-        $body .= "Content-Disposition: form-data; name=\"file\"; filename=\"{$filename}\"\r\n";
-        $body .= "Content-Type: application/octet-stream\r\n\r\n";
-        $body .= $audioContent . "\r\n";
-
-        // Add model
-        $model = $options->model ?? self::DEFAULT_MODEL;
-        $body .= "--{$boundary}\r\n";
-        $body .= "Content-Disposition: form-data; name=\"model\"\r\n\r\n";
-        $body .= $model . "\r\n";
-
-        // Add optional parameters (same as file version)
         if ($options->language !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"language\"\r\n\r\n";
-            $body .= $options->language . "\r\n";
+            $parts[] = ['name' => 'language', 'value' => $options->language];
         }
-
         if ($options->format !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"response_format\"\r\n\r\n";
-            $body .= $options->format . "\r\n";
+            $parts[] = ['name' => 'response_format', 'value' => $options->format];
         }
-
         if ($options->prompt !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"prompt\"\r\n\r\n";
-            $body .= $options->prompt . "\r\n";
+            $parts[] = ['name' => 'prompt', 'value' => $options->prompt];
         }
-
         if ($options->temperature !== null) {
-            $body .= "--{$boundary}\r\n";
-            $body .= "Content-Disposition: form-data; name=\"temperature\"\r\n\r\n";
-            $body .= (string)$options->temperature . "\r\n";
+            $parts[] = ['name' => 'temperature', 'value' => (string)$options->temperature];
         }
 
-        $body .= "--{$boundary}--\r\n";
-
-        return $body;
+        return $parts;
     }
 
     /**
-     * Send multipart request.
+     * Send the multipart request and return either the JSON-decoded
+     * body (for `json` / `verbose_json`) or the raw string body
+     * (`text` / `srt` / `vtt`). Whisper's response shape is
+     * format-dependent so the base's strict-array `executeRequest()`
+     * does not fit; this method owns the request lifecycle while
+     * still using the trait's `encodeMultipartBody()` for the wire
+     * payload and the base's `buildAuthHeaders()` for auth.
+     *
+     * @param list<array<string, mixed>> $parts
      *
      * @throws ServiceUnavailableException
+     * @throws ServiceConfigurationException
      *
-     * @return array<string, mixed>|string Response data
+     * @return array<string, mixed>|string
      */
-    private function sendMultipartRequest(
-        string $url,
-        string $body,
-        string $boundary,
-        TranscriptionOptions $options,
-    ): array|string {
-        $request = $this->requestFactory->createRequest('POST', $url)
-            ->withHeader('Authorization', 'Bearer ' . $this->apiKey)
-            ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
+    private function dispatchMultipart(string $endpoint, array $parts, TranscriptionOptions $options): array|string
+    {
+        $boundary = 'whisper-' . uniqid('', true);
+        $body     = $this->encodeMultipartBody($parts, $boundary);
+        $url      = $this->buildEndpointUrl($endpoint);
 
+        $request = $this->requestFactory->createRequest('POST', $url)
+            ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
         $request = $request->withBody($this->streamFactory->createStream($body));
 
         try {
@@ -456,10 +379,8 @@ final class WhisperTranscriptionService
             $responseBody = (string)$response->getBody();
 
             if ($statusCode >= 200 && $statusCode < 300) {
-                // Track usage for successful requests
                 $this->usageTracker->trackUsage('speech', 'whisper:transcription', []);
 
-                // Return raw text for text/srt/vtt formats
                 $format = $options->format ?? 'json';
                 if (in_array($format, ['text', 'srt', 'vtt'], true)) {
                     return $responseBody;
@@ -469,22 +390,14 @@ final class WhisperTranscriptionService
                 return json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
             }
 
-            /** @var array{error?: array{message?: string}} $error */
-            $error = json_decode($responseBody, true) ?? [];
-            $errorMessage = is_string($error['error']['message'] ?? null)
-                ? $error['error']['message']
-                : 'Unknown Whisper API error';
+            $errorMessage = $this->decodeErrorMessage($responseBody);
 
             $this->logger->error('Whisper API error', [
                 'status_code' => $statusCode,
-                'error' => $errorMessage,
+                'error'       => $errorMessage,
             ]);
 
-            throw match ($statusCode) {
-                401, 403 => ServiceConfigurationException::invalidApiKey('speech', 'whisper'),
-                429 => new ServiceUnavailableException('Whisper API rate limit exceeded', 'speech', ['provider' => 'whisper']),
-                default => new ServiceUnavailableException('Whisper API error: ' . $errorMessage, 'speech', ['provider' => 'whisper']),
-            };
+            throw $this->mapErrorStatus($statusCode, $errorMessage);
         } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
             throw $e;
         } catch (Throwable $e) {
@@ -513,7 +426,6 @@ final class WhisperTranscriptionService
     ): TranscriptionResult {
         $format = $options->format ?? 'json';
 
-        // Handle text formats
         if (is_string($response)) {
             return new TranscriptionResult(
                 text: $response,
@@ -522,7 +434,6 @@ final class WhisperTranscriptionService
             );
         }
 
-        // Handle JSON formats
         $text = is_string($response['text'] ?? null) ? $response['text'] : '';
         $language = is_string($response['language'] ?? null)
             ? $response['language']
@@ -531,7 +442,6 @@ final class WhisperTranscriptionService
             ? (float)$response['duration']
             : null;
 
-        // Parse segments for verbose_json
         /** @var array<int, Segment>|null $segments */
         $segments = null;
         if ($format === 'verbose_json' && isset($response['segments']) && is_array($response['segments'])) {

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -9,18 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Translation;
 
-use Exception;
 use Netresearch\NrLlm\Attribute\AsTranslator;
-use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * DeepL translation service integration.
@@ -35,10 +29,17 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * - HTML/XML tag handling with formatting preservation
  * - Document translation (PDFs, DOCX, etc.)
  *
+ * Inherits HTTP scaffolding from `AbstractSpecializedService` —
+ * including config loading, availability check, and error mapping.
+ * Owns its own request execution because DeepL needs the
+ * `User-Agent` header and accepts both POST (translate) and GET
+ * (usage / glossaries) requests; that's not generic enough for the
+ * base's `sendJsonRequest()` helper.
+ *
  * @see https://developers.deepl.com/docs
  */
 #[AsTranslator]
-final class DeepLTranslator implements TranslatorInterface
+final class DeepLTranslator extends AbstractSpecializedService implements TranslatorInterface
 {
     private const API_VERSION = 'v2';
     private const FREE_API_URL = 'https://api-free.deepl.com';
@@ -69,22 +70,6 @@ final class DeepLTranslator implements TranslatorInterface
         'de', 'fr', 'it', 'es', 'nl', 'pl', 'pt', 'pt-br', 'pt-pt', 'ru', 'ja',
     ];
 
-    private string $apiKey = '';
-    private string $baseUrl = '';
-    /** @phpstan-ignore property.onlyWritten (intended for future HTTP client configuration) */
-    private int $timeout = 30;
-
-    public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly UsageTrackerServiceInterface $usageTracker,
-        private readonly LoggerInterface $logger,
-    ) {
-        $this->loadConfiguration();
-    }
-
     public function getIdentifier(): string
     {
         return 'deepl';
@@ -100,11 +85,6 @@ final class DeepLTranslator implements TranslatorInterface
         return 90;
     }
 
-    public function isAvailable(): bool
-    {
-        return $this->apiKey !== '';
-    }
-
     public function translate(
         string $text,
         string $targetLanguage,
@@ -113,19 +93,15 @@ final class DeepLTranslator implements TranslatorInterface
     ): TranslatorResult {
         $this->ensureAvailable();
 
-        // Normalize language codes for DeepL
         $targetLanguage = $this->normalizeLanguageCode($targetLanguage, false);
         if ($sourceLanguage !== null) {
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
-        // Build request payload
         $payload = $this->buildTranslatePayload($text, $targetLanguage, $sourceLanguage, $options);
 
-        // Execute request
-        $response = $this->sendRequest('translate', $payload);
+        $response = $this->sendDeeplRequest('translate', $payload);
 
-        // Parse response
         /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
         if ($translations === []) {
@@ -139,7 +115,6 @@ final class DeepLTranslator implements TranslatorInterface
         $translation = $translations[0];
         $detectedSourceLanguage = strtolower($translation['detected_source_language'] ?? $sourceLanguage ?? 'en');
 
-        // Track usage
         $this->usageTracker->trackUsage('translation', 'deepl', [
             'characters' => mb_strlen($text),
         ]);
@@ -169,19 +144,15 @@ final class DeepLTranslator implements TranslatorInterface
 
         $this->ensureAvailable();
 
-        // Normalize language codes
         $targetLanguage = $this->normalizeLanguageCode($targetLanguage, false);
         if ($sourceLanguage !== null) {
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
-        // Build batch payload
         $payload = $this->buildBatchPayload($texts, $targetLanguage, $sourceLanguage, $options);
 
-        // Execute request
-        $response = $this->sendRequest('translate', $payload);
+        $response = $this->sendDeeplRequest('translate', $payload);
 
-        // Parse response
         /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
         $results = [];
@@ -202,7 +173,6 @@ final class DeepLTranslator implements TranslatorInterface
             );
         }
 
-        // Track batch usage
         $totalCharacters = array_sum(array_map(mb_strlen(...), $texts));
         $this->usageTracker->trackUsage('translation', 'deepl', [
             'characters' => $totalCharacters,
@@ -214,11 +184,10 @@ final class DeepLTranslator implements TranslatorInterface
 
     public function getSupportedLanguages(): array
     {
-        // Return union of source and target languages
         return array_values(array_unique(array_merge(
             self::SUPPORTED_SOURCE_LANGUAGES,
             array_map(
-                fn(string $lang) => explode('-', $lang)[0], // Normalize to base codes
+                fn(string $lang) => explode('-', $lang)[0],
                 self::SUPPORTED_TARGET_LANGUAGES,
             ),
         )));
@@ -228,19 +197,17 @@ final class DeepLTranslator implements TranslatorInterface
     {
         $this->ensureAvailable();
 
-        // DeepL doesn't have a dedicated language detection endpoint
-        // We use translation with auto-detection to get the source language
         $payload = [
-            'text' => [substr($text, 0, 100)], // Use first 100 chars for detection
-            'target_lang' => 'EN', // Translate to English for detection
+            'text' => [substr($text, 0, 100)],
+            'target_lang' => 'EN',
         ];
 
-        $response = $this->sendRequest('translate', $payload);
+        $response = $this->sendDeeplRequest('translate', $payload);
 
         /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
         if ($translations === []) {
-            return 'en'; // Fallback
+            return 'en';
         }
 
         return strtolower($translations[0]['detected_source_language'] ?? 'en');
@@ -278,7 +245,7 @@ final class DeepLTranslator implements TranslatorInterface
     {
         $this->ensureAvailable();
 
-        $response = $this->sendRequest('usage', [], 'GET');
+        $response = $this->sendDeeplRequest('usage', [], 'GET');
 
         $characterCount = $response['character_count'] ?? 0;
         $characterLimit = $response['character_limit'] ?? 0;
@@ -298,7 +265,7 @@ final class DeepLTranslator implements TranslatorInterface
     {
         $this->ensureAvailable();
 
-        $response = $this->sendRequest('glossaries', [], 'GET');
+        $response = $this->sendDeeplRequest('glossaries', [], 'GET');
 
         /** @var array<int, array{glossary_id: string, name: string, source_lang: string, target_lang: string}> $glossaries */
         $glossaries = $response['glossaries'] ?? [];
@@ -306,47 +273,93 @@ final class DeepLTranslator implements TranslatorInterface
         return $glossaries;
     }
 
-    /**
-     * Load configuration from extension settings.
-     */
-    private function loadConfiguration(): void
+    protected function getServiceDomain(): string
     {
-        try {
-            $config = $this->extensionConfiguration->get('nr_llm');
+        return 'translation';
+    }
 
-            if (!is_array($config)) {
-                return;
-            }
+    protected function getServiceProvider(): string
+    {
+        return 'deepl';
+    }
 
-            /** @var array{translators?: array{deepl?: array{apiKey?: string, timeout?: int, baseUrl?: string}}} $config */
-            $deeplConfig = $config['translators']['deepl'] ?? [];
+    protected function getDefaultBaseUrl(): string
+    {
+        return self::PRO_API_URL;
+    }
 
-            $this->apiKey = $deeplConfig['apiKey'] ?? '';
-            $this->timeout = (int)($deeplConfig['timeout'] ?? 30);
-
-            // Determine API URL based on API key type (free keys end with :fx)
-            if ($this->apiKey !== '' && str_ends_with($this->apiKey, ':fx')) {
-                $this->baseUrl = self::FREE_API_URL;
-            } else {
-                $this->baseUrl = $deeplConfig['baseUrl'] ?? self::PRO_API_URL;
-            }
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load DeepL configuration', [
-                'exception' => $e->getMessage(),
-            ]);
-        }
+    protected function getDefaultTimeout(): int
+    {
+        return 30;
     }
 
     /**
-     * Ensure translator is available.
-     *
-     * @throws ServiceUnavailableException
+     * @param array<string, mixed> $config
      */
-    private function ensureAvailable(): void
+    protected function loadServiceConfiguration(array $config): void
     {
-        if (!$this->isAvailable()) {
-            throw ServiceUnavailableException::notConfigured('translation', 'deepl');
+        /** @var array{translators?: array{deepl?: array{apiKey?: string, timeout?: int, baseUrl?: string}}} $config */
+        $deeplConfig = $config['translators']['deepl'] ?? [];
+
+        $this->apiKey = $deeplConfig['apiKey'] ?? '';
+        $this->timeout = (int)($deeplConfig['timeout'] ?? $this->getDefaultTimeout());
+
+        // DeepL Free vs Pro routing: free keys end with `:fx`. The Pro
+        // URL is the documented default; explicit `baseUrl` override
+        // wins over both.
+        if ($this->apiKey !== '' && str_ends_with($this->apiKey, ':fx')) {
+            $this->baseUrl = self::FREE_API_URL;
+        } else {
+            $this->baseUrl = $deeplConfig['baseUrl'] ?? self::PRO_API_URL;
         }
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return [
+            'Authorization' => 'DeepL-Auth-Key ' . $this->apiKey,
+            'User-Agent'    => 'TYPO3-NrLlm/1.0',
+        ];
+    }
+
+    protected function getProviderLabel(): string
+    {
+        return 'DeepL';
+    }
+
+    /**
+     * DeepL surfaces a top-level `message` key (no nested `error.message`).
+     */
+    protected function decodeErrorMessage(string $responseBody): string
+    {
+        if ($responseBody === '') {
+            return $this->unknownErrorLabel();
+        }
+        $error = json_decode($responseBody, true);
+        if (!is_array($error)) {
+            return $this->unknownErrorLabel();
+        }
+        $message = $error['message'] ?? null;
+        if (is_string($message) && $message !== '') {
+            return $message;
+        }
+        return $this->unknownErrorLabel();
+    }
+
+    /**
+     * DeepL surfaces a custom 456 quota-exceeded status that's worth
+     * a distinct exception payload so consumers can branch on it.
+     */
+    protected function mapErrorStatus(int $statusCode, string $errorMessage): Throwable
+    {
+        if ($statusCode === 456) {
+            return new ServiceUnavailableException(
+                'DeepL API quota exceeded',
+                $this->getServiceDomain(),
+                ['provider' => $this->getServiceProvider()],
+            );
+        }
+        return parent::mapErrorStatus($statusCode, $errorMessage);
     }
 
     /**
@@ -361,10 +374,9 @@ final class DeepLTranslator implements TranslatorInterface
     {
         $code = strtoupper($languageCode);
 
-        // DeepL uses specific codes for some languages
         $mapping = [
-            'NO' => 'NB', // Norwegian -> Norwegian Bokmål
-            'ZH' => $isSource ? 'ZH' : 'ZH-HANS', // Chinese -> Simplified Chinese for targets
+            'NO' => 'NB',
+            'ZH' => $isSource ? 'ZH' : 'ZH-HANS',
         ];
 
         return $mapping[$code] ?? $code;
@@ -392,27 +404,22 @@ final class DeepLTranslator implements TranslatorInterface
             $payload['source_lang'] = $sourceLanguage;
         }
 
-        // Apply DeepL-specific options
         $deepLOptions = isset($options['deepl']) && $options['deepl'] instanceof DeepLOptions
             ? $options['deepl']
             : DeepLOptions::fromArray($options);
 
-        // Formality (only if supported)
         if ($deepLOptions->formality !== null && $this->supportsFormality($targetLanguage)) {
             $payload['formality'] = $this->mapFormality($deepLOptions->formality);
         }
 
-        // Glossary
         if ($deepLOptions->glossaryId !== null) {
             $payload['glossary_id'] = $deepLOptions->glossaryId;
         }
 
-        // Formatting preservation
         if ($deepLOptions->preserveFormatting !== null) {
             $payload['preserve_formatting'] = $deepLOptions->preserveFormatting ? '1' : '0';
         }
 
-        // Tag handling
         if ($deepLOptions->tagHandling !== null) {
             $payload['tag_handling'] = $deepLOptions->tagHandling;
 
@@ -425,7 +432,6 @@ final class DeepLTranslator implements TranslatorInterface
             }
         }
 
-        // Split sentences
         if ($deepLOptions->splitSentences !== null) {
             $payload['split_sentences'] = $deepLOptions->splitSentences ? '1' : '0';
         }
@@ -456,7 +462,6 @@ final class DeepLTranslator implements TranslatorInterface
             $payload['source_lang'] = $sourceLanguage;
         }
 
-        // Apply same options as single translation
         $deepLOptions = isset($options['deepl']) && $options['deepl'] instanceof DeepLOptions
             ? $options['deepl']
             : DeepLOptions::fromArray($options);
@@ -505,76 +510,39 @@ final class DeepLTranslator implements TranslatorInterface
     }
 
     /**
-     * Send request to DeepL API.
+     * Send request to DeepL API. Custom variant of the base's
+     * `sendJsonRequest()` that adds the API version prefix to the
+     * URL, supports GET as well as POST, and reuses the base's
+     * `executeRequest()` for status / error handling.
      *
-     * @param string               $endpoint API endpoint (without version prefix)
-     * @param array<string, mixed> $payload  Request payload
-     * @param string               $method   HTTP method
+     * @param array<string, mixed> $payload
      *
      * @throws ServiceUnavailableException
+     * @throws ServiceConfigurationException
      *
-     * @return array<string, mixed> Response data
+     * @return array<string, mixed>
      */
-    private function sendRequest(string $endpoint, array $payload, string $method = 'POST'): array
+    private function sendDeeplRequest(string $endpoint, array $payload, string $method = 'POST'): array
     {
-        $url = sprintf('%s/%s/%s', rtrim($this->baseUrl, '/'), self::API_VERSION, ltrim($endpoint, '/'));
+        $url = sprintf(
+            '%s/%s/%s',
+            rtrim($this->baseUrl, '/'),
+            self::API_VERSION,
+            ltrim($endpoint, '/'),
+        );
 
         $request = $this->requestFactory->createRequest($method, $url)
-            ->withHeader('Authorization', 'DeepL-Auth-Key ' . $this->apiKey)
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('User-Agent', 'TYPO3-NrLlm/1.0');
+            ->withHeader('Content-Type', 'application/json');
+        foreach ($this->buildAuthHeaders() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
 
         if ($method === 'POST' && $payload !== []) {
-            $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
-            $request = $request->withBody($body);
-        }
-
-        try {
-            $response = $this->httpClient->sendRequest($request);
-            $statusCode = $response->getStatusCode();
-            $body = (string)$response->getBody();
-
-            if ($statusCode >= 200 && $statusCode < 300) {
-                $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
-
-                /** @var array<string, mixed> $result */
-                $result = is_array($decoded) ? $decoded : [];
-
-                return $result;
-            }
-
-            $errorData = json_decode($body, true);
-            $errorMessage = is_array($errorData) && isset($errorData['message']) && is_string($errorData['message'])
-                ? $errorData['message']
-                : 'Unknown DeepL API error';
-
-            $this->logger->error('DeepL API error', [
-                'status_code' => $statusCode,
-                'error' => $errorMessage,
-                'endpoint' => $endpoint,
-            ]);
-
-            throw match ($statusCode) {
-                401, 403 => ServiceConfigurationException::invalidApiKey('translation', 'deepl'),
-                429 => new ServiceUnavailableException('DeepL API rate limit exceeded', 'translation', ['provider' => 'deepl']),
-                456 => new ServiceUnavailableException('DeepL API quota exceeded', 'translation', ['provider' => 'deepl']),
-                default => new ServiceUnavailableException('DeepL API error: ' . $errorMessage, 'translation', ['provider' => 'deepl']),
-            };
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
-            throw $e;
-        } catch (Throwable $e) {
-            $this->logger->error('DeepL API connection error', [
-                'exception' => $e->getMessage(),
-                'endpoint' => $endpoint,
-            ]);
-
-            throw new ServiceUnavailableException(
-                'Failed to connect to DeepL API: ' . $e->getMessage(),
-                'translation',
-                ['endpoint' => $endpoint, 'exception' => $e->getMessage()],
-                0,
-                $e,
+            $request = $request->withBody(
+                $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR)),
             );
         }
+
+        return $this->executeRequest($request);
     }
 }

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -298,11 +298,20 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        /** @var array{translators?: array{deepl?: array{apiKey?: string, timeout?: int, baseUrl?: string}}} $config */
-        $deeplConfig = $config['translators']['deepl'] ?? [];
+        $translators = $config['translators'] ?? null;
+        $deeplConfig = is_array($translators) && is_array($translators['deepl'] ?? null)
+            ? $translators['deepl']
+            : [];
 
-        $this->apiKey = $deeplConfig['apiKey'] ?? '';
-        $this->timeout = (int)($deeplConfig['timeout'] ?? $this->getDefaultTimeout());
+        // is_string() / is_numeric() guards: extension config is YAML
+        // and the documented shape is not a runtime guarantee. Direct
+        // assignment would TypeError on a non-string apiKey and defeat
+        // the base's fail-soft contract.
+        $apiKey = $deeplConfig['apiKey'] ?? null;
+        $this->apiKey = is_string($apiKey) ? $apiKey : '';
+
+        $timeout = $deeplConfig['timeout'] ?? null;
+        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
 
         // DeepL Free vs Pro routing: free keys end with `:fx`. The Pro
         // URL is the documented default; explicit `baseUrl` override
@@ -310,7 +319,8 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         if ($this->apiKey !== '' && str_ends_with($this->apiKey, ':fx')) {
             $this->baseUrl = self::FREE_API_URL;
         } else {
-            $this->baseUrl = $deeplConfig['baseUrl'] ?? self::PRO_API_URL;
+            $baseUrl = $deeplConfig['baseUrl'] ?? null;
+            $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::PRO_API_URL;
         }
     }
 

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -276,6 +276,93 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function sendJsonRequestSkipsBodyForBodylessMethods(): void
+    {
+        // Regression: GET-with-body requests are non-standard and
+        // some upstreams / proxies reject them outright. The base
+        // must NOT attach a JSON body when the method is GET / HEAD /
+        // DELETE, even if `$payload` is non-empty.
+        $captured = null;
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+                $captured = $request;
+                return $this->createJsonResponseMock([], 200);
+            });
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        $subject->callSendJsonRequest('endpoint', ['ignored' => 'on-get'], 'GET');
+
+        self::assertNotNull($captured);
+        self::assertInstanceOf(TestableRequest::class, $captured);
+        // wasBodySet() tracks whether withBody() was ever called
+        // on the TestableRequest; for GET it should not have been.
+        self::assertFalse($captured->wasBodySet());
+    }
+
+    #[Test]
+    public function loadConfigurationIsResilientAgainstTypeError(): void
+    {
+        // Regression: previous catch was `Exception` only, but
+        // `TypeError` extends `Error`. A subclass parsing a malformed
+        // config that flips a property assignment from string to int
+        // would have raised a bootstrap fatal. Now it degrades to
+        // `isAvailable() === false`.
+        $extConf = self::createStub(ExtensionConfiguration::class);
+        $extConf->method('get')->willReturn(['apiKey' => 12345, 'baseUrl' => 'https://api.test']);
+
+        $subject = new TestableTypeErrorSpecializedService(
+            httpClient: self::createStub(ClientInterface::class),
+            requestFactory: $this->passthroughRequestFactory(),
+            streamFactory: $this->passthroughStreamFactory(),
+            extensionConfiguration: $extConf,
+            usageTracker: self::createStub(UsageTrackerServiceInterface::class),
+            logger: self::createStub(LoggerInterface::class),
+        );
+
+        self::assertFalse($subject->isAvailable());
+    }
+
+    #[Test]
+    public function multipartTraitStripsCrLfAndQuoteFromHeaderValues(): void
+    {
+        // Regression for the header-injection concern: untrusted
+        // filename / name / contentType values must have CR / LF /
+        // double-quote stripped before they land in the
+        // `Content-Disposition` / `Content-Type` headers, otherwise
+        // an attacker can inject arbitrary headers or break the
+        // body framing. The literal text "X-Injected: yes" may still
+        // appear AS DATA inside the value (CR/LF removed → no header
+        // boundary), but it must NOT appear on its own line.
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+
+        $body = $subject->callEncodeMultipartBody([
+            [
+                'name'        => "evil\r\nX-Injected: yes",
+                'filename'    => 'a".bin',
+                'content'     => 'BIN',
+                'contentType' => "image/png\r\nX-Forged: 1",
+            ],
+        ], 'BOUNDARY');
+
+        // The smoking-gun assertions: no CR before the injected
+        // header text, no LF before it. This catches the actual
+        // injection vector (header-on-its-own-line) while permitting
+        // the now-defanged literal text to remain inside the value.
+        self::assertStringNotContainsString("\r\nX-Injected", $body);
+        self::assertStringNotContainsString("\nX-Injected", $body);
+        self::assertStringNotContainsString("\r\nX-Forged", $body);
+        // No bare double-quote that would break the `name="..."` /
+        // `filename="..."` framing.
+        self::assertStringNotContainsString('filename="a".bin"', $body);
+        // Content survives, headers are clean.
+        self::assertStringContainsString('BIN', $body);
+        self::assertStringEndsWith("--BOUNDARY--\r\n", $body);
+    }
+
+    #[Test]
     public function multipartTraitSkipsPartsMissingName(): void
     {
         // Defensive: a caller that hands us a malformed part dict
@@ -360,9 +447,9 @@ final class TestableSpecializedService extends AbstractSpecializedService
      *
      * @return array<string, mixed>
      */
-    public function callSendJsonRequest(string $endpoint, array $payload): array
+    public function callSendJsonRequest(string $endpoint, array $payload, string $method = 'POST'): array
     {
-        return $this->sendJsonRequest($endpoint, $payload);
+        return $this->sendJsonRequest($endpoint, $payload, $method);
     }
 
     /**
@@ -417,6 +504,8 @@ final class TestableRequest implements RequestInterface
 
     private ?StreamInterface $body = null;
 
+    private bool $bodyWasSet = false;
+
     public function __construct(
         private readonly string $method,
         private readonly string $uri,
@@ -433,7 +522,13 @@ final class TestableRequest implements RequestInterface
     {
         $clone = clone $this;
         $clone->body = $body;
+        $clone->bodyWasSet = true;
         return $clone;
+    }
+
+    public function wasBodySet(): bool
+    {
+        return $this->bodyWasSet;
     }
 
     public function getHeaderLine(string $name): string
@@ -513,5 +608,48 @@ final class TestableRequest implements RequestInterface
     public function withUri(UriInterface $uri, bool $preserveHost = false): static
     {
         return $this;
+    }
+}
+
+/**
+ * Fixture whose `loadServiceConfiguration()` deliberately raises a
+ * `TypeError` (assigning an int to a `string`-typed property). Used
+ * to verify the base catches `Throwable` rather than `Exception`.
+ */
+final class TestableTypeErrorSpecializedService extends AbstractSpecializedService
+{
+    protected function getServiceDomain(): string
+    {
+        return 'test';
+    }
+
+    protected function getServiceProvider(): string
+    {
+        return 'typeerror';
+    }
+
+    protected function getDefaultBaseUrl(): string
+    {
+        return 'https://api.example.test';
+    }
+
+    protected function getDefaultTimeout(): int
+    {
+        return 30;
+    }
+
+    protected function loadServiceConfiguration(array $config): void
+    {
+        // Direct assignment without is_string() guard — TypeError when
+        // the config value is not a string. Mirrors the bug Copilot
+        // caught on PR #186 (DallE / DeepL `loadServiceConfiguration`
+        // before the fix).
+        /** @phpstan-ignore assign.propertyType */
+        $this->apiKey = $config['apiKey']; // @phpstan-ignore-line
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'Bearer ' . $this->apiKey];
     }
 }

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -1,0 +1,517 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized;
+
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
+use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(AbstractSpecializedService::class)]
+final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function isAvailableReturnsFalseWhenApiKeyIsEmpty(): void
+    {
+        $subject = $this->createSubject(apiKey: '');
+
+        self::assertFalse($subject->isAvailable());
+    }
+
+    #[Test]
+    public function isAvailableReturnsTrueWhenApiKeyIsConfigured(): void
+    {
+        $subject = $this->createSubject(apiKey: 'test-key');
+
+        self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function ensureAvailableThrowsWhenNotConfigured(): void
+    {
+        $subject = $this->createSubject(apiKey: '');
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->callEnsureAvailable();
+    }
+
+    #[Test]
+    public function ensureAvailableIsNoOpWhenConfigured(): void
+    {
+        $subject = $this->createSubject(apiKey: 'test-key');
+
+        $subject->callEnsureAvailable();
+
+        // Reaching here = no exception = pass.
+        self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function buildEndpointUrlConcatenatesWithSingleSlash(): void
+    {
+        $subject = $this->createSubject(baseUrl: 'https://api.example.test/v1');
+
+        self::assertSame('https://api.example.test/v1/foo', $subject->callBuildEndpointUrl('foo'));
+        self::assertSame('https://api.example.test/v1/foo', $subject->callBuildEndpointUrl('/foo'));
+    }
+
+    #[Test]
+    public function buildEndpointUrlHandlesTrailingSlashOnBase(): void
+    {
+        $subject = $this->createSubject(baseUrl: 'https://api.example.test/v1/');
+
+        self::assertSame('https://api.example.test/v1/foo', $subject->callBuildEndpointUrl('foo'));
+    }
+
+    #[Test]
+    public function buildEndpointUrlReturnsBaseWhenEndpointEmpty(): void
+    {
+        // TTS posts directly to the base URL — endpoint is empty.
+        $subject = $this->createSubject(baseUrl: 'https://api.example.test/v1/audio/speech');
+
+        self::assertSame('https://api.example.test/v1/audio/speech', $subject->callBuildEndpointUrl(''));
+    }
+
+    #[Test]
+    public function sendJsonRequestReturnsDecodedSuccessResponse(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['result' => 'ok'], 200));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
+
+        $result = $subject->callSendJsonRequest('endpoint', ['foo' => 'bar']);
+
+        self::assertSame(['result' => 'ok'], $result);
+    }
+
+    #[Test]
+    public function sendJsonRequestAddsAuthHeaderFromBuildAuthHeaders(): void
+    {
+        $captured = null;
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+                $captured = $request;
+                return $this->createJsonResponseMock([], 200);
+            });
+
+        $subject = $this->createSubject(apiKey: 'sekret', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
+
+        $subject->callSendJsonRequest('endpoint', []);
+
+        self::assertNotNull($captured);
+        self::assertSame('TestableScheme sekret', $captured->getHeaderLine('Authorization'));
+        self::assertSame('application/json', $captured->getHeaderLine('Content-Type'));
+    }
+
+    #[Test]
+    public function executeRequestThrowsConfigurationExceptionOn401(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'invalid key']], 401));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        $this->expectException(ServiceConfigurationException::class);
+
+        $subject->callSendJsonRequest('endpoint', []);
+    }
+
+    #[Test]
+    public function executeRequestThrowsConfigurationExceptionOn403(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'forbidden']], 403));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        $this->expectException(ServiceConfigurationException::class);
+
+        $subject->callSendJsonRequest('endpoint', []);
+    }
+
+    #[Test]
+    public function executeRequestThrowsRateLimitOn429(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'too many requests']], 429));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        try {
+            $subject->callSendJsonRequest('endpoint', []);
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertStringContainsString('rate limit', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function executeRequestExtractsErrorMessageFromOpenAiShape(): void
+    {
+        // `{"error": {"message": "..."}}` is the most common shape;
+        // `decodeErrorMessage()` handles it by default. This is the
+        // fallback for any subclass that doesn't override.
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'bad request — prompt empty']], 400));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        try {
+            $subject->callSendJsonRequest('endpoint', []);
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertStringContainsString('bad request — prompt empty', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function executeRequestWrapsTransportExceptionAsServiceUnavailable(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('connection reset'));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        try {
+            $subject->callSendJsonRequest('endpoint', []);
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertStringContainsString('Failed to connect', $e->getMessage());
+            self::assertInstanceOf(RuntimeException::class, $e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function executeRequestReturnsEmptyArrayForEmpty2xxBody(): void
+    {
+        // Some endpoints (e.g. TTS) return binary or empty bodies on
+        // success — the JSON decode path must not blow up.
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createHttpResponseMock(204, ''));
+
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+        $result = $subject->callSendJsonRequest('endpoint', []);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function loadConfigurationFailsSafelyOnException(): void
+    {
+        // Throws inside ExtensionConfiguration->get() — the service
+        // must come up uncrashed with `isAvailable() === false` so
+        // callers get a graceful unavailable error rather than a
+        // bootstrap fatal.
+        $extConf = self::createStub(ExtensionConfiguration::class);
+        $extConf->method('get')->willThrowException(new RuntimeException('boom'));
+
+        $subject = new TestableSpecializedService(
+            httpClient: self::createStub(ClientInterface::class),
+            requestFactory: $this->passthroughRequestFactory(),
+            streamFactory: $this->passthroughStreamFactory(),
+            extensionConfiguration: $extConf,
+            usageTracker: self::createStub(UsageTrackerServiceInterface::class),
+            logger: self::createStub(LoggerInterface::class),
+        );
+
+        self::assertFalse($subject->isAvailable());
+    }
+
+    #[Test]
+    public function multipartTraitBuildsExpectedBoundaryAndBody(): void
+    {
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+
+        $body = $subject->callEncodeMultipartBody([
+            ['name' => 'file', 'filename' => 'a.bin', 'content' => 'BIN', 'contentType' => 'application/octet-stream'],
+            ['name' => 'model', 'value' => 'whisper-1'],
+        ], 'BOUNDARY');
+
+        self::assertStringContainsString('--BOUNDARY', $body);
+        self::assertStringContainsString('Content-Disposition: form-data; name="file"; filename="a.bin"', $body);
+        self::assertStringContainsString('Content-Type: application/octet-stream', $body);
+        self::assertStringContainsString('BIN', $body);
+        self::assertStringContainsString('Content-Disposition: form-data; name="model"', $body);
+        self::assertStringContainsString('whisper-1', $body);
+        self::assertStringEndsWith("--BOUNDARY--\r\n", $body);
+    }
+
+    #[Test]
+    public function multipartTraitSkipsPartsMissingName(): void
+    {
+        // Defensive: a caller that hands us a malformed part dict
+        // shouldn't poison the entire body. The part is silently
+        // skipped (rather than throwing) so the surrounding parts
+        // still produce a valid body.
+        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+
+        $body = $subject->callEncodeMultipartBody([
+            ['name' => 'good', 'value' => 'x'],
+            ['value' => 'orphan'],          // missing name → skipped
+            ['name' => 'also-good', 'value' => 'y'],
+        ], 'B');
+
+        self::assertStringContainsString('name="good"', $body);
+        self::assertStringContainsString('name="also-good"', $body);
+        self::assertStringNotContainsString('orphan', $body);
+    }
+
+    private function createSubject(
+        string $apiKey = 'test-key',
+        string $baseUrl = 'https://api.example.test',
+        ?ClientInterface $httpClient = null,
+    ): TestableSpecializedService {
+        $extConf = self::createStub(ExtensionConfiguration::class);
+        $extConf->method('get')->willReturn(['apiKey' => $apiKey, 'baseUrl' => $baseUrl]);
+
+        return new TestableSpecializedService(
+            httpClient: $httpClient ?? self::createStub(ClientInterface::class),
+            requestFactory: $this->passthroughRequestFactory(),
+            streamFactory: $this->passthroughStreamFactory(),
+            extensionConfiguration: $extConf,
+            usageTracker: self::createStub(UsageTrackerServiceInterface::class),
+            logger: self::createStub(LoggerInterface::class),
+        );
+    }
+
+    private function passthroughRequestFactory(): RequestFactoryInterface
+    {
+        $stub = self::createStub(RequestFactoryInterface::class);
+        $stub->method('createRequest')
+            ->willReturnCallback(static function (string $method, mixed $uri): RequestInterface {
+                $uriString = is_string($uri) ? $uri : (is_object($uri) && method_exists($uri, '__toString') ? $uri->__toString() : '');
+                return new TestableRequest($method, $uriString);
+            });
+        return $stub;
+    }
+
+    private function passthroughStreamFactory(): StreamFactoryInterface
+    {
+        $stub = self::createStub(StreamFactoryInterface::class);
+        $stub->method('createStream')->willReturnCallback(function (string $content): StreamInterface {
+            $stream = $this->createStub(StreamInterface::class);
+            $stream->method('__toString')->willReturn($content);
+            $stream->method('getContents')->willReturn($content);
+            return $stream;
+        });
+        return $stub;
+    }
+}
+
+/**
+ * Concrete fixture exercising the abstract base. Public delegates
+ * (`callX()`) expose protected members for assertion convenience.
+ */
+final class TestableSpecializedService extends AbstractSpecializedService
+{
+    use MultipartBodyBuilderTrait;
+
+    public function callEnsureAvailable(): void
+    {
+        $this->ensureAvailable();
+    }
+
+    public function callBuildEndpointUrl(string $endpoint): string
+    {
+        return $this->buildEndpointUrl($endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function callSendJsonRequest(string $endpoint, array $payload): array
+    {
+        return $this->sendJsonRequest($endpoint, $payload);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $parts
+     */
+    public function callEncodeMultipartBody(array $parts, string $boundary): string
+    {
+        return $this->encodeMultipartBody($parts, $boundary);
+    }
+
+    protected function getServiceDomain(): string
+    {
+        return 'test';
+    }
+
+    protected function getServiceProvider(): string
+    {
+        return 'testable';
+    }
+
+    protected function getDefaultBaseUrl(): string
+    {
+        return 'https://api.example.test';
+    }
+
+    protected function getDefaultTimeout(): int
+    {
+        return 42;
+    }
+
+    protected function loadServiceConfiguration(array $config): void
+    {
+        $this->apiKey  = is_string($config['apiKey']  ?? null) ? $config['apiKey'] : '';
+        $this->baseUrl = is_string($config['baseUrl'] ?? null) ? $config['baseUrl'] : $this->getDefaultBaseUrl();
+    }
+
+    protected function buildAuthHeaders(): array
+    {
+        return ['Authorization' => 'TestableScheme ' . $this->apiKey];
+    }
+}
+
+/**
+ * Real-ish RequestInterface implementation for tests — captures
+ * headers / body so assertions can read them back. Trimmed to the
+ * subset the base class exercises.
+ */
+final class TestableRequest implements RequestInterface
+{
+    /** @var array<string, list<string>> */
+    private array $headers = [];
+
+    private ?StreamInterface $body = null;
+
+    public function __construct(
+        private readonly string $method,
+        private readonly string $uri,
+    ) {}
+
+    public function withHeader(string $name, $value): static
+    {
+        $clone = clone $this;
+        $clone->headers[$name] = array_values(is_array($value) ? array_map(strval(...), $value) : [(string)$value]);
+        return $clone;
+    }
+
+    public function withBody(StreamInterface $body): static
+    {
+        $clone = clone $this;
+        $clone->body = $body;
+        return $clone;
+    }
+
+    public function getHeaderLine(string $name): string
+    {
+        return implode(', ', $this->headers[$name] ?? []);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getRequestTarget(): string
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getHeader(string $name): array
+    {
+        return $this->headers[$name] ?? [];
+    }
+
+    public function hasHeader(string $name): bool
+    {
+        return isset($this->headers[$name]);
+    }
+
+    public function getBody(): StreamInterface
+    {
+        if ($this->body === null) {
+            throw new RuntimeException('No body set', 3134810639);
+        }
+        return $this->body;
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return '1.1';
+    }
+    public function withProtocolVersion(string $version): static
+    {
+        return $this;
+    }
+    public function withAddedHeader(string $name, $value): static
+    {
+        return $this->withHeader($name, $value);
+    }
+    public function withoutHeader(string $name): static
+    {
+        $clone = clone $this;
+        unset($clone->headers[$name]);
+        return $clone;
+    }
+    public function withRequestTarget(string $requestTarget): static
+    {
+        return $this;
+    }
+    public function withMethod(string $method): static
+    {
+        return $this;
+    }
+    public function getUri(): UriInterface
+    {
+        throw new RuntimeException('Not implemented', 4146456712);
+    }
+    public function withUri(UriInterface $uri, bool $preserveHost = false): static
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
## Summary

**Closes REC #7** of the architecture audit ("Extract AbstractSpecializedService + HTTP pipeline for DallE/Fal/Whisper/DeepL/TTS — reclaim ~300 LOC"). **Closes the entire audit** — this is the last of the 7 prioritised recommendations.

Single comprehensive PR per user direction (one PR rather than the originally proposed 6-slice cadence).

## What changed

### New abstract layer

- **`Classes/Specialized/AbstractSpecializedService.php`** (356 LOC) — base class for every single-task AI service that talks to a provider over HTTP. Owns: extension-config loading (with fail-soft logging), availability check, `sendJsonRequest()`, `executeRequest()` (status check + JSON decode + typed-exception mapping), `buildEndpointUrl()`, `decodeErrorMessage()` (default OpenAI-shape extraction), `mapErrorStatus()` (default auth/rate-limit/generic mapping).
- **`Classes/Specialized/MultipartBodyBuilderTrait.php`** (112 LOC) — multipart/form-data construction. Kept as a trait so JSON-only services (Fal/TTS/DeepL) don't pay the footprint.

### Migrated services

Every public method on every service keeps its exact signature; constructor dep set is identical (Symfony DI autowiring unaffected); all five remain `final`.

| Service | Before | After | Notes |
|---|---|---|---|
| `DallEImageService` | 607 | 511 | Extends base, uses multipart trait. Overrides `mapErrorStatus()` for 400 validation branch. |
| `FalImageService` | 594 | 522 | Extends base. Overrides `decodeErrorMessage()` for FAL's `detail`/`message` shape, `mapErrorStatus()` for 422 validation. Queue-based path stays self-contained (different host). |
| `WhisperTranscriptionService` | 557 | 467 | Owns request execution because text/srt/vtt formats return raw strings, not JSON. Body construction comes from the trait. |
| `TextToSpeechService` | 490 | 443 | Owns request execution because the response is binary audio bytes. |
| `DeepLTranslator` | 580 | 548 | Custom `sendDeeplRequest()` adapter for `/v2/...` URL prefix and GET-or-POST. Overrides `decodeErrorMessage()` for top-level `message` shape, `mapErrorStatus()` for 456 quota branch. Free-vs-Pro routing (`:fx` suffix) stays in `loadServiceConfiguration()`. |

## Honest LOC accounting

- Service files: 2828 → 2491 LOC (-337, ~12% average reduction).
- New code: 356 (base) + 112 (trait) + 480 (tests) = +948 LOC.
- Net total: **2828 → ~3439 (+611 raw LOC)**.

The audit's "~300 LOC reclaim" estimate was about the **visible boilerplate per service**; the typed scaffolding doesn't disappear, it gets centralised. The maintenance win is real even if the line-count headline isn't: a future bug in HTTP error handling, auth-header threading, or config loading lives in ONE place to fix instead of five.

## Tests

- **18 new tests** in `AbstractSpecializedServiceTest` (+38 assertions): availability, ensure-available throw vs. no-op, endpoint URL construction, JSON request happy path, auth-header threading, 401/403 → config exception, 429 → rate-limit exception, OpenAI-shape error message extraction, transport-exception wrap, empty 2xx body fallback, fail-soft config loading, multipart body construction, multipart defensive part-skipping. A `TestableSpecializedService` fixture exercises the abstract methods.
- All existing tests for the 5 services keep passing without modification — strongest possible regression guard for a refactor that preserves public API.

## Audit progress (after this PR)

| REC | Description | PR |
|---|---|---|
| #5 | TaskController split | slices 13a-e (earlier session) |
| #8 | typed `ProviderResponseException` | #176 |
| #4 | auto budget pre-flight | #177 + #178 |
| #6 | domain entity JSON/CSV → typed DTOs | #179 + #180 + #181 + #182 + #183 + #184 |
| #10 | remove legacy `Model::CAPABILITY_*` | #185 |
| **#7** | **AbstractSpecializedService extraction** | **this PR** |

**7/7 audit recommendations closed.**

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` (code style)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` (level 10)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` (dry-run)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — **3338 tests / 7243 assertions** all green (was 3320 → +18 / +38 from new abstract base tests)
- [x] `.Build/bin/typo3 list` — container compiles cleanly
- [ ] CI matrix on PR (PHP 8.2–8.5 × TYPO3 13.4 / 14.0)
- [ ] Bot review threads addressed