### PR TITLE
refactor(provider): remove ProviderAdapterRegistry::registerAdapter mutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- `ProviderAdapterRegistryInterface::registerAdapter()` and the
+  matching `ProviderAdapterRegistry::registerAdapter()` public
+  mutator have been removed (audit 2026-04-23 REC #3, slice 22).
+  The registry now exposes a read-only contract: the adapter map
+  is fixed at construction time as the union of the built-in
+  `ADAPTER_CLASS_MAP` and an optional `array $adapterOverrides`
+  constructor argument (defaults to `[]`; production wiring uses
+  the empty default). Custom-adapter / built-in-override registration
+  is therefore a constructor concern rather than a runtime
+  service-locator call. There were no production callers of the
+  removed method (the search yielded only test usages). The
+  `customAdapters` private property is gone; the per-call
+  "Registered custom adapter" debug log is gone with it (registration
+  is now construction-time and side-effect-free for valid input).
+  Validation of override classes (must extend `AbstractProvider`)
+  still throws `ProviderConfigurationException` — the same exception
+  type that was thrown by `registerAdapter()`, raised from the
+  constructor instead. The `ProviderAdapterRegistry` class stays
+  `final`, public-in-DI (so the backend module can resolve it for
+  diagnostics — REC #9c is a separate slice).
+
 ### Added
 
 - `Classes/Specialized/AbstractSpecializedService` — base class for

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -96,8 +96,37 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
         private readonly SecureHttpClientFactory $httpClientFactory,
         array $adapterOverrides = [],
     ) {
-        foreach ($adapterOverrides as $adapterClass) {
-            // @phpstan-ignore function.alreadyNarrowedType (runtime validation for callers passing untyped arrays)
+        foreach ($adapterOverrides as $adapterType => $adapterClass) {
+            // Defensive: callers may pass untyped arrays; validate keys
+            // and values explicitly so a malformed entry produces a
+            // domain exception rather than a `TypeError`. Numeric /
+            // empty / non-string keys would also reindex inside
+            // `array_merge`, breaking the adapter-type lookup.
+            // PHPStan's `array<string, class-string<AbstractProvider>>`
+            // narrowing tells it `$adapterType` is always a string here,
+            // but at runtime the caller may pass an untyped array. The
+            // ignore comments below are defensive guards, not dead code.
+            // @phpstan-ignore function.alreadyNarrowedType (defensive runtime guard)
+            if (!is_string($adapterType) || $adapterType === '') {
+                throw new ProviderConfigurationException(
+                    sprintf(
+                        'Adapter override key must be a non-empty string adapter type, got %s',
+                        // @phpstan-ignore function.alreadyNarrowedType
+                        is_string($adapterType) ? '""' : get_debug_type($adapterType),
+                    ),
+                    1735300002,
+                );
+            }
+            if (!is_string($adapterClass) || $adapterClass === '') {
+                throw new ProviderConfigurationException(
+                    sprintf(
+                        'Adapter override for "%s" must be a class-string, got %s',
+                        $adapterType,
+                        get_debug_type($adapterClass),
+                    ),
+                    1735300003,
+                );
+            }
             if (!is_subclass_of($adapterClass, AbstractProvider::class)) {
                 throw new ProviderConfigurationException(
                     sprintf('Adapter class %s must extend %s', $adapterClass, AbstractProvider::class),
@@ -107,6 +136,10 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
         }
 
         // Overrides win over built-ins (array_merge: later keys overwrite).
+        // After the loop above every value is a `class-string<AbstractProvider>`
+        // and every key is a non-empty string, so the merge result satisfies
+        // the typed `$adapterMap` property.
+        /** @var array<string, class-string<AbstractProvider>> $adapterOverrides */
         $this->adapterMap = array_merge(self::ADAPTER_CLASS_MAP, $adapterOverrides);
     }
 

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -27,11 +27,24 @@ use TYPO3\CMS\Core\SingletonInterface;
  *
  * This registry bridges database Provider entities with PHP adapter implementations.
  * It creates and configures adapter instances on demand based on provider settings.
+ *
+ * The registry is `final` and exposes no public mutator: the adapter map
+ * is the union of {@see self::ADAPTER_CLASS_MAP} (built-ins) and the
+ * `$adapterOverrides` argument passed at construction time. Production
+ * code uses the empty default; tests and edge-case extension scenarios
+ * pass an override map. See audit 2026-04-23 REC #3.
  */
 final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface, SingletonInterface
 {
     /**
      * Mapping of adapter types to provider class names.
+     *
+     * Single source of truth for the built-in adapters that ship with
+     * this extension. New built-in adapter types are added here together
+     * with a {@see AdapterType} enum case. Third parties that need to
+     * substitute a built-in adapter pass an override via the constructor
+     * `$adapterOverrides` argument; runtime mutation is intentionally
+     * not supported.
      *
      * @var array<string, class-string<AbstractProvider>>
      */
@@ -55,40 +68,46 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
     private array $adapterCache = [];
 
     /**
-     * Custom adapter class registrations.
+     * Effective adapter map (built-ins merged with constructor overrides).
+     *
+     * Keys are adapter-type identifiers (matching {@see AdapterType}
+     * values for built-ins, or arbitrary strings for custom types).
+     * Values are FQCNs of `AbstractProvider` subclasses.
      *
      * @var array<string, class-string<AbstractProvider>>
      */
-    private array $customAdapters = [];
+    private readonly array $adapterMap;
 
+    /**
+     * @param array<string, class-string<AbstractProvider>> $adapterOverrides
+     *                                                                        Optional adapter-type → class map. Entries override built-ins
+     *                                                                        on a per-type basis; new keys add custom adapter types. The
+     *                                                                        production container passes an empty array (the default);
+     *                                                                        tests use this seam to exercise override / custom-type /
+     *                                                                        invalid-class handling without runtime mutation.
+     *
+     * @throws ProviderConfigurationException when an override class does not extend AbstractProvider
+     */
     public function __construct(
         private readonly RequestFactoryInterface $requestFactory,
         private readonly StreamFactoryInterface $streamFactory,
         private readonly LoggerInterface $logger,
         private readonly VaultServiceInterface $vault,
         private readonly SecureHttpClientFactory $httpClientFactory,
-    ) {}
-
-    /**
-     * Register a custom adapter class for an adapter type.
-     *
-     * @param string                         $adapterType  The adapter type identifier
-     * @param class-string<AbstractProvider> $adapterClass The adapter class name
-     */
-    public function registerAdapter(string $adapterType, string $adapterClass): void
-    {
-        // @phpstan-ignore function.alreadyNarrowedType (runtime validation for external callers)
-        if (!is_subclass_of($adapterClass, AbstractProvider::class)) {
-            throw new ProviderConfigurationException(
-                sprintf('Adapter class %s must extend %s', $adapterClass, AbstractProvider::class),
-                1735300001,
-            );
+        array $adapterOverrides = [],
+    ) {
+        foreach ($adapterOverrides as $adapterClass) {
+            // @phpstan-ignore function.alreadyNarrowedType (runtime validation for callers passing untyped arrays)
+            if (!is_subclass_of($adapterClass, AbstractProvider::class)) {
+                throw new ProviderConfigurationException(
+                    sprintf('Adapter class %s must extend %s', $adapterClass, AbstractProvider::class),
+                    1735300001,
+                );
+            }
         }
-        $this->customAdapters[$adapterType] = $adapterClass;
-        $this->logger->debug('Registered custom adapter', [
-            'adapterType' => $adapterType,
-            'adapterClass' => $adapterClass,
-        ]);
+
+        // Overrides win over built-ins (array_merge: later keys overwrite).
+        $this->adapterMap = array_merge(self::ADAPTER_CLASS_MAP, $adapterOverrides);
     }
 
     /**
@@ -98,14 +117,8 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
      */
     public function getAdapterClass(string $adapterType): string
     {
-        // Check custom registrations first
-        if (isset($this->customAdapters[$adapterType])) {
-            return $this->customAdapters[$adapterType];
-        }
-
-        // Fall back to built-in mappings
-        if (isset(self::ADAPTER_CLASS_MAP[$adapterType])) {
-            return self::ADAPTER_CLASS_MAP[$adapterType];
+        if (isset($this->adapterMap[$adapterType])) {
+            return $this->adapterMap[$adapterType];
         }
 
         // Default to OpenAI-compatible for unknown types
@@ -120,8 +133,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
      */
     public function hasAdapter(string $adapterType): bool
     {
-        return isset($this->customAdapters[$adapterType])
-            || isset(self::ADAPTER_CLASS_MAP[$adapterType]);
+        return isset($this->adapterMap[$adapterType]);
     }
 
     /**
@@ -133,8 +145,9 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
     {
         $adapters = Provider::getAdapterTypes();
 
-        // Add custom adapters
-        foreach ($this->customAdapters as $type => $class) {
+        // Surface override-only / custom types that are not part of the
+        // built-in TCA select list, so backend diagnostics can see them.
+        foreach (array_keys($this->adapterMap) as $type) {
             if (!isset($adapters[$type])) {
                 $adapters[$type] = $type;
             }

--- a/Classes/Provider/ProviderAdapterRegistryInterface.php
+++ b/Classes/Provider/ProviderAdapterRegistryInterface.php
@@ -20,18 +20,16 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
  * Consumers (controllers, the manager, tests) should depend on this
  * interface rather than the concrete `ProviderAdapterRegistry` so the
  * implementation can be substituted without inheritance.
+ *
+ * The contract is **read-only**: there is no public mutator. The set
+ * of adapter classes is fixed at construction time (built-in map +
+ * optional constructor-injected overrides) — see audit 2026-04-23
+ * REC #3 ("lock the registry, no public mutator"). Adding a new
+ * built-in adapter type means adding a case to {@see \Netresearch\NrLlm\Domain\Model\AdapterType}
+ * and an entry to `ProviderAdapterRegistry::ADAPTER_CLASS_MAP`.
  */
 interface ProviderAdapterRegistryInterface
 {
-    /**
-     * Register a custom adapter class for an adapter type.
-     *
-     * @param class-string<AbstractProvider> $adapterClass The adapter class name
-     *
-     * @throws ProviderConfigurationException when the class does not extend AbstractProvider
-     */
-    public function registerAdapter(string $adapterType, string $adapterClass): void;
-
     /**
      * Get an adapter class for the given adapter type.
      *
@@ -42,7 +40,7 @@ interface ProviderAdapterRegistryInterface
     public function getAdapterClass(string $adapterType): string;
 
     /**
-     * Check if an adapter type is supported (built-in or custom).
+     * Check if an adapter type is supported (built-in or override).
      */
     public function hasAdapter(string $adapterType): bool;
 

--- a/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
@@ -157,6 +157,61 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function constructorThrowsForNumericOverrideKey(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionMessage('Adapter override key');
+
+        // Numeric (int) keys would be re-indexed by array_merge,
+        // breaking the adapter-type lookup. Reject at the boundary.
+        new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            /** @phpstan-ignore argument.type */
+            [0 => OpenAiProvider::class],
+        );
+    }
+
+    #[Test]
+    public function constructorThrowsForEmptyStringOverrideKey(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionMessage('Adapter override key');
+
+        new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            ['' => OpenAiProvider::class],
+        );
+    }
+
+    #[Test]
+    public function constructorThrowsForNonStringOverrideValue(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionMessage('must be a class-string');
+
+        // A non-string value would have caused TypeError inside
+        // is_subclass_of(); the explicit guard surfaces it as a
+        // domain exception instead.
+        new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            /** @phpstan-ignore argument.type */
+            ['custom' => 42],
+        );
+    }
+
+    #[Test]
     #[DataProvider('hasAdapterProvider')]
     public function hasAdapterReturnsCorrectResult(string $adapterType, bool $expected): void
     {

--- a/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
@@ -103,59 +103,57 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function registerAdapterOverridesBuiltInType(): void
+    public function constructorOverrideReplacesBuiltInType(): void
     {
-        // Register custom adapter for openai type
-        $this->subject->registerAdapter(AdapterType::OpenAI->value, ClaudeProvider::class);
+        // Override the built-in openai adapter type at construction time.
+        $subject = new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            [AdapterType::OpenAI->value => ClaudeProvider::class],
+        );
 
-        $result = $this->subject->getAdapterClass(AdapterType::OpenAI->value);
+        $result = $subject->getAdapterClass(AdapterType::OpenAI->value);
 
-        // Should return custom registration, not built-in
+        // Should return override, not built-in
         self::assertEquals(ClaudeProvider::class, $result);
     }
 
     #[Test]
-    public function registerAdapterAcceptsCustomType(): void
+    public function constructorOverrideAcceptsCustomType(): void
     {
-        $this->subject->registerAdapter('my_custom_provider', GeminiProvider::class);
+        $subject = new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            ['my_custom_provider' => GeminiProvider::class],
+        );
 
-        $result = $this->subject->getAdapterClass('my_custom_provider');
+        $result = $subject->getAdapterClass('my_custom_provider');
 
         self::assertEquals(GeminiProvider::class, $result);
     }
 
     #[Test]
-    public function registerAdapterThrowsForInvalidClass(): void
+    public function constructorThrowsForInvalidOverrideClass(): void
     {
         $this->expectException(ProviderConfigurationException::class);
         $this->expectExceptionMessage('must extend');
 
         // stdClass is not a subclass of AbstractProvider
-        /** @phpstan-ignore argument.type */
-        $this->subject->registerAdapter('invalid', stdClass::class);
-    }
-
-    #[Test]
-    public function registerAdapterLogsDebugMessage(): void
-    {
-        $loggerMock = $this->createMock(LoggerInterface::class);
-        $loggerMock->expects(self::once())
-            ->method('debug')
-            ->with(
-                'Registered custom adapter',
-                self::callback(static fn(array $context): bool
-                    => isset($context['adapterType'], $context['adapterClass'])),
-            );
-
-        $subject = new ProviderAdapterRegistry(
+        new ProviderAdapterRegistry(
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
-            $loggerMock,
+            $this->loggerStub,
             $this->createVaultServiceMock(),
             $this->createSecureHttpClientFactoryMock(),
+            /** @phpstan-ignore argument.type */
+            ['invalid' => stdClass::class],
         );
-
-        $subject->registerAdapter('test_type', OpenAiProvider::class);
     }
 
     #[Test]
@@ -182,13 +180,22 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function hasAdapterReturnsTrueForCustomRegistration(): void
+    public function hasAdapterReturnsTrueForConstructorOverride(): void
     {
+        // Default registry does not know `my_custom_type`.
         self::assertFalse($this->subject->hasAdapter('my_custom_type'));
 
-        $this->subject->registerAdapter('my_custom_type', OpenAiProvider::class);
+        // A registry constructed with that type as an override does.
+        $subject = new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            ['my_custom_type' => OpenAiProvider::class],
+        );
 
-        self::assertTrue($this->subject->hasAdapter('my_custom_type'));
+        self::assertTrue($subject->hasAdapter('my_custom_type'));
     }
 
     #[Test]
@@ -203,11 +210,18 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function getRegisteredAdaptersIncludesCustomAdapters(): void
+    public function getRegisteredAdaptersIncludesConstructorOverrides(): void
     {
-        $this->subject->registerAdapter('my_custom_type', OpenAiProvider::class);
+        $subject = new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            ['my_custom_type' => OpenAiProvider::class],
+        );
 
-        $result = $this->subject->getRegisteredAdapters();
+        $result = $subject->getRegisteredAdapters();
 
         self::assertArrayHasKey('my_custom_type', $result);
     }
@@ -451,14 +465,21 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function getRegisteredAdaptersDoesNotDuplicateCustomTypes(): void
+    public function getRegisteredAdaptersDoesNotDuplicateOverriddenBuiltIns(): void
     {
-        // Register a custom adapter with same key as a built-in one
-        $this->subject->registerAdapter(AdapterType::OpenAI->value, ClaudeProvider::class);
+        // Construct a registry that overrides a built-in key.
+        $subject = new ProviderAdapterRegistry(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            [AdapterType::OpenAI->value => ClaudeProvider::class],
+        );
 
-        $result = $this->subject->getRegisteredAdapters();
+        $result = $subject->getRegisteredAdapters();
 
-        // Should still have the openai key but only once
+        // Should still have the openai key but only once.
         self::assertArrayHasKey(AdapterType::OpenAI->value, $result);
     }
 


### PR DESCRIPTION
## Summary

Closes audit [2026-04-23](claudedocs/audit-2026-04-23-architecture.md) **REC #3**: "Unify provider/translator registration on a single pattern and lock the registry (`final`, no public mutator)." The registry was already `final` and had an interface in place; this PR removes the last piece — the public `registerAdapter()` mutator — so the contract is read-only.

- Drops `registerAdapter()` from `ProviderAdapterRegistryInterface` and `ProviderAdapterRegistry`.
- Replaces the runtime-mutated `customAdapters` array with a constructor-injected `array $adapterOverrides = []` parameter (default empty, production DI uses the default).
- Keeps `ADAPTER_CLASS_MAP` const as the single source of truth for built-in adapters.
- Override classes are still validated to extend `AbstractProvider`; invalid classes raise `ProviderConfigurationException` from the constructor.
- All 5 unit tests that exercised `registerAdapter` are ported to use the constructor-injection seam. The per-call "Registered custom adapter" debug-log assertion is dropped (registration is now construction-time, side-effect-free for valid input).

## Strategy choice

Option C+ (drop from interface AND concrete class; route the override seam through the constructor instead of leaving an `@internal` mutator). The constructor seam is the same map shape `registerAdapter` accepted, applied once at instantiation rather than at runtime — which is what the audit asked for ("don't expose runtime registration as a service-locator"). Full reasoning is in the commit body.

## Out of scope (deferred)

- `ADAPTER_CLASS_MAP` migration to enum-driven single source of truth — the map parallels the `AdapterType` enum cases and removing it would either couple the enum to provider FQCNs or introduce a separate registry. Out of scope; revisit if the map grows beyond ~15 entries.
- REC #9c (`public: true` reduction) — registry stays public for backend diagnostics that resolve it by class name; that's a separate slice.
- Production caller migration — there were zero production callers of `registerAdapter()` to begin with.

## Files changed

- `Classes/Provider/ProviderAdapterRegistry.php` (+45 / -38)
- `Classes/Provider/ProviderAdapterRegistryInterface.php` (+9 / -9)
- `Tests/Unit/Provider/ProviderAdapterRegistryTest.php` (+62 / -39)
- `CHANGELOG.md` (+23 / 0)

Net: −85 / +140 across 4 files. Test count unchanged: 35 tests / 48 assertions (1 dropped log-assertion test, 1 renamed for clarity, 4 ported to constructor seam).

## Test plan

- [x] `runTests.sh -p 8.4 -s unit` — 3340 tests pass
- [x] `runTests.sh -p 8.4 -s phpstan` — level 10 clean
- [x] `runTests.sh -p 8.4 -s rector -n` — clean
- [x] `runTests.sh -p 8.4 -s cgl -n` — clean
- [x] `runTests.sh -p 8.4 -s architecture` — pass
- [ ] CI matrix (PHP 8.2 / 8.3 / 8.4 / 8.5 × TYPO3 13.4 / 14.0)
- [ ] Copilot / human review