### PR TITLE
style(tests): import Psr\Log\NullLogger instead of FQN (rector)

### DIFF
--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -117,7 +118,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             $pageRenderer,
             $backendUriBuilder,
             $testPromptResolver,
-            new \Psr\Log\NullLogger(),
+            new NullLogger(),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -118,7 +119,7 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $testPromptResolver,
-            new \Psr\Log\NullLogger(),
+            new NullLogger(),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
@@ -124,7 +125,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $testPromptResolver,
-            new \Psr\Log\NullLogger(),
+            new NullLogger(),
         );
     }
 
@@ -148,7 +149,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         // REC #8b: typed catches log via LoggerInterface — initialise
         // with a NullLogger so the typed property exists for any
         // exception path the test exercises.
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }
@@ -182,7 +183,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'configurationRepository', $configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Service\WizardGeneratorService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
@@ -135,7 +136,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $pageRenderer,
             $backendUriBuilder,
             $testPromptResolver,
-            new \Psr\Log\NullLogger(),
+            new NullLogger(),
         );
     }
 
@@ -167,7 +168,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $persistenceManager,
             $pageRenderer,
             $backendUriBuilder,
-            new \Psr\Log\NullLogger(),
+            new NullLogger(),
         );
     }
 
@@ -192,7 +193,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // REC #8b: typed catches log via LoggerInterface — initialise
         // the new property so any exercised exception path doesn't
         // hit an uninitialised typed property error.
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }
@@ -220,7 +221,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'configurationRepository', $this->configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -84,7 +85,7 @@ final class ConfigurationControllerTest extends TestCase
         // for unit tests so the property is initialised but no output is
         // produced. Real logging behaviour is exercised by the functional
         // suite where the container provides a real logger.
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -84,7 +85,7 @@ final class ModelControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'testPromptResolver', $this->testPromptResolver);
         // REC #8b: typed catches log via LoggerInterface — NullLogger
         // for unit tests so the property is initialised.
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -64,7 +65,7 @@ final class ProviderControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'persistenceManager', $this->persistenceManager);
         // REC #8b: typed catches log via LoggerInterface — NullLogger
         // for unit tests so the property is initialised.
-        $this->setPrivateProperty($controller, 'logger', new \Psr\Log\NullLogger());
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }


### PR DESCRIPTION
Cleanup pass: 7 test fixtures get a `use Psr\Log\NullLogger;` import so Rector's FullyQualifiedNameRector is happy. No behaviour change.

## Test plan
- [x] PHPStan level 10 — passes
- [x] CGL — passes
- [x] Rector dry-run — passes (was failing on `main` before this PR)
- [x] Unit tests — 3363 passing