### PR TITLE
refactor(service): extract Feature service interfaces (REC #9a)

### DIFF
--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -32,7 +32,7 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  * Symfony container always autowires it from
  * `Configuration/Services.yaml`.
  */
-final readonly class CompletionService
+final readonly class CompletionService implements CompletionServiceInterface
 {
     use AutoPopulatesBeUserUidTrait;
 

--- a/Classes/Service/Feature/CompletionServiceInterface.php
+++ b/Classes/Service/Feature/CompletionServiceInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+
+/**
+ * Public surface of the high-level text-completion service.
+ *
+ * Consumers (controllers, schedulers, tests, downstream extensions)
+ * should depend on this interface rather than the concrete
+ * `CompletionService` so the implementation can be substituted without
+ * inheritance.
+ */
+interface CompletionServiceInterface
+{
+    /**
+     * Generate a text completion.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
+     * Generate a JSON-formatted completion (response_format=json).
+     *
+     * @throws InvalidArgumentException when the response is not valid JSON
+     *
+     * @return array<string, mixed> Parsed JSON response
+     */
+    public function completeJson(string $prompt, ?ChatOptions $options = null): array;
+
+    /**
+     * Generate a Markdown-formatted completion (system prompt augmented to request Markdown).
+     */
+    public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string;
+
+    /**
+     * Generate a low-creativity completion (factual / consistent presets).
+     */
+    public function completeFactual(string $prompt, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
+     * Generate a high-creativity completion (creative / diverse presets).
+     */
+    public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse;
+}

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -32,7 +32,7 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * tests omit it; production DI always autowires it via
  * `Configuration/Services.yaml`.
  */
-final readonly class EmbeddingService
+final readonly class EmbeddingService implements EmbeddingServiceInterface
 {
     use AutoPopulatesBeUserUidTrait;
 

--- a/Classes/Service/Feature/EmbeddingServiceInterface.php
+++ b/Classes/Service/Feature/EmbeddingServiceInterface.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
+
+/**
+ * Public surface of the high-level embedding service.
+ *
+ * Consumers (controllers, search/RAG indexers, tests, downstream
+ * extensions) should depend on this interface rather than the concrete
+ * `EmbeddingService` so the implementation can be substituted without
+ * inheritance.
+ */
+interface EmbeddingServiceInterface
+{
+    /**
+     * Generate embedding vector for a single text.
+     *
+     * @return array<int, float> Embedding vector
+     */
+    public function embed(string $text, ?EmbeddingOptions $options = null): array;
+
+    /**
+     * Generate embedding with the full response object (vector + metadata).
+     *
+     * @throws InvalidArgumentException when `$text` is empty
+     */
+    public function embedFull(string $text, ?EmbeddingOptions $options = null): EmbeddingResponse;
+
+    /**
+     * Generate embeddings for a batch of texts in a single provider call.
+     *
+     * @param array<int, string> $texts
+     *
+     * @return array<int, array<int, float>> Array of embedding vectors, indexed parallel to `$texts`
+     */
+    public function embedBatch(array $texts, ?EmbeddingOptions $options = null): array;
+
+    /**
+     * Cosine similarity between two vectors. Result is in `[-1, 1]`.
+     *
+     * @param array<int, float> $vectorA
+     * @param array<int, float> $vectorB
+     *
+     * @throws InvalidArgumentException when shapes mismatch
+     */
+    public function cosineSimilarity(array $vectorA, array $vectorB): float;
+
+    /**
+     * Top-K candidate vectors by cosine similarity to the query vector.
+     *
+     * @param array<int, float>             $queryVector
+     * @param array<int, array<int, float>> $candidateVectors
+     *
+     * @return array<int, array{index: int, similarity: float}> Sorted by similarity descending
+     */
+    public function findMostSimilar(
+        array $queryVector,
+        array $candidateVectors,
+        int $topK = 5,
+    ): array;
+
+    /**
+     * Pairwise cosine similarities between every vector. Self-similarity is `1.0`.
+     *
+     * @param array<int, array<int, float>> $vectors
+     *
+     * @return array<int, array<int, float>>
+     */
+    public function pairwiseSimilarities(array $vectors): array;
+
+    /**
+     * Normalise a vector to unit length. A zero-magnitude vector is returned unchanged.
+     *
+     * @param array<int, float> $vector
+     *
+     * @return array<int, float>
+     */
+    public function normalize(array $vector): array;
+}

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -43,7 +43,7 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * slice can route specialized translators through a similar
  * pre-flight if needed.
  */
-final readonly class TranslationService
+final readonly class TranslationService implements TranslationServiceInterface
 {
     private const SUPPORTED_FORMALITIES = ['default', 'formal', 'informal'];
     private const SUPPORTED_DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];

--- a/Classes/Service/Feature/TranslationServiceInterface.php
+++ b/Classes/Service/Feature/TranslationServiceInterface.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
+
+/**
+ * Public surface of the high-level translation service.
+ *
+ * Consumers (controllers, scheduled jobs, tests, downstream extensions)
+ * should depend on this interface rather than the concrete
+ * `TranslationService` so the implementation can be substituted without
+ * inheritance.
+ *
+ * The service exposes two execution paths:
+ * - LLM-based: `translate`, `translateBatch`, `detectLanguage`,
+ *   `scoreTranslationQuality` — go through `LlmServiceManager` and the
+ *   middleware pipeline (BudgetMiddleware aware).
+ * - Specialized translators: `translateWithTranslator`,
+ *   `translateBatchWithTranslator`, plus registry queries — bypass the
+ *   LLM pipeline and dispatch to translators registered via
+ *   `#[AsTranslator]` (DeepL, etc.).
+ */
+interface TranslationServiceInterface
+{
+    /**
+     * Translate text using the LLM-based path.
+     *
+     * @param string|null $sourceLanguage ISO 639-1 code, or null for auto-detection
+     *
+     * @throws InvalidArgumentException
+     */
+    public function translate(
+        string $text,
+        string $targetLanguage,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): TranslationResult;
+
+    /**
+     * Translate multiple texts using the LLM-based path. Empty input returns `[]`.
+     *
+     * @param array<int, string> $texts
+     *
+     * @return array<int, TranslationResult>
+     */
+    public function translateBatch(
+        array $texts,
+        string $targetLanguage,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): array;
+
+    /**
+     * Detect the language of the given text. Returns ISO 639-1 code (defaults to "en" on failure).
+     */
+    public function detectLanguage(string $text, ?TranslationOptions $options = null): string;
+
+    /**
+     * Score a translation's quality on `[0.0, 1.0]` (accuracy + fluency + consistency).
+     */
+    public function scoreTranslationQuality(
+        string $sourceText,
+        string $translatedText,
+        string $targetLanguage,
+        ?TranslationOptions $options = null,
+    ): float;
+
+    /**
+     * Translate via a specialized translator (DeepL etc.) resolved from options/preset/default.
+     *
+     * @throws InvalidArgumentException when input is empty or language code invalid
+     */
+    public function translateWithTranslator(
+        string $text,
+        string $targetLanguage,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): TranslatorResult;
+
+    /**
+     * Batch variant of `translateWithTranslator`. Empty input returns `[]`.
+     *
+     * @param array<int, string> $texts
+     *
+     * @return array<int, TranslatorResult>
+     */
+    public function translateBatchWithTranslator(
+        array $texts,
+        string $targetLanguage,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): array;
+
+    /**
+     * @return array<string, array{identifier: string, name: string, available: bool}>
+     */
+    public function getAvailableTranslators(): array;
+
+    public function hasTranslator(string $identifier): bool;
+
+    /**
+     * @throws ServiceUnavailableException when no translator is registered under `$identifier`
+     */
+    public function getTranslator(string $identifier): TranslatorInterface;
+
+    public function findBestTranslator(string $sourceLanguage, string $targetLanguage): ?TranslatorInterface;
+}

--- a/Classes/Service/Feature/TranslationServiceInterface.php
+++ b/Classes/Service/Feature/TranslationServiceInterface.php
@@ -109,12 +109,20 @@ interface TranslationServiceInterface
      */
     public function getAvailableTranslators(): array;
 
+    /**
+     * Whether a translator is registered under the given identifier.
+     */
     public function hasTranslator(string $identifier): bool;
 
     /**
+     * Look up a registered translator by identifier.
+     *
      * @throws ServiceUnavailableException when no translator is registered under `$identifier`
      */
     public function getTranslator(string $identifier): TranslatorInterface;
 
+    /**
+     * Pick the highest-priority translator that supports the given language pair, or `null` when none match.
+     */
     public function findBestTranslator(string $sourceLanguage, string $targetLanguage): ?TranslatorInterface;
 }

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -26,7 +26,7 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * (slice 15a). The resolver is optional so unit tests omit it;
  * production DI autowires it.
  */
-final readonly class VisionService
+final readonly class VisionService implements VisionServiceInterface
 {
     use AutoPopulatesBeUserUidTrait;
 

--- a/Classes/Service/Feature/VisionServiceInterface.php
+++ b/Classes/Service/Feature/VisionServiceInterface.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+
+/**
+ * Public surface of the high-level image-analysis service.
+ *
+ * Consumers (controllers, alt-text wizards, tests, downstream
+ * extensions) should depend on this interface rather than the concrete
+ * `VisionService` so the implementation can be substituted without
+ * inheritance.
+ *
+ * Most methods accept either a single image URL/data-URI or an array
+ * of them; pass an array to batch in a single call. The full-response
+ * variant `analyzeImageFull` always operates on a single image.
+ */
+interface VisionServiceInterface
+{
+    /**
+     * Generate accessibility-focused alt text (≤ 125 chars, screen-reader friendly).
+     *
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateAltText(string|array $imageUrl, ?VisionOptions $options = null): string|array;
+
+    /**
+     * Generate SEO-optimised title (≤ 60 chars, keyword-rich).
+     *
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateTitle(string|array $imageUrl, ?VisionOptions $options = null): string|array;
+
+    /**
+     * Generate a comprehensive description (subjects, setting, colors, mood, composition).
+     *
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateDescription(string|array $imageUrl, ?VisionOptions $options = null): string|array;
+
+    /**
+     * Analyse one or more images with an arbitrary user-supplied prompt.
+     *
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function analyzeImage(
+        string|array $imageUrl,
+        string $customPrompt,
+        ?VisionOptions $options = null,
+    ): string|array;
+
+    /**
+     * Analyse a single image and return the full `VisionResponse` (description + usage metadata).
+     *
+     * @throws InvalidArgumentException when `$imageUrl` is neither a valid URL nor a `data:image/...` URI
+     */
+    public function analyzeImageFull(
+        string $imageUrl,
+        string $prompt,
+        ?VisionOptions $options = null,
+    ): VisionResponse;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -80,13 +80,29 @@ services:
   Netresearch\NrLlm\Service\Feature\CompletionService:
     public: true
 
+  Netresearch\NrLlm\Service\Feature\CompletionServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\CompletionService
+    public: true
+
   Netresearch\NrLlm\Service\Feature\VisionService:
+    public: true
+
+  Netresearch\NrLlm\Service\Feature\VisionServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\VisionService
     public: true
 
   Netresearch\NrLlm\Service\Feature\EmbeddingService:
     public: true
 
+  Netresearch\NrLlm\Service\Feature\EmbeddingServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\EmbeddingService
+    public: true
+
   Netresearch\NrLlm\Service\Feature\TranslationService:
+    public: true
+
+  Netresearch\NrLlm\Service\Feature\TranslationServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\TranslationService
     public: true
 
   # ========================================


### PR DESCRIPTION
## Summary
- Extract \`CompletionServiceInterface\`, \`EmbeddingServiceInterface\`, \`TranslationServiceInterface\`, \`VisionServiceInterface\` mirroring each service's full public surface.
- Concrete \`final readonly class\`es now \`implements\` the new interface (no behaviour change).
- DI aliases in \`Configuration/Services.yaml\` so consumers wire against the interface.

## Context
Audit \`claudedocs/audit-2026-04-23-architecture.md\` REC #9 flagged inconsistent DI policy: \`BudgetServiceInterface\`, \`LlmConfigurationServiceInterface\`, \`CacheManagerInterface\`, \`UsageTrackerServiceInterface\`, \`LlmServiceManagerInterface\` etc. existed, but the four feature services on the public LLM surface had no interface. Consumers had to type-hint the concrete class (or use \`mixed\` in tests).

This is **slice 19a** of the audit close-out. After the prior closure summary, grepping confirmed RECs #2, #3, #5b, #6b, #8b, #9 were not actually fully done. Subsequent slices will close the rest.

## Test plan
- [x] PHPStan level 10 — passes
- [x] CGL (PHP-CS-Fixer) — passes
- [x] Rector dry-run — passes
- [x] Unit tests — 3341 / 7254 assertions pass
- [ ] Container compile (CI matrix)
- [ ] Bot reviews (Copilot, Gemini, CybotTM) — addressed before merge per "no auto-merge before reviews" rule

## Audit progress
| REC | Status |
|---|---|
| #1, #4, #7, #10 | Closed earlier |
| **#9a** (Feature interfaces) | **This PR** |
| #9b (supporting interfaces) | Next slice |
| #9c (\`public: true\` reduction) | Slice after that |
| #2, #3, #5b, #6b, #8b | Pending slices |