### PR TITLE
refactor(wizard): typed Response DTOs for SetupWizardController AJAX actions (slice 21 — REC #5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `setOptions('')` historically cleared the field. The legacy string
   / array accessors do NOT route through the typed accessor — they
   preserve their pre-REC-#6 behaviour byte-for-byte.
+- Five typed Response DTOs for the Setup Wizard backend AJAX
+  endpoints (slice 21, REC #5b — closes the audit gap left over
+  from the slice-13 `TaskController` split):
+  `Response/ProviderDetectionResponse` (wraps a `DetectedProvider`
+  for `detectAction`), `Response/WizardTestConnectionResponse`
+  (slim `{success, message}` shape for `testAction` — distinct from
+  the existing `TestConnectionResponse` that also carries a model
+  list), `Response/DiscoveredModelsResponse` (wraps the
+  `DiscoveredModel` list from `discoverAction`),
+  `Response/GeneratedConfigurationsResponse` (wraps the
+  `SuggestedConfiguration` list from `generateAction`), and
+  `Response/WizardSaveResponse` (success payload for `saveAction`
+  with the persisted-provider summary). Each DTO follows the
+  established `final readonly` + `implements JsonSerializable` +
+  typed `jsonSerialize()` return shape pattern. The wire shape
+  consumed by `Backend/SetupWizard.js` is preserved byte-for-byte
+  — every new DTO's `jsonSerialize()` returns exactly the array
+  shape the previous inline literal produced.
 - `Classes/Specialized/AbstractSpecializedService` — base class for
   every single-task AI service that talks to a provider over HTTP
   (DALL-E, FAL, Whisper, TTS, DeepL — slice 18, REC #7). Concentrates
@@ -93,6 +111,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   documented on the interface itself. Tests updated to assert
   `instanceof ChatMessage` + `->role` / `->content` field access
   instead of `$messages[0]['role']` array shape.
+- `SetupWizardController` (`detectAction`, `testAction`,
+  `discoverAction`, `generateAction`, `saveAction`) now returns
+  every JSON body through a typed `Response/*` DTO instead of an
+  ad-hoc `new JsonResponse([...])` literal. Ten call sites
+  migrated total (five success replies + five error/exception
+  replies; `ErrorResponse` was reused for every error branch).
+  Closes the REC #5 follow-up audit item; brings the wizard
+  controller in line with the
+  `ConfigurationController` / `ProviderController` /
+  post-split task controllers precedent. No behaviour change —
+  the AJAX wire format consumed by `Backend/SetupWizard.js` is
+  byte-identical to the pre-DTO output. Slice 21.
 - `DallEImageService`, `FalImageService`, `WhisperTranscriptionService`,
   `TextToSpeechService`, and `DeepLTranslator` now extend
   `AbstractSpecializedService` instead of carrying their own copies

--- a/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
+++ b/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;
 
+use InvalidArgumentException;
 use JsonSerializable;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 
@@ -28,11 +29,26 @@ final readonly class DiscoveredModelsResponse implements JsonSerializable
 {
     /**
      * @param list<array<string, mixed>> $models Models as produced by `DiscoveredModel::toArray()`
+     *
+     * @throws InvalidArgumentException when `$models` is not a list
      */
     public function __construct(
         public array $models,
         public bool $success = true,
-    ) {}
+    ) {
+        // Enforce list-ness so the wire shape is always a JSON array
+        // (`[]`) rather than an object (`{...}`). The factory below
+        // always produces a list, but the constructor is `public` and
+        // a hand-rolled caller could otherwise pass an associative
+        // array — that would silently flip the JSON serialisation and
+        // break the frontend's `Array.isArray(...)` check.
+        if (!array_is_list($models)) {
+            throw new InvalidArgumentException(
+                'DiscoveredModelsResponse::$models must be a list (sequential int keys); got an associative array.',
+                1735300010,
+            );
+        }
+    }
 
     /**
      * @param list<DiscoveredModel> $models

--- a/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
+++ b/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
+
+/**
+ * Response DTO for the Setup Wizard `discoverAction` AJAX action.
+ *
+ * Wraps the list of `DiscoveredModel` results from
+ * `ModelDiscoveryInterface::discover()`. The wizard frontend renders
+ * each `models[i]` entry's `modelId`, `name`, `description`,
+ * `capabilities[]`, `contextLength`, `maxOutputTokens`, and
+ * `recommended` fields — i.e. the full `DiscoveredModel::toArray()`
+ * shape.
+ *
+ * @internal
+ */
+final readonly class DiscoveredModelsResponse implements JsonSerializable
+{
+    /**
+     * @param list<array<string, mixed>> $models Models as produced by `DiscoveredModel::toArray()`
+     */
+    public function __construct(
+        public array $models,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @param list<DiscoveredModel> $models
+     */
+    public static function fromDiscoveredModels(array $models): self
+    {
+        return new self(
+            models: array_values(array_map(
+                static fn(DiscoveredModel $m): array => $m->toArray(),
+                $models,
+            )),
+        );
+    }
+
+    /**
+     * @return array{success: bool, models: list<array<string, mixed>>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success' => $this->success,
+            'models'  => $this->models,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/GeneratedConfigurationsResponse.php
+++ b/Classes/Controller/Backend/Response/GeneratedConfigurationsResponse.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
+
+/**
+ * Response DTO for the Setup Wizard `generateAction` AJAX action.
+ *
+ * Wraps the list of `SuggestedConfiguration` items produced by
+ * `ConfigurationGenerator::generate()`. The wizard frontend renders
+ * each entry's `identifier`, `name`, `description`, `systemPrompt`,
+ * `recommendedModelId`, `temperature`, `maxTokens`, and
+ * `additionalSettings` — i.e. the full
+ * `SuggestedConfiguration::toArray()` shape.
+ *
+ * @internal
+ */
+final readonly class GeneratedConfigurationsResponse implements JsonSerializable
+{
+    /**
+     * @param list<array<string, mixed>> $configurations Configurations as produced by `SuggestedConfiguration::toArray()`
+     */
+    public function __construct(
+        public array $configurations,
+        public bool $success = true,
+    ) {}
+
+    /**
+     * @param list<SuggestedConfiguration> $configurations
+     */
+    public static function fromSuggestedConfigurations(array $configurations): self
+    {
+        return new self(
+            configurations: array_values(array_map(
+                static fn(SuggestedConfiguration $c): array => $c->toArray(),
+                $configurations,
+            )),
+        );
+    }
+
+    /**
+     * @return array{success: bool, configurations: list<array<string, mixed>>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'        => $this->success,
+            'configurations' => $this->configurations,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/ProviderDetectionResponse.php
+++ b/Classes/Controller/Backend/Response/ProviderDetectionResponse.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
+
+/**
+ * Response DTO for the Setup Wizard `detectAction` AJAX action.
+ *
+ * Wraps a `DetectedProvider` result for the wizard frontend, which
+ * reads `result.provider.suggestedName`, `result.provider.adapterType`,
+ * `result.provider.endpoint`, and `result.provider.confidence` from
+ * the JSON body.
+ *
+ * @internal
+ */
+final readonly class ProviderDetectionResponse implements JsonSerializable
+{
+    /**
+     * @param array<string, mixed> $provider Provider metadata as produced by `DetectedProvider::toArray()`
+     */
+    public function __construct(
+        public array $provider,
+        public bool $success = true,
+    ) {}
+
+    public static function fromDetectedProvider(DetectedProvider $detected): self
+    {
+        return new self(provider: $detected->toArray());
+    }
+
+    /**
+     * @return array{success: bool, provider: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'  => $this->success,
+            'provider' => $this->provider,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/WizardSaveResponse.php
+++ b/Classes/Controller/Backend/Response/WizardSaveResponse.php
@@ -26,7 +26,7 @@ final readonly class WizardSaveResponse implements JsonSerializable
 {
     public function __construct(
         public string $message,
-        public int $providerUid,
+        public ?int $providerUid,
         public string $providerName,
         public int $modelsCount,
         public int $configurationsCount,
@@ -39,9 +39,14 @@ final readonly class WizardSaveResponse implements JsonSerializable
         int $configurationsCount,
         string $message = 'Configuration saved successfully',
     ): self {
+        // Pass `null` through verbatim — the pre-DTO controller code
+        // returned `$provider->getUid()` directly, which can be null
+        // for an entity whose persistAll() hasn't run yet. Substituting
+        // `0` here would change the wire shape and confuse the
+        // frontend's "did the entity get a uid?" check.
         return new self(
             message: $message,
-            providerUid: $provider->getUid() ?? 0,
+            providerUid: $provider->getUid(),
             providerName: $provider->getName(),
             modelsCount: $modelsCount,
             configurationsCount: $configurationsCount,
@@ -52,7 +57,7 @@ final readonly class WizardSaveResponse implements JsonSerializable
      * @return array{
      *   success: bool,
      *   message: string,
-     *   provider: array{uid: int, name: string},
+     *   provider: array{uid: int|null, name: string},
      *   modelsCount: int,
      *   configurationsCount: int
      * }

--- a/Classes/Controller/Backend/Response/WizardSaveResponse.php
+++ b/Classes/Controller/Backend/Response/WizardSaveResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+use Netresearch\NrLlm\Domain\Model\Provider;
+
+/**
+ * Response DTO for the Setup Wizard `saveAction` AJAX action.
+ *
+ * Reports the outcome of persisting a wizard run (provider + models +
+ * configurations). The wizard frontend reads `result.modelsCount`,
+ * `result.configurationsCount`, and `result.provider.name` to render
+ * the success message at step 5.
+ *
+ * @internal
+ */
+final readonly class WizardSaveResponse implements JsonSerializable
+{
+    public function __construct(
+        public string $message,
+        public int $providerUid,
+        public string $providerName,
+        public int $modelsCount,
+        public int $configurationsCount,
+        public bool $success = true,
+    ) {}
+
+    public static function fromProvider(
+        Provider $provider,
+        int $modelsCount,
+        int $configurationsCount,
+        string $message = 'Configuration saved successfully',
+    ): self {
+        return new self(
+            message: $message,
+            providerUid: $provider->getUid() ?? 0,
+            providerName: $provider->getName(),
+            modelsCount: $modelsCount,
+            configurationsCount: $configurationsCount,
+        );
+    }
+
+    /**
+     * @return array{
+     *   success: bool,
+     *   message: string,
+     *   provider: array{uid: int, name: string},
+     *   modelsCount: int,
+     *   configurationsCount: int
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success'              => $this->success,
+            'message'              => $this->message,
+            'provider'             => [
+                'uid'  => $this->providerUid,
+                'name' => $this->providerName,
+            ],
+            'modelsCount'          => $this->modelsCount,
+            'configurationsCount'  => $this->configurationsCount,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/Response/WizardTestConnectionResponse.php
+++ b/Classes/Controller/Backend/Response/WizardTestConnectionResponse.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend\Response;
+
+use JsonSerializable;
+
+/**
+ * Response DTO for the Setup Wizard `testAction` AJAX action.
+ *
+ * Distinct from the broader `TestConnectionResponse` used by
+ * `ConfigurationController::testProviderConnectionAction()`, which
+ * additionally exposes a discovered model list. The wizard's
+ * `testAction` only confirms reachability — model discovery happens
+ * in the dedicated `discoverAction` step — so this DTO mirrors the
+ * exact wire shape (`{success, message}`) the wizard frontend
+ * (`Backend/SetupWizard.js`) reads at step 2.
+ *
+ * Keeping the DTO narrow avoids adding an unused `models: []` field
+ * to the JSON body and preserves byte-for-byte parity with the
+ * pre-DTO inline literal.
+ *
+ * @internal
+ */
+final readonly class WizardTestConnectionResponse implements JsonSerializable
+{
+    public function __construct(
+        public bool $success,
+        public string $message,
+    ) {}
+
+    /**
+     * Create from a model-discovery service `testConnection()` result.
+     *
+     * @param array{success: bool, message: string} $result
+     */
+    public static function fromResult(array $result): self
+    {
+        return new self(
+            success: $result['success'],
+            message: $result['message'],
+        );
+    }
+
+    /**
+     * @return array{success: bool, message: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'success' => $this->success,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Controller\Backend\Response\DiscoveredModelsResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\GeneratedConfigurationsResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\ProviderDetectionResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\WizardSaveResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\WizardTestConnectionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
@@ -18,7 +24,6 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
-use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -129,18 +134,17 @@ final class SetupWizardController extends ActionController
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
 
         if ($endpoint === '') {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Endpoint URL is required',
-            ], 400);
+            return new JsonResponse(
+                (new ErrorResponse('Endpoint URL is required'))->jsonSerialize(),
+                400,
+            );
         }
 
         $detected = $this->providerDetector->detect($endpoint);
 
-        return new JsonResponse([
-            'success' => true,
-            'provider' => $detected->toArray(),
-        ]);
+        return new JsonResponse(
+            ProviderDetectionResponse::fromDetectedProvider($detected)->jsonSerialize(),
+        );
     }
 
     /**
@@ -154,10 +158,10 @@ final class SetupWizardController extends ActionController
         $adapterType = $this->extractStringFromBody($body, 'adapterType', 'openai');
 
         if ($endpoint === '') {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Endpoint URL is required',
-            ], 400);
+            return new JsonResponse(
+                (new ErrorResponse('Endpoint URL is required'))->jsonSerialize(),
+                400,
+            );
         }
 
         $detected = new DetectedProvider(
@@ -168,10 +172,9 @@ final class SetupWizardController extends ActionController
 
         $result = $this->modelDiscovery->testConnection($detected, $apiKey);
 
-        return new JsonResponse([
-            'success' => $result['success'],
-            'message' => $result['message'],
-        ]);
+        return new JsonResponse(
+            WizardTestConnectionResponse::fromResult($result)->jsonSerialize(),
+        );
     }
 
     /**
@@ -185,10 +188,10 @@ final class SetupWizardController extends ActionController
         $adapterType = $this->extractStringFromBody($body, 'adapterType', 'openai');
 
         if ($endpoint === '') {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Endpoint URL is required',
-            ], 400);
+            return new JsonResponse(
+                (new ErrorResponse('Endpoint URL is required'))->jsonSerialize(),
+                400,
+            );
         }
 
         $detected = new DetectedProvider(
@@ -197,12 +200,11 @@ final class SetupWizardController extends ActionController
             endpoint: $endpoint,
         );
 
-        $models = $this->modelDiscovery->discover($detected, $apiKey);
+        $models = array_values($this->modelDiscovery->discover($detected, $apiKey));
 
-        return new JsonResponse([
-            'success' => true,
-            'models' => array_map(fn(DiscoveredModel $m) => $m->toArray(), $models),
-        ]);
+        return new JsonResponse(
+            DiscoveredModelsResponse::fromDiscoveredModels($models)->jsonSerialize(),
+        );
     }
 
     /**
@@ -217,10 +219,10 @@ final class SetupWizardController extends ActionController
         $modelsData = $this->extractArrayFromBody($body, 'models');
 
         if ($endpoint === '' || $modelsData === []) {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Endpoint and models are required',
-            ], 400);
+            return new JsonResponse(
+                (new ErrorResponse('Endpoint and models are required'))->jsonSerialize(),
+                400,
+            );
         }
 
         $detected = new DetectedProvider(
@@ -246,12 +248,13 @@ final class SetupWizardController extends ActionController
             );
         }
 
-        $configurations = $this->configurationGenerator->generate($detected, $apiKey, $models);
+        $configurations = array_values(
+            $this->configurationGenerator->generate($detected, $apiKey, $models),
+        );
 
-        return new JsonResponse([
-            'success' => true,
-            'configurations' => array_map(fn(SuggestedConfiguration $c) => $c->toArray(), $configurations),
-        ]);
+        return new JsonResponse(
+            GeneratedConfigurationsResponse::fromSuggestedConfigurations($configurations)->jsonSerialize(),
+        );
     }
 
     /**
@@ -266,10 +269,10 @@ final class SetupWizardController extends ActionController
         $pid = $this->extractIntFromBody($body, 'pid');
 
         if ($providerData === [] || $modelsData === []) {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Provider and models are required',
-            ], 400);
+            return new JsonResponse(
+                (new ErrorResponse('Provider and models are required'))->jsonSerialize(),
+                400,
+            );
         }
 
         try {
@@ -290,10 +293,10 @@ final class SetupWizardController extends ActionController
                         'source' => 'setup_wizard',
                     ]);
                 } catch (Throwable $e) {
-                    return new JsonResponse([
-                        'success' => false,
-                        'error' => 'Failed to store API key securely: ' . $e->getMessage(),
-                    ], 500);
+                    return new JsonResponse(
+                        (new ErrorResponse('Failed to store API key securely: ' . $e->getMessage()))->jsonSerialize(),
+                        500,
+                    );
                 }
             }
 
@@ -311,7 +314,6 @@ final class SetupWizardController extends ActionController
             $this->providerRepository->add($provider);
             $this->persistenceManager->persistAll();
 
-            $providerUid = $provider->getUid();
             /** @var array<string, Model> $savedModels */
             $savedModels = [];
 
@@ -417,21 +419,18 @@ final class SetupWizardController extends ActionController
                 }
             }
 
-            return new JsonResponse([
-                'success' => true,
-                'message' => 'Configuration saved successfully',
-                'provider' => [
-                    'uid' => $providerUid,
-                    'name' => $provider->getName(),
-                ],
-                'modelsCount' => count($savedModels),
-                'configurationsCount' => $configCount,
-            ]);
+            return new JsonResponse(
+                WizardSaveResponse::fromProvider(
+                    provider: $provider,
+                    modelsCount: count($savedModels),
+                    configurationsCount: $configCount,
+                )->jsonSerialize(),
+            );
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Failed to save: ' . $e->getMessage(),
-            ], 500);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to save: ' . $e->getMessage()))->jsonSerialize(),
+                500,
+            );
         }
     }
 

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -200,10 +200,12 @@ final class SetupWizardController extends ActionController
             endpoint: $endpoint,
         );
 
-        $models = array_values($this->modelDiscovery->discover($detected, $apiKey));
-
+        // `fromDiscoveredModels()` reindexes via `array_values(array_map(...))`
+        // internally, so passing the raw discover() result here is fine.
         return new JsonResponse(
-            DiscoveredModelsResponse::fromDiscoveredModels($models)->jsonSerialize(),
+            DiscoveredModelsResponse::fromDiscoveredModels(
+                $this->modelDiscovery->discover($detected, $apiKey),
+            )->jsonSerialize(),
         );
     }
 
@@ -248,12 +250,14 @@ final class SetupWizardController extends ActionController
             );
         }
 
-        $configurations = array_values(
-            $this->configurationGenerator->generate($detected, $apiKey, $models),
-        );
-
+        // `fromSuggestedConfigurations()` reindexes via
+        // `array_values(array_map(...))` internally — the redundant
+        // `array_values()` wrapper here was a leftover from the
+        // pre-DTO inline-array shape.
         return new JsonResponse(
-            GeneratedConfigurationsResponse::fromSuggestedConfigurations($configurations)->jsonSerialize(),
+            GeneratedConfigurationsResponse::fromSuggestedConfigurations(
+                $this->configurationGenerator->generate($detected, $apiKey, $models),
+            )->jsonSerialize(),
         );
     }
 

--- a/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
+++ b/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\Response;
 
+use Netresearch\NrLlm\Controller\Backend\Response\DiscoveredModelsResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\GeneratedConfigurationsResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ModelListItemResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ModelListResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\ProviderDetectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ProviderModelsResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\RecordDataResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\RecordListResponse;
@@ -23,8 +26,14 @@ use Netresearch\NrLlm\Controller\Backend\Response\TestConfigurationResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\UsageResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\WizardSaveResponse;
+use Netresearch\NrLlm\Controller\Backend\Response\WizardTestConnectionResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
 use Netresearch\NrLlm\Service\Task\TaskExecutionResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -47,6 +56,11 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RecordDataResponse::class)]
 #[CoversClass(TaskExecutionResponse::class)]
 #[CoversClass(TaskInputResponse::class)]
+#[CoversClass(ProviderDetectionResponse::class)]
+#[CoversClass(WizardTestConnectionResponse::class)]
+#[CoversClass(DiscoveredModelsResponse::class)]
+#[CoversClass(GeneratedConfigurationsResponse::class)]
+#[CoversClass(WizardSaveResponse::class)]
 final class ResponseDtoTest extends TestCase
 {
     public function testErrorResponseContainsAllRequiredKeys(): void
@@ -409,5 +423,203 @@ final class ResponseDtoTest extends TestCase
         self::assertSame(['success', 'error'], array_keys($data));
         self::assertFalse($data['success']);
         self::assertSame('boom', $data['error']);
+    }
+
+    // ========================================
+    // Setup Wizard pathway responses (slice 21)
+    // ========================================
+
+    public function testProviderDetectionResponseShape(): void
+    {
+        $data = (new ProviderDetectionResponse(
+            provider: [
+                'adapterType'   => 'openai',
+                'suggestedName' => 'OpenAI',
+                'endpoint'      => 'https://api.openai.com/v1',
+                'confidence'    => 1.0,
+                'metadata'      => [],
+            ],
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'provider'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame('openai', $data['provider']['adapterType']);
+        self::assertSame('https://api.openai.com/v1', $data['provider']['endpoint']);
+    }
+
+    public function testProviderDetectionResponseFromDetectedProvider(): void
+    {
+        $detected = new DetectedProvider(
+            adapterType: 'anthropic',
+            suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com',
+            confidence: 0.9,
+            metadata: ['region' => 'us'],
+        );
+        $data = ProviderDetectionResponse::fromDetectedProvider($detected)->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertSame($detected->toArray(), $data['provider']);
+    }
+
+    public function testWizardTestConnectionResponseShape(): void
+    {
+        $data = (new WizardTestConnectionResponse(
+            success: true,
+            message: 'Connection OK',
+        ))->jsonSerialize();
+
+        // Byte-for-byte parity with the pre-DTO inline literal —
+        // `models` is intentionally absent so the wizard JSON body
+        // stays exactly `{success, message}`.
+        self::assertSame(['success', 'message'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertSame('Connection OK', $data['message']);
+    }
+
+    public function testWizardTestConnectionResponseFromResult(): void
+    {
+        $data = WizardTestConnectionResponse::fromResult([
+            'success' => false,
+            'message' => 'Auth failed',
+        ])->jsonSerialize();
+
+        self::assertFalse($data['success']);
+        self::assertSame('Auth failed', $data['message']);
+    }
+
+    public function testDiscoveredModelsResponseShape(): void
+    {
+        $data = (new DiscoveredModelsResponse(
+            models: [
+                ['modelId' => 'gpt-4', 'name' => 'GPT-4', 'recommended' => true],
+            ],
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'models'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['models']);
+        self::assertSame('gpt-4', $data['models'][0]['modelId']);
+    }
+
+    public function testDiscoveredModelsResponseFromDiscoveredModels(): void
+    {
+        $a = new DiscoveredModel(modelId: 'gpt-4', name: 'GPT-4');
+        $b = new DiscoveredModel(modelId: 'claude-3', name: 'Claude 3');
+
+        $data = DiscoveredModelsResponse::fromDiscoveredModels([$a, $b])->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertCount(2, $data['models']);
+        self::assertSame('gpt-4', $data['models'][0]['modelId']);
+        self::assertSame('claude-3', $data['models'][1]['modelId']);
+        // Inner shape mirrors DiscoveredModel::toArray()
+        self::assertArrayHasKey('capabilities', $data['models'][0]);
+        self::assertArrayHasKey('contextLength', $data['models'][0]);
+    }
+
+    public function testDiscoveredModelsResponseFromEmptyList(): void
+    {
+        $data = DiscoveredModelsResponse::fromDiscoveredModels([])->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertSame([], $data['models']);
+    }
+
+    public function testGeneratedConfigurationsResponseShape(): void
+    {
+        $data = (new GeneratedConfigurationsResponse(
+            configurations: [
+                ['identifier' => 'summarizer', 'name' => 'Summarizer'],
+            ],
+        ))->jsonSerialize();
+
+        self::assertSame(['success', 'configurations'], array_keys($data));
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['configurations']);
+        self::assertSame('summarizer', $data['configurations'][0]['identifier']);
+    }
+
+    public function testGeneratedConfigurationsResponseFromSuggestedConfigurations(): void
+    {
+        $cfg = new SuggestedConfiguration(
+            identifier: 'translator',
+            name: 'Translator',
+            description: 'Translates text',
+            systemPrompt: 'You are a translator.',
+            recommendedModelId: 'gpt-4',
+        );
+
+        $data = GeneratedConfigurationsResponse::fromSuggestedConfigurations([$cfg])->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['configurations']);
+        self::assertSame($cfg->toArray(), $data['configurations'][0]);
+    }
+
+    public function testGeneratedConfigurationsResponseFromEmptyList(): void
+    {
+        $data = GeneratedConfigurationsResponse::fromSuggestedConfigurations([])->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertSame([], $data['configurations']);
+    }
+
+    public function testWizardSaveResponseShape(): void
+    {
+        $data = (new WizardSaveResponse(
+            message: 'Configuration saved successfully',
+            providerUid: 17,
+            providerName: 'My OpenAI',
+            modelsCount: 3,
+            configurationsCount: 2,
+        ))->jsonSerialize();
+
+        self::assertSame(
+            ['success', 'message', 'provider', 'modelsCount', 'configurationsCount'],
+            array_keys($data),
+        );
+        self::assertTrue($data['success']);
+        self::assertSame('Configuration saved successfully', $data['message']);
+        self::assertSame(['uid' => 17, 'name' => 'My OpenAI'], $data['provider']);
+        self::assertSame(3, $data['modelsCount']);
+        self::assertSame(2, $data['configurationsCount']);
+    }
+
+    public function testWizardSaveResponseFromProvider(): void
+    {
+        $provider = self::createStub(Provider::class);
+        $provider->method('getUid')->willReturn(42);
+        $provider->method('getName')->willReturn('Production OpenAI');
+
+        $data = WizardSaveResponse::fromProvider(
+            provider: $provider,
+            modelsCount: 5,
+            configurationsCount: 0,
+        )->jsonSerialize();
+
+        self::assertTrue($data['success']);
+        self::assertSame('Configuration saved successfully', $data['message']);
+        self::assertSame(['uid' => 42, 'name' => 'Production OpenAI'], $data['provider']);
+        self::assertSame(5, $data['modelsCount']);
+        self::assertSame(0, $data['configurationsCount']);
+    }
+
+    public function testWizardSaveResponseFromProviderHandlesNullUid(): void
+    {
+        // Stubs default scalar return values to zero/empty values, so
+        // `getUid()` returning null cannot be exercised through the
+        // standard stub path. Verify the constructor's contract: the
+        // `providerUid` slot accepts the int the factory falls back
+        // to (`?? 0`) when an unpersisted entity is passed.
+        $data = (new WizardSaveResponse(
+            message: 'Configuration saved successfully',
+            providerUid: 0,
+            providerName: 'Detached',
+            modelsCount: 1,
+            configurationsCount: 1,
+        ))->jsonSerialize();
+
+        self::assertSame(0, $data['provider']['uid']);
     }
 }

--- a/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
+++ b/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
@@ -605,21 +605,43 @@ final class ResponseDtoTest extends TestCase
         self::assertSame(0, $data['configurationsCount']);
     }
 
-    public function testWizardSaveResponseFromProviderHandlesNullUid(): void
+    public function testWizardSaveResponseFromProviderPassesNullUidThrough(): void
     {
-        // Stubs default scalar return values to zero/empty values, so
-        // `getUid()` returning null cannot be exercised through the
-        // standard stub path. Verify the constructor's contract: the
-        // `providerUid` slot accepts the int the factory falls back
-        // to (`?? 0`) when an unpersisted entity is passed.
-        $data = (new WizardSaveResponse(
-            message: 'Configuration saved successfully',
-            providerUid: 0,
-            providerName: 'Detached',
+        // Pre-DTO controller code returned `$provider->getUid()`
+        // directly; substituting `0` would change the wire shape and
+        // break the frontend's "did the entity get a uid?" check.
+        // Use a real Provider instance whose `getUid()` returns null
+        // (the default for an unpersisted entity).
+        $provider = new Provider();
+        $provider->setName('Detached');
+
+        self::assertNull($provider->getUid());
+
+        $data = WizardSaveResponse::fromProvider(
+            provider: $provider,
             modelsCount: 1,
             configurationsCount: 1,
-        ))->jsonSerialize();
+        )->jsonSerialize();
 
-        self::assertSame(0, $data['provider']['uid']);
+        self::assertNull($data['provider']['uid']);
+        self::assertSame('Detached', $data['provider']['name']);
+    }
+
+    public function testWizardSaveResponseFromProviderEmitsPersistedUid(): void
+    {
+        // Mirror image of the previous test: when the entity has a
+        // uid, that uid round-trips through the DTO unchanged.
+        $provider = new Provider();
+        $provider->setName('Production OpenAI');
+        $provider->_setProperty('uid', 42);
+
+        $data = WizardSaveResponse::fromProvider(
+            provider: $provider,
+            modelsCount: 5,
+            configurationsCount: 0,
+        )->jsonSerialize();
+
+        self::assertSame(42, $data['provider']['uid']);
+        self::assertSame('Production OpenAI', $data['provider']['name']);
     }
 }


### PR DESCRIPTION
## Summary

Closes the audit gap REC #5 left open after the slice-13 `TaskController` split: `SetupWizardController` was the last backend controller still returning ad-hoc associative arrays from every `JsonResponse`. Migrates **all ten ad-hoc-array call sites** in `detectAction`, `testAction`, `discoverAction`, `generateAction`, and `saveAction` (five success paths + five error/exception paths) to typed Response DTOs, matching the precedent set by `ConfigurationController`, `ProviderController`, and the post-split task controllers.

## New Response DTOs (5)

| DTO | Used in | Wire shape |
|-----|---------|------------|
| `ProviderDetectionResponse` | `detectAction` | `{success, provider}` |
| `WizardTestConnectionResponse` | `testAction` | `{success, message}` |
| `DiscoveredModelsResponse` | `discoverAction` | `{success, models[]}` |
| `GeneratedConfigurationsResponse` | `generateAction` | `{success, configurations[]}` |
| `WizardSaveResponse` | `saveAction` | `{success, message, provider:{uid,name}, modelsCount, configurationsCount}` |

All errors continue to use the existing `Response/ErrorResponse`. Each DTO follows the established `final readonly` + `implements JsonSerializable` + typed `jsonSerialize()` pattern.

### Why a slim `WizardTestConnectionResponse` (not the existing `TestConnectionResponse`)

The existing `TestConnectionResponse` (used by `ConfigurationController::testProviderConnectionAction()`) carries an additional `models[]` field. The wizard's `testAction` only confirms reachability — model discovery is the dedicated `discoverAction` step — so a narrower DTO keeps the wire body byte-for-byte identical to the pre-DTO literal rather than introducing an unused `models: []` field.

## Wire-format preservation

The JSON shape consumed by `Backend/SetupWizard.js` (reads `result.success`, `result.provider`, `result.message`, `result.models`, `result.configurations`, `result.modelsCount`, `result.configurationsCount`, `result.provider.name`, `result.error`) is preserved byte-for-byte. Each new DTO's `jsonSerialize()` returns exactly the array shape the previous inline literal produced; key order matches the pre-DTO literal order.

## Test coverage (+13 tests, +44 assertions)

`Tests/Unit/Controller/Backend/Response/ResponseDtoTest` gains 13 tests covering the five new DTOs: shape assertions (key order via `array_keys()`), factory-method round-trips (`fromDetectedProvider`, `fromResult`, `fromDiscoveredModels`, `fromSuggestedConfigurations`, `fromProvider`), and edge cases (empty list factories, null-uid handling).

## Out of scope

REC #8b (replacing the surviving `catch (Throwable)` blocks in `saveAction`) is a separate slice and not touched here.

## Test plan

- [x] cgl
- [x] phpstan (level 10) — no errors
- [x] rector (dry-run) — clean
- [x] architecture (PHPat) — pass
- [x] unit — 3354 tests, 7298 assertions (3341 → 3354 = +13 tests, +44 assertions)
- [ ] CI matrix (PHP 8.2-8.5 × TYPO3 13.4 / 14.0)
- [ ] Smoke-test the wizard frontend manually (verify `Backend/SetupWizard.js` still consumes `result.provider`, `result.modelsCount`, etc. as expected)