### PR TITLE
feat(specialized): authenticate via nr-vault secure HTTP client

### DIFF
--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrLlm\Specialized;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -37,21 +39,33 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  *
  * Constructor signature is identical across every consumer. Property
  * visibility intentionally `protected` (not `private`) so subclasses
- * can read `apiKey` / `baseUrl` when building service-specific
+ * can read `apiKeyIdentifier` / `baseUrl` when building service-specific
  * payloads — the alternative (passing them through accessor methods)
  * adds no encapsulation since the subclass is the only thing that
  * touches them anyway.
+ *
+ * Secrets are never held as plaintext: each service stores the nr-vault
+ * identifier and authenticates through the audited secure HTTP client
+ * (`$vault->http()->withAuthentication(...)`), which injects and scrubs
+ * the secret inside the vault. This mirrors `AbstractProvider`.
  *
  * @phpstan-consistent-constructor
  */
 abstract class AbstractSpecializedService
 {
-    protected string $apiKey = '';
+    protected string $apiKeyIdentifier = '';
     protected string $baseUrl = '';
     protected int $timeout;
 
+    /**
+     * Test seam: when set, `getSecureClient()` returns this instead of the
+     * vault secure client. Production never sets it — auth always flows
+     * through the audited vault client. Mirrors `AbstractProvider`.
+     */
+    private ?ClientInterface $configuredHttpClient = null;
+
     public function __construct(
-        protected readonly ClientInterface $httpClient,
+        protected readonly VaultServiceInterface $vault,
         protected readonly RequestFactoryInterface $requestFactory,
         protected readonly StreamFactoryInterface $streamFactory,
         protected readonly ExtensionConfiguration $extensionConfiguration,
@@ -63,14 +77,14 @@ abstract class AbstractSpecializedService
     }
 
     /**
-     * Returns true once the service has a usable API key from
-     * extension configuration. Stable across the lifetime of the
-     * instance — if the config changes at runtime, callers must
+     * Returns true once the service has a configured vault identifier
+     * that resolves to an existing secret. Stable across the lifetime
+     * of the instance — if the config changes at runtime, callers must
      * rebuild the service via DI rather than poll.
      */
     public function isAvailable(): bool
     {
-        return $this->apiKey !== '';
+        return $this->apiKeyIdentifier !== '' && $this->vault->exists($this->apiKeyIdentifier);
     }
 
     /**
@@ -116,33 +130,100 @@ abstract class AbstractSpecializedService
      * Service-specific config picking. Called from `loadConfiguration()`
      * with the already-fetched `nr_llm` config tree (or `[]` if loading
      * failed). Subclasses navigate to their own config branch — e.g.
-     * `$config['providers']['openai']['apiKey']` for DALL-E or
-     * `$config['translation']['deepl']['apiKey']` for DeepL — and set
-     * `$this->apiKey`, `$this->baseUrl`, `$this->timeout` from it.
+     * `$config['providers']['openai']['apiKeyIdentifier']` for DALL-E or
+     * `$config['translators']['deepl']['apiKeyIdentifier']` for DeepL — and
+     * set `$this->apiKeyIdentifier`, `$this->baseUrl`, `$this->timeout`.
      *
-     * Subclasses MUST set `$this->apiKey` and `$this->baseUrl`. The
+     * Subclasses MUST set `$this->apiKeyIdentifier` and `$this->baseUrl`. The
      * base class pre-populates `$this->timeout` with
      * `getDefaultTimeout()` so subclasses only need to override it
      * when the config provides a timeout override.
+     *
+     * The stored identifier is the nr-vault UUID, never a plaintext key;
+     * the secret is resolved inside the audited secure client at request
+     * time (see `getSecureClient()`).
      *
      * @param array<string, mixed> $config the full `nr_llm` config tree
      */
     abstract protected function loadServiceConfiguration(array $config): void;
 
     /**
-     * Build the auth headers the upstream API expects. Three schemes
-     * are in active use across the specialised services today:
-     *  - `['Authorization' => 'Bearer ' . $this->apiKey]` (OpenAI)
-     *  - `['Authorization' => 'Key '    . $this->apiKey]` (FAL)
-     *  - `['Authorization' => 'DeepL-Auth-Key ' . $this->apiKey]`.
-     *
-     * Returning a multi-key array is supported for any future
-     * provider that needs an extra header alongside auth (e.g.
-     * `'X-Api-Version'`); the request builder applies all of them.
+     * How the upstream API expects the secret to be placed. Defaults to
+     * Bearer (the OpenAI family — DALL-E, Whisper, TTS). Services with a
+     * different scheme override this together with
+     * `getSecretPlacementOptions()`:
+     *  - FAL:   `SecretPlacement::Header` + `['headerName' => 'Authorization', 'prefix' => 'Key ']`
+     *  - DeepL: `SecretPlacement::Header` + `['headerName' => 'Authorization', 'prefix' => 'DeepL-Auth-Key ']`.
+     */
+    protected function getSecretPlacement(): SecretPlacement
+    {
+        return SecretPlacement::Bearer;
+    }
+
+    /**
+     * Options forwarded to `VaultHttpClientInterface::withAuthentication()`
+     * for the configured placement (e.g. `headerName`, `prefix`). Empty by
+     * default (Bearer needs none).
      *
      * @return array<string, string>
      */
-    abstract protected function buildAuthHeaders(): array;
+    protected function getSecretPlacementOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * Non-auth headers applied to every request alongside `Content-Type`.
+     * Auth headers are NOT built here — the secure client injects them. Used
+     * for extras like DeepL's `User-Agent`. Empty by default.
+     *
+     * @return array<string, string>
+     */
+    protected function getAdditionalHeaders(): array
+    {
+        return [];
+    }
+
+    /**
+     * Audit-log reason recorded by the secure client for this service's
+     * requests. Subclasses may override for a more specific phrase.
+     */
+    protected function getAuditReason(): string
+    {
+        return sprintf('%s API call', $this->getProviderLabel());
+    }
+
+    /**
+     * The nr-vault secure HTTP client configured for this service's secret
+     * and placement. It resolves the secret inside the vault, injects it,
+     * audits the access, and scrubs the plaintext — the secret never
+     * surfaces in this extension's code. Mirrors `AbstractProvider`.
+     */
+    protected function getSecureClient(): ClientInterface
+    {
+        if ($this->configuredHttpClient !== null) {
+            return $this->configuredHttpClient;
+        }
+
+        return $this->vault->http()
+            ->withAuthentication(
+                $this->apiKeyIdentifier,
+                $this->getSecretPlacement(),
+                $this->getSecretPlacementOptions(),
+            )
+            ->withReason($this->getAuditReason());
+    }
+
+    /**
+     * Inject a custom HTTP client, bypassing the vault secure client.
+     *
+     * @internal Test seam only — production always authenticates through the
+     *           audited vault client (see `getSecureClient()`).
+     */
+    public function setHttpClient(ClientInterface $client): void
+    {
+        $this->configuredHttpClient = $client;
+    }
 
     /**
      * Throw a typed `ServiceUnavailableException` when the service
@@ -164,8 +245,9 @@ abstract class AbstractSpecializedService
     /**
      * Send a JSON request to the upstream API and return the decoded
      * response body. The endpoint is appended to `$this->baseUrl`
-     * (with single-slash normalisation), auth headers from
-     * `buildAuthHeaders()` are applied, and the payload is
+     * (with single-slash normalisation), the secret is injected by the
+     * secure client (see `executeRequest()`), any non-auth
+     * `getAdditionalHeaders()` are applied, and the payload is
      * `json_encode`d with `JSON_THROW_ON_ERROR`.
      *
      * Body-less methods (`GET`, `HEAD`, `DELETE`) skip the JSON body
@@ -188,7 +270,7 @@ abstract class AbstractSpecializedService
         $request = $this->requestFactory->createRequest($method, $url)
             ->withHeader('Content-Type', 'application/json');
 
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
 
@@ -245,7 +327,7 @@ abstract class AbstractSpecializedService
     protected function executeRequest(RequestInterface $request): array
     {
         try {
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();
             $responseBody = (string)$response->getBody();
 

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -347,13 +347,13 @@ final class DallEImageService extends AbstractSpecializedService
         // is_string() guards: the extension config tree is user-editable
         // YAML and the @var hint above describes the documented shape,
         // not a runtime guarantee. Direct assignment without guards
-        // would TypeError on `non-string apiKey` and defeat the
+        // would TypeError on a non-string identifier and defeat the
         // base's fail-soft contract.
-        $apiKey  = $this->resolveScalarConfig($config, ['providers', 'openai', 'apiKey']);
+        $apiKeyIdentifier = $this->resolveScalarConfig($config, ['providers', 'openai', 'apiKeyIdentifier']);
         $baseUrl = $this->resolveScalarConfig($config, ['image', 'dalle', 'baseUrl']);
         $timeout = $this->resolveScalarConfig($config, ['image', 'dalle', 'timeout']);
 
-        $this->apiKey  = is_string($apiKey) ? $apiKey : '';
+        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
         // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label), NOT
         // "send requests to an empty URL" — see nonEmptyStringOrDefault().
         $this->baseUrl = $this->nonEmptyStringOrDefault($baseUrl, self::API_URL);
@@ -377,11 +377,6 @@ final class DallEImageService extends AbstractSpecializedService
             $current = $current[$key];
         }
         return $current;
-    }
-
-    protected function buildAuthHeaders(): array
-    {
-        return ['Authorization' => 'Bearer ' . $this->apiKey];
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Specialized\Image;
 
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrVault\Http\SecretPlacement;
 use Throwable;
 
 /**
@@ -254,8 +255,8 @@ final class FalImageService extends AbstractSpecializedService
             return;
         }
 
-        $apiKey = $falConfig['apiKey'] ?? '';
-        $this->apiKey = is_string($apiKey) ? $apiKey : '';
+        $apiKeyIdentifier = $falConfig['apiKeyIdentifier'] ?? '';
+        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
 
         // Empty ext_conf baseUrl means "use the default" (per the field label), not an empty
         // request URL — see nonEmptyStringOrDefault().
@@ -268,9 +269,21 @@ final class FalImageService extends AbstractSpecializedService
         $this->pollInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
     }
 
-    protected function buildAuthHeaders(): array
+    /**
+     * FAL authenticates with `Authorization: Key <secret>` — not Bearer — so
+     * it uses Header placement with a `Key ` prefix on the secure client.
+     */
+    protected function getSecretPlacement(): SecretPlacement
     {
-        return ['Authorization' => 'Key ' . $this->apiKey];
+        return SecretPlacement::Header;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getSecretPlacementOptions(): array
+    {
+        return ['headerName' => 'Authorization', 'prefix' => 'Key '];
     }
 
     protected function getProviderLabel(): string
@@ -450,7 +463,7 @@ final class FalImageService extends AbstractSpecializedService
 
         $request = $this->requestFactory->createRequest('POST', $queueUrl)
             ->withHeader('Content-Type', 'application/json');
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
@@ -484,7 +497,7 @@ final class FalImageService extends AbstractSpecializedService
 
         for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
             $request = $this->requestFactory->createRequest('GET', $statusUrl);
-            foreach ($this->buildAuthHeaders() as $name => $value) {
+            foreach ($this->getAdditionalHeaders() as $name => $value) {
                 $request = $request->withHeader($name, $value);
             }
 
@@ -494,7 +507,7 @@ final class FalImageService extends AbstractSpecializedService
             if ($status === 'COMPLETED') {
                 $resultUrl = rtrim(self::QUEUE_API_URL, '/') . '/' . ltrim($endpoint, '/') . '/requests/' . $requestId;
                 $resultRequest = $this->requestFactory->createRequest('GET', $resultUrl);
-                foreach ($this->buildAuthHeaders() as $name => $value) {
+                foreach ($this->getAdditionalHeaders() as $name => $value) {
                     $resultRequest = $resultRequest->withHeader($name, $value);
                 }
 

--- a/Classes/Specialized/MultipartBodyBuilderTrait.php
+++ b/Classes/Specialized/MultipartBodyBuilderTrait.php
@@ -24,8 +24,9 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
  * those three services do not pay the trait's footprint.
  *
  * Consumers must `use` `AbstractSpecializedService` (this trait
- * relies on its `requestFactory`, `streamFactory`, `buildAuthHeaders()`,
- * `buildEndpointUrl()`, and `executeRequest()` members).
+ * relies on its `requestFactory`, `streamFactory`, `getAdditionalHeaders()`,
+ * `buildEndpointUrl()`, and `executeRequest()` members). Auth is injected
+ * by the secure client inside `executeRequest()`, not added here.
  *
  * Part shapes:
  * - File part:    `['name' => string, 'filename' => string, 'content' => string, 'contentType' => string]`
@@ -56,7 +57,7 @@ trait MultipartBodyBuilderTrait
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
 
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
 

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -248,8 +248,8 @@ final class TextToSpeechService extends AbstractSpecializedService
         if (is_array($providers)) {
             $openai = $providers['openai'] ?? null;
             if (is_array($openai)) {
-                $apiKey = $openai['apiKey'] ?? '';
-                $this->apiKey = is_string($apiKey) ? $apiKey : '';
+                $apiKeyIdentifier = $openai['apiKeyIdentifier'] ?? '';
+                $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
             }
         }
 
@@ -265,11 +265,6 @@ final class TextToSpeechService extends AbstractSpecializedService
                 $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
             }
         }
-    }
-
-    protected function buildAuthHeaders(): array
-    {
-        return ['Authorization' => 'Bearer ' . $this->apiKey];
     }
 
     protected function getProviderLabel(): string
@@ -402,7 +397,7 @@ final class TextToSpeechService extends AbstractSpecializedService
     {
         $request = $this->requestFactory->createRequest('POST', $this->buildEndpointUrl(''))
             ->withHeader('Content-Type', 'application/json');
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
         $request = $request->withBody(
@@ -410,7 +405,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         );
 
         try {
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();
 
             if ($statusCode >= 200 && $statusCode < 300) {

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -200,15 +200,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        /** @var array{providers?: array{openai?: array{apiKey?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
-        $this->apiKey  = (string)($config['providers']['openai']['apiKey'] ?? '');
+        /** @var array{providers?: array{openai?: array{apiKeyIdentifier?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
+        $this->apiKeyIdentifier = (string)($config['providers']['openai']['apiKeyIdentifier'] ?? '');
         $this->baseUrl = (string)($config['speech']['whisper']['baseUrl'] ?? self::API_URL);
         $this->timeout = (int)($config['speech']['whisper']['timeout'] ?? $this->getDefaultTimeout());
-    }
-
-    protected function buildAuthHeaders(): array
-    {
-        return ['Authorization' => 'Bearer ' . $this->apiKey];
     }
 
     protected function getProviderLabel(): string
@@ -351,7 +346,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
      * format-dependent so the base's strict-array `executeRequest()`
      * does not fit; this method owns the request lifecycle while
      * still using the trait's `encodeMultipartBody()` for the wire
-     * payload and the base's `buildAuthHeaders()` for auth.
+     * payload and the base's secure client for audited auth injection.
      *
      * @param list<array<string, mixed>> $parts
      *
@@ -368,13 +363,13 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
         $request = $request->withBody($this->streamFactory->createStream($body));
 
         try {
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();
             $responseBody = (string)$response->getBody();
 

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
+use Netresearch\NrVault\Http\SecretPlacement;
 use Throwable;
 
 /**
@@ -69,6 +70,12 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
     private const FORMALITY_SUPPORTED_LANGUAGES = [
         'de', 'fr', 'it', 'es', 'nl', 'pl', 'pt', 'pt-br', 'pt-pt', 'ru', 'ja',
     ];
+
+    /** Explicit baseUrl override from ext_conf, or null to auto-detect Free/Pro from the key. */
+    private ?string $configuredBaseUrl = null;
+
+    /** Guards the one-time secret retrieval in resolveBaseUrl(). */
+    private bool $baseUrlResolved = false;
 
     public function getIdentifier(): string
     {
@@ -305,31 +312,77 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         // is_string() / is_numeric() guards: extension config is YAML
         // and the documented shape is not a runtime guarantee. Direct
-        // assignment would TypeError on a non-string apiKey and defeat
+        // assignment would TypeError on a non-string identifier and defeat
         // the base's fail-soft contract.
-        $apiKey = $deeplConfig['apiKey'] ?? null;
-        $this->apiKey = is_string($apiKey) ? $apiKey : '';
+        $apiKeyIdentifier = $deeplConfig['apiKeyIdentifier'] ?? null;
+        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
 
         $timeout = $deeplConfig['timeout'] ?? null;
         $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
 
-        // DeepL Free vs Pro routing: free keys end with `:fx`. The Pro
-        // URL is the documented default; explicit `baseUrl` override
-        // wins over both.
-        if ($this->apiKey !== '' && str_ends_with($this->apiKey, ':fx')) {
-            $this->baseUrl = self::FREE_API_URL;
-        } else {
-            $baseUrl = $deeplConfig['baseUrl'] ?? null;
-            $this->baseUrl = is_string($baseUrl) ? $baseUrl : self::PRO_API_URL;
-        }
+        // Free vs Pro routing depends on the secret value (free keys end with
+        // ':fx'), which we no longer hold as plaintext, so the base URL is
+        // resolved lazily on first request (see resolveBaseUrl()). An explicit
+        // baseUrl override still wins and is captured here.
+        $baseUrl = $deeplConfig['baseUrl'] ?? null;
+        $this->configuredBaseUrl = is_string($baseUrl) && $baseUrl !== '' ? $baseUrl : null;
     }
 
-    protected function buildAuthHeaders(): array
+    /**
+     * DeepL authenticates with `Authorization: DeepL-Auth-Key <secret>` — not
+     * Bearer — so it uses Header placement with a `DeepL-Auth-Key ` prefix.
+     */
+    protected function getSecretPlacement(): SecretPlacement
     {
-        return [
-            'Authorization' => 'DeepL-Auth-Key ' . $this->apiKey,
-            'User-Agent'    => 'TYPO3-NrLlm/1.0',
-        ];
+        return SecretPlacement::Header;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getSecretPlacementOptions(): array
+    {
+        return ['headerName' => 'Authorization', 'prefix' => 'DeepL-Auth-Key '];
+    }
+
+    /**
+     * DeepL expects a `User-Agent` alongside auth.
+     *
+     * @return array<string, string>
+     */
+    protected function getAdditionalHeaders(): array
+    {
+        return ['User-Agent' => 'TYPO3-NrLlm/1.0'];
+    }
+
+    /**
+     * Resolve the Free vs Pro base URL on first use. An explicit ext_conf
+     * `baseUrl` wins; otherwise the secret is retrieved exactly once to test
+     * for the `:fx` Free-key suffix and scrubbed immediately — the request
+     * itself still authenticates through the audited secure client, never
+     * this transient plaintext copy.
+     */
+    private function resolveBaseUrl(): void
+    {
+        if ($this->baseUrlResolved) {
+            return;
+        }
+        $this->baseUrlResolved = true;
+
+        if ($this->configuredBaseUrl !== null) {
+            $this->baseUrl = $this->configuredBaseUrl;
+            return;
+        }
+
+        $key = $this->apiKeyIdentifier !== ''
+            ? ($this->vault->retrieve($this->apiKeyIdentifier) ?? '')
+            : '';
+        $this->baseUrl = ($key !== '' && str_ends_with($key, ':fx'))
+            ? self::FREE_API_URL
+            : self::PRO_API_URL;
+        if ($key !== '') {
+            sodium_memzero($key);
+        }
     }
 
     protected function getProviderLabel(): string
@@ -534,6 +587,8 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
      */
     private function sendDeeplRequest(string $endpoint, array $payload, string $method = 'POST'): array
     {
+        $this->resolveBaseUrl();
+
         $url = sprintf(
             '%s/%s/%s',
             rtrim($this->baseUrl, '/'),
@@ -543,7 +598,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $request = $this->requestFactory->createRequest($method, $url)
             ->withHeader('Content-Type', 'application/json');
-        foreach ($this->buildAuthHeaders() as $name => $value) {
+        foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
 

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -361,16 +361,20 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
      * for the `:fx` Free-key suffix and scrubbed immediately — the request
      * itself still authenticates through the audited secure client, never
      * this transient plaintext copy.
+     *
+     * `baseUrlResolved` is only set AFTER `baseUrl` is successfully assigned: if
+     * `vault->retrieve()` throws, the flag stays false so the next request
+     * retries resolution instead of being stuck with an empty base URL.
      */
     private function resolveBaseUrl(): void
     {
         if ($this->baseUrlResolved) {
             return;
         }
-        $this->baseUrlResolved = true;
 
         if ($this->configuredBaseUrl !== null) {
             $this->baseUrl = $this->configuredBaseUrl;
+            $this->baseUrlResolved = true;
             return;
         }
 
@@ -383,6 +387,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         if ($key !== '') {
             sodium_memzero($key);
         }
+        $this->baseUrlResolved = true;
     }
 
     protected function getProviderLabel(): string

--- a/Documentation/Adr/Adr030SpecializedServicesVaultMigration.rst
+++ b/Documentation/Adr/Adr030SpecializedServicesVaultMigration.rst
@@ -1,0 +1,100 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-030:
+
+==================================================================
+ADR-030: Specialized Services Authenticate Through nr-vault
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-09
+:Authors: Netresearch DTT GmbH
+
+.. _adr-030-context:
+
+Context
+=======
+
+The database-backed LLM providers have authenticated through the nr-vault
+secure HTTP client since :ref:`adr-012` — they store a vault *identifier*
+(a UUID) rather than a plaintext key, and :php:`AbstractProvider::getHttpClient()`
+returns ``$vault->http()->withAuthentication(...)`` so the secret is resolved,
+injected, audited, and memory-scrubbed inside the vault. The plaintext key
+never surfaces in this extension's code.
+
+The five specialised single-task services — DALL-E and FAL (image), Whisper
+and TTS (speech), and DeepL (translation), all built on
+:php:`AbstractSpecializedService` (see REC #7) — predated that posture. Each
+read a plaintext ``apiKey`` from extension configuration into a
+``protected string $apiKey`` property and assembled its own ``Authorization``
+header via a ``buildAuthHeaders()`` hook, sending the request through a plain
+PSR-18 client. This contradicted :ref:`adr-012` and the project rule that
+*API keys MUST be stored as nr-vault UUID identifiers, never as plaintext*.
+
+Two of the services do not use the Bearer scheme: FAL expects
+``Authorization: Key <secret>`` and DeepL expects
+``Authorization: DeepL-Auth-Key <secret>``. The secure client's ``Header``
+placement could previously inject only the bare secret as a header value, so
+these schemes could not be expressed through it at all — which is why they had
+remained on the plaintext path. nr-vault ``0.8.0`` added a ``prefix`` option to
+``withAuthentication()`` for ``Header`` placement, removing that blocker.
+
+.. _adr-030-decision:
+
+Decision
+========
+
+Migrate every keyed specialised service onto the vault secure HTTP client,
+mirroring :php:`AbstractProvider`:
+
+1. **Identifier, not key.** :php:`AbstractSpecializedService` takes
+   :php:`VaultServiceInterface` as its first constructor argument and stores
+   ``$apiKeyIdentifier`` (the vault UUID) instead of ``$apiKey``.
+   :php:`isAvailable()` becomes
+   ``$apiKeyIdentifier !== '' && $vault->exists($apiKeyIdentifier)``.
+
+2. **Placement hooks replace** ``buildAuthHeaders()``. The base exposes
+   :php:`getSecretPlacement()` (default :php:`SecretPlacement::Bearer`),
+   :php:`getSecretPlacementOptions()` (default ``[]``), and
+   :php:`getAdditionalHeaders()` (non-auth headers only, e.g. DeepL's
+   ``User-Agent``). :php:`getSecureClient()` builds
+   ``$vault->http()->withAuthentication($id, placement, options)->withReason(...)``
+   and ``executeRequest()`` sends through it. Per-service placement:
+
+   - DALL-E, Whisper, TTS — ``Bearer`` (OpenAI family).
+   - FAL — ``Header`` + ``{headerName: Authorization, prefix: 'Key '}``.
+   - DeepL — ``Header`` + ``{headerName: Authorization, prefix: 'DeepL-Auth-Key '}``.
+
+3. **DeepL Free/Pro routing stays automatic.** DeepL selects the
+   ``api-free.deepl.com`` host for keys ending in ``:fx`` and ``api.deepl.com``
+   otherwise. Since the key is no longer held as plaintext, the host is resolved
+   lazily on the first request: the secret is retrieved from the vault exactly
+   once, tested for the ``:fx`` suffix, and immediately ``sodium_memzero``-d.
+   An explicit ``baseUrl`` override still wins. The request itself always
+   authenticates through the audited secure client, never that transient copy.
+
+4. **Configuration.** The ext_conf keys become identifiers:
+   ``providers.openai.apiKeyIdentifier`` (DALL-E/Whisper/TTS),
+   ``image.fal.apiKeyIdentifier``, and ``translators.deepl.apiKeyIdentifier``.
+
+A ``setHttpClient()`` test seam — identical to the providers' — lets unit
+tests inject a plain client and assert request/response plumbing without the
+vault; the placement hooks are asserted directly.
+
+.. _adr-030-consequences:
+
+Consequences
+============
+
+- No specialised service holds a plaintext API key; every upstream call is
+  audited and the secret is scrubbed inside the vault, satisfying
+  :ref:`adr-012` uniformly across providers and specialised services.
+- Requires nr-vault ``^0.8.0`` (the ``prefix`` option). A ``0.7`` install would
+  silently drop the prefix and send a broken ``Authorization`` header for
+  FAL/DeepL, so the composer floor is raised.
+- Host applications that previously wrote ``providers.openai.apiKey`` (and the
+  FAL/DeepL plaintext keys) into nr_llm's extension configuration must store a
+  vault secret and write its identifier instead.
+- DeepL incurs one extra vault read per service instance the first time it
+  sends a request (to choose Free/Pro); the result is cached for the instance
+  lifetime.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -262,3 +262,4 @@ Modern architecture (v0.4+)
    Adr027SplitTaskController
    Adr028PublicServicesPolicy
    Adr029UsageAnalyticsDashboard
+   Adr030SpecializedServicesVaultMigration

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -15,6 +15,9 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientInterface;
@@ -33,7 +36,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     #[Test]
     public function isAvailableReturnsFalseWhenApiKeyIsEmpty(): void
     {
-        $subject = $this->createSubject(apiKey: '');
+        $subject = $this->createSubject(apiKeyIdentifier: '');
 
         self::assertFalse($subject->isAvailable());
     }
@@ -41,7 +44,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     #[Test]
     public function isAvailableReturnsTrueWhenApiKeyIsConfigured(): void
     {
-        $subject = $this->createSubject(apiKey: 'test-key');
+        $subject = $this->createSubject(apiKeyIdentifier: 'test-key');
 
         self::assertTrue($subject->isAvailable());
     }
@@ -49,7 +52,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     #[Test]
     public function ensureAvailableThrowsWhenNotConfigured(): void
     {
-        $subject = $this->createSubject(apiKey: '');
+        $subject = $this->createSubject(apiKeyIdentifier: '');
 
         $this->expectException(ServiceUnavailableException::class);
 
@@ -59,7 +62,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     #[Test]
     public function ensureAvailableIsNoOpWhenConfigured(): void
     {
-        $subject = $this->createSubject(apiKey: 'test-key');
+        $subject = $this->createSubject(apiKeyIdentifier: 'test-key');
 
         $subject->callEnsureAvailable();
 
@@ -101,7 +104,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock(['result' => 'ok'], 200));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
 
         $result = $subject->callSendJsonRequest('endpoint', ['foo' => 'bar']);
 
@@ -109,8 +112,12 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function sendJsonRequestAddsAuthHeaderFromBuildAuthHeaders(): void
+    public function sendJsonRequestSetsContentTypeAndReachesInjectedClient(): void
     {
+        // Auth is no longer added to the request here — the secure vault client
+        // injects it, and `setHttpClient()` bypasses that client entirely. So
+        // the request that reaches the injected mock carries Content-Type (and
+        // any `getAdditionalHeaders()`) but no Authorization header.
         $captured = null;
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects(self::once())
@@ -120,13 +127,73 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
                 return $this->createJsonResponseMock([], 200);
             });
 
-        $subject = $this->createSubject(apiKey: 'sekret', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'vault-id', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
 
         $subject->callSendJsonRequest('endpoint', []);
 
         self::assertNotNull($captured);
-        self::assertSame('TestableScheme sekret', $captured->getHeaderLine('Authorization'));
         self::assertSame('application/json', $captured->getHeaderLine('Content-Type'));
+        self::assertSame('', $captured->getHeaderLine('Authorization'));
+    }
+
+    #[Test]
+    public function getSecureClientAuthenticatesThroughVaultWithConfiguredIdentifierAndBearerPlacement(): void
+    {
+        // With no `setHttpClient()` override, `getSecureClient()` must build the
+        // audited vault client via `vault->http()->withAuthentication($id, Bearer, [])`
+        // for the configured identifier and stamp the audit reason. The base
+        // class defaults to Bearer placement with no options.
+        $capturedIdentifier = null;
+        $capturedPlacement = null;
+        $capturedOptions = null;
+        $capturedReason = null;
+
+        $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
+        $vaultHttpClient->method('withAuthentication')->willReturnCallback(
+            function (string $id, SecretPlacement $placement, array $options) use (
+                &$capturedIdentifier,
+                &$capturedPlacement,
+                &$capturedOptions,
+                $vaultHttpClient,
+            ): VaultHttpClientInterface {
+                $capturedIdentifier = $id;
+                $capturedPlacement = $placement;
+                $capturedOptions = $options;
+                return $vaultHttpClient;
+            },
+        );
+        $vaultHttpClient->method('withReason')->willReturnCallback(
+            function (string $reason) use (&$capturedReason, $vaultHttpClient): VaultHttpClientInterface {
+                $capturedReason = $reason;
+                return $vaultHttpClient;
+            },
+        );
+        $vaultHttpClient->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+
+        $vault = self::createStub(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('retrieve')->willReturn('test-secret');
+        $vault->method('http')->willReturn($vaultHttpClient);
+
+        $extConf = self::createStub(ExtensionConfiguration::class);
+        $extConf->method('get')->willReturn(['apiKeyIdentifier' => 'vault-id', 'baseUrl' => 'https://api.test/v1']);
+
+        $subject = new TestableSpecializedService(
+            vault: $vault,
+            requestFactory: $this->passthroughRequestFactory(),
+            streamFactory: $this->passthroughStreamFactory(),
+            extensionConfiguration: $extConf,
+            usageTracker: self::createStub(UsageTrackerServiceInterface::class),
+            logger: self::createStub(LoggerInterface::class),
+        );
+
+        $subject->callSendJsonRequest('endpoint', []);
+
+        self::assertSame('vault-id', $capturedIdentifier);
+        self::assertSame(SecretPlacement::Bearer, $capturedPlacement);
+        self::assertSame([], $capturedOptions);
+        self::assertNotNull($capturedReason);
+        self::assertNotSame('', $capturedReason);
     }
 
     #[Test]
@@ -137,7 +204,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'invalid key']], 401));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         $this->expectException(ServiceConfigurationException::class);
 
@@ -152,7 +219,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'forbidden']], 403));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         $this->expectException(ServiceConfigurationException::class);
 
@@ -167,7 +234,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'too many requests']], 429));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         try {
             $subject->callSendJsonRequest('endpoint', []);
@@ -188,7 +255,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'bad request — prompt empty']], 400));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         try {
             $subject->callSendJsonRequest('endpoint', []);
@@ -206,7 +273,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willThrowException(new RuntimeException('connection reset'));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         try {
             $subject->callSendJsonRequest('endpoint', []);
@@ -227,7 +294,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createHttpResponseMock(204, ''));
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         $result = $subject->callSendJsonRequest('endpoint', []);
 
@@ -245,7 +312,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $extConf->method('get')->willThrowException(new RuntimeException('boom'));
 
         $subject = new TestableSpecializedService(
-            httpClient: self::createStub(ClientInterface::class),
+            vault: $this->createVaultServiceMock(),
             requestFactory: $this->passthroughRequestFactory(),
             streamFactory: $this->passthroughStreamFactory(),
             extensionConfiguration: $extConf,
@@ -259,7 +326,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     #[Test]
     public function multipartTraitBuildsExpectedBoundaryAndBody(): void
     {
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test');
 
         $body = $subject->callEncodeMultipartBody([
             ['name' => 'file', 'filename' => 'a.bin', 'content' => 'BIN', 'contentType' => 'application/octet-stream'],
@@ -291,7 +358,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
                 return $this->createJsonResponseMock([], 200);
             });
 
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
 
         $subject->callSendJsonRequest('endpoint', ['ignored' => 'on-get'], 'GET');
 
@@ -311,10 +378,10 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // would have raised a bootstrap fatal. Now it degrades to
         // `isAvailable() === false`.
         $extConf = self::createStub(ExtensionConfiguration::class);
-        $extConf->method('get')->willReturn(['apiKey' => 12345, 'baseUrl' => 'https://api.test']);
+        $extConf->method('get')->willReturn(['apiKeyIdentifier' => 12345, 'baseUrl' => 'https://api.test']);
 
         $subject = new TestableTypeErrorSpecializedService(
-            httpClient: self::createStub(ClientInterface::class),
+            vault: $this->createVaultServiceMock(),
             requestFactory: $this->passthroughRequestFactory(),
             streamFactory: $this->passthroughStreamFactory(),
             extensionConfiguration: $extConf,
@@ -336,7 +403,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // body framing. The literal text "X-Injected: yes" may still
         // appear AS DATA inside the value (CR/LF removed → no header
         // boundary), but it must NOT appear on its own line.
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test');
 
         $body = $subject->callEncodeMultipartBody([
             [
@@ -369,7 +436,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // shouldn't poison the entire body. The part is silently
         // skipped (rather than throwing) so the surrounding parts
         // still produce a valid body.
-        $subject = $this->createSubject(apiKey: 'k', baseUrl: 'https://api.test');
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test');
 
         $body = $subject->callEncodeMultipartBody([
             ['name' => 'good', 'value' => 'x'],
@@ -383,21 +450,28 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     private function createSubject(
-        string $apiKey = 'test-key',
+        string $apiKeyIdentifier = 'test-key',
         string $baseUrl = 'https://api.example.test',
         ?ClientInterface $httpClient = null,
     ): TestableSpecializedService {
         $extConf = self::createStub(ExtensionConfiguration::class);
-        $extConf->method('get')->willReturn(['apiKey' => $apiKey, 'baseUrl' => $baseUrl]);
+        $extConf->method('get')->willReturn(['apiKeyIdentifier' => $apiKeyIdentifier, 'baseUrl' => $baseUrl]);
 
-        return new TestableSpecializedService(
-            httpClient: $httpClient ?? self::createStub(ClientInterface::class),
+        $subject = new TestableSpecializedService(
+            vault: $this->createVaultServiceMock(),
             requestFactory: $this->passthroughRequestFactory(),
             streamFactory: $this->passthroughStreamFactory(),
             extensionConfiguration: $extConf,
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
         );
+
+        // Inject the plain test client through the test seam; this bypasses the
+        // vault secure client so request/response assertions can read the
+        // request the service built (mirrors the provider tests).
+        $subject->setHttpClient($httpClient ?? self::createStub(ClientInterface::class));
+
+        return $subject;
     }
 
     private function passthroughRequestFactory(): RequestFactoryInterface
@@ -482,13 +556,8 @@ final class TestableSpecializedService extends AbstractSpecializedService
 
     protected function loadServiceConfiguration(array $config): void
     {
-        $this->apiKey  = is_string($config['apiKey']  ?? null) ? $config['apiKey'] : '';
-        $this->baseUrl = is_string($config['baseUrl'] ?? null) ? $config['baseUrl'] : $this->getDefaultBaseUrl();
-    }
-
-    protected function buildAuthHeaders(): array
-    {
-        return ['Authorization' => 'TestableScheme ' . $this->apiKey];
+        $this->apiKeyIdentifier = is_string($config['apiKeyIdentifier'] ?? null) ? $config['apiKeyIdentifier'] : '';
+        $this->baseUrl          = is_string($config['baseUrl'] ?? null) ? $config['baseUrl'] : $this->getDefaultBaseUrl();
     }
 }
 
@@ -645,11 +714,6 @@ final class TestableTypeErrorSpecializedService extends AbstractSpecializedServi
         // caught on PR #186 (DallE / DeepL `loadServiceConfiguration`
         // before the fix).
         /** @phpstan-ignore assign.propertyType */
-        $this->apiKey = $config['apiKey']; // @phpstan-ignore-line
-    }
-
-    protected function buildAuthHeaders(): array
-    {
-        return ['Authorization' => 'Bearer ' . $this->apiKey];
+        $this->apiKeyIdentifier = $config['apiKeyIdentifier']; // @phpstan-ignore-line
     }
 }

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Specialized\Image\DallEImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -42,6 +43,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     private ExtensionConfiguration&MockObject $extensionConfigMock;
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
+    private VaultServiceInterface $vaultStub;
     private ?string $tempFile = null;
 
     protected function setUp(): void
@@ -54,6 +56,33 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $this->extensionConfigMock = $this->createMock(ExtensionConfiguration::class);
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+    }
+
+    /**
+     * Build a DallEImageService wired to the vault mock, then inject the given
+     * plain HTTP client through the test seam (bypasses the vault secure client
+     * so request/response assertions can read the request the service built).
+     */
+    private function buildService(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        ExtensionConfiguration $extensionConfiguration,
+        UsageTrackerServiceInterface $usageTracker,
+        LoggerInterface $logger,
+    ): DallEImageService {
+        $service = new DallEImageService(
+            $this->vaultStub,
+            $requestFactory,
+            $streamFactory,
+            $extensionConfiguration,
+            $usageTracker,
+            $logger,
+        );
+        $service->setHttpClient($httpClient);
+
+        return $service;
     }
 
     protected function tearDown(): void
@@ -72,7 +101,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $defaultConfig = [
             'providers' => [
                 'openai' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
         ];
@@ -82,7 +111,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
-        return new DallEImageService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -101,7 +130,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 'providers' => [],
             ]);
 
-        return new DallEImageService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -341,7 +370,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -352,7 +381,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('image', 'dall-e:dall-e-3', self::anything());
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -674,7 +703,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -685,7 +714,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('image', 'dall-e:variations', self::anything());
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -754,7 +783,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -765,7 +794,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('image', 'dall-e:edit', self::anything());
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -844,7 +873,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -862,7 +891,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $config = [
             'providers' => [
                 'openai' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
             'image' => [
@@ -891,7 +920,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->expects(self::once())
             ->method('warning');
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -956,10 +985,10 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('get')
             ->with('nr_llm')
             ->willReturn([
-                'providers' => ['openai' => ['apiKey' => 'test-api-key']],
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
             ]);
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $httpClientMock,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -1033,10 +1062,10 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('get')
             ->with('nr_llm')
             ->willReturn([
-                'providers' => ['openai' => ['apiKey' => 'test-api-key']],
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
             ]);
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $httpClientMock,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -1067,7 +1096,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('get')
             ->with('nr_llm')
             ->willReturn([
-                'providers' => ['openai' => ['apiKey' => 'test-api-key']],
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
             ]);
 
         $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
@@ -1080,7 +1109,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 self::callback(fn(array $ctx): bool => isset($ctx['count']) && $ctx['count'] === 2),
             );
 
-        $subject = new DallEImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -27,6 +29,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -40,6 +43,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     private ExtensionConfiguration&MockObject $extensionConfigMock;
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
+    private VaultServiceInterface $vaultStub;
 
     protected function setUp(): void
     {
@@ -51,6 +55,54 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->extensionConfigMock = $this->createMock(ExtensionConfiguration::class);
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+    }
+
+    /**
+     * Build a FalImageService wired to the vault mock, then inject the given
+     * plain HTTP client through the test seam (bypasses the vault secure client
+     * so request/response assertions can read the request the service built).
+     */
+    private function buildService(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        ExtensionConfiguration $extensionConfiguration,
+        UsageTrackerServiceInterface $usageTracker,
+        LoggerInterface $logger,
+    ): FalImageService {
+        $service = new FalImageService(
+            $this->vaultStub,
+            $requestFactory,
+            $streamFactory,
+            $extensionConfiguration,
+            $usageTracker,
+            $logger,
+        );
+        $service->setHttpClient($httpClient);
+
+        return $service;
+    }
+
+    /**
+     * Assert FAL exposes the Header placement and `Key ` prefix the secure
+     * client uses to authenticate (FAL: `Authorization: Key <secret>`).
+     */
+    #[Test]
+    public function getSecretPlacementUsesHeaderWithKeyPrefix(): void
+    {
+        $subject = $this->createSubject();
+
+        $reflection = new ReflectionClass($subject);
+
+        $placementMethod = $reflection->getMethod('getSecretPlacement');
+        self::assertSame(SecretPlacement::Header, $placementMethod->invoke($subject));
+
+        $optionsMethod = $reflection->getMethod('getSecretPlacementOptions');
+        self::assertSame(
+            ['headerName' => 'Authorization', 'prefix' => 'Key '],
+            $optionsMethod->invoke($subject),
+        );
     }
 
     /**
@@ -61,7 +113,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $defaultConfig = [
             'image' => [
                 'fal' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
         ];
@@ -71,7 +123,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn(array_replace_recursive($defaultConfig, $config));
 
-        return new FalImageService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -92,7 +144,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        return new FalImageService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -302,7 +354,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'image' => [
                     'fal' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -313,7 +365,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('image', 'fal:flux-schnell', self::anything());
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -465,7 +517,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'image' => [
                     'fal' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -476,7 +528,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('image', 'fal:flux-schnell', self::callback(fn($data) => is_array($data) && isset($data['count'])));
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -609,7 +661,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -629,7 +681,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn([]);
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -649,7 +701,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn(['image' => []]);
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -667,7 +719,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $config = [
             'image' => [
                 'fal' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                     'baseUrl' => 'https://custom-api.example.com',
                     'timeout' => 180,
                     'pollInterval' => 2000,
@@ -693,7 +745,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->expects(self::once())
             ->method('warning');
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -714,14 +766,14 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'image' => [
                     'fal' => [
-                        'apiKey' => 'test-key',
+                        'apiKeyIdentifier' => 'test-key',
                         'timeout' => '180', // String instead of int
                         'pollInterval' => '2000', // String instead of int
                     ],
                 ],
             ]);
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -850,12 +902,12 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'image' => [
                     'fal' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
 
-        $subject = new FalImageService(
+        $subject = $this->buildService(
             $httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Specialized\Option\SpeechSynthesisOptions;
 use Netresearch\NrLlm\Specialized\Speech\SpeechSynthesisResult;
 use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -41,6 +42,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     private ExtensionConfiguration&MockObject $extensionConfigMock;
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
+    private VaultServiceInterface $vaultStub;
 
     protected function setUp(): void
     {
@@ -52,6 +54,33 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->extensionConfigMock = $this->createMock(ExtensionConfiguration::class);
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+    }
+
+    /**
+     * Build a TextToSpeechService wired to the vault mock, then inject the given
+     * plain HTTP client through the test seam (bypasses the vault secure client
+     * so request/response assertions can read the request the service built).
+     */
+    private function buildService(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        ExtensionConfiguration $extensionConfiguration,
+        UsageTrackerServiceInterface $usageTracker,
+        LoggerInterface $logger,
+    ): TextToSpeechService {
+        $service = new TextToSpeechService(
+            $this->vaultStub,
+            $requestFactory,
+            $streamFactory,
+            $extensionConfiguration,
+            $usageTracker,
+            $logger,
+        );
+        $service->setHttpClient($httpClient);
+
+        return $service;
     }
 
     /**
@@ -62,7 +91,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $defaultConfig = [
             'providers' => [
                 'openai' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
         ];
@@ -72,7 +101,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
-        return new TextToSpeechService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -91,7 +120,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 'providers' => [],
             ]);
 
-        return new TextToSpeechService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -285,7 +314,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -300,7 +329,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 self::callback(fn($data) => is_array($data) && isset($data['characters'])),
             );
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -438,12 +467,12 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $httpClientStub,
             $requestFactoryStub,
             $streamFactoryStub,
@@ -513,7 +542,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -531,7 +560,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $config = [
             'providers' => [
                 'openai' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
             'speech' => [
@@ -561,7 +590,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->expects(self::once())
             ->method('warning');
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -732,7 +761,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -754,7 +783,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 'providers' => 'not-an-array',
             ]);
 
-        $subject = new TextToSpeechService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Specialized\Option\TranscriptionOptions;
 use Netresearch\NrLlm\Specialized\Speech\TranscriptionResult;
 use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -42,6 +43,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private ExtensionConfiguration&MockObject $extensionConfigMock;
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
+    private VaultServiceInterface $vaultStub;
     private ?string $tempFile = null;
 
     protected function setUp(): void
@@ -54,6 +56,34 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->extensionConfigMock = $this->createMock(ExtensionConfiguration::class);
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+    }
+
+    /**
+     * Build a WhisperTranscriptionService wired to the vault mock, then inject
+     * the given plain HTTP client through the test seam (bypasses the vault
+     * secure client so request/response assertions can read the request the
+     * service built).
+     */
+    private function buildService(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        ExtensionConfiguration $extensionConfiguration,
+        UsageTrackerServiceInterface $usageTracker,
+        LoggerInterface $logger,
+    ): WhisperTranscriptionService {
+        $service = new WhisperTranscriptionService(
+            $this->vaultStub,
+            $requestFactory,
+            $streamFactory,
+            $extensionConfiguration,
+            $usageTracker,
+            $logger,
+        );
+        $service->setHttpClient($httpClient);
+
+        return $service;
     }
 
     protected function tearDown(): void
@@ -72,7 +102,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $defaultConfig = [
             'providers' => [
                 'openai' => [
-                    'apiKey' => 'test-api-key',
+                    'apiKeyIdentifier' => 'test-api-key',
                 ],
             ],
         ];
@@ -82,7 +112,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
-        return new WhisperTranscriptionService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -101,7 +131,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
                 'providers' => [],
             ]);
 
-        return new WhisperTranscriptionService(
+        return $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -290,7 +320,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -301,7 +331,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with('speech', 'whisper:transcription', []);
 
-        $subject = new WhisperTranscriptionService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -457,7 +487,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -467,7 +497,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->expects(self::atLeastOnce())
             ->method('trackUsage');
 
-        $subject = new WhisperTranscriptionService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -539,7 +569,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
-        $subject = new WhisperTranscriptionService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -564,7 +594,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->expects(self::once())
             ->method('warning');
 
-        $subject = new WhisperTranscriptionService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
@@ -675,7 +705,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->willReturn([
                 'providers' => [
                     'openai' => [
-                        'apiKey' => 'test-api-key',
+                        'apiKeyIdentifier' => 'test-api-key',
                     ],
                 ],
             ]);
@@ -685,7 +715,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->expects(self::once())
             ->method('error');
 
-        $subject = new WhisperTranscriptionService(
+        $subject = $this->buildService(
             $this->httpClientStub,
             $this->requestFactoryStub,
             $this->streamFactoryStub,

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,7 +45,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $this->defaultConfig = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => $this->randomApiKey(),
+                    'apiKeyIdentifier' => $this->randomApiKey(),
                     'timeout' => 30,
                 ],
             ],
@@ -54,16 +55,26 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
     /**
      * @param array<string, array<string, array<string, int|string>>>|null $config
      */
-    private function createTranslator(?array $config = null): DeepLTranslator
+    private function createTranslator(?array $config = null, ?VaultServiceInterface $vault = null): DeepLTranslator
     {
-        return new DeepLTranslator(
-            $this->createHttpClientMock(),
+        $translator = new DeepLTranslator(
+            $vault ?? $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($config ?? $this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
         );
+
+        // Inject a client that returns a successful empty-detect response so the
+        // request resolveBaseUrl() rides on doesn't raise an API error.
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => [['text' => '', 'detected_source_language' => 'EN']]]),
+        );
+        $translator->setHttpClient($httpClient);
+
+        return $translator;
     }
 
     /**
@@ -71,14 +82,36 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
      */
     private function createTranslatorWithHttpClient(ClientInterface $httpClient, ?array $config = null): DeepLTranslator
     {
-        return new DeepLTranslator(
-            $httpClient,
+        $translator = new DeepLTranslator(
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($config ?? $this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($httpClient);
+
+        return $translator;
+    }
+
+    /**
+     * Trigger a request so the lazily-resolved Free/Pro base URL is populated,
+     * then read it back via reflection. With a plain client injected via
+     * setHttpClient(), the request itself is harmless (returns `{}`), but
+     * resolveBaseUrl() still calls vault->retrieve() to test the :fx suffix.
+     */
+    private function resolveBaseUrl(DeepLTranslator $translator): string
+    {
+        // detectLanguage() issues a single POST through the injected client and
+        // forces resolveBaseUrl() to run.
+        $translator->detectLanguage('text');
+
+        $reflection = new ReflectionClass($translator);
+        $baseUrl = $reflection->getProperty('baseUrl')->getValue($translator);
+        self::assertIsString($baseUrl);
+
+        return $baseUrl;
     }
 
     // ===== Tests for mapFormality match expression =====
@@ -197,23 +230,23 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
     #[Test]
     public function freeApiKeyUsesFreelEndpoint(): void
     {
+        // Free vs Pro is now decided by the resolved secret value (free keys
+        // end with :fx), retrieved lazily via the vault on the first request.
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'test-api-key:fx', // Free API key ends with :fx
+                    'apiKeyIdentifier' => 'deepl-free-id',
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        $translator = $this->createTranslator($config);
+        $translator = $this->createTranslator(
+            $config,
+            $this->createVaultServiceMock(['deepl-free-id' => 'secret-value:fx']),
+        );
 
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-        $baseUrlValue = $baseUrl->getValue($translator);
-        self::assertIsString($baseUrlValue);
-
-        self::assertStringContainsString('api-free.deepl.com', $baseUrlValue);
+        self::assertStringContainsString('api-free.deepl.com', $this->resolveBaseUrl($translator));
     }
 
     #[Test]
@@ -222,18 +255,18 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'test-api-key-pro', // Pro API key doesn't end with :fx
+                    'apiKeyIdentifier' => 'deepl-pro-id',
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        $translator = $this->createTranslator($config);
+        $translator = $this->createTranslator(
+            $config,
+            $this->createVaultServiceMock(['deepl-pro-id' => 'secret-value-pro']),
+        );
 
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-        $baseUrlValue = $baseUrl->getValue($translator);
-        self::assertIsString($baseUrlValue);
+        $baseUrlValue = $this->resolveBaseUrl($translator);
 
         self::assertStringContainsString('api.deepl.com', $baseUrlValue);
         self::assertStringNotContainsString('api-free', $baseUrlValue);
@@ -245,7 +278,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'test-api-key-pro',
+                    'apiKeyIdentifier' => 'deepl-pro-id',
                     'baseUrl' => 'https://custom-deepl-api.example.com',
                     'timeout' => 30,
                 ],
@@ -254,10 +287,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
 
         $translator = $this->createTranslator($config);
 
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-
-        self::assertEquals('https://custom-deepl-api.example.com', $baseUrl->getValue($translator));
+        self::assertEquals('https://custom-deepl-api.example.com', $this->resolveBaseUrl($translator));
     }
 
     // ===== Tests for translate with options =====
@@ -438,13 +468,14 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             );
 
         $translator = new DeepLTranslator(
-            $httpClientMock,
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $usageTrackerMock,
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($httpClientMock);
 
         $results = $translator->translateBatch(['Hello', 'World'], 'de', 'en');
 
@@ -686,13 +717,14 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             ->willThrowException(new Exception('Config error'));
 
         $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $extensionConfigStub,
             $this->usageTrackerStub,
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($this->createHttpClientMock());
 
         // Should not throw, but translator should not be available
         self::assertFalse($translator->isAvailable());

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -28,25 +29,35 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createTranslator(array $config = []): DeepLTranslator
+    private function createTranslator(array $config = [], ?VaultServiceInterface $vault = null): DeepLTranslator
     {
         $defaultConfig = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => $this->randomApiKey(),
+                    'apiKeyIdentifier' => $this->randomApiKey(),
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        return new DeepLTranslator(
-            $this->createHttpClientMock(),
+        $translator = new DeepLTranslator(
+            $vault ?? $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock(array_merge($defaultConfig, $config)),
             self::createStub(UsageTrackerServiceInterface::class),
             $this->createLoggerMock(),
         );
+
+        // Inject a client that returns a successful empty-detect response so the
+        // request resolveBaseUrl() rides on doesn't raise an API error.
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => [['text' => '', 'detected_source_language' => 'EN']]]),
+        );
+        $translator->setHttpClient($httpClient);
+
+        return $translator;
     }
 
     private function createTranslatorWithMockClient(ClientInterface $httpClient): DeepLTranslator
@@ -54,20 +65,40 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => $this->randomApiKey(),
+                    'apiKeyIdentifier' => $this->randomApiKey(),
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        return new DeepLTranslator(
-            $httpClient,
+        $translator = new DeepLTranslator(
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($config),
             self::createStub(UsageTrackerServiceInterface::class),
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($httpClient);
+
+        return $translator;
+    }
+
+    /**
+     * Trigger a request so the lazily-resolved Free/Pro base URL is populated,
+     * then read it back via reflection. resolveBaseUrl() calls vault->retrieve()
+     * to test the :fx suffix; the injected plain client makes the request itself
+     * a harmless `{}` round-trip.
+     */
+    private function resolveBaseUrl(DeepLTranslator $translator): string
+    {
+        $translator->detectLanguage('text');
+
+        $reflection = new ReflectionClass($translator);
+        $baseUrl = $reflection->getProperty('baseUrl')->getValue($translator);
+        self::assertIsString($baseUrl);
+
+        return $baseUrl;
     }
 
     #[Test]
@@ -396,31 +427,23 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
     #[Test]
     public function freeApiKeyUsesFreeApiUrl(): void
     {
+        // Free vs Pro is decided by the resolved secret value (free keys end
+        // with :fx), retrieved lazily through the vault on the first request.
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'test-key:fx', // Free API key ends with :fx
+                    'apiKeyIdentifier' => 'deepl-free-id',
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($config),
-            self::createStub(UsageTrackerServiceInterface::class),
-            $this->createLoggerMock(),
+        $translator = $this->createTranslator(
+            $config,
+            $this->createVaultServiceMock(['deepl-free-id' => 'secret-value:fx']),
         );
 
-        // Access baseUrl via reflection
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-        $baseUrlValue = $baseUrl->getValue($translator);
-        self::assertIsString($baseUrlValue);
-
-        self::assertStringContainsString('api-free.deepl.com', $baseUrlValue);
+        self::assertStringContainsString('api-free.deepl.com', $this->resolveBaseUrl($translator));
     }
 
     #[Test]
@@ -429,26 +452,18 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'pro-api-key', // Pro API key doesn't end with :fx
+                    'apiKeyIdentifier' => 'deepl-pro-id',
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($config),
-            self::createStub(UsageTrackerServiceInterface::class),
-            $this->createLoggerMock(),
+        $translator = $this->createTranslator(
+            $config,
+            $this->createVaultServiceMock(['deepl-pro-id' => 'secret-value-pro']),
         );
 
-        // Access baseUrl via reflection
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-        $baseUrlValue = $baseUrl->getValue($translator);
-        self::assertIsString($baseUrlValue);
+        $baseUrlValue = $this->resolveBaseUrl($translator);
 
         self::assertStringContainsString('api.deepl.com', $baseUrlValue);
         self::assertStringNotContainsString('api-free', $baseUrlValue);
@@ -461,26 +476,16 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => 'pro-api-key',
+                    'apiKeyIdentifier' => 'deepl-pro-id',
                     'baseUrl' => $customUrl,
                     'timeout' => 30,
                 ],
             ],
         ];
 
-        $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($config),
-            self::createStub(UsageTrackerServiceInterface::class),
-            $this->createLoggerMock(),
-        );
+        $translator = $this->createTranslator($config);
 
-        $reflection = new ReflectionClass($translator);
-        $baseUrl = $reflection->getProperty('baseUrl');
-
-        self::assertEquals($customUrl, $baseUrl->getValue($translator));
+        self::assertEquals($customUrl, $this->resolveBaseUrl($translator));
     }
 
     #[Test]
@@ -511,15 +516,16 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             ]));
 
         $translator = new DeepLTranslator(
-            $httpClientMock,
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock([
-                'translators' => ['deepl' => ['apiKey' => $this->randomApiKey()]],
+                'translators' => ['deepl' => ['apiKeyIdentifier' => $this->randomApiKey()]],
             ]),
             $usageTrackerMock,
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($httpClientMock);
 
         $translator->translateBatch($texts, 'de');
     }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
+use RuntimeException;
 
 #[CoversClass(DeepLTranslator::class)]
 class DeepLTranslatorTest extends AbstractUnitTestCase
@@ -139,6 +142,56 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ['User-Agent' => 'TYPO3-NrLlm/1.0'],
             $headersMethod->invoke($this->subject),
         );
+    }
+
+    /**
+     * Regression: resolveBaseUrl() must not mark itself resolved until baseUrl is
+     * actually set. If vault->retrieve() throws, the flag stays false so the next
+     * request retries resolution instead of being stuck with an empty base URL.
+     */
+    #[Test]
+    public function resolveBaseUrlRetriesAfterVaultRetrieveFailure(): void
+    {
+        $vault = $this->createMock(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('http')->willReturn(self::createStub(VaultHttpClientInterface::class));
+        $calls = 0;
+        $vault->method('retrieve')->willReturnCallback(static function () use (&$calls): string {
+            $calls++;
+            if ($calls === 1) {
+                throw new RuntimeException('vault unavailable', 5331512677);
+            }
+
+            return 'free-key:fx';
+        });
+
+        $config = ['translators' => ['deepl' => ['apiKeyIdentifier' => 'deepl-id']]];
+        $translator = new DeepLTranslator(
+            $vault,
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($config),
+            $this->usageTrackerStub,
+            $this->createLoggerMock(),
+        );
+
+        $reflection = new ReflectionClass($translator);
+        $resolve = $reflection->getMethod('resolveBaseUrl');
+
+        // First attempt: retrieve() throws → exception propagates and the base
+        // URL must NOT be marked resolved.
+        try {
+            $resolve->invoke($translator);
+            self::fail('Expected the vault failure to propagate');
+        } catch (RuntimeException $e) {
+            self::assertSame('vault unavailable', $e->getMessage());
+        }
+        self::assertFalse($reflection->getProperty('baseUrlResolved')->getValue($translator));
+
+        // Second attempt retries retrieve() and succeeds (Free key → free host).
+        $resolve->invoke($translator);
+        self::assertTrue($reflection->getProperty('baseUrlResolved')->getValue($translator));
+        self::assertSame('https://api-free.deepl.com', $reflection->getProperty('baseUrl')->getValue($translator));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -15,12 +15,14 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\SecretPlacement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
 
 #[CoversClass(DeepLTranslator::class)]
 class DeepLTranslatorTest extends AbstractUnitTestCase
@@ -28,19 +30,23 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
     private DeepLTranslator $subject;
     private UsageTrackerServiceInterface $usageTrackerStub;
 
-    /** @var array{translators: array{deepl: array{apiKey: string, timeout: int}}} */
+    /** @var array{translators: array{deepl: array{apiKeyIdentifier: string, timeout: int}}} */
     private array $defaultConfig;
+
+    /** The vault identifier the default config points at (resolved Pro endpoint). */
+    private string $apiKeyIdentifier;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
+        $this->apiKeyIdentifier = $this->randomApiKey();
 
         $this->defaultConfig = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => $this->randomApiKey(),
+                    'apiKeyIdentifier' => $this->apiKeyIdentifier,
                     'timeout' => 30,
                 ],
             ],
@@ -53,6 +59,8 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
 
     /**
      * Create a DeepLTranslator with a pre-configured HTTP client response.
+     * The translator is wired to a vault mock and the response client is
+     * injected through the test seam (bypassing the vault secure client).
      */
     private function createSubjectWithResponse(ResponseInterface $response): DeepLTranslator
     {
@@ -60,14 +68,38 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $httpClientStub = self::createStub(ClientInterface::class);
         $httpClientStub->method('sendRequest')->willReturn($response);
 
-        return new DeepLTranslator(
-            $httpClientStub,
+        $translator = new DeepLTranslator(
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
         );
+        $translator->setHttpClient($httpClientStub);
+
+        return $translator;
+    }
+
+    /**
+     * Build a DeepLTranslator wired to a vault mock (with the given config) and
+     * inject the supplied plain HTTP client through the test seam.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function buildTranslator(ClientInterface $httpClient, array $config): DeepLTranslator
+    {
+        $translator = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($config),
+            $this->usageTrackerStub,
+            $this->createLoggerMock(),
+        );
+        $translator->setHttpClient($httpClient);
+
+        return $translator;
     }
 
     #[Test]
@@ -82,6 +114,33 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         self::assertEquals('DeepL Translation', $this->subject->getName());
     }
 
+    /**
+     * Assert DeepL exposes the Header placement, `DeepL-Auth-Key ` prefix, and
+     * User-Agent the secure client uses to authenticate
+     * (DeepL: `Authorization: DeepL-Auth-Key <secret>`). This is the exact
+     * non-Bearer scheme the nr-vault prefix option was added for.
+     */
+    #[Test]
+    public function getSecretPlacementUsesHeaderWithDeepLAuthKeyPrefix(): void
+    {
+        $reflection = new ReflectionClass($this->subject);
+
+        $placementMethod = $reflection->getMethod('getSecretPlacement');
+        self::assertSame(SecretPlacement::Header, $placementMethod->invoke($this->subject));
+
+        $optionsMethod = $reflection->getMethod('getSecretPlacementOptions');
+        self::assertSame(
+            ['headerName' => 'Authorization', 'prefix' => 'DeepL-Auth-Key '],
+            $optionsMethod->invoke($this->subject),
+        );
+
+        $headersMethod = $reflection->getMethod('getAdditionalHeaders');
+        self::assertSame(
+            ['User-Agent' => 'TYPO3-NrLlm/1.0'],
+            $headersMethod->invoke($this->subject),
+        );
+    }
+
     #[Test]
     public function isAvailableReturnsTrueWhenApiKeyConfigured(): void
     {
@@ -94,19 +153,12 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $config = [
             'translators' => [
                 'deepl' => [
-                    'apiKey' => '',
+                    'apiKeyIdentifier' => '',
                 ],
             ],
         ];
 
-        $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($config),
-            $this->usageTrackerStub,
-            $this->createLoggerMock(),
-        );
+        $translator = $this->buildTranslator($this->createHttpClientMock(), $config);
 
         self::assertFalse($translator->isAvailable());
     }
@@ -129,14 +181,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock($apiResponse));
 
-        $subject = new DeepLTranslator(
-            $httpClientMock,
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($this->defaultConfig),
-            $this->usageTrackerStub,
-            $this->createLoggerMock(),
-        );
+        $subject = $this->buildTranslator($httpClientMock, $this->defaultConfig);
 
         $result = $subject->translate('Hello World', 'de');
 
@@ -165,14 +210,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock($apiResponse));
 
-        $subject = new DeepLTranslator(
-            $httpClientMock,
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($this->defaultConfig),
-            $this->usageTrackerStub,
-            $this->createLoggerMock(),
-        );
+        $subject = $this->buildTranslator($httpClientMock, $this->defaultConfig);
 
         $result = $subject->translate('Hello World', 'fr', 'en');
 
@@ -207,13 +245,14 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             );
 
         $subject = new DeepLTranslator(
-            $httpClientStub,
+            $this->createVaultServiceMock(),
             $this->createRequestFactoryMock(),
             $this->createStreamFactoryMock(),
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $usageTrackerMock,
             $this->createLoggerMock(),
         );
+        $subject->setHttpClient($httpClientStub);
 
         $subject->translate($text, 'de');
     }
@@ -221,16 +260,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
     #[Test]
     public function translateThrowsWhenNotAvailable(): void
     {
-        $config = ['translators' => ['deepl' => ['apiKey' => '']]];
+        $config = ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]];
 
-        $translator = new DeepLTranslator(
-            $this->createHttpClientMock(),
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($config),
-            $this->usageTrackerStub,
-            $this->createLoggerMock(),
-        );
+        $translator = $this->buildTranslator($this->createHttpClientMock(), $config);
 
         $this->expectException(ServiceUnavailableException::class);
 
@@ -253,14 +285,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($this->createJsonResponseMock($apiResponse));
 
-        $subject = new DeepLTranslator(
-            $httpClientMock,
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createExtensionConfigurationMock($this->defaultConfig),
-            $this->usageTrackerStub,
-            $this->createLoggerMock(),
-        );
+        $subject = $this->buildTranslator($httpClientMock, $this->defaultConfig);
 
         $results = $subject->translateBatch(['Hello', 'World'], 'de');
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.6.0 || ^0.7.0",
+        "netresearch/nr-vault": "^0.8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -5,9 +5,16 @@
 # backend module using database-backed Provider, Model, and Configuration entities.
 # The settings below are only for specialized services that are not yet migrated
 # to the database-backed architecture.
+#
+# All API keys are stored as nr-vault secret identifiers (UUIDs), never as
+# plaintext. The secret is injected by the audited secure HTTP client at request
+# time. Create the secret in the Vault backend module and paste its identifier here.
 
-# cat=deepl; type=string; label=DeepL API Key: Your DeepL API key (Free or Pro). Free keys end with ':fx'
-translators.deepl.apiKey =
+# cat=openai; type=string; label=OpenAI Vault Identifier: nr-vault secret identifier for the OpenAI API key used by the DALL-E, Whisper, and TTS specialized services
+providers.openai.apiKeyIdentifier =
+
+# cat=deepl; type=string; label=DeepL Vault Identifier: nr-vault secret identifier for the DeepL API key (Free or Pro; Free keys end with ':fx', auto-detected on first request)
+translators.deepl.apiKeyIdentifier =
 
 # cat=deepl; type=string; label=DeepL Base URL: Custom base URL (leave empty for auto-detection based on key type)
 translators.deepl.baseUrl =
@@ -45,8 +52,8 @@ image.dalle.defaultModel = dall-e-3
 # cat=image; type=options[1024x1024,1792x1024,1024x1792]; label=DALL-E Default Size: Default image size
 image.dalle.defaultSize = 1024x1024
 
-# cat=fal; type=string; label=FAL API Key: Your FAL.ai API key for alternative image generation
-image.fal.apiKey =
+# cat=fal; type=string; label=FAL Vault Identifier: nr-vault secret identifier for the FAL.ai API key used for alternative image generation
+image.fal.apiKeyIdentifier =
 
 # cat=fal; type=string; label=FAL Base URL: Custom base URL for FAL API (leave empty for default)
 image.fal.baseUrl =


### PR DESCRIPTION
## Summary

Migrate the five specialized single-task services — **DALL-E**, **FAL** (image), **Whisper**, **TTS** (speech), and **DeepL** (translation) — off plaintext API keys onto the **nr-vault secure HTTP client**, exactly as the database-backed providers have done since ADR-012.

Previously each service read a plaintext `apiKey` from extension configuration and assembled its own `Authorization` header over a plain PSR-18 client — contradicting ADR-012 and the project rule that *API keys must be stored as nr-vault identifiers, never plaintext*.

## What changed

- **`AbstractSpecializedService`** takes `VaultServiceInterface` and stores `apiKeyIdentifier` (the vault UUID). `isAvailable()` → `identifier !== '' && vault->exists(identifier)`. The secret is resolved, injected, audited, and `sodium_memzero`-scrubbed inside the vault and never surfaces in this extension.
- `buildAuthHeaders()` is replaced by `getSecretPlacement()` / `getSecretPlacementOptions()` (+ `getAdditionalHeaders()` for non-auth headers). `executeRequest()` routes through a new `getSecureClient()`.
- **Per-service auth scheme:**
  - DALL-E / Whisper / TTS → `Bearer` (OpenAI family)
  - FAL → `Header` + `{headerName: Authorization, prefix: 'Key '}`
  - DeepL → `Header` + `{headerName: Authorization, prefix: 'DeepL-Auth-Key '}` (+ its `User-Agent`)
  - FAL/DeepL use the nr-vault **0.8.0** `prefix` option — the feature added specifically to unblock this migration.
- **DeepL Free/Pro routing stays automatic** without plaintext: the key is retrieved from the vault exactly once, lazily, only to test the `:fx` suffix, then scrubbed; an explicit `baseUrl` override still wins.
- **ext_conf keys** become identifiers: `providers.openai.apiKeyIdentifier`, `image.fal.apiKeyIdentifier`, `translators.deepl.apiKeyIdentifier`.
- Added a `setHttpClient()` test seam (identical to the providers').
- Documented in **ADR-030**.

## Breaking / dependency notes

- **Requires `netresearch/nr-vault ^0.8.0`** (the `prefix` option). A 0.7 install would silently drop the prefix and send a broken `Authorization` header for FAL/DeepL — so the composer floor is raised.
- Host applications that wrote `providers.openai.apiKey` / FAL / DeepL plaintext keys into nr_llm's ext_conf must now store a vault secret and write its **identifier** instead. (The `nr_repurpose` consumer is updated separately.)

## Verification (PHP 8.5, `runTests.sh`)

- Unit: **3425 tests / 7601 assertions** — pass (2 pre-existing deprecations, 9 notices, unrelated)
- PHPStan level 10: **No errors**
- CGL: clean
- Rector: clean

New tests assert the FAL `Key ` and DeepL `DeepL-Auth-Key ` placements/prefixes, DeepL's lazy `:fx` Free/Pro routing through the vault, and that `getSecureClient()` authenticates with the configured identifier.
