### PR TITLE
fix(deps): require TYPO3 14.3 LTS instead of 14.0 sprint releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,15 +36,15 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",
-        "typo3/cms-core": "^13.4 || ^14.0"
+        "typo3/cms-core": "^13.4 || ^14.3"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",
         "fakerphp/faker": "^1.24",
         "giorgiosironi/eris": "^1.0",
         "netresearch/typo3-ci-workflows": "^1.2",
-        "typo3/cms-dashboard": "^13.4 || ^14.0",
-        "typo3/cms-install": "^13.4 || ^14.0"
+        "typo3/cms-dashboard": "^13.4 || ^14.3",
+        "typo3/cms-install": "^13.4 || ^14.3"
     },
     "suggest": {
         "typo3/cms-dashboard": "Adds AI usage / cost widgets to the TYPO3 dashboard"


### PR DESCRIPTION
## Description

TYPO3 **14.3 is the v14 LTS** (released 2026-04-21); 14.0/14.1/14.2 were sprint
releases that are now end-of-life. The `^14.0` constraint claimed support for
those dead releases. This narrows the v14 range to `^14.3` for `cms-core`,
`cms-dashboard`, and `cms-install`.

No behaviour change: `^14.0` already resolved to the highest available 14.x
(14.3.x), so the installed versions are identical — this corrects the *declared*
support window. `^13.4` (the v13 LTS) is unchanged.

## Type of Change
- [x] Bug fix (corrects declared dependency support)

## Notes
- `ext_emconf.php` keeps `13.4.0-14.99.99`: a single min–max range can't express
  the "13.4 **or** 14.3+" gap, so it stays as the loose TER-facing constraint
  (composer.json is the precise one).
- The CI matrix label `["^13.4","^14.0"]` is intentionally left unchanged — it
  already resolves to 14.3.x, and renaming it to `^14.3` would rename the
  required check contexts and stall the merge-queue ruleset. A coordinated
  matrix + ruleset rename can follow separately if you want the labels aligned.

## Checklist
- [x] composer.json valid + normalized
- [x] No behaviour change (identical resolved versions)
