### PR TITLE
fix: model-test backend-language crash + ddev start build

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -5,9 +5,13 @@
 RUN apt-get update && apt-get install -y php${PHP_VERSION}-pcov && rm -rf /var/lib/apt/lists/*
 
 # Upgrade PHP to latest patch version (get fixes before DDEV updates)
-# Use dist-upgrade to handle dependency changes between versions
+# Use dist-upgrade to handle dependency changes between versions.
+# Run non-interactively and keep DDEV's existing conffiles (e.g.
+# php8.4-fpm.conf) so the build does not stall on a dpkg conffile prompt.
 RUN apt-get update && \
-    apt-get dist-upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
+        -o Dpkg::Options::="--force-confdef" \
+        -o Dpkg::Options::="--force-confold" && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy landing page to web root with correct permissions

--- a/Classes/Service/TestPromptResolverService.php
+++ b/Classes/Service/TestPromptResolverService.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service;
 
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
-use TYPO3\CMS\Core\Context\UserAspect;
 
 /**
  * Resolves the backend test prompt, replacing `{lang}` with the current
@@ -74,36 +74,40 @@ final readonly class TestPromptResolverService implements TestPromptResolverInte
     }
 
     /**
-     * Read the backend user's `uc.lang` preference via the Context API.
+     * Read the authenticated backend user's interface language
+     * (the `be_users.lang` field).
+     *
+     * The Context `backend.user` aspect gates the lookup so non-backend
+     * contexts (CLI, frontend, tests) degrade gracefully. The aspect does not
+     * expose the user record, so the language itself is read from the backend
+     * user object.
      *
      * Returns `'default'` (→ English) when:
      *  - the backend.user aspect is not registered (non-BE context, CLI, tests)
+     *  - no backend user is logged in
      *  - the user has no language preference set
-     *  - the aspect exists but the user is not logged in
      */
     private function resolveBackendUserLanguage(): string
     {
         try {
-            $aspect = $this->context->getAspect('backend.user');
+            $isLoggedIn = (bool)$this->context->getAspect('backend.user')->get('isLoggedIn');
         } catch (AspectNotFoundException) {
             return 'default';
         }
 
-        if (!$aspect instanceof UserAspect) {
+        if (!$isLoggedIn) {
             return 'default';
         }
 
-        $user = $aspect->get('user');
-        if (!is_array($user)) {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
             return 'default';
         }
 
-        $uc = $user['uc'] ?? null;
-        if (!is_array($uc)) {
-            return 'default';
-        }
-
-        $lang = $uc['lang'] ?? null;
+        // BackendUserAuthentication::$user is untyped and may be null until a
+        // session is loaded; guard before the array access.
+        $record = $backendUser->user;
+        $lang = is_array($record) ? ($record['lang'] ?? null) : null;
         return is_string($lang) && $lang !== '' ? $lang : 'default';
     }
 }

--- a/Tests/Unit/Service/TestPromptResolverServiceTest.php
+++ b/Tests/Unit/Service/TestPromptResolverServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Service\TestPromptResolverService;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
+
+#[CoversClass(TestPromptResolverService::class)]
+final class TestPromptResolverServiceTest extends AbstractUnitTestCase
+{
+    private mixed $previousBeUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Regression: a logged-in backend user used to crash the model test with
+     * AspectPropertyNotFoundException because the service read the non-existent
+     * "user" property from the Context UserAspect. The language must now be
+     * read from the backend user record.
+     */
+    #[Test]
+    public function resolveSubstitutesLoggedInBackendUserLanguage(): void
+    {
+        $service = $this->createServiceForBackendUser('Reply in {lang}.', 'de');
+
+        self::assertSame('Reply in German.', $service->resolve());
+    }
+
+    #[Test]
+    public function resolveFallsBackToEnglishWhenBackendUserHasNoLanguage(): void
+    {
+        $service = $this->createServiceForBackendUser('Reply in {lang}.', '');
+
+        self::assertSame('Reply in English.', $service->resolve());
+    }
+
+    #[Test]
+    public function resolveFallsBackToEnglishOutsideBackendContext(): void
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['testing' => ['testPrompt' => 'Reply in {lang}.']]);
+
+        // A Context without a backend.user aspect (CLI, frontend, tests).
+        $service = new TestPromptResolverService($extensionConfiguration, new Context());
+
+        self::assertSame('Reply in English.', $service->resolve());
+    }
+
+    private function createServiceForBackendUser(string $prompt, string $language): TestPromptResolverService
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['testing' => ['testPrompt' => $prompt]]);
+
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'lang' => $language];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $context = new Context();
+        $context->setAspect('backend.user', new UserAspect($backendUser));
+
+        return new TestPromptResolverService($extensionConfiguration, $context);
+    }
+}


### PR DESCRIPTION
## Description

Two fixes found while bringing up the local DDEV instance to review the nr-vault 0.6.x upgrade.

**1. Model test crashed for any logged-in backend user.**
`ModelController::testModelAction` failed instantly ("Failed after 0s") with
`AspectPropertyNotFoundException: Property "user" not found in Aspect "UserAspect"`.
`TestPromptResolverService` read a non-existent `user` property off the Context
`UserAspect`, and the call sat *outside* the `try/catch`, so it surfaced as an
unexpected error. Fixed by gating on the `backend.user` aspect (graceful default
for CLI/frontend/tests) and reading the interface language from the authenticated
backend user record (`$GLOBALS['BE_USER']->user['lang']`) — the source the class
docblock already referenced. Adds a regression test that reproduces the crash on
the old code.

**2. `ddev start` web image build failed.**
`apt-get dist-upgrade` hit an interactive dpkg conffile prompt (e.g.
`php8.4-fpm.conf`) and aborted in the non-interactive build with
"Sub-process /usr/bin/dpkg returned an error code (1)". Fixed with
`DEBIAN_FRONTEND=noninteractive` + `--force-confdef`/`--force-confold` so dpkg
keeps DDEV's existing conffiles.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] My code follows the project's coding standards (cgl clean)
- [x] Verified locally: unit (new `TestPromptResolverServiceTest` passes; **fails on old code** with the exact crash), PHPStan level 10 clean, cgl clean
- [x] I have added tests that prove my fix works
- [x] My changes generate no new warnings
