### PR TITLE
build(deps): allow nr-vault ^0.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.8.0",
+        "netresearch/nr-vault": "^0.8.0 || ^0.9.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
Widens the nr-vault constraint to `^0.8.0 || ^0.9.0` — 0.9.0 is BC for this extension's usage (secure HTTP client + vault service APIs unchanged); `^0.8.0` alone excludes it under 0.x caret semantics. A patch release follows so installations can actually resolve nr-vault 0.9.0.