### PR TITLE
feat: configuration-based resolution for specialized services

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -155,7 +155,7 @@ Options:
         Database version (mariadb: 11.4, mysql: 8.4, postgres: 16)
 
     -p <8.2|8.3|8.4|8.5>
-        PHP version (default: 8.2)
+        PHP version (default: 8.5)
 
     -t <13|13.4|14|^13.4|...>
         TYPO3 core version to require before running the suite.
@@ -206,7 +206,7 @@ TEST_SUITE="unit"
 DATABASE_DRIVER=""
 DBMS="sqlite"
 DBMS_VERSION=""
-PHP_VERSION="8.2"
+PHP_VERSION="8.5"
 # TYPO3 core version constraint. Empty = use what's already installed
 # (whatever composer.json / composer.lock resolves to). Set via -t to
 # require a specific major, e.g. `-t 13.4` runs the suite against

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -88,6 +90,7 @@ abstract class AbstractSpecializedService
         protected readonly LoggerInterface $logger,
         protected readonly SpecializedCostCalculatorInterface $costCalculator,
         protected readonly ?ModelRepository $modelRepository = null,
+        protected readonly ?LlmConfigurationRepository $configurationRepository = null,
     ) {
         $this->timeout = $this->getDefaultTimeout();
         $this->loadConfiguration();
@@ -349,6 +352,104 @@ abstract class AbstractSpecializedService
         } catch (Throwable) {
             return 0;
         }
+    }
+
+    /**
+     * Resolve the model id to use for a named LlmConfiguration record
+     * (tx_nrllm_configuration). The configuration is the stable
+     * indirection layer consumers reference by identifier: an
+     * administrator swaps the model on the record and every consumer
+     * picks it up without re-configuring anything on their side.
+     *
+     * Resolution order:
+     *  1. the ACTIVE configuration's ACTIVE model record's model id —
+     *     records with an empty model id are skipped (they cannot be
+     *     sent to an upstream API),
+     *  2. the capability-based registry default
+     *     (`resolveDefaultModelFor()` semantics),
+     *  3. the given hardcoded fallback.
+     *
+     * Fail-soft like every resolver here: no repository in context, a
+     * persistence failure, or an unknown/inactive identifier moves
+     * resolution down the chain — this method never throws.
+     */
+    protected function resolveConfiguredModelFor(
+        ModelCapability $capability,
+        string $configurationIdentifier,
+        string $fallback,
+    ): string {
+        try {
+            $model = $this->findActiveConfiguration($configurationIdentifier)?->getLlmModel();
+            if ($model !== null && $model->isActive() && $model->getModelId() !== '') {
+                return $model->getModelId();
+            }
+        } catch (Throwable) {
+            // Extbase persistence may be unavailable in edge contexts
+            // (early CLI bootstrap); fall through to the capability-based
+            // default so the service call never breaks on resolution.
+        }
+
+        return $this->resolveDefaultModelFor($capability, $fallback);
+    }
+
+    /**
+     * System prompt of an ACTIVE LlmConfiguration record; the empty
+     * string when the identifier is unknown or inactive, the prompt is
+     * unset, no repository is in context, or the lookup fails — never
+     * throws. Consumers weave the prompt into their own requests; the
+     * extension never injects it implicitly, so the consumer always
+     * records the exact prompt it sent (transparency requirement).
+     */
+    public function getConfigurationSystemPrompt(string $configurationIdentifier): string
+    {
+        try {
+            return $this->findActiveConfiguration($configurationIdentifier)?->getSystemPrompt() ?? '';
+        } catch (Throwable) {
+            return '';
+        }
+    }
+
+    /**
+     * Resolve the tx_nrllm_configuration uid for an identifier so usage
+     * rows link to the configuration record and the Analytics module can
+     * aggregate spend per configuration. Fail-soft: null (no linked
+     * record) when no identifier was given, no repository is in context,
+     * the identifier is unknown/inactive, or the lookup fails — usage
+     * tracking must never break the service call.
+     */
+    protected function resolveConfigurationUid(?string $configurationIdentifier): ?int
+    {
+        if ($configurationIdentifier === null) {
+            return null;
+        }
+
+        try {
+            return $this->findActiveConfiguration($configurationIdentifier)?->getUid();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Fetch an ACTIVE configuration record by identifier. Returns null
+     * when no repository is in context, the identifier is empty or
+     * unknown, or the record is inactive — an inactive configuration is
+     * treated as nonexistent across the whole resolution layer.
+     * Persistence failures bubble up; callers wrap this in their own
+     * fail-soft handling.
+     */
+    private function findActiveConfiguration(string $identifier): ?LlmConfiguration
+    {
+        if ($this->configurationRepository === null || $identifier === '') {
+            return null;
+        }
+
+        $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
+        if ($configuration === null || !$configuration->isActive()) {
+            return null;
+        }
+
+        return $configuration;
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -374,7 +374,7 @@ abstract class AbstractSpecializedService
      * resolution down the chain — this method never throws.
      */
     protected function resolveConfiguredModelFor(
-        ModelCapability $capability,
+        ?ModelCapability $capability,
         string $configurationIdentifier,
         string $fallback,
     ): string {
@@ -389,7 +389,48 @@ abstract class AbstractSpecializedService
             // default so the service call never breaks on resolution.
         }
 
-        return $this->resolveDefaultModelFor($capability, $fallback);
+        return $capability === null ? $fallback : $this->resolveDefaultModelFor($capability, $fallback);
+    }
+
+    /**
+     * The model-registry capability this service's models carry, or null for
+     * services without registry-managed models (DeepL): the public resolvers
+     * below then skip the capability-based registry default.
+     */
+    protected function getModelCapability(): ?ModelCapability
+    {
+        return null;
+    }
+
+    /**
+     * Resolve the admin-preferred default model from the model registry: the
+     * ACTIVE tx_nrllm_model record carrying this service's capability,
+     * preferring the record flagged as default, then the lowest sorting.
+     * Fail-soft: any error, no repository in context, or no usable record
+     * returns the given fallback unchanged — this method never throws.
+     */
+    public function resolveDefaultModel(string $fallback): string
+    {
+        $capability = $this->getModelCapability();
+
+        return $capability === null ? $fallback : $this->resolveDefaultModelFor($capability, $fallback);
+    }
+
+    /**
+     * Resolve the model for a named LlmConfiguration record — the stable
+     * indirection layer consumers reference by identifier: an administrator
+     * swaps the assigned model on the record and every consumer picks it up
+     * without re-configuring anything. Resolution order: the ACTIVE
+     * configuration's ACTIVE model record's model id → the capability-based
+     * registry default → the given fallback. Fail-soft — never throws.
+     *
+     * Resolve the model BEFORE constructing the call options: image options
+     * validate the size against the concrete model value, so the model must
+     * be known at construction time.
+     */
+    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
+    {
+        return $this->resolveConfiguredModelFor($this->getModelCapability(), $configurationIdentifier, $fallback);
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -316,6 +316,12 @@ abstract class AbstractSpecializedService
                 if (!$candidate instanceof Model || $candidate->getModelId() === '') {
                     continue;
                 }
+                // The capability query is provider-agnostic, but model-id vocabularies
+                // are not (gpt-image-* vs flux-*): skip records this service cannot
+                // speak, so e.g. an OpenAI default never reaches the FAL endpoint.
+                if (!$this->acceptsModelId($candidate->getModelId())) {
+                    continue;
+                }
                 if ($candidate->isDefault()) {
                     $chosen = $candidate;
                     break;
@@ -380,7 +386,9 @@ abstract class AbstractSpecializedService
     ): string {
         try {
             $model = $this->findActiveConfiguration($configurationIdentifier)?->getLlmModel();
-            if ($model !== null && $model->isActive() && $model->getModelId() !== '') {
+            if ($model !== null && $model->isActive() && $model->getModelId() !== ''
+                && $this->acceptsModelId($model->getModelId())
+            ) {
                 return $model->getModelId();
             }
         } catch (Throwable) {
@@ -400,6 +408,17 @@ abstract class AbstractSpecializedService
     protected function getModelCapability(): ?ModelCapability
     {
         return null;
+    }
+
+    /**
+     * Whether this service can speak the given model id. The capability-based
+     * registry resolution is provider-agnostic while model-id vocabularies are
+     * not — services sharing a capability (OpenAI images vs FAL) override this
+     * to skip registry records they cannot send to their upstream API.
+     */
+    protected function acceptsModelId(string $modelId): bool
+    {
+        return true;
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -107,7 +107,7 @@ final class DallEImageService extends AbstractSpecializedService
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        $this->trackImageUsage($model, $size, $quality, 1, $response);
+        $this->trackImageUsage($model, $size, $quality, 1, $response, $options->configuration);
 
         return new ImageGenerationResult(
             url: $data['url'] ?? '',
@@ -191,7 +191,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $this->trackImageUsage($model, $size, $quality, count($results), $response);
+        $this->trackImageUsage($model, $size, $quality, count($results), $response, $options->configuration);
 
         return $results;
     }
@@ -331,6 +331,27 @@ final class DallEImageService extends AbstractSpecializedService
         return $this->resolveDefaultModelFor(ModelCapability::IMAGE, $fallback);
     }
 
+    /**
+     * Resolve the image model for a named LlmConfiguration record.
+     *
+     * The configuration (tx_nrllm_configuration) is the stable
+     * indirection layer consumers reference by identifier: an
+     * administrator swaps the assigned model on the record and every
+     * consumer picks it up without re-configuring anything. Resolution
+     * order: the ACTIVE configuration's ACTIVE model record's model id
+     * (records with an empty model id are skipped) → the
+     * capability-based registry default (`resolveDefaultModel()`
+     * semantics) → the given fallback. Fail-soft — never throws.
+     *
+     * Resolve the model BEFORE constructing `ImageGenerationOptions`:
+     * the options validate `size` against the concrete model value, so
+     * the model must be known at construction time.
+     */
+    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
+    {
+        return $this->resolveConfiguredModelFor(ModelCapability::IMAGE, $configurationIdentifier, $fallback);
+    }
+
     protected function getServiceDomain(): string
     {
         return 'image';
@@ -401,6 +422,10 @@ final class DallEImageService extends AbstractSpecializedService
      * dall-e-2/3 responses carry no `usage` object — token metrics are
      * omitted then and the cost falls back to the per-image catalog.
      *
+     * When the options carried an LlmConfiguration identifier, the usage
+     * row additionally links to that configuration record (resolved
+     * fail-soft) so Analytics can aggregate spend per configuration.
+     *
      * @param array<string, mixed> $response decoded API response
      */
     private function trackImageUsage(
@@ -409,6 +434,7 @@ final class DallEImageService extends AbstractSpecializedService
         string $quality,
         int $imageCount,
         array $response,
+        ?string $configuration = null,
     ): void {
         // gpt-image-* responses include a `usage` token object;
         // dall-e-2/3 never send one — token metrics are omitted then
@@ -447,6 +473,7 @@ final class DallEImageService extends AbstractSpecializedService
             'image',
             $this->getServiceProvider(),
             $metrics,
+            configurationUid: $this->resolveConfigurationUid($configuration),
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
         );

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -316,40 +316,9 @@ final class DallEImageService extends AbstractSpecializedService
         return self::MODEL_CAPABILITIES[$this->capabilityKey($model)]['sizes'] ?? ['1024x1024'];
     }
 
-    /**
-     * Resolve the default image-generation model from the model registry.
-     *
-     * Queries ACTIVE tx_nrllm_model records carrying the `image`
-     * capability (provider-agnostic), prefers the record flagged as
-     * default, then the lowest sorting, and returns that record's
-     * model id. Fail-soft: any error, no repository in context, or no
-     * matching record returns the given fallback unchanged — this
-     * method never throws.
-     */
-    public function resolveDefaultModel(string $fallback): string
+    protected function getModelCapability(): ModelCapability
     {
-        return $this->resolveDefaultModelFor(ModelCapability::IMAGE, $fallback);
-    }
-
-    /**
-     * Resolve the image model for a named LlmConfiguration record.
-     *
-     * The configuration (tx_nrllm_configuration) is the stable
-     * indirection layer consumers reference by identifier: an
-     * administrator swaps the assigned model on the record and every
-     * consumer picks it up without re-configuring anything. Resolution
-     * order: the ACTIVE configuration's ACTIVE model record's model id
-     * (records with an empty model id are skipped) → the
-     * capability-based registry default (`resolveDefaultModel()`
-     * semantics) → the given fallback. Fail-soft — never throws.
-     *
-     * Resolve the model BEFORE constructing `ImageGenerationOptions`:
-     * the options validate `size` against the concrete model value, so
-     * the model must be known at construction time.
-     */
-    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
-    {
-        return $this->resolveConfiguredModelFor(ModelCapability::IMAGE, $configurationIdentifier, $fallback);
+        return ModelCapability::IMAGE;
     }
 
     protected function getServiceDomain(): string

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -316,6 +316,16 @@ final class DallEImageService extends AbstractSpecializedService
         return self::MODEL_CAPABILITIES[$this->capabilityKey($model)]['sizes'] ?? ['1024x1024'];
     }
 
+    /**
+     * OpenAI image vocabulary: the DALL·E models plus the gpt-image-* family
+     * (mirrors ImageGenerationOptions::validateModel()).
+     */
+    protected function acceptsModelId(string $modelId): bool
+    {
+        return \in_array($modelId, ['dall-e-2', 'dall-e-3'], true)
+            || str_starts_with($modelId, 'gpt-image-');
+    }
+
     protected function getModelCapability(): ModelCapability
     {
         return ModelCapability::IMAGE;

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -227,11 +227,6 @@ final class FalImageService extends AbstractSpecializedService
     }
 
     /**
-     * FAL generates images, so the registry's image models steer it too —
-     * the inherited resolveDefaultModel()/resolveModelForConfiguration()
-     * resolve exactly like the OpenAI image service's.
-     */
-    /**
      * FAL vocabulary: only the model keys this service can map to fal-ai
      * endpoints (see self::MODELS) — an OpenAI image id from the shared
      * IMAGE-capability registry default must never reach the FAL endpoint.
@@ -241,6 +236,11 @@ final class FalImageService extends AbstractSpecializedService
         return \array_key_exists($modelId, self::MODELS);
     }
 
+    /**
+     * FAL generates images, so the registry's image models steer it too —
+     * the inherited resolveDefaultModel()/resolveModelForConfiguration()
+     * resolve like the OpenAI image service's, restricted by acceptsModelId().
+     */
     protected function getModelCapability(): ModelCapability
     {
         return ModelCapability::IMAGE;

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -231,6 +231,16 @@ final class FalImageService extends AbstractSpecializedService
      * the inherited resolveDefaultModel()/resolveModelForConfiguration()
      * resolve exactly like the OpenAI image service's.
      */
+    /**
+     * FAL vocabulary: only the model keys this service can map to fal-ai
+     * endpoints (see self::MODELS) — an OpenAI image id from the shared
+     * IMAGE-capability registry default must never reach the FAL endpoint.
+     */
+    protected function acceptsModelId(string $modelId): bool
+    {
+        return \array_key_exists($modelId, self::MODELS);
+    }
+
     protected function getModelCapability(): ModelCapability
     {
         return ModelCapability::IMAGE;

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -223,6 +224,16 @@ final class FalImageService extends AbstractSpecializedService
     public function getAspectRatios(): array
     {
         return self::ASPECT_RATIOS;
+    }
+
+    /**
+     * FAL generates images, so the registry's image models steer it too —
+     * the inherited resolveDefaultModel()/resolveModelForConfiguration()
+     * resolve exactly like the OpenAI image service's.
+     */
+    protected function getModelCapability(): ModelCapability
+    {
+        return ModelCapability::IMAGE;
     }
 
     protected function getServiceDomain(): string

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -39,12 +39,27 @@ final class ImageGenerationOptions extends AbstractOptions
     private const GPT_IMAGE_MAX_HEIGHT = 2160;
     private const GPT_IMAGE_MAX_ASPECT = 3;
 
+    /**
+     * @param string|null $configuration Optional LlmConfiguration identifier
+     *                                   (tx_nrllm_configuration) this call is
+     *                                   attributed to — pure usage metadata for
+     *                                   the per-configuration Analytics
+     *                                   breakdowns. It does NOT influence model
+     *                                   or size validation: the consumer
+     *                                   resolves the model via
+     *                                   `DallEImageService::resolveModelForConfiguration()`
+     *                                   BEFORE constructing the options,
+     *                                   because `size` is validated against
+     *                                   the concrete model value right here at
+     *                                   construction time.
+     */
     public function __construct(
         public readonly ?string $model = 'dall-e-3',
         public readonly ?string $size = '1024x1024',
         public readonly ?string $quality = 'standard',
         public readonly ?string $style = 'vivid',
         public readonly ?string $format = 'url',
+        public readonly ?string $configuration = null,
     ) {
         if ($this->model !== null) {
             $this->validateModel($this->model);
@@ -182,6 +197,8 @@ final class ImageGenerationOptions extends AbstractOptions
 
     public function toArray(): array
     {
+        // `configuration` is deliberately absent: it is consumer metadata
+        // for usage attribution, not an Images API parameter.
         return $this->filterNull([
             'model' => $this->model,
             'size' => $this->size,
@@ -201,6 +218,7 @@ final class ImageGenerationOptions extends AbstractOptions
         $quality = $options['quality'] ?? null;
         $style = $options['style'] ?? null;
         $format = $options['format'] ?? $options['response_format'] ?? null;
+        $configuration = $options['configuration'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
@@ -208,6 +226,7 @@ final class ImageGenerationOptions extends AbstractOptions
             quality: is_string($quality) ? $quality : null,
             style: is_string($style) ? $style : null,
             format: is_string($format) ? $format : null,
+            configuration: is_string($configuration) ? $configuration : null,
         );
     }
 

--- a/Classes/Specialized/Option/SpeechSynthesisOptions.php
+++ b/Classes/Specialized/Option/SpeechSynthesisOptions.php
@@ -20,11 +20,22 @@ final class SpeechSynthesisOptions extends AbstractOptions
     private const VALID_MODELS = ['tts-1', 'tts-1-hd'];
     private const VALID_FORMATS = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];
 
+    /**
+     * @param string|null $configuration Optional LlmConfiguration identifier
+     *                                   (tx_nrllm_configuration) this call is
+     *                                   attributed to — pure usage metadata for
+     *                                   the per-configuration Analytics
+     *                                   breakdowns. It does NOT change the
+     *                                   model: the consumer resolves the model
+     *                                   via `TextToSpeechService::resolveModelForConfiguration()`
+     *                                   BEFORE constructing the options.
+     */
     public function __construct(
         public readonly ?string $model = 'tts-1',
         public readonly ?string $voice = 'alloy',
         public readonly ?string $format = 'mp3',
         public readonly ?float $speed = 1.0,
+        public readonly ?string $configuration = null,
     ) {
         if ($this->model !== null) {
             self::validateEnum($this->model, self::VALID_MODELS, 'model');
@@ -42,6 +53,8 @@ final class SpeechSynthesisOptions extends AbstractOptions
 
     public function toArray(): array
     {
+        // `configuration` is deliberately absent: it is consumer metadata
+        // for usage attribution, not a TTS API parameter.
         return $this->filterNull([
             'model' => $this->model,
             'voice' => $this->voice,
@@ -59,12 +72,14 @@ final class SpeechSynthesisOptions extends AbstractOptions
         $voice = $options['voice'] ?? null;
         $format = $options['format'] ?? $options['response_format'] ?? null;
         $speed = $options['speed'] ?? null;
+        $configuration = $options['configuration'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
             voice: is_string($voice) ? $voice : null,
             format: is_string($format) ? $format : null,
             speed: is_float($speed) || is_int($speed) ? (float)$speed : null,
+            configuration: is_string($configuration) ? $configuration : null,
         );
     }
 

--- a/Classes/Specialized/Option/TranscriptionOptions.php
+++ b/Classes/Specialized/Option/TranscriptionOptions.php
@@ -18,12 +18,23 @@ final class TranscriptionOptions extends AbstractOptions
 {
     private const VALID_FORMATS = ['json', 'text', 'srt', 'vtt', 'verbose_json'];
 
+    /**
+     * @param string|null $configuration Optional LlmConfiguration identifier
+     *                                   (tx_nrllm_configuration) this call is
+     *                                   attributed to — pure usage metadata for
+     *                                   the per-configuration Analytics
+     *                                   breakdowns. It does NOT change the
+     *                                   model: the consumer resolves the model
+     *                                   via `WhisperTranscriptionService::resolveModelForConfiguration()`
+     *                                   BEFORE constructing the options.
+     */
     public function __construct(
         public readonly ?string $model = 'whisper-1',
         public readonly ?string $language = null,
         public readonly ?string $format = 'json',
         public readonly ?string $prompt = null,
         public readonly ?float $temperature = null,
+        public readonly ?string $configuration = null,
     ) {
         if ($this->format !== null) {
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
@@ -35,6 +46,8 @@ final class TranscriptionOptions extends AbstractOptions
 
     public function toArray(): array
     {
+        // `configuration` is deliberately absent: it is consumer metadata
+        // for usage attribution, not a transcription API parameter.
         return $this->filterNull([
             'model' => $this->model,
             'language' => $this->language,
@@ -54,6 +67,7 @@ final class TranscriptionOptions extends AbstractOptions
         $format = $options['format'] ?? $options['response_format'] ?? null;
         $prompt = $options['prompt'] ?? null;
         $temperature = $options['temperature'] ?? null;
+        $configuration = $options['configuration'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
@@ -61,6 +75,7 @@ final class TranscriptionOptions extends AbstractOptions
             format: is_string($format) ? $format : null,
             prompt: is_string($prompt) ? $prompt : null,
             temperature: is_float($temperature) || is_int($temperature) ? (float)$temperature : null,
+            configuration: is_string($configuration) ? $configuration : null,
         );
     }
 

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -229,6 +229,15 @@ final class TextToSpeechService extends AbstractSpecializedService
         return self::MAX_INPUT_LENGTH;
     }
 
+    /**
+     * OpenAI TTS vocabulary: the tts-* models plus *-tts members of newer
+     * families (gpt-4o-mini-tts, ...).
+     */
+    protected function acceptsModelId(string $modelId): bool
+    {
+        return str_starts_with($modelId, 'tts-') || str_ends_with($modelId, '-tts');
+    }
+
     protected function getModelCapability(): ModelCapability
     {
         return ModelCapability::TEXT_TO_SPEECH;

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -108,7 +108,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         $this->usageTracker->trackUsage('speech', $this->getServiceProvider(), [
             'characters' => $characterCount,
             'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
-        ], modelUid: $this->resolveModelUid($model), modelId: $model);
+        ], configurationUid: $this->resolveConfigurationUid($options->configuration), modelUid: $this->resolveModelUid($model), modelId: $model);
 
         return new SpeechSynthesisResult(
             audioContent: $audioContent,
@@ -235,6 +235,24 @@ final class TextToSpeechService extends AbstractSpecializedService
     public function resolveDefaultModel(string $fallback): string
     {
         return $this->resolveDefaultModelFor(ModelCapability::TEXT_TO_SPEECH, $fallback);
+    }
+
+    /**
+     * Resolve the speech-synthesis model for a named LlmConfiguration
+     * record.
+     *
+     * The configuration (tx_nrllm_configuration) is the stable
+     * indirection layer consumers reference by identifier: an
+     * administrator swaps the assigned model on the record and every
+     * consumer picks it up without re-configuring anything. Resolution
+     * order: the ACTIVE configuration's ACTIVE model record's model id
+     * (records with an empty model id are skipped) → the
+     * capability-based registry default (`resolveDefaultModel()`
+     * semantics) → the given fallback. Fail-soft — never throws.
+     */
+    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
+    {
+        return $this->resolveConfiguredModelFor(ModelCapability::TEXT_TO_SPEECH, $configurationIdentifier, $fallback);
     }
 
     protected function getServiceDomain(): string

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -222,37 +222,9 @@ final class TextToSpeechService extends AbstractSpecializedService
         return self::MAX_INPUT_LENGTH;
     }
 
-    /**
-     * Resolve the default speech-synthesis model from the model registry.
-     *
-     * Queries ACTIVE tx_nrllm_model records carrying the
-     * `text_to_speech` capability (provider-agnostic), prefers the
-     * record flagged as default, then the lowest sorting, and returns
-     * that record's model id. Fail-soft: any error, no repository in
-     * context, or no matching record returns the given fallback
-     * unchanged — this method never throws.
-     */
-    public function resolveDefaultModel(string $fallback): string
+    protected function getModelCapability(): ModelCapability
     {
-        return $this->resolveDefaultModelFor(ModelCapability::TEXT_TO_SPEECH, $fallback);
-    }
-
-    /**
-     * Resolve the speech-synthesis model for a named LlmConfiguration
-     * record.
-     *
-     * The configuration (tx_nrllm_configuration) is the stable
-     * indirection layer consumers reference by identifier: an
-     * administrator swaps the assigned model on the record and every
-     * consumer picks it up without re-configuring anything. Resolution
-     * order: the ACTIVE configuration's ACTIVE model record's model id
-     * (records with an empty model id are skipped) → the
-     * capability-based registry default (`resolveDefaultModel()`
-     * semantics) → the given fallback. Fail-soft — never throws.
-     */
-    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
-    {
-        return $this->resolveConfiguredModelFor(ModelCapability::TEXT_TO_SPEECH, $configurationIdentifier, $fallback);
+        return ModelCapability::TEXT_TO_SPEECH;
     }
 
     protected function getServiceDomain(): string

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -105,10 +105,17 @@ final class TextToSpeechService extends AbstractSpecializedService
         $audioContent = $this->sendBinaryRequest($payload);
 
         $characterCount = mb_strlen($text);
-        $this->usageTracker->trackUsage('speech', $this->getServiceProvider(), [
-            'characters' => $characterCount,
-            'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
-        ], configurationUid: $this->resolveConfigurationUid($options->configuration), modelUid: $this->resolveModelUid($model), modelId: $model);
+        $this->usageTracker->trackUsage(
+            'speech',
+            $this->getServiceProvider(),
+            [
+                'characters' => $characterCount,
+                'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
+            ],
+            configurationUid: $this->resolveConfigurationUid($options->configuration),
+            modelUid: $this->resolveModelUid($model),
+            modelId: $model,
+        );
 
         return new SpeechSynthesisResult(
             audioContent: $audioContent,

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -186,6 +186,24 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         return $this->resolveDefaultModelFor(ModelCapability::TRANSCRIPTION, $fallback);
     }
 
+    /**
+     * Resolve the transcription model for a named LlmConfiguration
+     * record.
+     *
+     * The configuration (tx_nrllm_configuration) is the stable
+     * indirection layer consumers reference by identifier: an
+     * administrator swaps the assigned model on the record and every
+     * consumer picks it up without re-configuring anything. Resolution
+     * order: the ACTIVE configuration's ACTIVE model record's model id
+     * (records with an empty model id are skipped) → the
+     * capability-based registry default (`resolveDefaultModel()`
+     * semantics) → the given fallback. Fail-soft — never throws.
+     */
+    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
+    {
+        return $this->resolveConfiguredModelFor(ModelCapability::TRANSCRIPTION, $configurationIdentifier, $fallback);
+    }
+
     protected function getServiceDomain(): string
     {
         return 'speech';
@@ -396,7 +414,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                     // Raw-string formats expose no duration — record the
                     // request without audio seconds (cost stays 0 rather
                     // than guessed).
-                    $this->trackTranscriptionUsage($model, null);
+                    $this->trackTranscriptionUsage($model, null, $options->configuration);
                     return $responseBody;
                 }
 
@@ -408,7 +426,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                 $duration = isset($decoded['duration']) && is_numeric($decoded['duration'])
                     ? (float)$decoded['duration']
                     : null;
-                $this->trackTranscriptionUsage($model, $duration);
+                $this->trackTranscriptionUsage($model, $duration, $options->configuration);
 
                 return $decoded;
             }
@@ -441,9 +459,12 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     /**
      * Record a transcription/translation request with real units: the
      * audio duration (when the response format exposes it), an estimated
-     * cost, and the model identifier.
+     * cost, and the model identifier. When the options carried an
+     * LlmConfiguration identifier, the usage row additionally links to
+     * that configuration record (resolved fail-soft) so Analytics can
+     * aggregate spend per configuration.
      */
-    private function trackTranscriptionUsage(string $model, ?float $duration): void
+    private function trackTranscriptionUsage(string $model, ?float $duration, ?string $configuration): void
     {
         $metrics = [];
         if ($duration !== null && $duration > 0.0) {
@@ -457,6 +478,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             'speech',
             $this->getServiceProvider(),
             $metrics,
+            configurationUid: $this->resolveConfigurationUid($configuration),
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
         );

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -171,6 +171,15 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         return self::RESPONSE_FORMATS;
     }
 
+    /**
+     * OpenAI transcription vocabulary: whisper-* plus *-transcribe members
+     * of newer families (gpt-4o-transcribe, ...).
+     */
+    protected function acceptsModelId(string $modelId): bool
+    {
+        return str_starts_with($modelId, 'whisper-') || str_ends_with($modelId, '-transcribe');
+    }
+
     protected function getModelCapability(): ModelCapability
     {
         return ModelCapability::TRANSCRIPTION;

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -171,37 +171,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         return self::RESPONSE_FORMATS;
     }
 
-    /**
-     * Resolve the default transcription model from the model registry.
-     *
-     * Queries ACTIVE tx_nrllm_model records carrying the
-     * `transcription` capability (provider-agnostic), prefers the
-     * record flagged as default, then the lowest sorting, and returns
-     * that record's model id. Fail-soft: any error, no repository in
-     * context, or no matching record returns the given fallback
-     * unchanged — this method never throws.
-     */
-    public function resolveDefaultModel(string $fallback): string
+    protected function getModelCapability(): ModelCapability
     {
-        return $this->resolveDefaultModelFor(ModelCapability::TRANSCRIPTION, $fallback);
-    }
-
-    /**
-     * Resolve the transcription model for a named LlmConfiguration
-     * record.
-     *
-     * The configuration (tx_nrllm_configuration) is the stable
-     * indirection layer consumers reference by identifier: an
-     * administrator swaps the assigned model on the record and every
-     * consumer picks it up without re-configuring anything. Resolution
-     * order: the ACTIVE configuration's ACTIVE model record's model id
-     * (records with an empty model id are skipped) → the
-     * capability-based registry default (`resolveDefaultModel()`
-     * semantics) → the given fallback. Fail-soft — never throws.
-     */
-    public function resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string
-    {
-        return $this->resolveConfiguredModelFor(ModelCapability::TRANSCRIPTION, $configurationIdentifier, $fallback);
+        return ModelCapability::TRANSCRIPTION;
     }
 
     protected function getServiceDomain(): string

--- a/Documentation/Adr/Adr033SpecializedModelRegistry.rst
+++ b/Documentation/Adr/Adr033SpecializedModelRegistry.rst
@@ -53,11 +53,46 @@ Decision
    speech spend to the curated records; ``0`` remains the value for
    models without a registry record.
 
-4. **Configurations stay chat-scoped by design.** The third tier of
-   :ref:`adr-013` (Configuration bundles: system prompt, temperature,
-   token limits, budgets) only makes sense for conversational models.
-   Image/TTS/transcription use Model records plus capability-based
-   default resolution — no Configuration records are created for them.
+4. **Configuration-based resolution for specialized services.**
+   ``tx_nrllm_configuration`` records are the stable indirection layer
+   for image/TTS/transcription exactly as for chat: a consumer
+   references a configuration by identifier, the administrator swaps
+   the assigned model (or adjusts the system prompt) on the record, and
+   every consumer picks it up without re-configuring anything. The
+   three services expose the consumer-facing API
+
+   - :php:`resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string`
+     — resolution order: the ACTIVE configuration's ACTIVE model
+     record's ``model_id`` (records with an empty ``model_id`` are
+     skipped) → the capability-based registry default (decision 2) →
+     the given fallback. Fail-soft, never throws.
+   - :php:`getConfigurationSystemPrompt(string $configurationIdentifier): string`
+     — the configuration's system prompt; the empty string when the
+     configuration is unknown, inactive, or unreadable. The prompt is
+     *returned to the consumer*, never injected implicitly, so the
+     consumer always records the exact prompt it sent (transparency
+     requirement).
+
+   For image generation the model MUST be resolved *before* the
+   options object is constructed: :php:`ImageGenerationOptions`
+   validates ``size`` against the concrete model value at construction
+   time.
+
+5. **Usage attribution per configuration.** The specialized options
+   DTOs (:php:`ImageGenerationOptions`, :php:`SpeechSynthesisOptions`,
+   :php:`TranscriptionOptions`) carry an optional ``configuration``
+   identifier — pure metadata that never reaches the upstream API and
+   never alters validation. When set, the services resolve the
+   configuration uid fail-soft and pass it as ``configurationUid`` to
+   ``trackUsage()``, so the Analytics module aggregates specialized
+   spend per configuration just like chat spend.
+
+6. **Snippet-enforcement hook (Phase 2).** The planned prompt-snippet
+   feature (pinning/enforcing prompt snippets) attaches at the
+   Configuration level. ``getConfigurationSystemPrompt()`` is the
+   single seam where enforced snippets will be folded into the
+   returned prompt — consumers keep calling the same method and stay
+   unchanged when Phase 2 lands.
 
 .. _adr-033-consequences:
 
@@ -70,9 +105,14 @@ Consequences
 - ● Consuming extensions resolve the instance-preferred specialized
   model via ``resolveDefaultModel()`` instead of hardcoding one, with
   a guaranteed-safe fallback.
+- ● Configurations are the stable consumer contract for specialized
+  calls too: model swaps and system-prompt changes are central,
+  one-record edits — no consumer redeployment.
 - ● Analytics model breakdowns link specialized spend to registry
-  records via ``model_uid``.
+  records via ``model_uid`` and to configurations via
+  ``configuration_uid``.
 - ◐ Hardcoded service defaults remain as fallbacks — instances without
   curated records keep working unchanged.
-- ◑ One additional fail-soft repository lookup per tracked specialized
-  call (indexed single-row query; negligible next to the API call).
+- ◑ Up to two additional fail-soft repository lookups per tracked
+  specialized call (indexed single-row queries; negligible next to the
+  API call).

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
@@ -643,11 +645,302 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         self::assertSame(0, $subject->callResolveModelUid('gpt-image-2'));
     }
 
+    #[Test]
+    public function resolveConfiguredModelForReturnsConfiguredModelId(): void
+    {
+        // An active configuration with an active, usable model wins
+        // outright — the capability-based registry default is not
+        // consulted at all.
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('alt-text-images')
+            ->willReturn($this->createConfiguration(modelId: 'gpt-image-2'));
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::never())->method('findByCapability');
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame(
+            'gpt-image-2',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForFallsBackToCapabilityDefaultForInactiveConfiguration(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willReturn($this->createConfiguration(modelId: 'gpt-image-2', active: false));
+
+        $registryDefault = new Model();
+        $registryDefault->setModelId('gpt-image-1');
+        $modelRepository = self::createStub(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$registryDefault]));
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame(
+            'gpt-image-1',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForFallsBackToCapabilityDefaultForUnknownIdentifier(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn(null);
+
+        $registryDefault = new Model();
+        $registryDefault->setModelId('gpt-image-1');
+        $modelRepository = self::createStub(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$registryDefault]));
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame(
+            'gpt-image-1',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'unknown', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForSkipsConfiguredModelWithoutModelId(): void
+    {
+        // A model record without a model id cannot be sent to an
+        // upstream API — resolution continues down the chain.
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willReturn($this->createConfiguration(modelId: ''));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'dall-e-3',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForSkipsInactiveConfiguredModel(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willReturn($this->createConfiguration(modelId: 'gpt-image-2', modelActive: false));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'dall-e-3',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForReturnsFallbackWithoutRepositories(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame(
+            'dall-e-3',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function resolveConfiguredModelForReturnsFallbackWhenRepositoryThrows(): void
+    {
+        // Extbase persistence may be unavailable (early CLI bootstrap):
+        // resolution is fail-soft and must never throw.
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'dall-e-3',
+            $subject->callResolveConfiguredModelFor(ModelCapability::IMAGE, 'alt-text-images', 'dall-e-3'),
+        );
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsPromptOfActiveConfiguration(): void
+    {
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('alt-text-images')
+            ->willReturn($this->createConfiguration(systemPrompt: 'Describe the image for screen readers.'));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'Describe the image for screen readers.',
+            $subject->getConfigurationSystemPrompt('alt-text-images'),
+        );
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsEmptyStringForInactiveConfiguration(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willReturn($this->createConfiguration(systemPrompt: 'Hidden prompt.', active: false));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('', $subject->getConfigurationSystemPrompt('alt-text-images'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsEmptyStringForUnknownIdentifier(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn(null);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('', $subject->getConfigurationSystemPrompt('unknown'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsEmptyStringWithoutRepository(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('', $subject->getConfigurationSystemPrompt('alt-text-images'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsEmptyStringWhenRepositoryThrows(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('', $subject->getConfigurationSystemPrompt('alt-text-images'));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsUidOfActiveConfiguration(): void
+    {
+        $configuration = $this->createConfiguration();
+        $configuration->_setProperty('uid', 12);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('alt-text-images')
+            ->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(12, $subject->callResolveConfigurationUid('alt-text-images'));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsNullForNullIdentifierWithoutQuerying(): void
+    {
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::never())->method('findOneByIdentifier');
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertNull($subject->callResolveConfigurationUid(null));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsNullForEmptyIdentifierWithoutQuerying(): void
+    {
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::never())->method('findOneByIdentifier');
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertNull($subject->callResolveConfigurationUid(''));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsNullWithoutRepository(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertNull($subject->callResolveConfigurationUid('alt-text-images'));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsNullForInactiveConfiguration(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willReturn($this->createConfiguration(active: false));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertNull($subject->callResolveConfigurationUid('alt-text-images'));
+    }
+
+    #[Test]
+    public function resolveConfigurationUidReturnsNullWhenRepositoryThrows(): void
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->willThrowException(new RuntimeException('persistence unavailable'));
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertNull($subject->callResolveConfigurationUid('alt-text-images'));
+    }
+
+    /**
+     * Build an LlmConfiguration fixture. `$modelId === null` leaves the
+     * configuration without a model relation; otherwise a Model record
+     * with the given id and active flag is attached.
+     */
+    private function createConfiguration(
+        ?string $modelId = null,
+        bool $active = true,
+        bool $modelActive = true,
+        string $systemPrompt = '',
+    ): LlmConfiguration {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('alt-text-images');
+        $configuration->setIsActive($active);
+        $configuration->setSystemPrompt($systemPrompt);
+
+        if ($modelId !== null) {
+            $model = new Model();
+            $model->setModelId($modelId);
+            $model->setIsActive($modelActive);
+            $configuration->setLlmModel($model);
+        }
+
+        return $configuration;
+    }
+
     private function createSubject(
         string $apiKeyIdentifier = 'test-key',
         string $baseUrl = 'https://api.example.test',
         ?ClientInterface $httpClient = null,
         ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
     ): TestableSpecializedService {
         $extConf = self::createStub(ExtensionConfiguration::class);
         $extConf->method('get')->willReturn(['apiKeyIdentifier' => $apiKeyIdentifier, 'baseUrl' => $baseUrl]);
@@ -661,6 +954,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
         );
 
         // Inject the plain test client through the test seam; this bypasses the
@@ -749,6 +1043,19 @@ final class TestableSpecializedService extends AbstractSpecializedService
     public function callResolveModelUid(string $modelId): int
     {
         return $this->resolveModelUid($modelId);
+    }
+
+    public function callResolveConfiguredModelFor(
+        ModelCapability $capability,
+        string $configurationIdentifier,
+        string $fallback,
+    ): string {
+        return $this->resolveConfiguredModelFor($capability, $configurationIdentifier, $fallback);
+    }
+
+    public function callResolveConfigurationUid(?string $configurationIdentifier): ?int
+    {
+        return $this->resolveConfigurationUid($configurationIdentifier);
     }
 
     protected function getServiceDomain(): string

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -84,6 +86,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
         ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
     ): DallEImageService {
         $service = new DallEImageService(
             $this->vaultStub,
@@ -94,6 +97,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             $modelRepository,
+            $configurationRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -111,8 +115,11 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): DallEImageService
-    {
+    private function createSubject(
+        array $config = [],
+        ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
+    ): DallEImageService {
         $defaultConfig = [
             'providers' => [
                 'openai' => [
@@ -134,6 +141,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->usageTrackerStub,
             $this->loggerStub,
             $modelRepository,
+            $configurationRepository,
         );
     }
 
@@ -511,6 +519,128 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject(modelRepository: $modelRepository);
 
         self::assertSame('dall-e-3', $subject->resolveDefaultModel('dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationUsesConfiguredModel(): void
+    {
+        $model = new Model();
+        $model->setModelId('gpt-image-2');
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('alt-text-images');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('alt-text-images')
+            ->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('gpt-image-2', $subject->resolveModelForConfiguration('alt-text-images', 'dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationFallsBackToImageCapabilityDefault(): void
+    {
+        // Unknown configuration identifier: the capability-based registry
+        // default applies — for this service the `image` capability.
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn(null);
+
+        $registryDefault = new Model();
+        $registryDefault->setModelId('gpt-image-2');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('image')
+            ->willReturn(new InMemoryQueryResult([$registryDefault]));
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame('gpt-image-2', $subject->resolveModelForConfiguration('unknown', 'dall-e-3'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationReturnsFallbackWithoutRepositories(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('dall-e-3', $subject->resolveModelForConfiguration('alt-text-images', 'dall-e-3'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsPromptOfActiveConfiguration(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('alt-text-images');
+        $configuration->setSystemPrompt('Generate decorative, brand-neutral imagery.');
+
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'Generate decorative, brand-neutral imagery.',
+            $subject->getConfigurationSystemPrompt('alt-text-images'),
+        );
+    }
+
+    #[Test]
+    public function generateLinksUsageRowToConfigurationUid(): void
+    {
+        // When the options carry an LlmConfiguration identifier, the usage
+        // row links to that configuration record so the Analytics module
+        // can aggregate image spend per configuration.
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('alt-text-images');
+        $configuration->_setProperty('uid', 23);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->with('alt-text-images')
+            ->willReturn($configuration);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(static fn(array $metrics): bool => $metrics['images'] === 1),
+                23,
+                0,
+                'dall-e-3',
+            );
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+        $this->setupSuccessfulRequest([
+            'data' => [['url' => 'https://example.com/image.png']],
+        ]);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+            null,
+            $configurationRepository,
+        );
+
+        $subject->generate('A cat', ['configuration' => 'alt-text-images']);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -77,6 +77,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
      * Build a DallEImageService wired to the vault mock, then inject the given
      * plain HTTP client through the test seam (bypasses the vault secure client
      * so request/response assertions can read the request the service built).
+     *
+     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null} $repositories
      */
     private function buildService(
         ClientInterface $httpClient,
@@ -85,8 +87,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
-        ?ModelRepository $modelRepository = null,
-        ?LlmConfigurationRepository $configurationRepository = null,
+        array $repositories = [],
     ): DallEImageService {
         $service = new DallEImageService(
             $this->vaultStub,
@@ -96,8 +97,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
-            $modelRepository,
-            $configurationRepository,
+            $repositories['model'] ?? null,
+            $repositories['configuration'] ?? null,
         );
         $service->setHttpClient($httpClient);
 
@@ -140,8 +141,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
-            $modelRepository,
-            $configurationRepository,
+            ['model' => $modelRepository, 'configuration' => $configurationRepository],
         );
     }
 
@@ -472,7 +472,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $usageTrackerMock,
             $this->loggerStub,
-            $modelRepository,
+            ['model' => $modelRepository],
         );
 
         $subject->generate('A cat');
@@ -636,8 +636,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $usageTrackerMock,
             $this->loggerStub,
-            null,
-            $configurationRepository,
+            ['configuration' => $configurationRepository],
         );
 
         $subject->generate('A cat', ['configuration' => 'alt-text-images']);

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -499,6 +499,26 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function resolveDefaultModelSkipsForeignProviderModelIds(): void
+    {
+        // The IMAGE capability is shared across providers: a FAL record — even
+        // default-flagged — must never be sent to the OpenAI images endpoint.
+        $foreignDefault = new Model();
+        $foreignDefault->setModelId('flux-schnell');
+        $foreignDefault->setIsDefault(true);
+        $acceptable = new Model();
+        $acceptable->setModelId('gpt-image-2');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$foreignDefault, $acceptable]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('gpt-image-2', $subject->resolveDefaultModel('dall-e-3'));
+    }
+
+    #[Test]
     public function resolveDefaultModelReturnsFallbackWhenNoImageRecordExists(): void
     {
         $modelRepository = $this->createMock(ModelRepository::class);

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -16,6 +18,7 @@ use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -84,6 +87,36 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $service->setHttpClient($httpClient);
 
         return $service;
+    }
+
+    /**
+     * The IMAGE capability is shared across providers: an OpenAI record — even
+     * default-flagged — must never reach the FAL endpoint. With no FAL-speakable
+     * record in the registry, resolution returns the caller's fallback.
+     */
+    #[Test]
+    public function resolveDefaultModelSkipsForeignProviderModelIds(): void
+    {
+        $foreignDefault = new Model();
+        $foreignDefault->setModelId('gpt-image-2');
+        $foreignDefault->setIsDefault(true);
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$foreignDefault]));
+
+        $service = new FalImageService(
+            $this->vaultStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+            self::createStub(SpecializedCostCalculatorInterface::class),
+            $modelRepository,
+        );
+
+        self::assertSame('flux-schnell', $service->resolveDefaultModel('flux-schnell'));
     }
 
     /**

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -436,6 +436,65 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function configurationDefaultsToNull(): void
+    {
+        $options = new ImageGenerationOptions();
+
+        self::assertNull($options->configuration);
+    }
+
+    #[Test]
+    public function constructorAcceptsConfigurationIdentifier(): void
+    {
+        $options = new ImageGenerationOptions(configuration: 'alt-text-images');
+
+        self::assertSame('alt-text-images', $options->configuration);
+    }
+
+    #[Test]
+    public function fromArrayReadsConfigurationIdentifier(): void
+    {
+        $options = ImageGenerationOptions::fromArray(['configuration' => 'alt-text-images']);
+
+        self::assertSame('alt-text-images', $options->configuration);
+    }
+
+    #[Test]
+    public function toArrayOmitsConfiguration(): void
+    {
+        // `configuration` is consumer metadata for usage attribution,
+        // not an Images API parameter — it must never reach the payload.
+        $options = new ImageGenerationOptions(configuration: 'alt-text-images');
+
+        self::assertArrayNotHasKey('configuration', $options->toArray());
+    }
+
+    #[Test]
+    public function configurationDoesNotRelaxSizeValidation(): void
+    {
+        // The configuration is pure metadata: size is still validated
+        // against the concrete model value — the consumer must resolve
+        // the model via resolveModelForConfiguration() BEFORE building
+        // the options.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid size');
+
+        new ImageGenerationOptions(model: 'dall-e-3', size: '256x256', configuration: 'alt-text-images');
+    }
+
+    #[Test]
+    public function configurationDoesNotAffectGptImageSizeValidation(): void
+    {
+        $options = new ImageGenerationOptions(
+            model: 'gpt-image-2',
+            size: '2048x1152',
+            configuration: 'alt-text-images',
+        );
+
+        self::assertSame('2048x1152', $options->size);
+    }
+
+    #[Test]
     public function landscapePresetReturns1792x1024(): void
     {
         $options = ImageGenerationOptions::landscape();

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -476,10 +476,12 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
         // against the concrete model value — the consumer must resolve
         // the model via resolveModelForConfiguration() BEFORE building
         // the options.
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid size');
-
-        new ImageGenerationOptions(model: 'dall-e-3', size: '256x256', configuration: 'alt-text-images');
+        try {
+            $options = new ImageGenerationOptions(model: 'dall-e-3', size: '256x256', configuration: 'alt-text-images');
+            self::fail(sprintf('Expected the constructor to reject the size, got %s', $options::class));
+        } catch (InvalidArgumentException $e) {
+            self::assertStringContainsString('Invalid size', $e->getMessage());
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
@@ -243,6 +243,40 @@ class SpeechSynthesisOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function configurationDefaultsToNull(): void
+    {
+        $options = new SpeechSynthesisOptions();
+
+        self::assertNull($options->configuration);
+    }
+
+    #[Test]
+    public function constructorAcceptsConfigurationIdentifier(): void
+    {
+        $options = new SpeechSynthesisOptions(configuration: 'podcast-narration');
+
+        self::assertSame('podcast-narration', $options->configuration);
+    }
+
+    #[Test]
+    public function fromArrayReadsConfigurationIdentifier(): void
+    {
+        $options = SpeechSynthesisOptions::fromArray(['configuration' => 'podcast-narration']);
+
+        self::assertSame('podcast-narration', $options->configuration);
+    }
+
+    #[Test]
+    public function toArrayOmitsConfiguration(): void
+    {
+        // `configuration` is consumer metadata for usage attribution,
+        // not a TTS API parameter — it must never reach the payload.
+        $options = new SpeechSynthesisOptions(configuration: 'podcast-narration');
+
+        self::assertArrayNotHasKey('configuration', $options->toArray());
+    }
+
+    #[Test]
     public function fromArrayHandlesMissingValues(): void
     {
         $options = SpeechSynthesisOptions::fromArray([]);

--- a/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
@@ -193,6 +193,41 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function configurationDefaultsToNull(): void
+    {
+        $options = new TranscriptionOptions();
+
+        self::assertNull($options->configuration);
+    }
+
+    #[Test]
+    public function constructorAcceptsConfigurationIdentifier(): void
+    {
+        $options = new TranscriptionOptions(configuration: 'meeting-minutes');
+
+        self::assertSame('meeting-minutes', $options->configuration);
+    }
+
+    #[Test]
+    public function fromArrayReadsConfigurationIdentifier(): void
+    {
+        $options = TranscriptionOptions::fromArray(['configuration' => 'meeting-minutes']);
+
+        self::assertSame('meeting-minutes', $options->configuration);
+    }
+
+    #[Test]
+    public function toArrayOmitsConfiguration(): void
+    {
+        // `configuration` is consumer metadata for usage attribution,
+        // not a transcription API parameter — it must never reach the
+        // multipart payload.
+        $options = new TranscriptionOptions(configuration: 'meeting-minutes');
+
+        self::assertArrayNotHasKey('configuration', $options->toArray());
+    }
+
+    #[Test]
     public function fromArrayHandlesMissingValues(): void
     {
         $options = TranscriptionOptions::fromArray([]);

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -83,6 +85,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
         ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
     ): TextToSpeechService {
         $service = new TextToSpeechService(
             $this->vaultStub,
@@ -93,6 +96,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             $modelRepository,
+            $configurationRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -102,8 +106,11 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): TextToSpeechService
-    {
+    private function createSubject(
+        array $config = [],
+        ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
+    ): TextToSpeechService {
         $defaultConfig = [
             'providers' => [
                 'openai' => [
@@ -125,6 +132,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->usageTrackerStub,
             $this->loggerStub,
             $modelRepository,
+            $configurationRepository,
         );
     }
 
@@ -452,6 +460,123 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject(modelRepository: $modelRepository);
 
         self::assertSame('tts-1', $subject->resolveDefaultModel('tts-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationUsesConfiguredModel(): void
+    {
+        $model = new Model();
+        $model->setModelId('tts-1-hd');
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('podcast-narration');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('podcast-narration')
+            ->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('tts-1-hd', $subject->resolveModelForConfiguration('podcast-narration', 'tts-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationFallsBackToTextToSpeechCapabilityDefault(): void
+    {
+        // Unknown configuration identifier: the capability-based registry
+        // default applies — for this service the `text_to_speech` capability.
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn(null);
+
+        $registryDefault = new Model();
+        $registryDefault->setModelId('tts-1-hd');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('text_to_speech')
+            ->willReturn(new InMemoryQueryResult([$registryDefault]));
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame('tts-1-hd', $subject->resolveModelForConfiguration('unknown', 'tts-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationReturnsFallbackWithoutRepositories(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('tts-1', $subject->resolveModelForConfiguration('podcast-narration', 'tts-1'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsPromptOfActiveConfiguration(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('podcast-narration');
+        $configuration->setSystemPrompt('Speak slowly and clearly.');
+
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('Speak slowly and clearly.', $subject->getConfigurationSystemPrompt('podcast-narration'));
+    }
+
+    #[Test]
+    public function synthesizeLinksUsageRowToConfigurationUid(): void
+    {
+        // When the options carry an LlmConfiguration identifier, the usage
+        // row links to that configuration record so the Analytics module
+        // can aggregate speech spend per configuration.
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('podcast-narration');
+        $configuration->_setProperty('uid', 11);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->with('podcast-narration')
+            ->willReturn($configuration);
+
+        $this->setupSuccessfulRequest();
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'tts',
+                self::callback(static fn(array $metrics): bool => $metrics['characters'] === 9),
+                11,
+                0,
+                'tts-1',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+            null,
+            $configurationRepository,
+        );
+
+        $subject->synthesize('Test text', ['configuration' => 'podcast-narration']);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -76,6 +76,8 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
      * Build a TextToSpeechService wired to the vault mock, then inject the given
      * plain HTTP client through the test seam (bypasses the vault secure client
      * so request/response assertions can read the request the service built).
+     *
+     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null} $repositories
      */
     private function buildService(
         ClientInterface $httpClient,
@@ -84,8 +86,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
-        ?ModelRepository $modelRepository = null,
-        ?LlmConfigurationRepository $configurationRepository = null,
+        array $repositories = [],
     ): TextToSpeechService {
         $service = new TextToSpeechService(
             $this->vaultStub,
@@ -95,8 +96,8 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
-            $modelRepository,
-            $configurationRepository,
+            $repositories['model'] ?? null,
+            $repositories['configuration'] ?? null,
         );
         $service->setHttpClient($httpClient);
 
@@ -131,8 +132,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
-            $modelRepository,
-            $configurationRepository,
+            ['model' => $modelRepository, 'configuration' => $configurationRepository],
         );
     }
 
@@ -413,7 +413,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $usageTrackerMock,
             $this->loggerStub,
-            $modelRepository,
+            ['model' => $modelRepository],
         );
 
         $subject->synthesize('Test text');
@@ -572,8 +572,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $usageTrackerMock,
             $this->loggerStub,
-            null,
-            $configurationRepository,
+            ['configuration' => $configurationRepository],
         );
 
         $subject->synthesize('Test text', ['configuration' => 'podcast-narration']);

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -88,6 +88,8 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
      * the given plain HTTP client through the test seam (bypasses the vault
      * secure client so request/response assertions can read the request the
      * service built).
+     *
+     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null} $repositories
      */
     private function buildService(
         ClientInterface $httpClient,
@@ -96,8 +98,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
-        ?ModelRepository $modelRepository = null,
-        ?LlmConfigurationRepository $configurationRepository = null,
+        array $repositories = [],
     ): WhisperTranscriptionService {
         $service = new WhisperTranscriptionService(
             $this->vaultStub,
@@ -107,8 +108,8 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $usageTracker,
             $logger,
             $this->costCalculator,
-            $modelRepository,
-            $configurationRepository,
+            $repositories['model'] ?? null,
+            $repositories['configuration'] ?? null,
         );
         $service->setHttpClient($httpClient);
 
@@ -151,8 +152,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
-            $modelRepository,
-            $configurationRepository,
+            ['model' => $modelRepository, 'configuration' => $configurationRepository],
         );
     }
 
@@ -471,8 +471,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $usageTrackerMock,
             $this->loggerStub,
-            null,
-            $configurationRepository,
+            ['configuration' => $configurationRepository],
         );
 
         $subject->transcribe($audioFile, ['configuration' => 'meeting-minutes']);

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Speech;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -95,6 +97,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
         ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
     ): WhisperTranscriptionService {
         $service = new WhisperTranscriptionService(
             $this->vaultStub,
@@ -105,6 +108,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             $modelRepository,
+            $configurationRepository,
         );
         $service->setHttpClient($httpClient);
 
@@ -122,8 +126,11 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     /**
      * @param array<string, mixed> $config
      */
-    private function createSubject(array $config = [], ?ModelRepository $modelRepository = null): WhisperTranscriptionService
-    {
+    private function createSubject(
+        array $config = [],
+        ?ModelRepository $modelRepository = null,
+        ?LlmConfigurationRepository $configurationRepository = null,
+    ): WhisperTranscriptionService {
         $defaultConfig = [
             'providers' => [
                 'openai' => [
@@ -145,6 +152,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $this->usageTrackerStub,
             $this->loggerStub,
             $modelRepository,
+            $configurationRepository,
         );
     }
 
@@ -346,6 +354,128 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject(modelRepository: $modelRepository);
 
         self::assertSame('whisper-1', $subject->resolveDefaultModel('whisper-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationUsesConfiguredModel(): void
+    {
+        $model = new Model();
+        $model->setModelId('gpt-4o-transcribe');
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('meeting-minutes');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('meeting-minutes')
+            ->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame('gpt-4o-transcribe', $subject->resolveModelForConfiguration('meeting-minutes', 'whisper-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationFallsBackToTranscriptionCapabilityDefault(): void
+    {
+        // Unknown configuration identifier: the capability-based registry
+        // default applies — for this service the `transcription` capability.
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn(null);
+
+        $registryDefault = new Model();
+        $registryDefault->setModelId('gpt-4o-transcribe');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->expects(self::once())
+            ->method('findByCapability')
+            ->with('transcription')
+            ->willReturn(new InMemoryQueryResult([$registryDefault]));
+
+        $subject = $this->createSubject(
+            modelRepository: $modelRepository,
+            configurationRepository: $configurationRepository,
+        );
+
+        self::assertSame('gpt-4o-transcribe', $subject->resolveModelForConfiguration('unknown', 'whisper-1'));
+    }
+
+    #[Test]
+    public function resolveModelForConfigurationReturnsFallbackWithoutRepositories(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('whisper-1', $subject->resolveModelForConfiguration('meeting-minutes', 'whisper-1'));
+    }
+
+    #[Test]
+    public function getConfigurationSystemPromptReturnsPromptOfActiveConfiguration(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('meeting-minutes');
+        $configuration->setSystemPrompt('Use formal meeting-minutes vocabulary.');
+
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = $this->createSubject(configurationRepository: $configurationRepository);
+
+        self::assertSame(
+            'Use formal meeting-minutes vocabulary.',
+            $subject->getConfigurationSystemPrompt('meeting-minutes'),
+        );
+    }
+
+    #[Test]
+    public function transcribeLinksUsageRowToConfigurationUid(): void
+    {
+        // When the options carry an LlmConfiguration identifier, the usage
+        // row links to that configuration record so the Analytics module
+        // can aggregate transcription spend per configuration.
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('meeting-minutes');
+        $configuration->_setProperty('uid', 31);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findOneByIdentifier')
+            ->with('meeting-minutes')
+            ->willReturn($configuration);
+
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $this->extensionConfigMock
+            ->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'whisper',
+                [],
+                31,
+                0,
+                'whisper-1',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+            null,
+            $configurationRepository,
+        );
+
+        $subject->transcribe($audioFile, ['configuration' => 'meeting-minutes']);
     }
 
     // ==================== transcribe tests ====================


### PR DESCRIPTION
## Summary

Builds on #239: image, TTS and transcription calls now resolve through **Configuration records** — the stable indirection layer where editors swap models without reconfiguring consumers, maintain system prompts (image style preambles), and where the planned snippet-enforcement (prompt-snippet phase 2) will attach.

- `resolveModelForConfiguration(string $configurationIdentifier, string $fallback): string` on DallE/TTS/Whisper services: ACTIVE configuration by identifier → its ACTIVE model's model_id → capability default → fallback; fail-soft, never throws.
- `getConfigurationSystemPrompt(string $configurationIdentifier): string` on the shared base — returned to consumers, never silently injected (prompt transparency stays with the consumer).
- `ImageGenerationOptions`/`SpeechSynthesisOptions`/`TranscriptionOptions` gain `?string $configuration` (usage-attribution metadata only; deliberately excluded from `toArray()` so it never leaks into API payloads); all trackUsage paths pass the resolved `configurationUid` for per-configuration cost breakdowns.
- ADR-033 updated (configuration layer + phase-2 snippet-enforcement seam).

Consumer side already merged: netresearch/t3x-nr-repurpose#18 (`nr_repurpose_image` / `nr_repurpose_tts`).

## Test plan

- `Build/Scripts/runTests.sh -p 8.4 -s unit` — green (re-run after rebase onto merged #239)
- `-s cgl -n` / `-s phpstan` (level 10) — green
- architecture (phpat) — green