### PR TITLE
fix(model): add getIsActive() so Fluid can resolve {snippet.isActive}

### DIFF
--- a/Classes/Domain/Model/PromptSnippet.php
+++ b/Classes/Domain/Model/PromptSnippet.php
@@ -76,6 +76,16 @@ class PromptSnippet extends AbstractEntity
         return $this->metadata;
     }
 
+    /**
+     * Getter pair as in the other models (Provider, Model, Task, ...): Fluid resolves
+     * the template path {snippet.isActive} via getIsActive() — isActive() alone makes
+     * ObjectAccess fall back to the protected property and crash the module.
+     */
+    public function getIsActive(): bool
+    {
+        return $this->isActive;
+    }
+
     public function isActive(): bool
     {
         return $this->isActive;

--- a/Tests/Unit/Domain/Model/PromptSnippetTest.php
+++ b/Tests/Unit/Domain/Model/PromptSnippetTest.php
@@ -82,9 +82,11 @@ final class PromptSnippetTest extends AbstractUnitTestCase
     {
         $this->subject->setIsActive(false);
         self::assertFalse($this->subject->isActive());
+        self::assertFalse($this->subject->getIsActive());
 
         $this->subject->setIsActive(true);
         self::assertTrue($this->subject->isActive());
+        self::assertTrue($this->subject->getIsActive());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

The Snippets backend module crashes with `Cannot access protected property ...PromptSnippet::$isActive` as soon as an inactive snippet exists: the list template accesses `{snippet.isActive}` (same pattern as the Provider/Model/Configuration/Task lists), but `PromptSnippet` only had `isActive()` — Fluid's ObjectAccess needs `getIsActive()` and otherwise falls back to the protected property. All other models carry the `getIsActive()`/`isActive()` pair for exactly this reason; this adds it to `PromptSnippet` and covers both getters in the model test.

## Test plan

- `Build/Scripts/runTests.sh -p 8.4 -s unit` — green
- `Build/Scripts/runTests.sh -p 8.4 -s cgl -n` / `-s phpstan` — green