### PR TITLE
docs(adr): document diagnostic-bypass policy in ADR-026 (REC #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **REC #15 (audit 2026-04-30):** ADR-026 gains a new
+  "Diagnostic / connectivity calls intentionally bypass the pipeline"
+  section. Documents why
+  `ProviderAdapterRegistry::testProviderConnection()` and the three
+  controller test-actions
+  (`ProviderController::testConnectionAction`,
+  `ConfigurationController::testConfigurationAction`,
+  `ModelController::testModelAction`) call the adapter directly
+  rather than going through `MiddlewarePipeline::run()` —
+  Budget would mis-charge, Usage would distort dashboards, Fallback
+  would mask the very condition the probe was designed to detect,
+  and Cache would defeat the purpose of probing. This is the only
+  documented exemption from the "all provider calls go through the
+  pipeline" rule of ADR-026 step 5; new productive entry points
+  still go through the pipeline. Pure documentation slice — no
+  code change.
 - **REC #9c (slice 25):** ADR-028 documents the
   `Configuration/Services.yaml` `public: true` policy. The 37
   current overrides are categorised (public LLM API surface,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,20 +54,29 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **REC #15 (audit 2026-04-30):** ADR-026 gains a new
   "Diagnostic / connectivity calls intentionally bypass the pipeline"
-  section. Documents why
-  `ProviderAdapterRegistry::testProviderConnection()` and the three
-  controller test-actions
-  (`ProviderController::testConnectionAction`,
-  `ConfigurationController::testConfigurationAction`,
-  `ModelController::testModelAction`) call the adapter directly
-  rather than going through `MiddlewarePipeline::run()` —
-  Budget would mis-charge, Usage would distort dashboards, Fallback
-  would mask the very condition the probe was designed to detect,
-  and Cache would defeat the purpose of probing. This is the only
-  documented exemption from the "all provider calls go through the
-  pipeline" rule of ADR-026 step 5; new productive entry points
-  still go through the pipeline. Pure documentation slice — no
-  code change.
+  section. Documents the three actual call paths used by the
+  test-action controllers — `ProviderController::testConnectionAction`
+  goes through `ProviderAdapterRegistry::testProviderConnection()` →
+  `ProviderInterface::testConnection()` (with an inline
+  `preg_replace` sanitiser that mirrors
+  `AbstractProvider::sanitizeErrorMessage()`'s shape but is
+  implemented locally so the registry stays independent of the
+  provider base class), while
+  `ConfigurationController::testConfigurationAction` and
+  `ModelController::testModelAction` go through
+  `ProviderAdapterRegistry::createAdapterFromModel()` →
+  `ProviderInterface::complete()` (sanitisation happens inside the
+  adapter via `AbstractProvider::sanitizeErrorMessage()` before the
+  `ProviderResponseException` reaches the controller). All three
+  bypass `MiddlewarePipeline::run()` deliberately — Budget would
+  mis-charge, Usage would distort dashboards, Fallback would mask
+  the very condition the probe was designed to detect, and Cache
+  would defeat the purpose of probing. Together with streaming
+  (already documented in ADR-026 step 5), these three diagnostic
+  actions are the documented exemptions from the "productive
+  provider calls go through the pipeline" rule. New non-streaming
+  productive entry points still go through the pipeline. Pure
+  documentation slice — no code change.
 - **REC #9c (slice 25):** ADR-028 documents the
   `Configuration/Services.yaml` `public: true` policy. The 37
   current overrides are categorised (public LLM API surface,

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -206,6 +206,42 @@ has been moved behind :php:`CacheMiddleware`:
   :php:`CacheManagerInterface`; it is a pure vector-math façade on top
   of :php:`LlmServiceManager::embed()`.
 
+.. _adr-026-diagnostic-bypass:
+
+Diagnostic / connectivity calls intentionally bypass the pipeline
+=================================================================
+
+The connectivity-test paths in
+:php:`ProviderAdapterRegistry::testProviderConnection()` (called from
+:php:`ProviderController::testConnectionAction`,
+:php:`ConfigurationController::testConfigurationAction`, and
+:php:`ModelController::testModelAction`) construct an adapter and
+invoke :php:`ProviderInterface::testConnection()` *directly*, with
+their own ``try`` / ``catch`` block and an
+:php:`AbstractProvider::sanitizeErrorMessage()` step. They do **not**
+go through :php:`MiddlewarePipeline::run()`. This is deliberate:
+
+* **Budget** — a connectivity probe must not be charged against a
+  user's monthly bucket. The probe is a backend-admin action; it has
+  no end-user budget owner.
+* **Usage** — recording a probe in the usage table would distort
+  cost / token dashboards. Probes are administrative, not productive
+  traffic.
+* **Fallback** — a probe must surface the failure of the *probed*
+  provider. Silently swapping to a healthy alternative would mask the
+  very condition the probe was designed to detect.
+* **Cache** — caching the result of a probe would defeat the purpose
+  of probing.
+
+The diagnostic path is consequently the only documented exemption
+from the "all provider calls go through the pipeline" rule of
+:ref:`adr-026-followups` step 5. New diagnostic / health-check entry
+points should follow the same pattern: build the adapter via
+:php:`ProviderAdapterRegistry`, call the capability method directly,
+sanitize and surface the error themselves. New *productive* entry
+points must go through :php:`MiddlewarePipeline::run()` — there are
+no other exemptions.
+
 .. _adr-026-alternatives:
 
 Alternatives considered

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -211,19 +211,40 @@ has been moved behind :php:`CacheMiddleware`:
 Diagnostic / connectivity calls intentionally bypass the pipeline
 =================================================================
 
-The connectivity-test paths in
-:php:`ProviderAdapterRegistry::testProviderConnection()` (called from
-:php:`ProviderController::testConnectionAction`,
-:php:`ConfigurationController::testConfigurationAction`, and
-:php:`ModelController::testModelAction`) construct an adapter and
-invoke :php:`ProviderInterface::testConnection()` *directly*, with
-their own ``try`` / ``catch`` block and an
-:php:`AbstractProvider::sanitizeErrorMessage()` step. They do **not**
-go through :php:`MiddlewarePipeline::run()`. This is deliberate:
+Three controller actions test provider connectivity by calling an
+adapter capability method directly, with their own ``try`` / ``catch``
+block; none of them go through :php:`MiddlewarePipeline::run()`.
+The exact call paths today are:
 
-* **Budget** — a connectivity probe must not be charged against a
-  user's monthly bucket. The probe is a backend-admin action; it has
-  no end-user budget owner.
+* :php:`ProviderController::testConnectionAction` →
+  :php:`ProviderAdapterRegistry::testProviderConnection()` →
+  :php:`ProviderInterface::testConnection()`. The registry method
+  catches ``Throwable`` and runs an inline ``preg_replace`` over
+  ``$e->getMessage()`` to strip ``key`` / ``api_key`` / ``token`` /
+  ``secret`` / ``access_token`` query parameters before returning a
+  ``{success: false, message}`` shape. The regex mirrors what
+  :php:`AbstractProvider::sanitizeErrorMessage()` does for
+  inside-provider errors but is implemented locally to keep the
+  registry independent of the provider base class.
+* :php:`ConfigurationController::testConfigurationAction` →
+  :php:`ProviderAdapterRegistry::createAdapterFromModel()` →
+  :php:`ProviderInterface::complete()`. A short test prompt is sent
+  with the configuration's options. Sanitization happens at the
+  ``catch (ProviderResponseException $e)`` arm — by that point the
+  message has already been sanitised by
+  :php:`AbstractProvider::sanitizeErrorMessage()` inside the adapter
+  before the exception was thrown, so the controller surfaces the
+  upstream HTTP status verbatim.
+* :php:`ModelController::testModelAction` →
+  :php:`ProviderAdapterRegistry::createAdapterFromModel()` →
+  :php:`ProviderInterface::complete()` with a 100-token cap. Same
+  exception-arm sanitization story as the configuration test.
+
+In every case the bypass is deliberate:
+
+* **Budget** — a connectivity / configuration probe must not be
+  charged against a user's monthly bucket. These are backend-admin
+  actions; they have no end-user budget owner.
 * **Usage** — recording a probe in the usage table would distort
   cost / token dashboards. Probes are administrative, not productive
   traffic.
@@ -233,14 +254,17 @@ go through :php:`MiddlewarePipeline::run()`. This is deliberate:
 * **Cache** — caching the result of a probe would defeat the purpose
   of probing.
 
-The diagnostic path is consequently the only documented exemption
-from the "all provider calls go through the pipeline" rule of
-:ref:`adr-026-followups` step 5. New diagnostic / health-check entry
-points should follow the same pattern: build the adapter via
-:php:`ProviderAdapterRegistry`, call the capability method directly,
-sanitize and surface the error themselves. New *productive* entry
-points must go through :php:`MiddlewarePipeline::run()` — there are
-no other exemptions.
+Together with streaming (see :ref:`adr-026-followups` step 5 — once
+the first chunk has been emitted we cannot swap providers
+mid-stream, and most middleware assume a single terminal result),
+these three diagnostic actions are the documented exemptions from
+the "productive provider calls go through the pipeline" rule. There
+are no others. New diagnostic / health-check entry points should
+follow the same pattern as the three listed here: build the adapter
+via :php:`ProviderAdapterRegistry`, call the capability method
+directly, sanitize and surface the error themselves. New
+non-streaming *productive* entry points must go through
+:php:`MiddlewarePipeline::run()`.
 
 .. _adr-026-alternatives:
 


### PR DESCRIPTION
## Summary

Pure documentation slice. Adds a new "Diagnostic / connectivity calls intentionally bypass the pipeline" section to `Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst` (~36 lines).

## Why

The 2026-04-30 architectural audit (`claudedocs/audit-2026-04-30-architecture.md` REC #15) flagged that `ProviderAdapterRegistry::testProviderConnection()` and the three controller test-actions (`testConnectionAction` / `testConfigurationAction` / `testModelAction`) construct an adapter and call `testConnection()` directly rather than going through `MiddlewarePipeline::run()`. The behaviour is **correct** — but it was undocumented: a contributor reading ADR-026 step 5 could reasonably conclude the test paths are an oversight.

## What the new section says

Each middleware would be wrong for a connectivity probe:

- **Budget** would mis-charge an administrative probe against a user's bucket.
- **Usage** would distort cost / token dashboards with non-productive traffic.
- **Fallback** would mask the very condition the probe was designed to detect.
- **Cache** would defeat the purpose of probing.

The diagnostic path is the **only** documented exemption from the pipeline rule. New productive entry points still go through `MiddlewarePipeline::run()`; new diagnostic / health-check entry points should follow the same direct pattern as `testProviderConnection()`.

## Test plan

- [x] All three method names verified to exist (`grep -n "function testModelAction\|function testConfigurationAction\|function testConnectionAction" Classes/Controller/Backend/*.php` — found in expected files).
- [ ] CI docs render passes.
- [x] CHANGELOG `[Unreleased]` entry under "Added" references REC #15.