### PR TITLE
refactor(domain): ProviderOptions DTO + typed accessors (REC #6 slice 20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Classes/Domain/DTO/ProviderOptions` — typed value object for
+  `Provider::$options` (REC #6 slice 20, closes the typed-DTO follow-up
+  to slice 16f). `final readonly class` with three fields: `proxy`
+  (`?string`), `customHeaders` (`array<string, string>`), and `extra`
+  (`array<string, mixed>`) for everything else. The well-known fields
+  cover the transport-level options that real adapters consume today
+  (the TCA placeholder is `{"custom_header": "value"}` and existing
+  test fixtures use `proxy`); the rest of the open-ended JSON column
+  flows through `$extra` so a hand-edited DB row never silently loses
+  data. Permissive parsing — `fromArray()` / `fromJson()` drop
+  type-mismatched well-known fields rather than throwing; sibling
+  helpers (`get()`, `has()`, `withProxy()`, `withCustomHeaders()`,
+  `withExtra()`) mirror the read patterns existing
+  `getOptionsArray()` callers already use so migration is a straight
+  substitution. The DTO is the typed application-level surface; the
+  entity still persists JSON to keep Extbase property mapping working
+  unchanged.
+- `Provider::getOptionsObject(): ProviderOptions` and
+  `Provider::setOptionsObject(ProviderOptions): void` — typed accessors
+  on the entity (REC #6 slice 20). The DTO is built fresh from the
+  persisted JSON on each `get` call (cheap — single `json_decode` plus
+  a few key extractions) and never throws on malformed input.
+  `setOptionsObject()` collapses an empty DTO to the empty-string
+  sentinel `''` rather than persisting `'[]'`, matching how
+  `setOptions('')` historically cleared the field. The legacy string
+  / array accessors do NOT route through the typed accessor — they
+  preserve their pre-REC-#6 behaviour byte-for-byte.
 - `Classes/Specialized/AbstractSpecializedService` — base class for
   every single-task AI service that talks to a provider over HTTP
   (DALL-E, FAL, Whisper, TTS, DeepL — slice 18, REC #7). Concentrates
@@ -69,17 +96,34 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecated
 
+- `Provider::getOptionsArray(): array<string, mixed>` and
+  `setOptionsArray(array<string, mixed>)` are now also deprecated
+  since 0.8.0 in favour of the typed
+  `getOptionsObject(): ProviderOptions` /
+  `setOptionsObject(ProviderOptions)` accessors (REC #6 slice 20 —
+  follow-up to slice 16f). Slice 16f had stopped at the array-typed
+  surface on the rationale that the `options` column was too
+  open-ended for a typed DTO; that argument was reconsidered against
+  the parallel `Capabilities`/`FallbackChain`/`ModelSelectionCriteria`
+  DTOs and the small but well-defined transport keys actually used
+  in production (TCA placeholder `{"custom_header": "value"}`, test
+  fixtures `proxy`, `custom_param`). The new `ProviderOptions` DTO
+  types those well-known keys (`proxy`, `customHeaders`) and routes
+  everything else through an `extra: array<string, mixed>` bag so no
+  existing data is lost. The array accessor is retained for
+  back-compat with the `ProviderAdapterRegistry::buildAdapterConfig()`
+  call site that merges it into the adapter-init config; that call
+  site will migrate in a follow-up slice. The string and array
+  accessors will not be removed before a major version bump.
 - `Provider::getOptions(): string` and `setOptions(string)` are
   deprecated since 0.8.0 in favour of the typed
-  `getOptionsArray(): array<string, mixed>` /
-  `setOptionsArray(array<string, mixed>)` accessors. Same rationale
-  as the parallel `LlmConfiguration` deprecation in slice 16e — the
-  `options` field carries provider-adapter-specific extras beyond
-  the typed `Provider` entity columns and its shape is open-ended
-  by design, so REC #6 stops at the array-typed surface rather
-  than introducing a typed DTO. The legacy raw-JSON methods remain
-  for Extbase property mapping and will not be removed before a
-  major version bump. REC #6 slice 16f — closes REC #6.
+  `getOptionsObject(): ProviderOptions` /
+  `setOptionsObject(ProviderOptions)` accessors (REC #6 slice 20,
+  updated rationale from slice 16f). The legacy raw-JSON methods
+  remain for Extbase property mapping (the framework hydrates the
+  entity through this getter / setter pair) and will not be removed
+  before a major version bump. REC #6 slice 16f — superseded by
+  slice 20.
 - `LlmConfiguration::getOptions(): string` and `setOptions(string)` are
   deprecated since 0.8.0 in favour of the typed
   `getOptionsArray(): array<string, mixed>` /

--- a/Classes/Domain/DTO/ProviderOptions.php
+++ b/Classes/Domain/DTO/ProviderOptions.php
@@ -1,0 +1,291 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\DTO;
+
+use JsonSerializable;
+
+/**
+ * Typed value object for `Provider::$options` (REC #6 slice 20).
+ *
+ * `tx_nrllm_provider.options` is a free-form JSON column whose label in
+ * TCA reads "Additional Options" and whose description reads "Additional
+ * provider-specific options as JSON" — by design it carries
+ * adapter-extras that go BEYOND the typed entity columns
+ * (`api_key`, `endpoint_url`, `api_timeout`, `max_retries`,
+ * `organization_id`). The placeholder shipped in TCA is
+ * `{"custom_header": "value"}` and real test fixtures use `proxy`,
+ * `custom_param`, etc., so the field is genuinely open-ended.
+ *
+ * That open-endedness is why slices 16e/16f initially stopped at the
+ * `array<string, mixed>` surface. This slice walks the rest of the way:
+ * a small set of well-known transport-level keys gets typed (`proxy`,
+ * `customHeaders`) and everything else flows through `$extra` as
+ * `array<string, mixed>` — same permissive shape callers already see
+ * via `Provider::getOptionsArray()`, just behind a typed accessor.
+ *
+ * The DTO is the typed application-level surface; the entity still
+ * persists JSON to keep Extbase property mapping working unchanged
+ * (`Provider::$options` stays a `string` column). Round-trip is via
+ * `fromJson()` / `toJson()`. `fromArray()` is permissive — unknown keys
+ * are not dropped, they go into `$extra`, so a hand-edited DB row never
+ * silently loses data.
+ *
+ * Constructor contract: like the sibling DTOs (`FallbackChain`,
+ * `CapabilitySet`, `ModelSelectionCriteria`), the public constructor
+ * TRUSTS its input. `fromArray()` and `fromJson()` are the safe entry
+ * points for arbitrary input — they extract the well-known keys and
+ * funnel the rest into `$extra` without throwing.
+ */
+final readonly class ProviderOptions implements JsonSerializable
+{
+    /**
+     * @param string|null           $proxy         HTTP proxy URL (e.g. `http://proxy.example.com:3128`).
+     *                                             Null means "no proxy override" — the adapter uses its
+     *                                             process-default routing.
+     * @param array<string, string> $customHeaders Extra HTTP headers to send on every API call.
+     *                                             Keys are header names, values are header values.
+     *                                             Both must be strings; non-string values are dropped
+     *                                             by `fromArray()` rather than silently coerced.
+     * @param array<string, mixed>  $extra         Adapter-specific keys that don't fit a well-known
+     *                                             slot. Preserved verbatim through round-trip so a
+     *                                             hand-edited DB row never loses data when it passes
+     *                                             through this DTO.
+     */
+    public function __construct(
+        public ?string $proxy = null,
+        public array $customHeaders = [],
+        public array $extra = [],
+    ) {}
+
+    /**
+     * Build from an arbitrary array (e.g. `json_decode($options, true)`).
+     *
+     * Well-known keys are extracted into typed properties; everything
+     * else lands in `$extra`. Type-mismatches on the well-known keys
+     * are dropped silently — the goal is "never crash on a hand-edited
+     * row", not "validate every byte". Callers that need strict
+     * validation should run their own checks before construction.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $proxy = null;
+        if (isset($data['proxy']) && is_string($data['proxy']) && $data['proxy'] !== '') {
+            $proxy = $data['proxy'];
+        }
+
+        $customHeaders = [];
+        if (isset($data['customHeaders']) && is_array($data['customHeaders'])) {
+            foreach ($data['customHeaders'] as $name => $value) {
+                if (is_string($name) && is_string($value)) {
+                    $customHeaders[$name] = $value;
+                }
+            }
+        }
+
+        $extra = $data;
+        unset($extra['proxy'], $extra['customHeaders']);
+
+        // Re-key extra so PHPStan / consumers see `array<string, mixed>`
+        // (json_decode of a JSON object always yields string keys, but
+        // a programmatic caller could hand us a list — defend against it).
+        $extraStringKeyed = [];
+        foreach ($extra as $key => $value) {
+            if (is_string($key)) {
+                $extraStringKeyed[$key] = $value;
+            }
+        }
+
+        return new self(
+            proxy: $proxy,
+            customHeaders: $customHeaders,
+            extra: $extraStringKeyed,
+        );
+    }
+
+    /**
+     * Build from the JSON string the entity persists.
+     *
+     * Empty string and any non-object JSON yield an empty options
+     * object so consumers never have to null-check before reading.
+     */
+    public static function fromJson(string $json): self
+    {
+        if ($json === '') {
+            return new self();
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return new self();
+        }
+        /** @var array<string, mixed> $decoded */
+        return self::fromArray($decoded);
+    }
+
+    /**
+     * Convert to an array suitable for `json_encode()` or for merging
+     * into an adapter-init config.
+     *
+     * Empty well-known fields (null `proxy`, empty `customHeaders`)
+     * are omitted so a freshly constructed empty DTO round-trips to
+     * `[]` rather than `['proxy' => null, 'customHeaders' => []]`.
+     *
+     * Extra-key collisions: a key in `$extra` that shadows a
+     * well-known key (e.g. `extra: ['proxy' => 'foo']`) is silently
+     * overwritten by the typed field on output. This is intentional —
+     * the typed field is the source of truth; if a caller stuffs
+     * `proxy` into `$extra` directly, the next round-trip
+     * (`fromArray(toArray())`) will normalise it back into the typed
+     * slot.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = $this->extra;
+
+        if ($this->customHeaders !== []) {
+            $out['customHeaders'] = $this->customHeaders;
+        } else {
+            unset($out['customHeaders']);
+        }
+
+        if ($this->proxy !== null) {
+            $out['proxy'] = $this->proxy;
+        } else {
+            unset($out['proxy']);
+        }
+
+        return $out;
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * True when no proxy, no custom headers, and no extras are set.
+     * Useful when the caller wants to persist `''` rather than `'[]'`
+     * for an empty options object (matches the `LlmConfiguration`
+     * `setOptions('')` convention for "nothing configured").
+     */
+    public function isEmpty(): bool
+    {
+        return $this->proxy === null
+            && $this->customHeaders === []
+            && $this->extra === [];
+    }
+
+    /**
+     * Read a single key — checks the well-known typed fields first,
+     * then falls through to `$extra`. Returns `$default` (null by
+     * default) when the key is absent.
+     *
+     * Mirrors the read pattern that `getOptionsArray()` callers
+     * already use (`$options['proxy'] ?? null`) so migration is a
+     * straight substitution.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return match ($key) {
+            'proxy' => $this->proxy ?? $default,
+            'customHeaders' => $this->customHeaders === [] ? $default : $this->customHeaders,
+            default => $this->extra[$key] ?? $default,
+        };
+    }
+
+    /**
+     * Membership check across well-known fields and `$extra`. A
+     * well-known field counts as "present" only when it carries a
+     * non-default value — `proxy` set to null or `customHeaders` set
+     * to `[]` does NOT register, mirroring the `toArray()` omission
+     * rule.
+     */
+    public function has(string $key): bool
+    {
+        return match ($key) {
+            'proxy' => $this->proxy !== null,
+            'customHeaders' => $this->customHeaders !== [],
+            default => array_key_exists($key, $this->extra),
+        };
+    }
+
+    /**
+     * Return a new instance with the proxy set (or cleared via null).
+     */
+    public function withProxy(?string $proxy): self
+    {
+        if ($proxy === '') {
+            $proxy = null;
+        }
+        return new self(
+            proxy: $proxy,
+            customHeaders: $this->customHeaders,
+            extra: $this->extra,
+        );
+    }
+
+    /**
+     * Return a new instance with custom headers replaced.
+     *
+     * Non-string keys / values in `$headers` are dropped (mirrors
+     * `fromArray()`'s normalisation) so the typed property always
+     * carries `array<string, string>`.
+     *
+     * @param array<string, string> $headers
+     */
+    public function withCustomHeaders(array $headers): self
+    {
+        $sanitised = [];
+        foreach ($headers as $name => $value) {
+            if (is_string($name) && is_string($value)) {
+                $sanitised[$name] = $value;
+            }
+        }
+        return new self(
+            proxy: $this->proxy,
+            customHeaders: $sanitised,
+            extra: $this->extra,
+        );
+    }
+
+    /**
+     * Return a new instance with an extra key set.
+     *
+     * Cannot be used to overwrite the well-known typed fields —
+     * passing `proxy` or `customHeaders` here is a no-op and the
+     * caller should use `withProxy()` / `withCustomHeaders()` instead.
+     * Returning the same instance (rather than throwing) keeps the
+     * fluent chain robust against accidental misuse.
+     */
+    public function withExtra(string $key, mixed $value): self
+    {
+        if ($key === 'proxy' || $key === 'customHeaders') {
+            return $this;
+        }
+        $extra = $this->extra;
+        $extra[$key] = $value;
+        return new self(
+            proxy: $this->proxy,
+            customHeaders: $this->customHeaders,
+            extra: $extra,
+        );
+    }
+}

--- a/Classes/Domain/DTO/ProviderOptions.php
+++ b/Classes/Domain/DTO/ProviderOptions.php
@@ -207,7 +207,11 @@ final readonly class ProviderOptions implements JsonSerializable
         return match ($key) {
             'proxy' => $this->proxy ?? $default,
             'customHeaders' => $this->customHeaders === [] ? $default : $this->customHeaders,
-            default => $this->extra[$key] ?? $default,
+            // `array_key_exists` instead of `??` so a stored `null`
+            // value is preserved instead of being replaced with the
+            // default — keeps `get()` and `has()` semantics aligned
+            // (the latter already uses `array_key_exists`).
+            default => array_key_exists($key, $this->extra) ? $this->extra[$key] : $default,
         };
     }
 

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Domain\Model;
 
 use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\DTO\ProviderOptions;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -162,16 +163,11 @@ class Provider extends AbstractEntity
 
     /**
      * @deprecated since 0.8.0 — application code should use the typed
-     *             `getOptionsArray()` (returns `array<string, mixed>`).
-     *             The `options` field carries provider-adapter-specific
-     *             extras beyond the typed entity columns; its shape is
-     *             open-ended by design and varies per adapter, so
-     *             REC #6 stops at the array-typed surface rather than
-     *             introducing a typed DTO that would impose false
-     *             structure. The raw-JSON accessor is retained for
-     *             Extbase property mapping (the framework hydrates the
-     *             entity through this getter / setter pair) and will
-     *             not be removed before a major version bump.
+     *             `getOptionsObject(): ProviderOptions` (REC #6 slice 20).
+     *             The raw-JSON accessor is retained for Extbase property
+     *             mapping (the framework hydrates the entity through this
+     *             getter / setter pair) and will not be removed before a
+     *             major version bump.
      */
     public function getOptions(): string
     {
@@ -182,6 +178,14 @@ class Provider extends AbstractEntity
      * Get parsed options array.
      *
      * @return array<string, mixed>
+     *
+     * @deprecated since 0.8.0 — use `getOptionsObject()` for the typed
+     *             `ProviderOptions` value object (REC #6 slice 20). The
+     *             array accessor is retained for back-compat with
+     *             pre-DTO callers (`ProviderAdapterRegistry` merges it
+     *             into the adapter-init config) and will not be removed
+     *             before a major version bump; new code should consume
+     *             the DTO directly.
      */
     public function getOptionsArray(): array
     {
@@ -194,6 +198,25 @@ class Provider extends AbstractEntity
         }
         /** @var array<string, mixed> $decoded */
         return $decoded;
+    }
+
+    /**
+     * Get options as a typed `ProviderOptions` value object (REC #6 slice 20).
+     *
+     * Preferred accessor for new callers. The DTO is built fresh from
+     * the persisted JSON on each call (cheap — single `json_decode`
+     * plus a few key extractions); it never throws on malformed input
+     * (returns an empty object instead) so consumers never have to
+     * defensive-decode.
+     *
+     * The legacy string / array accessors do NOT route through this
+     * method — they preserve their pre-REC-#6 behaviour byte-for-byte.
+     * A future slice will migrate `ProviderAdapterRegistry` and other
+     * call sites onto this typed surface.
+     */
+    public function getOptionsObject(): ProviderOptions
+    {
+        return ProviderOptions::fromJson($this->options);
     }
 
     public function getIsActive(): bool
@@ -332,8 +355,8 @@ class Provider extends AbstractEntity
 
     /**
      * @deprecated since 0.8.0 — application code should use the typed
-     *             `setOptionsArray(array<string, mixed>)` so the
-     *             persisted JSON is produced by `json_encode()` rather
+     *             `setOptionsObject(ProviderOptions)` so the persisted
+     *             JSON is produced by the DTO's own serialiser rather
      *             than passed in as an arbitrary string. The raw-JSON
      *             setter is retained for Extbase property mapping and
      *             will not be removed before a major version bump.
@@ -347,10 +370,32 @@ class Provider extends AbstractEntity
      * Set options from array.
      *
      * @param array<string, mixed> $options
+     *
+     * @deprecated since 0.8.0 — use `setOptionsObject(ProviderOptions)`
+     *             for typed validation of well-known fields (`proxy`,
+     *             `customHeaders`) and to centralise the encoding rule.
+     *             The array setter is retained for back-compat and
+     *             will not be removed before a major version bump.
      */
     public function setOptionsArray(array $options): void
     {
         $this->options = json_encode($options, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Set options from a typed `ProviderOptions` value object (REC #6 slice 20).
+     *
+     * Preferred setter — invariants on the DTO (`proxy` is `?string`,
+     * `customHeaders` is `array<string, string>`) flow through to the
+     * persisted JSON. An empty DTO collapses to the empty-string
+     * sentinel `''` (matching how `setOptions('')` historically
+     * cleared the field) rather than persisting `'[]'`, so the
+     * round-trip through Extbase does not produce noisier JSON than
+     * the entity actually needs.
+     */
+    public function setOptionsObject(ProviderOptions $options): void
+    {
+        $this->options = $options->isEmpty() ? '' : $options->toJson();
     }
 
     public function setIsActive(bool $isActive): void

--- a/Tests/Architecture/DomainLayerTest.php
+++ b/Tests/Architecture/DomainLayerTest.php
@@ -119,6 +119,8 @@ final class DomainLayerTest
             ->classes(
                 // Other domain models
                 Selector::inNamespace('Netresearch\NrLlm\Domain\Model'),
+                // Domain DTOs (typed value objects — REC #6: ProviderOptions)
+                Selector::inNamespace('Netresearch\NrLlm\Domain\DTO'),
                 // Vault service (required for API key handling via nr-vault)
                 Selector::inNamespace('Netresearch\NrVault\Service'),
                 // Extbase infrastructure

--- a/Tests/Unit/Domain/DTO/ProviderOptionsTest.php
+++ b/Tests/Unit/Domain/DTO/ProviderOptionsTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\DTO;
+
+use Netresearch\NrLlm\Domain\DTO\ProviderOptions;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ProviderOptions::class)]
+final class ProviderOptionsTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function emptyConstructorYieldsEmptyOptions(): void
+    {
+        $options = new ProviderOptions();
+
+        self::assertTrue($options->isEmpty());
+        self::assertNull($options->proxy);
+        self::assertSame([], $options->customHeaders);
+        self::assertSame([], $options->extra);
+        self::assertSame([], $options->toArray());
+        self::assertSame('[]', $options->toJson());
+    }
+
+    #[Test]
+    public function fromArrayExtractsWellKnownTypedFields(): void
+    {
+        $options = ProviderOptions::fromArray([
+            'proxy' => 'http://proxy.example.com:3128',
+            'customHeaders' => [
+                'X-Org' => 'acme',
+                'X-Env' => 'prod',
+            ],
+        ]);
+
+        self::assertSame('http://proxy.example.com:3128', $options->proxy);
+        self::assertSame(['X-Org' => 'acme', 'X-Env' => 'prod'], $options->customHeaders);
+        self::assertSame([], $options->extra);
+        self::assertFalse($options->isEmpty());
+    }
+
+    #[Test]
+    public function fromArrayFunnelsUnknownKeysIntoExtra(): void
+    {
+        // Pre-existing test fixtures used keys like `custom_param` and
+        // `timeout` (transport-level overrides). Those must round-trip
+        // unchanged through the DTO so a DB row that was written by an
+        // older controller path is preserved verbatim.
+        $options = ProviderOptions::fromArray([
+            'proxy' => 'http://proxy.example.com',
+            'custom_param' => 'custom_value',
+            'retry_backoff_ms' => 250,
+            'feature_flags' => ['fast_mode', 'beta_endpoints'],
+        ]);
+
+        self::assertSame('http://proxy.example.com', $options->proxy);
+        self::assertSame([
+            'custom_param' => 'custom_value',
+            'retry_backoff_ms' => 250,
+            'feature_flags' => ['fast_mode', 'beta_endpoints'],
+        ], $options->extra);
+    }
+
+    #[Test]
+    public function fromArrayDropsTypeMismatchedWellKnownFields(): void
+    {
+        // Defensive: a hand-edited DB row with `proxy: 42` (instead of
+        // a string URL) must not crash — silently drop and keep the
+        // rest of the row.
+        $options = ProviderOptions::fromArray([
+            'proxy' => 42,
+            'customHeaders' => 'not-a-map',
+            'extra_thing' => 'kept',
+        ]);
+
+        self::assertNull($options->proxy);
+        self::assertSame([], $options->customHeaders);
+        self::assertSame(['extra_thing' => 'kept'], $options->extra);
+    }
+
+    #[Test]
+    public function fromArrayDropsNonStringHeaderKeysAndValues(): void
+    {
+        // `customHeaders` must always be `array<string, string>` so
+        // adapters can splice it into HTTP request headers without
+        // type-checking every entry.
+        $options = ProviderOptions::fromArray([
+            'customHeaders' => [
+                'X-Org' => 'acme',
+                'X-Numeric-Value' => 42, // value not a string -> dropped
+                123 => 'numeric-key',     // key not a string -> dropped
+                'X-Env' => 'prod',
+            ],
+        ]);
+
+        self::assertSame(['X-Org' => 'acme', 'X-Env' => 'prod'], $options->customHeaders);
+    }
+
+    #[Test]
+    public function fromArrayDropsEmptyProxyString(): void
+    {
+        // An empty `proxy` is "not configured", same as null. This
+        // matches how `Provider::$options` is hydrated from TCA when
+        // the field has been cleared but not deleted.
+        $options = ProviderOptions::fromArray(['proxy' => '']);
+
+        self::assertNull($options->proxy);
+        self::assertTrue($options->isEmpty());
+    }
+
+    #[Test]
+    public function fromJsonRoundtripsThroughToJson(): void
+    {
+        $original = new ProviderOptions(
+            proxy: 'http://proxy.example.com',
+            customHeaders: ['X-Org' => 'acme'],
+            extra: ['custom_param' => 'value'],
+        );
+
+        $rebuilt = ProviderOptions::fromJson($original->toJson());
+
+        self::assertSame($original->proxy, $rebuilt->proxy);
+        self::assertSame($original->customHeaders, $rebuilt->customHeaders);
+        self::assertSame($original->extra, $rebuilt->extra);
+    }
+
+    #[Test]
+    public function fromJsonHandlesEmptyAndInvalidInput(): void
+    {
+        // Empty string is the entity's "nothing configured" sentinel
+        // (Extbase initialises `Provider::$options` to ''). Invalid
+        // JSON and non-object JSON must not throw — yield empty.
+        self::assertTrue(ProviderOptions::fromJson('')->isEmpty());
+        self::assertTrue(ProviderOptions::fromJson('not valid json')->isEmpty());
+        self::assertTrue(ProviderOptions::fromJson('"just a string"')->isEmpty());
+        self::assertTrue(ProviderOptions::fromJson('[1,2,3]')->isEmpty());
+    }
+
+    #[Test]
+    public function toArrayOmitsEmptyWellKnownFields(): void
+    {
+        // An empty DTO must round-trip to `[]`, not
+        // `['proxy' => null, 'customHeaders' => []]` — otherwise the
+        // persisted JSON gets noisier on every save cycle.
+        self::assertSame([], (new ProviderOptions())->toArray());
+
+        $partialOptions = new ProviderOptions(
+            extra: ['custom_param' => 'v'],
+        );
+
+        self::assertSame(['custom_param' => 'v'], $partialOptions->toArray());
+    }
+
+    #[Test]
+    public function toArrayPlacesWellKnownFieldsAfterExtraToFavourTypedSourceOfTruth(): void
+    {
+        // If `$extra` carries a key that shadows a typed field
+        // (only possible if a caller bypassed `withExtra()` — which
+        // refuses well-known keys), the typed field wins on output.
+        // This keeps `fromArray(toArray($x)) == $x` even after an
+        // adversarial constructor call.
+        $options = new ProviderOptions(
+            proxy: 'http://typed-proxy.example.com',
+            extra: ['proxy' => 'http://shadow.example.com'],
+        );
+
+        $serialised = $options->toArray();
+
+        self::assertSame('http://typed-proxy.example.com', $serialised['proxy']);
+    }
+
+    #[Test]
+    public function getReturnsTypedFieldsAndExtras(): void
+    {
+        $options = new ProviderOptions(
+            proxy: 'http://proxy.example.com',
+            customHeaders: ['X-Org' => 'acme'],
+            extra: ['custom_param' => 'v'],
+        );
+
+        self::assertSame('http://proxy.example.com', $options->get('proxy'));
+        self::assertSame(['X-Org' => 'acme'], $options->get('customHeaders'));
+        self::assertSame('v', $options->get('custom_param'));
+        self::assertNull($options->get('absent'));
+        self::assertSame('fallback', $options->get('absent', 'fallback'));
+    }
+
+    #[Test]
+    public function hasChecksWellKnownAndExtraKeys(): void
+    {
+        $options = new ProviderOptions(
+            proxy: 'http://proxy.example.com',
+            extra: ['custom_param' => 'v', 'null_extra' => null],
+        );
+
+        self::assertTrue($options->has('proxy'));
+        self::assertFalse($options->has('customHeaders'));
+        self::assertTrue($options->has('custom_param'));
+        // `null` in $extra still counts as "present" — array_key_exists,
+        // not isset — matching the read semantics of getOptionsArray().
+        self::assertTrue($options->has('null_extra'));
+        self::assertFalse($options->has('absent'));
+    }
+
+    #[Test]
+    public function withProxyReturnsNewInstance(): void
+    {
+        $original = new ProviderOptions();
+        $modified = $original->withProxy('http://proxy.example.com');
+
+        self::assertNull($original->proxy);
+        self::assertSame('http://proxy.example.com', $modified->proxy);
+
+        // Empty string clears, matching `fromArray()` normalisation.
+        self::assertNull($modified->withProxy('')->proxy);
+        self::assertNull($modified->withProxy(null)->proxy);
+    }
+
+    #[Test]
+    public function withCustomHeadersReplacesAndSanitises(): void
+    {
+        $options = (new ProviderOptions())->withCustomHeaders([
+            'X-Org' => 'acme',
+        ]);
+
+        self::assertSame(['X-Org' => 'acme'], $options->customHeaders);
+
+        // Non-string values must be dropped — exercise via fromArray()
+        // since the typed signature on withCustomHeaders() forbids
+        // non-string values at the type level.
+        $sanitised = ProviderOptions::fromArray([
+            'customHeaders' => ['X-Org' => 'acme', 'X-Drop' => 42],
+        ]);
+        self::assertSame(['X-Org' => 'acme'], $sanitised->customHeaders);
+    }
+
+    #[Test]
+    public function withExtraSetsArbitraryKeyButRefusesWellKnownNames(): void
+    {
+        $base = new ProviderOptions(proxy: 'http://typed.example.com');
+
+        $augmented = $base->withExtra('custom_param', 'v');
+        self::assertSame('v', $augmented->extra['custom_param']);
+        self::assertSame('http://typed.example.com', $augmented->proxy);
+
+        // Refuses to overwrite typed fields via the extra bag.
+        $rejected = $augmented->withExtra('proxy', 'http://injected.example.com');
+        self::assertSame($augmented, $rejected);
+
+        $rejectedHeaders = $augmented->withExtra('customHeaders', ['X' => 'y']);
+        self::assertSame($augmented, $rejectedHeaders);
+    }
+
+    #[Test]
+    public function realWorldFixtureRoundTripsLossless(): void
+    {
+        // Pinned against the `proxy` + `timeout` shape used in
+        // `Tests/Unit/Domain/Model/ProviderTest::getOptionsArrayDecodesValidJson`,
+        // and the `custom_header` shape advertised by the TCA
+        // placeholder, to ensure no existing DB row is mis-mapped
+        // by the new accessor.
+        $persisted = '{"proxy":"http://proxy.example.com","timeout":30,"custom_header":"value"}';
+
+        $options = ProviderOptions::fromJson($persisted);
+
+        self::assertSame('http://proxy.example.com', $options->proxy);
+        self::assertSame(30, $options->extra['timeout']);
+        self::assertSame('value', $options->extra['custom_header']);
+
+        // Roundtrip preserves every key.
+        $rebuilt = ProviderOptions::fromJson($options->toJson());
+        self::assertSame($options->proxy, $rebuilt->proxy);
+        self::assertSame($options->extra, $rebuilt->extra);
+    }
+
+    #[Test]
+    public function jsonSerializeMatchesToArray(): void
+    {
+        $options = new ProviderOptions(
+            proxy: 'http://proxy.example.com',
+            customHeaders: ['X-Org' => 'acme'],
+            extra: ['custom_param' => 'v'],
+        );
+
+        self::assertSame($options->toArray(), $options->jsonSerialize());
+        self::assertSame(
+            json_encode($options->toArray(), JSON_THROW_ON_ERROR),
+            json_encode($options, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    #[Test]
+    public function publicConstructorTrustsCallerInputForUnsanitisedHeaders(): void
+    {
+        // Documented contract: like sibling DTOs, the public
+        // constructor TRUSTS its input. Use `fromArray()` /
+        // `withCustomHeaders()` for arbitrary input. This test pins
+        // the contract so an accidental "let's add validation to the
+        // constructor" change forces a deliberate decision.
+        $options = new ProviderOptions(
+            customHeaders: ['X-Trusted' => 'yes'],
+        );
+
+        self::assertSame(['X-Trusted' => 'yes'], $options->customHeaders);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the typed-DTO follow-up to slice 16f by completing the four-DTO set promised in REC #6: `CapabilitySet`, `FallbackChain`, `ModelSelectionCriteria`, and now `ProviderOptions`.

- Adds `Classes/Domain/DTO/ProviderOptions` — `final readonly` value object with three fields: `proxy: ?string`, `customHeaders: array<string, string>`, `extra: array<string, mixed>`. Well-known transport keys are typed; everything else flows through `extra` so a hand-edited DB row never silently loses data.
- Adds `Provider::getOptionsObject()` / `setOptionsObject()` typed accessors. The DTO is built fresh from persisted JSON on each get; the setter collapses an empty DTO to the empty-string sentinel `''` rather than persisting `'[]'` (matching how `setOptions('')` cleared the field historically).
- Marks `Provider::getOptions()`, `setOptions()`, `getOptionsArray()`, `setOptionsArray()` `@deprecated since 0.8.0`. All four remain functional — `getOptions`/`setOptions` for Extbase property mapping; `getOptionsArray` for the `ProviderAdapterRegistry` call site that will migrate in a follow-up slice.
- Updates `DomainLayerTest::testProviderModelLimitedDependencies()` to add `Domain\DTO` to the Provider allowlist (mirrors slice 16a's `Model -> CapabilitySet` precedent).
- Amends slice 16f's CHANGELOG rationale to point at slice 20 as the follow-up that completes the typed DTO.

## Field design rationale

`Provider::$options` is genuinely free-form — TCA describes it as "Additional provider-specific options as JSON" with placeholder `{"custom_header": "value"}`. Real test fixtures use `proxy`, `custom_param`, `timeout`. The typed surface is conservative: `proxy` and `customHeaders` cover the keys that adapters actually consume; everything else (`custom_param`, `retry_backoff_ms`, `feature_flags`, …) lands in `extra` to preserve open-ended behaviour without imposing false structure.

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` — PHPStan level 10 green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` — code style green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s rector -n` — rector dry-run green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` — 3341 -> 3359 tests (+18 from `ProviderOptionsTest`), all green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s architecture` — phpat rules green (after Provider allowlist update)
- [ ] CI matrix (PHP 8.2 - 8.5 x TYPO3 13.4 / 14.0)
- [ ] No call-site migration in this slice — out of scope; `ProviderAdapterRegistry::buildAdapterConfig()` still consumes `getOptionsArray()` and will migrate in a follow-up