### PR TITLE
feat: specialized models join the model registry

### DIFF
--- a/Classes/Domain/Enum/ModelCapability.php
+++ b/Classes/Domain/Enum/ModelCapability.php
@@ -24,6 +24,9 @@ enum ModelCapability: string
     case TOOLS = 'tools';
     case JSON_MODE = 'json_mode';
     case AUDIO = 'audio';
+    case IMAGE = 'image';
+    case TEXT_TO_SPEECH = 'text_to_speech';
+    case TRANSCRIPTION = 'transcription';
 
     /**
      * Get all capability values as an array.

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -55,6 +55,23 @@ class ModelRepository extends Repository
     }
 
     /**
+     * Find a model by its provider model id (the API model string,
+     * e.g. "gpt-image-2"). Multiple records may share a model id when
+     * the same model is offered through several providers; the default
+     * ordering (sorting, name) decides which one wins.
+     */
+    public function findOneByModelId(string $modelId): ?Model
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('modelId', $modelId),
+        );
+        /** @var Model|null $result */
+        $result = $query->execute()->getFirst();
+        return $result;
+    }
+
+    /**
      * Find all active models.
      *
      * @return QueryResultInterface<int, Model>

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -66,9 +66,9 @@ class ModelRepository extends Repository
         $query->matching(
             $query->equals('modelId', $modelId),
         );
-        /** @var Model|null $result */
         $result = $query->execute()->getFirst();
-        return $result;
+
+        return $result instanceof Model ? $result : null;
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -306,18 +306,21 @@ abstract class AbstractSpecializedService
         try {
             // Results arrive ordered by the repository default (sorting, name),
             // so the first usable record already is the lowest-sorting one.
-            $first = null;
+            // A default-flagged record overrides it and ends the scan.
+            $chosen = null;
             foreach ($this->modelRepository->findByCapability($capability->value) as $candidate) {
-                if ($candidate->getModelId() === '') {
+                // @phpstan-ignore instanceof.alwaysTrue (defensive check for QueryResult)
+                if (!$candidate instanceof Model || $candidate->getModelId() === '') {
                     continue;
                 }
                 if ($candidate->isDefault()) {
-                    return $candidate->getModelId();
+                    $chosen = $candidate;
+                    break;
                 }
-                $first ??= $candidate;
+                $chosen ??= $candidate;
             }
-            if ($first instanceof Model) {
-                return $first->getModelId();
+            if ($chosen instanceof Model) {
+                return $chosen->getModelId();
             }
         } catch (Throwable) {
             // Extbase persistence may be unavailable in edge contexts

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -84,6 +87,7 @@ abstract class AbstractSpecializedService
         protected readonly UsageTrackerServiceInterface $usageTracker,
         protected readonly LoggerInterface $logger,
         protected readonly SpecializedCostCalculatorInterface $costCalculator,
+        protected readonly ?ModelRepository $modelRepository = null,
     ) {
         $this->timeout = $this->getDefaultTimeout();
         $this->loadConfiguration();
@@ -277,6 +281,70 @@ abstract class AbstractSpecializedService
                 $this->getServiceDomain(),
                 $this->getServiceProvider(),
             );
+        }
+    }
+
+    /**
+     * Resolve the admin-preferred default model for a capability from
+     * the model registry (tx_nrllm_model). Considers ACTIVE records
+     * carrying the capability — provider-agnostic — preferring the
+     * record flagged as default, then the lowest sorting, and returns
+     * that record's model id (the API model string). Records without a
+     * model id are skipped: they cannot be sent to an upstream API.
+     *
+     * Fail-soft, mirroring `SpecializedCostCalculator::estimateFromModelRow()`:
+     * no repository in context, a persistence failure, or no usable
+     * record returns the given fallback unchanged — resolving a default
+     * must never break the service call. Never throws.
+     */
+    protected function resolveDefaultModelFor(ModelCapability $capability, string $fallback): string
+    {
+        if ($this->modelRepository === null) {
+            return $fallback;
+        }
+
+        try {
+            // Results arrive ordered by the repository default (sorting, name),
+            // so the first usable record already is the lowest-sorting one.
+            $first = null;
+            foreach ($this->modelRepository->findByCapability($capability->value) as $candidate) {
+                if ($candidate->getModelId() === '') {
+                    continue;
+                }
+                if ($candidate->isDefault()) {
+                    return $candidate->getModelId();
+                }
+                $first ??= $candidate;
+            }
+            if ($first instanceof Model) {
+                return $first->getModelId();
+            }
+        } catch (Throwable) {
+            // Extbase persistence may be unavailable in edge contexts
+            // (early CLI bootstrap); the hardcoded fallback keeps the
+            // service usable.
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * Resolve the tx_nrllm_model uid for a model id so usage rows link
+     * to the registry record and the Analytics model breakdowns can
+     * aggregate by record. Fail-soft: returns 0 (no linked record) when
+     * no repository is in context, no record matches, or the lookup
+     * fails — usage tracking must never break the service call.
+     */
+    protected function resolveModelUid(string $modelId): int
+    {
+        if ($this->modelRepository === null || $modelId === '') {
+            return 0;
+        }
+
+        try {
+            return $this->modelRepository->findOneByModelId($modelId)?->getUid() ?? 0;
+        } catch (Throwable) {
+            return 0;
         }
     }
 

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
@@ -315,6 +316,21 @@ final class DallEImageService extends AbstractSpecializedService
         return self::MODEL_CAPABILITIES[$this->capabilityKey($model)]['sizes'] ?? ['1024x1024'];
     }
 
+    /**
+     * Resolve the default image-generation model from the model registry.
+     *
+     * Queries ACTIVE tx_nrllm_model records carrying the `image`
+     * capability (provider-agnostic), prefers the record flagged as
+     * default, then the lowest sorting, and returns that record's
+     * model id. Fail-soft: any error, no repository in context, or no
+     * matching record returns the given fallback unchanged — this
+     * method never throws.
+     */
+    public function resolveDefaultModel(string $fallback): string
+    {
+        return $this->resolveDefaultModelFor(ModelCapability::IMAGE, $fallback);
+    }
+
     protected function getServiceDomain(): string
     {
         return 'image';
@@ -417,6 +433,7 @@ final class DallEImageService extends AbstractSpecializedService
             'image',
             $this->getServiceProvider(),
             $metrics,
+            modelUid: $this->resolveModelUid($model),
             modelId: $model,
         );
     }

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -410,13 +410,27 @@ final class DallEImageService extends AbstractSpecializedService
         int $imageCount,
         array $response,
     ): void {
-        $usage = $this->extractUsageTokens($response);
+        // gpt-image-* responses include a `usage` token object;
+        // dall-e-2/3 never send one — token metrics are omitted then
+        // (all-zero counts) so the cost falls back to the per-image
+        // catalog instead of a fabricated token price.
+        $usage = $response['usage'] ?? null;
+        $input = $output = $total = $imageInput = 0;
+        if (is_array($usage)) {
+            $input = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
+            $output = is_numeric($usage['output_tokens'] ?? null) ? (int)$usage['output_tokens'] : 0;
+            $total = is_numeric($usage['total_tokens'] ?? null) ? (int)$usage['total_tokens'] : $input + $output;
+            $details = $usage['input_tokens_details'] ?? null;
+            $imageInput = is_array($details) && is_numeric($details['image_tokens'] ?? null)
+                ? (int)$details['image_tokens']
+                : 0;
+        }
 
         $metrics = ['images' => $imageCount];
-        if ($usage !== null) {
-            $metrics['tokens'] = $usage['total'];
-            $metrics['promptTokens'] = $usage['input'];
-            $metrics['completionTokens'] = $usage['output'];
+        if ($input > 0 || $output > 0 || $total > 0) {
+            $metrics['tokens'] = $total;
+            $metrics['promptTokens'] = $input;
+            $metrics['completionTokens'] = $output;
         }
 
         $metrics['cost'] = $this->costCalculator->estimateImageCost(
@@ -424,9 +438,9 @@ final class DallEImageService extends AbstractSpecializedService
             $quality,
             $size,
             $imageCount,
-            $usage['input'] ?? 0,
-            $usage['output'] ?? 0,
-            $usage['imageInput'] ?? 0,
+            $input,
+            $output,
+            $imageInput,
         );
 
         $this->usageTracker->trackUsage(
@@ -436,38 +450,6 @@ final class DallEImageService extends AbstractSpecializedService
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
         );
-    }
-
-    /**
-     * Extract the token usage gpt-image-* responses include. Returns null
-     * when the response has no usable `usage` object (dall-e-2/3 never
-     * send one) so callers can omit token metrics gracefully.
-     *
-     * @param array<string, mixed> $response
-     *
-     * @return array{input: int, output: int, total: int, imageInput: int}|null
-     */
-    private function extractUsageTokens(array $response): ?array
-    {
-        $usage = $response['usage'] ?? null;
-        if (!is_array($usage)) {
-            return null;
-        }
-
-        $input = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
-        $output = is_numeric($usage['output_tokens'] ?? null) ? (int)$usage['output_tokens'] : 0;
-        $total = is_numeric($usage['total_tokens'] ?? null) ? (int)$usage['total_tokens'] : $input + $output;
-
-        if ($input === 0 && $output === 0 && $total === 0) {
-            return null;
-        }
-
-        $details = $usage['input_tokens_details'] ?? null;
-        $imageInput = is_array($details) && is_numeric($details['image_tokens'] ?? null)
-            ? (int)$details['image_tokens']
-            : 0;
-
-        return ['input' => $input, 'output' => $output, 'total' => $total, 'imageInput' => $imageInput];
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -100,7 +100,7 @@ final class FalImageService extends AbstractSpecializedService
         // SpecializedCostCalculatorInterface).
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => 1,
-        ], modelId: $model);
+        ], modelUid: $this->resolveModelUid($model), modelId: $model);
 
         $imageUrl = isset($image['url']) && is_string($image['url']) ? $image['url'] : '';
 
@@ -176,7 +176,7 @@ final class FalImageService extends AbstractSpecializedService
 
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => count($results),
-        ], modelId: $model);
+        ], modelUid: $this->resolveModelUid($model), modelId: $model);
 
         return $results;
     }

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -107,7 +108,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         $this->usageTracker->trackUsage('speech', $this->getServiceProvider(), [
             'characters' => $characterCount,
             'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
-        ], modelId: $model);
+        ], modelUid: $this->resolveModelUid($model), modelId: $model);
 
         return new SpeechSynthesisResult(
             audioContent: $audioContent,
@@ -219,6 +220,21 @@ final class TextToSpeechService extends AbstractSpecializedService
     public function getMaxInputLength(): int
     {
         return self::MAX_INPUT_LENGTH;
+    }
+
+    /**
+     * Resolve the default speech-synthesis model from the model registry.
+     *
+     * Queries ACTIVE tx_nrllm_model records carrying the
+     * `text_to_speech` capability (provider-agnostic), prefers the
+     * record flagged as default, then the lowest sorting, and returns
+     * that record's model id. Fail-soft: any error, no repository in
+     * context, or no matching record returns the given fallback
+     * unchanged — this method never throws.
+     */
+    public function resolveDefaultModel(string $fallback): string
+    {
+        return $this->resolveDefaultModelFor(ModelCapability::TEXT_TO_SPEECH, $fallback);
     }
 
     protected function getServiceDomain(): string

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -168,6 +169,21 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     public function getSupportedResponseFormats(): array
     {
         return self::RESPONSE_FORMATS;
+    }
+
+    /**
+     * Resolve the default transcription model from the model registry.
+     *
+     * Queries ACTIVE tx_nrllm_model records carrying the
+     * `transcription` capability (provider-agnostic), prefers the
+     * record flagged as default, then the lowest sorting, and returns
+     * that record's model id. Fail-soft: any error, no repository in
+     * context, or no matching record returns the given fallback
+     * unchanged — this method never throws.
+     */
+    public function resolveDefaultModel(string $fallback): string
+    {
+        return $this->resolveDefaultModelFor(ModelCapability::TRANSCRIPTION, $fallback);
     }
 
     protected function getServiceDomain(): string
@@ -441,6 +457,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             'speech',
             $this->getServiceProvider(),
             $metrics,
+            modelUid: $this->resolveModelUid($model),
             modelId: $model,
         );
     }

--- a/Configuration/TCA/tx_nrllm_model.php
+++ b/Configuration/TCA/tx_nrllm_model.php
@@ -214,6 +214,21 @@ return [
                         'value' => 'audio',
                         'icon' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.audio.description',
                     ],
+                    [
+                        'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.image',
+                        'value' => 'image',
+                        'icon' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.image.description',
+                    ],
+                    [
+                        'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.text_to_speech',
+                        'value' => 'text_to_speech',
+                        'icon' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.text_to_speech.description',
+                    ],
+                    [
+                        'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.transcription',
+                        'value' => 'transcription',
+                        'icon' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.capabilities.transcription.description',
+                    ],
                 ],
                 'default' => 'chat',
             ],

--- a/Documentation/Adr/Adr033SpecializedModelRegistry.rst
+++ b/Documentation/Adr/Adr033SpecializedModelRegistry.rst
@@ -1,0 +1,78 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-033:
+
+==================================================================
+ADR-033: Specialized Models in the Model Registry
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-11
+:Authors: Netresearch DTT GmbH
+
+.. _adr-033-context:
+
+Context
+=======
+
+The backend Models module manages ``tx_nrllm_model`` records for the
+chat/embedding pipeline, but the specialized services (image
+generation, text-to-speech, transcription — :ref:`adr-030`,
+:ref:`adr-032`) selected their models from hardcoded constants
+(``dall-e-3``, ``tts-1``, ``whisper-1``) and never consulted the
+registry. Image and speech models were therefore invisible in the
+backend: administrators could not curate them, mark a preferred
+default, or see usage linked to a record. Consuming extensions had no
+way to ask "which image model should I use on this instance?".
+
+.. _adr-033-decision:
+
+Decision
+========
+
+1. **Specialized capabilities.** :php:`ModelCapability` gains
+   ``IMAGE``, ``TEXT_TO_SPEECH`` and ``TRANSCRIPTION`` cases, exposed
+   in the ``tx_nrllm_model`` TCA capabilities select, the BE group
+   capability permissions and the model-picker capability badges.
+   Image, TTS and transcription models are regular registry records.
+
+2. **Capability-based default resolution.**
+   :php:`DallEImageService`, :php:`TextToSpeechService` and
+   :php:`WhisperTranscriptionService` expose
+   :php:`resolveDefaultModel(string $fallback): string`: ACTIVE
+   registry records carrying the service's capability are considered
+   provider-agnostically; an ``is_default`` record wins, then the
+   lowest ``sorting``; the record's ``model_id`` is returned.
+   Fail-soft — any error, missing repository, or no matching record
+   returns the fallback unchanged; the method never throws (the same
+   posture as :php:`SpecializedCostCalculator`, :ref:`adr-032`).
+
+3. **Usage linkage.** Specialized usage rows now carry the matching
+   registry record's uid as ``model_uid`` (resolved fail-soft from the
+   used ``model_id``), so the Analytics model breakdowns link image and
+   speech spend to the curated records; ``0`` remains the value for
+   models without a registry record.
+
+4. **Configurations stay chat-scoped by design.** The third tier of
+   :ref:`adr-013` (Configuration bundles: system prompt, temperature,
+   token limits, budgets) only makes sense for conversational models.
+   Image/TTS/transcription use Model records plus capability-based
+   default resolution — no Configuration records are created for them.
+
+.. _adr-033-consequences:
+
+Consequences
+============
+
+- ● Image, TTS and transcription models are first-class registry
+  citizens: curated, activatable, default-flagged and visible in the
+  backend Models module like chat models.
+- ● Consuming extensions resolve the instance-preferred specialized
+  model via ``resolveDefaultModel()`` instead of hardcoding one, with
+  a guaranteed-safe fallback.
+- ● Analytics model breakdowns link specialized spend to registry
+  records via ``model_uid``.
+- ◐ Hardcoded service defaults remain as fallbacks — instances without
+  curated records keep working unchanged.
+- ◑ One additional fail-soft repository lookup per tracked specialized
+  call (indexed single-row query; negligible next to the API call).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -265,3 +265,4 @@ Modern architecture (v0.4+)
    Adr030SpecializedServicesVaultMigration
    Adr031PromptSnippetLibrary
    Adr032SpecializedUsageAndPricingCatalog
+   Adr033SpecializedModelRegistry

--- a/Documentation/Developer/CapabilityPermissions.rst
+++ b/Documentation/Developer/CapabilityPermissions.rst
@@ -9,7 +9,8 @@ BE group permission checks
 Every :php:`ModelCapability` enum value is registered as a native
 TYPO3 ``customPermOptions`` entry under the ``nrllm`` namespace.
 Administrators see a checkbox per capability (chat, completion,
-embeddings, vision, streaming, tools, json_mode, audio) on the
+embeddings, vision, streaming, tools, json_mode, audio, image,
+text_to_speech, transcription) on the
 :guilabel:`Backend Users > Access Options` tab when editing a BE
 group. Consumer code asks the
 :php:`\Netresearch\NrLlm\Service\CapabilityPermissionService`

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -39,6 +39,18 @@
                 <source>Audio (speech transcription / synthesis)</source>
                 <target>Audio (Sprachtranskription/-synthese)</target>
             </trans-unit>
+            <trans-unit id="permissions.capability.image">
+                <source>Image generation</source>
+                <target>Bilderzeugung</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.text_to_speech">
+                <source>Text to speech (audio synthesis)</source>
+                <target>Text-zu-Sprache (Audiosynthese)</target>
+            </trans-unit>
+            <trans-unit id="permissions.capability.transcription">
+                <source>Transcription (speech-to-text)</source>
+                <target>Transkription (Sprache-zu-Text)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -630,6 +630,33 @@
                 <target>Audioeingabe verarbeiten (Sprache-zu-Text) oder Audioausgabe erzeugen (Text-zu-Sprache).</target>
             </trans-unit>
 
+            <trans-unit id="tx_nrllm_model.capabilities.image">
+                <source>Image Generation</source>
+                <target>Bilderzeugung</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.image.description">
+                <source>Generate images from text prompts. Used by the specialized image services (DALL-E / gpt-image, FAL) to resolve their default model.</source>
+                <target>Bilder aus Textbeschreibungen erzeugen. Die spezialisierten Bilddienste (DALL-E / gpt-image, FAL) ermitteln darüber ihr Standardmodell.</target>
+            </trans-unit>
+
+            <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">
+                <source>Text to Speech</source>
+                <target>Text-zu-Sprache</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.text_to_speech.description">
+                <source>Synthesize spoken audio from text. Used by the specialized TTS service to resolve its default model.</source>
+                <target>Gesprochenes Audio aus Text erzeugen. Der spezialisierte TTS-Dienst ermittelt darüber sein Standardmodell.</target>
+            </trans-unit>
+
+            <trans-unit id="tx_nrllm_model.capabilities.transcription">
+                <source>Transcription</source>
+                <target>Transkription</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.transcription.description">
+                <source>Transcribe audio to text (speech-to-text). Used by the specialized Whisper service to resolve its default model.</source>
+                <target>Audio zu Text transkribieren (Sprache-zu-Text). Der spezialisierte Whisper-Dienst ermittelt darüber sein Standardmodell.</target>
+            </trans-unit>
+
             <trans-unit id="tx_nrllm_model.default_timeout">
                 <source>Default Timeout</source>
                 <target>Standard-Timeout</target>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -635,8 +635,8 @@
                 <target>Bilderzeugung</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.image.description">
-                <source>Generate images from text prompts. Used by the specialized image services (DALL-E / gpt-image, FAL) to resolve their default model.</source>
-                <target>Bilder aus Textbeschreibungen erzeugen. Die spezialisierten Bilddienste (DALL-E / gpt-image, FAL) ermitteln darüber ihr Standardmodell.</target>
+                <source>Generate images from text prompts. The DALL-E / gpt-image service resolves its default model from active records carrying this capability.</source>
+                <target>Bilder aus Textbeschreibungen erzeugen. Der DALL-E-/gpt-image-Dienst ermittelt sein Standardmodell aus aktiven Datensätzen mit dieser Fähigkeit.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -30,6 +30,15 @@
             <trans-unit id="permissions.capability.audio">
                 <source>Audio (speech transcription / synthesis)</source>
             </trans-unit>
+            <trans-unit id="permissions.capability.image">
+                <source>Image generation</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.text_to_speech">
+                <source>Text to speech (audio synthesis)</source>
+            </trans-unit>
+            <trans-unit id="permissions.capability.transcription">
+                <source>Transcription (speech-to-text)</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -492,6 +492,27 @@
                 <source>Process audio input (speech-to-text) or generate audio output (text-to-speech).</source>
             </trans-unit>
 
+            <trans-unit id="tx_nrllm_model.capabilities.image">
+                <source>Image Generation</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.image.description">
+                <source>Generate images from text prompts. Used by the specialized image services (DALL-E / gpt-image, FAL) to resolve their default model.</source>
+            </trans-unit>
+
+            <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">
+                <source>Text to Speech</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.text_to_speech.description">
+                <source>Synthesize spoken audio from text. Used by the specialized TTS service to resolve its default model.</source>
+            </trans-unit>
+
+            <trans-unit id="tx_nrllm_model.capabilities.transcription">
+                <source>Transcription</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_model.capabilities.transcription.description">
+                <source>Transcribe audio to text (speech-to-text). Used by the specialized Whisper service to resolve its default model.</source>
+            </trans-unit>
+
             <trans-unit id="tx_nrllm_model.default_timeout">
                 <source>Default Timeout</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -496,7 +496,7 @@
                 <source>Image Generation</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.image.description">
-                <source>Generate images from text prompts. Used by the specialized image services (DALL-E / gpt-image, FAL) to resolve their default model.</source>
+                <source>Generate images from text prompts. The DALL-E / gpt-image service resolves its default model from active records carrying this capability.</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -48,7 +48,8 @@
         var labels = {
             chat: 'Chat', completion: 'Completion', embeddings: 'Embed',
             vision: 'Vision', streaming: 'Stream', tools: 'Tools',
-            json_mode: 'JSON', audio: 'Audio', reasoning: 'Reasoning'
+            json_mode: 'JSON', audio: 'Audio', reasoning: 'Reasoning',
+            image: 'Image', text_to_speech: 'TTS', transcription: 'Transcribe'
         };
         return capabilities.map(function (cap) {
             return labels[cap] || cap;

--- a/Tests/Unit/Configuration/ModelCapabilityRegistrationTest.php
+++ b/Tests/Unit/Configuration/ModelCapabilityRegistrationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Configuration;
+
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the ModelCapability enum, the tx_nrllm_model TCA capabilities
+ * select, and the EN/DE translation catalogs together.
+ *
+ * A capability added to the enum without its TCA item is invisible in
+ * the Models module; a TCA item without locallang entries renders raw
+ * LLL keys; a missing locallang_be entry breaks the BE group permission
+ * checkboxes that ext_localconf.php derives from the enum cases. This
+ * test fails the build on any of those drifts.
+ */
+#[CoversNothing]
+final class ModelCapabilityRegistrationTest extends TestCase
+{
+    #[Test]
+    public function tcaCapabilityItemsMatchEnumCases(): void
+    {
+        $tca = require __DIR__ . '/../../../Configuration/TCA/tx_nrllm_model.php';
+
+        self::assertIsArray($tca);
+        assert(isset($tca['columns']) && is_array($tca['columns']));
+        assert(isset($tca['columns']['capabilities']) && is_array($tca['columns']['capabilities']));
+        assert(isset($tca['columns']['capabilities']['config']) && is_array($tca['columns']['capabilities']['config']));
+        $items = $tca['columns']['capabilities']['config']['items'] ?? null;
+        self::assertIsArray($items);
+
+        $itemValues = [];
+        foreach ($items as $item) {
+            self::assertIsArray($item);
+            assert(isset($item['value']) && is_string($item['value']));
+            $itemValues[] = $item['value'];
+        }
+
+        $enumValues = ModelCapability::values();
+        sort($itemValues);
+        sort($enumValues);
+
+        self::assertSame(
+            $enumValues,
+            $itemValues,
+            'tx_nrllm_model.capabilities TCA items must mirror the ModelCapability enum cases',
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function languageFileProvider(): array
+    {
+        return [
+            'EN TCA labels' => ['Resources/Private/Language/locallang_tca.xlf'],
+            'DE TCA labels' => ['Resources/Private/Language/de.locallang_tca.xlf'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('languageFileProvider')]
+    public function everyCapabilityHasTcaLabelAndDescription(string $relativePath): void
+    {
+        $xlf = file_get_contents(__DIR__ . '/../../../' . $relativePath);
+        self::assertIsString($xlf);
+
+        foreach (ModelCapability::values() as $value) {
+            self::assertStringContainsString(
+                sprintf('id="tx_nrllm_model.capabilities.%s"', $value),
+                $xlf,
+                sprintf('Missing capability label "%s" in %s', $value, $relativePath),
+            );
+            self::assertStringContainsString(
+                sprintf('id="tx_nrllm_model.capabilities.%s.description"', $value),
+                $xlf,
+                sprintf('Missing capability description "%s" in %s', $value, $relativePath),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function permissionLanguageFileProvider(): array
+    {
+        return [
+            'EN BE permission labels' => ['Resources/Private/Language/locallang_be.xlf'],
+            'DE BE permission labels' => ['Resources/Private/Language/de.locallang_be.xlf'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('permissionLanguageFileProvider')]
+    public function everyCapabilityHasPermissionLabel(string $relativePath): void
+    {
+        $xlf = file_get_contents(__DIR__ . '/../../../' . $relativePath);
+        self::assertIsString($xlf);
+
+        foreach (ModelCapability::values() as $value) {
+            self::assertStringContainsString(
+                sprintf('id="permissions.capability.%s"', $value),
+                $xlf,
+                sprintf('Missing BE permission label "%s" in %s', $value, $relativePath),
+            );
+        }
+    }
+}

--- a/Tests/Unit/Configuration/ModelCapabilityRegistrationTest.php
+++ b/Tests/Unit/Configuration/ModelCapabilityRegistrationTest.php
@@ -31,20 +31,26 @@ final class ModelCapabilityRegistrationTest extends TestCase
     #[Test]
     public function tcaCapabilityItemsMatchEnumCases(): void
     {
-        $tca = require __DIR__ . '/../../../Configuration/TCA/tx_nrllm_model.php';
+        // require_once is safe here: no other unit-suite test includes this
+        // TCA file, so the return value is always the configuration array.
+        $tca = require_once __DIR__ . '/../../../Configuration/TCA/tx_nrllm_model.php';
 
         self::assertIsArray($tca);
-        assert(isset($tca['columns']) && is_array($tca['columns']));
-        assert(isset($tca['columns']['capabilities']) && is_array($tca['columns']['capabilities']));
-        assert(isset($tca['columns']['capabilities']['config']) && is_array($tca['columns']['capabilities']['config']));
-        $items = $tca['columns']['capabilities']['config']['items'] ?? null;
+        $columns = $tca['columns'] ?? null;
+        self::assertIsArray($columns);
+        $capabilitiesColumn = $columns['capabilities'] ?? null;
+        self::assertIsArray($capabilitiesColumn);
+        $config = $capabilitiesColumn['config'] ?? null;
+        self::assertIsArray($config);
+        $items = $config['items'] ?? null;
         self::assertIsArray($items);
 
         $itemValues = [];
         foreach ($items as $item) {
             self::assertIsArray($item);
-            assert(isset($item['value']) && is_string($item['value']));
-            $itemValues[] = $item['value'];
+            $value = $item['value'] ?? null;
+            self::assertIsString($value);
+            $itemValues[] = $value;
         }
 
         $enumValues = ModelCapability::values();

--- a/Tests/Unit/Domain/Enum/ModelCapabilityTest.php
+++ b/Tests/Unit/Domain/Enum/ModelCapabilityTest.php
@@ -20,11 +20,11 @@ use PHPUnit\Framework\TestCase;
 final class ModelCapabilityTest extends TestCase
 {
     #[Test]
-    public function allEightCasesExist(): void
+    public function allElevenCasesExist(): void
     {
         $cases = ModelCapability::cases();
 
-        self::assertCount(8, $cases);
+        self::assertCount(11, $cases);
     }
 
     #[Test]
@@ -38,6 +38,9 @@ final class ModelCapabilityTest extends TestCase
         self::assertSame('tools', ModelCapability::TOOLS->value);
         self::assertSame('json_mode', ModelCapability::JSON_MODE->value);
         self::assertSame('audio', ModelCapability::AUDIO->value);
+        self::assertSame('image', ModelCapability::IMAGE->value);
+        self::assertSame('text_to_speech', ModelCapability::TEXT_TO_SPEECH->value);
+        self::assertSame('transcription', ModelCapability::TRANSCRIPTION->value);
     }
 
     #[Test]
@@ -45,7 +48,7 @@ final class ModelCapabilityTest extends TestCase
     {
         $values = ModelCapability::values();
 
-        self::assertCount(8, $values);
+        self::assertCount(11, $values);
         self::assertContains('chat', $values);
         self::assertContains('completion', $values);
         self::assertContains('embeddings', $values);
@@ -54,6 +57,9 @@ final class ModelCapabilityTest extends TestCase
         self::assertContains('tools', $values);
         self::assertContains('json_mode', $values);
         self::assertContains('audio', $values);
+        self::assertContains('image', $values);
+        self::assertContains('text_to_speech', $values);
+        self::assertContains('transcription', $values);
     }
 
     /**
@@ -70,6 +76,9 @@ final class ModelCapabilityTest extends TestCase
             'tools' => ['tools'],
             'json_mode' => ['json_mode'],
             'audio' => ['audio'],
+            'image' => ['image'],
+            'text_to_speech' => ['text_to_speech'],
+            'transcription' => ['transcription'],
         ];
     }
 
@@ -115,6 +124,9 @@ final class ModelCapabilityTest extends TestCase
             'tools' => ['tools', ModelCapability::TOOLS],
             'json_mode' => ['json_mode', ModelCapability::JSON_MODE],
             'audio' => ['audio', ModelCapability::AUDIO],
+            'image' => ['image', ModelCapability::IMAGE],
+            'text_to_speech' => ['text_to_speech', ModelCapability::TEXT_TO_SPEECH],
+            'transcription' => ['transcription', ModelCapability::TRANSCRIPTION],
         ];
     }
 

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -16,6 +19,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -484,10 +488,166 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         self::assertStringNotContainsString('orphan', $body);
     }
 
+    #[Test]
+    public function resolveDefaultModelForReturnsFallbackWithoutRepository(): void
+    {
+        // "No repository in context" is a legal state (e.g. a manually
+        // constructed service): the fallback must come back unchanged.
+        $subject = $this->createSubject();
+
+        self::assertSame('fallback-model', $subject->callResolveDefaultModelFor(ModelCapability::IMAGE, 'fallback-model'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelForPrefersDefaultFlaggedRecord(): void
+    {
+        // The default-flagged record wins even when a lower-sorting
+        // record precedes it in the result.
+        $lowerSorting = new Model();
+        $lowerSorting->setModelId('gpt-image-1');
+        $default = new Model();
+        $default->setModelId('gpt-image-2');
+        $default->setIsDefault(true);
+
+        $repository = $this->createMock(ModelRepository::class);
+        $repository->expects(self::once())
+            ->method('findByCapability')
+            ->with(ModelCapability::IMAGE->value)
+            ->willReturn(new InMemoryQueryResult([$lowerSorting, $default]));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame('gpt-image-2', $subject->callResolveDefaultModelFor(ModelCapability::IMAGE, 'dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelForFallsBackToLowestSortingRecordWithoutDefaultFlag(): void
+    {
+        // findByCapability() returns records ordered by sorting — the
+        // first usable one wins when no record is flagged as default.
+        $first = new Model();
+        $first->setModelId('tts-1-hd');
+        $second = new Model();
+        $second->setModelId('tts-1');
+
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$first, $second]));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame('tts-1-hd', $subject->callResolveDefaultModelFor(ModelCapability::TEXT_TO_SPEECH, 'tts-1'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelForSkipsRecordsWithoutModelId(): void
+    {
+        // A registry record without a model id cannot be sent to an
+        // upstream API — it must never be returned as the default.
+        $unusable = new Model();
+        $usable = new Model();
+        $usable->setModelId('whisper-1');
+
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$unusable, $usable]));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame('whisper-1', $subject->callResolveDefaultModelFor(ModelCapability::TRANSCRIPTION, 'fallback'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelForReturnsFallbackWhenNoRecordMatches(): void
+    {
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([]));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame('dall-e-3', $subject->callResolveDefaultModelFor(ModelCapability::IMAGE, 'dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelForReturnsFallbackWhenRepositoryThrows(): void
+    {
+        // Extbase persistence may be unavailable (early CLI bootstrap):
+        // resolution is fail-soft and must never throw.
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findByCapability')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame('dall-e-3', $subject->callResolveDefaultModelFor(ModelCapability::IMAGE, 'dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveModelUidReturnsUidOfMatchingRecord(): void
+    {
+        $record = new Model();
+        $record->setModelId('gpt-image-2');
+        $record->_setProperty('uid', 42);
+
+        $repository = $this->createMock(ModelRepository::class);
+        $repository->expects(self::once())
+            ->method('findOneByModelId')
+            ->with('gpt-image-2')
+            ->willReturn($record);
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame(42, $subject->callResolveModelUid('gpt-image-2'));
+    }
+
+    #[Test]
+    public function resolveModelUidReturnsZeroWithoutRepository(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame(0, $subject->callResolveModelUid('gpt-image-2'));
+    }
+
+    #[Test]
+    public function resolveModelUidReturnsZeroForEmptyModelIdWithoutQuerying(): void
+    {
+        $repository = $this->createMock(ModelRepository::class);
+        $repository->expects(self::never())->method('findOneByModelId');
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame(0, $subject->callResolveModelUid(''));
+    }
+
+    #[Test]
+    public function resolveModelUidReturnsZeroWhenNoRecordMatches(): void
+    {
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByModelId')->willReturn(null);
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame(0, $subject->callResolveModelUid('unknown-model'));
+    }
+
+    #[Test]
+    public function resolveModelUidReturnsZeroWhenRepositoryThrows(): void
+    {
+        $repository = self::createStub(ModelRepository::class);
+        $repository->method('findOneByModelId')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(modelRepository: $repository);
+
+        self::assertSame(0, $subject->callResolveModelUid('gpt-image-2'));
+    }
+
     private function createSubject(
         string $apiKeyIdentifier = 'test-key',
         string $baseUrl = 'https://api.example.test',
         ?ClientInterface $httpClient = null,
+        ?ModelRepository $modelRepository = null,
     ): TestableSpecializedService {
         $extConf = self::createStub(ExtensionConfiguration::class);
         $extConf->method('get')->willReturn(['apiKeyIdentifier' => $apiKeyIdentifier, 'baseUrl' => $baseUrl]);
@@ -500,6 +660,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             usageTracker: self::createStub(UsageTrackerServiceInterface::class),
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
+            modelRepository: $modelRepository,
         );
 
         // Inject the plain test client through the test seam; this bypasses the
@@ -578,6 +739,16 @@ final class TestableSpecializedService extends AbstractSpecializedService
     public function callEncodeMultipartBody(array $parts, string $boundary): string
     {
         return $this->encodeMultipartBody($parts, $boundary);
+    }
+
+    public function callResolveDefaultModelFor(ModelCapability $capability, string $fallback): string
+    {
+        return $this->resolveDefaultModelFor($capability, $fallback);
+    }
+
+    public function callResolveModelUid(string $modelId): int
+    {
+        return $this->resolveModelUid($modelId);
     }
 
     protected function getServiceDomain(): string

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -19,6 +20,7 @@ use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -81,6 +83,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
+        ?ModelRepository $modelRepository = null,
     ): DallEImageService {
         $service = new DallEImageService(
             $this->vaultStub,
@@ -90,6 +93,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
+            $modelRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -107,7 +111,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = []): DallEImageService
+    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): DallEImageService
     {
         $defaultConfig = [
             'providers' => [
@@ -129,6 +133,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
+            $modelRepository,
         );
     }
 
@@ -416,6 +421,96 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         );
 
         $subject->generate('A cat');
+    }
+
+    #[Test]
+    public function generateLinksUsageRowToRegistryRecordUid(): void
+    {
+        // When the used model id matches a tx_nrllm_model record, the
+        // usage row carries that record's uid so the Analytics model
+        // breakdowns link back to the registry.
+        $record = new Model();
+        $record->setModelId('dall-e-3');
+        $record->_setProperty('uid', 42);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findOneByModelId')->with('dall-e-3')->willReturn($record);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(static fn(array $metrics): bool => $metrics['images'] === 1),
+                null,
+                42,
+                'dall-e-3',
+            );
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+        $this->setupSuccessfulRequest([
+            'data' => [['url' => 'https://example.com/image.png']],
+        ]);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+            $modelRepository,
+        );
+
+        $subject->generate('A cat');
+    }
+
+    #[Test]
+    public function resolveDefaultModelPrefersDefaultFlaggedImageRecord(): void
+    {
+        $regular = new Model();
+        $regular->setModelId('gpt-image-1');
+        $default = new Model();
+        $default->setModelId('gpt-image-2');
+        $default->setIsDefault(true);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('image')
+            ->willReturn(new InMemoryQueryResult([$regular, $default]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('gpt-image-2', $subject->resolveDefaultModel('dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenNoImageRecordExists(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')->willReturn(new InMemoryQueryResult([]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('dall-e-3', $subject->resolveDefaultModel('dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenRepositoryThrows(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('dall-e-3', $subject->resolveDefaultModel('dall-e-3'));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -19,6 +20,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\SpeechSynthesisResult;
 use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -80,6 +82,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
+        ?ModelRepository $modelRepository = null,
     ): TextToSpeechService {
         $service = new TextToSpeechService(
             $this->vaultStub,
@@ -89,6 +92,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
+            $modelRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -98,7 +102,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = []): TextToSpeechService
+    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): TextToSpeechService
     {
         $defaultConfig = [
             'providers' => [
@@ -120,6 +124,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
+            $modelRepository,
         );
     }
 
@@ -359,6 +364,94 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         );
 
         $subject->synthesize('Test text');
+    }
+
+    #[Test]
+    public function synthesizeLinksUsageRowToRegistryRecordUid(): void
+    {
+        // When the used model id matches a tx_nrllm_model record, the
+        // usage row carries that record's uid so the Analytics model
+        // breakdowns link back to the registry.
+        $record = new Model();
+        $record->setModelId('tts-1');
+        $record->_setProperty('uid', 7);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findOneByModelId')->with('tts-1')->willReturn($record);
+
+        $this->setupSuccessfulRequest();
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'tts',
+                self::callback(static fn(array $metrics): bool => $metrics['characters'] === 9),
+                null,
+                7,
+                'tts-1',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+            $modelRepository,
+        );
+
+        $subject->synthesize('Test text');
+    }
+
+    #[Test]
+    public function resolveDefaultModelPrefersDefaultFlaggedTextToSpeechRecord(): void
+    {
+        $regular = new Model();
+        $regular->setModelId('tts-1');
+        $default = new Model();
+        $default->setModelId('tts-1-hd');
+        $default->setIsDefault(true);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('text_to_speech')
+            ->willReturn(new InMemoryQueryResult([$regular, $default]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('tts-1-hd', $subject->resolveDefaultModel('tts-1'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenNoTextToSpeechRecordExists(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')->willReturn(new InMemoryQueryResult([]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('tts-1', $subject->resolveDefaultModel('tts-1'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenRepositoryThrows(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('tts-1', $subject->resolveDefaultModel('tts-1'));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -20,6 +21,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\TranscriptionResult;
 use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -92,6 +94,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
+        ?ModelRepository $modelRepository = null,
     ): WhisperTranscriptionService {
         $service = new WhisperTranscriptionService(
             $this->vaultStub,
@@ -101,6 +104,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
+            $modelRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -118,7 +122,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = []): WhisperTranscriptionService
+    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): WhisperTranscriptionService
     {
         $defaultConfig = [
             'providers' => [
@@ -140,6 +144,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
+            $modelRepository,
         );
     }
 
@@ -296,6 +301,51 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         self::assertContains('srt', $formats);
         self::assertContains('vtt', $formats);
         self::assertContains('verbose_json', $formats);
+    }
+
+    // ==================== resolveDefaultModel tests ====================
+
+    #[Test]
+    public function resolveDefaultModelPrefersDefaultFlaggedTranscriptionRecord(): void
+    {
+        $regular = new Model();
+        $regular->setModelId('whisper-1');
+        $default = new Model();
+        $default->setModelId('gpt-4o-transcribe');
+        $default->setIsDefault(true);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('transcription')
+            ->willReturn(new InMemoryQueryResult([$regular, $default]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('gpt-4o-transcribe', $subject->resolveDefaultModel('whisper-1'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenNoTranscriptionRecordExists(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')->willReturn(new InMemoryQueryResult([]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('whisper-1', $subject->resolveDefaultModel('whisper-1'));
+    }
+
+    #[Test]
+    public function resolveDefaultModelReturnsFallbackWhenRepositoryThrows(): void
+    {
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('whisper-1', $subject->resolveDefaultModel('whisper-1'));
     }
 
     // ==================== transcribe tests ====================

--- a/Tests/Unit/Support/InMemoryQueryResult.php
+++ b/Tests/Unit/Support/InMemoryQueryResult.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Support;
+
+use ArrayIterator;
+use LogicException;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Array-backed QueryResultInterface double for unit tests.
+ *
+ * Lets a mocked repository hand back a fixed, already-ordered list of
+ * domain objects without touching Extbase persistence. Iteration is
+ * delegated to an ArrayIterator; query access and mutation are not
+ * supported — unit tests assert on the consumed objects, not on the
+ * query that produced them.
+ *
+ * @template T of object
+ *
+ * @implements QueryResultInterface<int, T>
+ */
+final readonly class InMemoryQueryResult implements QueryResultInterface
+{
+    /** @var ArrayIterator<int, T> */
+    private ArrayIterator $iterator;
+
+    /**
+     * @param list<T> $items already in the order the simulated query would return
+     */
+    public function __construct(private array $items)
+    {
+        $this->iterator = new ArrayIterator($items);
+    }
+
+    public function setQuery(QueryInterface $query): void
+    {
+        throw new LogicException('InMemoryQueryResult carries no query', 4039312101);
+    }
+
+    public function getQuery(): QueryInterface
+    {
+        throw new LogicException('InMemoryQueryResult carries no query', 4039312102);
+    }
+
+    public function getFirst(): ?object
+    {
+        return $this->items[0] ?? null;
+    }
+
+    /**
+     * @return list<T>
+     */
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    public function current(): mixed
+    {
+        return $this->iterator->current();
+    }
+
+    public function key(): mixed
+    {
+        return $this->iterator->key();
+    }
+
+    public function next(): void
+    {
+        $this->iterator->next();
+    }
+
+    public function rewind(): void
+    {
+        $this->iterator->rewind();
+    }
+
+    public function valid(): bool
+    {
+        return $this->iterator->valid();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return is_int($offset) && isset($this->items[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return is_int($offset) ? ($this->items[$offset] ?? null) : null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new LogicException('InMemoryQueryResult is immutable', 4039312103);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new LogicException('InMemoryQueryResult is immutable', 4039312104);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -67,6 +67,9 @@ defined('TYPO3') or die();
         ModelCapability::TOOLS->value => 'actions-wrench',
         ModelCapability::JSON_MODE->value => 'mimetypes-text-js',
         ModelCapability::AUDIO->value => 'mimetypes-media-audio',
+        ModelCapability::IMAGE->value => 'mimetypes-media-image',
+        ModelCapability::TEXT_TO_SPEECH->value => 'mimetypes-media-audio',
+        ModelCapability::TRANSCRIPTION->value => 'mimetypes-text-text',
     ];
     $capabilityItems = [];
     foreach (ModelCapability::cases() as $capability) {


### PR DESCRIPTION
## Summary

Image-generation, TTS and transcription models become first-class citizens of the model registry: new `ModelCapability` cases `image` / `text_to_speech` / `transcription` (TCA select, icons, JS labels, EN+DE), and the specialized services resolve their default model from active `tx_nrllm_model` records carrying the matching capability via `resolveDefaultModel(string $fallback): string` — preferring the default-flagged record, then lowest sorting; fail-soft to the caller's fallback, never throwing. Usage rows now also link `model_uid` (resolved fail-soft by model id) so the Analytics per-model breakdowns aggregate by registry record. ADR-033 documents the design.

Consumer side (netresearch/t3x-nr-repurpose#17, merged) already resolves its image/TTS models through this seam.

## Test plan

- `Build/Scripts/runTests.sh -p 8.4 -s unit` — green (new coverage: resolution preference/fallback/throwing-repository, capability registration, modelUid pass-through)
- `-s cgl -n` / `-s phpstan` — green
- functional: not run in CI (`run-functional-tests` defaults to false in the reusable workflow — worth a follow-up issue). Local baseline comparison completed: the failing-test set is **byte-identical** between `origin/main` (63e41b8) and this branch (237 distinct failures, 188 E / 49 F of 856, stale reflection-based controller tests and E2E-backend tests; none in Specialized/UsageTracker areas) — zero functional regressions from this PR.
