### PR TITLE
feat(specialized): usage + cost tracking, accurate audit reasons, gpt-image WxH sizes

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -216,6 +217,13 @@ abstract class AbstractProvider implements ProviderInterface
         }
 
         $httpClient = $this->getHttpClient();
+        // Stamp a per-request audit reason (purpose + model) on the vault
+        // client so the audit log records what each secret access served.
+        // Test doubles injected via setHttpClient() are plain PSR-18
+        // clients and skip this — the instanceof guard keeps them working.
+        if ($httpClient instanceof VaultHttpClientInterface) {
+            $httpClient = $httpClient->withReason($this->buildAuditReason($endpoint, $payload));
+        }
         $attempt = 0;
         $lastException = null;
 
@@ -269,6 +277,38 @@ abstract class AbstractProvider implements ProviderInterface
     protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
     {
         return $request;
+    }
+
+    /**
+     * Build the per-request audit reason recorded by the vault secure
+     * client, e.g. `'LLM chat call to OpenAI (gpt-4o)'`. The purpose is
+     * derived from the endpoint shape (covers the chat/embedding endpoint
+     * names of every bundled provider); the model comes from the request
+     * payload when present (Gemini encodes it in the URL instead, so its
+     * reason carries purpose + provider only). MUST never include prompt
+     * text or other payload content.
+     *
+     * @param array<string, mixed> $payload
+     */
+    protected function buildAuditReason(string $endpoint, array $payload): string
+    {
+        $purpose = match (true) {
+            str_contains($endpoint, 'embed') => 'embedding',
+            str_contains($endpoint, 'chat'),
+            str_contains($endpoint, 'messages'),
+            str_contains($endpoint, 'generateContent'),
+            str_contains($endpoint, 'api/generate') => 'chat',
+            default => 'API',
+        };
+
+        $model = isset($payload['model']) && is_string($payload['model']) ? $payload['model'] : '';
+
+        $reason = sprintf('LLM %s call to %s', $purpose, $this->getName());
+        if ($model !== '') {
+            $reason .= sprintf(' (%s)', $model);
+        }
+
+        return $reason;
     }
 
     /**

--- a/Classes/Service/UsageTrackerService.php
+++ b/Classes/Service/UsageTrackerService.php
@@ -65,7 +65,10 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
 
-        // Check if record exists for today (model_uid is part of the aggregation key)
+        // Check if record exists for today. model_uid AND model_id are both part of
+        // the aggregation key: specialized calls carry model_uid=0 with only the
+        // model_id string, so without it different models (gpt-image-2 vs dall-e-3)
+        // would collide into one daily row and break the per-model breakdowns.
         $existingUid = $queryBuilder
             ->select('uid')
             ->from(self::TABLE)
@@ -74,6 +77,7 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
                 $queryBuilder->expr()->eq('service_provider', $queryBuilder->createNamedParameter($provider)),
                 $queryBuilder->expr()->eq('be_user', $beUser),
                 $queryBuilder->expr()->eq('model_uid', $modelUid),
+                $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($modelId)),
                 $queryBuilder->expr()->eq('task_uid', $taskUid),
                 $queryBuilder->expr()->eq('request_date', $today),
             )

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -215,12 +215,18 @@ abstract class AbstractSpecializedService
      * requests, e.g. `'OpenAI Images API call (gpt-image-2, generate)'`.
      * Subclasses may override for a more specific phrase; most should
      * just call `setAuditContext()` before dispatching.
+     *
+     * The per-request context is CONSUMED here: it is cleared once it has
+     * been folded into a reason, so a later request that does not set its
+     * own context falls back to the plain default instead of silently
+     * reusing the previous request's context in the vault audit log.
      */
     protected function getAuditReason(): string
     {
         $reason = sprintf('%s API call', $this->getProviderLabel());
         if ($this->auditContext !== '') {
             $reason .= sprintf(' (%s)', $this->auditContext);
+            $this->auditContext = '';
         }
         return $reason;
     }

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Specialized;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientInterface;
@@ -82,6 +83,7 @@ abstract class AbstractSpecializedService
         protected readonly ExtensionConfiguration $extensionConfiguration,
         protected readonly UsageTrackerServiceInterface $usageTracker,
         protected readonly LoggerInterface $logger,
+        protected readonly SpecializedCostCalculatorInterface $costCalculator,
     ) {
         $this->timeout = $this->getDefaultTimeout();
         $this->loadConfiguration();

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -60,6 +60,15 @@ abstract class AbstractSpecializedService
     protected int $timeout;
 
     /**
+     * Per-request audit context appended to the audit reason, e.g.
+     * `'gpt-image-2, generate'` or `'tts-1, voice nova'`. Set by subclasses
+     * via `setAuditContext()` right before dispatching a request so the
+     * vault audit log records which model and purpose a secret access
+     * served. MUST never contain prompt text or other payload content.
+     */
+    private string $auditContext = '';
+
+    /**
      * Test seam: when set, `getSecureClient()` returns this instead of the
      * vault secure client. Production never sets it — auth always flows
      * through the audited vault client. Mirrors `AbstractProvider`.
@@ -187,12 +196,31 @@ abstract class AbstractSpecializedService
     }
 
     /**
+     * Set the per-request audit context (model, purpose, …) recorded with
+     * the next secret access, e.g. `'gpt-image-2, generate'`. The secure
+     * client is built per request (`getSecureClient()` inside the send
+     * path), so a context set immediately before dispatch is what lands
+     * in the vault audit log. Pass only request *metadata* — never prompt
+     * text, file contents, or anything secret-bearing.
+     */
+    protected function setAuditContext(string $context): void
+    {
+        $this->auditContext = $context;
+    }
+
+    /**
      * Audit-log reason recorded by the secure client for this service's
-     * requests. Subclasses may override for a more specific phrase.
+     * requests, e.g. `'OpenAI Images API call (gpt-image-2, generate)'`.
+     * Subclasses may override for a more specific phrase; most should
+     * just call `setAuditContext()` before dispatching.
      */
     protected function getAuditReason(): string
     {
-        return sprintf('%s API call', $this->getProviderLabel());
+        $reason = sprintf('%s API call', $this->getProviderLabel());
+        if ($this->auditContext !== '') {
+            $reason .= sprintf(' (%s)', $this->auditContext);
+        }
+        return $reason;
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -16,13 +16,16 @@ use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
 use Throwable;
 
 /**
- * DALL-E image generation service.
+ * OpenAI Images generation service.
  *
- * Provides AI image generation via OpenAI's DALL-E API.
+ * Provides AI image generation via OpenAI's Images API. The class name
+ * predates the gpt-image-* family and is kept for API stability; the
+ * service covers both the legacy DALL-E models and their gpt-image-*
+ * successors (gpt-image-2 is current).
  *
  * Features:
- * - DALL-E 2 and DALL-E 3 models
- * - Multiple sizes (256x256 to 1792x1024)
+ * - DALL-E 2/3 and gpt-image-* models
+ * - Multiple sizes (256x256 to 1792x1024; arbitrary WxH for gpt-image-*)
  * - HD quality option (DALL-E 3)
  * - Vivid and natural styles
  * - Image editing and variations (DALL-E 2)
@@ -96,6 +99,7 @@ final class DallEImageService extends AbstractSpecializedService
         $this->validatePrompt($prompt, $model);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
+        $this->setAuditContext(sprintf('%s, generate', $model));
         $response = $this->sendJsonRequest('generations', $payload);
 
         /** @var array<int, array{url?: string, b64_json?: string, revised_prompt?: string}> $responseData */
@@ -167,6 +171,7 @@ final class DallEImageService extends AbstractSpecializedService
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $payload['n'] = $count;
 
+        $this->setAuditContext(sprintf('%s, generate', $model));
         $response = $this->sendJsonRequest('generations', $payload);
 
         $results = [];
@@ -218,6 +223,7 @@ final class DallEImageService extends AbstractSpecializedService
 
         $count = min(max($count, 1), 10);
 
+        $this->setAuditContext('dall-e-2, variations');
         $response = $this->sendImageMultipart('variations', $imagePath, null, [
             'n' => (string)$count,
             'size' => $size,
@@ -273,6 +279,7 @@ final class DallEImageService extends AbstractSpecializedService
             $this->validateImageFile($maskPath);
         }
 
+        $this->setAuditContext('dall-e-2, edit');
         $response = $this->sendImageMultipart('edits', $imagePath, $maskPath, [
             'prompt' => $prompt,
             'size' => $size,
@@ -366,7 +373,7 @@ final class DallEImageService extends AbstractSpecializedService
 
     protected function getProviderLabel(): string
     {
-        return 'DALL-E';
+        return 'OpenAI Images';
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -106,10 +106,7 @@ final class DallEImageService extends AbstractSpecializedService
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        $this->usageTracker->trackUsage('image', 'dall-e:' . $model, [
-            'size' => $size,
-            'quality' => $quality,
-        ]);
+        $this->trackImageUsage($model, $size, $quality, 1, $response);
 
         return new ImageGenerationResult(
             url: $data['url'] ?? '',
@@ -193,10 +190,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $this->usageTracker->trackUsage('image', 'dall-e:' . $model, [
-            'size' => $size,
-            'count' => count($results),
-        ]);
+        $this->trackImageUsage($model, $size, $quality, count($results), $response);
 
         return $results;
     }
@@ -246,10 +240,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $this->usageTracker->trackUsage('image', 'dall-e:variations', [
-            'size' => $size,
-            'count' => count($results),
-        ]);
+        $this->trackImageUsage('dall-e-2', $size, 'standard', count($results), $response);
 
         return $results;
     }
@@ -290,9 +281,7 @@ final class DallEImageService extends AbstractSpecializedService
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        $this->usageTracker->trackUsage('image', 'dall-e:edit', [
-            'size' => $size,
-        ]);
+        $this->trackImageUsage('dall-e-2', $size, 'standard', 1, $response);
 
         return new ImageGenerationResult(
             url: $data['url'] ?? '',
@@ -385,6 +374,83 @@ final class DallEImageService extends AbstractSpecializedService
     private function capabilityKey(string $model): string
     {
         return str_starts_with($model, 'gpt-image-') ? 'gpt-image-1' : $model;
+    }
+
+    /**
+     * Record an image generation in the usage table with real units:
+     * image count, the token usage gpt-image-* responses report, an
+     * estimated cost, and the model identifier (so the Analytics module
+     * can aggregate image spend alongside chat spend).
+     *
+     * dall-e-2/3 responses carry no `usage` object — token metrics are
+     * omitted then and the cost falls back to the per-image catalog.
+     *
+     * @param array<string, mixed> $response decoded API response
+     */
+    private function trackImageUsage(
+        string $model,
+        string $size,
+        string $quality,
+        int $imageCount,
+        array $response,
+    ): void {
+        $usage = $this->extractUsageTokens($response);
+
+        $metrics = ['images' => $imageCount];
+        if ($usage !== null) {
+            $metrics['tokens'] = $usage['total'];
+            $metrics['promptTokens'] = $usage['input'];
+            $metrics['completionTokens'] = $usage['output'];
+        }
+
+        $metrics['cost'] = $this->costCalculator->estimateImageCost(
+            $model,
+            $quality,
+            $size,
+            $imageCount,
+            $usage['input'] ?? 0,
+            $usage['output'] ?? 0,
+            $usage['imageInput'] ?? 0,
+        );
+
+        $this->usageTracker->trackUsage(
+            'image',
+            $this->getServiceProvider(),
+            $metrics,
+            modelId: $model,
+        );
+    }
+
+    /**
+     * Extract the token usage gpt-image-* responses include. Returns null
+     * when the response has no usable `usage` object (dall-e-2/3 never
+     * send one) so callers can omit token metrics gracefully.
+     *
+     * @param array<string, mixed> $response
+     *
+     * @return array{input: int, output: int, total: int, imageInput: int}|null
+     */
+    private function extractUsageTokens(array $response): ?array
+    {
+        $usage = $response['usage'] ?? null;
+        if (!is_array($usage)) {
+            return null;
+        }
+
+        $input = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
+        $output = is_numeric($usage['output_tokens'] ?? null) ? (int)$usage['output_tokens'] : 0;
+        $total = is_numeric($usage['total_tokens'] ?? null) ? (int)$usage['total_tokens'] : $input + $output;
+
+        if ($input === 0 && $output === 0 && $total === 0) {
+            return null;
+        }
+
+        $details = $usage['input_tokens_details'] ?? null;
+        $imageInput = is_array($details) && is_numeric($details['image_tokens'] ?? null)
+            ? (int)$details['image_tokens']
+            : 0;
+
+        return ['input' => $input, 'output' => $output, 'total' => $total, 'imageInput' => $imageInput];
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -85,6 +85,7 @@ final class FalImageService extends AbstractSpecializedService
 
         $payload = $this->buildGeneratePayload($prompt, $options);
 
+        $this->setAuditContext(sprintf('%s, generate', $model));
         $usesQueue = $this->modelUsesQueue($model);
         $response = $usesQueue
             ? $this->sendQueueRequest($modelEndpoint, $payload)
@@ -140,6 +141,7 @@ final class FalImageService extends AbstractSpecializedService
         $modelEndpoint = $this->resolveModelEndpoint($model);
         $payload = $this->buildGeneratePayload($prompt, $options);
 
+        $this->setAuditContext(sprintf('%s, generate', $model));
         $usesQueue = $this->modelUsesQueue($model);
         $response = $usesQueue
             ? $this->sendQueueRequest($modelEndpoint, $payload)

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -95,9 +95,12 @@ final class FalImageService extends AbstractSpecializedService
         /** @var array<string, mixed> $image */
         $image = is_array($images) && isset($images[0]) && is_array($images[0]) ? $images[0] : [];
 
-        $this->usageTracker->trackUsage('image', 'fal:' . $model, [
-            'size' => $options['image_size'] ?? 'square_hd',
-        ]);
+        // FAL publishes no static price list (billing varies per hosted
+        // model), so no cost is recorded — never guess (see
+        // SpecializedCostCalculatorInterface).
+        $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
+            'images' => 1,
+        ], modelId: $model);
 
         $imageUrl = isset($image['url']) && is_string($image['url']) ? $image['url'] : '';
 
@@ -171,9 +174,9 @@ final class FalImageService extends AbstractSpecializedService
             }
         }
 
-        $this->usageTracker->trackUsage('image', 'fal:' . $model, [
-            'count' => count($results),
-        ]);
+        $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
+            'images' => count($results),
+        ], modelId: $model);
 
         return $results;
     }

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -29,6 +29,16 @@ final class ImageGenerationOptions extends AbstractOptions
     private const VALID_SIZES_GPT_IMAGE = ['1024x1024', '1536x1024', '1024x1536', 'auto'];
     private const GPT_IMAGE_PREFIX = 'gpt-image-';
 
+    // Arbitrary WxH sizes for gpt-image-* (per OpenAI docs, June 2026): gpt-image-2
+    // accepts any WIDTHxHEIGHT where both dimensions are divisible by 16, the aspect
+    // ratio lies between 1:3 and 3:1 (inclusive), and the size does not exceed
+    // 3840x2160. The standard sizes above remain valid (they satisfy these rules);
+    // 'auto' lets the model pick. Other extensions rely on this contract.
+    private const GPT_IMAGE_DIMENSION_STEP = 16;
+    private const GPT_IMAGE_MAX_WIDTH = 3840;
+    private const GPT_IMAGE_MAX_HEIGHT = 2160;
+    private const GPT_IMAGE_MAX_ASPECT = 3;
+
     public function __construct(
         public readonly ?string $model = 'dall-e-3',
         public readonly ?string $size = '1024x1024',
@@ -78,12 +88,11 @@ final class ImageGenerationOptions extends AbstractOptions
         }
 
         if ($this->model !== null && str_starts_with($this->model, self::GPT_IMAGE_PREFIX)) {
-            $validSizes = self::VALID_SIZES_GPT_IMAGE;
-        } elseif ($this->model === 'dall-e-2') {
-            $validSizes = self::VALID_SIZES_DALLE2;
-        } else {
-            $validSizes = self::VALID_SIZES_DALLE3;
+            $this->validateGptImageSize($this->size);
+            return;
         }
+
+        $validSizes = $this->model === 'dall-e-2' ? self::VALID_SIZES_DALLE2 : self::VALID_SIZES_DALLE3;
 
         if (!in_array($this->size, $validSizes, true)) {
             throw new InvalidArgumentException(
@@ -94,6 +103,79 @@ final class ImageGenerationOptions extends AbstractOptions
                     implode(', ', $validSizes),
                 ),
                 9662872869,
+            );
+        }
+    }
+
+    /**
+     * Validate a gpt-image-* size: the documented standard sizes, 'auto',
+     * or any arbitrary WIDTHxHEIGHT where both dimensions are divisible
+     * by 16, the aspect ratio is between 1:3 and 3:1 (inclusive), and
+     * the size does not exceed 3840x2160 (per OpenAI docs, June 2026).
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateGptImageSize(string $size): void
+    {
+        if (in_array($size, self::VALID_SIZES_GPT_IMAGE, true)) {
+            return;
+        }
+
+        if (preg_match('/^(\d{1,5})x(\d{1,5})$/', $size, $matches) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid size "%s" for model %s. Expected WIDTHxHEIGHT (e.g. "1024x1024"), "auto", or one of: %s',
+                    $size,
+                    $this->model,
+                    implode(', ', self::VALID_SIZES_GPT_IMAGE),
+                ),
+                9662872869,
+            );
+        }
+
+        $width = (int)$matches[1];
+        $height = (int)$matches[2];
+
+        if (
+            $width < self::GPT_IMAGE_DIMENSION_STEP
+            || $height < self::GPT_IMAGE_DIMENSION_STEP
+            || $width % self::GPT_IMAGE_DIMENSION_STEP !== 0
+            || $height % self::GPT_IMAGE_DIMENSION_STEP !== 0
+        ) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid size "%s" for model %s: width and height must both be divisible by %d',
+                    $size,
+                    $this->model,
+                    self::GPT_IMAGE_DIMENSION_STEP,
+                ),
+                4810231766,
+            );
+        }
+
+        if ($width > self::GPT_IMAGE_MAX_WIDTH || $height > self::GPT_IMAGE_MAX_HEIGHT) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid size "%s" for model %s: maximum supported size is %dx%d',
+                    $size,
+                    $this->model,
+                    self::GPT_IMAGE_MAX_WIDTH,
+                    self::GPT_IMAGE_MAX_HEIGHT,
+                ),
+                7269345118,
+            );
+        }
+
+        // Aspect ratio between 1:3 and 3:1 inclusive — integer math avoids
+        // float comparison artefacts: W/H <= 3 ⇔ W <= 3H, W/H >= 1/3 ⇔ 3W >= H.
+        if ($width > self::GPT_IMAGE_MAX_ASPECT * $height || $height > self::GPT_IMAGE_MAX_ASPECT * $width) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid size "%s" for model %s: aspect ratio must be between 1:3 and 3:1',
+                    $size,
+                    $this->model,
+                ),
+                6203914577,
             );
         }
     }
@@ -162,7 +244,10 @@ final class ImageGenerationOptions extends AbstractOptions
     }
 
     /**
-     * Get valid sizes for a model.
+     * Get the standard (enumerable) sizes for a model. gpt-image-* models
+     * additionally accept arbitrary WIDTHxHEIGHT strings — both dimensions
+     * divisible by 16, aspect ratio between 1:3 and 3:1, max 3840x2160 —
+     * which cannot be enumerated here; see `validateGptImageSize()`.
      *
      * @return array<int, string>
      */

--- a/Classes/Specialized/Pricing/OpenAiPriceCatalog.php
+++ b/Classes/Specialized/Pricing/OpenAiPriceCatalog.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Pricing;
+
+/**
+ * Static USD price catalog for the OpenAI specialized SKUs the
+ * specialized services dispatch (images, text-to-speech, speech-to-text).
+ *
+ * Why a static catalog: the tx_nrllm_model table only carries token
+ * pricing for admin-curated chat/embedding models; the specialized
+ * services (DALL-E / gpt-image-*, tts-*, whisper-1) usually have no
+ * model row, so without this catalog their spend would be recorded as
+ * zero and the Analytics module / MonthlyCost widget / BudgetService
+ * would systematically under-report total cost.
+ *
+ * Maintenance contract:
+ *  - every constant documents its source URL and verification date;
+ *  - unknown models/sizes/qualities return null — callers record a cost
+ *    of 0 rather than guessing;
+ *  - when OpenAI changes list prices, update the tables here and the
+ *    verification dates in one commit.
+ *
+ * All prices verified 2026-06-10 against
+ * https://platform.openai.com/docs/pricing (mirror:
+ * https://developers.openai.com/api/docs/pricing) and
+ * https://openai.com/api/pricing/.
+ */
+final class OpenAiPriceCatalog
+{
+    /**
+     * Token prices for the gpt-image-* family in USD per 1M tokens.
+     * gpt-image-* bills by tokens (the response carries a `usage`
+     * object); the per-image table below is only a fallback estimate.
+     *
+     * Keys: model (longest prefix wins, so dated point releases like
+     * "gpt-image-2-2026-04-21" resolve to their base model).
+     * Values: [text input, image input, image output] per 1M tokens.
+     *
+     * Source: https://developers.openai.com/api/docs/pricing (2026-06-10):
+     *  - gpt-image-2:      text in $5.00, image in $8.00, image out $30.00
+     *  - gpt-image-1.5:    text in $5.00, image in $8.00, image out $32.00
+     *  - gpt-image-1-mini: text in $2.00, image in $2.50, image out  $8.00
+     *  - gpt-image-1:      text in $5.00, image in $10.00, image out $40.00
+     *    (launch list price, https://openai.com/api/pricing/, 2025)
+     *
+     * @var array<string, array{textInput: float, imageInput: float, output: float}>
+     */
+    private const IMAGE_TOKEN_PRICES_PER_MILLION = [
+        'gpt-image-2'      => ['textInput' => 5.00, 'imageInput' => 8.00, 'output' => 30.00],
+        'gpt-image-1.5'    => ['textInput' => 5.00, 'imageInput' => 8.00, 'output' => 32.00],
+        'gpt-image-1-mini' => ['textInput' => 2.00, 'imageInput' => 2.50, 'output' => 8.00],
+        'gpt-image-1'      => ['textInput' => 5.00, 'imageInput' => 10.00, 'output' => 40.00],
+    ];
+
+    /**
+     * Per-image USD prices, keyed model => quality => size.
+     *
+     * DALL-E list prices (stable since 2023, verified 2026-06-10 against
+     * https://openai.com/api/pricing/):
+     *  - dall-e-3 standard: 1024x1024 $0.040; 1792x1024 / 1024x1792 $0.080
+     *  - dall-e-3 hd:       1024x1024 $0.080; 1792x1024 / 1024x1792 $0.120
+     *  - dall-e-2:          1024x1024 $0.020; 512x512 $0.018; 256x256 $0.016
+     *    (dall-e-2 has a single quality tier, keyed 'standard')
+     *
+     * gpt-image per-image values are OpenAI's own calculator estimates
+     * (token billing is authoritative — these apply only when a response
+     * unexpectedly carries no usage object):
+     *  - gpt-image-1 (https://platform.openai.com/docs/guides/image-generation,
+     *    2025): low $0.011/$0.016/$0.016, medium $0.042/$0.063/$0.063,
+     *    high $0.167/$0.25/$0.25 for 1024x1024 / 1024x1536 / 1536x1024
+     *  - gpt-image-2 (OpenAI image-generation guide calculator, 2026-06-10):
+     *    1024x1024 low $0.006, medium $0.053, high $0.211
+     *
+     * @var array<string, array<string, array<string, float>>>
+     */
+    private const IMAGE_PRICES = [
+        'dall-e-3' => [
+            'standard' => ['1024x1024' => 0.040, '1792x1024' => 0.080, '1024x1792' => 0.080],
+            'hd'       => ['1024x1024' => 0.080, '1792x1024' => 0.120, '1024x1792' => 0.120],
+        ],
+        'dall-e-2' => [
+            'standard' => ['1024x1024' => 0.020, '512x512' => 0.018, '256x256' => 0.016],
+        ],
+        'gpt-image-2' => [
+            'low'    => ['1024x1024' => 0.006],
+            'medium' => ['1024x1024' => 0.053],
+            'high'   => ['1024x1024' => 0.211],
+        ],
+        'gpt-image-1' => [
+            'low'    => ['1024x1024' => 0.011, '1024x1536' => 0.016, '1536x1024' => 0.016],
+            'medium' => ['1024x1024' => 0.042, '1024x1536' => 0.063, '1536x1024' => 0.063],
+            'high'   => ['1024x1024' => 0.167, '1024x1536' => 0.250, '1536x1024' => 0.250],
+        ],
+    ];
+
+    /**
+     * Text-to-speech prices in USD per 1M input characters.
+     *
+     * Source: https://openai.com/api/pricing/ (verified 2026-06-10):
+     *  - tts-1:    $15.00 per 1M characters
+     *  - tts-1-hd: $30.00 per 1M characters
+     *
+     * @var array<string, float>
+     */
+    private const TTS_PRICES_PER_MILLION_CHARS = [
+        'tts-1'    => 15.00,
+        'tts-1-hd' => 30.00,
+    ];
+
+    /**
+     * Speech-to-text prices in USD per minute of audio.
+     *
+     * Source: https://openai.com/api/pricing/ (verified 2026-06-10):
+     *  - whisper-1: $0.006 per minute
+     *
+     * @var array<string, float>
+     */
+    private const TRANSCRIPTION_PRICES_PER_MINUTE = [
+        'whisper-1' => 0.006,
+    ];
+
+    private function __construct()
+    {
+        // Static catalog — not instantiable.
+    }
+
+    /**
+     * Token-based cost for a gpt-image-* call. Input tokens are billed at
+     * the text-input rate unless the caller splits them via
+     * `$imageInputTokens` (the API's `usage.input_tokens_details`).
+     * Returns null for models without a catalog entry — never guesses.
+     */
+    public static function imageTokenCost(
+        string $model,
+        int $inputTokens,
+        int $outputTokens,
+        int $imageInputTokens = 0,
+    ): ?float {
+        $prices = self::matchByPrefix(self::IMAGE_TOKEN_PRICES_PER_MILLION, $model);
+        if ($prices === null) {
+            return null;
+        }
+
+        $textInputTokens = max(0, $inputTokens - $imageInputTokens);
+
+        return ($textInputTokens / 1_000_000) * $prices['textInput']
+            + ($imageInputTokens / 1_000_000) * $prices['imageInput']
+            + ($outputTokens / 1_000_000) * $prices['output'];
+    }
+
+    /**
+     * Per-image price for an exact (model, quality, size) combination.
+     * Returns null when any part is unknown (e.g. arbitrary gpt-image-2
+     * WxH sizes, or unknown quality tiers) — never guesses.
+     */
+    public static function imagePrice(string $model, string $quality, string $size): ?float
+    {
+        $qualities = self::matchByPrefix(self::IMAGE_PRICES, $model);
+
+        return $qualities[$quality][$size] ?? null;
+    }
+
+    /**
+     * Cost for synthesizing `$characters` characters with a TTS model.
+     * Returns null for unknown models — never guesses.
+     */
+    public static function speechSynthesisCost(string $model, int $characters): ?float
+    {
+        $pricePerMillion = self::TTS_PRICES_PER_MILLION_CHARS[$model] ?? null;
+        if ($pricePerMillion === null) {
+            return null;
+        }
+
+        return ($characters / 1_000_000) * $pricePerMillion;
+    }
+
+    /**
+     * Cost for transcribing/translating `$audioSeconds` seconds of audio.
+     * Returns null for unknown models — never guesses.
+     */
+    public static function transcriptionCost(string $model, float $audioSeconds): ?float
+    {
+        $pricePerMinute = self::TRANSCRIPTION_PRICES_PER_MINUTE[$model] ?? null;
+        if ($pricePerMinute === null) {
+            return null;
+        }
+
+        return ($audioSeconds / 60) * $pricePerMinute;
+    }
+
+    /**
+     * Resolve a model id against a price table by longest matching prefix,
+     * so dated point releases ("gpt-image-2-2026-04-21") inherit their base
+     * model's pricing while "gpt-image-1-mini" still wins over "gpt-image-1".
+     *
+     * @template T
+     *
+     * @param array<string, T> $table
+     *
+     * @return T|null
+     */
+    private static function matchByPrefix(array $table, string $model): mixed
+    {
+        if (isset($table[$model])) {
+            return $table[$model];
+        }
+
+        $bestKey = null;
+        foreach (array_keys($table) as $key) {
+            if (str_starts_with($model, $key . '-') && ($bestKey === null || strlen($key) > strlen($bestKey))) {
+                $bestKey = $key;
+            }
+        }
+
+        return $bestKey === null ? null : $table[$bestKey];
+    }
+}

--- a/Classes/Specialized/Pricing/SpecializedCostCalculator.php
+++ b/Classes/Specialized/Pricing/SpecializedCostCalculator.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Pricing;
+
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Throwable;
+
+/**
+ * Default cost estimator for specialized service calls.
+ *
+ * Token-based pricing prefers an admin-curated tx_nrllm_model row
+ * (looked up by model identifier, reusing Model::estimateCost()) so an
+ * instance can override list prices with negotiated ones; otherwise the
+ * static OpenAiPriceCatalog applies. Unknown models cost 0.0 — never
+ * guessed (see the interface contract).
+ *
+ * The repository lookup is fail-soft: tracking a cost must never break
+ * the actual generation call, so any persistence-layer failure falls
+ * back to the static catalog.
+ */
+final readonly class SpecializedCostCalculator implements SpecializedCostCalculatorInterface
+{
+    public function __construct(
+        private ModelRepository $modelRepository,
+    ) {}
+
+    public function estimateImageCost(
+        string $model,
+        string $quality,
+        string $size,
+        int $imageCount,
+        int $inputTokens = 0,
+        int $outputTokens = 0,
+        int $imageInputTokens = 0,
+    ): float {
+        if ($inputTokens > 0 || $outputTokens > 0) {
+            $dbCost = $this->estimateFromModelRow($model, $inputTokens, $outputTokens);
+            if ($dbCost !== null) {
+                return $dbCost;
+            }
+
+            $catalogCost = OpenAiPriceCatalog::imageTokenCost($model, $inputTokens, $outputTokens, $imageInputTokens);
+            if ($catalogCost !== null) {
+                return $catalogCost;
+            }
+        }
+
+        $perImage = OpenAiPriceCatalog::imagePrice($model, $quality, $size);
+        if ($perImage !== null && $imageCount > 0) {
+            return $perImage * $imageCount;
+        }
+
+        return 0.0;
+    }
+
+    public function estimateSpeechSynthesisCost(string $model, int $characters): float
+    {
+        return OpenAiPriceCatalog::speechSynthesisCost($model, $characters) ?? 0.0;
+    }
+
+    public function estimateTranscriptionCost(string $model, float $audioSeconds): float
+    {
+        if ($audioSeconds <= 0.0) {
+            return 0.0;
+        }
+
+        return OpenAiPriceCatalog::transcriptionCost($model, $audioSeconds) ?? 0.0;
+    }
+
+    /**
+     * Token-based cost from an admin-curated model row, when one exists
+     * for this identifier and carries pricing. Fail-soft on persistence
+     * errors — cost estimation must never break the service call.
+     */
+    private function estimateFromModelRow(string $model, int $inputTokens, int $outputTokens): ?float
+    {
+        try {
+            $modelRow = $this->modelRepository->findOneByIdentifier($model);
+            if ($modelRow !== null && $modelRow->hasPricing()) {
+                return $modelRow->estimateCost($inputTokens, $outputTokens);
+            }
+        } catch (Throwable) {
+            // Extbase persistence may be unavailable in edge contexts
+            // (early CLI bootstrap); fall back to the static catalog.
+        }
+
+        return null;
+    }
+}

--- a/Classes/Specialized/Pricing/SpecializedCostCalculator.php
+++ b/Classes/Specialized/Pricing/SpecializedCostCalculator.php
@@ -40,24 +40,16 @@ final readonly class SpecializedCostCalculator implements SpecializedCostCalcula
         int $outputTokens = 0,
         int $imageInputTokens = 0,
     ): float {
+        $tokenBased = null;
         if ($inputTokens > 0 || $outputTokens > 0) {
-            $dbCost = $this->estimateFromModelRow($model, $inputTokens, $outputTokens);
-            if ($dbCost !== null) {
-                return $dbCost;
-            }
-
-            $catalogCost = OpenAiPriceCatalog::imageTokenCost($model, $inputTokens, $outputTokens, $imageInputTokens);
-            if ($catalogCost !== null) {
-                return $catalogCost;
-            }
+            $tokenBased = $this->estimateFromModelRow($model, $inputTokens, $outputTokens)
+                ?? OpenAiPriceCatalog::imageTokenCost($model, $inputTokens, $outputTokens, $imageInputTokens);
         }
 
         $perImage = OpenAiPriceCatalog::imagePrice($model, $quality, $size);
-        if ($perImage !== null && $imageCount > 0) {
-            return $perImage * $imageCount;
-        }
+        $perImageBased = ($perImage !== null && $imageCount > 0) ? $perImage * $imageCount : null;
 
-        return 0.0;
+        return $tokenBased ?? $perImageBased ?? 0.0;
     }
 
     public function estimateSpeechSynthesisCost(string $model, int $characters): float

--- a/Classes/Specialized/Pricing/SpecializedCostCalculatorInterface.php
+++ b/Classes/Specialized/Pricing/SpecializedCostCalculatorInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Pricing;
+
+/**
+ * Estimates the cost of specialized (non-chat) AI service calls so the
+ * usage tracker can record spend for image generation, text-to-speech
+ * and transcription alongside the token-based chat costs.
+ *
+ * Contract: implementations must never guess — an unknown model, size
+ * or quality yields 0.0 so the Analytics module reports "no price data"
+ * rather than a fabricated number.
+ */
+interface SpecializedCostCalculatorInterface
+{
+    /**
+     * Estimate the cost of an image generation call.
+     *
+     * Resolution order:
+     *  1. token-based via an admin-curated tx_nrllm_model row matching
+     *     `$model` (when usage tokens are present and the row has pricing);
+     *  2. token-based via the static OpenAI catalog (gpt-image-*);
+     *  3. per-image via the static catalog (model, quality, size);
+     *  4. 0.0.
+     *
+     * @param string $model            Model identifier (e.g. "gpt-image-2", "dall-e-3")
+     * @param string $quality          Requested quality tier ('' when not applicable)
+     * @param string $size             Requested size, e.g. "1024x1024"
+     * @param int    $imageCount       Number of images produced
+     * @param int    $inputTokens      `usage.input_tokens` from the response, 0 when absent
+     * @param int    $outputTokens     `usage.output_tokens` from the response, 0 when absent
+     * @param int    $imageInputTokens `usage.input_tokens_details.image_tokens`, 0 when absent
+     */
+    public function estimateImageCost(
+        string $model,
+        string $quality,
+        string $size,
+        int $imageCount,
+        int $inputTokens = 0,
+        int $outputTokens = 0,
+        int $imageInputTokens = 0,
+    ): float;
+
+    /**
+     * Estimate the cost of synthesizing `$characters` characters of speech.
+     */
+    public function estimateSpeechSynthesisCost(string $model, int $characters): float;
+
+    /**
+     * Estimate the cost of transcribing/translating `$audioSeconds` seconds
+     * of audio. Pass 0.0 when the response did not expose a duration.
+     */
+    public function estimateTranscriptionCost(string $model, float $audioSeconds): float;
+}

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -100,6 +100,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             'speed' => $speed,
         ];
 
+        $this->setAuditContext(sprintf('%s, voice %s', $model, $voice));
         $audioContent = $this->sendBinaryRequest($payload);
 
         $this->usageTracker->trackUsage('speech', 'tts:' . $model, [
@@ -249,7 +250,7 @@ final class TextToSpeechService extends AbstractSpecializedService
 
     protected function getProviderLabel(): string
     {
-        return 'TTS';
+        return 'OpenAI TTS';
     }
 
     /**

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -103,10 +103,11 @@ final class TextToSpeechService extends AbstractSpecializedService
         $this->setAuditContext(sprintf('%s, voice %s', $model, $voice));
         $audioContent = $this->sendBinaryRequest($payload);
 
-        $this->usageTracker->trackUsage('speech', 'tts:' . $model, [
-            'characters' => mb_strlen($text),
-            'voice' => $voice,
-        ]);
+        $characterCount = mb_strlen($text);
+        $this->usageTracker->trackUsage('speech', $this->getServiceProvider(), [
+            'characters' => $characterCount,
+            'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
+        ], modelId: $model);
 
         return new SpeechSynthesisResult(
             audioContent: $audioContent,

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -431,7 +431,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     {
         $metrics = [];
         if ($duration !== null && $duration > 0.0) {
-            $metrics['audioSeconds'] = (int)round($duration);
+            // Floor of 1: a sub-half-second clip must not round to 0 seconds while
+            // carrying a positive cost — units and cost stay consistent in analytics.
+            $metrics['audioSeconds'] = max(1, (int)round($duration));
             $metrics['cost'] = $this->costCalculator->estimateTranscriptionCost($model, $duration);
         }
 

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -145,13 +145,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
 
         $response = $this->sendTranslationRequest($audioPath, $options);
 
-        $result = $this->parseTranscriptionResponse($response, $options);
-
-        $this->usageTracker->trackUsage('speech', 'whisper:translation', [
-            'file_size' => filesize($audioPath),
-        ]);
-
-        return $result;
+        // Usage is recorded once inside dispatchMultipart() — no extra
+        // tracking here, a second call would double-count the request.
+        return $this->parseTranscriptionResponse($response, $options);
     }
 
     /**
@@ -377,15 +373,28 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             $responseBody = (string)$response->getBody();
 
             if ($statusCode >= 200 && $statusCode < 300) {
-                $this->usageTracker->trackUsage('speech', 'whisper:transcription', []);
+                $model = $options->model ?? self::DEFAULT_MODEL;
 
                 $format = $options->format ?? 'json';
                 if (in_array($format, ['text', 'srt', 'vtt'], true)) {
+                    // Raw-string formats expose no duration — record the
+                    // request without audio seconds (cost stays 0 rather
+                    // than guessed).
+                    $this->trackTranscriptionUsage($model, null);
                     return $responseBody;
                 }
 
-                /** @var array<string, mixed> */
-                return json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+
+                // `verbose_json` reports the audio duration in seconds;
+                // plain `json` does not — track what the response exposes.
+                $duration = isset($decoded['duration']) && is_numeric($decoded['duration'])
+                    ? (float)$decoded['duration']
+                    : null;
+                $this->trackTranscriptionUsage($model, $duration);
+
+                return $decoded;
             }
 
             $errorMessage = $this->decodeErrorMessage($responseBody);
@@ -411,6 +420,27 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                 $e,
             );
         }
+    }
+
+    /**
+     * Record a transcription/translation request with real units: the
+     * audio duration (when the response format exposes it), an estimated
+     * cost, and the model identifier.
+     */
+    private function trackTranscriptionUsage(string $model, ?float $duration): void
+    {
+        $metrics = [];
+        if ($duration !== null && $duration > 0.0) {
+            $metrics['audioSeconds'] = (int)round($duration);
+            $metrics['cost'] = $this->costCalculator->estimateTranscriptionCost($model, $duration);
+        }
+
+        $this->usageTracker->trackUsage(
+            'speech',
+            $this->getServiceProvider(),
+            $metrics,
+            modelId: $model,
+        );
     }
 
     /**

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -358,6 +358,12 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $body     = $this->encodeMultipartBody($parts, $boundary);
         $url      = $this->buildEndpointUrl($endpoint);
 
+        $this->setAuditContext(sprintf(
+            '%s, %s',
+            $options->model ?? self::DEFAULT_MODEL,
+            $endpoint === 'translations' ? 'translate' : 'transcribe',
+        ));
+
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary);
         foreach ($this->getAdditionalHeaders() as $name => $value) {

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -108,12 +108,15 @@ final readonly class LlmTranslator implements TranslatorInterface
 
         $response = $this->llmManager->chat($prompt['messages'], $chatOptions);
 
-        // Track usage
+        // Track the translation-level view (request + characters). Tokens
+        // and cost are deliberately NOT recorded here: the middleware
+        // pipeline (UsageMiddleware) already records them on the underlying
+        // chat row — repeating them here double-counted every translated
+        // token in the analytics aggregates.
         $providerUsed = $provider ?? 'default';
         $this->usageTracker->trackUsage('translation', 'llm:' . $providerUsed, [
-            'tokens' => $response->usage->totalTokens,
             'characters' => mb_strlen($text),
-        ]);
+        ], modelId: $response->model);
 
         // Calculate confidence from finish reason
         $confidence = match ($response->finishReason) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -156,6 +156,9 @@ services:
   Netresearch\NrLlm\Service\WizardGeneratorServiceInterface:
     alias: Netresearch\NrLlm\Service\WizardGeneratorService
 
+  Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface:
+    alias: Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator
+
   # ========================================
   # Repositories (PUBLIC)
   # ========================================

--- a/Documentation/Adr/Adr032SpecializedUsageAndPricingCatalog.rst
+++ b/Documentation/Adr/Adr032SpecializedUsageAndPricingCatalog.rst
@@ -1,0 +1,100 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-032:
+
+==================================================================
+ADR-032: Specialized Usage Tracking and Pricing Catalog
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-10
+:Authors: Netresearch DTT GmbH
+
+.. _adr-032-context:
+
+Context
+=======
+
+The chat/embedding path records complete usage rows: the middleware
+pipeline (:ref:`adr-026`) tracks tokens and derives a cost from the
+admin-curated ``tx_nrllm_model`` pricing via :php:`Model::estimateCost()`.
+
+The specialised services bypass that pipeline by design — but they
+recorded almost nothing. The image services passed metric keys
+(``size``, ``quality``, ``count``) that
+:php:`UsageTrackerService::trackUsage()` does not map, so only
+``request_count = 1`` landed in ``tx_nrllm_service_usage``: no cost, no
+tokens, no ``images_generated``, no ``model_id``. TTS recorded
+characters but no cost; Whisper recorded nothing but the request.
+Consequently the Analytics module, the MonthlyCost widget and
+BudgetService systematically excluded all image and speech spend —
+defeating the requirement that nr_llm can monitor *total* AI spend.
+
+Two structural problems compounded this:
+
+- the specialised services have no access to model pricing (their
+  models — ``gpt-image-2``, ``tts-1``, ``whisper-1`` — usually have no
+  ``tx_nrllm_model`` row), and
+- ``gpt-image-*`` responses carry a ``usage`` token object (DALL·E
+  responses do not), which was discarded.
+
+.. _adr-032-decision:
+
+Decision
+========
+
+1. **Real units in the callers.** The services pass the metric keys the
+   tracker actually maps: ``images`` (→ ``images_generated``),
+   ``characters``, ``audioSeconds`` (→ ``audio_seconds_used``, from the
+   ``verbose_json`` Whisper duration), token keys when the response
+   reports them, and the model identifier as ``modelId`` (→
+   ``model_id``). Provider strings drop the ad-hoc ``provider:model``
+   suffixes (``dall-e:dall-e-3`` → provider ``dall-e`` + ``model_id``).
+
+2. **Token usage parsing.** :php:`DallEImageService` parses the
+   ``usage`` object of ``gpt-image-*`` responses (``input_tokens``,
+   ``output_tokens``, ``total_tokens``, ``input_tokens_details``) so
+   token aggregates include image calls; DALL·E responses without
+   ``usage`` gracefully omit token metrics.
+
+3. **Static price catalog with a DB override.**
+   :php:`Specialized\Pricing\OpenAiPriceCatalog` encodes the published
+   OpenAI list prices (each constant documents source URL and
+   verification date): gpt-image-* token prices and per-image fallback
+   estimates, DALL·E per-image prices by quality/size, ``tts-1`` /
+   ``tts-1-hd`` per 1M characters, ``whisper-1`` per minute.
+   :php:`SpecializedCostCalculator` (injected into
+   :php:`AbstractSpecializedService`) resolves in order: admin-curated
+   ``tx_nrllm_model`` row matching the model identifier (reusing
+   :php:`Model::estimateCost()`, so negotiated prices win) → catalog
+   token prices → catalog per-image price → ``0.0``. **Unknown models
+   never get a guessed cost** — a zero cost signals "no price data"
+   instead of fabricating numbers.
+
+4. **No double counting.** :php:`LlmTranslator` no longer repeats the
+   token count on its translation row (the pipeline already records
+   tokens and cost on the underlying chat row); it keeps the
+   translation-level request/characters view.
+   :php:`WhisperTranscriptionService::translateToEnglish()` loses its
+   second ``trackUsage()`` call — the dispatch path records the request
+   exactly once.
+
+.. _adr-032-consequences:
+
+Consequences
+============
+
+- ● Image, TTS and Whisper spend appears in the Analytics module, the
+  MonthlyCost widget and BudgetService aggregates — total spend
+  monitoring covers all service types.
+- ● Costs follow published list prices and can be overridden per model
+  by creating a ``tx_nrllm_model`` row with token pricing.
+- ◑ The catalog requires manual maintenance when OpenAI changes list
+  prices; constants carry source URLs and verification dates to make
+  the review mechanical.
+- ◑ Analytics grouped by ``service_provider`` now shows ``dall-e`` /
+  ``fal`` / ``tts`` / ``whisper`` instead of suffixed variants
+  (``dall-e:dall-e-3``); historic rows keep their old strings, the
+  model dimension moved to ``model_id``.
+- ◑ FAL calls record images but cost ``0.0`` — FAL publishes no static
+  list prices for its hosted models.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -264,3 +264,4 @@ Modern architecture (v0.4+)
    Adr029UsageAnalyticsDashboard
    Adr030SpecializedServicesVaultMigration
    Adr031PromptSnippetLibrary
+   Adr032SpecializedUsageAndPricingCatalog

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -104,6 +104,33 @@ final class UsageTrackerServiceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function trackUsageKeepsSeparateRecordsForDifferentModelIds(): void
+    {
+        // Specialized calls carry model_uid=0 and only a model_id string — two
+        // different models on the same day must yield two rows, not collide.
+        $this->service->trackUsage('image', 'dall-e', ['images' => 1, 'cost' => 0.05], modelId: 'gpt-image-2');
+        $this->service->trackUsage('image', 'dall-e', ['images' => 2, 'cost' => 0.08], modelId: 'dall-e-3');
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $count = $connection->count('*', self::TABLE, ['service_type' => 'image', 'service_provider' => 'dall-e']);
+        self::assertSame(2, $count);
+
+        $row = $connection->select(
+            ['request_count', 'images_generated'],
+            self::TABLE,
+            ['service_type' => 'image', 'model_id' => 'gpt-image-2'],
+        )->fetchAssociative();
+        self::assertIsArray($row);
+        self::assertSame(1, (int)$row['request_count']);
+        self::assertSame(1, (int)$row['images_generated']);
+
+        // Same model again aggregates into ITS row only.
+        $this->service->trackUsage('image', 'dall-e', ['images' => 1, 'cost' => 0.05], modelId: 'gpt-image-2');
+        $count = $connection->count('*', self::TABLE, ['service_type' => 'image', 'service_provider' => 'dall-e']);
+        self::assertSame(2, $count);
+    }
+
+    #[Test]
     public function trackUsageKeepsSeparateRecordsForDifferentProviders(): void
     {
         $this->service->trackUsage('translation', 'deepl', ['characters' => 100]);

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Provider\GroqProvider;
 use Netresearch\NrLlm\Provider\MistralProvider;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -454,5 +456,50 @@ class AbstractProviderTest extends AbstractUnitTestCase
             self::assertSame(503, $e->getCode());
             self::assertStringContainsString('503', $e->getMessage());
         }
+    }
+
+    #[Test]
+    public function sendRequestStampsPerRequestAuditReasonWithPurposeAndModel(): void
+    {
+        // A chat call through the vault secure client must record an audit
+        // reason carrying the purpose and the model actually requested —
+        // "LLM chat call to OpenAI (gpt-4o)" — not the static client-level
+        // default. The reason must never contain prompt text.
+        $capturedReasons = [];
+
+        $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
+        $vaultHttpClient->method('withAuthentication')->willReturn($vaultHttpClient);
+        $vaultHttpClient->method('withReason')->willReturnCallback(
+            function (string $reason) use (&$capturedReasons, $vaultHttpClient): VaultHttpClientInterface {
+                $capturedReasons[] = $reason;
+                return $vaultHttpClient;
+            },
+        );
+        $vaultHttpClient->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'id' => 'test',
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'gpt-4o',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]));
+
+        $vault = self::createStub(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('http')->willReturn($vaultHttpClient);
+
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $vault,
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => 'vault-id',
+            'defaultModel' => 'gpt-4o',
+        ]);
+
+        $provider->complete('hello, do not leak me');
+
+        self::assertSame(['LLM chat call to OpenAI (gpt-4o)'], $capturedReasons);
     }
 }

--- a/Tests/Unit/Service/UsageTrackerServiceTest.php
+++ b/Tests/Unit/Service/UsageTrackerServiceTest.php
@@ -265,6 +265,57 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function trackUsageStoresModelIdAndUnitsForSpecializedRows(): void
+    {
+        // Specialized services (image / TTS / Whisper) pass the model as a
+        // string identifier with no tx_nrllm_model row — model_id must land
+        // in the row alongside the real units so the Analytics module can
+        // aggregate their spend.
+        $this->setupBackendUser(7);
+
+        $resultStub = self::createStub(Result::class);
+        $resultStub->method('fetchOne')->willReturn(false);
+
+        $queryBuilderStub = self::createStub(QueryBuilder::class);
+        $queryBuilderStub->method('select')->willReturnSelf();
+        $queryBuilderStub->method('from')->willReturnSelf();
+        $queryBuilderStub->method('where')->willReturnSelf();
+        $queryBuilderStub->method('expr')->willReturn($this->exprStub);
+        $queryBuilderStub->method('createNamedParameter')->willReturnCallback(fn(string|int|float $v): string => "'$v'");
+        $queryBuilderStub->method('executeQuery')->willReturn($resultStub);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->method('createQueryBuilder')->willReturn($queryBuilderStub);
+        $connectionMock
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrllm_service_usage',
+                self::callback(fn(array $data) => $data['service_type'] === 'image'
+                        && $data['service_provider'] === 'dall-e'
+                        && $data['model_id'] === 'gpt-image-2'
+                        && $data['model_uid'] === 0
+                        && $data['images_generated'] === 1
+                        && $data['tokens_used'] === 1050
+                        && $data['estimated_cost'] === 0.03028
+                        && $data['be_user'] === 7),
+            );
+
+        $connectionPoolStub = self::createStub(ConnectionPool::class);
+        $connectionPoolStub
+            ->method('getConnectionForTable')
+            ->willReturn($connectionMock);
+
+        $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
+        $subject->trackUsage(
+            'image',
+            'dall-e',
+            ['images' => 1, 'tokens' => 1050, 'cost' => 0.03028],
+            modelId: 'gpt-image-2',
+        );
+    }
+
+    #[Test]
     public function trackUsageWithNoBackendUserUsesZero(): void
     {
         $this->setupNoBackendUser();

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -197,6 +197,37 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function auditReasonDefaultsToProviderLabelApiCall(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('TESTABLE API call', $subject->callGetAuditReason());
+    }
+
+    #[Test]
+    public function auditReasonCarriesModelAndPurposeContextWhenSet(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->callSetAuditContext('gpt-image-2, generate');
+
+        self::assertSame('TESTABLE API call (gpt-image-2, generate)', $subject->callGetAuditReason());
+    }
+
+    #[Test]
+    public function auditContextOfLatestRequestWins(): void
+    {
+        // The context is per-request state: a later setAuditContext()
+        // replaces the earlier one entirely.
+        $subject = $this->createSubject();
+
+        $subject->callSetAuditContext('tts-1, voice nova');
+        $subject->callSetAuditContext('tts-1-hd, voice alloy');
+
+        self::assertSame('TESTABLE API call (tts-1-hd, voice alloy)', $subject->callGetAuditReason());
+    }
+
+    #[Test]
     public function executeRequestThrowsConfigurationExceptionOn401(): void
     {
         $httpClient = $this->createMock(ClientInterface::class);
@@ -514,6 +545,16 @@ final class TestableSpecializedService extends AbstractSpecializedService
     public function callBuildEndpointUrl(string $endpoint): string
     {
         return $this->buildEndpointUrl($endpoint);
+    }
+
+    public function callSetAuditContext(string $context): void
+    {
+        $this->setAuditContext($context);
+    }
+
+    public function callGetAuditReason(): string
+    {
+        return $this->getAuditReason();
     }
 
     /**

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
@@ -185,6 +186,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             extensionConfiguration: $extConf,
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
+            costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         $subject->callSendJsonRequest('endpoint', []);
@@ -349,6 +351,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             extensionConfiguration: $extConf,
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
+            costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -418,6 +421,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             extensionConfiguration: $extConf,
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
+            costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -495,6 +499,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             extensionConfiguration: $extConf,
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
+            costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         // Inject the plain test client through the test seam; this bypasses the

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -1083,7 +1083,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         );
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessageMatches('/Failed to connect to DALL-E API/');
+        $this->expectExceptionMessageMatches('/Failed to connect to OpenAI Images API/');
 
         $subject->generate('A cat');
     }

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\DallEImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -44,6 +47,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
     private VaultServiceInterface $vaultStub;
+    private SpecializedCostCalculatorInterface $costCalculator;
     private ?string $tempFile = null;
 
     protected function setUp(): void
@@ -57,6 +61,12 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
         $this->vaultStub = $this->createVaultServiceMock();
+
+        // Real calculator over a model-less repository: catalog prices apply,
+        // so the cost assertions below exercise the real pricing math.
+        $modelRepositoryStub = self::createStub(ModelRepository::class);
+        $modelRepositoryStub->method('findOneByIdentifier')->willReturn(null);
+        $this->costCalculator = new SpecializedCostCalculator($modelRepositoryStub);
     }
 
     /**
@@ -79,6 +89,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $extensionConfiguration,
             $usageTracker,
             $logger,
+            $this->costCalculator,
         );
         $service->setHttpClient($httpClient);
 
@@ -379,7 +390,21 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('image', 'dall-e:dall-e-3', self::anything());
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    // dall-e-3 responses carry no usage object: token metrics
+                    // are omitted, the cost falls back to the per-image list
+                    // price (standard 1024x1024 = $0.040).
+                    fn(array $metrics): bool => $metrics['images'] === 1
+                        && !isset($metrics['tokens'])
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.040) < 1e-9,
+                ),
+                null,
+                0,
+                'dall-e-3',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -712,7 +737,19 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('image', 'dall-e:variations', self::anything());
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    // One variation at the default 1024x1024 — dall-e-2 list
+                    // price $0.020 per image.
+                    fn(array $metrics): bool => $metrics['images'] === 1
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.020) < 1e-9,
+                ),
+                null,
+                0,
+                'dall-e-2',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -792,7 +829,17 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('image', 'dall-e:edit', self::anything());
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    fn(array $metrics): bool => $metrics['images'] === 1
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.020) < 1e-9,
+                ),
+                null,
+                0,
+                'dall-e-2',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -1093,7 +1140,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     #[Test]
     public function generateMultipleWithDallE2TracksUsageWithCount(): void
     {
-        // DALL-E 2 batch path tracks usage with a 'count' key after the loop.
+        // DALL-E 2 batch path tracks the produced image count after the loop.
         $imageData = [
             ['url' => 'https://example.com/image1.png'],
             ['url' => 'https://example.com/image2.png'],
@@ -1113,8 +1160,15 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with(
                 'image',
-                'dall-e:dall-e-2',
-                self::callback(fn(array $ctx): bool => isset($ctx['count']) && $ctx['count'] === 2),
+                'dall-e',
+                self::callback(
+                    // Two 512x512 dall-e-2 images at $0.018 list price each.
+                    fn(array $metrics): bool => $metrics['images'] === 2
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.036) < 1e-9,
+                ),
+                null,
+                0,
+                'dall-e-2',
             );
 
         $subject = $this->buildService(
@@ -1130,6 +1184,108 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $results = $subject->generateMultiple('Two cats', 2, $options);
 
         self::assertCount(2, $results);
+    }
+
+    // ==================== gpt-image usage object parsing ====================
+
+    #[Test]
+    public function generateWithGptImageModelTracksUsageTokensAndTokenCost(): void
+    {
+        // gpt-image-* responses include a usage object; its tokens must land
+        // in the usage row and price the call token-based:
+        // 40 text-in × $5/1M + 10 image-in × $8/1M + 1000 out × $30/1M.
+        $this->setupSuccessfulRequest([
+            'data' => [['b64_json' => base64_encode('png-bytes')]],
+            'usage' => [
+                'input_tokens' => 50,
+                'output_tokens' => 1000,
+                'total_tokens' => 1050,
+                'input_tokens_details' => ['text_tokens' => 40, 'image_tokens' => 10],
+            ],
+        ]);
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
+            ]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    fn(array $metrics): bool => $metrics['images'] === 1
+                        && $metrics['tokens'] === 1050
+                        && $metrics['promptTokens'] === 50
+                        && $metrics['completionTokens'] === 1000
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.03028) < 1e-9,
+                ),
+                null,
+                0,
+                'gpt-image-2',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A cat', ['model' => 'gpt-image-2']);
+    }
+
+    #[Test]
+    public function generateWithGptImageModelWithoutUsageObjectRecordsZeroCost(): void
+    {
+        // Defensive path: should a gpt-image response ever lack the usage
+        // object, token metrics are omitted and no cost is guessed — the
+        // per-image fallback has no entry for the DALL-E quality vocabulary.
+        $this->setupSuccessfulRequest([
+            'data' => [['b64_json' => base64_encode('png-bytes')]],
+        ]);
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
+            ]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    fn(array $metrics): bool => $metrics['images'] === 1
+                        && !isset($metrics['tokens'])
+                        && $metrics['cost'] === 0.0,
+                ),
+                null,
+                0,
+                'gpt-image-2',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A cat', ['model' => 'gpt-image-2']);
     }
 
     // ==================== buildGeneratePayload DALL-E 3 quality/style options ====================

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -78,6 +79,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             $extensionConfiguration,
             $usageTracker,
             $logger,
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $service->setHttpClient($httpClient);
 
@@ -419,7 +421,14 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('image', 'fal:flux-schnell', self::anything());
+            ->with(
+                'image',
+                'fal',
+                ['images' => 1],
+                null,
+                0,
+                'flux-schnell',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -582,7 +591,14 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('image', 'fal:flux-schnell', self::callback(fn($data) => is_array($data) && isset($data['count'])));
+            ->with(
+                'image',
+                'fal',
+                self::callback(fn(array $metrics): bool => isset($metrics['images'])),
+                null,
+                0,
+                'flux-schnell',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -295,14 +295,80 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function constructorThrowsForDalleSizeOnGptImageModel(): void
+    #[DataProvider('validArbitraryGptImageSizeProvider')]
+    public function constructorAcceptsArbitraryGptImageSizes(string $size): void
     {
-        // DALL·E-3's 1792x1024 is not a valid gpt-image size.
+        // gpt-image-* accepts any WIDTHxHEIGHT with both dimensions divisible
+        // by 16, aspect ratio between 1:3 and 3:1 (inclusive), max 3840x2160
+        // (per OpenAI docs, June 2026). Other extensions rely on this contract.
+        $options = new ImageGenerationOptions(model: 'gpt-image-2', size: $size);
+
+        self::assertEquals($size, $options->size);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function validArbitraryGptImageSizeProvider(): array
+    {
+        return [
+            'former DALL-E-3 wide size'   => ['1792x1024'],
+            '16:9 HD'                     => ['2048x1152'],
+            'maximum 3840x2160'           => ['3840x2160'],
+            'exact 1:3 portrait'          => ['720x2160'],
+            'exact 3:1 landscape'         => ['2160x720'],
+            'widest at max width'         => ['3840x1280'],
+            'minimum 16x16'               => ['16x16'],
+            '2:1 landscape'               => ['1024x512'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidArbitraryGptImageSizeProvider')]
+    public function constructorRejectsInvalidArbitraryGptImageSizes(string $size, int $expectedCode): void
+    {
+        try {
+            new ImageGenerationOptions(model: 'gpt-image-2', size: $size);
+            self::fail(sprintf('Expected the constructor to reject size "%s"', $size));
+        } catch (InvalidArgumentException $e) {
+            self::assertSame($expectedCode, $e->getCode());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public static function invalidArbitraryGptImageSizeProvider(): array
+    {
+        return [
+            // Both dimensions must be divisible by 16.
+            'width not divisible by 16'  => ['1000x1024', 4810231766],
+            'height not divisible by 16' => ['1024x1000', 4810231766],
+            'zero dimensions'            => ['0x0', 4810231766],
+            // Maximum size is 3840x2160.
+            'width above 3840'           => ['3856x2160', 7269345118],
+            'height above 2160'          => ['3840x2176', 7269345118],
+            // Aspect ratio must stay between 1:3 and 3:1.
+            'taller than 1:3'            => ['512x1552', 6203914577],
+            'wider than 3:1'             => ['1552x512', 6203914577],
+            // Malformed strings are rejected outright.
+            'missing height'             => ['1024x', 9662872869],
+            'missing width'              => ['x1024', 9662872869],
+            'non-numeric'                => ['widexhigh', 9662872869],
+            'negative width'             => ['-1024x1024', 9662872869],
+            'whitespace'                 => [' 1024x1024', 9662872869],
+        ];
+    }
+
+    #[Test]
+    public function constructorStillRejectsArbitrarySizesForDalleModels(): void
+    {
+        // The WxH freedom is a gpt-image-* contract only; DALL·E models keep
+        // their fixed size lists.
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid size');
 
-        $options = new ImageGenerationOptions(model: 'gpt-image-1', size: '1792x1024');
-        self::fail('Expected the constructor to reject size, got: ' . $options->size);
+        new ImageGenerationOptions(model: 'dall-e-3', size: '2048x1152');
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -328,8 +328,8 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsInvalidArbitraryGptImageSizes(string $size, int $expectedCode): void
     {
         try {
-            new ImageGenerationOptions(model: 'gpt-image-2', size: $size);
-            self::fail(sprintf('Expected the constructor to reject size "%s"', $size));
+            $options = new ImageGenerationOptions(model: 'gpt-image-2', size: $size);
+            self::fail(sprintf('Expected the constructor to reject size "%s", got %s', $size, $options::class));
         } catch (InvalidArgumentException $e) {
             self::assertSame($expectedCode, $e->getCode());
         }
@@ -365,10 +365,12 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     {
         // The WxH freedom is a gpt-image-* contract only; DALL·E models keep
         // their fixed size lists.
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid size');
-
-        new ImageGenerationOptions(model: 'dall-e-3', size: '2048x1152');
+        try {
+            $options = new ImageGenerationOptions(model: 'dall-e-3', size: '2048x1152');
+            self::fail(sprintf('Expected the constructor to reject the size, got %s', $options::class));
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('Invalid size', $e->getMessage());
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Pricing/OpenAiPriceCatalogTest.php
+++ b/Tests/Unit/Specialized/Pricing/OpenAiPriceCatalogTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized\Pricing;
+
+use Netresearch\NrLlm\Specialized\Pricing\OpenAiPriceCatalog;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(OpenAiPriceCatalog::class)]
+class OpenAiPriceCatalogTest extends AbstractUnitTestCase
+{
+    // ==================== imageTokenCost ====================
+
+    #[Test]
+    public function imageTokenCostPricesGptImage2TokensAtListPrice(): void
+    {
+        // 40 text-in × $5/1M + 10 image-in × $8/1M + 1000 out × $30/1M.
+        $cost = OpenAiPriceCatalog::imageTokenCost('gpt-image-2', 50, 1000, 10);
+
+        self::assertNotNull($cost);
+        self::assertEqualsWithDelta(0.03028, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageTokenCostBillsAllInputAsTextWhenNoImageTokenSplitGiven(): void
+    {
+        // 50 in × $5/1M + 1000 out × $30/1M
+        $cost = OpenAiPriceCatalog::imageTokenCost('gpt-image-2', 50, 1000);
+
+        self::assertNotNull($cost);
+        self::assertEqualsWithDelta(0.03025, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageTokenCostResolvesDatedPointReleasesByPrefix(): void
+    {
+        $exact = OpenAiPriceCatalog::imageTokenCost('gpt-image-2', 100, 100);
+        $dated = OpenAiPriceCatalog::imageTokenCost('gpt-image-2-2026-04-21', 100, 100);
+
+        self::assertNotNull($exact);
+        self::assertSame($exact, $dated);
+    }
+
+    #[Test]
+    public function imageTokenCostPrefersLongestPrefixForMiniVariant(): void
+    {
+        // gpt-image-1-mini must not resolve to the gpt-image-1 prices.
+        // 1M output tokens: mini = $8, base model = $40.
+        $cost = OpenAiPriceCatalog::imageTokenCost('gpt-image-1-mini', 0, 1_000_000);
+
+        self::assertNotNull($cost);
+        self::assertEqualsWithDelta(8.0, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageTokenCostReturnsNullForUnknownModel(): void
+    {
+        self::assertNull(OpenAiPriceCatalog::imageTokenCost('dall-e-3', 50, 1000));
+        self::assertNull(OpenAiPriceCatalog::imageTokenCost('some-future-model', 50, 1000));
+    }
+
+    // ==================== imagePrice ====================
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string, 3: float}>
+     */
+    public static function imageListPriceProvider(): array
+    {
+        // List prices, see the catalog source documentation.
+        return [
+            'dall-e-3 standard square'   => ['dall-e-3', 'standard', '1024x1024', 0.040],
+            'dall-e-3 standard wide'     => ['dall-e-3', 'standard', '1792x1024', 0.080],
+            'dall-e-3 hd square'         => ['dall-e-3', 'hd', '1024x1024', 0.080],
+            'dall-e-3 hd tall'           => ['dall-e-3', 'hd', '1024x1792', 0.120],
+            'dall-e-2 1024'              => ['dall-e-2', 'standard', '1024x1024', 0.020],
+            'dall-e-2 512'               => ['dall-e-2', 'standard', '512x512', 0.018],
+            'dall-e-2 256'               => ['dall-e-2', 'standard', '256x256', 0.016],
+            'gpt-image-1 medium square'  => ['gpt-image-1', 'medium', '1024x1024', 0.042],
+            'gpt-image-2 high square'    => ['gpt-image-2', 'high', '1024x1024', 0.211],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('imageListPriceProvider')]
+    public function imagePriceReturnsListPrice(string $model, string $quality, string $size, float $expected): void
+    {
+        self::assertSame($expected, OpenAiPriceCatalog::imagePrice($model, $quality, $size));
+    }
+
+    #[Test]
+    public function imagePriceReturnsNullForUnknownCombinations(): void
+    {
+        // Never guess: unknown model, quality tier, or size yields null.
+        self::assertNull(OpenAiPriceCatalog::imagePrice('unknown-model', 'standard', '1024x1024'));
+        self::assertNull(OpenAiPriceCatalog::imagePrice('dall-e-3', 'low', '1024x1024'));
+        self::assertNull(OpenAiPriceCatalog::imagePrice('dall-e-3', 'standard', '2048x2048'));
+        // Arbitrary gpt-image-2 WxH sizes have no per-image list price.
+        self::assertNull(OpenAiPriceCatalog::imagePrice('gpt-image-2', 'high', '3840x2160'));
+    }
+
+    // ==================== speechSynthesisCost ====================
+
+    #[Test]
+    public function speechSynthesisCostPricesPerMillionCharacters(): void
+    {
+        self::assertEqualsWithDelta(15.00, (float)OpenAiPriceCatalog::speechSynthesisCost('tts-1', 1_000_000), 1e-9);
+        self::assertEqualsWithDelta(30.00, (float)OpenAiPriceCatalog::speechSynthesisCost('tts-1-hd', 1_000_000), 1e-9);
+        self::assertEqualsWithDelta(0.0015, (float)OpenAiPriceCatalog::speechSynthesisCost('tts-1', 100), 1e-12);
+    }
+
+    #[Test]
+    public function speechSynthesisCostReturnsNullForUnknownModel(): void
+    {
+        self::assertNull(OpenAiPriceCatalog::speechSynthesisCost('unknown-tts', 1000));
+    }
+
+    // ==================== transcriptionCost ====================
+
+    #[Test]
+    public function transcriptionCostPricesPerMinute(): void
+    {
+        self::assertEqualsWithDelta(0.006, (float)OpenAiPriceCatalog::transcriptionCost('whisper-1', 60.0), 1e-12);
+        self::assertEqualsWithDelta(0.009, (float)OpenAiPriceCatalog::transcriptionCost('whisper-1', 90.0), 1e-12);
+    }
+
+    #[Test]
+    public function transcriptionCostReturnsNullForUnknownModel(): void
+    {
+        self::assertNull(OpenAiPriceCatalog::transcriptionCost('unknown-stt', 60.0));
+    }
+}

--- a/Tests/Unit/Specialized/Pricing/SpecializedCostCalculatorTest.php
+++ b/Tests/Unit/Specialized/Pricing/SpecializedCostCalculatorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized\Pricing;
+
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+#[CoversClass(SpecializedCostCalculator::class)]
+class SpecializedCostCalculatorTest extends AbstractUnitTestCase
+{
+    private function calculatorWithoutModelRows(): SpecializedCostCalculator
+    {
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn(null);
+
+        return new SpecializedCostCalculator($repository);
+    }
+
+    #[Test]
+    public function imageCostPrefersAdminCuratedModelRowPricingOverCatalog(): void
+    {
+        // An admin-curated tx_nrllm_model row with token pricing wins over
+        // the static catalog (e.g. negotiated prices).
+        $model = new Model();
+        $model->setCostInputDollars(10.00);   // $10 / 1M input tokens
+        $model->setCostOutputDollars(60.00);  // $60 / 1M output tokens
+
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($model);
+
+        $calculator = new SpecializedCostCalculator($repository);
+
+        // 1M input + 1M output at the row's pricing = $70, not the catalog's $35.
+        $cost = $calculator->estimateImageCost('gpt-image-2', '', '1024x1024', 1, 1_000_000, 1_000_000);
+
+        self::assertEqualsWithDelta(70.0, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageCostIgnoresModelRowWithoutPricing(): void
+    {
+        $model = new Model(); // costInput = costOutput = 0 → hasPricing() false
+
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($model);
+
+        $calculator = new SpecializedCostCalculator($repository);
+
+        // Falls through to the catalog token prices: 1M out × $30/1M.
+        $cost = $calculator->estimateImageCost('gpt-image-2', '', '1024x1024', 1, 0, 1_000_000);
+
+        self::assertEqualsWithDelta(30.0, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageCostUsesCatalogTokenPricesWhenNoModelRowExists(): void
+    {
+        $cost = $this->calculatorWithoutModelRows()
+            ->estimateImageCost('gpt-image-2', '', '1024x1024', 1, 50, 1000, 10);
+
+        self::assertEqualsWithDelta(0.03028, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageCostFallsBackToPerImagePriceWithoutTokens(): void
+    {
+        // dall-e-3 responses carry no usage object — per-image list price.
+        $cost = $this->calculatorWithoutModelRows()
+            ->estimateImageCost('dall-e-3', 'hd', '1024x1024', 2);
+
+        self::assertEqualsWithDelta(0.160, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function imageCostIsZeroForUnknownModels(): void
+    {
+        // Never guess.
+        $cost = $this->calculatorWithoutModelRows()
+            ->estimateImageCost('some-unknown-model', 'standard', '1024x1024', 1);
+
+        self::assertSame(0.0, $cost);
+    }
+
+    #[Test]
+    public function imageCostSurvivesRepositoryFailures(): void
+    {
+        // Cost estimation must never break the generation call: persistence
+        // failures fall back to the static catalog.
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByIdentifier')->willThrowException(new RuntimeException('no extbase'));
+
+        $calculator = new SpecializedCostCalculator($repository);
+
+        $cost = $calculator->estimateImageCost('gpt-image-2', '', '1024x1024', 1, 0, 1_000_000);
+
+        self::assertEqualsWithDelta(30.0, $cost, 1e-9);
+    }
+
+    #[Test]
+    public function speechSynthesisCostUsesCatalogAndNeverGuesses(): void
+    {
+        $calculator = $this->calculatorWithoutModelRows();
+
+        self::assertEqualsWithDelta(0.000135, $calculator->estimateSpeechSynthesisCost('tts-1', 9), 1e-12);
+        self::assertSame(0.0, $calculator->estimateSpeechSynthesisCost('unknown-tts', 9));
+    }
+
+    #[Test]
+    public function transcriptionCostUsesCatalogAndNeverGuesses(): void
+    {
+        $calculator = $this->calculatorWithoutModelRows();
+
+        self::assertEqualsWithDelta(0.009, $calculator->estimateTranscriptionCost('whisper-1', 90.0), 1e-12);
+        self::assertSame(0.0, $calculator->estimateTranscriptionCost('whisper-1', 0.0));
+        self::assertSame(0.0, $calculator->estimateTranscriptionCost('unknown-stt', 90.0));
+    }
+}

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\SpeechSynthesisOptions;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\SpeechSynthesisResult;
 use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -44,6 +47,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
     private VaultServiceInterface $vaultStub;
+    private SpecializedCostCalculatorInterface $costCalculator;
 
     protected function setUp(): void
     {
@@ -56,6 +60,12 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
         $this->vaultStub = $this->createVaultServiceMock();
+
+        // Real calculator over a model-less repository: catalog prices apply,
+        // so cost assertions exercise the real pricing math.
+        $modelRepositoryStub = self::createStub(ModelRepository::class);
+        $modelRepositoryStub->method('findOneByIdentifier')->willReturn(null);
+        $this->costCalculator = new SpecializedCostCalculator($modelRepositoryStub);
     }
 
     /**
@@ -78,6 +88,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $extensionConfiguration,
             $usageTracker,
             $logger,
+            $this->costCalculator,
         );
         $service->setHttpClient($httpClient);
 
@@ -326,8 +337,16 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->method('trackUsage')
             ->with(
                 'speech',
-                self::stringStartsWith('tts:'),
-                self::callback(fn($data) => is_array($data) && isset($data['characters'])),
+                'tts',
+                self::callback(
+                    // 'Test text' = 9 characters at the tts-1 list price of
+                    // $15 per 1M characters.
+                    fn(array $metrics): bool => $metrics['characters'] === 9
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 9 * 15.00 / 1_000_000) < 1e-12,
+                ),
+                null,
+                0,
+                'tts-1',
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
 use Netresearch\NrLlm\Specialized\Option\TranscriptionOptions;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\TranscriptionResult;
 use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -45,6 +48,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
     private VaultServiceInterface $vaultStub;
+    private SpecializedCostCalculatorInterface $costCalculator;
     private ?string $tempFile = null;
 
     /**
@@ -67,6 +71,12 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
         $this->loggerStub = self::createStub(LoggerInterface::class);
         $this->vaultStub = $this->createVaultServiceMock();
+
+        // Real calculator over a model-less repository: catalog prices apply,
+        // so cost assertions exercise the real pricing math.
+        $modelRepositoryStub = self::createStub(ModelRepository::class);
+        $modelRepositoryStub->method('findOneByIdentifier')->willReturn(null);
+        $this->costCalculator = new SpecializedCostCalculator($modelRepositoryStub);
     }
 
     /**
@@ -90,6 +100,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $extensionConfiguration,
             $usageTracker,
             $logger,
+            $this->costCalculator,
         );
         $service->setHttpClient($httpClient);
 
@@ -363,7 +374,16 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $usageTrackerMock
             ->expects(self::once())
             ->method('trackUsage')
-            ->with('speech', 'whisper:transcription', []);
+            ->with(
+                'speech',
+                'whisper',
+                // Plain `json` responses expose no duration — the request is
+                // recorded without audio seconds and without a guessed cost.
+                [],
+                null,
+                0,
+                'whisper-1',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -528,8 +548,19 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
         $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
         $usageTrackerMock
-            ->expects(self::atLeastOnce())
-            ->method('trackUsage');
+            ->expects(self::once())
+            // Exactly once: the request is recorded inside the dispatch path;
+            // translateToEnglish() used to add a second row, double-counting
+            // every translation request.
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'whisper',
+                [],
+                null,
+                0,
+                'whisper-1',
+            );
 
         $subject = $this->buildService(
             $this->httpClientStub,
@@ -541,6 +572,57 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         );
 
         $subject->translateToEnglish($audioFile);
+    }
+
+    #[Test]
+    public function transcribeWithVerboseJsonTracksAudioSecondsAndCost(): void
+    {
+        // verbose_json reports the audio duration; 90 seconds of whisper-1
+        // at $0.006/minute = $0.009.
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode([
+            'text' => 'Hello',
+            'language' => 'en',
+            'duration' => 90.0,
+        ]));
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'providers' => [
+                    'openai' => [
+                        'apiKeyIdentifier' => 'test-api-key',
+                    ],
+                ],
+            ]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'whisper',
+                self::callback(
+                    fn(array $metrics): bool => $metrics['audioSeconds'] === 90
+                        && is_float($metrics['cost']) && abs($metrics['cost'] - 0.009) < 1e-12,
+                ),
+                null,
+                0,
+                'whisper-1',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->transcribe($audioFile, new TranscriptionOptions(format: 'verbose_json'));
     }
 
     // ==================== API error handling tests ====================

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -64,6 +65,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($config ?? $this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -89,6 +91,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($config ?? $this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClient);
 
@@ -474,6 +477,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $usageTrackerMock,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClientMock);
 
@@ -723,6 +727,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $extensionConfigStub,
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($this->createHttpClientMock());
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -47,6 +48,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock(array_merge($defaultConfig, $config)),
             self::createStub(UsageTrackerServiceInterface::class),
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -78,6 +80,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($config),
             self::createStub(UsageTrackerServiceInterface::class),
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClient);
 
@@ -524,6 +527,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             ]),
             $usageTrackerMock,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClientMock);
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -78,6 +79,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -99,6 +101,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($config),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $translator->setHttpClient($httpClient);
 
@@ -173,6 +176,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($config),
             $this->usageTrackerStub,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
 
         $reflection = new ReflectionClass($translator);
@@ -304,6 +308,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createExtensionConfigurationMock($this->defaultConfig),
             $usageTrackerMock,
             $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
         );
         $subject->setHttpClient($httpClientStub);
 

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -149,7 +149,17 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             ->with(
                 'translation',
                 self::stringStartsWith('llm:'),
-                self::callback(fn($data) => is_array($data) && isset($data['tokens'], $data['characters'])),
+                self::callback(
+                    // Characters only: tokens and cost are recorded by the
+                    // middleware pipeline on the underlying chat row —
+                    // repeating them here would double-count them.
+                    fn(array $metrics): bool => isset($metrics['characters'])
+                        && !isset($metrics['tokens'])
+                        && !isset($metrics['cost']),
+                ),
+                null,
+                0,
+                'gpt-5.2',
             );
 
         $subject = new LlmTranslator(

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -394,7 +394,7 @@ CREATE TABLE tx_nrllm_service_usage (
 
     PRIMARY KEY (uid),
     KEY parent (pid),
-    KEY lookup (service_type, service_provider, request_date, model_uid),
+    KEY lookup (service_type, service_provider, request_date, model_uid, model_id),
     KEY user_lookup (be_user, service_type, request_date),
     KEY config_lookup (configuration_uid, request_date),
     KEY model_lookup (model_uid, request_date),


### PR DESCRIPTION
## Summary

The specialized services (image / TTS / Whisper) bypass the middleware pipeline and recorded almost nothing: the image services passed metric keys (`size`, `quality`, `count`) that `UsageTrackerService` silently drops, so only `request_count = 1` landed in `tx_nrllm_service_usage` — no cost, no tokens, no `images_generated`, `model_id = ''`. TTS recorded characters without cost. The Analytics module, MonthlyCost widget and BudgetService therefore systematically excluded all image and speech spend. The vault audit log also recorded only static phrases ("DALL-E API call", "LLM API call to OpenAI") although the models in use are gpt-image-* and the model/purpose are known at request time.

### Audit reasons (`f58f796`)
- `DallEImageService` provider label `DALL-E` → `OpenAI Images` (class name and `dall-e` service identifier stay).
- Per-request audit context in `AbstractSpecializedService`: `OpenAI Images API call (gpt-image-2, generate)`, `OpenAI TTS API call (tts-1, voice nova)`, `Whisper API call (whisper-1, transcribe)`, `FAL API call (flux-schnell, generate)`.
- `AbstractProvider::sendRequest()` stamps a per-request reason on the vault client: `LLM chat call to OpenAI (gpt-4o)` / `LLM embedding call to …`. Reasons carry request metadata only — never prompt text or secrets.

### gpt-image arbitrary sizes (`7940eb5`) — contract other extensions rely on
`ImageGenerationOptions` accepts for every `gpt-image-*` model: the standard sizes (`1024x1024`, `1536x1024`, `1024x1536`, `auto`) plus any `WIDTHxHEIGHT` where **both dimensions are divisible by 16**, **aspect ratio between 1:3 and 3:1 (inclusive)**, **max 3840x2160** (per OpenAI docs, June 2026). dall-e-2/3 keep their fixed size lists. Distinct exception codes per violation (malformed / divisibility / max size / aspect).

### Usage + cost tracking (`a89be68`)
- Services now pass the metric keys the tracker maps: `images` → `images_generated`, `characters`, `audioSeconds` → `audio_seconds_used` (from the `verbose_json` Whisper duration), token keys, `cost`; the model lands in `model_id` instead of ad-hoc `provider:model` strings.
- `DallEImageService` parses the `usage` token object of gpt-image-* responses (`input_tokens`/`output_tokens`/`total_tokens`/`input_tokens_details`); dall-e-2/3 responses have no usage and gracefully omit token metrics.
- New `Specialized\Pricing\OpenAiPriceCatalog` with documented USD list prices (source URL + verification date 2026-06-10 per constant): gpt-image-2/1.5/1/1-mini token prices, DALL-E per-image prices, tts-1/tts-1-hd per 1M characters, whisper-1 per minute. **Unknown model/size/quality → cost 0, never guessed.**
- New `SpecializedCostCalculator` (injected via the `AbstractSpecializedService` constructor): admin-curated `tx_nrllm_model` row with token pricing wins (`Model::estimateCost` via identifier lookup, fail-soft) → catalog token prices → catalog per-image price → 0.
- Double counting removed: `LlmTranslator` no longer repeats tokens already recorded by `UsageMiddleware` on the chat row; `WhisperTranscriptionService::translateToEnglish()` loses its second `trackUsage()` call.
- FAL records image counts with cost 0 (no published static price list).

### Docs (`654f655`)
ADR-032 records the design (units, pricing cascade, never-guess rule, double-count removal).

## Test plan

- [x] `Build/Scripts/runTests.sh -p 8.4 -s cgl -n` — SUCCESS
- [x] `Build/Scripts/runTests.sh -p 8.4 -s phpstan` — `[OK] No errors` (level 10)
- [x] `Build/Scripts/runTests.sh -p 8.4 -s unit` — 3543 tests, 7861 assertions, SUCCESS (main baseline: 3488 tests; the 19 PHPUnit notices pre-exist on main)
- [x] New unit tests: gpt-image WxH validation (valid/invalid divisibility, aspect bounds, max resolution, malformed strings), `OpenAiPriceCatalog`, `SpecializedCostCalculator` (model-row precedence, fail-soft, never-guess), gpt-image usage-object parsing incl. graceful absence, tracker `model_id`/unit mapping, per-request audit reasons (specialized + chat), Whisper single-tracking regression
