### PR TITLE
docs: state TYPO3 v13.4 / v14.3 LTS support

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -40,7 +40,7 @@ Requirements
 Ensure your system meets these requirements:
 
 - PHP 8.2 or higher.
-- TYPO3 v13.4 or higher.
+- TYPO3 v13.4 LTS or v14.3 LTS.
 - Composer 2.x.
 - :composer:`netresearch/nr-vault` ^0.6.0 (required for
   API key encryption; installed automatically via

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -250,7 +250,7 @@ Requirements
 ============
 
 - **PHP**: 8.2 or higher.
-- **TYPO3**: v13.4 or higher.
+- **TYPO3**: v13.4 LTS or v14.3 LTS.
 - **HTTP client**: PSR-18 compatible (e.g., :composer:`guzzlehttp/guzzle`).
 
 .. _introduction-provider-requirements:

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The three-tier configuration hierarchy separates concerns cleanly:
 ## Requirements
 
 - PHP 8.2+
-- TYPO3 v13.4+ or v14.x
+- TYPO3 v13.4 LTS or v14.3 LTS
 - PSR-18 HTTP Client (e.g., guzzlehttp/guzzle)
 
 ## Installation


### PR DESCRIPTION
## Description

Follow-up to #215 (which narrowed the composer constraint to TYPO3 `^14.3`).
Aligns the user-facing requirement statements with that constraint — 14.0/14.1/14.2
are end-of-life sprint releases, so the docs now name the supported **LTS** versions:

- `README.md` requirements: "v13.4+ or v14.x" → "v13.4 LTS or v14.3 LTS"
- `Documentation/Installation/Index.rst`: "v13.4 or higher" → "v13.4 LTS or v14.3 LTS"
- `Documentation/Introduction/Index.rst`: same

(Left as-is: the README "v13.4+" minimum badge, and the `CiConfiguration.rst` /
`IntegrationGuide.rst` snippets that mirror the still-`^14.0` CI matrix + loose
ext_emconf range — consistent with what they document.)

## Type of Change
- [x] Documentation update
