### PR TITLE
fix(audit-followup): address 4 unresolved review comments on PRs #202/#203

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,21 +14,49 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   opaque `[ERROR]` and never reached the mutation step. Root cause:
   three test classes carried `#[CoversClass(...)]` attributes
   pointing at classes that are excluded from the coverage source
-  in `Build/phpunit.xml` — `MessageRole` (an enum, whole
-  `Classes/Domain/Enum/` directory excluded), `ProviderResponseException`
-  (whole `Classes/Provider/Exception/` excluded), and the
-  `MessageRole` reference on `ChatMessageTest`. PHPUnit 12 raises
-  "Class … is not a valid target for code coverage" warnings for
-  those, and `failOnWarning=true` turns them fatal under
-  `--coverage` runs only — which is what Infection does. Replaced
-  the offending `#[CoversClass]` attributes with `#[CoversNothing]`
-  on `MessageRoleTest` and `ProviderResponseExceptionTest`, and
-  dropped the `#[CoversClass(MessageRole::class)]` line from
-  `ChatMessageTest` (the `#[CoversClass(ChatMessage::class)]`
-  attribution stays). The warnings drop from 39 to 0 under the
-  `unitCoverage` suite; Infection can now run end-to-end. Mirrors
-  the guidance already in `Tests/AGENTS.md`: "use
-  `#[CoversNothing]` for enums/exceptions".
+  in `Build/phpunit.xml` — `MessageRole` (an enum; the whole
+  `Classes/Domain/Enum/` directory is excluded), `ProviderResponseException.php`
+  excluded as a specific file (alongside most other files in
+  `Classes/Provider/Exception/`, but not all — e.g.
+  `FallbackChainExhaustedException.php` is not on the exclude
+  list), and the `MessageRole` reference on `ChatMessageTest`.
+  PHPUnit 12 raises "Class … is not a valid target for code
+  coverage" warnings for those, and `failOnWarning=true` turns
+  them fatal under `--coverage` runs only — which is what
+  Infection does. Replaced the offending `#[CoversClass]`
+  attributes with `#[CoversNothing]` on `MessageRoleTest` and
+  `ProviderResponseExceptionTest`, and dropped the
+  `#[CoversClass(MessageRole::class)]` line from `ChatMessageTest`
+  (the `#[CoversClass(ChatMessage::class)]` attribution stays).
+  The warnings drop from 39 to 0 under the `unitCoverage` suite;
+  Infection can now run end-to-end. Mirrors the guidance already
+  in `Tests/AGENTS.md`: "use `#[CoversNothing]` for
+  enums/exceptions".
+- **Audit-review-followup (audit 2026-04-30):** Four review
+  comments left by Copilot and gemini-code-assist on the
+  audit-merged PRs (#202 and #203) were missed in the merge
+  rush — the merge queue does not gate on review-thread
+  resolution and the threads were not cleared before merge.
+  Addressed in this slice:
+  (a) `TaskInputResolver::resolveTable()` — the comment on the
+  `catch (InvalidArgumentException)` arm previously said the
+  exception text was "safe to surface", which conflicted with
+  the REC #11b contract that error-arm output never surfaces
+  `$e->getMessage()` regardless of type. Comment rewritten to
+  match what the code actually does.
+  (b) `Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php`
+  docblock — clarified that the coverage exclusion is per-file
+  in `Build/phpunit.xml`, not directory-wide
+  (`FallbackChainExhaustedException.php` is in the same directory
+  but is not excluded).
+  (c) `Tests/Unit/Domain/ValueObject/ChatMessageTest.php` — the
+  inline note about why `MessageRole` is no longer attributed
+  via `#[CoversClass]` is now a DocBlock (matches the rest of
+  the test suite), with bare class names rather than path-like
+  syntax.
+  (d) The CHANGELOG entry for the mutation-tool fix above is
+  rewritten not to overstate the directory-wide exclusion.
+  Pure follow-up — no code behaviour change.
 
 ### Changed
 

--- a/Classes/Service/Task/TaskInputResolver.php
+++ b/Classes/Service/Task/TaskInputResolver.php
@@ -140,11 +140,16 @@ final readonly class TaskInputResolver implements TaskInputResolverInterface
         try {
             $rows = $this->recordTableReader->fetchAll($table, $limit);
         } catch (InvalidArgumentException $e) {
-            // Table on the picker exclusion list. The exception text
-            // describes the policy ("Table 'xyz' is not allowed for
-            // record selection"); it doesn't carry user data and is
-            // safe to surface, but we still log so an admin can see
-            // the rejection in the system log.
+            // Table on the picker exclusion list — a policy rejection,
+            // not a runtime error, so route through `info` rather than
+            // `warning`. The user-facing return value is the same generic
+            // "see system log" string the broad arm below produces; the
+            // specific policy reason ("Table 'xyz' is not allowed for
+            // record selection") stays in the log for the admin and is
+            // deliberately NOT surfaced to the LLM input — the REC #11b
+            // contract is that error-arm output never carries
+            // `$e->getMessage()` regardless of the underlying exception
+            // type.
             $this->logger->info('Task table input: table rejected by record-picker policy', [
                 'exception' => $e,
                 'taskUid'   => $task->getUid(),

--- a/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
+++ b/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
@@ -17,10 +17,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-// MessageRole is a backed enum and `Classes/Domain/Enum/` is excluded from
-// the coverage source set, so PHPUnit 12 rejects `#[CoversClass(MessageRole::class)]`
-// with a "not a valid target for code coverage" warning. Coverage for
-// `ChatMessage` itself stays attributed below.
+/**
+ * MessageRole is a backed enum and its directory is excluded from
+ * the coverage source set, so PHPUnit 12 rejects #[CoversClass(MessageRole::class)]
+ * with a "not a valid target for code coverage" warning. Coverage for
+ * ChatMessage itself stays attributed below.
+ */
 #[CoversClass(ChatMessage::class)]
 class ChatMessageTest extends AbstractUnitTestCase
 {

--- a/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php
@@ -16,14 +16,16 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * `ProviderResponseException` lives under `Classes/Provider/Exception/` which
- * is excluded from the coverage source set in `Build/phpunit.xml` (the whole
- * exception hierarchy carries no logic worth measuring). The behaviour
+ * `ProviderResponseException.php` is excluded from the coverage source set
+ * in `Build/phpunit.xml` (along with most other files in
+ * `Classes/Provider/Exception/` — but not all of them: e.g.
+ * `FallbackChainExhaustedException.php` is not on the exclude list, so
+ * the exclusion is per-file, not directory-wide). The behaviour
  * exercised below — typed properties, legacy constructor signatures,
  * endpoint sanitisation — is still tested; we just cannot claim coverage
  * for it via `#[CoversClass]`. Use `#[CoversNothing]` to silence the
- * "not a valid target for code coverage" warning under `--coverage` runs
- * (which `failOnWarning=true` would otherwise turn fatal, breaking
+ * "not a valid target for code coverage" warning under `--coverage`
+ * runs (which `failOnWarning=true` would otherwise turn fatal, breaking
  * Infection's initial test suite).
  */
 #[CoversNothing]


### PR DESCRIPTION
## Summary

Pure follow-up. Copilot and gemini-code-assist left review comments on the audit-follow-up PRs **#202** (REC #11b) and **#203** (mutation tooling) that were not addressed before those PRs merged — the merge queue does not gate on review-thread resolution, and the unresolved-thread state was missed in the merge rush.

This PR resolves all four threads with no code-behaviour change.

## What this addresses

| # | File | Reviewer / comment | Fix |
|---|------|--------------------|-----|
| (a) | `Classes/Service/Task/TaskInputResolver.php` | [Copilot 3173854691](https://github.com/netresearch/t3x-nr-llm/pull/202#discussion_r3173854691) on #202 | Comment claimed the `InvalidArgumentException` text was "safe to surface" — contradicts the REC #11b contract that error-arm output never surfaces `$e->getMessage()`. Comment rewritten to match actual behaviour. |
| (b) | `Tests/Unit/Provider/Exception/ProviderResponseExceptionTest.php` | [Copilot 3173953332](https://github.com/netresearch/t3x-nr-llm/pull/203#discussion_r3173953332) on #203 | Docblock said the "whole `Classes/Provider/Exception/` directory" is excluded. `Build/phpunit.xml` lists specific files; `FallbackChainExhaustedException.php` is NOT excluded. Rephrased to describe per-file exclusion accurately. |
| (c) | `Tests/Unit/Domain/ValueObject/ChatMessageTest.php` | [gemini-code-assist 3173948124](https://github.com/netresearch/t3x-nr-llm/pull/203#discussion_r3173948124) on #203 | Inline `//` comment converted to DocBlock with bare class names instead of path-like syntax. |
| (d) | `CHANGELOG.md` | [Copilot 3173953365](https://github.com/netresearch/t3x-nr-llm/pull/203#discussion_r3173953365) on #203 | Same directory-wide overstatement as (b) in the changelog entry. Rewritten with concrete counterexample. New "Audit-review-followup" entry added documenting this slice. |

## Test plan

- [x] `./Build/Scripts/runTests.sh -p 8.4 -s unit --filter TaskInputResolverTest|ChatMessageTest|ProviderResponseExceptionTest` → 43/43 OK
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s phpstan` → SUCCESS
- [x] `./Build/Scripts/runTests.sh -p 8.4 -s cgl -n` → SUCCESS
- [ ] CI matrix passes
- [ ] **All review threads resolved before merge** — this is the explicit gate the user has flagged three times now

## Merge policy

**This PR will NOT be auto-merged.** Per memory feedback (third correction this round), all PRs must:
1. Receive full Copilot / gemini-code-assist review activity (1–5 min after push).
2. Have every review thread explicitly resolved.
3. Then — and only then — be merged.

After this PR merges, replies on the original threads (3173854691, 3173953332, 3173948124, 3173953365) will reference the fix-commit hash and the threads will be resolved on their original PRs.