### PR TITLE
build(deps): require netresearch/nr-vault ^0.6.0

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -42,7 +42,7 @@ Ensure your system meets these requirements:
 - PHP 8.2 or higher.
 - TYPO3 v13.4 or higher.
 - Composer 2.x.
-- :composer:`netresearch/nr-vault` ^0.4.0 (required for
+- :composer:`netresearch/nr-vault` ^0.6.0 (required for
   API key encryption; installed automatically via
   Composer).
 

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
@@ -66,6 +67,11 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
         $persistenceManager = $this->get(PersistenceManagerInterface::class);
         self::assertInstanceOf(PersistenceManagerInterface::class, $persistenceManager);
 
+        // saveAction persists the API key through nr-vault, so the controller
+        // needs the vault service injected as well.
+        $vaultService = $this->get(VaultServiceInterface::class);
+        self::assertInstanceOf(VaultServiceInterface::class, $vaultService);
+
         // Create controller via reflection to inject only AJAX-required dependencies
         // This bypasses initializeAction() which requires Extbase request context
         $this->controller = $this->createControllerWithDependencies(
@@ -76,7 +82,14 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
             $modelRepository,
             $llmConfigurationRepository,
             $persistenceManager,
+            $vaultService,
         );
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        parent::tearDown();
     }
 
     /**
@@ -91,6 +104,7 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
         ModelRepository $modelRepository,
         LlmConfigurationRepository $llmConfigurationRepository,
         PersistenceManagerInterface $persistenceManager,
+        VaultServiceInterface $vaultService,
     ): SetupWizardController {
         $reflection = new ReflectionClass(SetupWizardController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
@@ -103,6 +117,7 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'modelRepository', $modelRepository);
         $this->setPrivateProperty($controller, 'llmConfigurationRepository', $llmConfigurationRepository);
         $this->setPrivateProperty($controller, 'persistenceManager', $persistenceManager);
+        $this->setPrivateProperty($controller, 'vaultService', $vaultService);
 
         return $controller;
     }
@@ -423,6 +438,13 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function saveActionCreatesProviderAndModels(): void
     {
+        // saveAction stores the API key through nr-vault, which since
+        // nr-vault 0.6.0 requires an authorized actor (VaultService::store()
+        // calls canCreate()). The wizard's AJAX save route is backend-only in
+        // production, so set up the authenticated backend user it relies on.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
         $request = new ServerRequest('POST', '/ajax/nrllm/wizard/save');
         $request = $request->withHeader('Content-Type', 'application/json');
         $request = $request->withBody(Utils::streamFor(json_encode([
@@ -467,6 +489,11 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function saveActionCreatesProviderWithConfigurations(): void
     {
+        // Authenticated backend user required for the nr-vault store() call
+        // (see saveActionCreatesProviderAndModels).
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
         $request = new ServerRequest('POST', '/ajax/nrllm/wizard/save');
         $request = $request->withHeader('Content-Type', 'application/json');
         $request = $request->withBody(Utils::streamFor(json_encode([

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.4.0 || ^0.5.0",
+        "netresearch/nr-vault": "^0.6.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
## Description

Bump the `netresearch/nr-vault` constraint from `^0.4.0 || ^0.5.0` to `^0.6.0`
(the chosen "0.6.0 only" policy) and update the installation docs pin.

nr-vault 0.6.0 is a security-hardening release. The one behavioural change that
touches nr-llm: `VaultService::store()` now requires an authorized actor
(`canCreate()`). The wizard's `save` AJAX route is backend-authenticated in
production (no `access: public`), so any authenticated backend user passes —
**no production regression**. The functional test, however, drove `saveAction`
without a backend-user context, so it needed `setUpBackendUser(1)`.

While fixing that, the test surfaced a **pre-existing** defect: the
reflection-built test controller never injected `vaultService` (missing since
the controller gained that constructor parameter), so `saveAction` returned 500
("must not be accessed before initialization") — independent of the vault
version. Both are fixed so `saveAction` actually exercises the `store()` path.

## Related Issue

Supersedes #211 (Renovate): that PR widened to `^0.4.0 || ^0.5.0 || ^0.6.0`
(not the chosen `^0.6.0`) and lacked the required functional-test fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards (cgl clean)
- [x] Verified locally under nr-vault 0.6.0: unit 3386, PHPStan L10, integration 39, `SetupWizardControllerTest` 16 (mariadb) — all green
- [x] Tests prove the fix (the two `saveAction*` cases now pass)
- [x] I have updated the documentation (Installation pin -> ^0.6.0)
- [x] My changes generate no new warnings

## Notes

`^0.6.0` already permits 0.6.1; once nr-vault 0.6.1 (netresearch/t3x-nr-vault#156, the SSRF `allowed_hosts` fix) is published, a follow-up will add the Ollama allowlist docs note.
