### PR TITLE
fix(task): stop leaking DBAL error text into LLM input + add tests (REC #11b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **REC #11b (audit 2026-04-30, follow-up to REC #11):**
+  `TaskInputResolver` no longer interpolates `$e->getMessage()` into
+  the LLM input string when sys_log or record-table reads fail.
+  Three behaviour changes, all in
+  `Classes/Service/Task/TaskInputResolver.php`:
+  1. The constructor takes a new `LoggerInterface` parameter (autowired
+     by Symfony DI — no `Services.yaml` change needed).
+  2. The two `catch (Throwable $e)` arms now `$this->logger->warning(...)`
+     the full exception together with task-uid / table / limit context,
+     and return a generic localised "see system log" message instead
+     of the raw exception text. The previous behaviour leaked DBAL
+     error fragments (table names, column hints, sometimes SQL) into
+     the LLM prompt and onward to user-visible task output.
+  3. The table branch grew a dedicated `catch (InvalidArgumentException)`
+     arm in front of the broad Throwable arm — picker-policy
+     rejections (table on the exclusion list) are not runtime errors
+     and now route through `$this->logger->info(...)` instead of
+     `warning`. The user-facing string is the same generic
+     "see system log" message.
+  XLIFF: `task.syslog.readError` and `task.table.readError` lost
+  their `: %s` placeholder — the new source / target strings are
+  "Error reading X. See system log for details." (EN) and
+  "Fehler beim Lesen ... Details siehe Systemlog." (DE). Plus a
+  new private `translate()` helper wraps `LocalizationUtility::translate()`
+  in a defensive try/catch so the resolver stays unit-testable
+  without bootstrapping `LanguageServiceFactory` (which
+  `LocalizationUtility::translate()` instantiates eagerly and
+  which throws when called outside the TYPO3 framework
+  bootstrap). New
+  `Tests/Unit/Service/Task/TaskInputResolverTest.php` provides 8
+  unit tests / 64 assertions covering the happy paths, both
+  read-failure regression contracts (no message leak + warning
+  emitted), and the picker-policy info-log routing.
 - **REC #11 (audit 2026-04-30, partial):** Bare `catch (Throwable)`
   cleanup outside REC #8b's admin-controller scope. Two surgical
   changes:

--- a/Classes/Service/Task/TaskInputResolver.php
+++ b/Classes/Service/Task/TaskInputResolver.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
+use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\Model\Task;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -25,7 +27,15 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * `ConnectionPool` / filesystem coupling.
  *
  * Behaviour matches the pre-13b `TaskController::getInputData()`
- * private helper exactly — this slice is a pure refactor.
+ * private helper exactly with one deliberate exception: REC #11b
+ * (audit 2026-04-30) replaced the `$e->getMessage()` interpolation
+ * in the two read-error arms with a generic "see system log"
+ * message and a `LoggerInterface::warning()` call carrying the full
+ * exception. The previous behaviour leaked DBAL error text (table
+ * names, column hints, sometimes SQL fragments) into the LLM input
+ * string and onward to the model and the user-visible task output;
+ * the new behaviour preserves the operational signal in `sys_log`
+ * where it belongs.
  */
 final readonly class TaskInputResolver implements TaskInputResolverInterface
 {
@@ -36,6 +46,7 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
         private SystemLogReaderInterface $systemLogReader,
         private DeprecationLogReaderInterface $deprecationLogReader,
         private RecordTableReaderInterface $recordTableReader,
+        private LoggerInterface $logger,
     ) {}
 
     public function resolve(Task $task): string
@@ -57,12 +68,16 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
         try {
             $rows = $this->systemLogReader->readRecent($limit, $errorOnly);
         } catch (Throwable $e) {
-            return sprintf(
-                LocalizationUtility::translate(
-                    'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.readError',
-                    'NrLlm',
-                ) ?? 'Error reading sys_log: %s',
-                $e->getMessage(),
+            $this->logger->warning('Task syslog input: sys_log read failed', [
+                'exception' => $e,
+                'taskUid'   => $task->getUid(),
+                'limit'     => $limit,
+                'errorOnly' => $errorOnly,
+            ]);
+
+            return $this->translate(
+                'task.syslog.readError',
+                'Error reading sys_log. See system log for details.',
             );
         }
 
@@ -76,7 +91,7 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
             $time  = date('Y-m-d H:i:s', $tstamp);
             $type  = $this->translateSyslogType($typeValue);
             $error = $errorValue > 0
-                ? (LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.syslog.errorMarker', 'NrLlm') ?? '[ERROR]')
+                ? $this->translate('task.syslog.errorMarker', '[ERROR]')
                 : '';
 
             $output[] = "[{$time}] [{$type}] {$error} {$details}";
@@ -109,10 +124,7 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
             default => 'OTHER',
         };
 
-        return LocalizationUtility::translate(
-            'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:' . $key,
-            'NrLlm',
-        ) ?? $fallback;
+        return $this->translate($key, $fallback);
     }
 
     private function resolveTable(Task $task): string
@@ -122,24 +134,64 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
         $limit  = isset($config['limit']) && is_numeric($config['limit']) ? (int)$config['limit'] : self::TABLE_DEFAULT_LIMIT;
 
         if ($table === '') {
-            return LocalizationUtility::translate(
-                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.notConfigured',
-                'NrLlm',
-            ) ?? 'No table configured.';
+            return $this->translate('task.table.notConfigured', 'No table configured.');
         }
 
         try {
             $rows = $this->recordTableReader->fetchAll($table, $limit);
+        } catch (InvalidArgumentException $e) {
+            // Table on the picker exclusion list. The exception text
+            // describes the policy ("Table 'xyz' is not allowed for
+            // record selection"); it doesn't carry user data and is
+            // safe to surface, but we still log so an admin can see
+            // the rejection in the system log.
+            $this->logger->info('Task table input: table rejected by record-picker policy', [
+                'exception' => $e,
+                'taskUid'   => $task->getUid(),
+                'table'     => $table,
+            ]);
+
+            return $this->translate(
+                'task.table.readError',
+                'Error reading table. See system log for details.',
+            );
         } catch (Throwable $e) {
-            return sprintf(
-                LocalizationUtility::translate(
-                    'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.table.readError',
-                    'NrLlm',
-                ) ?? 'Error reading table: %s',
-                $e->getMessage(),
+            $this->logger->warning('Task table input: table read failed', [
+                'exception' => $e,
+                'taskUid'   => $task->getUid(),
+                'table'     => $table,
+                'limit'     => $limit,
+            ]);
+
+            return $this->translate(
+                'task.table.readError',
+                'Error reading table. See system log for details.',
             );
         }
 
         return json_encode($rows, JSON_PRETTY_PRINT) ?: '[]';
+    }
+
+    /**
+     * Translate a locallang key with a hardcoded English fallback.
+     *
+     * `LocalizationUtility::translate()` is the canonical translator,
+     * but it can throw in unit-test contexts where the language
+     * service hasn't been bootstrapped. Wrapping it lets callers stay
+     * straight-line while preserving the production translation
+     * behaviour and giving unit tests a deterministic fallback.
+     */
+    private function translate(string $key, string $fallback): string
+    {
+        try {
+            $translated = LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:' . $key,
+                'NrLlm',
+            );
+        } catch (Throwable) {
+            return $fallback;
+        }
+
+        return $translated ?? $fallback;
     }
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -339,12 +339,12 @@
                 <target>Keine Tabelle konfiguriert.</target>
             </trans-unit>
             <trans-unit id="task.table.readError">
-                <source>Error reading table: %s</source>
-                <target>Fehler beim Lesen der Tabelle: %s</target>
+                <source>Error reading table. See system log for details.</source>
+                <target>Fehler beim Lesen der Tabelle. Details siehe Systemlog.</target>
             </trans-unit>
             <trans-unit id="task.syslog.readError">
-                <source>Error reading sys_log: %s</source>
-                <target>Fehler beim Lesen des sys_log: %s</target>
+                <source>Error reading sys_log. See system log for details.</source>
+                <target>Fehler beim Lesen des sys_log. Details siehe Systemlog.</target>
             </trans-unit>
 
             <!-- Configuration controller -->

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -258,10 +258,10 @@
                 <source>No table configured.</source>
             </trans-unit>
             <trans-unit id="task.table.readError">
-                <source>Error reading table: %s</source>
+                <source>Error reading table. See system log for details.</source>
             </trans-unit>
             <trans-unit id="task.syslog.readError">
-                <source>Error reading sys_log: %s</source>
+                <source>Error reading sys_log. See system log for details.</source>
             </trans-unit>
 
             <!-- Configuration controller -->

--- a/Tests/Unit/Service/Task/TaskInputResolverTest.php
+++ b/Tests/Unit/Service/Task/TaskInputResolverTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Task;
+
+use InvalidArgumentException;
+use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Service\Task\DeprecationLogReaderInterface;
+use Netresearch\NrLlm\Service\Task\RecordTableReaderInterface;
+use Netresearch\NrLlm\Service\Task\SystemLogReaderInterface;
+use Netresearch\NrLlm\Service\Task\TaskInputResolver;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @internal Coverage for the REC #11b refactor: read-failure arms log
+ *           full exception detail and surface a generic "see system
+ *           log" string instead of interpolating `$e->getMessage()`
+ *           into the LLM input.
+ */
+#[CoversClass(TaskInputResolver::class)]
+final class TaskInputResolverTest extends AbstractUnitTestCase
+{
+    private SystemLogReaderInterface&MockObject $systemLogReader;
+    private DeprecationLogReaderInterface&MockObject $deprecationLogReader;
+    private RecordTableReaderInterface&MockObject $recordTableReader;
+    private LoggerInterface&MockObject $logger;
+    private TaskInputResolver $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->systemLogReader      = $this->createMock(SystemLogReaderInterface::class);
+        $this->deprecationLogReader = $this->createMock(DeprecationLogReaderInterface::class);
+        $this->recordTableReader    = $this->createMock(RecordTableReaderInterface::class);
+        $this->logger               = $this->createMock(LoggerInterface::class);
+
+        $this->subject = new TaskInputResolver(
+            $this->systemLogReader,
+            $this->deprecationLogReader,
+            $this->recordTableReader,
+            $this->logger,
+        );
+    }
+
+    private static function makeTask(string $inputType, string $inputSourceJson = ''): Task
+    {
+        $task = new Task();
+        $task->setInputType($inputType);
+        $task->setInputSource($inputSourceJson);
+
+        return $task;
+    }
+
+    #[Test]
+    public function unknownInputTypeReturnsEmptyString(): void
+    {
+        $this->systemLogReader->expects(self::never())->method('readRecent');
+        $this->deprecationLogReader->expects(self::never())->method('readTail');
+        $this->recordTableReader->expects(self::never())->method('fetchAll');
+        $this->logger->expects(self::never())->method(self::anything());
+
+        self::assertSame('', $this->subject->resolve(self::makeTask('unknown')));
+    }
+
+    #[Test]
+    public function deprecationLogInputDelegatesToReader(): void
+    {
+        $this->deprecationLogReader
+            ->expects(self::once())
+            ->method('readTail')
+            ->willReturn('deprecation-log-content');
+        $this->logger->expects(self::never())->method(self::anything());
+
+        self::assertSame(
+            'deprecation-log-content',
+            $this->subject->resolve(self::makeTask(Task::INPUT_DEPRECATION_LOG)),
+        );
+    }
+
+    #[Test]
+    public function syslogInputFormatsRowsWithoutHittingLogger(): void
+    {
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->with(50, true)
+            ->willReturn([
+                ['tstamp' => 1714521600, 'type' => 1, 'error' => 0, 'details' => 'first'],
+                ['tstamp' => 1714521660, 'type' => 5, 'error' => 1, 'details' => 'second'],
+            ]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+
+        self::assertStringContainsString('first', $output);
+        self::assertStringContainsString('second', $output);
+        // Two rows -> two lines.
+        self::assertCount(2, explode("\n", $output));
+    }
+
+    /**
+     * REC #11b regression guard: when sys_log reading throws, the resolver
+     * (a) emits a `warning` log carrying the full exception, and
+     * (b) returns a localized error string that does NOT contain the
+     *     raw exception message — DBAL error text used to leak into the
+     *     LLM prompt and onward to user-visible task output.
+     */
+    #[Test]
+    public function syslogReadFailureLogsWarningAndReturnsGenericMessage(): void
+    {
+        $sensitive = 'SQLSTATE[42S02]: Base table or view not found: 1146 Table sys_log_secret missing';
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->willThrowException(new RuntimeException($sensitive));
+
+        $this->logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('sys_log read failed'),
+                self::callback(static function (array $context) use ($sensitive): bool {
+                    self::assertArrayHasKey('exception', $context);
+                    self::assertArrayHasKey('taskUid', $context);
+                    self::assertArrayHasKey('limit', $context);
+                    self::assertArrayHasKey('errorOnly', $context);
+                    self::assertSame(50, $context['limit']);
+                    self::assertTrue($context['errorOnly']);
+                    self::assertInstanceOf(RuntimeException::class, $context['exception']);
+                    self::assertSame($sensitive, $context['exception']->getMessage());
+
+                    return true;
+                }),
+            );
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+
+        self::assertStringNotContainsString('SQLSTATE', $output);
+        self::assertStringNotContainsString('sys_log_secret', $output);
+        self::assertStringNotContainsString($sensitive, $output);
+        self::assertSame('Error reading sys_log. See system log for details.', $output);
+    }
+
+    #[Test]
+    public function tableInputReturnsNotConfiguredWhenTableEmpty(): void
+    {
+        $this->recordTableReader->expects(self::never())->method('fetchAll');
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_TABLE, '{"limit":10}'));
+
+        self::assertSame('No table configured.', $output);
+    }
+
+    #[Test]
+    public function tableInputJsonEncodesRowsWithoutHittingLogger(): void
+    {
+        $this->recordTableReader
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with('be_users', 5)
+            ->willReturn([
+                ['uid' => 1, 'username' => 'admin'],
+                ['uid' => 2, 'username' => 'editor'],
+            ]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_TABLE,
+            '{"table":"be_users","limit":5}',
+        ));
+
+        self::assertJson($output);
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertCount(2, $decoded);
+    }
+
+    /**
+     * REC #11b regression guard for the table branch — same contract as
+     * the syslog version: warning logged with full context, generic
+     * localized output, no `$e->getMessage()` leak.
+     */
+    #[Test]
+    public function tableReadFailureLogsWarningAndReturnsGenericMessage(): void
+    {
+        $sensitive = 'SQLSTATE[HY000]: General error: 145 Table./var/lib/mysql/secret_table./broken';
+        $this->recordTableReader
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with('be_users', 50)
+            ->willThrowException(new RuntimeException($sensitive));
+
+        $this->logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('table read failed'),
+                self::callback(static function (array $context) use ($sensitive): bool {
+                    self::assertArrayHasKey('exception', $context);
+                    self::assertSame('be_users', $context['table'] ?? null);
+                    self::assertSame(50, $context['limit'] ?? null);
+                    $exception = $context['exception'];
+                    self::assertInstanceOf(RuntimeException::class, $exception);
+                    self::assertSame($sensitive, $exception->getMessage());
+
+                    return true;
+                }),
+            );
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_TABLE,
+            '{"table":"be_users"}',
+        ));
+
+        self::assertStringNotContainsString('SQLSTATE', $output);
+        self::assertStringNotContainsString('secret_table', $output);
+        self::assertStringNotContainsString($sensitive, $output);
+        self::assertSame('Error reading table. See system log for details.', $output);
+    }
+
+    /**
+     * Picker-policy rejection (table on the exclusion list) goes through
+     * `InvalidArgumentException`. The resolver routes that to an `info`
+     * log (it's a policy decision, not a runtime error) and surfaces the
+     * same generic table-read error to the user.
+     */
+    #[Test]
+    public function tableExcludedByPickerPolicyLogsInfoAndReturnsGenericMessage(): void
+    {
+        $this->recordTableReader
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with('be_groups', 50)
+            ->willThrowException(new InvalidArgumentException("Table 'be_groups' is not allowed for record selection"));
+
+        $this->logger
+            ->expects(self::once())
+            ->method('info')
+            ->with(
+                self::stringContains('rejected by record-picker policy'),
+                self::callback(static function (array $context): bool {
+                    self::assertSame('be_groups', $context['table'] ?? null);
+                    self::assertInstanceOf(InvalidArgumentException::class, $context['exception']);
+
+                    return true;
+                }),
+            );
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_TABLE,
+            '{"table":"be_groups"}',
+        ));
+
+        self::assertSame('Error reading table. See system log for details.', $output);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the deferred follow-up to REC #11 (audit 2026-04-30). The original REC #11 sweep shipped only the OllamaProvider + Provider sites because `TaskInputResolver:59,133` needed a constructor change (no `LoggerInterface` injected) and a test-first refactor (no unit tests existed). This PR ships both.

## Behaviour changes — `Classes/Service/Task/TaskInputResolver.php`

1. **Constructor** adds a `LoggerInterface` parameter (autowired — no `Services.yaml` change).
2. **Two read-failure catch arms** (sys_log read in `resolveSyslog()`, record-table read in `resolveTable()`) now log the full exception via `$this->logger->warning(...)` and return a generic localised "see system log" message instead of the raw `$e->getMessage()`. The previous behaviour leaked DBAL error fragments (table names, column hints, sometimes SQL) into the LLM prompt and onward to user-visible task output.
3. **New typed `catch (InvalidArgumentException)`** in front of the broad Throwable arm in `resolveTable()` — picker-policy exclusion is a policy decision, not a runtime error, so it routes through `$this->logger->info(...)` instead of `warning`. User-facing string is unchanged (same generic message).

## XLIFF

`task.syslog.readError` and `task.table.readError` lost their `: %s` placeholder.

| Key | EN (new) | DE (new) |
|-----|----------|----------|
| `task.syslog.readError` | Error reading sys_log. See system log for details. | Fehler beim Lesen des sys_log. Details siehe Systemlog. |
| `task.table.readError` | Error reading table. See system log for details. | Fehler beim Lesen der Tabelle. Details siehe Systemlog. |

## Test infra

New private `translate()` helper wraps `LocalizationUtility::translate()` in a defensive try/catch — the static method instantiates `LanguageServiceFactory` eagerly and throws outside the framework bootstrap (i.e. in unit tests). The helper falls back to the inline English string on any throw. Production behaviour is unchanged; unit tests get a deterministic fallback.

New `Tests/Unit/Service/Task/TaskInputResolverTest.php` — 8 tests, 64 assertions:

- `unknownInputTypeReturnsEmptyString`
- `deprecationLogInputDelegatesToReader`
- `syslogInputFormatsRowsWithoutHittingLogger`
- **`syslogReadFailureLogsWarningAndReturnsGenericMessage`** — REC #11b regression guard
- `tableInputReturnsNotConfiguredWhenTableEmpty`
- `tableInputJsonEncodesRowsWithoutHittingLogger`
- **`tableReadFailureLogsWarningAndReturnsGenericMessage`** — REC #11b regression guard
- **`tableExcludedByPickerPolicyLogsInfoAndReturnsGenericMessage`** — picker-policy info-log routing

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` → all green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` → SUCCESS
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s architecture` → SUCCESS
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` → SUCCESS
- [ ] CI matrix passes on PHP 8.2/8.3/8.4/8.5 × TYPO3 13.4 / 14.0
- [x] CHANGELOG `[Unreleased]` entry under "Changed" references REC #11b