### PR TITLE
fix(tests): drop CoversClass on coverage-excluded classes (unblocks mutation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mutation testing tool error (audit 2026-04-30, deferred item):**
+  `Build/Scripts/runTests.sh -s mutation` previously errored out
+  partway through Infection's initial test suite phase with an
+  opaque `[ERROR]` and never reached the mutation step. Root cause:
+  three test classes carried `#[CoversClass(...)]` attributes
+  pointing at classes that are excluded from the coverage source
+  in `Build/phpunit.xml` — `MessageRole` (an enum, whole
+  `Classes/Domain/Enum/` directory excluded), `ProviderResponseException`
+  (whole `Classes/Provider/Exception/` excluded), and the
+  `MessageRole` reference on `ChatMessageTest`. PHPUnit 12 raises
+  "Class … is not a valid target for code coverage" warnings for
+  those, and `failOnWarning=true` turns them fatal under
+  `--coverage` runs only — which is what Infection does. Replaced
+  the offending `#[CoversClass]` attributes with `#[CoversNothing]`
+  on `MessageRoleTest` and `ProviderResponseExceptionTest`, and
+  dropped the `#[CoversClass(MessageRole::class)]` line from
+  `ChatMessageTest` (the `#[CoversClass(ChatMessage::class)]`
+  attribution stays). The warnings drop from 39 to 0 under the
+  `unitCoverage` suite; Infection can now run end-to-end. Mirrors
+  the guidance already in `Tests/AGENTS.md`: "use
+  `#[CoversNothing]` for enums/exceptions".
+
 ### Changed
 
 - **REC #11b (audit 2026-04-30, follow-up to REC #11):**

--- a/Tests/Unit/Domain/Enum/MessageRoleTest.php
+++ b/Tests/Unit/Domain/Enum/MessageRoleTest.php
@@ -10,11 +10,20 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
 
 use Netresearch\NrLlm\Domain\Enum\MessageRole;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(MessageRole::class)]
+/**
+ * `MessageRole` is a backed enum and `Classes/Domain/Enum/` is excluded from
+ * the coverage source set in `Build/phpunit.xml` (PHPUnit 12 cannot attribute
+ * coverage to enum classes). The behaviour is still tested below — we just
+ * cannot claim coverage for it via `#[CoversClass]`. Use `#[CoversNothing]`
+ * to silence the "not a valid target for code coverage" warning under
+ * `--coverage` runs (which `failOnWarning=true` would otherwise turn fatal,
+ * breaking Infection's initial test suite).
+ */
+#[CoversNothing]
 final class MessageRoleTest extends TestCase
 {
     #[Test]

--- a/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
+++ b/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
@@ -17,8 +17,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
+// MessageRole is a backed enum and `Classes/Domain/Enum/` is excluded from
+// the coverage source set, so PHPUnit 12 rejects `#[CoversClass(MessageRole::class)]`
+// with a "not a valid target for code coverage" warning. Coverage for
+// `ChatMessage` itself stays attributed below.
 #[CoversClass(ChatMessage::class)]
-#[CoversClass(MessageRole::class)]
 class ChatMessageTest extends AbstractUnitTestCase
 {
     // ──────────────────────────────────────────────

--- a/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
@@ -10,12 +10,23 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Exception;
 
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-#[CoversClass(ProviderResponseException::class)]
+/**
+ * `ProviderResponseException` lives under `Classes/Provider/Exception/` which
+ * is excluded from the coverage source set in `Build/phpunit.xml` (the whole
+ * exception hierarchy carries no logic worth measuring). The behaviour
+ * exercised below — typed properties, legacy constructor signatures,
+ * endpoint sanitisation — is still tested; we just cannot claim coverage
+ * for it via `#[CoversClass]`. Use `#[CoversNothing]` to silence the
+ * "not a valid target for code coverage" warning under `--coverage` runs
+ * (which `failOnWarning=true` would otherwise turn fatal, breaking
+ * Infection's initial test suite).
+ */
+#[CoversNothing]
 final class ProviderResponseExceptionTest extends TestCase
 {
     #[Test]


### PR DESCRIPTION
## Summary

Closes the audit's deferred release-blocker: `runTests.sh -s mutation` previously errored out during Infection's initial test suite phase with an opaque `[ERROR]` and never reached the actual mutation step.

## Root cause

Three test classes carried `#[CoversClass(...)]` attributes pointing at classes that are excluded from the coverage source set in `Build/phpunit.xml`:

| File | Excluded target |
|------|-----------------|
| `Tests/Unit/Domain/Enum/MessageRoleTest.php` | `MessageRole` (whole `Classes/Domain/Enum/` excluded — PHPUnit 12 can't attribute coverage to enums) |
| `Tests/Unit/Domain/ValueObject/ChatMessageTest.php` | `MessageRole` (same) |
| `Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php` | `ProviderResponseException` (whole exception hierarchy excluded — no logic worth measuring) |

Under `--coverage` runs, PHPUnit 12 raises "Class … is not a valid target for code coverage" — 39 such warnings. With `failOnWarning=true` (set in `Build/phpunit.xml`), those turn fatal — which is what kills Infection's initial test phase. Standalone `runTests.sh -s unit` runs without coverage so never sees the warnings, which is why this stayed invisible.

## Fix

- Replace `#[CoversClass(MessageRole::class)]` with `#[CoversNothing]` on `MessageRoleTest`.
- Replace `#[CoversClass(ProviderResponseException::class)]` with `#[CoversNothing]` on `ProviderResponseExceptionTest`.
- Drop the `#[CoversClass(MessageRole::class)]` line from `ChatMessageTest`. The `#[CoversClass(ChatMessage::class)]` attribution stays — only the un-coverable enum target is dropped.

Mirrors the guidance already in `Tests/AGENTS.md`: *"use `#[CoversNothing]` for enums/exceptions"*.

## Verification

| Run | Before | After |
|-----|--------|-------|
| `runTests.sh -p 8.4 -s unitCoverage` | Tests: 3386, Warnings: 39, FAILURE | Tests: 3386, Notices: 9, SUCCESS |
| `runTests.sh -p 8.4 -s mutation` | opaque `[ERROR]` during initial test suite | initial suite passes; mutations now running (verified against current run at ~63 % through 6229 mutations) |

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit` → all green
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unitCoverage` → SUCCESS (was FAILURE)
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s mutation` reaches mutation phase (was crashing in initial suite)
- [ ] CI matrix passes
- [x] CHANGELOG `[Unreleased]` entry under "Fixed" references the audit deferred item

## Audit reference

`claudedocs/audit-2026-04-30-architecture.md` — "Action recommended before next release" section. The note about Infection failing during initial test suite is now resolved.