### PR TITLE
refactor(model): delegate isActive() to getIsActive()

### DIFF
--- a/Classes/Domain/Model/PromptSnippet.php
+++ b/Classes/Domain/Model/PromptSnippet.php
@@ -88,7 +88,7 @@ class PromptSnippet extends AbstractEntity
 
     public function isActive(): bool
     {
-        return $this->isActive;
+        return $this->getIsActive();
     }
 
     public function getSorting(): int


### PR DESCRIPTION
## Summary

SonarCloud flagged php:S4144 on PR #235 (identical method bodies of the Fluid-required `getIsActive()`/`isActive()` getter pair). `isActive()` now delegates instead of duplicating.

## Test plan

- `Build/Scripts/runTests.sh -p 8.4 -s unit` (PromptSnippetTest) — green
- `-s cgl -n` / `-s phpstan` — green