### PR TITLE
test(architecture): ServiceLayerTest phpat rules (REC #13)

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -149,3 +149,7 @@ services:
     class: Netresearch\NrLlm\Tests\Architecture\ControllerLayerTest
     tags:
       - phpat.test
+  -
+    class: Netresearch\NrLlm\Tests\Architecture\ServiceLayerTest
+    tags:
+      - phpat.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **REC #13 (audit 2026-04-30):** New
+  `Tests/Architecture/ServiceLayerTest.php` (phpat) codifies the
+  Service-layer rules previously enforced by convention only:
+  (1) `Service\*` must not depend on `Controller\*` (reverse-dependency
+  guard); (2) `Service\*` must not depend on concrete provider adapter
+  classes (`OpenAiProvider`, `ClaudeProvider`, …) — provider invocation
+  goes through `Provider\Contract\ProviderInterface` /
+  `Provider\Middleware\MiddlewarePipeline` /
+  `ProviderAdapterRegistry`, never via direct adapter imports
+  (ADR-026). Cross-feature `Service\Feature\*` coupling is still
+  convention-guarded — a precise rule is left to a follow-up because
+  the obvious form would also forbid each service depending on its
+  own `*ServiceInterface` in the same namespace. No code changes were
+  required: both new rules pass against the current tree.
 - **REC #9c (slice 25):** ADR-028 documents the
   `Configuration/Services.yaml` `public: true` policy. The 37
   current overrides are categorised (public LLM API surface,

--- a/Tests/Architecture/ServiceLayerTest.php
+++ b/Tests/Architecture/ServiceLayerTest.php
@@ -9,13 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Architecture;
 
-use Netresearch\NrLlm\Provider\ClaudeProvider;
-use Netresearch\NrLlm\Provider\GeminiProvider;
-use Netresearch\NrLlm\Provider\GroqProvider;
-use Netresearch\NrLlm\Provider\MistralProvider;
-use Netresearch\NrLlm\Provider\OllamaProvider;
-use Netresearch\NrLlm\Provider\OpenAiProvider;
-use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
@@ -63,6 +56,14 @@ final class ServiceLayerTest
      * the `Provider\Middleware\MiddlewarePipeline`, or `ProviderAdapterRegistry`.
      * Importing a concrete adapter (e.g. `OpenAiProvider`) bypasses Fallback,
      * Budget, Usage, and Cache middleware — see ADR-026.
+     *
+     * The deny set is expressed as a regex over the FQCN so newly added
+     * adapter classes (any `Netresearch\NrLlm\Provider\<Name>Provider`
+     * directly under the `Provider` namespace, including `AbstractProvider`)
+     * are caught automatically without anyone remembering to update this
+     * test. Sub-namespaces (`Provider\Contract`, `Provider\Middleware`,
+     * `Provider\Exception`) and sibling classes that don't end in
+     * `Provider` (`ProviderAdapterRegistry`) are intentionally excluded.
      */
     public function testServicesDoNotDependOnConcreteProviderAdapters(): Rule
     {
@@ -70,13 +71,7 @@ final class ServiceLayerTest
             ->classes(Selector::inNamespace('Netresearch\NrLlm\Service'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::classname(OpenAiProvider::class),
-                Selector::classname(ClaudeProvider::class),
-                Selector::classname(GeminiProvider::class),
-                Selector::classname(OllamaProvider::class),
-                Selector::classname(GroqProvider::class),
-                Selector::classname(MistralProvider::class),
-                Selector::classname(OpenRouterProvider::class),
+                Selector::classname('/^Netresearch\\\\NrLlm\\\\Provider\\\\[A-Z][A-Za-z0-9]*Provider$/', true),
             )
             ->because('Services must invoke providers through ProviderInterface / MiddlewarePipeline / ProviderAdapterRegistry, never via concrete adapter classes (ADR-026).');
     }

--- a/Tests/Architecture/ServiceLayerTest.php
+++ b/Tests/Architecture/ServiceLayerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Architecture;
+
+use Netresearch\NrLlm\Provider\ClaudeProvider;
+use Netresearch\NrLlm\Provider\GeminiProvider;
+use Netresearch\NrLlm\Provider\GroqProvider;
+use Netresearch\NrLlm\Provider\MistralProvider;
+use Netresearch\NrLlm\Provider\OllamaProvider;
+use Netresearch\NrLlm\Provider\OpenAiProvider;
+use Netresearch\NrLlm\Provider\OpenRouterProvider;
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * Architectural tests for Service layer dependencies.
+ *
+ * Codifies the layering convention documented in `Classes/AGENTS.md` and
+ * ADR-026 (Provider Middleware Pipeline) so future drift is caught by the
+ * test suite instead of code review:
+ *
+ *   1. Services must not call into Controllers (reverse-dependency guard).
+ *   2. Services must reach providers through abstractions
+ *      (`Provider\Contract`, `Provider\Middleware`, `LlmServiceManager`,
+ *      `ProviderAdapterRegistry`) and never depend on concrete adapter
+ *      classes — that would bypass Fallback / Budget / Usage / Cache
+ *      middleware.
+ *
+ * Cross-feature coupling between `Service\Feature\*` classes is currently
+ * guarded only by convention; a precise phpat rule for that case is left
+ * to a follow-up because the obvious form ("Feature\\* must not depend on
+ * Feature\\*") would also forbid the legitimate self-namespace dependency
+ * of each service on its own `*ServiceInterface`.
+ */
+final class ServiceLayerTest
+{
+    /**
+     * Services must not depend on Controllers.
+     *
+     * Controllers depend on services, never the other way around.
+     */
+    public function testServicesDoNotDependOnControllers(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Service'))
+            ->shouldNotDependOn()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Controller'))
+            ->because('Services must not depend on Controllers — reverse layering violates dependency inversion.');
+    }
+
+    /**
+     * Services must not depend on concrete provider adapter classes.
+     *
+     * All provider invocation goes through `Provider\Contract\ProviderInterface`,
+     * the `Provider\Middleware\MiddlewarePipeline`, or `ProviderAdapterRegistry`.
+     * Importing a concrete adapter (e.g. `OpenAiProvider`) bypasses Fallback,
+     * Budget, Usage, and Cache middleware — see ADR-026.
+     */
+    public function testServicesDoNotDependOnConcreteProviderAdapters(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Service'))
+            ->shouldNotDependOn()
+            ->classes(
+                Selector::classname(OpenAiProvider::class),
+                Selector::classname(ClaudeProvider::class),
+                Selector::classname(GeminiProvider::class),
+                Selector::classname(OllamaProvider::class),
+                Selector::classname(GroqProvider::class),
+                Selector::classname(MistralProvider::class),
+                Selector::classname(OpenRouterProvider::class),
+            )
+            ->because('Services must invoke providers through ProviderInterface / MiddlewarePipeline / ProviderAdapterRegistry, never via concrete adapter classes (ADR-026).');
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Tests/Architecture/ServiceLayerTest.php` with two phpat rules so the layering convention from `Classes/AGENTS.md` and ADR-026 (Provider Middleware Pipeline) is enforced by the test suite, not code review:

1. **`Service\*` must not depend on `Controller\*`** — reverse-dependency guard.
2. **`Service\*` must not depend on concrete provider adapter classes** (`OpenAiProvider`, `ClaudeProvider`, `GeminiProvider`, `OllamaProvider`, `GroqProvider`, `MistralProvider`, `OpenRouterProvider`). Provider invocation goes through `ProviderInterface` / `MiddlewarePipeline` / `ProviderAdapterRegistry` — a direct adapter import would bypass Fallback / Budget / Usage / Cache middleware.

Both rules pass against the current tree — no code changes required.

The cross-feature `Service\Feature\*` ↔ `Service\Feature\*` guard is **intentionally omitted** from this slice. The naive form would also forbid each concrete service depending on its own `*ServiceInterface` in the same namespace. A precise rule listing the four concrete service classes belongs to a follow-up.

## Audit context

This is the first slice from the 2026-04-30 architectural audit (`claudedocs/audit-2026-04-30-architecture.md`). The audit found the existing phpat suite covers Controller / Domain / DTO layers but not Service. REC #13 closes that gap.

## Test plan

- [x] Local verification: `./Build/Scripts/runTests.sh -p 8.4 -s architecture` → 402 phpat checks, no errors.
- [ ] CI architecture suite passes on PHP 8.2 / 8.3 / 8.4 / 8.5 × TYPO3 13.4 / 14.0.
- [ ] No new PHPStan errors introduced by the test file.
- [ ] CHANGELOG `[Unreleased]` entry under "Added" references REC #13.