### PR TITLE
fix(backend): repair Task module routing after controller split (ADR-027)

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -287,7 +287,7 @@ IMAGE_ALPINE="${IMAGE_PREFIX}alpine:3.20"
 IMAGE_MARIADB="docker.io/mariadb:${DBMS_VERSION}"
 IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"
-IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.57.0-noble"
+IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.60.0-noble"
 
 shift $((OPTIND - 1))
 

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -92,7 +92,8 @@ final class LlmModuleController extends ActionController
             'dbConfigurationCount' => $dbConfigurationCount,
             'dbTaskCount' => $dbTaskCount,
             'taskWizardUrl' => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
-                'tx_nrllm_task[action]' => 'wizardForm',
+                'controller' => 'Backend\\TaskWizard',
+                'action'     => 'wizardForm',
             ]),
         ]);
 

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -93,7 +93,10 @@ final class TaskExecutionController extends ActionController
                 LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.error', 'NrLlm') ?? 'Error',
                 ContextualFeedbackSeverity::ERROR,
             );
-            return new RedirectResponse($this->uriBuilder->reset()->uriFor('list', [], 'TaskList'));
+            return new RedirectResponse($this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
+                'controller' => 'Backend\\TaskList',
+                'action'     => 'list',
+            ]));
         }
 
         $this->pageRenderer->addInlineSettingArray('ajaxUrls', [
@@ -118,8 +121,9 @@ final class TaskExecutionController extends ActionController
 
         // Return URL for FormEngine: back to this specific task's execute form.
         $executeReturnUrl = (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
-            'tx_nrllm_task[action]' => 'executeForm',
-            'tx_nrllm_task[uid]'    => $task->getUid(),
+            'controller' => 'Backend\\TaskExecution',
+            'action'     => 'executeForm',
+            'uid'        => $task->getUid(),
         ]);
 
         // Build edit URLs for the full chain: task → configuration → model → provider.

--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -100,11 +100,20 @@ final class TaskListController extends ActionController
             ->setHref($this->buildNewUrl());
         $buttonBar->addButton($createButton);
 
+        // The wizard action moved to TaskWizardController in the slice 13e
+        // split (ADR-027). Build a module-route URI to it directly; the
+        // controller identifier is the Extbase alias, which for a class in
+        // the Controller\Backend\ namespace resolves to "Backend\TaskWizard"
+        // (see ExtensionUtility::resolveControllerAliasFromControllerClassName).
+        $wizardUrl = (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
+            'controller' => 'Backend\\TaskWizard',
+            'action'     => 'wizardForm',
+        ]);
         $aiButton = $buttonBar->makeLinkButton()
             ->setIcon($this->iconFactory->getIcon('actions-bolt', IconSize::SMALL))
             ->setTitle('Create with AI')
             ->setShowLabelText(true)
-            ->setHref($this->uriBuilder->reset()->uriFor('wizardForm', [], 'TaskWizard'));
+            ->setHref($wizardUrl);
         $buttonBar->addButton($aiButton, ButtonBar::BUTTON_POSITION_LEFT, 2);
 
         return $moduleTemplate->renderResponse('Backend/Task/List');

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -266,12 +266,17 @@ final class TaskWizardController extends ActionController
             // Redirect to the task's execute form (now on TaskExecutionController).
             $taskUid = $task->getUid();
             if ($taskUid !== null) {
-                return new RedirectResponse(
-                    $this->uriBuilder->reset()->uriFor('executeForm', ['uid' => $taskUid], 'TaskExecution'),
-                );
+                return new RedirectResponse($this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
+                    'controller' => 'Backend\\TaskExecution',
+                    'action'     => 'executeForm',
+                    'uid'        => $taskUid,
+                ]));
             }
 
-            return new RedirectResponse($this->uriBuilder->reset()->uriFor('list', [], 'TaskList'));
+            return new RedirectResponse($this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
+                'controller' => 'Backend\\TaskList',
+                'action'     => 'list',
+            ]));
         } catch (Throwable $e) {
             // wizardCreateAction persists Extbase entities through the
             // PersistenceManager. Failure modes are mostly Doctrine /

--- a/Tests/E2E/Playwright/fixtures.ts
+++ b/Tests/E2E/Playwright/fixtures.ts
@@ -151,7 +151,7 @@ async function navigateToConfigWizard(page: Page): Promise<FrameLocator> {
  * Navigate to Task Wizard form.
  */
 async function navigateToTaskWizard(page: Page): Promise<FrameLocator> {
-  await page.goto('/typo3/module/nrllm/tasks?action=wizardForm');
+  await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskWizard&action=wizardForm');
   const moduleFrame = getModuleFrame(page);
   await moduleFrame.getByRole('heading', { level: 1 }).waitFor({ state: 'visible', timeout: 10000 });
   return moduleFrame;

--- a/Tests/E2E/Playwright/fixtures.ts
+++ b/Tests/E2E/Playwright/fixtures.ts
@@ -148,6 +148,18 @@ async function navigateToConfigWizard(page: Page): Promise<FrameLocator> {
 }
 
 /**
+ * Build the URL for a Task Execute form.
+ *
+ * The controller identifier is the Extbase alias; for a class in the
+ * Controller\Backend\ namespace that resolves to "Backend\TaskExecution"
+ * (%5C is the encoded backslash). Centralized so a future controller rename
+ * only touches one place.
+ */
+function taskExecuteFormUrl(uid: number): string {
+  return `/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=${uid}`;
+}
+
+/**
  * Navigate to Task Wizard form.
  */
 async function navigateToTaskWizard(page: Page): Promise<FrameLocator> {
@@ -169,4 +181,5 @@ export {
   navigateToSetupWizard,
   navigateToConfigWizard,
   navigateToTaskWizard,
+  taskExecuteFormUrl,
 };

--- a/Tests/E2E/Playwright/task-execute.spec.ts
+++ b/Tests/E2E/Playwright/task-execute.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, getModuleFrame, navigateToTasks } from './fixtures';
+import { test, expect, getModuleFrame, navigateToTasks, taskExecuteFormUrl } from './fixtures';
+import type { Page, FrameLocator } from '@playwright/test';
 
 /**
  * E2E tests for the Task execution module.
@@ -6,6 +7,34 @@ import { test, expect, getModuleFrame, navigateToTasks } from './fixtures';
  * These tests verify the Task execute form loads correctly and
  * task execution functionality works as expected.
  */
+
+/**
+ * Open the Task execute form for the table-picker fixture task (uid 5) and
+ * return its module frame, or null when the test should bail early — the task
+ * is absent (controller redirects to list) or has no table picker. The
+ * relevant fallback is asserted before returning null.
+ */
+async function openTablePickerForm(page: Page): Promise<FrameLocator | null> {
+  await page.goto(taskExecuteFormUrl(5));
+  const moduleFrame = getModuleFrame(page);
+  await page.waitForTimeout(1000);
+
+  const tablePickerCard = moduleFrame.locator('#tablePickerCard');
+  const taskInput = moduleFrame.locator('#taskInput');
+
+  if ((await tablePickerCard.count()) === 0 && (await taskInput.count()) === 0) {
+    // Redirected to task list because the task doesn't exist.
+    await expect(moduleFrame.getByRole('heading', { level: 1 })).toBeVisible();
+    return null;
+  }
+  if ((await tablePickerCard.count()) === 0) {
+    // Task has no table picker - the plain input textarea is shown instead.
+    await expect(taskInput).toBeVisible();
+    return null;
+  }
+  return moduleFrame;
+}
+
 test.describe('Task Execute Module', () => {
   test.describe('Task List Page', () => {
     test('should load task list page without errors', async ({ authenticatedPage }) => {
@@ -38,7 +67,7 @@ test.describe('Task Execute Module', () => {
       const page = authenticatedPage;
 
       // Navigate directly to execute form for task UID 1
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
 
@@ -54,7 +83,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display input textarea for task execution', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
 
@@ -72,7 +101,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display execute button', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -88,7 +117,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display task details (prompt template preview)', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -103,7 +132,7 @@ test.describe('Task Execute Module', () => {
 
     test('should have loading elements in DOM for execute button', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -143,7 +172,7 @@ test.describe('Task Execute Module', () => {
 
     test('should have output panel with placeholder', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -175,7 +204,7 @@ test.describe('Task Execute Module', () => {
       test.setTimeout(120000); // 2 minute timeout for LLM response
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
+      await page.goto(taskExecuteFormUrl(1));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -234,7 +263,7 @@ test.describe('Task Execute Module', () => {
   test.describe('Table Picker', () => {
     test('should have AJAX URLs available for table loading', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
+      await page.goto(taskExecuteFormUrl(5));
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -275,26 +304,8 @@ test.describe('Task Execute Module', () => {
       });
 
       // Task UID 5 should have manual input type (which shows table picker)
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
-
-      const moduleFrame = getModuleFrame(page);
-      await page.waitForTimeout(1000);
-
-      // Task UID 5 may not exist on fresh installs - controller redirects to list
-      const tablePickerCard = moduleFrame.locator('#tablePickerCard');
-      const taskInput = moduleFrame.locator('#taskInput');
-
-      if (await tablePickerCard.count() === 0 && await taskInput.count() === 0) {
-        // Redirected to task list because task doesn't exist - verify list page loaded
-        const heading = moduleFrame.getByRole('heading', { level: 1 });
-        await expect(heading).toBeVisible();
-        return;
-      }
-
-      // Check if table picker card exists (only for manual input tasks)
-      if (await tablePickerCard.count() === 0) {
-        // Task doesn't have table picker - verify the input textarea is shown instead
-        await expect(taskInput).toBeVisible();
+      const moduleFrame = await openTablePickerForm(page);
+      if (moduleFrame === null) {
         return;
       }
 
@@ -354,25 +365,8 @@ test.describe('Task Execute Module', () => {
     test('should show error notification if table loading fails', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
-
-      const moduleFrame = getModuleFrame(page);
-      await page.waitForTimeout(1000);
-
-      // Task UID 5 may not exist on fresh installs - controller redirects to list
-      const tablePickerCard = moduleFrame.locator('#tablePickerCard');
-      const taskInput = moduleFrame.locator('#taskInput');
-
-      if (await tablePickerCard.count() === 0 && await taskInput.count() === 0) {
-        // Redirected to task list because task doesn't exist - verify list page loaded
-        const heading = moduleFrame.getByRole('heading', { level: 1 });
-        await expect(heading).toBeVisible();
-        return;
-      }
-
-      if (await tablePickerCard.count() === 0) {
-        // Task doesn't have table picker - verify the input textarea is shown instead
-        await expect(taskInput).toBeVisible();
+      const moduleFrame = await openTablePickerForm(page);
+      if (moduleFrame === null) {
         return;
       }
 

--- a/Tests/E2E/Playwright/task-execute.spec.ts
+++ b/Tests/E2E/Playwright/task-execute.spec.ts
@@ -38,7 +38,7 @@ test.describe('Task Execute Module', () => {
       const page = authenticatedPage;
 
       // Navigate directly to execute form for task UID 1
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
 
@@ -54,7 +54,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display input textarea for task execution', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
 
@@ -72,7 +72,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display execute button', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -88,7 +88,7 @@ test.describe('Task Execute Module', () => {
 
     test('should display task details (prompt template preview)', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -103,7 +103,7 @@ test.describe('Task Execute Module', () => {
 
     test('should have loading elements in DOM for execute button', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -143,7 +143,7 @@ test.describe('Task Execute Module', () => {
 
     test('should have output panel with placeholder', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -175,7 +175,7 @@ test.describe('Task Execute Module', () => {
       test.setTimeout(120000); // 2 minute timeout for LLM response
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=1');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=1');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -234,7 +234,7 @@ test.describe('Task Execute Module', () => {
   test.describe('Table Picker', () => {
     test('should have AJAX URLs available for table loading', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=5');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -275,7 +275,7 @@ test.describe('Task Execute Module', () => {
       });
 
       // Task UID 5 should have manual input type (which shows table picker)
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=5');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);
@@ -354,7 +354,7 @@ test.describe('Task Execute Module', () => {
     test('should show error notification if table loading fails', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm/tasks?action=executeForm&uid=5');
+      await page.goto('/typo3/module/nrllm/tasks?controller=Backend%5CTaskExecution&action=executeForm&uid=5');
 
       const moduleFrame = getModuleFrame(page);
       await page.waitForTimeout(1000);


### PR DESCRIPTION
## Summary

The scheduled **E2E Tests** workflow has been failing on `main` since the slice 13e controller split ([ADR-027], commit fd1e8a5) landed on 2026-04-30 — e2e last passed 2026-04-26. The split moved the wizard/execute actions out of the monolithic `TaskController` into `TaskWizardController` / `TaskExecutionController`, which broke two routing paths. Both surfaced as the TYPO3 "Whoops" exception page, which the e2e assertions correctly caught.

### 1. Invalid docheader button on the Tasks list (`#1441706370`)
`TaskListController::listAction()` built the "Create with AI" button href with cross-controller Extbase `uriFor('wizardForm', [], 'TaskWizard')`, which returns an **empty string**. An empty href makes the `LinkButton` invalid, so `ButtonBar::addButton()` threw `InvalidArgumentException #1441706370` and the entire list module rendered the exception page. Now built via `backendUriBuilder->buildUriFromRoute('nrllm_tasks', [controller, action])`.

### 2. `InvalidActionNameException` on direct action URLs (`#1313855175`)
The E2E navigation URLs used bare `?action=wizardForm` / `?action=executeForm` with no controller. TYPO3 reads those directly and dispatches to the **default** controller (`TaskList`), which no longer owns those actions → `#1313855175`. Pre-split this worked because the single `TaskController` owned every action. Added the `controller=` parameter so the URLs reach `TaskWizard` / `TaskExecution`.

Also bumps the local `runTests.sh` Playwright image to `v1.60.0-noble` to match `@playwright/test` (separate commit; CI is unaffected — its e2e workflow installs browsers via `npx playwright install`).

## Verification
- Root cause confirmed from the failed-run Playwright artifacts (exception screenshots show both `#1441706370` and `#1313855175`).
- The authoritative E2E workflow on this PR is the verification — local e2e on the dev machine is unreliable (unrelated modules time out).

[ADR-027]: Documentation/Adr/