### PR TITLE
refactor(service): build typed ChatMessage in feature services (REC #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **REC #2 (slice 24):** Feature services (`CompletionService`,
+  `TranslationService`) now build typed `ChatMessage` VOs at the
+  point of construction instead of inline associative arrays.
+  `LlmServiceManager` would normalise either shape via
+  `ChatMessage::fromArray()`, but typed-from-the-source means
+  PHPStan catches role/content drift earlier and the call site is
+  self-documenting. The provider/manager interfaces keep accepting
+  the `list<ChatMessage|array<string, mixed>>` union for back-compat
+  with third-party callers — that's the intentional end-state
+  documented on the interface itself. Tests updated to assert
+  `instanceof ChatMessage` + `->role` / `->content` field access
+  instead of `$messages[0]['role']` array shape.
 - `DallEImageService`, `FalImageService`, `WhisperTranscriptionService`,
   `TextToSpeechService`, and `DeepLTranslator` now extend
   `AbstractSpecializedService` instead of carrying their own copies

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
@@ -57,19 +58,16 @@ final readonly class CompletionService implements CompletionServiceInterface
 
         $messages = [];
 
-        // Add system prompt if provided
+        // REC #2 closure: build typed `ChatMessage` VOs at construction
+        // rather than relying on `LlmServiceManager`'s back-compat
+        // normalisation. Typed-from-the-source means PHPStan catches
+        // shape drift earlier and the call site is self-documenting.
         $systemPrompt = $optionsArray['system_prompt'] ?? null;
         if (is_string($systemPrompt) && $systemPrompt !== '') {
-            $messages[] = [
-                'role' => 'system',
-                'content' => $systemPrompt,
-            ];
+            $messages[] = ChatMessage::system($systemPrompt);
         }
 
-        $messages[] = [
-            'role' => 'user',
-            'content' => $prompt,
-        ];
+        $messages[] = ChatMessage::user($prompt);
 
         // Handle response format
         $responseFormat = $optionsArray['response_format'] ?? null;

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
@@ -95,16 +96,12 @@ final readonly class TranslationService implements TranslationServiceInterface
             $optionsArray,
         );
 
-        // Execute translation
+        // Execute translation. REC #2 closure: build typed
+        // `ChatMessage` VOs at the construction site rather than
+        // relying on LlmServiceManager's back-compat normalisation.
         $messages = [
-            [
-                'role' => 'system',
-                'content' => $prompt['system'],
-            ],
-            [
-                'role' => 'user',
-                'content' => $prompt['user'],
-            ],
+            ChatMessage::system($prompt['system']),
+            ChatMessage::user($prompt['user']),
         ];
 
         $chatOptions = new ChatOptions(
@@ -166,14 +163,8 @@ final readonly class TranslationService implements TranslationServiceInterface
     {
         $options ??= new TranslationOptions();
         $messages = [
-            [
-                'role' => 'system',
-                'content' => 'You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.',
-            ],
-            [
-                'role' => 'user',
-                'content' => "Detect the language of this text:\n\n" . $text,
-            ],
+            ChatMessage::system('You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.'),
+            ChatMessage::user("Detect the language of this text:\n\n" . $text),
         ];
 
         $chatOptions = new ChatOptions(
@@ -216,19 +207,13 @@ final readonly class TranslationService implements TranslationServiceInterface
     ): float {
         $options ??= new TranslationOptions();
         $messages = [
-            [
-                'role' => 'system',
-                'content' => 'You are a translation quality expert. Evaluate the translation quality based on accuracy, fluency, and consistency. Respond with ONLY a number between 0.0 and 1.0 (e.g., "0.85"). No explanation.',
-            ],
-            [
-                'role' => 'user',
-                'content' => sprintf(
-                    "Source text:\n%s\n\nTranslation to %s:\n%s\n\nQuality score:",
-                    $sourceText,
-                    $targetLanguage,
-                    $translatedText,
-                ),
-            ],
+            ChatMessage::system('You are a translation quality expert. Evaluate the translation quality based on accuracy, fluency, and consistency. Respond with ONLY a number between 0.0 and 1.0 (e.g., "0.85"). No explanation.'),
+            ChatMessage::user(sprintf(
+                "Source text:\n%s\n\nTranslation to %s:\n%s\n\nQuality score:",
+                $sourceText,
+                $targetLanguage,
+                $translatedText,
+            )),
         ];
 
         $chatOptions = new ChatOptions(

--- a/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -216,11 +217,10 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::callback(function (array $messages): bool {
-                    /** @var array{role: string, content: string}|null $systemMessage */
                     $systemMessage = $messages[0] ?? null;
-                    return $systemMessage !== null
-                        && $systemMessage['role'] === 'system'
-                        && str_contains($systemMessage['content'], 'Markdown');
+                    return $systemMessage instanceof ChatMessage
+                        && $systemMessage->role === 'system'
+                        && str_contains($systemMessage->content, 'Markdown');
                 }),
                 self::anything(),
             )
@@ -448,11 +448,10 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                 self::callback(
                     // Should have system message when markdown format
                     function (array $messages): bool {
-                        /** @var array{role: string, content: string}|null $msg */
                         $msg = $messages[0] ?? null;
-                        return $msg !== null
-                            && $msg['role'] === 'system'
-                            && str_contains($msg['content'], 'Markdown');
+                        return $msg instanceof ChatMessage
+                            && $msg->role === 'system'
+                            && str_contains($msg->content, 'Markdown');
                     },
                 ),
                 self::anything(),
@@ -476,13 +475,13 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     if (count($messages) !== 2) {
                         return false;
                     }
-                    /** @var array{role: string, content: string} $msg0 */
                     $msg0 = $messages[0];
-                    /** @var array{role: string, content: string} $msg1 */
                     $msg1 = $messages[1];
-                    return $msg0['role'] === 'system'
-                        && $msg0['content'] === 'Be helpful'
-                        && $msg1['role'] === 'user';
+                    return $msg0 instanceof ChatMessage
+                        && $msg1 instanceof ChatMessage
+                        && $msg0->role === 'system'
+                        && $msg0->content === 'Be helpful'
+                        && $msg1->role === 'user';
                 }),
                 self::anything(),
             )
@@ -506,10 +505,10 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     if (count($messages) !== 1) {
                         return false;
                     }
-                    /** @var array{role: string, content: string} $msg */
                     $msg = $messages[0];
-                    return $msg['role'] === 'user'
-                        && $msg['content'] === 'User prompt';
+                    return $msg instanceof ChatMessage
+                        && $msg->role === 'user'
+                        && $msg->content === 'User prompt';
                 }),
                 self::anything(),
             )

--- a/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
@@ -219,7 +219,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                 self::callback(function (array $messages): bool {
                     $systemMessage = $messages[0] ?? null;
                     return $systemMessage instanceof ChatMessage
-                        && $systemMessage->role === 'system'
+                        && $systemMessage->isSystem()
                         && str_contains($systemMessage->content, 'Markdown');
                 }),
                 self::anything(),
@@ -450,7 +450,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     function (array $messages): bool {
                         $msg = $messages[0] ?? null;
                         return $msg instanceof ChatMessage
-                            && $msg->role === 'system'
+                            && $msg->isSystem()
                             && str_contains($msg->content, 'Markdown');
                     },
                 ),
@@ -479,9 +479,9 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     $msg1 = $messages[1];
                     return $msg0 instanceof ChatMessage
                         && $msg1 instanceof ChatMessage
-                        && $msg0->role === 'system'
+                        && $msg0->isSystem()
                         && $msg0->content === 'Be helpful'
-                        && $msg1->role === 'user';
+                        && $msg1->isUser();
                 }),
                 self::anything(),
             )
@@ -507,7 +507,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     }
                     $msg = $messages[0];
                     return $msg instanceof ChatMessage
-                        && $msg->role === 'user'
+                        && $msg->isUser()
                         && $msg->content === 'User prompt';
                 }),
                 self::anything(),

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
@@ -63,9 +64,10 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::callback(function (array $messages) use ($prompt): bool {
-                    /** @var array{role: string, content: string} $msg */
                     $msg = $messages[0];
-                    return $msg['role'] === 'user' && $msg['content'] === $prompt;
+                    return $msg instanceof ChatMessage
+                        && $msg->role === 'user'
+                        && $msg->content === $prompt;
                 }),
                 self::anything(),
             )
@@ -96,14 +98,14 @@ class CompletionServiceTest extends AbstractUnitTestCase
                     if (count($messages) !== 2) {
                         return false;
                     }
-                    /** @var array{role: string, content: string} $msg0 */
                     $msg0 = $messages[0];
-                    /** @var array{role: string, content: string} $msg1 */
                     $msg1 = $messages[1];
-                    return $msg0['role'] === 'system'
-                        && $msg0['content'] === $systemPrompt
-                        && $msg1['role'] === 'user'
-                        && $msg1['content'] === $prompt;
+                    return $msg0 instanceof ChatMessage
+                        && $msg1 instanceof ChatMessage
+                        && $msg0->role === 'system'
+                        && $msg0->content === $systemPrompt
+                        && $msg1->role === 'user'
+                        && $msg1->content === $prompt;
                 }),
                 self::anything(),
             )

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -66,7 +66,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
                 self::callback(function (array $messages) use ($prompt): bool {
                     $msg = $messages[0];
                     return $msg instanceof ChatMessage
-                        && $msg->role === 'user'
+                        && $msg->isUser()
                         && $msg->content === $prompt;
                 }),
                 self::anything(),
@@ -102,9 +102,9 @@ class CompletionServiceTest extends AbstractUnitTestCase
                     $msg1 = $messages[1];
                     return $msg0 instanceof ChatMessage
                         && $msg1 instanceof ChatMessage
-                        && $msg0->role === 'system'
+                        && $msg0->isSystem()
                         && $msg0->content === $systemPrompt
-                        && $msg1->role === 'user'
+                        && $msg1->isUser()
                         && $msg1->content === $prompt;
                 }),
                 self::anything(),


### PR DESCRIPTION
## Summary
- \`CompletionService\` (1 site) and \`TranslationService\` (3 sites: \`translate\`, \`detectLanguage\`, \`scoreTranslationQuality\`) now build typed \`ChatMessage\` VOs at construction.
- Provider/manager interfaces keep the \`list<ChatMessage|array>\` union for back-compat (intentional end-state — already documented as such on the interface).
- 6 test callbacks updated from \`\$messages[0]['role']\` array shape to \`->role\` field access on \`ChatMessage\`.

## Context
Audit \`claudedocs/audit-2026-04-23-architecture.md\` REC #2 wanted to "kill the array-of-arrays pattern at the root". The VOs landed earlier (PR #162); this slice migrates the inline-array constructions in the feature services. \`LlmServiceManager\` still normalises arrays via \`ChatMessage::fromArray()\` for back-compat, so third-party callers / tests with raw arrays keep working.

## Test plan
- [x] PHPStan level 10 — passes
- [x] CGL — passes
- [x] Rector dry-run — passes
- [x] Unit tests — 3340 / 7251 passing