### PR TITLE
feat: tagged prompt-snippet library (entity, composer API, backend module)

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -17,4 +17,9 @@ sonar.exclusions=Resources/Public/JavaScript/Vendor/**,Resources/Private/Templat
 #  - XLIFF translation files — the EN source and DE target files necessarily
 #    mirror each other's structure; that is translation, not duplication.
 #  - Test code — repeated arrange/act/assert scaffolding is idiomatic in tests.
-sonar.cpd.exclusions=Resources/Public/JavaScript/Vendor/**,Resources/Private/Templates/**,Resources/Private/Language/**,Tests/**
+#  - TYPO3 TCA files and the icon registry — declarative arrays whose shape is
+#    dictated by the TCA schema / icon API: every table repeats the same
+#    ctrl/columns scaffolding, every icon entry the same provider/source pair.
+#    The repetition is the format, not copy-paste (TYPO3 convention is one
+#    plain-array file per table, see Configuration/AGENTS.md).
+sonar.cpd.exclusions=Resources/Public/JavaScript/Vendor/**,Resources/Private/Templates/**,Resources/Private/Language/**,Tests/**,Configuration/TCA/**,Configuration/Icons.php

--- a/Classes/Controller/Backend/FormEngineUrlBuilder.php
+++ b/Classes/Controller/Backend/FormEngineUrlBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+
+/**
+ * Builds TYPO3 FormEngine record URLs for backend list modules.
+ *
+ * Centralizes the record_edit route construction every backend list
+ * controller needs: edit and new-record links that send the user back
+ * to the originating module after save/close.
+ */
+final readonly class FormEngineUrlBuilder
+{
+    public function __construct(
+        private BackendUriBuilder $backendUriBuilder,
+    ) {}
+
+    /**
+     * Build a FormEngine URL editing an existing record.
+     *
+     * @param string $tableName   record table, e.g. 'tx_nrllm_promptsnippet'
+     * @param int    $uid         uid of the record to edit
+     * @param string $returnRoute backend module route to return to after save/close
+     */
+    public function buildEditUrl(string $tableName, int $uid, string $returnRoute): string
+    {
+        return $this->buildRecordUrl($tableName, [$uid => 'edit'], $returnRoute);
+    }
+
+    /**
+     * Build a FormEngine URL creating a new record.
+     *
+     * @param string $tableName   record table, e.g. 'tx_nrllm_promptsnippet'
+     * @param string $returnRoute backend module route to return to after save/close
+     */
+    public function buildNewUrl(string $tableName, string $returnRoute): string
+    {
+        return $this->buildRecordUrl($tableName, [0 => 'new'], $returnRoute);
+    }
+
+    /**
+     * @param array<int, string> $commands FormEngine edit commands, uid => 'edit' | 'new'
+     */
+    private function buildRecordUrl(string $tableName, array $commands, string $returnRoute): string
+    {
+        return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
+            'edit' => [$tableName => $commands],
+            'returnUrl' => (string)$this->backendUriBuilder->buildUriFromRoute($returnRoute),
+        ]);
+    }
+}

--- a/Classes/Controller/Backend/PromptSnippetController.php
+++ b/Classes/Controller/Backend/PromptSnippetController.php
@@ -14,7 +14,6 @@ use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
-use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
@@ -36,11 +35,13 @@ final class PromptSnippetController extends ActionController
 {
     private const TABLE_NAME = 'tx_nrllm_promptsnippet';
 
+    private const MODULE_ROUTE = 'nrllm_snippets';
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly IconFactory $iconFactory,
         private readonly PromptSnippetRepository $promptSnippetRepository,
-        private readonly BackendUriBuilder $backendUriBuilder,
+        private readonly FormEngineUrlBuilder $formEngineUrlBuilder,
     ) {}
 
     /**
@@ -64,14 +65,17 @@ final class PromptSnippetController extends ActionController
             if ($uid === null) {
                 continue;
             }
-            $editUrls[$uid] = $this->buildEditUrl($uid);
+            $editUrls[$uid] = $this->formEngineUrlBuilder
+                ->buildEditUrl(self::TABLE_NAME, $uid, self::MODULE_ROUTE);
         }
+
+        $newUrl = $this->formEngineUrlBuilder->buildNewUrl(self::TABLE_NAME, self::MODULE_ROUTE);
 
         $moduleTemplate->assignMultiple([
             'snippets' => $snippets,
             'totalCount' => $snippets->count(),
             'editUrls' => $editUrls,
-            'newUrl' => $this->buildNewUrl(),
+            'newUrl' => $newUrl,
         ]);
 
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
@@ -79,39 +83,9 @@ final class PromptSnippetController extends ActionController
             ->setIcon($this->iconFactory->getIcon('actions-plus', IconSize::SMALL))
             ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.snippet.new', 'NrLlm') ?? 'New Snippet')
             ->setShowLabelText(true)
-            ->setHref($this->buildNewUrl());
+            ->setHref($newUrl);
         $buttonBar->addButton($createButton);
 
         return $moduleTemplate->renderResponse('Backend/PromptSnippet/List');
-    }
-
-    /**
-     * Build FormEngine edit URL for a snippet.
-     */
-    private function buildEditUrl(int $uid): string
-    {
-        return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
-            'edit' => [self::TABLE_NAME => [$uid => 'edit']],
-            'returnUrl' => $this->buildReturnUrl(),
-        ]);
-    }
-
-    /**
-     * Build FormEngine new record URL.
-     */
-    private function buildNewUrl(): string
-    {
-        return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
-            'edit' => [self::TABLE_NAME => [0 => 'new']],
-            'returnUrl' => $this->buildReturnUrl(),
-        ]);
-    }
-
-    /**
-     * Build return URL for FormEngine (back to list).
-     */
-    private function buildReturnUrl(): string
-    {
-        return (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_snippets');
     }
 }

--- a/Classes/Controller/Backend/PromptSnippetController.php
+++ b/Classes/Controller/Backend/PromptSnippetController.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Countable;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Backend controller for the prompt snippet library (list view).
+ *
+ * Snippets are small tagged prompt fragments (personas, tones of voice,
+ * target audiences, image styles, layouts) managed centrally and queried
+ * by consuming extensions. See ADR-031.
+ *
+ * Uses TYPO3 FormEngine for record editing (TCA-based forms).
+ */
+#[AsController]
+final class PromptSnippetController extends ActionController
+{
+    private const TABLE_NAME = 'tx_nrllm_promptsnippet';
+
+    public function __construct(
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly IconFactory $iconFactory,
+        private readonly PromptSnippetRepository $promptSnippetRepository,
+        private readonly BackendUriBuilder $backendUriBuilder,
+    ) {}
+
+    /**
+     * List all prompt snippets.
+     */
+    public function listAction(): ResponseInterface
+    {
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->makeDocHeaderModuleMenu();
+
+        /** @var QueryResultInterface<int, PromptSnippet>&Countable $snippets */
+        $snippets = $this->promptSnippetRepository->findAll();
+
+        /** @var array<int, string> $editUrls */
+        $editUrls = [];
+        foreach ($snippets as $snippet) {
+            if (!$snippet instanceof PromptSnippet) { // @phpstan-ignore instanceof.alwaysTrue
+                continue;
+            }
+            $uid = $snippet->getUid();
+            if ($uid === null) {
+                continue;
+            }
+            $editUrls[$uid] = $this->buildEditUrl($uid);
+        }
+
+        $moduleTemplate->assignMultiple([
+            'snippets' => $snippets,
+            'totalCount' => $snippets->count(),
+            'editUrls' => $editUrls,
+            'newUrl' => $this->buildNewUrl(),
+        ]);
+
+        $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
+        $createButton = $buttonBar->makeLinkButton()
+            ->setIcon($this->iconFactory->getIcon('actions-plus', IconSize::SMALL))
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.snippet.new', 'NrLlm') ?? 'New Snippet')
+            ->setShowLabelText(true)
+            ->setHref($this->buildNewUrl());
+        $buttonBar->addButton($createButton);
+
+        return $moduleTemplate->renderResponse('Backend/PromptSnippet/List');
+    }
+
+    /**
+     * Build FormEngine edit URL for a snippet.
+     */
+    private function buildEditUrl(int $uid): string
+    {
+        return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
+            'edit' => [self::TABLE_NAME => [$uid => 'edit']],
+            'returnUrl' => $this->buildReturnUrl(),
+        ]);
+    }
+
+    /**
+     * Build FormEngine new record URL.
+     */
+    private function buildNewUrl(): string
+    {
+        return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
+            'edit' => [self::TABLE_NAME => [0 => 'new']],
+            'returnUrl' => $this->buildReturnUrl(),
+        ]);
+    }
+
+    /**
+     * Build return URL for FormEngine (back to list).
+     */
+    private function buildReturnUrl(): string
+    {
+        return (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_snippets');
+    }
+}

--- a/Classes/Domain/Model/PromptSnippet.php
+++ b/Classes/Domain/Model/PromptSnippet.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+/**
+ * Domain model for prompt snippets.
+ *
+ * A prompt snippet is a small named prompt fragment (persona, tone of
+ * voice, target audience, image style, layout, ...) that editors manage
+ * centrally. Consuming extensions query snippets by tag and compose them
+ * into their prompts.
+ *
+ * Deliberately NOT a PromptTemplate: templates are complete prompts with
+ * model parameters and versioning, snippets are reusable fragments.
+ * See ADR-031.
+ */
+class PromptSnippet extends AbstractEntity
+{
+    protected string $identifier = '';
+    protected string $name = '';
+    protected string $description = '';
+
+    /** Comma-separated free-form tags, e.g. "audience,tone_of_voice". */
+    protected string $tags = '';
+
+    /** The prompt fragment text. */
+    protected string $snippet = '';
+
+    /**
+     * Optional metadata as JSON object string ('' when unused),
+     * e.g. {"voice":"nova"} on persona snippets.
+     */
+    protected string $metadata = '';
+
+    protected bool $isActive = true;
+    protected int $sorting = 0;
+
+    // Getters
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getTags(): string
+    {
+        return $this->tags;
+    }
+
+    public function getSnippet(): string
+    {
+        return $this->snippet;
+    }
+
+    public function getMetadata(): string
+    {
+        return $this->metadata;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function getSorting(): int
+    {
+        return $this->sorting;
+    }
+
+    // Setters
+
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function setTags(string $tags): void
+    {
+        $this->tags = $tags;
+    }
+
+    public function setSnippet(string $snippet): void
+    {
+        $this->snippet = $snippet;
+    }
+
+    public function setMetadata(string $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function setIsActive(bool $isActive): void
+    {
+        $this->isActive = $isActive;
+    }
+
+    public function setSorting(int $sorting): void
+    {
+        $this->sorting = $sorting;
+    }
+
+    /**
+     * Get the tags as a normalized list.
+     *
+     * Each tag is trimmed and lowercased; empty entries are dropped.
+     *
+     * @return list<string>
+     */
+    public function getTagList(): array
+    {
+        $tags = array_map(
+            static fn(string $tag): string => strtolower(trim($tag)),
+            explode(',', $this->tags),
+        );
+
+        return array_values(array_filter(
+            $tags,
+            static fn(string $tag): bool => $tag !== '',
+        ));
+    }
+
+    /**
+     * Get the metadata as a decoded JSON object.
+     *
+     * Returns an empty array when the metadata field is empty or does not
+     * contain a valid JSON object — bad editor input never throws.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMetadataArray(): array
+    {
+        if (trim($this->metadata) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($this->metadata, true);
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            return [];
+        }
+
+        $metadata = [];
+        foreach ($decoded as $key => $value) {
+            $metadata[(string)$key] = $value;
+        }
+
+        return $metadata;
+    }
+}

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Repository;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * Repository for PromptSnippet domain model.
+ *
+ * @extends Repository<PromptSnippet>
+ */
+class PromptSnippetRepository extends Repository
+{
+    protected $defaultOrderings = [
+        'sorting' => QueryInterface::ORDER_ASCENDING,
+        'name' => QueryInterface::ORDER_ASCENDING,
+    ];
+
+    /**
+     * Initialize repository for backend module use.
+     * Ignores storage page and enable fields restrictions.
+     */
+    public function initializeObject(): void
+    {
+        $querySettings = $this->createQuery()->getQuerySettings();
+        $querySettings->setRespectStoragePage(false);
+        $querySettings->setIgnoreEnableFields(true);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Find active snippets carrying the given tag.
+     *
+     * The tag is matched as an exact, case-insensitive token against the
+     * comma-separated tags field — never as a substring: tag 'style' does
+     * NOT match a snippet tagged 'lifestyle'.
+     *
+     * @return list<PromptSnippet> ordered by sorting, then name
+     */
+    public function findActiveByTag(string $tag): array
+    {
+        $normalizedTag = strtolower(trim($tag));
+        if ($normalizedTag === '') {
+            return [];
+        }
+
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('isActive', true),
+        );
+        $query->setOrderings([
+            'sorting' => QueryInterface::ORDER_ASCENDING,
+            'name' => QueryInterface::ORDER_ASCENDING,
+        ]);
+
+        $snippets = [];
+        foreach ($query->execute() as $snippet) {
+            if (in_array($normalizedTag, $snippet->getTagList(), true)) {
+                $snippets[] = $snippet;
+            }
+        }
+
+        return $snippets;
+    }
+
+    /**
+     * Find active snippets by uid, preserving the input order.
+     *
+     * Unknown and inactive uids are silently skipped.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<PromptSnippet>
+     */
+    public function findByUids(array $uids): array
+    {
+        if ($uids === []) {
+            return [];
+        }
+
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('isActive', true),
+                $query->in('uid', $uids),
+            ),
+        );
+
+        /** @var array<int, PromptSnippet> $snippetsByUid */
+        $snippetsByUid = [];
+        foreach ($query->execute() as $snippet) {
+            $uid = $snippet->getUid();
+            if ($uid !== null) {
+                $snippetsByUid[$uid] = $snippet;
+            }
+        }
+
+        $ordered = [];
+        foreach ($uids as $uid) {
+            if (isset($snippetsByUid[$uid])) {
+                $ordered[] = $snippetsByUid[$uid];
+            }
+        }
+
+        return $ordered;
+    }
+}

--- a/Classes/Service/Prompt/PromptSnippetComposer.php
+++ b/Classes/Service/Prompt/PromptSnippetComposer.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Prompt;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+
+/**
+ * Composes prompt snippets into labeled prompt sections.
+ *
+ * Consuming extensions resolve snippets (e.g. via
+ * PromptSnippetRepository::findActiveByTag()) and pass them here to
+ * build the snippet-backed part of their prompt.
+ */
+final class PromptSnippetComposer
+{
+    /**
+     * Compose labeled prompt sections from snippets.
+     *
+     * Each non-null snippet with non-empty text becomes a block of the
+     * form "LABEL:\n<snippet text>"; blocks are joined by a blank line.
+     * Null entries and snippets with empty text are skipped. Returns an
+     * empty string when there is nothing to compose.
+     *
+     * @param array<string, PromptSnippet|null> $sectionsByLabel ordered map of section label to snippet
+     */
+    public function composeSections(array $sectionsByLabel): string
+    {
+        $blocks = [];
+        foreach ($sectionsByLabel as $label => $snippet) {
+            if ($snippet === null) {
+                continue;
+            }
+
+            $text = trim($snippet->getSnippet());
+            if ($text === '') {
+                continue;
+            }
+
+            $blocks[] = $label . ":\n" . $text;
+        }
+
+        return implode("\n\n", $blocks);
+    }
+}

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -11,6 +11,7 @@ use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
 use Netresearch\NrLlm\Controller\Backend\ModelController;
+use Netresearch\NrLlm\Controller\Backend\PromptSnippetController;
 use Netresearch\NrLlm\Controller\Backend\ProviderController;
 use Netresearch\NrLlm\Controller\Backend\SetupWizardController;
 use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
@@ -149,6 +150,21 @@ return [
                 'wizardGenerate',
                 'wizardGenerateChain',
                 'wizardCreate',
+            ],
+        ],
+    ],
+    // Prompt snippet library - child of main module
+    // Note: new/edit/save/delete use FormEngine (record_edit route)
+    'nrllm_snippets' => [
+        'parent' => 'nrllm',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-snippet',
+        'path' => '/module/nrllm/snippets',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_snippet.xlf',
+        'extensionName' => 'NrLlm',
+        'controllerActions' => [
+            PromptSnippetController::class => [
+                'list',
             ],
         ],
     ],

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
@@ -95,6 +96,14 @@ return [
             ],
             'isSystem' => [
                 'fieldName' => 'is_system',
+            ],
+        ],
+    ],
+    PromptSnippet::class => [
+        'tableName' => 'tx_nrllm_promptsnippet',
+        'properties' => [
+            'isActive' => [
+                'fieldName' => 'is_active',
             ],
         ],
     ],

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -31,6 +31,10 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:nr_llm/Resources/Public/Icons/Task.svg',
     ],
+    'module-nrllm-snippet' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:nr_llm/Resources/Public/Icons/Snippet.svg',
+    ],
     'module-nrllm-analytics' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:nr_llm/Resources/Public/Icons/Analytics.svg',

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -120,6 +120,9 @@ services:
     alias: Netresearch\NrLlm\Service\PromptTemplateService
     public: true
 
+  Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer:
+    public: true
+
   Netresearch\NrLlm\Service\CacheManager:
     public: true
 
@@ -167,6 +170,9 @@ services:
     public: true
 
   Netresearch\NrLlm\Domain\Repository\TaskRepository:
+    public: true
+
+  Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository:
     public: true
 
   Netresearch\NrLlm\Domain\Repository\UserBudgetRepository:

--- a/Configuration/TCA/tx_nrllm_promptsnippet.php
+++ b/Configuration/TCA/tx_nrllm_promptsnippet.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet',
+        'label' => 'name',
+        'label_alt' => 'identifier',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'default_sortby' => 'sorting ASC, name ASC',
+        'searchFields' => 'identifier,name,description,tags,snippet',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:nr_llm/Resources/Public/Icons/Snippet.svg',
+        'rootLevel' => -1,
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;core.form.tabs:general,
+                    --palette--;;identity,
+                    tags,
+                    snippet,
+                    metadata,
+                --div--;core.form.tabs:access,
+                    --palette--;;status,
+            ',
+        ],
+    ],
+    'palettes' => [
+        'identity' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:palette.identity',
+            'showitem' => 'identifier, --linebreak--, name, --linebreak--, description',
+        ],
+        'status' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:palette.status',
+            'showitem' => 'is_active, hidden',
+        ],
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        'identifier' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.identifier',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.identifier.description',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'max' => 100,
+                'trim' => true,
+                'eval' => 'alphanum_x,lower',
+                'required' => true,
+                'placeholder' => 'persona-friendly-expert',
+            ],
+        ],
+        'name' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.name',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.name.description',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 255,
+                'trim' => true,
+                'required' => true,
+            ],
+        ],
+        'description' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3,
+            ],
+        ],
+        'tags' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.tags',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.tags.description',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 255,
+                'trim' => true,
+                'placeholder' => 'audience, tone_of_voice',
+            ],
+        ],
+        'snippet' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.snippet',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.snippet.description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 80,
+                'rows' => 8,
+                'required' => true,
+                'placeholder' => 'Write for marketing professionals with limited technical background.',
+            ],
+        ],
+        'metadata' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.metadata',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.metadata.description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3,
+                'placeholder' => '{"voice": "nova"}',
+                'searchable' => false,
+            ],
+        ],
+        'is_active' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.is_active',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_promptsnippet.is_active.description',
+            'config' => [
+                'type' => 'check',
+                'default' => 1,
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_nrllm_promptsnippet.php
+++ b/Configuration/TCA/tx_nrllm_promptsnippet.php
@@ -66,7 +66,7 @@ return [
                 'size' => 30,
                 'max' => 100,
                 'trim' => true,
-                'eval' => 'alphanum_x,lower',
+                'eval' => 'alphanum_x,lower,unique',
                 'required' => true,
                 'placeholder' => 'persona-friendly-expert',
             ],

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -31,7 +31,7 @@ section, and AI wizard buttons.
    The LLM dashboard with setup progress, wizard
    buttons, and quick-reference PHP snippets.
 
-The module has five sections accessible from the
+The module has six sections accessible from the
 left-hand navigation:
 
 - **Dashboard** — overview and wizards
@@ -39,6 +39,7 @@ left-hand navigation:
 - **Models** — available LLM models
 - **Configurations** — use-case presets
 - **Tasks** — one-shot prompt templates
+- **Snippets** — tagged reusable prompt fragments
 
 .. toctree::
    :maxdepth: 2
@@ -47,6 +48,7 @@ left-hand navigation:
    Models
    Configurations
    Tasks
+   PromptSnippets
    Wizards
    UserBudgets
    Analytics

--- a/Documentation/Administration/PromptSnippets.rst
+++ b/Documentation/Administration/PromptSnippets.rst
@@ -1,0 +1,112 @@
+.. include:: /Includes.rst.txt
+
+.. _administration-snippets:
+
+========================
+Managing prompt snippets
+========================
+
+Prompt snippets are small named prompt *fragments* —
+personas, tones of voice, target audiences, image
+styles, layouts — that editors manage centrally.
+Consuming extensions (for example ``nr_repurpose``)
+query snippets by tag and compose them into their
+prompts.
+
+Snippets are deliberately **not** prompt templates:
+a :ref:`prompt template <adr-031>` is a complete,
+versioned prompt with model parameters, while a
+snippet is a reusable building block without any
+model binding.
+
+.. _administration-snippets-add:
+
+Adding a snippet
+================
+
+1. Navigate to :guilabel:`Admin Tools > LLM >
+   Snippets`.
+2. Click :guilabel:`New Snippet`.
+3. Fill in the fields:
+
+   :guilabel:`Identifier`
+      Unique technical identifier (e.g.,
+      ``persona-friendly-expert``).
+
+   :guilabel:`Name`
+      Display name (e.g., ``Friendly Expert``).
+
+   :guilabel:`Tags`
+      Comma-separated tags consuming extensions
+      search for (see below).
+
+   :guilabel:`Snippet text`
+      The prompt fragment itself.
+
+   :guilabel:`Metadata (JSON)`
+      Optional JSON object with extra settings.
+
+4. Click :guilabel:`Save`.
+
+.. _administration-snippets-tags:
+
+Tag convention
+==============
+
+Tags are free-form, comma-separated strings. There
+is no fixed vocabulary — consuming extensions agree
+on tags with the editors. Matching is exact per tag
+and case-insensitive: the tag ``style`` does *not*
+match a snippet tagged ``lifestyle``.
+
+Established tags so far:
+
+==================  =============================================
+Tag                 Used for
+==================  =============================================
+``audience``        Target audience descriptions
+``tone_of_voice``   Tone-of-voice instructions
+``persona``         Writing/speaking personas
+``layout``          Layout instructions (e.g. for slides)
+``style``           Image / visual style descriptions
+==================  =============================================
+
+Persona snippets may carry a voice hint in their
+metadata so speech features can pick a matching
+text-to-speech voice:
+
+..  code-block:: json
+    :caption: Metadata of a persona snippet
+
+    {"voice": "nova"}
+
+.. _administration-snippets-developer:
+
+Using snippets from an extension
+================================
+
+Query snippets by tag through the public
+:php:`PromptSnippetRepository` and compose the
+selected fragments with the
+:php:`PromptSnippetComposer`:
+
+..  code-block:: php
+    :caption: Composing snippets into a prompt
+
+    $audiences = $this->promptSnippetRepository
+        ->findActiveByTag('audience');
+    $tones = $this->promptSnippetRepository
+        ->findActiveByTag('tone_of_voice');
+
+    $sections = $this->promptSnippetComposer->composeSections([
+        'TARGET AUDIENCE' => $audiences[0] ?? null,
+        'TONE OF VOICE' => $tones[0] ?? null,
+    ]);
+
+:php:`composeSections()` renders each non-null
+snippet as a ``LABEL:`` block followed by the
+snippet text, joined by blank lines. Null entries
+and empty snippets are skipped.
+
+See :ref:`ADR-031 <adr-031>` for the design
+rationale.

--- a/Documentation/Adr/Adr028PublicServicesPolicy.rst
+++ b/Documentation/Adr/Adr028PublicServicesPolicy.rst
@@ -118,29 +118,34 @@ The unit test
 ``Configuration/Services.yaml`` and asserts:
 
 * The total count of ``public: true`` keys matches the expected
-  total (currently **38**).
+  total (currently **40**).
 * The ADR file exists and references both ``REC #9c`` and the
   ``public: true`` policy text.
 
-Breakdown of the 38:
+Breakdown of the 40:
 
-* **21** Category 1 — Public LLM API surface
-  (12 concrete services + 9 interface aliases).
-  Note the 12 / 9 asymmetry: ``CompletionService``,
+* **22** Category 1 — Public LLM API surface
+  (13 concrete services + 9 interface aliases).
+  Note the 13 / 9 asymmetry: ``CompletionService``,
   ``EmbeddingService``, ``TranslationService``, ``VisionService``
   contribute 4 concrete entries but their interface aliases are
-  registered separately (4 aliases). The remaining 8 concrete
-  services pair with 5 interface aliases; three core services
+  registered separately (4 aliases). Of the remaining 9 concrete
+  services, three core services
   (``LlmServiceManager``, ``ProviderAdapterRegistry``,
   ``TranslatorRegistry``) keep the interface-alias entry while
   ``BudgetService``, ``CacheManager``, ``UsageTrackerService``,
   ``LlmConfigurationService``, ``PromptTemplateService`` each have
-  both a concrete + interface entry. The maths: 12 concrete + 9
-  aliases = 21.
+  both a concrete + interface entry, and
+  ``Service\Prompt\PromptSnippetComposer`` (ADR-031) is
+  concrete-only — consuming extensions resolve it by class name,
+  it has no interface alias. The maths: 13 concrete + 9
+  aliases = 22.
 * **4** Category 2 — Specialized services
   (Whisper, TextToSpeech, DallE, Fal).
-* **5** Category 3 — Repositories
-  (LlmConfiguration, Provider, Model, Task, UserBudget).
+* **6** Category 3 — Repositories
+  (LlmConfiguration, Provider, Model, Task, PromptSnippet,
+  UserBudget). ``PromptSnippetRepository`` is additionally the
+  documented query surface for consuming extensions (ADR-031).
 * **4** Category 4 — SetupWizard
   (3 concrete: ProviderDetector, ModelDiscovery,
   ConfigurationGenerator + 1 alias: ModelDiscoveryInterface).

--- a/Documentation/Adr/Adr031PromptSnippetLibrary.rst
+++ b/Documentation/Adr/Adr031PromptSnippetLibrary.rst
@@ -1,0 +1,95 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-031:
+
+==================================================================
+ADR-031: Tagged Prompt Snippet Library
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-10
+:Authors: Netresearch DTT GmbH
+
+.. _adr-031-context:
+
+Context
+=======
+
+Consuming extensions — first ``nr_repurpose`` — assemble prompts from
+recurring building blocks: a persona, a tone of voice, a target
+audience, an image style, a layout instruction. Editors want to manage
+these fragments centrally, once, instead of re-typing them into every
+extension's own configuration.
+
+The existing :php:`PromptTemplate` entity does not fit this need. It is
+a heavyweight *complete* prompt: it binds a feature, carries model
+parameters (temperature, max tokens, top-p), supports versioning with
+parent/variant relations, and tracks usage performance. A persona like
+"You are Nova, a friendly expert." has none of these concerns — it is a
+fragment that only becomes a prompt when a consumer composes it with
+its own instructions. Forcing fragments into :php:`PromptTemplate`
+would either bloat every fragment record with irrelevant model fields
+or fork the template semantics depending on a "fragment" flag.
+
+A second question is how consumers select fragments. A fixed category
+enum (like :php:`Task` categories) would require an nr-llm release
+every time a consuming extension introduces a new fragment kind, which
+contradicts the goal of nr-llm being a shared foundation that consumers
+extend without touching it.
+
+.. _adr-031-decision:
+
+Decision
+========
+
+Introduce a separate, lightweight :php:`PromptSnippet` entity
+(table ``tx_nrllm_promptsnippet``) next to — not on top of —
+:php:`PromptTemplate`:
+
+1. **Fragments, not templates.** A snippet is identifier + name +
+   description + fragment text. No model parameters, no versioning, no
+   performance tracking. :php:`PromptTemplate` stays untouched.
+
+2. **Free-form CSV tags instead of a category enum.** Snippets carry a
+   comma-separated ``tags`` field. Consumers query
+   :php:`PromptSnippetRepository::findActiveByTag()`, which matches
+   tags as exact, case-insensitive tokens — ``style`` never matches
+   ``lifestyle``. The tag vocabulary is a *convention* between editors
+   and consumers (established so far: ``audience``, ``tone_of_voice``,
+   ``persona``, ``layout``, ``style``), documented in the TCA field
+   description and the administration guide. New fragment kinds need no
+   nr-llm release.
+
+3. **JSON metadata side-channel.** An optional ``metadata`` JSON object
+   carries consumer-specific settings (e.g. ``{"voice": "nova"}`` on
+   persona snippets so speech features can pick a matching TTS voice).
+   :php:`getMetadataArray()` returns ``[]`` for empty or invalid JSON —
+   bad editor input must never break a consumer.
+
+4. **Composition stays in nr-llm.** :php:`PromptSnippetComposer`
+   renders an ordered label-to-snippet map into labeled prompt blocks
+   (``LABEL:`` + fragment text, blank-line separated), so all consumers
+   produce uniformly structured prompt sections.
+
+5. **Editing via FormEngine.** The backend module gets a "Snippets"
+   list following the established Providers/Models/Tasks pattern;
+   create/edit links into FormEngine, no custom forms.
+
+.. _adr-031-consequences:
+
+Consequences
+============
+
+- Editors manage personas, tones, audiences, styles, and layouts once,
+  centrally; every consuming extension reads the same library.
+- The free-tag model keeps nr-llm release-independent from consumer
+  vocabulary — at the cost of no referential integrity: a typo in a tag
+  silently yields an empty query result. The documented convention and
+  the tag badges in the list view mitigate this.
+- Token matching is implemented over the CSV field in PHP, not SQL
+  ``LIKE``, guaranteeing exact-token semantics on every database
+  platform. The snippet library is small (tens of records), so loading
+  active snippets for tag filtering is not a performance concern.
+- Two prompt-related entities now coexist. The split is intentional
+  (template = complete prompt, snippet = fragment) and documented here,
+  in the administration guide, and in both entities' PHPDoc.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -263,3 +263,4 @@ Modern architecture (v0.4+)
    Adr028PublicServicesPolicy
    Adr029UsageAnalyticsDashboard
    Adr030SpecializedServicesVaultMigration
+   Adr031PromptSnippetLibrary

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -276,6 +276,10 @@
                 <source>New Configuration</source>
                 <target>Neue Konfiguration</target>
             </trans-unit>
+            <trans-unit id="btn.snippet.new">
+                <source>New Snippet</source>
+                <target>Neues Snippet</target>
+            </trans-unit>
             <trans-unit id="btn.refresh">
                 <source>Refresh</source>
                 <target>Aktualisieren</target>

--- a/Resources/Private/Language/de.locallang_mod_snippet.xlf
+++ b/Resources/Private/Language/de.locallang_mod_snippet.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Prompt Snippets</source>
+                <target>LLM-Prompt-Snippets</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Snippets</source>
+                <target>Snippets</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tagged prompt fragments (personas, tones of voice, audiences, styles, layouts) for consuming extensions</source>
+                <target>Mit Tags versehene Prompt-Fragmente (Personas, Tonalitäten, Zielgruppen, Stile, Layouts) für konsumierende Extensions</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -929,6 +929,64 @@
                 <source>DeepL</source>
                 <target>DeepL</target>
             </trans-unit>
+
+            <!-- Prompt snippet table -->
+            <trans-unit id="tx_nrllm_promptsnippet">
+                <source>LLM Prompt Snippet</source>
+                <target>LLM-Prompt-Snippet</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.identifier">
+                <source>Identifier</source>
+                <target>Bezeichner</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.identifier.description">
+                <source>Unique technical identifier (lowercase, e.g. persona-friendly-expert)</source>
+                <target>Eindeutiger technischer Bezeichner (Kleinschreibung, z. B. persona-friendly-expert)</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.name">
+                <source>Name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.name.description">
+                <source>Display name shown to editors</source>
+                <target>Anzeigename für Redakteure</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.description">
+                <source>Description</source>
+                <target>Beschreibung</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.tags">
+                <source>Tags</source>
+                <target>Tags</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.tags.description">
+                <source>Comma-separated free-form tags used by consuming extensions to find snippets. Established tags: audience, tone_of_voice, persona, layout, style. Matching is case-insensitive and exact per tag.</source>
+                <target>Kommagetrennte, frei wählbare Tags, über die konsumierende Extensions Snippets finden. Etablierte Tags: audience, tone_of_voice, persona, layout, style. Der Abgleich erfolgt pro Tag exakt und ohne Beachtung der Groß-/Kleinschreibung.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.snippet">
+                <source>Snippet text</source>
+                <target>Snippet-Text</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.snippet.description">
+                <source>The prompt fragment that is composed into the consuming extension's prompt</source>
+                <target>Das Prompt-Fragment, das in den Prompt der konsumierenden Extension eingesetzt wird</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.metadata">
+                <source>Metadata (JSON)</source>
+                <target>Metadaten (JSON)</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.metadata.description">
+                <source>Optional JSON object with extra settings for consuming extensions, e.g. {"voice": "nova"} on persona snippets</source>
+                <target>Optionales JSON-Objekt mit Zusatzeinstellungen für konsumierende Extensions, z. B. {"voice": "nova"} bei Persona-Snippets</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.is_active">
+                <source>Active</source>
+                <target>Aktiv</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.is_active.description">
+                <source>Only active snippets are returned to consuming extensions</source>
+                <target>Nur aktive Snippets werden an konsumierende Extensions ausgeliefert</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -210,6 +210,9 @@
             <trans-unit id="btn.configuration.new">
                 <source>New Configuration</source>
             </trans-unit>
+            <trans-unit id="btn.snippet.new">
+                <source>New Snippet</source>
+            </trans-unit>
             <trans-unit id="btn.refresh">
                 <source>Refresh</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_mod_snippet.xlf
+++ b/Resources/Private/Language/locallang_mod_snippet.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Prompt Snippets</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Snippets</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tagged prompt fragments (personas, tones of voice, audiences, styles, layouts) for consuming extensions</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -726,6 +726,50 @@
             <trans-unit id="tx_nrllm_configuration.translator.deepl">
                 <source>DeepL</source>
             </trans-unit>
+
+            <!-- Prompt snippet table -->
+            <trans-unit id="tx_nrllm_promptsnippet">
+                <source>LLM Prompt Snippet</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.identifier">
+                <source>Identifier</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.identifier.description">
+                <source>Unique technical identifier (lowercase, e.g. persona-friendly-expert)</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.name">
+                <source>Name</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.name.description">
+                <source>Display name shown to editors</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.description">
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.tags">
+                <source>Tags</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.tags.description">
+                <source>Comma-separated free-form tags used by consuming extensions to find snippets. Established tags: audience, tone_of_voice, persona, layout, style. Matching is case-insensitive and exact per tag.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.snippet">
+                <source>Snippet text</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.snippet.description">
+                <source>The prompt fragment that is composed into the consuming extension's prompt</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.metadata">
+                <source>Metadata (JSON)</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.metadata.description">
+                <source>Optional JSON object with extra settings for consuming extensions, e.g. {"voice": "nova"} on persona snippets</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.is_active">
+                <source>Active</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_promptsnippet.is_active.description">
+                <source>Only active snippets are returned to consuming extensions</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Templates/Backend/PromptSnippet/List.html
+++ b/Resources/Private/Templates/Backend/PromptSnippet/List.html
@@ -1,0 +1,90 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <div>
+        <h1>
+            <core:icon identifier="module-nrllm-snippet" size="medium" />
+            Prompt Snippets ({totalCount})
+        </h1>
+
+        <f:be.infobox state="-2">
+            <p>Prompt snippets are small reusable prompt <strong>fragments</strong> — personas, tones of voice, target audiences, image styles, layouts — managed centrally in one place. Consuming extensions query them by tag and compose them into their prompts.</p>
+            <p class="mb-0">Tag snippets with comma-separated free-form tags. Established tags: <code>audience</code>, <code>tone_of_voice</code>, <code>persona</code>, <code>layout</code>, <code>style</code>. Snippets are not prompt templates: templates are complete prompts with model parameters, snippets are building blocks.</p>
+        </f:be.infobox>
+
+        <f:if condition="{totalCount} == 0">
+            <f:then>
+                <f:be.infobox
+                    title="No Prompt Snippets Configured"
+                    state="-1"
+                >
+                    <p>No prompt snippets have been created yet.</p>
+                    <p><a href="{newUrl}" class="btn btn-primary btn-sm"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.snippet.new" default="New Snippet" /></a></p>
+                </f:be.infobox>
+            </f:then>
+            <f:else>
+                <div class="card mb-4">
+                    <div class="card-body p-0">
+                        <table class="table table-striped table-hover mb-0">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40px;"></th>
+                                    <th>Name</th>
+                                    <th>Identifier</th>
+                                    <th>Tags</th>
+                                    <th style="width: 120px;">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <f:for each="{snippets}" as="snippet">
+                                    <tr class="{f:if(condition: '!{snippet.isActive}', then: 'table-secondary')}">
+                                        <td>
+                                            <f:if condition="{snippet.isActive}">
+                                                <f:then>
+                                                    <span class="badge text-bg-success" title="Active">
+                                                        <core:icon identifier="actions-check" size="small" />
+                                                    </span>
+                                                </f:then>
+                                                <f:else>
+                                                    <span class="badge text-bg-secondary" title="Inactive">
+                                                        <core:icon identifier="actions-close" size="small" />
+                                                    </span>
+                                                </f:else>
+                                            </f:if>
+                                        </td>
+                                        <td>
+                                            <strong>{snippet.name}</strong>
+                                            <f:if condition="{snippet.description}">
+                                                <br><small class="text-muted">{snippet.description}</small>
+                                            </f:if>
+                                        </td>
+                                        <td><code>{snippet.identifier}</code></td>
+                                        <td>
+                                            <f:for each="{snippet.tagList}" as="tag">
+                                                <span class="badge text-bg-info me-1">{tag}</span>
+                                            </f:for>
+                                        </td>
+                                        <td>
+                                            <div class="btn-group btn-group-sm">
+                                                <a href="{editUrls.{snippet.uid}}" class="btn btn-secondary" title="Edit">
+                                                    <core:icon identifier="actions-open" size="small" />
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </f:for>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+
+</html>

--- a/Resources/Public/Icons/Snippet.svg
+++ b/Resources/Public/Icons/Snippet.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Tag for tagged prompt fragments -->
+    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.83z"/>
+    <line x1="7" y1="7" x2="7.01" y2="7"/>
+</svg>

--- a/Tests/E2E/TCA/TcaFieldCompletionTest.php
+++ b/Tests/E2E/TCA/TcaFieldCompletionTest.php
@@ -44,6 +44,7 @@ final class TcaFieldCompletionTest extends TestCase
             'model' => ['tx_nrllm_model'],
             'configuration' => ['tx_nrllm_configuration'],
             'task' => ['tx_nrllm_task'],
+            'promptsnippet' => ['tx_nrllm_promptsnippet'],
         ];
     }
 

--- a/Tests/Functional/Fixtures/PromptSnippets.csv
+++ b/Tests/Functional/Fixtures/PromptSnippets.csv
@@ -1,0 +1,11 @@
+"tx_nrllm_promptsnippet"
+,"uid","pid","identifier","name","description","tags","snippet","metadata","is_active","sorting","tstamp","crdate","deleted","hidden"
+,1,0,"tone-casual","Casual tone","A relaxed tone of voice","tone_of_voice","Write in a relaxed, casual tone.","",1,20,1703347200,1703347200,0,0
+,2,0,"tone-formal","Formal tone","A formal tone of voice","tone_of_voice","Use a formal, professional tone of voice.","",1,10,1703347200,1703347200,0,0
+,3,0,"audience-developers","Developers","Software developer audience","audience","Write for software developers.","",1,30,1703347200,1703347200,0,0
+,4,0,"audience-marketers","Marketers","Marketing professional audience","audience","Write for marketing professionals.","",1,30,1703347200,1703347200,0,0
+,5,0,"style-minimalist","Minimalist style","A minimalist image style"," Style , image","Use a minimalist visual style.","",1,40,1703347200,1703347200,0,0
+,6,0,"layout-lifestyle","Lifestyle magazine layout","A lifestyle magazine layout","lifestyle,layout","Arrange like a lifestyle magazine spread.","",1,50,1703347200,1703347200,0,0
+,7,0,"tone-inactive","Inactive tone","An inactive snippet","tone_of_voice","This snippet is inactive.","",0,60,1703347200,1703347200,0,0
+,8,0,"tone-deleted","Deleted tone","A deleted snippet","tone_of_voice","This snippet is deleted.","",1,70,1703347200,1703347200,1,0
+,9,0,"persona-nova","Nova persona","A persona carrying voice metadata","persona","You are Nova, a friendly expert.","{""voice"":""nova""}",1,80,1703347200,1703347200,0,0

--- a/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
+++ b/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
@@ -125,8 +125,11 @@ final class PromptSnippetRepositoryTest extends AbstractFunctionalTestCase
         // tone-formal (sorting 10) before tone-casual (sorting 20),
         // although 'Casual tone' sorts before 'Formal tone' by name
         self::assertSame(
-            ['tone-formal', 'tone-casual'],
-            $this->identifiersOf($snippets),
+            [10, 20],
+            array_map(
+                static fn(PromptSnippet $snippet): int => $snippet->getSorting(),
+                $snippets,
+            ),
         );
     }
 

--- a/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
+++ b/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Repository;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Functional tests for PromptSnippetRepository.
+ *
+ * Verifies the tag-token query contract consumed by other extensions
+ * (e.g. nr_repurpose): exact case-insensitive token matching and
+ * order-preserving uid lookups.
+ */
+#[CoversClass(PromptSnippetRepository::class)]
+final class PromptSnippetRepositoryTest extends AbstractFunctionalTestCase
+{
+    private PromptSnippetRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('PromptSnippets.csv');
+
+        $repository = $this->get(PromptSnippetRepository::class);
+        self::assertInstanceOf(PromptSnippetRepository::class, $repository);
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param list<PromptSnippet> $snippets
+     *
+     * @return list<string>
+     */
+    private function identifiersOf(array $snippets): array
+    {
+        return array_map(
+            static fn(PromptSnippet $snippet): string => $snippet->getIdentifier(),
+            $snippets,
+        );
+    }
+
+    // =========================================================================
+    // findActiveByTag(): token matching
+    // =========================================================================
+
+    #[Test]
+    public function findActiveByTagReturnsOnlyActiveSnippetsWithExactTag(): void
+    {
+        $snippets = $this->repository->findActiveByTag('tone_of_voice');
+
+        // Inactive (uid 7) and deleted (uid 8) snippets must be excluded
+        self::assertSame(
+            ['tone-formal', 'tone-casual'],
+            $this->identifiersOf($snippets),
+        );
+    }
+
+    #[Test]
+    public function findActiveByTagDoesNotMatchSubstrings(): void
+    {
+        // 'style' must NOT match the 'lifestyle' tag of layout-lifestyle
+        $snippets = $this->repository->findActiveByTag('style');
+
+        self::assertSame(['style-minimalist'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findActiveByTagDoesNotMatchPartialTokens(): void
+    {
+        // 'life' is a substring of 'lifestyle' but no exact token
+        self::assertSame([], $this->repository->findActiveByTag('life'));
+    }
+
+    #[Test]
+    public function findActiveByTagIsCaseInsensitive(): void
+    {
+        $snippets = $this->repository->findActiveByTag('STYLE');
+
+        // Stored tag is ' Style ' (mixed case, padded) — still matches
+        self::assertSame(['style-minimalist'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findActiveByTagTrimsTheRequestedTag(): void
+    {
+        $snippets = $this->repository->findActiveByTag('  layout  ');
+
+        self::assertSame(['layout-lifestyle'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findActiveByTagReturnsEmptyListForUnknownTag(): void
+    {
+        self::assertSame([], $this->repository->findActiveByTag('unknown-tag'));
+    }
+
+    #[Test]
+    public function findActiveByTagReturnsEmptyListForEmptyTag(): void
+    {
+        self::assertSame([], $this->repository->findActiveByTag(''));
+        self::assertSame([], $this->repository->findActiveByTag('   '));
+    }
+
+    // =========================================================================
+    // findActiveByTag(): ordering
+    // =========================================================================
+
+    #[Test]
+    public function findActiveByTagOrdersBySortingFirst(): void
+    {
+        $snippets = $this->repository->findActiveByTag('tone_of_voice');
+
+        // tone-formal (sorting 10) before tone-casual (sorting 20),
+        // although 'Casual tone' sorts before 'Formal tone' by name
+        self::assertSame(
+            ['tone-formal', 'tone-casual'],
+            $this->identifiersOf($snippets),
+        );
+    }
+
+    #[Test]
+    public function findActiveByTagOrdersByNameWhenSortingIsEqual(): void
+    {
+        $snippets = $this->repository->findActiveByTag('audience');
+
+        // Both have sorting 30 — 'Developers' before 'Marketers'
+        self::assertSame(
+            ['audience-developers', 'audience-marketers'],
+            $this->identifiersOf($snippets),
+        );
+    }
+
+    // =========================================================================
+    // findByUids()
+    // =========================================================================
+
+    #[Test]
+    public function findByUidsPreservesInputOrder(): void
+    {
+        $snippets = $this->repository->findByUids([5, 2, 3]);
+
+        self::assertSame(
+            ['style-minimalist', 'tone-formal', 'audience-developers'],
+            $this->identifiersOf($snippets),
+        );
+    }
+
+    #[Test]
+    public function findByUidsSilentlySkipsUnknownUids(): void
+    {
+        $snippets = $this->repository->findByUids([999, 2, 12345]);
+
+        self::assertSame(['tone-formal'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findByUidsSilentlySkipsInactiveAndDeletedUids(): void
+    {
+        // uid 7 is inactive, uid 8 is deleted
+        $snippets = $this->repository->findByUids([7, 8, 1]);
+
+        self::assertSame(['tone-casual'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findByUidsReturnsEmptyListForEmptyInput(): void
+    {
+        self::assertSame([], $this->repository->findByUids([]));
+    }
+
+    // =========================================================================
+    // Persisted properties
+    // =========================================================================
+
+    #[Test]
+    public function persistedMetadataDecodesToArray(): void
+    {
+        $snippets = $this->repository->findByUids([9]);
+
+        self::assertCount(1, $snippets);
+        self::assertSame('persona-nova', $snippets[0]->getIdentifier());
+        self::assertSame(['voice' => 'nova'], $snippets[0]->getMetadataArray());
+    }
+
+    #[Test]
+    public function persistedTagsDecodeToNormalizedTagList(): void
+    {
+        $snippets = $this->repository->findByUids([5]);
+
+        self::assertCount(1, $snippets);
+        self::assertSame(['style', 'image'], $snippets[0]->getTagList());
+    }
+}

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -36,11 +36,15 @@ final class PublicServicesPolicyTest extends TestCase
      * Audited count of `public: true` overrides as of slice 25
      * (REC #9c, ADR-028). Categories per ADR-028:
      *
-     * - Category 1 (Public LLM API surface): 12 concrete services
-     *   + 9 interface aliases = 21
+     * - Category 1 (Public LLM API surface): 13 concrete services
+     *   + 9 interface aliases = 22. Includes the concrete-only
+     *   PromptSnippetComposer (ADR-031), the snippet composition
+     *   surface for consuming extensions.
      * - Category 2 (Specialized services): 4
      * - Category 3 (Repositories — required public for
-     *   FunctionalTestCase::get()): 5
+     *   FunctionalTestCase::get(); PromptSnippetRepository is also
+     *   the documented query surface for consuming extensions,
+     *   ADR-031): 6
      * - Category 4 (SetupWizard collaborators): 3 concrete +
      *   1 interface alias = 4
      * - Doctrine + provider wiring tail (services exposed for
@@ -49,14 +53,14 @@ final class PublicServicesPolicyTest extends TestCase
      *   UsageAnalyticsService, public solely so the Analytics
      *   functional test resolves it via FunctionalTestCase::get().
      *
-     * Total: 21 + 4 + 5 + 4 + 4 = **38**.
+     * Total: 22 + 4 + 6 + 4 + 4 = **40**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
      * `Documentation/Adr/Adr028PublicServicesPolicy.rst` in the
      * same PR — the diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 38;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 40;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Controller/Backend/FormEngineUrlBuilderTest.php
+++ b/Tests/Unit/Controller/Backend/FormEngineUrlBuilderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\FormEngineUrlBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+
+/**
+ * Unit tests for FormEngineUrlBuilder.
+ */
+#[CoversClass(FormEngineUrlBuilder::class)]
+final class FormEngineUrlBuilderTest extends TestCase
+{
+    /**
+     * Recorded buildUriFromRoute() invocations: [route name, parameters].
+     *
+     * @var list<array{string, array<int|string, mixed>}>
+     */
+    private array $routeCalls = [];
+
+    private FormEngineUrlBuilder $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $uriBuilder = $this->createMock(BackendUriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')->willReturnCallback(
+            /** @param array<int|string, mixed> $parameters */
+            function (string $name, array $parameters = []): Uri {
+                $this->routeCalls[] = [$name, $parameters];
+
+                return new Uri(
+                    $name === 'record_edit' ? '/typo3/record/edit' : '/typo3/module/' . $name,
+                );
+            },
+        );
+
+        $this->subject = new FormEngineUrlBuilder($uriBuilder);
+    }
+
+    #[Test]
+    public function buildEditUrlTargetsRecordEditWithEditCommandAndReturnUrl(): void
+    {
+        $url = $this->subject->buildEditUrl('tx_nrllm_promptsnippet', 42, 'nrllm_snippets');
+
+        self::assertSame('/typo3/record/edit', $url);
+        self::assertSame(
+            [
+                ['nrllm_snippets', []],
+                [
+                    'record_edit',
+                    [
+                        'edit' => ['tx_nrllm_promptsnippet' => [42 => 'edit']],
+                        'returnUrl' => '/typo3/module/nrllm_snippets',
+                    ],
+                ],
+            ],
+            $this->routeCalls,
+        );
+    }
+
+    #[Test]
+    public function buildNewUrlTargetsRecordEditWithNewCommandAndReturnUrl(): void
+    {
+        $url = $this->subject->buildNewUrl('tx_nrllm_promptsnippet', 'nrllm_snippets');
+
+        self::assertSame('/typo3/record/edit', $url);
+        self::assertSame(
+            [
+                ['nrllm_snippets', []],
+                [
+                    'record_edit',
+                    [
+                        'edit' => ['tx_nrllm_promptsnippet' => [0 => 'new']],
+                        'returnUrl' => '/typo3/module/nrllm_snippets',
+                    ],
+                ],
+            ],
+            $this->routeCalls,
+        );
+    }
+}

--- a/Tests/Unit/Domain/Model/PromptSnippetTest.php
+++ b/Tests/Unit/Domain/Model/PromptSnippetTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Unit tests for PromptSnippet domain entity.
+ *
+ * Note: Domain models are excluded from coverage in phpunit.xml.
+ */
+#[CoversNothing]
+final class PromptSnippetTest extends AbstractUnitTestCase
+{
+    private PromptSnippet $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new PromptSnippet();
+    }
+
+    // ========================================
+    // Basic getter / setter tests
+    // ========================================
+
+    #[Test]
+    public function identifierGetterAndSetter(): void
+    {
+        $this->subject->setIdentifier('persona-friendly-expert');
+        self::assertSame('persona-friendly-expert', $this->subject->getIdentifier());
+    }
+
+    #[Test]
+    public function nameGetterAndSetter(): void
+    {
+        $this->subject->setName('Friendly Expert');
+        self::assertSame('Friendly Expert', $this->subject->getName());
+    }
+
+    #[Test]
+    public function descriptionGetterAndSetter(): void
+    {
+        $this->subject->setDescription('A friendly, approachable expert persona');
+        self::assertSame('A friendly, approachable expert persona', $this->subject->getDescription());
+    }
+
+    #[Test]
+    public function tagsGetterAndSetter(): void
+    {
+        $this->subject->setTags('persona,tone_of_voice');
+        self::assertSame('persona,tone_of_voice', $this->subject->getTags());
+    }
+
+    #[Test]
+    public function snippetGetterAndSetter(): void
+    {
+        $this->subject->setSnippet('You are a friendly expert.');
+        self::assertSame('You are a friendly expert.', $this->subject->getSnippet());
+    }
+
+    #[Test]
+    public function metadataGetterAndSetter(): void
+    {
+        $this->subject->setMetadata('{"voice":"nova"}');
+        self::assertSame('{"voice":"nova"}', $this->subject->getMetadata());
+    }
+
+    #[Test]
+    public function isActiveGetterAndSetter(): void
+    {
+        $this->subject->setIsActive(false);
+        self::assertFalse($this->subject->isActive());
+
+        $this->subject->setIsActive(true);
+        self::assertTrue($this->subject->isActive());
+    }
+
+    #[Test]
+    public function sortingGetterAndSetter(): void
+    {
+        $this->subject->setSorting(42);
+        self::assertSame(42, $this->subject->getSorting());
+    }
+
+    #[Test]
+    public function defaultsAreEmptyAndActive(): void
+    {
+        self::assertSame('', $this->subject->getIdentifier());
+        self::assertSame('', $this->subject->getName());
+        self::assertSame('', $this->subject->getDescription());
+        self::assertSame('', $this->subject->getTags());
+        self::assertSame('', $this->subject->getSnippet());
+        self::assertSame('', $this->subject->getMetadata());
+        self::assertTrue($this->subject->isActive());
+        self::assertSame(0, $this->subject->getSorting());
+    }
+
+    // ========================================
+    // getTagList()
+    // ========================================
+
+    /**
+     * @return array<string, array{0: string, 1: list<string>}>
+     */
+    public static function tagListProvider(): array
+    {
+        return [
+            'empty string' => ['', []],
+            'whitespace only' => ['   ', []],
+            'separators only' => [' , ,, ', []],
+            'single tag' => ['audience', ['audience']],
+            'multiple tags' => ['audience,tone_of_voice', ['audience', 'tone_of_voice']],
+            'tags are trimmed' => [' audience , tone_of_voice ', ['audience', 'tone_of_voice']],
+            'tags are lowercased' => ['Audience,TONE_OF_VOICE', ['audience', 'tone_of_voice']],
+            'empty entries dropped' => ['audience,,style,', ['audience', 'style']],
+            'mixed normalization' => [' Persona ,, Layout , STYLE ', ['persona', 'layout', 'style']],
+        ];
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    #[Test]
+    #[DataProvider('tagListProvider')]
+    public function getTagListNormalizesCsvTags(string $tags, array $expected): void
+    {
+        $this->subject->setTags($tags);
+
+        self::assertSame($expected, $this->subject->getTagList());
+    }
+
+    // ========================================
+    // getMetadataArray()
+    // ========================================
+
+    #[Test]
+    public function getMetadataArrayDecodesJsonObject(): void
+    {
+        $this->subject->setMetadata('{"voice":"nova","temperature":0.5}');
+
+        self::assertSame(
+            ['voice' => 'nova', 'temperature' => 0.5],
+            $this->subject->getMetadataArray(),
+        );
+    }
+
+    #[Test]
+    public function getMetadataArrayDecodesNestedJsonObject(): void
+    {
+        $this->subject->setMetadata('{"image":{"style":"watercolor","size":"1024x1024"}}');
+
+        self::assertSame(
+            ['image' => ['style' => 'watercolor', 'size' => '1024x1024']],
+            $this->subject->getMetadataArray(),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidMetadataProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'whitespace only' => ["  \n "],
+            'invalid json' => ['{not json'],
+            'truncated json' => ['{"voice":'],
+            'json string scalar' => ['"nova"'],
+            'json number scalar' => ['42'],
+            'json boolean scalar' => ['true'],
+            'json null' => ['null'],
+            'json list' => ['["audience","style"]'],
+            'empty json object' => ['{}'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidMetadataProvider')]
+    public function getMetadataArrayReturnsEmptyArrayWithoutThrowing(string $metadata): void
+    {
+        $this->subject->setMetadata($metadata);
+
+        self::assertSame([], $this->subject->getMetadataArray());
+    }
+}

--- a/Tests/Unit/Service/Prompt/PromptSnippetComposerTest.php
+++ b/Tests/Unit/Service/Prompt/PromptSnippetComposerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Prompt;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Unit tests for PromptSnippetComposer.
+ */
+#[CoversClass(PromptSnippetComposer::class)]
+final class PromptSnippetComposerTest extends AbstractUnitTestCase
+{
+    private PromptSnippetComposer $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new PromptSnippetComposer();
+    }
+
+    private function createSnippet(string $text): PromptSnippet
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setSnippet($text);
+
+        return $snippet;
+    }
+
+    #[Test]
+    public function composeSectionsBuildsLabeledBlocksJoinedByBlankLines(): void
+    {
+        $result = $this->subject->composeSections([
+            'TARGET AUDIENCE' => $this->createSnippet('Marketing professionals.'),
+            'TONE OF VOICE' => $this->createSnippet('Friendly and concise.'),
+        ]);
+
+        self::assertSame(
+            "TARGET AUDIENCE:\nMarketing professionals.\n\nTONE OF VOICE:\nFriendly and concise.",
+            $result,
+        );
+    }
+
+    #[Test]
+    public function composeSectionsPreservesInputOrder(): void
+    {
+        $result = $this->subject->composeSections([
+            'ZULU' => $this->createSnippet('Last label first.'),
+            'ALPHA' => $this->createSnippet('First label last.'),
+        ]);
+
+        self::assertSame(
+            "ZULU:\nLast label first.\n\nALPHA:\nFirst label last.",
+            $result,
+        );
+    }
+
+    #[Test]
+    public function composeSectionsSkipsNullEntries(): void
+    {
+        $result = $this->subject->composeSections([
+            'TARGET AUDIENCE' => $this->createSnippet('Marketing professionals.'),
+            'TONE OF VOICE' => null,
+            'IMAGE STYLE' => $this->createSnippet('Minimalist.'),
+        ]);
+
+        self::assertSame(
+            "TARGET AUDIENCE:\nMarketing professionals.\n\nIMAGE STYLE:\nMinimalist.",
+            $result,
+        );
+    }
+
+    #[Test]
+    public function composeSectionsSkipsSnippetsWithEmptyText(): void
+    {
+        $result = $this->subject->composeSections([
+            'EMPTY' => $this->createSnippet(''),
+            'WHITESPACE' => $this->createSnippet("  \n\t "),
+            'PERSONA' => $this->createSnippet('You are a friendly expert.'),
+        ]);
+
+        self::assertSame("PERSONA:\nYou are a friendly expert.", $result);
+    }
+
+    #[Test]
+    public function composeSectionsTrimsSnippetText(): void
+    {
+        $result = $this->subject->composeSections([
+            'PERSONA' => $this->createSnippet("\n  You are a friendly expert.  \n"),
+        ]);
+
+        self::assertSame("PERSONA:\nYou are a friendly expert.", $result);
+    }
+
+    #[Test]
+    public function composeSectionsReturnsEmptyStringForEmptyMap(): void
+    {
+        self::assertSame('', $this->subject->composeSections([]));
+    }
+
+    #[Test]
+    public function composeSectionsReturnsEmptyStringWhenAllEntriesAreNull(): void
+    {
+        $result = $this->subject->composeSections([
+            'TARGET AUDIENCE' => null,
+            'TONE OF VOICE' => null,
+        ]);
+
+        self::assertSame('', $result);
+    }
+
+    #[Test]
+    public function composeSectionsKeepsMultilineSnippetTextIntact(): void
+    {
+        $result = $this->subject->composeSections([
+            'LAYOUT' => $this->createSnippet("Use two columns.\nHeadline on top."),
+        ]);
+
+        self::assertSame("LAYOUT:\nUse two columns.\nHeadline on top.", $result);
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -313,6 +313,44 @@ CREATE TABLE tx_nrllm_prompttemplate (
 );
 
 #
+# Table structure for table 'tx_nrllm_promptsnippet'
+# Tagged prompt fragments (personas, tones of voice, audiences, styles, layouts)
+#
+CREATE TABLE tx_nrllm_promptsnippet (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    -- Identity
+    identifier varchar(100) DEFAULT '' NOT NULL,
+    name varchar(255) DEFAULT '' NOT NULL,
+    description text,
+
+    -- Tagging (comma-separated free-form tags)
+    tags varchar(255) DEFAULT '' NOT NULL,
+
+    -- Fragment content
+    snippet text,
+
+    -- Additional metadata (JSON object, e.g. {"voice":"nova"})
+    metadata text,
+
+    -- Status
+    is_active tinyint(1) DEFAULT '1' NOT NULL,
+    sorting int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
+    hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    KEY identifier (identifier)
+);
+
+#
 # Table for tracking specialized service usage (translation, speech, image)
 #
 CREATE TABLE tx_nrllm_service_usage (

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -347,7 +347,8 @@ CREATE TABLE tx_nrllm_promptsnippet (
 
     PRIMARY KEY (uid),
     KEY parent (pid),
-    KEY identifier (identifier)
+    KEY identifier (identifier),
+    KEY active_sorted (is_active, sorting, name)
 );
 
 #


### PR DESCRIPTION
## Summary

Editors manage small named prompt **fragments** (personas, tones of voice, target audiences, image styles, layouts) centrally; consuming extensions query them by tag and compose them into their prompts. Deliberately a new lean entity — NOT the heavyweight `PromptTemplate` (full templates with model params/versioning), see the ADR.

## API contract (consumed by netresearch/t3x-nr-repurpose#14, built in parallel)

- `Domain\Model\PromptSnippet`: identifier, name, description, tags (CSV) + `getTagList()`, snippet, metadata (JSON) + `getMetadataArray()` (tolerant of bad editor input), isActive, sorting
- `Domain\Repository\PromptSnippetRepository`: `findActiveByTag()` (exact token match — 'style' ≠ 'lifestyle'), `findByUids()` (input order, skips unknown/inactive)
- `Service\Prompt\PromptSnippetComposer::composeSections()`: `"LABEL:\n<text>"` blocks, blank-line joined, skips nulls

Plus: `tx_nrllm_promptsnippet` schema, TCA (EN+DE), a **Snippets** backend-module area following the Providers/Models pattern, documentation page + ADR-031. Tag convention is free-form CSV; established tags: `audience`, `tone_of_voice`, `persona` (metadata may carry `{"voice":"nova"}`), `layout`, `style`.

## Gates (local)
Unit 3486 ✅ · PHPStan level 10 ✅ · CGL ✅ · Rector ✅ (PHP 8.4); functional runs in CI.