### PR TITLE
feat(image): support gpt-image-* models; fix OpenAI JSON mode and base-URL fallback

### DIFF
--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -111,6 +111,11 @@ final class OpenAiProvider extends AbstractProvider implements
             ...$this->buildSamplingParams($model, $options),
         ];
 
+        $responseFormat = $this->buildResponseFormat($options);
+        if ($responseFormat !== null) {
+            $payload['response_format'] = $responseFormat;
+        }
+
         if (isset($options['stop'])) {
             $payload['stop'] = $options['stop'];
         }
@@ -158,6 +163,11 @@ final class OpenAiProvider extends AbstractProvider implements
             'max_completion_tokens' => $this->getInt($options, 'max_tokens', 4096),
             ...$this->buildSamplingParams($model, $options),
         ];
+
+        $responseFormat = $this->buildResponseFormat($options);
+        if ($responseFormat !== null) {
+            $payload['response_format'] = $responseFormat;
+        }
 
         if (isset($options['tool_choice'])) {
             $payload['tool_choice'] = $options['tool_choice'];
@@ -394,6 +404,28 @@ final class OpenAiProvider extends AbstractProvider implements
     private function isReasoningModel(string $model): bool
     {
         return (bool)preg_match('/^(o[1-9]|gpt-5)/', $model);
+    }
+
+    /**
+     * Map the high-level `response_format` option to OpenAI's payload field.
+     *
+     * `completeJson()` requests `'json'` and then strictly `json_decode`s the
+     * reply, so the request MUST carry `response_format: {type: json_object}`
+     * — otherwise the model is free to wrap the JSON in prose/Markdown fences
+     * and the decode throws "Failed to decode JSON response". OpenAI's JSON
+     * mode requires the word "json" somewhere in the messages, which the
+     * callers (e.g. nr_repurpose's DocumentAnalyzer) already guarantee. `text`
+     * and `markdown` map to plain text, so we leave the field unset.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array{type: string}|null
+     */
+    private function buildResponseFormat(array $options): ?array
+    {
+        return $this->getString($options, 'response_format') === 'json'
+            ? ['type' => 'json_object']
+            : null;
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -74,6 +74,16 @@ abstract class AbstractSpecializedService
     }
 
     /**
+     * Resolve a configured value to a non-empty string, falling back to a default. An empty
+     * ext_conf base-URL string (the documented "use the provider default" value) must not be
+     * used verbatim — a scheme-less URL makes the HTTP client fail — so empty falls back here.
+     */
+    protected function nonEmptyStringOrDefault(mixed $value, string $default): string
+    {
+        return is_string($value) && $value !== '' ? $value : $default;
+    }
+
+    /**
      * Service domain used by `ServiceUnavailableException` /
      * `ServiceConfigurationException` (`'image'`, `'speech'`,
      * `'translation'`, …) so log sinks and downstream catches can

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -354,10 +354,9 @@ final class DallEImageService extends AbstractSpecializedService
         $timeout = $this->resolveScalarConfig($config, ['image', 'dalle', 'timeout']);
 
         $this->apiKey  = is_string($apiKey) ? $apiKey : '';
-        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
-        // NOT "send requests to an empty URL" — guarding on '' avoids a Guzzle
-        // "scheme \"\" is not allowed" failure on a stock install.
-        $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
+        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label), NOT
+        // "send requests to an empty URL" — see nonEmptyStringOrDefault().
+        $this->baseUrl = $this->nonEmptyStringOrDefault($baseUrl, self::API_URL);
         $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
     }
 
@@ -496,10 +495,11 @@ final class DallEImageService extends AbstractSpecializedService
             'size' => $options['size'] ?? self::DEFAULT_SIZE,
         ];
 
-        // `response_format` (url|b64_json) is a dall-e-2-only parameter. dall-e-3 rejects it
-        // with "Unknown parameter: 'response_format'" and defaults to returning a URL, so we
-        // only send it for dall-e-2. (gpt-image-1 likewise omits it and always returns b64.)
-        if ($model === 'dall-e-2') {
+        // `response_format` (url|b64_json) is a DALL·E parameter that selects URL vs base64
+        // output; both dall-e-2 and dall-e-3 accept it. The gpt-image-* family rejects it
+        // ("Unknown parameter") and always returns b64_json, so send it for DALL·E models and
+        // omit it only for gpt-image-*.
+        if (!is_string($model) || !str_starts_with($model, 'gpt-image-')) {
             $payload['response_format'] = $options['response_format'] ?? 'url';
         }
 

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -55,6 +55,16 @@ final class DallEImageService extends AbstractSpecializedService
             'supports_editing' => false,
             'supports_variations' => false,
         ],
+        // OpenAI's gpt-image-* family replaced DALL·E. It accepts neither `response_format`
+        // nor `style`/`quality:standard|hd`, always returns b64_json, and uses its own size set.
+        'gpt-image-1' => [
+            'sizes' => ['1024x1024', '1536x1024', '1024x1536', 'auto'],
+            'max_prompt_length' => 32000,
+            'supports_quality' => false,
+            'supports_style' => false,
+            'supports_editing' => true,
+            'supports_variations' => false,
+        ],
     ];
 
     /**
@@ -344,7 +354,10 @@ final class DallEImageService extends AbstractSpecializedService
         $timeout = $this->resolveScalarConfig($config, ['image', 'dalle', 'timeout']);
 
         $this->apiKey  = is_string($apiKey) ? $apiKey : '';
-        $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
+        // NOT "send requests to an empty URL" — guarding on '' avoids a Guzzle
+        // "scheme \"\" is not allowed" failure on a stock install.
+        $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
         $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
     }
 
@@ -470,8 +483,14 @@ final class DallEImageService extends AbstractSpecializedService
             'prompt' => $prompt,
             'n' => 1,
             'size' => $options['size'] ?? self::DEFAULT_SIZE,
-            'response_format' => $options['response_format'] ?? 'url',
         ];
+
+        // `response_format` (url|b64_json) is a dall-e-2-only parameter. dall-e-3 rejects it
+        // with "Unknown parameter: 'response_format'" and defaults to returning a URL, so we
+        // only send it for dall-e-2. (gpt-image-1 likewise omits it and always returns b64.)
+        if ($model === 'dall-e-2') {
+            $payload['response_format'] = $options['response_format'] ?? 'url';
+        }
 
         // DALL-E 3 specific options
         if ($model === 'dall-e-3') {

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -316,7 +316,7 @@ final class DallEImageService extends AbstractSpecializedService
      */
     public function getSupportedSizes(string $model = 'dall-e-3'): array
     {
-        return self::MODEL_CAPABILITIES[$model]['sizes'] ?? ['1024x1024'];
+        return self::MODEL_CAPABILITIES[$this->capabilityKey($model)]['sizes'] ?? ['1024x1024'];
     }
 
     protected function getServiceDomain(): string
@@ -408,6 +408,17 @@ final class DallEImageService extends AbstractSpecializedService
     }
 
     /**
+     * Resolve a model id to its MODEL_CAPABILITIES key. The whole gpt-image-* family
+     * (gpt-image-1, -mini, -1.5, -2, …) shares one capability profile keyed under
+     * 'gpt-image-1'; without this, prefix-matched variants would miss the table and fall
+     * back to DALL·E defaults (4000 chars, 1024x1024 only).
+     */
+    private function capabilityKey(string $model): string
+    {
+        return str_starts_with($model, 'gpt-image-') ? 'gpt-image-1' : $model;
+    }
+
+    /**
      * Validate prompt for model.
      *
      * @throws ServiceUnavailableException
@@ -422,7 +433,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $maxLength = self::MODEL_CAPABILITIES[$model]['max_prompt_length'] ?? 4000;
+        $maxLength = self::MODEL_CAPABILITIES[$this->capabilityKey($model)]['max_prompt_length'] ?? 4000;
 
         if (mb_strlen($prompt) > $maxLength) {
             throw new ServiceUnavailableException(

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -258,7 +258,9 @@ final class FalImageService extends AbstractSpecializedService
         $this->apiKey = is_string($apiKey) ? $apiKey : '';
 
         $baseUrl = $falConfig['baseUrl'] ?? self::API_URL;
-        $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+        // Empty ext_conf baseUrl means "use the default" (per the field label), not an
+        // empty request URL — guard on '' to avoid a Guzzle scheme failure on stock installs.
+        $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
 
         $timeout = $falConfig['timeout'] ?? $this->getDefaultTimeout();
         $this->timeout = is_int($timeout) ? $timeout : (is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout());

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -257,10 +257,9 @@ final class FalImageService extends AbstractSpecializedService
         $apiKey = $falConfig['apiKey'] ?? '';
         $this->apiKey = is_string($apiKey) ? $apiKey : '';
 
-        $baseUrl = $falConfig['baseUrl'] ?? self::API_URL;
-        // Empty ext_conf baseUrl means "use the default" (per the field label), not an
-        // empty request URL — guard on '' to avoid a Guzzle scheme failure on stock installs.
-        $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
+        // Empty ext_conf baseUrl means "use the default" (per the field label), not an empty
+        // request URL — see nonEmptyStringOrDefault().
+        $this->baseUrl = $this->nonEmptyStringOrDefault($falConfig['baseUrl'] ?? null, self::API_URL);
 
         $timeout = $falConfig['timeout'] ?? $this->getDefaultTimeout();
         $this->timeout = is_int($timeout) ? $timeout : (is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout());

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Option;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Option\AbstractOptions;
 
 /**
@@ -23,6 +23,11 @@ final class ImageGenerationOptions extends AbstractOptions
     private const VALID_FORMATS = ['url', 'b64_json'];
     private const VALID_SIZES_DALLE3 = ['1024x1024', '1792x1024', '1024x1792'];
     private const VALID_SIZES_DALLE2 = ['256x256', '512x512', '1024x1024'];
+    // OpenAI's gpt-image-* family (gpt-image-1, -mini, -1.5, -2, …) replaced DALL·E. It exposes
+    // a different square/landscape/portrait size set and always returns b64_json; `response_format`
+    // and `style` are not accepted (the service omits them for non-DALL·E models).
+    private const VALID_SIZES_GPT_IMAGE = ['1024x1024', '1536x1024', '1024x1536', 'auto'];
+    private const GPT_IMAGE_PREFIX = 'gpt-image';
 
     public function __construct(
         public readonly ?string $model = 'dall-e-3',
@@ -32,7 +37,7 @@ final class ImageGenerationOptions extends AbstractOptions
         public readonly ?string $format = 'url',
     ) {
         if ($this->model !== null) {
-            self::validateEnum($this->model, self::VALID_MODELS, 'model');
+            $this->validateModel($this->model);
         }
         if ($this->quality !== null) {
             self::validateEnum($this->quality, self::VALID_QUALITIES, 'quality');
@@ -46,15 +51,39 @@ final class ImageGenerationOptions extends AbstractOptions
         $this->validateSize();
     }
 
+    /**
+     * Accept the two DALL·E models plus any member of the gpt-image-* family (resolved by
+     * prefix so new point releases like gpt-image-2-2026-04-21 need no code change).
+     */
+    private function validateModel(string $model): void
+    {
+        if (in_array($model, self::VALID_MODELS, true) || str_starts_with($model, self::GPT_IMAGE_PREFIX)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf(
+                'model must be one of: %s, or a gpt-image-* model, got "%s"',
+                implode(', ', self::VALID_MODELS),
+                $model,
+            ),
+            8287317141,
+        );
+    }
+
     private function validateSize(): void
     {
         if ($this->size === null) {
             return;
         }
 
-        $validSizes = $this->model === 'dall-e-2'
-            ? self::VALID_SIZES_DALLE2
-            : self::VALID_SIZES_DALLE3;
+        if ($this->model !== null && str_starts_with($this->model, self::GPT_IMAGE_PREFIX)) {
+            $validSizes = self::VALID_SIZES_GPT_IMAGE;
+        } elseif ($this->model === 'dall-e-2') {
+            $validSizes = self::VALID_SIZES_DALLE2;
+        } else {
+            $validSizes = self::VALID_SIZES_DALLE3;
+        }
 
         if (!in_array($this->size, $validSizes, true)) {
             throw new InvalidArgumentException(
@@ -139,6 +168,10 @@ final class ImageGenerationOptions extends AbstractOptions
      */
     public static function getValidSizes(string $model = 'dall-e-3'): array
     {
+        if (str_starts_with($model, self::GPT_IMAGE_PREFIX)) {
+            return self::VALID_SIZES_GPT_IMAGE;
+        }
+
         return $model === 'dall-e-2' ? self::VALID_SIZES_DALLE2 : self::VALID_SIZES_DALLE3;
     }
 }

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -27,7 +27,7 @@ final class ImageGenerationOptions extends AbstractOptions
     // a different square/landscape/portrait size set and always returns b64_json; `response_format`
     // and `style` are not accepted (the service omits them for non-DALL·E models).
     private const VALID_SIZES_GPT_IMAGE = ['1024x1024', '1536x1024', '1024x1536', 'auto'];
-    private const GPT_IMAGE_PREFIX = 'gpt-image';
+    private const GPT_IMAGE_PREFIX = 'gpt-image-';
 
     public function __construct(
         public readonly ?string $model = 'dall-e-3',

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -258,10 +258,9 @@ final class TextToSpeechService extends AbstractSpecializedService
         if (is_array($speech)) {
             $tts = $speech['tts'] ?? null;
             if (is_array($tts)) {
-                $baseUrl = $tts['baseUrl'] ?? null;
                 // Empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
-                // not an empty request URL — guard on '' to avoid a Guzzle scheme failure.
-                $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
+                // not an empty request URL — see nonEmptyStringOrDefault().
+                $this->baseUrl = $this->nonEmptyStringOrDefault($tts['baseUrl'] ?? null, self::API_URL);
                 $timeout = $tts['timeout'] ?? null;
                 $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
             }

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -259,7 +259,9 @@ final class TextToSpeechService extends AbstractSpecializedService
             $tts = $speech['tts'] ?? null;
             if (is_array($tts)) {
                 $baseUrl = $tts['baseUrl'] ?? null;
-                $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::API_URL;
+                // Empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
+                // not an empty request URL — guard on '' to avoid a Guzzle scheme failure.
+                $this->baseUrl = (is_string($baseUrl) && $baseUrl !== '') ? $baseUrl : self::API_URL;
                 $timeout = $tts['timeout'] ?? null;
                 $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
             }

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(OpenAiProvider::class)]
@@ -189,6 +190,83 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $result = $this->subject->chatCompletion($messages);
 
         self::assertEquals('Hi', $result->content);
+    }
+
+    #[Test]
+    public function chatCompletionMapsJsonResponseFormatToJsonObject(): void
+    {
+        $payload = $this->captureChatCompletionPayload(['response_format' => 'json']);
+
+        self::assertArrayHasKey('response_format', $payload);
+        self::assertSame(['type' => 'json_object'], $payload['response_format']);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsResponseFormatForTextAndWhenUnset(): void
+    {
+        self::assertArrayNotHasKey(
+            'response_format',
+            $this->captureChatCompletionPayload(['response_format' => 'text']),
+        );
+        self::assertArrayNotHasKey(
+            'response_format',
+            $this->captureChatCompletionPayload([]),
+        );
+    }
+
+    /**
+     * Run chatCompletion with the given options and return the JSON request body the
+     * provider hands to the stream factory, so payload shaping can be asserted directly.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function captureChatCompletionPayload(array $options): array
+    {
+        $captured = null;
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$captured): StreamInterface {
+                $captured = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $subject = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+
+        $httpClientStub = $this->createHttpClientMock();
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'id' => 'chatcmpl-test',
+            'choices' => [['message' => ['content' => '{}'], 'finish_reason' => 'stop']],
+            'model' => 'gpt-4o',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]));
+        $subject->setHttpClient($httpClientStub);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'reply in json']], $options);
+
+        self::assertIsString($captured);
+        $decoded = json_decode($captured, true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -375,6 +375,108 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function generateWithGptImageModelSendsMinimalPayload(): void
+    {
+        // gpt-image-* reject response_format/style/quality and return b64_json; the request
+        // payload must therefore carry only model/prompt/n/size.
+        $captured = $this->captureGeneratePayload(
+            ['data' => [['b64_json' => base64_encode('img')]]],
+            new ImageGenerationOptions(model: 'gpt-image-1', size: '1536x1024'),
+        );
+
+        self::assertSame('gpt-image-1', $captured['payload']['model']);
+        self::assertSame('1536x1024', $captured['payload']['size']);
+        self::assertArrayNotHasKey('response_format', $captured['payload']);
+        self::assertArrayNotHasKey('style', $captured['payload']);
+        self::assertArrayNotHasKey('quality', $captured['payload']);
+        self::assertInstanceOf(ImageGenerationResult::class, $captured['result']);
+    }
+
+    #[Test]
+    public function generateFallsBackToDefaultUrlWhenConfiguredBaseUrlIsEmpty(): void
+    {
+        // The ext_conf default for image.dalle.baseUrl is an empty string meaning "use the
+        // OpenAI default" — it must NOT be sent as the (scheme-less) request URL.
+        $capturedUrl = null;
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturnCallback(
+            function (string $method, string $url) use (&$capturedUrl, $requestStub): RequestInterface {
+                $capturedUrl = $url;
+                return $requestStub;
+            },
+        );
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturn($streamStub);
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode(['data' => [['url' => 'x']]]));
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+        $this->httpClientStub->method('sendRequest')->willReturn($responseStub);
+
+        $subject = $this->createSubject(['image' => ['dalle' => ['baseUrl' => '']]]);
+        $subject->generate('x', new ImageGenerationOptions(model: 'gpt-image-1', size: '1024x1024'));
+
+        self::assertIsString($capturedUrl);
+        self::assertStringStartsWith('https://api.openai.com/v1/images', $capturedUrl);
+    }
+
+    #[Test]
+    public function generateWithDalle2StillSendsResponseFormat(): void
+    {
+        // response_format is a dall-e-2 parameter and must still be sent for that model.
+        $captured = $this->captureGeneratePayload(
+            ['data' => [['url' => 'https://example.com/i.png']]],
+            new ImageGenerationOptions(model: 'dall-e-2', size: '1024x1024'),
+        );
+
+        self::assertSame('dall-e-2', $captured['payload']['model']);
+        self::assertSame('url', $captured['payload']['response_format']);
+    }
+
+    /**
+     * Run generate() while recording the JSON request body the service builds.
+     *
+     * @param array<string, mixed> $responseData
+     *
+     * @return array{payload: array<string, mixed>, result: ImageGenerationResult}
+     */
+    private function captureGeneratePayload(array $responseData, ImageGenerationOptions $options): array
+    {
+        $captured = null;
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturnCallback(
+            function (string $json) use (&$captured, $streamStub): StreamInterface {
+                $captured = $json;
+                return $streamStub;
+            },
+        );
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode($responseData));
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+        $this->httpClientStub->method('sendRequest')->willReturn($responseStub);
+
+        $result = $this->createSubject()->generate('A test prompt', $options);
+
+        self::assertIsString($captured);
+        $payload = json_decode($captured, true);
+        self::assertIsArray($payload);
+
+        /** @var array<string, mixed> $payload */
+        return ['payload' => $payload, 'result' => $result];
+    }
+
+    #[Test]
     public function generateWithBase64Response(): void
     {
         $subject = $this->createSubject();

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -430,8 +430,10 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $requestStub->method('withHeader')->willReturnSelf();
         $requestStub->method('withBody')->willReturnSelf();
         $this->requestFactoryStub->method('createRequest')->willReturnCallback(
-            function (string $method, string $url) use (&$capturedUrl, $requestStub): RequestInterface {
-                $capturedUrl = $url;
+            function () use (&$capturedUrl, $requestStub): RequestInterface {
+                // createRequest($method, $url) — capture the URL (the second positional argument).
+                $args = func_get_args();
+                $capturedUrl = is_string($args[1] ?? null) ? $args[1] : '';
                 return $requestStub;
             },
         );
@@ -452,16 +454,29 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function generateWithDalle2StillSendsResponseFormat(): void
+    #[DataProvider('dalleModelProvider')]
+    public function generateSendsResponseFormatForDalleModels(string $model): void
     {
-        // response_format is a dall-e-2 parameter and must still be sent for that model.
+        // response_format (url|b64_json) is accepted by BOTH dall-e-2 and dall-e-3 and must be
+        // sent for them — only gpt-image-* omits it.
         $captured = $this->captureGeneratePayload(
             ['data' => [['url' => 'https://example.com/i.png']]],
-            new ImageGenerationOptions(model: 'dall-e-2', size: '1024x1024'),
+            new ImageGenerationOptions(model: $model, size: '1024x1024'),
         );
 
-        self::assertSame('dall-e-2', $captured['payload']['model']);
+        self::assertSame($model, $captured['payload']['model']);
         self::assertSame('url', $captured['payload']['response_format']);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function dalleModelProvider(): array
+    {
+        return [
+            'dall-e-2' => ['dall-e-2'],
+            'dall-e-3' => ['dall-e-3'],
+        ];
     }
 
     /**

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
@@ -232,6 +233,33 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         self::assertContains('256x256', $sizes);
         self::assertContains('512x512', $sizes);
         self::assertContains('1024x1024', $sizes);
+    }
+
+    #[Test]
+    #[DataProvider('gptImageVariantProvider')]
+    public function getSupportedSizesResolvesGptImageFamilyToSharedCapabilities(string $model): void
+    {
+        $subject = $this->createSubject();
+
+        // Every gpt-image-* variant shares the gpt-image-1 capability profile rather than
+        // silently falling back to the DALL·E default size set.
+        $sizes = $subject->getSupportedSizes($model);
+
+        self::assertContains('1536x1024', $sizes);
+        self::assertContains('1024x1536', $sizes);
+        self::assertNotContains('1792x1024', $sizes);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function gptImageVariantProvider(): array
+    {
+        return [
+            'gpt-image-1' => ['gpt-image-1'],
+            'gpt-image-1-mini' => ['gpt-image-1-mini'],
+            'gpt-image-2' => ['gpt-image-2'],
+        ];
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -226,6 +226,71 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    #[DataProvider('gptImageModelProvider')]
+    public function constructorAcceptsGptImageModelsByPrefix(string $model): void
+    {
+        // gpt-image-* models are accepted by prefix so future point releases need no code change.
+        $options = new ImageGenerationOptions(model: $model, size: '1024x1024');
+
+        self::assertEquals($model, $options->model);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function gptImageModelProvider(): array
+    {
+        return [
+            'gpt-image-1' => ['gpt-image-1'],
+            'gpt-image-1-mini' => ['gpt-image-1-mini'],
+            'gpt-image-2' => ['gpt-image-2'],
+            'dated point release' => ['gpt-image-2-2026-04-21'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('validGptImageSizeProvider')]
+    public function constructorAcceptsValidGptImageSizes(string $size): void
+    {
+        $options = new ImageGenerationOptions(model: 'gpt-image-1', size: $size);
+
+        self::assertEquals($size, $options->size);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function validGptImageSizeProvider(): array
+    {
+        return [
+            '1024x1024' => ['1024x1024'],
+            '1536x1024' => ['1536x1024'],
+            '1024x1536' => ['1024x1536'],
+            'auto' => ['auto'],
+        ];
+    }
+
+    #[Test]
+    public function constructorThrowsForDalleSizeOnGptImageModel(): void
+    {
+        // DALL·E-3's 1792x1024 is not a valid gpt-image size.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid size');
+
+        new ImageGenerationOptions(model: 'gpt-image-1', size: '1792x1024');
+    }
+
+    #[Test]
+    public function getValidSizesReturnsGptImageSizes(): void
+    {
+        $sizes = ImageGenerationOptions::getValidSizes('gpt-image-1');
+
+        self::assertContains('1536x1024', $sizes);
+        self::assertContains('1024x1536', $sizes);
+        self::assertNotContains('1792x1024', $sizes);
+    }
+
+    #[Test]
     public function toArrayIncludesAllOptions(): void
     {
         $options = new ImageGenerationOptions(

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -256,7 +256,8 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('model must be one of');
 
-        new ImageGenerationOptions(model: $model);
+        $options = new ImageGenerationOptions(model: $model);
+        self::fail('Expected the constructor to reject model: ' . $options->model);
     }
 
     /**
@@ -300,7 +301,8 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid size');
 
-        new ImageGenerationOptions(model: 'gpt-image-1', size: '1792x1024');
+        $options = new ImageGenerationOptions(model: 'gpt-image-1', size: '1792x1024');
+        self::fail('Expected the constructor to reject size, got: ' . $options->size);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -249,6 +249,29 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    #[DataProvider('gptImageLookalikeProvider')]
+    public function constructorRejectsGptImageLookalikesWithoutTrailingDash(string $model): void
+    {
+        // The prefix is strict ("gpt-image-"), so near-misses without the dash are not the family.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('model must be one of');
+
+        new ImageGenerationOptions(model: $model);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function gptImageLookalikeProvider(): array
+    {
+        return [
+            'gpt-imagery' => ['gpt-imagery'],
+            'gpt-imageX' => ['gpt-imageX'],
+            'gpt-image' => ['gpt-image'],
+        ];
+    }
+
+    #[Test]
     #[DataProvider('validGptImageSizeProvider')]
     public function constructorAcceptsValidGptImageSizes(string $size): void
     {


### PR DESCRIPTION
## Summary

These fixes surfaced while integrating nr-llm against the **current** OpenAI API. Three independent problems, all of which break image generation and JSON completions on a stock, up-to-date account:

1. **JSON mode was never sent.** `CompletionService::completeJson()` requests `response_format=json` and then strictly `json_decode`s the reply, but `OpenAiProvider` dropped the option on the floor — the model returned prose / Markdown-fenced JSON and the decode threw *"Failed to decode JSON response"*. Now mapped to `{"type":"json_object"}` in `chatCompletion()` and `chatCompletionWithTools()`.

2. **DALL·E-3 is retired.** OpenAI accounts now expose the `gpt-image-*` family instead (`gpt-image-1`, `-mini`, `-1.5`, `-2`, …). It uses a different size set (`1024x1024 / 1536x1024 / 1024x1536 / auto`), returns `b64_json`, and **rejects** `response_format` / `style` / `quality`. `ImageGenerationOptions` now accepts the family by prefix and validates its sizes; `DallEImageService` sends `response_format` only for dall-e-2 and `quality`/`style` only for dall-e-3, so gpt-image-* gets a minimal `model/prompt/n/size` payload.

3. **Empty `baseUrl` broke specialized services.** The ext_conf default for `image.dalle.baseUrl` / `image.fal.baseUrl` / `speech.tts.baseUrl` is an empty string meaning *"use the provider default"*, but the services used it verbatim as the request URL — producing a scheme-less URL and a Guzzle *`scheme "" is not allowed`* failure on a stock install. Empty now falls back to the provider default.

## Testing

All via `./Build/Scripts/runTests.sh` on PHP 8.5 (and unit also on 8.4):

- `-s unit` — green (incl. new gpt-image / response_format / base-URL coverage)
- `-s phpstan` — level 10, no errors
- `-s cgl` — clean

New tests: `OpenAiProviderTest` (response_format → json_object, omitted otherwise), `ImageGenerationOptionsTest` (gpt-image models + sizes), `DallEImageServiceTest` (gpt-image minimal payload, dall-e-2 keeps response_format, empty-baseUrl fallback).

No version bump or CHANGELOG entry (handled by the release flow).
