### PR TITLE
fix(provider): log Ollama discovery failures, document Provider silent-vault swallow (REC #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **REC #11 (audit 2026-04-30, partial):** Bare `catch (Throwable)`
+  cleanup outside REC #8b's admin-controller scope. Two surgical
+  changes:
+  - `OllamaProvider::getAvailableModels()` — the catch arm that
+    falls back to a hardcoded model list when the Ollama server is
+    unreachable now logs a `warning` (with `exception` and
+    `baseUrl` context) before returning the defaults. Operators
+    can see when their endpoint is silently down instead of
+    discovering it later via "the model picker only shows five
+    options". `$this->logger` is already injected by
+    `AbstractProvider`.
+  - `Provider::getDecryptedApiKey()` — the silent
+    `catch (Throwable) { return ''; }` is **kept** but the comment
+    is sharpened to document why: the empty-string return is
+    load-bearing for `isFullyConfigured()`, `toFullArray()`, and
+    the two `ModelController` adapter-construction sites; adding a
+    logger here trips `failOnWarning=true` in unit-test paths that
+    construct providers without a vault service. The operational
+    signal belongs at the controller call sites — deferred to a
+    follow-up. Two other sites flagged by the audit
+    (`TaskInputResolver:59,133`, `TextToSpeechService:429`) are
+    not touched in this slice — see audit doc for the rationale
+    (TaskInputResolver needs a test-first refactor; TextToSpeechService
+    is already a typed-final-arm pattern that matches REC #8b's
+    intent).
 - **REC #8b (slice 23b):** Replaced catch-all `catch (Throwable $e)`
   blocks with typed exception handlers across the four admin
   controllers (`ProviderController`, `ModelController`,

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -133,7 +133,21 @@ class Provider extends AbstractEntity
             $vault = GeneralUtility::makeInstance(VaultServiceInterface::class);
             return $vault->retrieve($this->apiKey) ?? '';
         } catch (Throwable) {
-            // If retrieval fails, return empty string
+            // Vault retrieval failed — return empty string so callers fall
+            // through to "API key may be missing" rather than crashing the
+            // whole admin page. The empty-string return is load-bearing
+            // for `isFullyConfigured()`, `toFullArray()`, and the two
+            // `ModelController` adapter-construction sites — each of those
+            // already surfaces a user-visible "API key missing" / "provider
+            // not configured" message at the operational call site.
+            //
+            // We do NOT log here: the model is constructed in countless
+            // unit-test paths that do not bootstrap a vault service, and
+            // the failure is already surfaced operationally. Adding a
+            // logger seam to a domain-entity getter would either invert
+            // the dependency (entity → service-locator) or require
+            // touching every caller. Moving the logging to the controller
+            // call sites is the right slice — see audit doc REC #11.
             return '';
         }
     }

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -92,14 +92,21 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             }
 
             return $result;
-        } catch (Throwable) {
-            // Return default models if we can't fetch from server
+        } catch (Throwable $e) {
+            // Server unreachable — fall back to a small hardcoded list so the
+            // model picker still has something to show. Log so operators know
+            // their Ollama endpoint isn't responding (REC #11).
+            $this->logger->warning('Ollama: getAvailableModels failed, returning hardcoded defaults', [
+                'exception' => $e,
+                'baseUrl'   => $this->baseUrl,
+            ]);
+
             return [
-                'llama3.2' => 'Llama 3.2',
+                'llama3.2'     => 'Llama 3.2',
                 'llama3.2:70b' => 'Llama 3.2 70B',
-                'mistral' => 'Mistral',
-                'codellama' => 'Code Llama',
-                'phi3' => 'Phi-3',
+                'mistral'      => 'Mistral',
+                'codellama'    => 'Code Llama',
+                'phi3'         => 'Phi-3',
             ];
         }
     }

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -95,10 +95,13 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         } catch (Throwable $e) {
             // Server unreachable — fall back to a small hardcoded list so the
             // model picker still has something to show. Log so operators know
-            // their Ollama endpoint isn't responding (REC #11).
+            // their Ollama endpoint isn't responding (REC #11). Userinfo
+            // (`https://user:pass@host`) and query / fragment are stripped
+            // before the URL hits the log so credentials accidentally embedded
+            // in a misconfigured baseUrl don't leak into sys_log.
             $this->logger->warning('Ollama: getAvailableModels failed, returning hardcoded defaults', [
                 'exception' => $e,
-                'baseUrl'   => $this->baseUrl,
+                'baseUrl'   => self::sanitizeUrlForLog($this->baseUrl),
             ]);
 
             return [
@@ -109,6 +112,38 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                 'phi3'         => 'Phi-3',
             ];
         }
+    }
+
+    /**
+     * Strip userinfo + query + fragment from a URL so it is safe to log.
+     *
+     * Returns scheme://host[:port][/path] for valid URLs, or the empty
+     * string if the input is unparseable. Used by the
+     * `getAvailableModels()` failure log so a baseUrl misconfigured with
+     * embedded credentials (`https://user:pass@host:11434`) does not leak
+     * those credentials into sys_log.
+     */
+    private static function sanitizeUrlForLog(string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false) {
+            return '';
+        }
+
+        $scheme = isset($parts['scheme']) ? $parts['scheme'] . '://' : '';
+        $host   = $parts['host'] ?? '';
+        $port   = isset($parts['port']) ? ':' . $parts['port'] : '';
+        $path   = $parts['path'] ?? '';
+
+        if ($host === '') {
+            return '';
+        }
+
+        return $scheme . $host . $port . $path;
     }
 
     /**

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -19,9 +19,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
-use Psr\Log\LoggerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
 

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use ReflectionClass;
@@ -188,6 +189,68 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $models = $this->subject->getAvailableModels();
 
         // Should return default models when server is unavailable
+        self::assertNotEmpty($models);
+        self::assertArrayHasKey('llama3.2', $models);
+    }
+
+    /**
+     * REC #11 (audit 2026-04-30): the catch arm that returns hardcoded
+     * defaults on transport failure must surface a `warning` log so
+     * operators see when their endpoint isn't responding instead of
+     * silently inheriting a stale model picker.
+     *
+     * The log payload's `baseUrl` field must be sanitised — userinfo
+     * and query/fragment stripped — so credentials accidentally
+     * embedded in a misconfigured baseUrl (`https://user:pass@host`)
+     * cannot leak into sys_log.
+     */
+    #[Test]
+    public function getAvailableModelsLogsWarningWithSanitisedBaseUrlOnFailure(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $logger,
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel'     => 'llama3.2',
+            'baseUrl'          => 'https://leaky-user:leaky-pass@ollama.example:11434/v1?token=secret#frag',
+            'timeout'          => 30,
+        ]);
+        $httpClient = $this->createHttpClientMock();
+        $httpClient
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('Connection refused'));
+        $subject->setHttpClient($httpClient);
+
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('getAvailableModels failed'),
+                self::callback(static function (array $context): bool {
+                    self::assertArrayHasKey('baseUrl', $context);
+                    self::assertArrayHasKey('exception', $context);
+                    self::assertIsString($context['baseUrl']);
+
+                    self::assertSame('https://ollama.example:11434/v1', $context['baseUrl']);
+                    self::assertStringNotContainsString('leaky-user', $context['baseUrl']);
+                    self::assertStringNotContainsString('leaky-pass', $context['baseUrl']);
+                    self::assertStringNotContainsString('token=secret', $context['baseUrl']);
+                    self::assertStringNotContainsString('#frag', $context['baseUrl']);
+
+                    return true;
+                }),
+            );
+
+        $models = $subject->getAvailableModels();
+
+        // Defaults are still returned — operational fallback unchanged.
         self::assertNotEmpty($models);
         self::assertArrayHasKey('llama3.2', $models);
     }


### PR DESCRIPTION
## Summary

Partial slice for the 2026-04-30 architectural audit's REC #11 — bare `catch (Throwable)` cleanup outside REC #8b's admin-controller scope. Two surgical changes; the other two flagged sites are deferred / no-action with rationale captured below.

### `OllamaProvider::getAvailableModels()`

The catch arm that falls back to a hardcoded model list when the Ollama server is unreachable now logs a `warning` before returning the defaults. `\$this->logger` is already injected by `AbstractProvider`. Context: `exception`, `baseUrl`. Operators can see "Ollama endpoint not responding" in the system log instead of discovering it later via "the model picker only shows five options".

### `Provider::getDecryptedApiKey()`

The silent `catch (Throwable) { return ''; }` is **kept**; only the comment is sharpened to document the load-bearing contract: the empty-string return is consumed by `isFullyConfigured()`, `toFullArray()`, and the two `ModelController` adapter-construction sites — each surfaces a user-visible "API key missing" message at the operational call site. Adding a logger seam here trips `failOnWarning=true` in unit-test paths that construct providers without a vault service. The operational signal belongs at the controller call sites — deferred to a follow-up slice (REC #11b).

## Sites intentionally not touched

| Site | Reason |
|------|--------|
| `TaskInputResolver:59,133` | Deferred — needs `LoggerInterface` injection (DI change), `locallang.xlf` updates to drop the `%s` placeholder, and a unit test (none exists today). Test-first follow-up REC #11b. |
| `TextToSpeechService:429` | No action — re-read of the code shows it's already a typed-final-arm pattern (`ServiceUnavailableException\|ServiceConfigurationException` first, `Throwable` final arm with logger). Matches REC #8b's intent. The audit flag was over-cautious. |

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` → 1061 tests OK
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` → SUCCESS
- [ ] CI matrix passes on PHP 8.2/8.3/8.4/8.5 × TYPO3 13.4 / 14.0
- [x] CHANGELOG `[Unreleased]` entry under "Changed" references REC #11 (partial)