### PR TITLE
fix(test): relax BudgetServiceTest assertion to allow equal window starts

### DIFF
--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -251,10 +251,16 @@ class BudgetServiceTest extends AbstractUnitTestCase
         self::assertTrue($result->allowed);
         self::assertNotNull($capturedDailyFrom, 'Daily window should be requested');
         self::assertNotNull($capturedMonthlyFrom, 'Monthly window should be requested');
-        self::assertLessThan(
+        // Monthly start must be **at or before** daily start. On the first
+        // day of a month both windows start at the same instant (00:00 of
+        // the 1st), which is correct production behaviour — using strict
+        // `assertLessThan` here previously caused this test to fail every
+        // month-start when run in CI, even though the production code was
+        // doing the right thing.
+        self::assertLessThanOrEqual(
             $capturedDailyFrom,
             $capturedMonthlyFrom,
-            'Monthly start must precede daily start',
+            'Monthly start must precede or equal daily start',
         );
     }
 


### PR DESCRIPTION
## Summary

Calendar-edge bug in `BudgetServiceTest::combinesDailyAndMonthlyIntoASingleAggregationCall` — the assertion `assertLessThan($dailyFrom, $monthlyFrom)` fails unconditionally on the **first day of any month**. On 2026-05-01 the start-of-month and start-of-day timestamps both equal `1777593600`, and strict `<` rejects the legitimate equality.

The production code is correct; only the test assertion was overly strict.

## Impact

- CI on `main` goes red on every month-start until the calendar rolls over.
- Every open PR inherits the failure — discovered today on three separate audit branches (#198, #199, #200).
- The window is small (≤24h) but recurring, monthly.

## Fix

Relax the assertion to `assertLessThanOrEqual`, with a comment explaining why equality is correct production behaviour. The test's stated intent — "combines daily and monthly into a single aggregation call" — still holds: both windows are still verified to be requested, and monthly is still asserted to be no later than daily.

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` → 3378 tests, 7380 assertions, all green (was 1 failure on 2026-05-01).
- [ ] CI matrix passes on PHP 8.2/8.3/8.4/8.5 × TYPO3 13.4 / 14.0.

## Note

Once this lands and the audit-follow-up PRs (#198, #199, #200) are rebased / re-run, their CI should go green too.