### PR TITLE
ci(e2e): run E2E on pull_request and merge_group

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,10 @@
 name: E2E Tests
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * 0'


### PR DESCRIPTION
## Summary
`e2e.yml` only triggered on `workflow_dispatch` and the weekly `schedule`, yet `e2e / E2E` is a **required** status check. Two problems followed:

1. **Regressions went undetected on `main`** until the weekly run — the Task-module routing break ([#209](https://github.com/netresearch/t3x-nr-llm/pull/209)) sat red for ~3 weeks before anyone saw it.
2. **Manual PRs could not transit the merge queue** — the required `e2e / E2E` check never ran on the `merge_group` commit, so PRs stayed `BLOCKED` and had to be admin-merged.

This triggers E2E on the same events as `ci.yml` (`push` to `main`, `pull_request`, `merge_group`). The reusable workflow's `Preflight (event gate)` already dedups `push` vs `merge_group` runs, so this doesn't double-run.

## Effect
- E2E now runs on every PR → regressions caught before merge.
- The merge queue can satisfy `e2e / E2E` on the `merge_group` commit → manual PRs merge through the queue normally (no admin override).

## Verification
- `actionlint` clean; YAML valid.