### PR TITLE
feat(service): resolve default DB configuration for generic completion

### DIFF
--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -80,10 +80,15 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
         $configuration = $this->configurationRepository?->findDefault();
 
-        // A default configuration without a model cannot build an adapter
-        // (getAdapterFromConfiguration() would throw). Treat that as "no default"
-        // so the extension-config fallback path is preserved as documented.
-        if ($configuration === null || $configuration->getLlmModel() === null) {
+        // Treat as "no default" — preserving the extension-config fallback — when the default
+        // configuration is missing, has no model (getAdapterFromConfiguration() would throw), or
+        // is access-restricted to specific BE groups. The generic chat()/complete()/streamChat()
+        // path has no backend-user context to enforce group membership against (notably the CLI
+        // worker), so an access-restricted default must not be auto-applied to arbitrary callers.
+        if ($configuration === null
+            || $configuration->getLlmModel() === null
+            || $configuration->hasAccessRestrictions()
+        ) {
             return null;
         }
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -55,8 +56,29 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         private readonly ProviderAdapterRegistryInterface $adapterRegistry,
         private readonly MiddlewarePipeline $pipeline,
         private readonly CacheManagerInterface $cacheManager,
+        private readonly ?LlmConfigurationRepository $configurationRepository = null,
     ) {
         $this->loadConfiguration();
+    }
+
+    /**
+     * Resolve the backend-module-managed default configuration for a generic
+     * (provider-agnostic) completion/chat call. Returns null when the caller
+     * pinned an explicit provider, when no repository is wired (unit tests), or
+     * when no active default configuration exists — in which case the caller
+     * falls back to the extension-config default provider.
+     *
+     * Uses the repository directly rather than LlmConfigurationService, whose
+     * getDefaultConfiguration() enforces a backend-user access check that the
+     * CLI worker (Symfony Messenger consumer) has no user for.
+     */
+    private function resolveDefaultConfiguration(?string $providerKey): ?LlmConfiguration
+    {
+        if ($providerKey !== null) {
+            return null;
+        }
+
+        return $this->configurationRepository?->findDefault();
     }
 
     private function loadConfiguration(): void
@@ -163,6 +185,20 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
 
+        // Single source of truth: with no explicit provider pinned, prefer the
+        // backend-module-managed default DB configuration so it drives generation.
+        // The per-call options override the configuration's stored defaults; falls
+        // back to the extension-config default provider when no default exists.
+        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        if ($defaultConfiguration !== null) {
+            return $this->chatWithConfiguration(
+                $messages,
+                $defaultConfiguration,
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+                $optionsArray,
+            );
+        }
+
         $normalisedMessages = $this->normaliseMessages($messages);
 
         return $this->runThroughPipeline(
@@ -182,6 +218,17 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
         unset($optionsArray['provider']);
+
+        // Single source of truth: prefer the default DB configuration (see chat()).
+        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        if ($defaultConfiguration !== null) {
+            return $this->completeWithConfiguration(
+                $prompt,
+                $defaultConfiguration,
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+                $optionsArray,
+            );
+        }
 
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
@@ -448,17 +495,18 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $metadata
+     * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
      */
-    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = []): CompletionResponse
+    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse
     {
         $normalisedMessages = $this->normaliseMessages($messages);
 
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Chat,
-            function (LlmConfiguration $config) use ($normalisedMessages): CompletionResponse {
+            function (LlmConfiguration $config) use ($normalisedMessages, $optionOverrides): CompletionResponse {
                 $adapter = $this->getAdapterFromConfiguration($config);
-                $options = $config->toOptionsArray();
+                $options = array_merge($config->toOptionsArray(), $optionOverrides);
                 unset($options['provider']);
                 return $adapter->chatCompletion($normalisedMessages, $options);
             },
@@ -472,15 +520,16 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * Fallback chain is applied when configured; see chatWithConfiguration().
      *
      * @param array<string, mixed> $metadata
+     * @param array<string, mixed> $optionOverrides per-call options that take precedence over the configuration's stored defaults
      */
-    public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = []): CompletionResponse
+    public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse
     {
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Completion,
-            function (LlmConfiguration $config) use ($prompt): CompletionResponse {
+            function (LlmConfiguration $config) use ($prompt, $optionOverrides): CompletionResponse {
                 $adapter = $this->getAdapterFromConfiguration($config);
-                $options = $config->toOptionsArray();
+                $options = array_merge($config->toOptionsArray(), $optionOverrides);
                 unset($options['provider']);
                 return $adapter->complete($prompt, $options);
             },

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -78,7 +78,16 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             return null;
         }
 
-        return $this->configurationRepository?->findDefault();
+        $configuration = $this->configurationRepository?->findDefault();
+
+        // A default configuration without a model cannot build an adapter
+        // (getAdapterFromConfiguration() would throw). Treat that as "no default"
+        // so the extension-config fallback path is preserved as documented.
+        if ($configuration === null || $configuration->getLlmModel() === null) {
+            return null;
+        }
+
+        return $configuration;
     }
 
     private function loadConfiguration(): void

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -359,8 +359,16 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $options ??= new ChatOptions();
         $optionsArray = $options->toArray();
         $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        $provider = $this->getProvider($providerKey);
         unset($optionsArray['provider']);
+
+        // Single source of truth: prefer the default DB configuration (see chat()),
+        // so streaming and non-streaming calls resolve the same provider/model.
+        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        if ($defaultConfiguration !== null) {
+            return $this->streamChatWithConfiguration($messages, $defaultConfiguration, $optionsArray);
+        }
+
+        $provider = $this->getProvider($providerKey);
 
         if (!$provider instanceof StreamingCapableInterface) {
             throw new UnsupportedFeatureException(
@@ -690,13 +698,14 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * normalised via `ChatMessage::fromArray()` before dispatch.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
      *
      * @return Generator<int, string, mixed, void>
      */
-    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration): Generator
+    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = []): Generator
     {
         $adapter = $this->getAdapterFromConfiguration($configuration);
-        $options = $configuration->toOptionsArray();
+        $options = array_merge($configuration->toOptionsArray(), $optionOverrides);
 
         // Remove provider key as we already have the adapter
         unset($options['provider']);

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -64,8 +64,9 @@ interface LlmServiceManagerInterface
      * Complete a prompt using a specific LLM configuration.
      *
      * @param array<string, mixed> $metadata
+     * @param array<string, mixed> $optionOverrides per-call options that take precedence over the configuration's stored defaults
      */
-    public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = []): CompletionResponse;
+    public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse;
 
     /**
      * Chat using a specific LLM configuration (database-backed provider resolution).
@@ -75,8 +76,9 @@ interface LlmServiceManagerInterface
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $metadata
+     * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
      */
-    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = []): CompletionResponse;
+    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse;
 
     /**
      * Stream chat completion using a specific LLM configuration.

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -87,10 +87,11 @@ interface LlmServiceManagerInterface
      * and normalised via `ChatMessage::fromArray()` before dispatch.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
      *
      * @return Generator<int, string, mixed, void>
      */
-    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration): Generator;
+    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = []): Generator;
 
     /**
      * @param string|array<int, string> $input

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
@@ -691,6 +692,114 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $result = $manager->completeWithConfiguration('Test prompt', $config);
 
         self::assertSame($expectedResponse, $result);
+    }
+
+    #[Test]
+    public function chatRoutesThroughDefaultConfigurationWhenNoProviderPinned(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('nr_repurpose');
+        $config->method('toOptionsArray')->willReturn([
+            'temperature' => 0.7,
+            'max_tokens' => 4096,
+            'model' => 'gpt-4o',
+            'provider' => 'openai',
+        ]);
+
+        $expectedResponse = new CompletionResponse(
+            content: '{"ok":true}',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(1, 1, 2),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $captured = [];
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->method('chatCompletion')->willReturnCallback(
+            function (array $messages, array $options) use (&$captured, $expectedResponse): CompletionResponse {
+                $captured = $options;
+                return $expectedResponse;
+            },
+        );
+
+        $registryStub = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryStub->method('createAdapterFromModel')->willReturn($adapter);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+
+        $result = $manager->chat(
+            [['role' => 'user', 'content' => 'Hello']],
+            (new ChatOptions(temperature: 0.3))->withResponseFormat('json'),
+        );
+
+        self::assertSame($expectedResponse, $result);
+        // Per-call options override the configuration's stored defaults.
+        self::assertSame(0.3, $captured['temperature']);
+        self::assertSame('json', $captured['response_format']);
+        // Configuration-only defaults survive the merge.
+        self::assertSame(4096, $captured['max_tokens']);
+        self::assertSame('gpt-4o', $captured['model']);
+        // The provider key is never forwarded to the adapter.
+        self::assertArrayNotHasKey('provider', $captured);
+    }
+
+    #[Test]
+    public function chatBypassesDefaultConfigurationWhenProviderPinned(): void
+    {
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        // A pinned provider must short-circuit before the default-config lookup.
+        $configRepo->expects(self::never())->method('findDefault');
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        $result = $manager->chat(
+            [['role' => 'user', 'content' => 'Hello']],
+            new ChatOptions(provider: 'openai'),
+        );
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    #[Test]
+    public function chatFallsBackToDefaultProviderWhenNoDefaultConfigurationExists(): void
+    {
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn(null);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
     }
 
     #[Test]

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -803,6 +803,101 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function completeRoutesThroughDefaultConfigurationWhenNoProviderPinned(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('nr_repurpose');
+        $config->method('toOptionsArray')->willReturn([
+            'temperature' => 0.7,
+            'model' => 'gpt-4o',
+            'provider' => 'openai',
+        ]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'text',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(1, 1, 2),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $captured = [];
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->method('complete')->willReturnCallback(
+            function (string $prompt, array $options) use (&$captured, $expectedResponse): CompletionResponse {
+                $captured = $options;
+                return $expectedResponse;
+            },
+        );
+
+        $registryStub = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryStub->method('createAdapterFromModel')->willReturn($adapter);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+
+        $result = $manager->complete('Prompt', new ChatOptions(temperature: 0.2));
+
+        self::assertSame($expectedResponse, $result);
+        self::assertSame(0.2, $captured['temperature']);
+        self::assertSame('gpt-4o', $captured['model']);
+        self::assertArrayNotHasKey('provider', $captured);
+    }
+
+    #[Test]
+    public function completeBypassesDefaultConfigurationWhenProviderPinned(): void
+    {
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->expects(self::never())->method('findDefault');
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        $result = $manager->complete('Prompt', new ChatOptions(provider: 'openai'));
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    #[Test]
+    public function completeFallsBackToDefaultProviderWhenNoDefaultConfigurationExists(): void
+    {
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn(null);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        $result = $manager->complete('Prompt');
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    #[Test]
     public function streamChatWithConfigurationUsesAdapter(): void
     {
         $model = self::createStub(Model::class);

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -829,6 +829,34 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatFallsBackToDefaultProviderWhenDefaultConfigurationIsAccessRestricted(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('hasAccessRestrictions')->willReturn(true);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        // A group-restricted default must not be auto-applied without a BE-user
+        // context to enforce membership — the extension-config provider handles it.
+        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    #[Test]
     public function completeRoutesThroughDefaultConfigurationWhenNoProviderPinned(): void
     {
         $model = self::createStub(Model::class);

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -960,61 +960,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $config->method('getIdentifier')->willReturn('test-config');
         $config->method('toOptionsArray')->willReturn(['temperature' => 0.5]);
 
-        // Create a streaming-capable mock adapter
-        $mockAdapter = new class implements ProviderInterface, StreamingCapableInterface {
-            public function getIdentifier(): string
-            {
-                return 'mock';
-            }
-            public function getName(): string
-            {
-                return 'Mock';
-            }
-            public function isAvailable(): bool
-            {
-                return true;
-            }
-            public function supportsFeature(string|ModelCapability $feature): bool
-            {
-                return true;
-            }
-            public function configure(array $config): void {}
-            public function chatCompletion(array $messages, array $options = []): CompletionResponse
-            {
-                throw new RuntimeException('Not implemented', 3106251534);
-            }
-            public function complete(string $prompt, array $options = []): CompletionResponse
-            {
-                throw new RuntimeException('Not implemented', 7104913232);
-            }
-            public function embeddings(string|array $input, array $options = []): EmbeddingResponse
-            {
-                throw new RuntimeException('Not implemented', 5854205295);
-            }
-            public function getAvailableModels(): array
-            {
-                return [];
-            }
-            public function getDefaultModel(): string
-            {
-                return 'test';
-            }
-            public function testConnection(): array
-            {
-                return ['success' => true, 'message' => 'OK'];
-            }
-
-            public function streamChatCompletion(array $messages, array $options = []): Generator
-            {
-                yield 'Streaming';
-                yield ' response';
-            }
-
-            public function supportsStreaming(): bool
-            {
-                return true;
-            }
-        };
+        $mockAdapter = new StubStreamingProvider();
 
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
@@ -1027,6 +973,50 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         }
 
         self::assertEquals(['Streaming', ' response'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatRoutesThroughDefaultConfigurationWithOptionOverrides(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('hasAccessRestrictions')->willReturn(false);
+        $config->method('toOptionsArray')->willReturn([
+            'temperature' => 0.7,
+            'max_tokens' => 4096,
+            'model' => 'gpt-4o',
+            'provider' => 'openai',
+        ]);
+
+        $adapter = new StubStreamingProvider();
+        $registryStub = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryStub->method('createAdapterFromModel')->willReturn($adapter);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+
+        $chunks = [];
+        foreach ($manager->streamChat([['role' => 'user', 'content' => 'Hello']], (new ChatOptions(temperature: 0.3))->withResponseFormat('json')) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertEquals(['Streaming', ' response'], $chunks);
+        // Per-call options override config defaults; config-only defaults survive; provider stripped.
+        self::assertSame(0.3, $adapter->capturedOptions['temperature']);
+        self::assertSame('json', $adapter->capturedOptions['response_format']);
+        self::assertSame(4096, $adapter->capturedOptions['max_tokens']);
+        self::assertSame('gpt-4o', $adapter->capturedOptions['model']);
+        self::assertArrayNotHasKey('provider', $adapter->capturedOptions);
     }
 
     #[Test]
@@ -1579,6 +1569,33 @@ class TestableStreamingProvider extends TestableProvider implements StreamingCap
     {
         yield 'Hello';
         yield ' World';
+    }
+
+    public function supportsStreaming(): bool
+    {
+        return true;
+    }
+}
+
+/**
+ * Streaming-capable provider stub that records the options it received — shared by the
+ * streaming tests so the throw-stubs live in one place (avoids duplicated fixtures).
+ */
+class StubStreamingProvider extends TestableProvider implements StreamingCapableInterface
+{
+    /** @var array<string, mixed> */
+    public array $capturedOptions = [];
+
+    public function __construct()
+    {
+        parent::__construct('mock', 'Mock', true);
+    }
+
+    public function streamChatCompletion(array $messages, array $options = []): Generator
+    {
+        $this->capturedOptions = $options;
+        yield 'Streaming';
+        yield ' response';
     }
 
     public function supportsStreaming(): bool

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -46,7 +46,6 @@ use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 #[CoversClass(LlmServiceManager::class)]

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -803,6 +803,32 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatFallsBackToDefaultProviderWhenDefaultConfigurationHasNoModel(): void
+    {
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn(null);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = new LlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        // A model-less default config must not route into *WithConfiguration()
+        // (which would throw) — the extension-config provider handles it instead.
+        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    #[Test]
     public function completeRoutesThroughDefaultConfigurationWhenNoProviderPinned(): void
     {
         $model = self::createStub(Model::class);


### PR DESCRIPTION
## Summary

Makes the backend-module-managed **default LLM Configuration** the source of truth for generic completion. Previously `chat()` / `complete()` always resolved the extension-config `defaultProvider`, so the DB-backed Provider/Model/Configuration records (created via the backend module / setup wizard) were never used by callers that don't pin a provider — the module could display a full setup while generation ran off a separate config layer.

## Behaviour

- When **no provider is pinned**, `chat()` / `complete()` now route through the active **default** `LlmConfiguration` (`LlmConfigurationRepository::findDefault()`), which supplies the provider adapter, model and vault-backed credentials.
- Per-call `ChatOptions` (temperature, `response_format`, system prompt, …) **override** the configuration's stored defaults, so JSON mode and per-call prompts keep working.
- **Backwards compatible:** falls back to the extension-config default provider when no default configuration exists. The repository is an optional constructor dependency, so existing 5-arg instantiations (and unit tests) are unaffected.
- The repository's `findDefault()` is used directly rather than `LlmConfigurationService::getDefaultConfiguration()`, which enforces a backend-user access check that the CLI Messenger worker has no user for.

`chatWithConfiguration()` / `completeWithConfiguration()` gain an `$optionOverrides` parameter to support the per-call merge.

## Why

Downstream consumers (e.g. `nr_repurpose` generation) call `CompletionService` without pinning a provider. With this change they transparently use whatever the operator configures in the nr-llm backend module, instead of requiring a parallel extension-config wiring.

## Tests

- `chatRoutesThroughDefaultConfigurationWhenNoProviderPinned` — verifies routing + per-call/option-default merge (per-call wins; config-only defaults survive; provider key stripped).
- `chatBypassesDefaultConfigurationWhenProviderPinned` — pinned provider short-circuits the lookup.
- `chatFallsBackToDefaultProviderWhenNoDefaultConfigurationExists` — extension-config fallback preserved.

Unit (3429) ✅ · PHPStan level 10 ✅ · CGL ✅ (PHP 8.4)
