### PR TITLE
fix: rectify code-review findings (streaming errors, wizard SSRF hardening, input validation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ nr_llm/
 │   ├── Provider/               # 7 LLM adapters + Contract interfaces + exceptions
 │   ├── Service/                # Feature services, wizard, options, fallback chain
 │   ├── Specialized/            # DeepL, speech (Whisper/TTS), image (DALL-E/FAL)
-│   ├── Utility/                # SafeCastTrait
+│   ├── Utility/                # SafeCastTrait, ErrorMessageSanitizerTrait
 │   └── Widgets/DataProvider/   # Backend dashboard widgets (cost, requests)
 ├── Configuration/              # TYPO3 config (TCA, services, caching, icons, routes)
 ├── Documentation/              # 69 RST files + guides.xml + brand assets
@@ -156,6 +156,7 @@ nr_llm/
 ## Shared Utilities — Don't Reinvent
 
 - **Type coercion**: `Classes/Utility/SafeCastTrait` exposes private helpers (`toStr`, `toInt`, `toFloat`) for internal coercion when raw values come from untrusted sources. Use them inside the trait consumer; do not invent `safeIntCast`-style public methods.
+- **Error-message sanitizing**: `Classes/Utility/ErrorMessageSanitizerTrait::sanitizeErrorMessage()` strips secret-bearing query parameters (`?key=`, `?token=`, …) before a message is logged or surfaced. Use the trait; do not copy the regex.
 - **Provider invocation**: `Classes/Domain/DTO/FallbackChain.php` defines fallback chains; `Classes/Provider/Middleware/FallbackMiddleware.php` enforces them at runtime. Always go through the middleware pipeline rather than calling provider classes directly — it handles retries, fallback ordering, and error mapping.
 - **Cost tracking**: `Classes/Provider/Middleware/UsageMiddleware.php` records usage after each successful provider call via `UsageTrackerServiceInterface::trackUsage()`. Don't write to the usage table directly.
 - **Cache config**: `Configuration/Caching.php` declares the `nrllm_responses` cache. Add new caches there (no hardcoded backend — let the host instance configure Redis/Valkey/Memcached).

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -50,7 +50,7 @@ Full test matrix in root `AGENTS.md` Setup section.
 | `Service/Option/` | ChatOptions, EmbeddingOptions, ToolOptions, TranslationOptions, VisionOptions |
 | `Service/SetupWizard/` | ProviderDetector, ModelDiscovery, ConfigurationGenerator + DTOs |
 | `Specialized/` | Image (DALL-E, FAL), Speech (Whisper, TTS), Translation (DeepL, LLM) |
-| `Utility/` | SafeCastTrait |
+| `Utility/` | SafeCastTrait, ErrorMessageSanitizerTrait |
 | `Widgets/DataProvider/` | Backend dashboard widgets (MonthlyCost, RequestsByProvider) |
 <!-- AGENTS-GENERATED:END filemap -->
 

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -30,7 +31,11 @@ use Throwable;
 
 abstract class AbstractProvider implements ProviderInterface
 {
+    use ErrorMessageSanitizerTrait;
     use ResponseParserTrait;
+
+    /** Placeholder for provider error payloads that carry no message. */
+    private const UNKNOWN_ERROR = 'Unknown error';
 
     /**
      * Feature constants for provider capabilities.
@@ -228,7 +233,7 @@ abstract class AbstractProvider implements ProviderInterface
                 if ($statusCode >= 400 && $statusCode < 500) {
                     $body = (string)$response->getBody();
                     $decoded = json_decode($body, true);
-                    $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => 'Unknown error']];
+                    $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => self::UNKNOWN_ERROR]];
                     throw new ProviderResponseException(
                         message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
                         httpStatus: $statusCode,
@@ -255,7 +260,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         throw new ProviderConnectionException(
             'Failed to connect to provider after ' . $this->maxRetries . ' attempts: '
-            . $this->sanitizeErrorMessage($lastException?->getMessage() ?? 'Unknown error'),
+            . $this->sanitizeErrorMessage($lastException?->getMessage() ?? self::UNKNOWN_ERROR),
             0,
             $lastException,
         );
@@ -289,7 +294,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         if ($statusCode >= 400 && $statusCode < 500) {
             $decoded = json_decode($body, true);
-            $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => 'Unknown error']];
+            $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => self::UNKNOWN_ERROR]];
             throw new ProviderResponseException(
                 message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
                 httpStatus: $statusCode,
@@ -301,22 +306,6 @@ abstract class AbstractProvider implements ProviderInterface
         throw new ProviderConnectionException(
             sprintf('Server returned status %d', $statusCode),
             $statusCode,
-        );
-    }
-
-    /**
-     * Sanitize error messages to prevent leaking secrets (API keys in URLs, headers, etc.).
-     *
-     * HTTP client exceptions may include full URLs with query parameters containing API keys
-     * (e.g., Gemini's ?key=... pattern). This strips sensitive query parameters.
-     */
-    protected function sanitizeErrorMessage(string $message): string
-    {
-        // Strip query parameters that may contain API keys from URLs in the message
-        return (string)preg_replace(
-            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
-            '$1$2=***',
-            $message,
         );
     }
 

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -23,6 +23,7 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -263,6 +264,44 @@ abstract class AbstractProvider implements ProviderInterface
     protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
     {
         return $request;
+    }
+
+    /**
+     * Map a non-2xx streaming response to the same typed exceptions that
+     * `sendRequest()` raises, so a failed stream surfaces the error instead
+     * of silently yielding an empty generator.
+     *
+     * Streaming bypasses `sendRequest()` (the SSE body must be read lazily),
+     * and the fallback middleware excludes streaming from its retry/fallback
+     * handling — so surfacing the typed error here is the correct contract.
+     *
+     * @throws ProviderResponseException   on a 4xx response
+     * @throws ProviderConnectionException on any other non-2xx response
+     */
+    protected function assertStreamingResponseOk(ResponseInterface $response, string $endpoint): void
+    {
+        $statusCode = $response->getStatusCode();
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return;
+        }
+
+        $body = (string)$response->getBody();
+
+        if ($statusCode >= 400 && $statusCode < 500) {
+            $decoded = json_decode($body, true);
+            $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => 'Unknown error']];
+            throw new ProviderResponseException(
+                message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
+                httpStatus: $statusCode,
+                responseBody: $body,
+                endpoint: $endpoint,
+            );
+        }
+
+        throw new ProviderConnectionException(
+            sprintf('Server returned status %d', $statusCode),
+            $statusCode,
+        );
     }
 
     /**

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -445,6 +445,7 @@ final class ClaudeProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'messages');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -443,6 +443,7 @@ final class GeminiProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, sprintf('models/%s:streamGenerateContent', $model));
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -256,6 +256,7 @@ final class GroqProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'chat/completions');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -47,6 +47,8 @@ final class GroqProvider extends AbstractProvider implements
         self::FEATURE_TOOLS,
     ];
 
+    private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
+
     private const DEFAULT_CHAT_MODEL = 'llama-3.3-70b-versatile';
 
     /** @var array<string, string> */
@@ -140,7 +142,7 @@ final class GroqProvider extends AbstractProvider implements
             $payload['seed'] = $this->getInt($options, 'seed');
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -190,7 +192,7 @@ final class GroqProvider extends AbstractProvider implements
             $payload['parallel_tool_calls'] = $this->getBool($options, 'parallel_tool_calls');
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -246,7 +248,7 @@ final class GroqProvider extends AbstractProvider implements
             'stream' => true,
         ];
 
-        $url = rtrim($this->baseUrl, '/') . '/chat/completions';
+        $url = rtrim($this->baseUrl, '/') . '/' . self::ENDPOINT_CHAT_COMPLETIONS;
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
@@ -256,7 +258,7 @@ final class GroqProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
-        $this->assertStreamingResponseOk($response, 'chat/completions');
+        $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -281,6 +281,7 @@ final class MistralProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'chat/completions');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -46,6 +46,8 @@ final class MistralProvider extends AbstractProvider implements
         self::FEATURE_TOOLS,
     ];
 
+    private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
+
     private const DEFAULT_CHAT_MODEL = 'mistral-large-latest';
     private const DEFAULT_EMBEDDING_MODEL = 'mistral-embed';
 
@@ -126,7 +128,7 @@ final class MistralProvider extends AbstractProvider implements
             $payload['safe_prompt'] = $this->getBool($options, 'safe_prompt');
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -171,7 +173,7 @@ final class MistralProvider extends AbstractProvider implements
             $payload['tool_choice'] = $options['tool_choice'];
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -271,7 +273,7 @@ final class MistralProvider extends AbstractProvider implements
             'stream' => true,
         ];
 
-        $url = rtrim($this->baseUrl, '/') . '/chat/completions';
+        $url = rtrim($this->baseUrl, '/') . '/' . self::ENDPOINT_CHAT_COMPLETIONS;
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
@@ -281,7 +283,7 @@ final class MistralProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
-        $this->assertStreamingResponseOk($response, 'chat/completions');
+        $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -277,6 +277,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'api/chat');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -37,6 +37,8 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         self::FEATURE_STREAMING,
     ];
 
+    private const ENDPOINT_CHAT = 'api/chat';
+
     private const DEFAULT_MODEL = 'llama3.2';
 
     public function getName(): string
@@ -186,7 +188,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $payload['options'] = $payloadOptions;
         }
 
-        $response = $this->sendRequest('api/chat', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload);
 
         $message = $this->getArray($response, 'message');
 
@@ -268,7 +270,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $payload['options'] = $payloadOptions;
         }
 
-        $url = rtrim($this->baseUrl, '/') . '/api/chat';
+        $url = rtrim($this->baseUrl, '/') . '/' . self::ENDPOINT_CHAT;
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json');
@@ -277,7 +279,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
-        $this->assertStreamingResponseOk($response, 'api/chat');
+        $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT);
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -351,6 +351,7 @@ final class OpenAiProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'chat/completions');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -40,6 +40,8 @@ final class OpenAiProvider extends AbstractProvider implements
         self::FEATURE_TOOLS,
     ];
 
+    private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
+
     private const DEFAULT_CHAT_MODEL = 'gpt-5.2';
     private const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
 
@@ -120,7 +122,7 @@ final class OpenAiProvider extends AbstractProvider implements
             $payload['stop'] = $options['stop'];
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -173,7 +175,7 @@ final class OpenAiProvider extends AbstractProvider implements
             $payload['tool_choice'] = $options['tool_choice'];
         }
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -281,7 +283,7 @@ final class OpenAiProvider extends AbstractProvider implements
             'max_completion_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];
 
-        $response = $this->sendRequest('chat/completions', $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -341,7 +343,7 @@ final class OpenAiProvider extends AbstractProvider implements
             ...$this->buildSamplingParams($model, $options),
         ];
 
-        $url = rtrim($this->baseUrl, '/') . '/chat/completions';
+        $url = rtrim($this->baseUrl, '/') . '/' . self::ENDPOINT_CHAT_COMPLETIONS;
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
@@ -351,7 +353,7 @@ final class OpenAiProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
-        $this->assertStreamingResponseOk($response, 'chat/completions');
+        $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -569,6 +569,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
+        $this->assertStreamingResponseOk($response, 'chat/completions');
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -58,6 +58,8 @@ final class OpenRouterProvider extends AbstractProvider implements
         self::FEATURE_TOOLS,
     ];
 
+    private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
+
     private const DEFAULT_CHAT_MODEL = 'anthropic/claude-sonnet-4-5';
     private const DEFAULT_EMBEDDING_MODEL = 'openai/text-embedding-3-small';
 
@@ -295,7 +297,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $payload['transforms'] = $transforms;
         }
 
-        $response = $this->sendOpenRouterRequest('chat/completions', $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -360,7 +362,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             }
         }
 
-        $response = $this->sendOpenRouterRequest('chat/completions', $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -479,7 +481,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $payload['route'] = 'fallback';
         }
 
-        $response = $this->sendOpenRouterRequest('chat/completions', $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -551,7 +553,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             }
         }
 
-        $url = rtrim($this->baseUrl, '/') . '/chat/completions';
+        $url = rtrim($this->baseUrl, '/') . '/' . self::ENDPOINT_CHAT_COMPLETIONS;
 
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
@@ -569,7 +571,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);
-        $this->assertStreamingResponseOk($response, 'chat/completions');
+        $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 
         $buffer = '';

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -37,8 +37,8 @@ final class ConfigurationGenerator
     use SecureHttpDispatchTrait;
 
     /**
-     * Audit-log reason recorded by the vault secure client for every
-     * outbound request (see `SecureHttpDispatchTrait::dispatch()`).
+     * Audit-log reason the vault secure client records for every outbound
+     * request, passed to `SecureHttpDispatchTrait::dispatch()`.
      */
     private const VAULT_DISPATCH_REASON = 'LLM setup-wizard configuration generation';
 
@@ -70,12 +70,17 @@ final class ConfigurationGenerator
         PROMPT;
 
     public function __construct(
-        private readonly VaultServiceInterface $vault,
-        private readonly SecureHttpClientFactory $httpClientFactory,
+        VaultServiceInterface $vault,
+        SecureHttpClientFactory $httpClientFactory,
         private readonly RequestFactoryInterface $requestFactory,
         private readonly StreamFactoryInterface $streamFactory,
         private readonly LoggerInterface $logger,
-    ) {}
+    ) {
+        // Initialise the readonly collaborators declared in
+        // SecureHttpDispatchTrait (no promotion — the trait owns them).
+        $this->vault = $vault;
+        $this->httpClientFactory = $httpClientFactory;
+    }
 
     /**
      * Generate configuration suggestions using the LLM.
@@ -204,7 +209,7 @@ final class ConfigurationGenerator
             default => $request->withHeader('Authorization', 'Bearer ' . $apiKey),
         };
 
-        $response = $this->dispatch($request);
+        $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
         if ($response->getStatusCode() !== 200) {
             throw new RuntimeException('LLM API error: ' . $response->getStatusCode(), 6587111580);

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -12,9 +12,14 @@ namespace Netresearch\NrLlm\Service\SetupWizard;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
 
@@ -22,9 +27,13 @@ use Throwable;
  * Generates configuration suggestions using the connected LLM.
  *
  * Uses the newly connected LLM to generate optimal configuration presets
- * for common use cases.
+ * for common use cases. The single outbound call is dispatched through the
+ * nr-vault secure HTTP client (`$vault->http()`) and the target host is
+ * gated via `SecureHttpClientFactory::isHostAllowed()` first, so the wizard
+ * cannot be coerced into an SSRF request — the same hardened path the
+ * providers and specialised services use.
  */
-final readonly class ConfigurationGenerator
+final class ConfigurationGenerator
 {
     private const SYSTEM_PROMPT = <<<'PROMPT'
         You are an expert at configuring LLM integrations. Generate practical configuration presets for common business use cases.
@@ -53,11 +62,79 @@ final readonly class ConfigurationGenerator
         Focus on: content creation, translation, summarization, customer support, and code/technical assistance.
         PROMPT;
 
+    /**
+     * Test seam: when set, requests go through this client instead of the
+     * vault secure client. Production never sets it.
+     */
+    private ?ClientInterface $configuredHttpClient = null;
+
     public function __construct(
-        private ClientInterface $httpClient,
-        private RequestFactoryInterface $requestFactory,
-        private StreamFactoryInterface $streamFactory,
+        private readonly VaultServiceInterface $vault,
+        private readonly SecureHttpClientFactory $httpClientFactory,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly LoggerInterface $logger,
     ) {}
+
+    /**
+     * Inject a custom HTTP client, bypassing the vault secure client.
+     *
+     * @internal Test seam only — production always dispatches through the
+     *           audited vault client (see `dispatch()`).
+     */
+    public function setHttpClient(ClientInterface $client): void
+    {
+        $this->configuredHttpClient = $client;
+    }
+
+    /**
+     * Send a request through the SSRF-guarded vault secure client.
+     *
+     * The host is gated up front via `isHostAllowed()` so a disallowed /
+     * private-range target is rejected before any secret-bearing header is
+     * sent; the vault client re-checks the host and validates the scheme as
+     * defence in depth.
+     *
+     * @throws Throwable when the host is disallowed or the request fails
+     */
+    private function dispatch(RequestInterface $request): ResponseInterface
+    {
+        // Test seam: an injected client bypasses the vault path entirely so
+        // unit tests can assert on the request the wizard built without hitting
+        // DNS or the host allowlist.
+        if ($this->configuredHttpClient !== null) {
+            return $this->configuredHttpClient->sendRequest($request);
+        }
+
+        // Reject a disallowed / private-range target up front, before any
+        // secret-bearing header reaches the wire. The vault client re-checks
+        // the host and validates the scheme inside sendRequest() as defence in
+        // depth, but failing here yields a clear, typed rejection.
+        $host = $request->getUri()->getHost();
+        if (!$this->httpClientFactory->isHostAllowed($host)) {
+            throw new RuntimeException(
+                sprintf('Host "%s" is not in the allowed hosts list', $host),
+                7438190002,
+            );
+        }
+
+        return $this->vault->http()
+            ->withReason('LLM setup-wizard configuration generation')
+            ->sendRequest($request);
+    }
+
+    /**
+     * Strip secret-bearing query parameters from a message before it is
+     * logged. Mirrors `AbstractProvider`.
+     */
+    private function sanitizeErrorMessage(string $message): string
+    {
+        return (string)preg_replace(
+            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
+            '$1$2=***',
+            $message,
+        );
+    }
 
     /**
      * Generate configuration suggestions using the LLM.
@@ -89,7 +166,18 @@ final readonly class ConfigurationGenerator
             $configurations = $this->parseResponse($response, $generationModel->modelId);
 
             return $configurations !== [] ? $configurations : $this->getFallbackConfigurations($models);
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            // Fail soft to the static fallback presets, but log the sanitised
+            // reason server-side (the raw message can carry the endpoint URL
+            // or an SSRF-rejection detail) so operators can diagnose.
+            $this->logger->warning(
+                'LLM setup-wizard configuration generation failed; using fallback presets',
+                [
+                    'provider'  => $provider->adapterType,
+                    'exception' => $this->sanitizeErrorMessage($e->getMessage()),
+                ],
+            );
+
             return $this->getFallbackConfigurations($models);
         }
     }
@@ -175,7 +263,7 @@ final readonly class ConfigurationGenerator
             default => $request->withHeader('Authorization', 'Bearer ' . $apiKey),
         };
 
-        $response = $this->httpClient->sendRequest($request);
+        $response = $this->dispatch($request);
 
         if ($response->getStatusCode() !== 200) {
             throw new RuntimeException('LLM API error: ' . $response->getStatusCode(), 6587111580);

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -12,12 +12,10 @@ namespace Netresearch\NrLlm\Service\SetupWizard;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -35,6 +33,15 @@ use Throwable;
  */
 final class ConfigurationGenerator
 {
+    use ErrorMessageSanitizerTrait;
+    use SecureHttpDispatchTrait;
+
+    /**
+     * Audit-log reason recorded by the vault secure client for every
+     * outbound request (see `SecureHttpDispatchTrait::dispatch()`).
+     */
+    private const VAULT_DISPATCH_REASON = 'LLM setup-wizard configuration generation';
+
     private const SYSTEM_PROMPT = <<<'PROMPT'
         You are an expert at configuring LLM integrations. Generate practical configuration presets for common business use cases.
 
@@ -62,12 +69,6 @@ final class ConfigurationGenerator
         Focus on: content creation, translation, summarization, customer support, and code/technical assistance.
         PROMPT;
 
-    /**
-     * Test seam: when set, requests go through this client instead of the
-     * vault secure client. Production never sets it.
-     */
-    private ?ClientInterface $configuredHttpClient = null;
-
     public function __construct(
         private readonly VaultServiceInterface $vault,
         private readonly SecureHttpClientFactory $httpClientFactory,
@@ -75,66 +76,6 @@ final class ConfigurationGenerator
         private readonly StreamFactoryInterface $streamFactory,
         private readonly LoggerInterface $logger,
     ) {}
-
-    /**
-     * Inject a custom HTTP client, bypassing the vault secure client.
-     *
-     * @internal Test seam only — production always dispatches through the
-     *           audited vault client (see `dispatch()`).
-     */
-    public function setHttpClient(ClientInterface $client): void
-    {
-        $this->configuredHttpClient = $client;
-    }
-
-    /**
-     * Send a request through the SSRF-guarded vault secure client.
-     *
-     * The host is gated up front via `isHostAllowed()` so a disallowed /
-     * private-range target is rejected before any secret-bearing header is
-     * sent; the vault client re-checks the host and validates the scheme as
-     * defence in depth.
-     *
-     * @throws Throwable when the host is disallowed or the request fails
-     */
-    private function dispatch(RequestInterface $request): ResponseInterface
-    {
-        // Test seam: an injected client bypasses the vault path entirely so
-        // unit tests can assert on the request the wizard built without hitting
-        // DNS or the host allowlist.
-        if ($this->configuredHttpClient !== null) {
-            return $this->configuredHttpClient->sendRequest($request);
-        }
-
-        // Reject a disallowed / private-range target up front, before any
-        // secret-bearing header reaches the wire. The vault client re-checks
-        // the host and validates the scheme inside sendRequest() as defence in
-        // depth, but failing here yields a clear, typed rejection.
-        $host = $request->getUri()->getHost();
-        if (!$this->httpClientFactory->isHostAllowed($host)) {
-            throw new RuntimeException(
-                sprintf('Host "%s" is not in the allowed hosts list', $host),
-                7438190002,
-            );
-        }
-
-        return $this->vault->http()
-            ->withReason('LLM setup-wizard configuration generation')
-            ->sendRequest($request);
-    }
-
-    /**
-     * Strip secret-bearing query parameters from a message before it is
-     * logged. Mirrors `AbstractProvider`.
-     */
-    private function sanitizeErrorMessage(string $message): string
-    {
-        return (string)preg_replace(
-            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
-            '$1$2=***',
-            $message,
-        );
-    }
 
     /**
      * Generate configuration suggestions using the LLM.

--- a/Classes/Service/SetupWizard/Exception/HostNotAllowedException.php
+++ b/Classes/Service/SetupWizard/Exception/HostNotAllowedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\SetupWizard\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when the setup wizard refuses to dispatch an HTTP request because
+ * the target host is not covered by the nr-vault SSRF host allowlist
+ * (`SecureHttpClientFactory::isHostAllowed()`).
+ */
+final class HostNotAllowedException extends RuntimeException
+{
+    public static function forHost(string $host): self
+    {
+        return new self(
+            sprintf('Host "%s" is not in the allowed hosts list', $host),
+            7438190001,
+        );
+    }
+}

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -38,18 +38,23 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     use SecureHttpDispatchTrait;
 
     /**
-     * Audit-log reason recorded by the vault secure client for every
-     * outbound request (see `SecureHttpDispatchTrait::dispatch()`).
+     * Audit-log reason the vault secure client records for every outbound
+     * request, passed to `SecureHttpDispatchTrait::dispatch()`.
      */
     private const VAULT_DISPATCH_REASON = 'LLM setup-wizard model discovery';
 
     public function __construct(
-        private readonly VaultServiceInterface $vault,
-        private readonly SecureHttpClientFactory $httpClientFactory,
+        VaultServiceInterface $vault,
+        SecureHttpClientFactory $httpClientFactory,
         private readonly RequestFactoryInterface $requestFactory,
         private readonly StreamFactoryInterface $streamFactory,
         private readonly LoggerInterface $logger,
-    ) {}
+    ) {
+        // Initialise the readonly collaborators declared in
+        // SecureHttpDispatchTrait (no promotion — the trait owns them).
+        $this->vault = $vault;
+        $this->httpClientFactory = $httpClientFactory;
+    }
 
     /**
      * Test connection to provider.
@@ -77,7 +82,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 default => $request->withHeader('Authorization', 'Bearer ' . $apiKey),
             };
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
             $statusCode = $response->getStatusCode();
 
             if ($statusCode >= 200 && $statusCode < 300) {
@@ -153,7 +158,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('Authorization', 'Bearer ' . $apiKey)
                 ->withHeader('Content-Type', 'application/json');
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getOpenAIFallbackModels();
@@ -427,7 +432,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('x-api-key', $apiKey)
                 ->withHeader('anthropic-version', '2023-06-01');
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getAnthropicFallbackModels();
@@ -615,7 +620,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
         try {
             $url = $endpoint . '/models?key=' . $apiKey;
             $request = $this->requestFactory->createRequest('GET', $url);
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getGeminiFallbackModels();
@@ -804,7 +809,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     {
         try {
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/tags');
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return [];
@@ -871,7 +876,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('Content-Type', 'application/json')
                 ->withBody($stream);
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return $defaults;
@@ -989,7 +994,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return [];
@@ -1056,7 +1061,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getMistralFallbackModels();
@@ -1141,7 +1146,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->dispatch($request);
+            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
                 return [];

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -11,23 +11,105 @@ namespace Netresearch\NrLlm\Service\SetupWizard;
 
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
  * Discovers available models from LLM provider APIs.
  *
+ * Outbound requests are dispatched through the nr-vault secure HTTP client
+ * (`$vault->http()`), which enforces the SSRF host guard, scheme validation,
+ * redirect blocking and audit logging — the same hardened path the providers
+ * and specialised services use. The wizard authenticates with the plaintext
+ * key the operator just typed (it is not yet stored in the vault), so it
+ * builds its own auth headers but still routes through the secure client and
+ * pre-gates the target host via `SecureHttpClientFactory::isHostAllowed()`.
+ *
  * Model information updated: March 2026
  */
-final readonly class ModelDiscovery implements ModelDiscoveryInterface
+final class ModelDiscovery implements ModelDiscoveryInterface
 {
+    /**
+     * Test seam: when set, requests go through this client instead of the
+     * vault secure client. Production never sets it.
+     */
+    private ?ClientInterface $configuredHttpClient = null;
+
     public function __construct(
-        private ClientInterface $httpClient,
-        private RequestFactoryInterface $requestFactory,
-        private StreamFactoryInterface $streamFactory,
+        private readonly VaultServiceInterface $vault,
+        private readonly SecureHttpClientFactory $httpClientFactory,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly LoggerInterface $logger,
     ) {}
+
+    /**
+     * Inject a custom HTTP client, bypassing the vault secure client.
+     *
+     * @internal Test seam only — production always dispatches through the
+     *           audited vault client (see `dispatch()`).
+     */
+    public function setHttpClient(ClientInterface $client): void
+    {
+        $this->configuredHttpClient = $client;
+    }
+
+    /**
+     * Send a request through the SSRF-guarded vault secure client.
+     *
+     * The host is gated up front via `isHostAllowed()` so a disallowed /
+     * private-range target is rejected before any secret-bearing header is
+     * sent; the vault client re-checks the host and validates the scheme as
+     * defence in depth.
+     *
+     * @throws Throwable when the host is disallowed or the request fails
+     */
+    private function dispatch(RequestInterface $request): ResponseInterface
+    {
+        // Test seam: an injected client bypasses the vault path entirely so
+        // unit tests can assert on the request the wizard built without hitting
+        // DNS or the host allowlist.
+        if ($this->configuredHttpClient !== null) {
+            return $this->configuredHttpClient->sendRequest($request);
+        }
+
+        // Reject a disallowed / private-range target up front, before any
+        // secret-bearing header reaches the wire. The vault client re-checks
+        // the host and validates the scheme inside sendRequest() as defence in
+        // depth, but failing here yields a clear, typed rejection.
+        $host = $request->getUri()->getHost();
+        if (!$this->httpClientFactory->isHostAllowed($host)) {
+            throw new RuntimeException(
+                sprintf('Host "%s" is not in the allowed hosts list', $host),
+                7438190001,
+            );
+        }
+
+        return $this->vault->http()
+            ->withReason('LLM setup-wizard model discovery')
+            ->sendRequest($request);
+    }
+
+    /**
+     * Strip secret-bearing query parameters from a message before it is
+     * returned to the client or logged. Mirrors `AbstractProvider`.
+     */
+    private function sanitizeErrorMessage(string $message): string
+    {
+        return (string)preg_replace(
+            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
+            '$1$2=***',
+            $message,
+        );
+    }
 
     /**
      * Test connection to provider.
@@ -55,7 +137,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
                 default => $request->withHeader('Authorization', 'Bearer ' . $apiKey),
             };
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
             $statusCode = $response->getStatusCode();
 
             if ($statusCode >= 200 && $statusCode < 300) {
@@ -77,9 +159,20 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
                 'message' => sprintf('Connection failed with status code %d', $statusCode),
             ];
         } catch (Throwable $e) {
+            // Don't echo the raw exception back to the client: it can carry the
+            // target URL (incl. a `?key=` secret) or internal host details. Log
+            // the sanitised detail server-side and return a generic message.
+            $this->logger->warning(
+                'LLM setup-wizard connection test failed',
+                [
+                    'provider'  => $provider->adapterType,
+                    'exception' => $this->sanitizeErrorMessage($e->getMessage()),
+                ],
+            );
+
             return [
                 'success' => false,
-                'message' => 'Connection error: ' . $e->getMessage(),
+                'message' => 'Connection error. Please verify the endpoint and API key, then try again.',
             ];
         }
     }
@@ -120,7 +213,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('Authorization', 'Bearer ' . $apiKey)
                 ->withHeader('Content-Type', 'application/json');
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getOpenAIFallbackModels();
@@ -394,7 +487,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('x-api-key', $apiKey)
                 ->withHeader('anthropic-version', '2023-06-01');
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getAnthropicFallbackModels();
@@ -582,7 +675,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
         try {
             $url = $endpoint . '/models?key=' . $apiKey;
             $request = $this->requestFactory->createRequest('GET', $url);
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getGeminiFallbackModels();
@@ -771,7 +864,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
     {
         try {
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/tags');
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return [];
@@ -838,7 +931,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
                 ->withHeader('Content-Type', 'application/json')
                 ->withBody($stream);
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return $defaults;
@@ -956,7 +1049,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return [];
@@ -1023,7 +1116,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return $this->getMistralFallbackModels();
@@ -1108,7 +1201,7 @@ final readonly class ModelDiscovery implements ModelDiscoveryInterface
             $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
                 ->withHeader('Authorization', 'Bearer ' . $apiKey);
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $this->dispatch($request);
 
             if ($response->getStatusCode() !== 200) {
                 return [];

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -11,15 +11,12 @@ namespace Netresearch\NrLlm\Service\SetupWizard;
 
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -37,11 +34,14 @@ use Throwable;
  */
 final class ModelDiscovery implements ModelDiscoveryInterface
 {
+    use ErrorMessageSanitizerTrait;
+    use SecureHttpDispatchTrait;
+
     /**
-     * Test seam: when set, requests go through this client instead of the
-     * vault secure client. Production never sets it.
+     * Audit-log reason recorded by the vault secure client for every
+     * outbound request (see `SecureHttpDispatchTrait::dispatch()`).
      */
-    private ?ClientInterface $configuredHttpClient = null;
+    private const VAULT_DISPATCH_REASON = 'LLM setup-wizard model discovery';
 
     public function __construct(
         private readonly VaultServiceInterface $vault,
@@ -50,66 +50,6 @@ final class ModelDiscovery implements ModelDiscoveryInterface
         private readonly StreamFactoryInterface $streamFactory,
         private readonly LoggerInterface $logger,
     ) {}
-
-    /**
-     * Inject a custom HTTP client, bypassing the vault secure client.
-     *
-     * @internal Test seam only — production always dispatches through the
-     *           audited vault client (see `dispatch()`).
-     */
-    public function setHttpClient(ClientInterface $client): void
-    {
-        $this->configuredHttpClient = $client;
-    }
-
-    /**
-     * Send a request through the SSRF-guarded vault secure client.
-     *
-     * The host is gated up front via `isHostAllowed()` so a disallowed /
-     * private-range target is rejected before any secret-bearing header is
-     * sent; the vault client re-checks the host and validates the scheme as
-     * defence in depth.
-     *
-     * @throws Throwable when the host is disallowed or the request fails
-     */
-    private function dispatch(RequestInterface $request): ResponseInterface
-    {
-        // Test seam: an injected client bypasses the vault path entirely so
-        // unit tests can assert on the request the wizard built without hitting
-        // DNS or the host allowlist.
-        if ($this->configuredHttpClient !== null) {
-            return $this->configuredHttpClient->sendRequest($request);
-        }
-
-        // Reject a disallowed / private-range target up front, before any
-        // secret-bearing header reaches the wire. The vault client re-checks
-        // the host and validates the scheme inside sendRequest() as defence in
-        // depth, but failing here yields a clear, typed rejection.
-        $host = $request->getUri()->getHost();
-        if (!$this->httpClientFactory->isHostAllowed($host)) {
-            throw new RuntimeException(
-                sprintf('Host "%s" is not in the allowed hosts list', $host),
-                7438190001,
-            );
-        }
-
-        return $this->vault->http()
-            ->withReason('LLM setup-wizard model discovery')
-            ->sendRequest($request);
-    }
-
-    /**
-     * Strip secret-bearing query parameters from a message before it is
-     * returned to the client or logged. Mirrors `AbstractProvider`.
-     */
-    private function sanitizeErrorMessage(string $message): string
-    {
-        return (string)preg_replace(
-            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
-            '$1$2=***',
-            $message,
-        );
-    }
 
     /**
      * Test connection to provider.

--- a/Classes/Service/SetupWizard/SecureHttpDispatchTrait.php
+++ b/Classes/Service/SetupWizard/SecureHttpDispatchTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\SetupWizard;
+
+use Netresearch\NrLlm\Service\SetupWizard\Exception\HostNotAllowedException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+/**
+ * Shared SSRF-guarded HTTP dispatch for the setup-wizard services.
+ *
+ * Consumers must provide the nr-vault collaborators as promoted constructor
+ * properties (`$vault`, `$httpClientFactory`) and declare a
+ * `VAULT_DISPATCH_REASON` class constant — the human-readable reason the
+ * vault secure client records in its audit log for every outbound request.
+ */
+trait SecureHttpDispatchTrait
+{
+    /**
+     * Test seam: when set, requests go through this client instead of the
+     * vault secure client. Production never sets it.
+     */
+    private ?ClientInterface $configuredHttpClient = null;
+
+    /**
+     * Inject a custom HTTP client, bypassing the vault secure client.
+     *
+     * @internal Test seam only — production always dispatches through the
+     *           audited vault client (see `dispatch()`).
+     */
+    public function setHttpClient(ClientInterface $client): void
+    {
+        $this->configuredHttpClient = $client;
+    }
+
+    /**
+     * Send a request through the SSRF-guarded vault secure client.
+     *
+     * The host is gated up front via `isHostAllowed()` so a disallowed /
+     * private-range target is rejected before any secret-bearing header is
+     * sent; the vault client re-checks the host and validates the scheme as
+     * defence in depth.
+     *
+     * @throws HostNotAllowedException when the host is disallowed
+     * @throws Throwable               when the request fails
+     */
+    private function dispatch(RequestInterface $request): ResponseInterface
+    {
+        // Test seam: an injected client bypasses the vault path entirely so
+        // unit tests can assert on the request the wizard built without hitting
+        // DNS or the host allowlist.
+        if ($this->configuredHttpClient !== null) {
+            return $this->configuredHttpClient->sendRequest($request);
+        }
+
+        // Reject a disallowed / private-range target up front, before any
+        // secret-bearing header reaches the wire. The vault client re-checks
+        // the host and validates the scheme inside sendRequest() as defence in
+        // depth, but failing here yields a clear, typed rejection.
+        $host = $request->getUri()->getHost();
+        if (!$this->httpClientFactory->isHostAllowed($host)) {
+            throw HostNotAllowedException::forHost($host);
+        }
+
+        return $this->vault->http()
+            ->withReason(self::VAULT_DISPATCH_REASON)
+            ->sendRequest($request);
+    }
+}

--- a/Classes/Service/SetupWizard/SecureHttpDispatchTrait.php
+++ b/Classes/Service/SetupWizard/SecureHttpDispatchTrait.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\SetupWizard;
 
 use Netresearch\NrLlm\Service\SetupWizard\Exception\HostNotAllowedException;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -18,13 +20,17 @@ use Throwable;
 /**
  * Shared SSRF-guarded HTTP dispatch for the setup-wizard services.
  *
- * Consumers must provide the nr-vault collaborators as promoted constructor
- * properties (`$vault`, `$httpClientFactory`) and declare a
- * `VAULT_DISPATCH_REASON` class constant — the human-readable reason the
- * vault secure client records in its audit log for every outbound request.
+ * The nr-vault collaborators consumed by `dispatch()` are declared here;
+ * the composing class initialises them in its constructor (trait members
+ * are flattened into the composing class, which therefore counts as the
+ * declaring scope of the readonly properties).
  */
 trait SecureHttpDispatchTrait
 {
+    private readonly VaultServiceInterface $vault;
+
+    private readonly SecureHttpClientFactory $httpClientFactory;
+
     /**
      * Test seam: when set, requests go through this client instead of the
      * vault secure client. Production never sets it.
@@ -50,10 +56,13 @@ trait SecureHttpDispatchTrait
      * sent; the vault client re-checks the host and validates the scheme as
      * defence in depth.
      *
+     * @param string $reason Human-readable reason the vault secure client
+     *                       records in its audit log for this request
+     *
      * @throws HostNotAllowedException when the host is disallowed
      * @throws Throwable               when the request fails
      */
-    private function dispatch(RequestInterface $request): ResponseInterface
+    private function dispatch(RequestInterface $request, string $reason): ResponseInterface
     {
         // Test seam: an injected client bypasses the vault path entirely so
         // unit tests can assert on the request the wizard built without hitting
@@ -72,7 +81,7 @@ trait SecureHttpDispatchTrait
         }
 
         return $this->vault->http()
-            ->withReason(self::VAULT_DISPATCH_REASON)
+            ->withReason($reason)
             ->sendRequest($request);
     }
 }

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -53,6 +53,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  */
 abstract class AbstractSpecializedService
 {
+    use ServiceConfigurationTrait;
+
     protected string $apiKeyIdentifier = '';
     protected string $baseUrl = '';
     protected int $timeout;

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -344,39 +344,7 @@ final class DallEImageService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        // is_string() guards: the extension config tree is user-editable
-        // YAML and the @var hint above describes the documented shape,
-        // not a runtime guarantee. Direct assignment without guards
-        // would TypeError on a non-string identifier and defeat the
-        // base's fail-soft contract.
-        $apiKeyIdentifier = $this->resolveScalarConfig($config, ['providers', 'openai', 'apiKeyIdentifier']);
-        $baseUrl = $this->resolveScalarConfig($config, ['image', 'dalle', 'baseUrl']);
-        $timeout = $this->resolveScalarConfig($config, ['image', 'dalle', 'timeout']);
-
-        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
-        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label), NOT
-        // "send requests to an empty URL" — see nonEmptyStringOrDefault().
-        $this->baseUrl = $this->nonEmptyStringOrDefault($baseUrl, self::API_URL);
-        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
-    }
-
-    /**
-     * Walk a nested array path safely. Returns the leaf value or null
-     * if any intermediate hop is missing / not an array.
-     *
-     * @param array<string, mixed> $config
-     * @param list<string>         $path
-     */
-    private function resolveScalarConfig(array $config, array $path): mixed
-    {
-        $current = $config;
-        foreach ($path as $key) {
-            if (!is_array($current) || !array_key_exists($key, $current)) {
-                return null;
-            }
-            $current = $current[$key];
-        }
-        return $current;
+        $this->loadOpenAiServiceConfiguration($config, ['image', 'dalle']);
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -269,7 +269,7 @@ final class FalImageService extends AbstractSpecializedService
         // Clamp to >= 1ms: a configured 0 (or negative) would make the poll-attempt
         // count a division by zero and turn usleep() into a busy-loop. max(1, …)
         // keeps the service fail-soft on a misconfigured interval.
-        $resolvedInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
+        $resolvedInterval = is_numeric($pollInterval) ? (int)$pollInterval : 1000;
         $this->pollInterval = max(1, $resolvedInterval);
     }
 

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -266,7 +266,11 @@ final class FalImageService extends AbstractSpecializedService
         $this->timeout = is_int($timeout) ? $timeout : (is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout());
 
         $pollInterval = $falConfig['pollInterval'] ?? 1000;
-        $this->pollInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
+        // Clamp to >= 1ms: a configured 0 (or negative) would make the poll-attempt
+        // count a division by zero and turn usleep() into a busy-loop. max(1, …)
+        // keeps the service fail-soft on a misconfigured interval.
+        $resolvedInterval = is_int($pollInterval) ? $pollInterval : (is_numeric($pollInterval) ? (int)$pollInterval : 1000);
+        $this->pollInterval = max(1, $resolvedInterval);
     }
 
     /**

--- a/Classes/Specialized/ServiceConfigurationTrait.php
+++ b/Classes/Specialized/ServiceConfigurationTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized;
+
+/**
+ * Shared, fail-soft parsing of the user-editable extension configuration
+ * tree for the specialised services. The documented config shape is not a
+ * runtime guarantee, so every hop is type-guarded instead of trusted.
+ */
+trait ServiceConfigurationTrait
+{
+    /**
+     * Walk a nested array path safely. Returns the leaf value or null
+     * if any intermediate hop is missing / not an array.
+     *
+     * @param array<string, mixed> $config
+     * @param list<string>         $path
+     */
+    protected function resolveScalarConfig(array $config, array $path): mixed
+    {
+        $current = $config;
+        foreach ($path as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                return null;
+            }
+            $current = $current[$key];
+        }
+        return $current;
+    }
+
+    /**
+     * Standard configuration loader for OpenAI-backed services: vault key
+     * identifier from `providers.openai.apiKeyIdentifier`, `baseUrl` and
+     * `timeout` from the given service path (e.g. `['speech', 'tts']`).
+     *
+     * An empty ext_conf baseUrl means "use the provider default" (per the
+     * field label), NOT "send requests to an empty URL" — see
+     * `nonEmptyStringOrDefault()`.
+     *
+     * @param array<string, mixed> $config
+     * @param list<string>         $servicePath
+     */
+    protected function loadOpenAiServiceConfiguration(array $config, array $servicePath): void
+    {
+        $apiKeyIdentifier = $this->resolveScalarConfig($config, ['providers', 'openai', 'apiKeyIdentifier']);
+        $baseUrl = $this->resolveScalarConfig($config, [...$servicePath, 'baseUrl']);
+        $timeout = $this->resolveScalarConfig($config, [...$servicePath, 'timeout']);
+
+        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
+        $this->baseUrl = $this->nonEmptyStringOrDefault($baseUrl, $this->getDefaultBaseUrl());
+        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
+    }
+}

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -312,7 +312,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         $sentences = preg_split('/(?<=[.!?])\s+/', $text, -1, PREG_SPLIT_NO_EMPTY);
 
         if ($sentences === false) {
-            return str_split($text, self::MAX_INPUT_LENGTH) ?: [$text];
+            return mb_str_split($text, self::MAX_INPUT_LENGTH) ?: [$text];
         }
 
         foreach ($sentences as $sentence) {
@@ -374,9 +374,11 @@ final class TextToSpeechService extends AbstractSpecializedService
                     // A single comma-delimited part can itself exceed the limit
                     // (e.g. a clause with no internal commas). Emitting it whole
                     // would produce an over-limit chunk that synthesize() rejects,
-                    // so hard-split it at the byte boundary first.
+                    // so hard-split it at the character boundary first —
+                    // mb_str_split() keeps multibyte UTF-8 sequences intact
+                    // where a byte-wise str_split() would corrupt them.
                     if (mb_strlen($part . $separator) > self::MAX_INPUT_LENGTH) {
-                        foreach (str_split($part, self::MAX_INPUT_LENGTH) ?: [$part] as $hardChunk) {
+                        foreach (mb_str_split($part, self::MAX_INPUT_LENGTH) ?: [$part] as $hardChunk) {
                             $chunks[] = $hardChunk;
                         }
                     } else {
@@ -392,7 +394,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             return $chunks;
         }
 
-        return str_split($sentence, self::MAX_INPUT_LENGTH) ?: [$sentence];
+        return mb_str_split($sentence, self::MAX_INPUT_LENGTH) ?: [$sentence];
     }
 
     /**

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -244,27 +244,7 @@ final class TextToSpeechService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        $providers = $config['providers'] ?? null;
-        if (is_array($providers)) {
-            $openai = $providers['openai'] ?? null;
-            if (is_array($openai)) {
-                $apiKeyIdentifier = $openai['apiKeyIdentifier'] ?? '';
-                $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
-            }
-        }
-
-        $this->baseUrl = self::API_URL;
-        $speech = $config['speech'] ?? null;
-        if (is_array($speech)) {
-            $tts = $speech['tts'] ?? null;
-            if (is_array($tts)) {
-                // Empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
-                // not an empty request URL — see nonEmptyStringOrDefault().
-                $this->baseUrl = $this->nonEmptyStringOrDefault($tts['baseUrl'] ?? null, self::API_URL);
-                $timeout = $tts['timeout'] ?? null;
-                $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
-            }
-        }
+        $this->loadOpenAiServiceConfiguration($config, ['speech', 'tts']);
     }
 
     protected function getProviderLabel(): string

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -369,8 +369,19 @@ final class TextToSpeechService extends AbstractSpecializedService
                 } else {
                     if ($currentChunk !== '') {
                         $chunks[] = rtrim($currentChunk, ', ');
+                        $currentChunk = '';
                     }
-                    $currentChunk = $part . $separator;
+                    // A single comma-delimited part can itself exceed the limit
+                    // (e.g. a clause with no internal commas). Emitting it whole
+                    // would produce an over-limit chunk that synthesize() rejects,
+                    // so hard-split it at the byte boundary first.
+                    if (mb_strlen($part . $separator) > self::MAX_INPUT_LENGTH) {
+                        foreach (str_split($part, self::MAX_INPUT_LENGTH) ?: [$part] as $hardChunk) {
+                            $chunks[] = $hardChunk;
+                        }
+                    } else {
+                        $currentChunk = $part . $separator;
+                    }
                 }
             }
 

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -201,9 +201,16 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     protected function loadServiceConfiguration(array $config): void
     {
         /** @var array{providers?: array{openai?: array{apiKeyIdentifier?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
-        $this->apiKeyIdentifier = (string)($config['providers']['openai']['apiKeyIdentifier'] ?? '');
-        $this->baseUrl = (string)($config['speech']['whisper']['baseUrl'] ?? self::API_URL);
-        $this->timeout = (int)($config['speech']['whisper']['timeout'] ?? $this->getDefaultTimeout());
+        // is_string()/is_numeric() guards: the extension config tree is user-editable
+        // and the @var hint above describes the documented shape, not a runtime
+        // guarantee — mirror the sibling services (DALL-E, TTS, FAL).
+        $apiKeyIdentifier = $config['providers']['openai']['apiKeyIdentifier'] ?? null;
+        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
+        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
+        // not an empty request URL — see nonEmptyStringOrDefault().
+        $this->baseUrl = $this->nonEmptyStringOrDefault($config['speech']['whisper']['baseUrl'] ?? null, self::API_URL);
+        $timeout = $config['speech']['whisper']['timeout'] ?? null;
+        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
     }
 
     protected function getProviderLabel(): string

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -200,17 +200,31 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        /** @var array{providers?: array{openai?: array{apiKeyIdentifier?: string}}, speech?: array{whisper?: array{baseUrl?: string, timeout?: int}}} $config */
-        // is_string()/is_numeric() guards: the extension config tree is user-editable
-        // and the @var hint above describes the documented shape, not a runtime
-        // guarantee — mirror the sibling services (DALL-E, TTS, FAL).
-        $apiKeyIdentifier = $config['providers']['openai']['apiKeyIdentifier'] ?? null;
-        $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
-        // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
-        // not an empty request URL — see nonEmptyStringOrDefault().
-        $this->baseUrl = $this->nonEmptyStringOrDefault($config['speech']['whisper']['baseUrl'] ?? null, self::API_URL);
-        $timeout = $config['speech']['whisper']['timeout'] ?? null;
-        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
+        // is_array()/is_string()/is_numeric() guards at each level: the
+        // extension config tree is user-editable, so the documented shape is
+        // not a runtime guarantee — mirror the sibling services (TTS, FAL).
+        $providers = $config['providers'] ?? null;
+        if (is_array($providers)) {
+            $openai = $providers['openai'] ?? null;
+            if (is_array($openai)) {
+                $apiKeyIdentifier = $openai['apiKeyIdentifier'] ?? '';
+                $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
+            }
+        }
+
+        $this->baseUrl = self::API_URL;
+        $this->timeout = $this->getDefaultTimeout();
+        $speech = $config['speech'] ?? null;
+        if (is_array($speech)) {
+            $whisper = $speech['whisper'] ?? null;
+            if (is_array($whisper)) {
+                // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
+                // not an empty request URL — see nonEmptyStringOrDefault().
+                $this->baseUrl = $this->nonEmptyStringOrDefault($whisper['baseUrl'] ?? null, self::API_URL);
+                $timeout = $whisper['timeout'] ?? null;
+                $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
+            }
+        }
     }
 
     protected function getProviderLabel(): string

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -200,31 +200,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
      */
     protected function loadServiceConfiguration(array $config): void
     {
-        // is_array()/is_string()/is_numeric() guards at each level: the
-        // extension config tree is user-editable, so the documented shape is
-        // not a runtime guarantee — mirror the sibling services (TTS, FAL).
-        $providers = $config['providers'] ?? null;
-        if (is_array($providers)) {
-            $openai = $providers['openai'] ?? null;
-            if (is_array($openai)) {
-                $apiKeyIdentifier = $openai['apiKeyIdentifier'] ?? '';
-                $this->apiKeyIdentifier = is_string($apiKeyIdentifier) ? $apiKeyIdentifier : '';
-            }
-        }
-
-        $this->baseUrl = self::API_URL;
-        $this->timeout = $this->getDefaultTimeout();
-        $speech = $config['speech'] ?? null;
-        if (is_array($speech)) {
-            $whisper = $speech['whisper'] ?? null;
-            if (is_array($whisper)) {
-                // An empty ext_conf baseUrl means "use the OpenAI default" (per the field label),
-                // not an empty request URL — see nonEmptyStringOrDefault().
-                $this->baseUrl = $this->nonEmptyStringOrDefault($whisper['baseUrl'] ?? null, self::API_URL);
-                $timeout = $whisper['timeout'] ?? null;
-                $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
-            }
-        }
+        $this->loadOpenAiServiceConfiguration($config, ['speech', 'whisper']);
     }
 
     protected function getProviderLabel(): string

--- a/Classes/Utility/ErrorMessageSanitizerTrait.php
+++ b/Classes/Utility/ErrorMessageSanitizerTrait.php
@@ -10,22 +10,23 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Utility;
 
 /**
- * Trait for stripping secrets from error messages before they are logged
- * or surfaced.
+ * Trait for redacting known credential query parameters from error
+ * messages before they are logged or surfaced.
  *
- * HTTP client exceptions may include full URLs with query parameters
- * containing API keys (e.g., Gemini's `?key=...` pattern). This strips
- * sensitive query parameters so providers and the setup wizard never leak
- * a secret into logs or client-facing messages.
+ * HTTP client exceptions may include the full request URL (e.g., Gemini's
+ * `?key=...` pattern). This redacts the values of the well-known credential
+ * query parameters (`key`, `api_key`, `apikey`, `token`, `secret`,
+ * `access_token`) in any URL embedded in the message. It deliberately does
+ * NOT scrub other secret material such as header values — callers must not
+ * write raw header dumps into error messages in the first place.
  */
 trait ErrorMessageSanitizerTrait
 {
     /**
-     * Sanitize error messages to prevent leaking secrets (API keys in URLs, headers, etc.).
+     * Redact well-known credential query parameters from URLs in the message.
      */
     protected function sanitizeErrorMessage(string $message): string
     {
-        // Strip query parameters that may contain API keys from URLs in the message
         return (string)preg_replace(
             '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
             '$1$2=***',

--- a/Classes/Utility/ErrorMessageSanitizerTrait.php
+++ b/Classes/Utility/ErrorMessageSanitizerTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Utility;
+
+/**
+ * Trait for stripping secrets from error messages before they are logged
+ * or surfaced.
+ *
+ * HTTP client exceptions may include full URLs with query parameters
+ * containing API keys (e.g., Gemini's `?key=...` pattern). This strips
+ * sensitive query parameters so providers and the setup wizard never leak
+ * a secret into logs or client-facing messages.
+ */
+trait ErrorMessageSanitizerTrait
+{
+    /**
+     * Sanitize error messages to prevent leaking secrets (API keys in URLs, headers, etc.).
+     */
+    protected function sanitizeErrorMessage(string $message): string
+    {
+        // Strip query parameters that may contain API keys from URLs in the message
+        return (string)preg_replace(
+            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
+            '$1$2=***',
+            $message,
+        );
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,6 +20,7 @@ services:
       - '../Classes/Attribute/*'
       - '../Classes/Domain/Model/*'
       - '../Classes/Provider/Exception/*'
+      - '../Classes/Service/SetupWizard/Exception/*'
       - '../Classes/Specialized/Exception/*'
       - '../Classes/Widgets/*'
 

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Provider\AbstractProvider;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Provider\GroqProvider;
 use Netresearch\NrLlm\Provider\MistralProvider;
@@ -19,6 +21,7 @@ use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 
 /**
  * Tests common provider behavior across all implementations.
@@ -312,5 +315,144 @@ class AbstractProviderTest extends AbstractUnitTestCase
         $provider->setHttpClient($freshClient);
 
         $provider->complete('test');
+    }
+
+    #[Test]
+    public function sanitizeErrorMessageRedactsApiKeyOnFourxxResponse(): void
+    {
+        // A 4xx error body whose message embeds a URL with `?key=<secret>` must
+        // come back redacted to `key=***` — the secret must never surface in
+        // the thrown exception's message.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'maxRetries' => 1,
+        ]);
+
+        $errorBody = [
+            'error' => [
+                'message' => 'Request to https://api.openai.com/v1/chat/completions?key=sk-secret123 was rejected',
+            ],
+        ];
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock($errorBody, 400));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hello');
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            self::assertStringContainsString('key=***', $e->getMessage());
+            self::assertStringNotContainsString('sk-secret123', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function sanitizeErrorMessageRedactsApiKeyOnConnectionExhaustion(): void
+    {
+        // When all retries fail, the surfaced "Failed to connect …" message must
+        // also be scrubbed of a `?key=<secret>` carried by the underlying
+        // exception message.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'maxRetries' => 1,
+        ]);
+
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willThrowException(
+            new RuntimeException('cURL error connecting to https://api.openai.com/v1/chat/completions?key=sk-secret123'),
+        );
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hello');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('key=***', $e->getMessage());
+            self::assertStringNotContainsString('sk-secret123', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function streamingFourxxResponseThrowsTypedResponseException(): void
+    {
+        // A 4xx streaming response must surface as the same typed exception
+        // sendRequest() raises — with any `?key=<secret>` redacted — instead
+        // of silently yielding an empty generator.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+        ]);
+
+        $errorBody = [
+            'error' => [
+                'message' => 'Invalid key for https://api.openai.com/v1/chat/completions?key=sk-secret123',
+            ],
+        ];
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock($errorBody, 401));
+        $provider->setHttpClient($client);
+
+        try {
+            // Generators execute lazily — the guard fires on first iteration.
+            $provider->streamChatCompletion([['role' => 'user', 'content' => 'hello']])->current();
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            self::assertSame(401, $e->getCode());
+            self::assertStringContainsString('key=***', $e->getMessage());
+            self::assertStringNotContainsString('sk-secret123', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function streamingServerErrorThrowsConnectionException(): void
+    {
+        // A 5xx streaming response maps to ProviderConnectionException, the
+        // same contract as the non-streaming path.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+        ]);
+
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock([], 503));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->streamChatCompletion([['role' => 'user', 'content' => 'hello']])->current();
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertSame(503, $e->getCode());
+            self::assertStringContainsString('503', $e->getMessage());
+        }
     }
 }

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -623,6 +623,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub
@@ -656,6 +657,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub
@@ -682,6 +684,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -953,6 +953,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         });
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock
@@ -986,6 +987,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         });
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock
@@ -1025,6 +1027,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         });
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock
@@ -1059,6 +1062,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         });
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -666,6 +666,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -710,6 +711,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -755,6 +757,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -798,6 +801,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -842,6 +846,7 @@ class GroqProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -586,6 +586,7 @@ class MistralProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -630,6 +631,7 @@ class MistralProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -674,6 +676,7 @@ class MistralProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -717,6 +720,7 @@ class MistralProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn($streamContent);
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -578,6 +578,7 @@ class OllamaProviderTest extends AbstractUnitTestCase
         );
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -618,6 +619,7 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn("{\"message\":{\"content\":\"Test\"},\"done\":true}\n");
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -658,6 +660,7 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn("\n\n{\"message\":{\"content\":\"Test\"},\"done\":true}\n");
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -698,6 +701,7 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn("invalid-json\n{\"message\":{\"content\":\"Valid\"},\"done\":true}\n");
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();
@@ -738,6 +742,7 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $streamStub->method('read')->willReturn("{\"message\":{\"content\":\"\"},\"done\":false}\n{\"message\":{\"content\":\"Test\"},\"done\":true}\n");
 
         $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
         $responseStub->method('getBody')->willReturn($streamStub);
 
         $httpClientMock = $this->createHttpClientWithExpectations();

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -636,6 +636,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub
@@ -665,6 +666,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub
@@ -1077,6 +1079,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub
@@ -1109,6 +1112,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientStub

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -1094,6 +1094,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientMock
@@ -1126,6 +1127,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientMock
@@ -1154,6 +1156,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $stream->method('read')->willReturn($streamData);
 
         $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
         $response->method('getBody')->willReturn($stream);
 
         $this->httpClientMock

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -152,7 +152,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'http://169.254.169.254/v1',
+            endpoint: 'https://169.254.169.254/v1',
             suggestedName: 'Metadata SSRF',
         );
 

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\SuggestedConfiguration;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
@@ -22,6 +23,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 #[CoversClass(ConfigurationGenerator::class)]
@@ -31,6 +33,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
     private ClientInterface&Stub $httpClientStub;
     private RequestFactoryInterface&Stub $requestFactoryStub;
     private StreamFactoryInterface&Stub $streamFactoryStub;
+    private VaultServiceInterface $vaultStub;
+    private LoggerInterface&Stub $loggerStub;
     private ConfigurationGenerator $subject;
 
     protected function setUp(): void
@@ -40,12 +44,20 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $this->httpClientStub = self::createStub(ClientInterface::class);
         $this->requestFactoryStub = self::createStub(RequestFactoryInterface::class);
         $this->streamFactoryStub = self::createStub(StreamFactoryInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+        $this->loggerStub = self::createStub(LoggerInterface::class);
 
         $this->subject = new ConfigurationGenerator(
-            $this->httpClientStub,
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
             $this->requestFactoryStub,
             $this->streamFactoryStub,
+            $this->loggerStub,
         );
+        // Test seam: requests bypass the vault secure client so the stubbed
+        // HTTP responses drive the test. The SSRF test uses a fresh subject
+        // WITHOUT the seam to exercise the host gate.
+        $this->subject->setHttpClient($this->httpClientStub);
     }
 
     private function createJsonResponseStubForGenerator(int $statusCode, string $body): ResponseInterface&Stub
@@ -122,6 +134,32 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', []);
 
         self::assertNotEmpty($result);
+    }
+
+    #[Test]
+    public function generateRejectsDisallowedHostAndReturnsFallback(): void
+    {
+        // No setHttpClient() seam → dispatch() runs the real isHostAllowed()
+        // gate. The cloud metadata IP (169.254.169.254) is always blocked, so
+        // the request never reaches the wire and generate() fails soft.
+        $subject = new ConfigurationGenerator(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+        );
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'http://169.254.169.254/v1',
+            suggestedName: 'Metadata SSRF',
+        );
+
+        $result = $subject->generate($provider, 'test-key', $this->createTestModels());
+
+        self::assertNotEmpty($result);
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -13,6 +13,8 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscovery;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -22,6 +24,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 #[CoversClass(ModelDiscovery::class)]
@@ -33,6 +36,9 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     private ClientInterface&Stub $httpClientStub;
     private RequestFactoryInterface&Stub $requestFactoryStub;
     private StreamFactoryInterface&Stub $streamFactoryStub;
+    private VaultServiceInterface $vaultStub;
+    private SecureHttpClientFactory $httpClientFactory;
+    private LoggerInterface&Stub $loggerStub;
     private ModelDiscovery $subject;
 
     protected function setUp(): void
@@ -42,12 +48,22 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $this->httpClientStub = self::createStub(ClientInterface::class);
         $this->requestFactoryStub = self::createStub(RequestFactoryInterface::class);
         $this->streamFactoryStub = self::createStub(StreamFactoryInterface::class);
+        $this->vaultStub = $this->createVaultServiceMock();
+        $this->httpClientFactory = $this->createSecureHttpClientFactoryMock();
+        $this->loggerStub = self::createStub(LoggerInterface::class);
 
         $this->subject = new ModelDiscovery(
-            $this->httpClientStub,
+            $this->vaultStub,
+            $this->httpClientFactory,
             $this->requestFactoryStub,
             $this->streamFactoryStub,
+            $this->loggerStub,
         );
+        // Inject the plain HTTP stub through the test seam so requests bypass
+        // the vault secure client (which would otherwise resolve DNS / enforce
+        // the host allowlist). The dedicated SSRF tests use a fresh subject
+        // WITHOUT the seam to exercise the host gate.
+        $this->subject->setHttpClient($this->httpClientStub);
     }
 
     private function createJsonResponseStubForDiscovery(int $statusCode, string $body): ResponseInterface&Stub
@@ -219,7 +235,63 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $result = $this->subject->testConnection($provider, 'test-key');
 
         self::assertFalse($result['success']);
-        self::assertStringContainsString('Network error', $result['message']);
+        // The raw exception detail must NOT leak back to the client — only a
+        // generic message is returned; the detail is logged server-side.
+        self::assertStringNotContainsString('Network error', $result['message']);
+        self::assertStringContainsString('Connection error', $result['message']);
+    }
+
+    // ==================== SSRF host-guard tests ====================
+
+    #[Test]
+    public function testConnectionRejectsDisallowedHost(): void
+    {
+        // No setHttpClient() seam → dispatch() runs the real isHostAllowed()
+        // gate. The cloud metadata IP (169.254.169.254) is always blocked.
+        $subject = new ModelDiscovery(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+        );
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'http://169.254.169.254/latest/meta-data',
+            suggestedName: 'Metadata SSRF',
+        );
+
+        $result = $subject->testConnection($provider, 'test-key');
+
+        self::assertFalse($result['success']);
+        self::assertStringContainsString('Connection error', $result['message']);
+    }
+
+    #[Test]
+    public function discoverRejectsDisallowedHostAndReturnsFallback(): void
+    {
+        $subject = new ModelDiscovery(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->loggerStub,
+        );
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'http://127.0.0.1:8080/v1',
+            suggestedName: 'Loopback SSRF',
+        );
+
+        // The host gate rejects the loopback target before any request is sent;
+        // discover() fails soft to the static fallback list rather than leaking.
+        $models = $subject->discover($provider, 'test-key');
+
+        self::assertNotEmpty($models);
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-5.3', $modelIds);
     }
 
     // ==================== discover tests ====================
@@ -1734,7 +1806,14 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             suggestedName: 'Ollama',
         );
 
-        $subject = new ModelDiscovery($httpClient, $requestFactory, $streamFactory);
+        $subject = new ModelDiscovery(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $requestFactory,
+            $streamFactory,
+            $this->loggerStub,
+        );
+        $subject->setHttpClient($httpClient);
         $models = $subject->discover($provider, '');
 
         // Model is still added with fallback details (contextLength = 0)

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -258,7 +258,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'http://169.254.169.254/latest/meta-data',
+            endpoint: 'https://169.254.169.254/latest/meta-data',
             suggestedName: 'Metadata SSRF',
         );
 

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -847,9 +847,17 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
         $this->setupFailedRequest(400, 'Invalid request');
 
-        $this->expectException(ServiceUnavailableException::class);
-
-        $subject->generate('A cat');
+        try {
+            $subject->generate('A cat');
+            self::fail('Expected ServiceUnavailableException was not thrown');
+        } catch (ServiceUnavailableException $e) {
+            // DALL-E maps 400 to a distinct validation branch (see mapErrorStatus()):
+            // the message carries the upstream detail and the context flags 'validation'
+            // so downstream catches that branched on it keep working.
+            self::assertStringContainsString('DALL-E API error: Invalid request', $e->getMessage());
+            self::assertIsArray($e->context);
+            self::assertSame('validation', $e->context['type'] ?? null);
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -230,8 +230,64 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturnOnConsecutiveCalls($queueSubmitResponse, $statusResponse, $resultResponse);
     }
 
+    /**
+     * Drive the queue flow with an explicit status sequence: one submit
+     * response (carrying request_id), then one status response per entry in
+     * $statuses, then (when $finalResponseData is given) the result fetch.
+     *
+     * @param list<string>              $statuses
+     * @param array<string, mixed>|null $finalResponseData
+     */
+    private function setupQueueResponses(array $statuses, ?array $finalResponseData): void
+    {
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturn($streamStub);
+
+        $responses = [];
+
+        $submitBody = self::createStub(StreamInterface::class);
+        $submitBody->method('__toString')->willReturn((string)json_encode(['request_id' => 'test-request-123']));
+        $submitResponse = self::createStub(ResponseInterface::class);
+        $submitResponse->method('getStatusCode')->willReturn(200);
+        $submitResponse->method('getBody')->willReturn($submitBody);
+        $responses[] = $submitResponse;
+
+        foreach ($statuses as $status) {
+            $statusBody = self::createStub(StreamInterface::class);
+            $statusBody->method('__toString')->willReturn((string)json_encode(['status' => $status]));
+            $statusResponse = self::createStub(ResponseInterface::class);
+            $statusResponse->method('getStatusCode')->willReturn(200);
+            $statusResponse->method('getBody')->willReturn($statusBody);
+            $responses[] = $statusResponse;
+        }
+
+        if ($finalResponseData !== null) {
+            $resultBody = self::createStub(StreamInterface::class);
+            $resultBody->method('__toString')->willReturn((string)json_encode($finalResponseData));
+            $resultResponse = self::createStub(ResponseInterface::class);
+            $resultResponse->method('getStatusCode')->willReturn(200);
+            $resultResponse->method('getBody')->willReturn($resultBody);
+            $responses[] = $resultResponse;
+        }
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls(...$responses);
+    }
+
     private function setupFailedRequest(int $statusCode, string $errorMessage = 'API Error'): void
     {
+
         $requestStub = self::createStub(RequestInterface::class);
         $requestStub->method('withHeader')->willReturnSelf();
         $requestStub->method('withBody')->willReturnSelf();
@@ -636,6 +692,8 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->setupFailedRequest(422, 'Invalid prompt');
 
         $this->expectException(ServiceUnavailableException::class);
+        // FAL surfaces 422 with its own validation wording (see mapErrorStatus()).
+        $this->expectExceptionMessage('FAL API validation error');
 
         $subject->generate('A sunset');
     }
@@ -783,6 +841,84 @@ class FalImageServiceTest extends AbstractUnitTestCase
         );
 
         self::assertTrue($subject->isAvailable());
+    }
+
+    // ==================== Polling tests ====================
+
+    #[Test]
+    public function generateWithQueueDoesNotCrashWhenPollIntervalIsZero(): void
+    {
+        // A configured pollInterval of 0 must be clamped (max(1, …)) so the
+        // maxAttempts division and the usleep() loop don't blow up.
+        $config = [
+            'image' => [
+                'fal' => [
+                    'apiKeyIdentifier' => 'test-api-key',
+                    'pollInterval' => 0,
+                ],
+            ],
+        ];
+        $subject = $this->createSubject($config);
+
+        // Queue path: submit → status COMPLETED → result.
+        $this->setupQueueResponses(
+            ['COMPLETED'],
+            ['images' => [['url' => 'https://example.com/image.png']]],
+        );
+
+        $result = $subject->generate('A sunset', 'sdxl');
+
+        self::assertSame('sdxl', $result->model);
+    }
+
+    #[Test]
+    public function pollForResultThrowsTimeoutWhenStatusNeverCompletes(): void
+    {
+        // timeout 1s / pollInterval 1000ms → exactly one non-terminal poll,
+        // then the loop is exhausted and a timeout is raised.
+        $config = [
+            'image' => [
+                'fal' => [
+                    'apiKeyIdentifier' => 'test-api-key',
+                    'timeout' => 1,
+                    'pollInterval' => 1000,
+                ],
+            ],
+        ];
+        $subject = $this->createSubject($config);
+
+        $this->setupQueueResponses(['IN_PROGRESS'], null);
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('FAL generation timed out');
+
+        $subject->generate('A sunset', 'sdxl');
+    }
+
+    #[Test]
+    public function pollForResultSucceedsAfterAPendingPoll(): void
+    {
+        // timeout 1s / pollInterval 200ms → up to 5 polls. The first status is
+        // non-terminal, the second COMPLETED — covers a multi-iteration poll.
+        $config = [
+            'image' => [
+                'fal' => [
+                    'apiKeyIdentifier' => 'test-api-key',
+                    'timeout' => 1,
+                    'pollInterval' => 200,
+                ],
+            ],
+        ];
+        $subject = $this->createSubject($config);
+
+        $this->setupQueueResponses(
+            ['IN_PROGRESS', 'COMPLETED'],
+            ['images' => [['url' => 'https://example.com/image.png']]],
+        );
+
+        $result = $subject->generate('A sunset', 'sdxl');
+
+        self::assertSame('sdxl', $result->model);
     }
 
     // ==================== Queue error handling tests ====================

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -509,6 +509,29 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         }
     }
 
+    #[Test]
+    public function splitTextIntoChunksHardSplitKeepsMultibyteCharactersIntact(): void
+    {
+        // The hard-split must cut at character boundaries: a byte-wise split
+        // would slice multibyte UTF-8 sequences in half and feed invalid
+        // UTF-8 to the synthesis API. 5000 two-byte characters exceed the
+        // 4096-character limit, so the clause is hard-split.
+        $subject = $this->createSubject();
+
+        $sentence = str_repeat('ü', 5000) . ', tail clause.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $sentence);
+
+        self::assertIsArray($chunks);
+        self::assertNotEmpty($chunks);
+        foreach ($chunks as $chunk) {
+            self::assertIsString($chunk);
+            self::assertTrue(mb_check_encoding($chunk, 'UTF-8'), 'Chunk must remain valid UTF-8');
+            self::assertLessThanOrEqual(4096, mb_strlen($chunk));
+        }
+    }
+
     // ==================== API error handling tests ====================
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -29,6 +29,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -484,6 +485,28 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $result = $subject->synthesizeLong($longText);
 
         self::assertGreaterThan(1, count($result));
+    }
+
+    #[Test]
+    public function splitTextIntoChunksHardSplitsAnOverLimitClause(): void
+    {
+        // A comma-delimited sentence whose first clause already exceeds the
+        // input limit must be hard-split: emitting the clause whole would
+        // produce an over-limit chunk that synthesize() rejects.
+        $subject = $this->createSubject();
+
+        $firstClause = str_repeat('a', 5000); // > MAX_INPUT_LENGTH (4096)
+        $sentence = $firstClause . ', tail clause.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $sentence);
+
+        self::assertIsArray($chunks);
+        self::assertNotEmpty($chunks);
+        foreach ($chunks as $chunk) {
+            self::assertIsString($chunk);
+            self::assertLessThanOrEqual(4096, mb_strlen($chunk));
+        }
     }
 
     // ==================== API error handling tests ====================

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -29,8 +29,8 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
-use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -46,6 +46,12 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private LoggerInterface&Stub $loggerStub;
     private VaultServiceInterface $vaultStub;
     private ?string $tempFile = null;
+
+    /**
+     * URL of the last request built through `setupSuccessfulRequest()` —
+     * lets tests assert the endpoint without reflecting into the service.
+     */
+    private string $lastRequestUrl = '';
 
     protected function setUp(): void
     {
@@ -157,7 +163,13 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
         $this->requestFactoryStub
             ->method('createRequest')
-            ->willReturn($requestStub);
+            ->willReturnCallback(
+                function (string $method, UriInterface|string $uri) use ($requestStub): RequestInterface {
+                    $this->lastRequestUrl = (string)$uri;
+
+                    return $requestStub;
+                },
+            );
 
         $streamStub = self::createStub(StreamInterface::class);
         $this->streamFactoryStub
@@ -229,12 +241,14 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         // An empty ext_conf baseUrl is the documented "use the default" value;
         // it must not be sent verbatim (a scheme-less URL breaks the HTTP
         // client) — it falls back to the OpenAI default like the siblings do.
+        // Observed through the request the service builds (no reflection).
         $subject = $this->createSubject(['speech' => ['whisper' => ['baseUrl' => '']]]);
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello world']));
 
-        $reflection = new ReflectionClass($subject);
-        $baseUrl = $reflection->getProperty('baseUrl')->getValue($subject);
+        $subject->transcribe($audioFile);
 
-        self::assertSame('https://api.openai.com/v1/audio', $baseUrl);
+        self::assertStringStartsWith('https://api.openai.com/v1/audio', $this->lastRequestUrl);
     }
 
     // ==================== getters tests ====================

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -30,6 +30,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -220,6 +221,20 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubjectWithoutApiKey();
 
         self::assertFalse($subject->isAvailable());
+    }
+
+    #[Test]
+    public function emptyStringBaseUrlFallsBackToApiUrl(): void
+    {
+        // An empty ext_conf baseUrl is the documented "use the default" value;
+        // it must not be sent verbatim (a scheme-less URL breaks the HTTP
+        // client) — it falls back to the OpenAI default like the siblings do.
+        $subject = $this->createSubject(['speech' => ['whisper' => ['baseUrl' => '']]]);
+
+        $reflection = new ReflectionClass($subject);
+        $baseUrl = $reflection->getProperty('baseUrl')->getValue($subject);
+
+        self::assertSame('https://api.openai.com/v1/audio', $baseUrl);
     }
 
     // ==================== getters tests ====================

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -48,9 +48,12 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private ?string $tempFile = null;
 
     /**
-     * URL of the last request built through `setupSuccessfulRequest()` —
-     * lets tests assert the endpoint without reflecting into the service.
+     * Method and URL of the last request built through
+     * `setupSuccessfulRequest()` — lets tests assert the endpoint without
+     * reflecting into the service.
      */
+    private string $lastRequestMethod = '';
+
     private string $lastRequestUrl = '';
 
     protected function setUp(): void
@@ -165,6 +168,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->method('createRequest')
             ->willReturnCallback(
                 function (string $method, UriInterface|string $uri) use ($requestStub): RequestInterface {
+                    $this->lastRequestMethod = $method;
                     $this->lastRequestUrl = (string)$uri;
 
                     return $requestStub;
@@ -248,6 +252,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
         $subject->transcribe($audioFile);
 
+        self::assertSame('POST', $this->lastRequestMethod);
         self::assertStringStartsWith('https://api.openai.com/v1/audio', $this->lastRequestUrl);
     }
 


### PR DESCRIPTION
Rectifies the findings of the skills-based code review (#9 follow-up). Recreated on top of current `main` (after the DB-configuration bridge, #228) from the preserved WIP, completed and fully gated.

## Findings → Fixes

### 1. Streaming errors silently swallowed (error handling)
A non-2xx response on a streaming request yielded an empty generator with no error. New `AbstractProvider::assertStreamingResponseOk()` maps 4xx → `ProviderResponseException` (sanitized message + status) and other non-2xx → `ProviderConnectionException`; called in all seven adapters' `streamChatCompletion()`.
`Classes/Provider/AbstractProvider.php`, `Classes/Provider/{OpenAi,Claude,Gemini,Groq,Mistral,Ollama,OpenRouter}Provider.php`

### 2. API-key leakage in provider error messages (secret hygiene)
Regression tests prove `?key=<secret>` is redacted to `key=***` in both the 4xx-response path and the retry-exhaustion path, and never surfaces in exception messages.
`Tests/Unit/Provider/AbstractProviderTest.php`

### 3. Setup-wizard HTTP bypassed the vault secure client (SSRF hardening)
`ModelDiscovery` and `ConfigurationGenerator` used a plain PSR-18 client with an operator-supplied endpoint. Both now dispatch through `$vault->http()` (host guard, scheme validation, redirect blocking, audit log) and pre-gate the host via `SecureHttpClientFactory::isHostAllowed()` before any secret-bearing header is built. SSRF tests cover the metadata IP (`169.254.169.254`) and loopback targets.
`Classes/Service/SetupWizard/ModelDiscovery.php`, `Classes/Service/SetupWizard/ConfigurationGenerator.php`

### 4. Information disclosure in connection test (error handling)
`ModelDiscovery::testConnection()` echoed the raw exception message (can carry the target URL incl. a `?key=` secret) back to the client. It now returns a generic message and logs the sanitized detail server-side.
`Classes/Service/SetupWizard/ModelDiscovery.php`

### 5. Silent failure in configuration generation (error handling)
`ConfigurationGenerator::generate()` swallowed every `Throwable` on its way to the fallback presets. The fail-soft behaviour is kept, but the sanitized failure reason is now logged for operators.
`Classes/Service/SetupWizard/ConfigurationGenerator.php`

### 6. FAL poll interval of 0 → division by zero / busy-loop (input validation)
`pollInterval` is clamped to >= 1 ms; a configured 0 or negative value no longer breaks the poll-attempt computation or turns `usleep()` into a busy-loop. New tests cover the zero-interval queue flow, poll timeout, and multi-poll success.
`Classes/Specialized/Image/FalImageService.php`

### 7. TTS chunking could emit over-limit chunks (input validation)
A comma-delimited clause exceeding `MAX_INPUT_LENGTH` was emitted whole and later rejected by `synthesize()`. Such clauses are now hard-split, matching the existing terminal hard-split fallback.
`Classes/Specialized/Speech/TextToSpeechService.php`

### 8. Whisper config parsed with blind casts (input validation)
`(string)`/`(int)` casts of the user-editable extension configuration replaced with `is_string()`/`is_numeric()` guards; an empty `baseUrl` now falls back to the OpenAI default via `nonEmptyStringOrDefault()` — mirroring the sibling services.
`Classes/Specialized/Speech/WhisperTranscriptionService.php`

### 9. Weak image-service error assertions (test fixes)
DALL-E 400 and FAL 422 tests now assert the distinct validation branch of `mapErrorStatus()` (message wording and `type => 'validation'` context payload) instead of only the exception class.
`Tests/Unit/Specialized/Image/DallEImageServiceTest.php`, `Tests/Unit/Specialized/Image/FalImageServiceTest.php`

## Completions on top of the preserved WIP

- Added the missing covering tests for finding 1 (streaming 4xx/5xx → typed exception, lazy-generator semantics).
- Updated 28 pre-existing streaming happy-path stubs to stub `getStatusCode(200)` (required by the new guard) and one missed `ModelDiscovery` construction site.
- Removed a stray blank line the WIP had introduced inside the `SYSTEM_PROMPT` heredoc (it changed the prompt content).
- Fixed a PHPStan level-10 `cast.string` error in the new TTS test.

## Tests

All via the Docker runner (`./Build/Scripts/runTests.sh -p 8.4 -s <suite>`):

| Suite | Result |
|-------|--------|
| `unit` | SUCCESS — 3447 tests, 7669 assertions (17 PHPUnit notices, pre-existing: pristine `main` shows the same 17) |
| `phpstan` (level 10) | SUCCESS — 0 errors |
| `cgl -n` | SUCCESS |
| `rector -n` | SUCCESS |
