### PR TITLE
refactor(controller): typed exception handlers for admin pathway (REC #8b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **REC #8b (slice 23b):** Replaced catch-all `catch (Throwable $e)`
+  blocks with typed exception handlers across the four admin
+  controllers (`ProviderController`, `ModelController`,
+  `ConfigurationController`, `LlmModuleController`). 13 catch sites
+  updated. Provider errors (`ProviderResponseException`, base
+  `ProviderException`) and Doctrine DBAL errors now route to specific
+  arms with appropriate HTTP statuses (502 for upstream provider
+  failures); the final `Throwable` arm logs full exception detail and
+  surfaces a generic message instead of leaking `$e->getMessage()`
+  (which can carry SQL error text or provider response bodies). All
+  four controllers gained a `LoggerInterface` constructor parameter
+  (autowired by Symfony DI). The `ConfigurationController::testConfigurationAction`
+  intentionally still surfaces `ProviderResponseException::getMessage()`
+  with the upstream HTTP status — the message is already sanitised
+  by `AbstractProvider::sanitizeErrorMessage()` and the frontend toast
+  needs the model-specific text to be useful for diagnostics. Unit
+  test assertions updated to assert "See system log" instead of the
+  raw exception text — verifying the new generic-message contract.
+
 ### Removed
 
 - `ProviderAdapterRegistryInterface::registerAdapter()` and the

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Doctrine\DBAL\Exception as DbalException;
 use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ProviderModelsResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
@@ -17,6 +18,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
@@ -25,6 +27,7 @@ use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
@@ -64,6 +67,7 @@ final class ConfigurationController extends ActionController
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly TestPromptResolverInterface $testPromptResolver,
+        private readonly LoggerInterface $logger,
     ) {}
 
     protected function initializeAction(): void
@@ -184,8 +188,13 @@ final class ConfigurationController extends ActionController
                 'configurationUid' => $configurationUid,
             ]);
             return $this->moduleTemplate->renderResponse('Backend/Configuration/WizardPreview');
+        } catch (ProviderException $e) {
+            $this->logger->error('Configuration wizard: provider error', ['exception' => $e]);
+            $this->addFlashMessage('Generation failed (LLM provider error). See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+            return $this->redirect('wizardForm');
         } catch (Throwable $e) {
-            $this->addFlashMessage('Generation failed: ' . $e->getMessage(), 'Error', ContextualFeedbackSeverity::ERROR);
+            $this->logger->error('Configuration wizard: unexpected error', ['exception' => $e]);
+            $this->addFlashMessage('Generation failed. See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
             return $this->redirect('wizardForm');
         }
     }
@@ -213,8 +222,18 @@ final class ConfigurationController extends ActionController
                 success: true,
                 isActive: $configuration->isActive(),
             ))->jsonSerialize());
+        } catch (DbalException $e) {
+            $this->logger->error('Configuration toggleActive: persistence failed', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while toggling configuration status.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Configuration toggleActive: unexpected error', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to toggle configuration status. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -238,8 +257,18 @@ final class ConfigurationController extends ActionController
         try {
             $this->configurationService->setAsDefault($configuration);
             return new JsonResponse((new SuccessResponse())->jsonSerialize());
+        } catch (DbalException $e) {
+            $this->logger->error('Configuration setDefault: persistence failed', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while setting default configuration.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Configuration setDefault: unexpected error', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to set default configuration. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -270,8 +299,18 @@ final class ConfigurationController extends ActionController
                 models: $models,
                 defaultModel: $defaultModel,
             ))->jsonSerialize());
+        } catch (ProviderException $e) {
+            $this->logger->warning('Configuration getModels: provider error', ['exception' => $e, 'provider' => $providerKey]);
+            return new JsonResponse(
+                (new ErrorResponse('LLM provider error while listing models. See system log for details.'))->jsonSerialize(),
+                502,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Configuration getModels: unexpected error', ['exception' => $e, 'provider' => $providerKey]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to load models. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -307,18 +346,34 @@ final class ConfigurationController extends ActionController
                 TestConfigurationResponse::fromCompletionResponse($response)->jsonSerialize(),
             );
         } catch (ProviderResponseException $e) {
-            // Provider returned a typed error response — surface the actual
-            // upstream HTTP status (4xx OR 5xx; OpenRouter's default branch
-            // wraps server errors in this exception too) so the JS frontend
-            // can distinguish "your API key is wrong" (401), "your prompt
-            // was rejected" (400), and "the model is overloaded" (5xx)
-            // instead of always seeing 500.
+            // Provider returned a typed error response. Surface the actual
+            // upstream HTTP status so the JS frontend can distinguish
+            // "your API key is wrong" (401), "your prompt was rejected"
+            // (400), and "the model is overloaded" (5xx). The message is
+            // already sanitised (`AbstractProvider::sanitizeErrorMessage()`
+            // strips API keys from URLs) so it's safe to surface.
+            $this->logger->warning('Configuration test: provider returned an error', [
+                'exception'   => $e,
+                'http_status' => $e->httpStatus,
+                'endpoint'    => $e->endpoint,
+                'config_uid'  => $uid,
+            ]);
             return new JsonResponse(
                 (new ErrorResponse($e->getMessage()))->jsonSerialize(),
                 $e->httpStatus >= 400 && $e->httpStatus < 600 ? $e->httpStatus : 500,
             );
+        } catch (ProviderException $e) {
+            $this->logger->error('Configuration test: provider error', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('LLM provider error during configuration test. See system log for details.'))->jsonSerialize(),
+                502,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Configuration test: unexpected error', ['exception' => $e, 'config_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Configuration test failed. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -14,10 +14,12 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
@@ -38,6 +40,7 @@ final class LlmModuleController extends ActionController
         private readonly TaskRepository $taskRepository,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly TestPromptResolverInterface $testPromptResolver,
+        private readonly LoggerInterface $logger,
     ) {}
 
     public function indexAction(): ResponseInterface
@@ -147,10 +150,17 @@ final class LlmModuleController extends ActionController
                     'totalTokens' => $response->usage->totalTokens,
                 ],
             ]);
-        } catch (Throwable $e) {
+        } catch (ProviderException $e) {
+            $this->logger->warning('LlmModule test: provider error', ['exception' => $e]);
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error'   => 'LLM provider error during test. See system log for details.',
+            ], 502);
+        } catch (Throwable $e) {
+            $this->logger->error('LlmModule test: unexpected error', ['exception' => $e]);
+            return new JsonResponse([
+                'success' => false,
+                'error'   => 'Test failed. See system log for details.',
             ], 500);
         }
     }

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Doctrine\DBAL\Exception as DbalException;
 use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ModelListResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
@@ -17,12 +18,14 @@ use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
@@ -60,6 +63,7 @@ final class ModelController extends ActionController
         private readonly ProviderAdapterRegistryInterface $providerAdapterRegistry,
         private readonly ModelDiscoveryInterface $modelDiscovery,
         private readonly TestPromptResolverInterface $testPromptResolver,
+        private readonly LoggerInterface $logger,
     ) {}
 
     protected function initializeAction(): void
@@ -156,8 +160,18 @@ final class ModelController extends ActionController
                 success: true,
                 isActive: $model->isActive(),
             ))->jsonSerialize());
+        } catch (DbalException $e) {
+            $this->logger->error('Model toggleActive: persistence failed', ['exception' => $e, 'model_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while toggling model status.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Model toggleActive: unexpected error', ['exception' => $e, 'model_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to toggle model status. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -182,8 +196,18 @@ final class ModelController extends ActionController
             $this->modelRepository->setAsDefault($model);
             $this->persistenceManager->persistAll();
             return new JsonResponse((new SuccessResponse())->jsonSerialize());
+        } catch (DbalException $e) {
+            $this->logger->error('Model setDefault: persistence failed', ['exception' => $e, 'model_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while setting default model.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Model setDefault: unexpected error', ['exception' => $e, 'model_uid' => $uid]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to set default model. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -202,8 +226,18 @@ final class ModelController extends ActionController
         try {
             $models = $this->modelRepository->findByProviderUid($providerUid);
             return new JsonResponse(ModelListResponse::fromModels($models)->jsonSerialize());
+        } catch (DbalException $e) {
+            $this->logger->error('Model getByProvider: query failed', ['exception' => $e, 'provider_uid' => $providerUid]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while loading models.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Model getByProvider: unexpected error', ['exception' => $e, 'provider_uid' => $providerUid]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to load models. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -272,10 +306,28 @@ final class ModelController extends ActionController
                 success: true,
                 message: $message,
             ))->jsonSerialize());
-        } catch (Throwable $e) {
+        } catch (ProviderException $e) {
+            // REC #8b: provider error text often references upstream
+            // bodies / endpoints / auth artefacts — log full detail,
+            // surface a short upstream-error message stripped of
+            // internal context. The frontend renders this verbatim
+            // in the test-connection toast.
+            $this->logger->warning('Model test: provider rejected request', [
+                'exception' => $e,
+                'model_uid' => $uid,
+            ]);
             return new JsonResponse((new TestConnectionResponse(
                 success: false,
-                message: $e->getMessage(),
+                message: 'LLM provider rejected the test request. See system log for details.',
+            ))->jsonSerialize());
+        } catch (Throwable $e) {
+            $this->logger->error('Model test: unexpected error', [
+                'exception' => $e,
+                'model_uid' => $uid,
+            ]);
+            return new JsonResponse((new TestConnectionResponse(
+                success: false,
+                message: 'Test failed. See system log for details.',
             ))->jsonSerialize());
         }
     }
@@ -341,10 +393,17 @@ final class ModelController extends ActionController
                 'models' => $models,
                 'providerName' => $provider->getName(),
             ]);
-        } catch (Throwable $e) {
+        } catch (ProviderException $e) {
+            $this->logger->warning('Model fetchAvailableIds: provider error', ['exception' => $e]);
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error' => 'LLM provider error while fetching model IDs. See system log for details.',
+            ], 502);
+        } catch (Throwable $e) {
+            $this->logger->error('Model fetchAvailableIds: unexpected error', ['exception' => $e]);
+            return new JsonResponse([
+                'success' => false,
+                'error' => 'Failed to fetch model IDs. See system log for details.',
             ], 500);
         }
     }
@@ -424,10 +483,17 @@ final class ModelController extends ActionController
                 'costInput' => $foundModel->costInput,
                 'costOutput' => $foundModel->costOutput,
             ]);
-        } catch (Throwable $e) {
+        } catch (ProviderException $e) {
+            $this->logger->warning('Model detectLimits: provider error', ['exception' => $e]);
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error' => 'LLM provider error while detecting model limits. See system log for details.',
+            ], 502);
+        } catch (Throwable $e) {
+            $this->logger->error('Model detectLimits: unexpected error', ['exception' => $e]);
+            return new JsonResponse([
+                'success' => false,
+                'error' => 'Failed to detect model limits. See system log for details.',
             ], 500);
         }
     }

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -394,13 +394,13 @@ final class ModelController extends ActionController
                 'providerName' => $provider->getName(),
             ]);
         } catch (ProviderException $e) {
-            $this->logger->warning('Model fetchAvailableIds: provider error', ['exception' => $e]);
+            $this->logger->warning('Model fetchAvailableModels: provider error', ['exception' => $e]);
             return new JsonResponse([
                 'success' => false,
                 'error' => 'LLM provider error while fetching model IDs. See system log for details.',
             ], 502);
         } catch (Throwable $e) {
-            $this->logger->error('Model fetchAvailableIds: unexpected error', ['exception' => $e]);
+            $this->logger->error('Model fetchAvailableModels: unexpected error', ['exception' => $e]);
             return new JsonResponse([
                 'success' => false,
                 'error' => 'Failed to fetch model IDs. See system log for details.',

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -9,14 +9,18 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Doctrine\DBAL\Exception as DbalException;
 use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
@@ -51,6 +55,7 @@ final class ProviderController extends ActionController
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
+        private readonly LoggerInterface $logger,
     ) {}
 
     protected function initializeAction(): void
@@ -142,8 +147,25 @@ final class ProviderController extends ActionController
                 success: true,
                 isActive: $provider->isActive(),
             ))->jsonSerialize());
+        } catch (DbalException $e) {
+            // REC #8b: SQL error text → log, surface generic message.
+            $this->logger->error('Provider toggleActive: persistence failed', [
+                'exception'    => $e,
+                'provider_uid' => $uid,
+            ]);
+            return new JsonResponse(
+                (new ErrorResponse('Database error while toggling provider status.'))->jsonSerialize(),
+                500,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Provider toggleActive: unexpected error', [
+                'exception'    => $e,
+                'provider_uid' => $uid,
+            ]);
+            return new JsonResponse(
+                (new ErrorResponse('Failed to toggle provider status. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 
@@ -168,8 +190,37 @@ final class ProviderController extends ActionController
             $result = $this->providerAdapterRegistry->testProviderConnection($provider);
 
             return new JsonResponse(TestConnectionResponse::fromResult($result)->jsonSerialize());
+        } catch (ProviderResponseException $e) {
+            // REC #8b: provider response bodies often reference upstream
+            // endpoints / model names — log full detail, surface generic.
+            $this->logger->error('Provider testConnection: provider returned an error', [
+                'exception'    => $e,
+                'http_status'  => $e->httpStatus,
+                'endpoint'     => $e->endpoint,
+                'provider_uid' => $uid,
+            ]);
+            return new JsonResponse(
+                (new ErrorResponse('Upstream LLM provider returned an error during connection test.'))->jsonSerialize(),
+                502,
+            );
+        } catch (ProviderException $e) {
+            $this->logger->error('Provider testConnection: provider error', [
+                'exception'    => $e,
+                'provider_uid' => $uid,
+            ]);
+            return new JsonResponse(
+                (new ErrorResponse('LLM provider error during connection test. See system log for details.'))->jsonSerialize(),
+                502,
+            );
         } catch (Throwable $e) {
-            return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 500);
+            $this->logger->error('Provider testConnection: unexpected error', [
+                'exception'    => $e,
+                'provider_uid' => $uid,
+            ]);
+            return new JsonResponse(
+                (new ErrorResponse('Connection test failed. See system log for details.'))->jsonSerialize(),
+                500,
+            );
         }
     }
 

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -117,6 +117,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             $pageRenderer,
             $backendUriBuilder,
             $extensionConfiguration,
+            new \Psr\Log\NullLogger(),
         );
     }
 

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -19,12 +19,12 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -102,8 +102,8 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         $wizardGeneratorService = $this->get(WizardGeneratorService::class);
         self::assertInstanceOf(WizardGeneratorService::class, $wizardGeneratorService);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return new ConfigurationController(
             $moduleTemplateFactory,
@@ -116,7 +116,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             $wizardGeneratorService,
             $pageRenderer,
             $backendUriBuilder,
-            $extensionConfiguration,
+            $testPromptResolver,
             new \Psr\Log\NullLogger(),
         );
     }

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -16,13 +16,13 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -103,8 +103,8 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
         $wizardGeneratorService = $this->get(WizardGeneratorService::class);
         self::assertInstanceOf(WizardGeneratorService::class, $wizardGeneratorService);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return new ConfigurationController(
             $moduleTemplateFactory,
@@ -117,7 +117,7 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
             $wizardGeneratorService,
             $pageRenderer,
             $backendUriBuilder,
-            $extensionConfiguration,
+            $testPromptResolver,
             new \Psr\Log\NullLogger(),
         );
     }

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -118,6 +118,7 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $extensionConfiguration,
+            new \Psr\Log\NullLogger(),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -108,8 +109,8 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $wizardGeneratorService = $this->get(WizardGeneratorService::class);
         self::assertInstanceOf(WizardGeneratorService::class, $wizardGeneratorService);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return new ConfigurationController(
             $moduleTemplateFactory,
@@ -122,7 +123,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
             $wizardGeneratorService,
             $pageRenderer,
             $backendUriBuilder,
-            $extensionConfiguration,
+            $testPromptResolver,
             new \Psr\Log\NullLogger(),
         );
     }
@@ -144,6 +145,10 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'taskExecutionService', $taskExecutionService);
         $this->setPrivateProperty($controller, 'taskInputResolver', $taskInputResolver);
+        // REC #8b: typed catches log via LoggerInterface — initialise
+        // with a NullLogger so the typed property exists for any
+        // exception path the test exercises.
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }
@@ -177,6 +182,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'configurationRepository', $configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -123,6 +123,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $extensionConfiguration,
+            new \Psr\Log\NullLogger(),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -22,6 +22,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -119,8 +120,8 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $wizardGeneratorService = $this->get(WizardGeneratorService::class);
         self::assertInstanceOf(WizardGeneratorService::class, $wizardGeneratorService);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return new ConfigurationController(
             $moduleTemplateFactory,
@@ -133,7 +134,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $wizardGeneratorService,
             $pageRenderer,
             $backendUriBuilder,
-            $extensionConfiguration,
+            $testPromptResolver,
             new \Psr\Log\NullLogger(),
         );
     }
@@ -188,6 +189,10 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'providerRepository', $this->providerRepository);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
+        // REC #8b: typed catches log via LoggerInterface — initialise
+        // the new property so any exercised exception path doesn't
+        // hit an uninitialised typed property error.
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }
@@ -215,6 +220,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'configurationRepository', $this->configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -134,6 +134,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $extensionConfiguration,
+            new \Psr\Log\NullLogger(),
         );
     }
 
@@ -165,6 +166,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $persistenceManager,
             $pageRenderer,
             $backendUriBuilder,
+            new \Psr\Log\NullLogger(),
         );
     }
 

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -80,6 +80,11 @@ final class ConfigurationControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $this->providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'modelRepository', $this->modelRepository);
         $this->setPrivateProperty($controller, 'testPromptResolver', $this->testPromptResolver);
+        // REC #8b: typed catches log via LoggerInterface — use a NullLogger
+        // for unit tests so the property is initialised but no output is
+        // produced. Real logging behaviour is exercised by the functional
+        // suite where the container provides a real logger.
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }
@@ -270,7 +275,7 @@ final class ConfigurationControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // setDefaultAction tests
@@ -360,7 +365,7 @@ final class ConfigurationControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // getModelsAction tests
@@ -444,7 +449,7 @@ final class ConfigurationControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Provider error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // testConfigurationAction tests
@@ -559,7 +564,7 @@ final class ConfigurationControllerTest extends TestCase
         self::assertFalse($data['success']);
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('API error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     #[Test]

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -82,6 +82,9 @@ final class ModelControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $this->providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'modelDiscovery', $this->modelDiscovery);
         $this->setPrivateProperty($controller, 'testPromptResolver', $this->testPromptResolver);
+        // REC #8b: typed catches log via LoggerInterface — NullLogger
+        // for unit tests so the property is initialised.
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }
@@ -251,7 +254,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // setDefaultAction tests
@@ -344,7 +347,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // getByProviderAction tests
@@ -486,7 +489,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // testModelAction tests
@@ -644,7 +647,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertFalse($data['success']);
         self::assertIsString($data['message']);
-        self::assertStringContainsString('API connection failed', $data['message']);
+        self::assertStringContainsString('See system log', $data['message']);
     }
 
     private function createProvider(int $uid): Provider
@@ -774,7 +777,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertFalse($data['success']);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('API unavailable', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // detectLimitsAction tests
@@ -924,7 +927,7 @@ final class ModelControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertFalse($data['success']);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('API unavailable', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     // Edge case tests for non-array body

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -62,6 +62,9 @@ final class ProviderControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'providerRepository', $this->providerRepository);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $this->providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'persistenceManager', $this->persistenceManager);
+        // REC #8b: typed catches log via LoggerInterface — NullLogger
+        // for unit tests so the property is initialised.
+        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
 
         return $controller;
     }
@@ -228,7 +231,7 @@ final class ProviderControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Database error', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     #[Test]
@@ -319,7 +322,7 @@ final class ProviderControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertFalse($data['success']);
         self::assertIsString($data['error']);
-        self::assertStringContainsString('Connection failed', $data['error']);
+        self::assertStringContainsString('See system log', $data['error']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- 13 \`catch (Throwable)\` sites in 4 admin controllers (\`ProviderController\`, \`ModelController\`, \`ConfigurationController\`, \`LlmModuleController\`) replaced with typed handlers.
- Doctrine \`DBAL\Exception\`, \`ProviderResponseException\`, base \`ProviderException\` arms each map to a meaningful HTTP status; final \`Throwable\` logs + surfaces "See system log" (no more leaked \`\$e->getMessage()\`).
- All 4 controllers gained \`LoggerInterface\` constructor parameter.
- Unit/functional/E2E test fixtures updated to inject \`NullLogger\`.

## Context
Companion to PR #194 (Task pathway controllers). Closes the admin half of REC #8 second clause.

## Test plan
- [x] PHPStan level 10 — passes
- [x] CGL — passes
- [x] Rector dry-run — passes
- [x] Unit tests — 3361 passing