### PR TITLE
docs: note allowed_hosts requirement for self-hosted (Ollama) endpoints

### DIFF
--- a/Documentation/Administration/Providers.rst
+++ b/Documentation/Administration/Providers.rst
@@ -85,6 +85,23 @@ and reports:
    Successful connection test for the Local Ollama
    provider.
 
+.. note::
+
+   Self-hosted endpoints (such as Ollama) reached through a hostname
+   that resolves to a private or loopback address are subject to the
+   SSRF protection built into nr-vault's HTTP client. If a connection
+   test fails with a *"disallowed IP range"* error, add the endpoint
+   host to the TYPO3 HTTP allowlist:
+
+   .. code-block:: php
+      :caption: config/system/additional.php
+
+      $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'][] = 'ollama';
+
+   The request-time allowlist is honored by nr-vault 0.6.1 and later.
+   Endpoints given as an IP literal (for example
+   ``http://127.0.0.1:11434``) are not affected.
+
 .. _administration-providers-edit:
 
 Editing and deleting providers


### PR DESCRIPTION
## Description

Adds a note to the provider connection-testing docs: self-hosted endpoints
(e.g. Ollama) reached via a hostname that resolves to a private/loopback IP are
subject to nr-vault's request-time SSRF protection. Operators add the endpoint
host to `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']` (honored by
nr-vault 0.6.1+). IP-literal endpoints are unaffected.

Completes the nr-vault 0.6.x adoption (companion to #212 and
netresearch/t3x-nr-vault#156 / v0.6.1).

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] Documentation only (single `.. note::` in Administration/Providers.rst, page stays well under 250 lines)
- [x] No new warnings
