### PR TITLE
fix: vault identifier handling, discovery fallback transparency, overview cards

### DIFF
--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -38,7 +39,9 @@ final class LlmModuleController extends ActionController
         private readonly ModelRepository $modelRepository,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly TaskRepository $taskRepository,
+        private readonly PromptSnippetRepository $promptSnippetRepository,
         private readonly BackendUriBuilder $backendUriBuilder,
+        private readonly FormEngineUrlBuilder $formEngineUrlBuilder,
         private readonly TestPromptResolverInterface $testPromptResolver,
         private readonly LoggerInterface $logger,
     ) {}
@@ -83,6 +86,7 @@ final class LlmModuleController extends ActionController
         $dbModelCount = $this->modelRepository->countActive();
         $dbConfigurationCount = $this->configurationRepository->countActive();
         $dbTaskCount = $this->taskRepository->countActive();
+        $dbSnippetCount = $this->promptSnippetRepository->countActive();
 
         $moduleTemplate->assignMultiple([
             'providers' => $providerDetails,
@@ -91,10 +95,17 @@ final class LlmModuleController extends ActionController
             'dbModelCount' => $dbModelCount,
             'dbConfigurationCount' => $dbConfigurationCount,
             'dbTaskCount' => $dbTaskCount,
+            'dbSnippetCount' => $dbSnippetCount,
             'taskWizardUrl' => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_tasks', [
                 'controller' => 'Backend\\TaskWizard',
                 'action'     => 'wizardForm',
             ]),
+            // FormEngine new-record URLs for the "+ New …" card actions
+            'newProviderUrl' => $this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_provider', 'nrllm_overview'),
+            'newModelUrl' => $this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_model', 'nrllm_overview'),
+            'newConfigurationUrl' => $this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_configuration', 'nrllm_overview'),
+            'newTaskUrl' => $this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_task', 'nrllm_overview'),
+            'newSnippetUrl' => $this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_promptsnippet', 'nrllm_overview'),
         ]);
 
         return $moduleTemplate->renderResponse('Backend/Index');

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -405,6 +405,7 @@ final class ModelController extends ActionController
                 'success' => true,
                 'models' => $models,
                 'providerName' => $provider->getName(),
+                'source' => $this->modelDiscovery->wasLastDiscoveryFromFallback() ? 'fallback' : 'live',
             ]);
         } catch (ProviderException $e) {
             $this->logger->warning('Model fetchAvailableModels: provider error', ['exception' => $e]);

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Domain\Model;
 use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\DTO\ProviderOptions;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Utility\IdentifierValidator;
 use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -25,6 +26,17 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  */
 class Provider extends AbstractEntity
 {
+    /**
+     * Known API-key prefixes identifying a value as a plaintext secret.
+     *
+     * Some plaintext keys (e.g. Google "AIza…" keys) would otherwise satisfy
+     * nr-vault's name-style identifier pattern, so known prefixes are
+     * rejected before delegating to the vault's identifier rules.
+     * 'sk-' also covers 'sk-proj-' (OpenAI), 'sk-ant-' (Anthropic),
+     * and 'sk-or-' (OpenRouter) keys.
+     */
+    private const PLAINTEXT_API_KEY_PREFIXES = ['sk-', 'xai-', 'AIza', 'gsk_'];
+
     protected string $identifier = '';
     protected string $name = '';
     protected string $description = '';
@@ -313,17 +325,18 @@ class Provider extends AbstractEntity
      *
      * The actual secret storage is handled by nr-vault's TCA form element
      * or by the SetupWizardController via VaultServiceInterface::store().
-     * This method only accepts vault identifiers (UUIDs), not raw secrets.
+     * This method only accepts vault identifiers (UUID v7 or name-style
+     * identifiers such as "nr_repurpose_openai"), not raw secrets.
      *
-     * @throws InvalidArgumentException If the value looks like a raw API key instead of a vault UUID
+     * @throws InvalidArgumentException If the value looks like a raw API key instead of a vault identifier
      */
     public function setApiKey(string $apiKey): void
     {
         // Allow empty string (no key / clearing)
-        // Reject values that look like raw API keys (not vault UUIDs)
+        // Reject values that look like raw API keys (not vault identifiers)
         if ($apiKey !== '' && !self::isVaultIdentifier($apiKey)) {
             throw new InvalidArgumentException(
-                'API key must be a vault identifier (UUID), not a raw secret. '
+                'API key must be a vault identifier (UUID v7 or name-style identifier), not a raw secret. '
                 . 'Use VaultServiceInterface::store() first.',
                 1741268400,
             );
@@ -333,15 +346,23 @@ class Provider extends AbstractEntity
     }
 
     /**
-     * Check whether a value looks like a vault identifier (UUID v7).
+     * Check whether a value is a valid nr-vault identifier.
+     *
+     * Delegates to nr-vault's `IdentifierValidator`, which accepts both
+     * UUID v7 (TCA/FlexForm vault fields) and name-style identifiers
+     * (e.g. "nr_repurpose_openai"). Values starting with a known API-key
+     * prefix are conservatively treated as legacy plaintext secrets, since
+     * some raw keys would otherwise match the name-style pattern.
      */
     private static function isVaultIdentifier(string $value): bool
     {
-        // UUID v7 format: 8-4-4-4-12 hex digits with version 7
-        return (bool)preg_match(
-            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
-            $value,
-        );
+        foreach (self::PLAINTEXT_API_KEY_PREFIXES as $prefix) {
+            if (str_starts_with($value, $prefix)) {
+                return false;
+            }
+        }
+
+        return IdentifierValidator::isValid($value);
     }
 
     public function setOrganizationId(string $organizationId): void

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -38,6 +38,20 @@ class PromptSnippetRepository extends Repository
     }
 
     /**
+     * Count all non-deleted, non-hidden snippets.
+     */
+    public function countActive(): int
+    {
+        $query = $this->createQuery();
+        $querySettings = $query->getQuerySettings();
+        $querySettings->setRespectStoragePage(false);
+        $querySettings->setIgnoreEnableFields(false);
+        $querySettings->setEnableFieldsToBeIgnored(['hidden']);
+
+        return $query->count();
+    }
+
+    /**
      * Find active snippets carrying the given tag.
      *
      * The tag is matched as an exact, case-insensitive token against the

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -38,7 +38,9 @@ class PromptSnippetRepository extends Repository
     }
 
     /**
-     * Count all non-deleted, non-hidden snippets (what the Snippets module lists).
+     * Count all non-deleted snippets — including hidden ones, matching what
+     * the Snippets backend module lists (the repository default query
+     * settings from initializeObject() ignore enable-fields).
      */
     public function countActive(): int
     {

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -38,15 +38,12 @@ class PromptSnippetRepository extends Repository
     }
 
     /**
-     * Count all non-deleted, non-hidden snippets.
+     * Count all non-deleted, non-hidden snippets (what the Snippets module lists).
      */
     public function countActive(): int
     {
         $query = $this->createQuery();
-        $querySettings = $query->getQuerySettings();
-        $querySettings->setRespectStoragePage(false);
-        $querySettings->setIgnoreEnableFields(false);
-        $querySettings->setEnableFieldsToBeIgnored(['hidden']);
+        $query->getQuerySettings()->setRespectStoragePage(false);
 
         return $query->count();
     }

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -522,19 +522,15 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      */
     private function defaultOpenAICapabilities(string $modelId): array
     {
-        if (str_starts_with($modelId, 'dall-e-') || str_starts_with($modelId, 'gpt-image')) {
-            return ['image'];
-        }
-
-        if (str_starts_with($modelId, 'tts-') || str_ends_with($modelId, '-tts')) {
-            return ['text_to_speech'];
-        }
-
-        if (str_starts_with($modelId, 'whisper-') || str_ends_with($modelId, '-transcribe')) {
-            return ['transcription'];
-        }
-
-        return ['chat'];
+        return match (true) {
+            str_starts_with($modelId, 'dall-e-'),
+            str_starts_with($modelId, 'gpt-image') => ['image'],
+            str_starts_with($modelId, 'tts-'),
+            str_ends_with($modelId, '-tts') => ['text_to_speech'],
+            str_starts_with($modelId, 'whisper-'),
+            str_ends_with($modelId, '-transcribe') => ['transcription'],
+            default => ['chat'],
+        };
     }
 
     /**

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -30,7 +30,7 @@ use Throwable;
  * builds its own auth headers but still routes through the secure client and
  * pre-gates the target host via `SecureHttpClientFactory::isHostAllowed()`.
  *
- * Model information updated: March 2026
+ * Model information updated: June 2026
  */
 final class ModelDiscovery implements ModelDiscoveryInterface
 {
@@ -42,6 +42,13 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      * request, passed to `SecureHttpDispatchTrait::dispatch()`.
      */
     private const VAULT_DISPATCH_REASON = 'LLM setup-wizard model discovery';
+
+    /**
+     * Whether the most recent discover() call substituted a static fallback
+     * catalog for live API data (failed request, unexpected status, or
+     * malformed/empty response).
+     */
+    private bool $lastDiscoveryUsedFallback = false;
 
     public function __construct(
         VaultServiceInterface $vault,
@@ -132,6 +139,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      */
     public function discover(DetectedProvider $provider, string $apiKey): array
     {
+        $this->lastDiscoveryUsedFallback = false;
         $endpoint = rtrim($provider->endpoint, '/');
 
         return match ($provider->adapterType) {
@@ -144,6 +152,52 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             'groq' => $this->discoverGroq($endpoint, $apiKey),
             default => $this->getDefaultModels($provider->adapterType),
         };
+    }
+
+    public function wasLastDiscoveryFromFallback(): bool
+    {
+        return $this->lastDiscoveryUsedFallback;
+    }
+
+    /**
+     * Mark the current discovery as served from a static fallback catalog.
+     *
+     * @param array<DiscoveredModel> $models
+     *
+     * @return array<DiscoveredModel>
+     */
+    private function asFallback(array $models): array
+    {
+        $this->lastDiscoveryUsedFallback = true;
+
+        return $models;
+    }
+
+    /**
+     * Log a failed discovery request.
+     *
+     * Never includes the API key: only the exception class and its
+     * sanitised message are recorded.
+     */
+    private function logDiscoveryFailure(string $adapterType, Throwable $e): void
+    {
+        $this->logger->warning('LLM model discovery request failed', [
+            'provider' => $adapterType,
+            'exception' => $e::class,
+            'message' => $this->sanitizeErrorMessage($e->getMessage()),
+        ]);
+    }
+
+    /**
+     * Log a discovery response with an unexpected HTTP status
+     * (e.g. 401 for an invalid or missing API key).
+     */
+    private function logDiscoveryHttpError(string $adapterType, int $statusCode): void
+    {
+        $this->logger->warning('LLM model discovery returned an unexpected HTTP status', [
+            'provider' => $adapterType,
+            'status' => $statusCode,
+        ]);
     }
 
     /**
@@ -161,19 +215,21 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
-                return $this->getOpenAIFallbackModels();
+                $this->logDiscoveryHttpError('openai', $response->getStatusCode());
+
+                return $this->asFallback($this->getOpenAIFallbackModels());
             }
 
             $data = json_decode($response->getBody()->getContents(), true);
             $models = [];
 
             if (!is_array($data)) {
-                return $this->getOpenAIFallbackModels();
+                return $this->asFallback($this->getOpenAIFallbackModels());
             }
 
             $dataList = $data['data'] ?? [];
             if (!is_array($dataList)) {
-                return $this->getOpenAIFallbackModels();
+                return $this->asFallback($this->getOpenAIFallbackModels());
             }
 
             foreach ($dataList as $model) {
@@ -191,9 +247,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             // Sort by recommendation
             usort($models, fn(DiscoveredModel $a, DiscoveredModel $b) => $b->recommended <=> $a->recommended);
 
-            return $models !== [] ? $models : $this->getOpenAIFallbackModels();
-        } catch (Throwable) {
-            return $this->getOpenAIFallbackModels();
+            return $models !== [] ? $models : $this->asFallback($this->getOpenAIFallbackModels());
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('openai', $e);
+
+            return $this->asFallback($this->getOpenAIFallbackModels());
         }
     }
 
@@ -211,6 +269,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             '/^o[1234]-/',      // o1, o3, o4 series
             '/^gpt-image/',
             '/^chatgpt-/',      // chatgpt-4o-latest etc.
+            '/^tts-/',          // tts-1, tts-1-hd (text-to-speech)
+            '/-tts$/',          // gpt-4o-mini-tts etc.
+            '/^whisper-/',      // whisper-1 (transcription)
+            '/-transcribe$/',   // gpt-4o-transcribe etc.
+            '/^dall-e-/',       // dall-e-3 (image generation)
         ];
 
         foreach ($patterns as $pattern) {
@@ -219,11 +282,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
         }
 
-        // Exclude known non-chat models
-        if (str_starts_with($modelId, 'dall-e')
-            || str_starts_with($modelId, 'whisper')
-            || str_starts_with($modelId, 'tts')
-            || str_starts_with($modelId, 'text-embedding')
+        // Exclude known irrelevant models
+        if (str_starts_with($modelId, 'text-embedding')
             || str_starts_with($modelId, 'babbage')
             || str_starts_with($modelId, 'davinci')
             || str_contains($modelId, 'instruct')
@@ -242,11 +302,21 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      */
     private function enrichOpenAIModel(string $modelId): DiscoveredModel
     {
-        // March 2026 OpenAI model specifications
+        // June 2026 OpenAI model specifications
         $specs = [
+            'gpt-5.5' => [
+                'name' => 'GPT-5.5',
+                'description' => 'Latest flagship model with enhanced reasoning',
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'contextLength' => 400000,
+                'maxOutputTokens' => 128000,
+                'costInput' => 500,
+                'costOutput' => 3000,
+                'recommended' => true,
+            ],
             'gpt-5.3' => [
                 'name' => 'GPT-5.3',
-                'description' => 'Latest flagship model with enhanced reasoning',
+                'description' => 'Flagship model with enhanced reasoning',
                 'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
                 'contextLength' => 400000,
                 'maxOutputTokens' => 128000,
@@ -374,12 +444,55 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 'costOutput' => 160,
                 'recommended' => false,
             ],
+            // Specialized models: context length / max output tokens and
+            // token-based costs do not apply (priced per image / character /
+            // minute), hence 0. Capability values match the ModelCapability enum.
+            'gpt-image-2' => [
+                'name' => 'GPT Image 2',
+                'description' => 'Image generation model',
+                'capabilities' => ['image'],
+                'contextLength' => 0,
+                'maxOutputTokens' => 0,
+                'costInput' => 0,
+                'costOutput' => 0,
+                'recommended' => false,
+            ],
+            'tts-1' => [
+                'name' => 'TTS-1',
+                'description' => 'Text-to-speech model optimized for speed',
+                'capabilities' => ['text_to_speech'],
+                'contextLength' => 0,
+                'maxOutputTokens' => 0,
+                'costInput' => 0,
+                'costOutput' => 0,
+                'recommended' => false,
+            ],
+            'tts-1-hd' => [
+                'name' => 'TTS-1 HD',
+                'description' => 'Text-to-speech model optimized for quality',
+                'capabilities' => ['text_to_speech'],
+                'contextLength' => 0,
+                'maxOutputTokens' => 0,
+                'costInput' => 0,
+                'costOutput' => 0,
+                'recommended' => false,
+            ],
+            'whisper-1' => [
+                'name' => 'Whisper',
+                'description' => 'Speech-to-text transcription model',
+                'capabilities' => ['transcription'],
+                'contextLength' => 0,
+                'maxOutputTokens' => 0,
+                'costInput' => 0,
+                'costOutput' => 0,
+                'recommended' => false,
+            ],
         ];
 
         $spec = $specs[$modelId] ?? [
             'name' => $modelId,
             'description' => 'OpenAI model',
-            'capabilities' => ['chat'],
+            'capabilities' => $this->defaultOpenAICapabilities($modelId),
             'contextLength' => 0,
             'maxOutputTokens' => 0,
             'costInput' => 0,
@@ -401,6 +514,30 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     }
 
     /**
+     * Derive default capabilities from the model id shape for OpenAI models
+     * without an explicit spec entry. The returned values match the
+     * ModelCapability enum (image / text_to_speech / transcription / chat).
+     *
+     * @return array<string>
+     */
+    private function defaultOpenAICapabilities(string $modelId): array
+    {
+        if (str_starts_with($modelId, 'dall-e-') || str_starts_with($modelId, 'gpt-image')) {
+            return ['image'];
+        }
+
+        if (str_starts_with($modelId, 'tts-') || str_ends_with($modelId, '-tts')) {
+            return ['text_to_speech'];
+        }
+
+        if (str_starts_with($modelId, 'whisper-') || str_ends_with($modelId, '-transcribe')) {
+            return ['transcription'];
+        }
+
+        return ['chat'];
+    }
+
+    /**
      * Get OpenAI fallback models (when API discovery fails).
      *
      * @return array<DiscoveredModel>
@@ -408,6 +545,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private function getOpenAIFallbackModels(): array
     {
         return [
+            $this->enrichOpenAIModel('gpt-5.5'),
             $this->enrichOpenAIModel('gpt-5.3'),
             $this->enrichOpenAIModel('gpt-5.3-chat-latest'),
             $this->enrichOpenAIModel('gpt-5.3-mini'),
@@ -417,6 +555,10 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $this->enrichOpenAIModel('gpt-4o'),
             $this->enrichOpenAIModel('o4-mini'),
             $this->enrichOpenAIModel('o3'),
+            $this->enrichOpenAIModel('gpt-image-2'),
+            $this->enrichOpenAIModel('tts-1'),
+            $this->enrichOpenAIModel('tts-1-hd'),
+            $this->enrichOpenAIModel('whisper-1'),
         ];
     }
 
@@ -435,17 +577,19 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
-                return $this->getAnthropicFallbackModels();
+                $this->logDiscoveryHttpError('anthropic', $response->getStatusCode());
+
+                return $this->asFallback($this->getAnthropicFallbackModels());
             }
 
             $data = json_decode($response->getBody()->getContents(), true);
             if (!is_array($data)) {
-                return $this->getAnthropicFallbackModels();
+                return $this->asFallback($this->getAnthropicFallbackModels());
             }
 
             $modelList = $data['data'] ?? [];
             if (!is_array($modelList) || $modelList === []) {
-                return $this->getAnthropicFallbackModels();
+                return $this->asFallback($this->getAnthropicFallbackModels());
             }
 
             $models = [];
@@ -465,9 +609,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             // Sort: recommended first, then by name
             usort($models, fn(DiscoveredModel $a, DiscoveredModel $b) => $b->recommended <=> $a->recommended);
 
-            return $models !== [] ? $models : $this->getAnthropicFallbackModels();
-        } catch (Throwable) {
-            return $this->getAnthropicFallbackModels();
+            return $models !== [] ? $models : $this->asFallback($this->getAnthropicFallbackModels());
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('anthropic', $e);
+
+            return $this->asFallback($this->getAnthropicFallbackModels());
         }
     }
 
@@ -623,19 +769,21 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
-                return $this->getGeminiFallbackModels();
+                $this->logDiscoveryHttpError('gemini', $response->getStatusCode());
+
+                return $this->asFallback($this->getGeminiFallbackModels());
             }
 
             $data = json_decode($response->getBody()->getContents(), true);
             $models = [];
 
             if (!is_array($data)) {
-                return $this->getGeminiFallbackModels();
+                return $this->asFallback($this->getGeminiFallbackModels());
             }
 
             $modelList = $data['models'] ?? [];
             if (!is_array($modelList)) {
-                return $this->getGeminiFallbackModels();
+                return $this->asFallback($this->getGeminiFallbackModels());
             }
 
             foreach ($modelList as $model) {
@@ -655,9 +803,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 $models[] = $this->enrichGeminiModel($modelId, $model);
             }
 
-            return $models !== [] ? $models : $this->getGeminiFallbackModels();
-        } catch (Throwable) {
-            return $this->getGeminiFallbackModels();
+            return $models !== [] ? $models : $this->asFallback($this->getGeminiFallbackModels());
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('gemini', $e);
+
+            return $this->asFallback($this->getGeminiFallbackModels());
         }
     }
 
@@ -812,6 +962,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
+                $this->logDiscoveryHttpError('ollama', $response->getStatusCode());
+
                 return [];
             }
 
@@ -848,7 +1000,9 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
 
             return $models;
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('ollama', $e);
+
             return [];
         }
     }
@@ -997,6 +1151,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
+                $this->logDiscoveryHttpError('openrouter', $response->getStatusCode());
+
                 return [];
             }
 
@@ -1045,7 +1201,9 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
 
             return $models;
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('openrouter', $e);
+
             return [];
         }
     }
@@ -1064,7 +1222,9 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
-                return $this->getMistralFallbackModels();
+                $this->logDiscoveryHttpError('mistral', $response->getStatusCode());
+
+                return $this->asFallback($this->getMistralFallbackModels());
             }
 
             $data = json_decode($response->getBody()->getContents(), true);
@@ -1096,9 +1256,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 );
             }
 
-            return $models !== [] ? $models : $this->getMistralFallbackModels();
-        } catch (Throwable) {
-            return $this->getMistralFallbackModels();
+            return $models !== [] ? $models : $this->asFallback($this->getMistralFallbackModels());
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('mistral', $e);
+
+            return $this->asFallback($this->getMistralFallbackModels());
         }
     }
 
@@ -1149,6 +1311,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
+                $this->logDiscoveryHttpError('groq', $response->getStatusCode());
+
                 return [];
             }
 
@@ -1186,7 +1350,9 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
 
             return $models;
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            $this->logDiscoveryFailure('groq', $e);
+
             return [];
         }
     }

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -444,49 +444,11 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 'costOutput' => 160,
                 'recommended' => false,
             ],
-            // Specialized models: context length / max output tokens and
-            // token-based costs do not apply (priced per image / character /
-            // minute), hence 0. Capability values match the ModelCapability enum.
-            'gpt-image-2' => [
-                'name' => 'GPT Image 2',
-                'description' => 'Image generation model',
-                'capabilities' => ['image'],
-                'contextLength' => 0,
-                'maxOutputTokens' => 0,
-                'costInput' => 0,
-                'costOutput' => 0,
-                'recommended' => false,
-            ],
-            'tts-1' => [
-                'name' => 'TTS-1',
-                'description' => 'Text-to-speech model optimized for speed',
-                'capabilities' => ['text_to_speech'],
-                'contextLength' => 0,
-                'maxOutputTokens' => 0,
-                'costInput' => 0,
-                'costOutput' => 0,
-                'recommended' => false,
-            ],
-            'tts-1-hd' => [
-                'name' => 'TTS-1 HD',
-                'description' => 'Text-to-speech model optimized for quality',
-                'capabilities' => ['text_to_speech'],
-                'contextLength' => 0,
-                'maxOutputTokens' => 0,
-                'costInput' => 0,
-                'costOutput' => 0,
-                'recommended' => false,
-            ],
-            'whisper-1' => [
-                'name' => 'Whisper',
-                'description' => 'Speech-to-text transcription model',
-                'capabilities' => ['transcription'],
-                'contextLength' => 0,
-                'maxOutputTokens' => 0,
-                'costInput' => 0,
-                'costOutput' => 0,
-                'recommended' => false,
-            ],
+            // Specialized models — see specializedSpec() for the shared shape.
+            'gpt-image-2' => self::specializedSpec('GPT Image 2', 'Image generation model', 'image'),
+            'tts-1' => self::specializedSpec('TTS-1', 'Text-to-speech model optimized for speed', 'text_to_speech'),
+            'tts-1-hd' => self::specializedSpec('TTS-1 HD', 'Text-to-speech model optimized for quality', 'text_to_speech'),
+            'whisper-1' => self::specializedSpec('Whisper', 'Speech-to-text transcription model', 'transcription'),
         ];
 
         $spec = $specs[$modelId] ?? [
@@ -531,6 +493,29 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             str_ends_with($modelId, '-transcribe') => ['transcription'],
             default => ['chat'],
         };
+    }
+
+    /**
+     * Build a spec entry for a specialized (non-chat) model.
+     *
+     * Context length, max output tokens, and token-based costs do not apply
+     * to these models (priced per image / character / minute), hence 0.
+     * The capability value matches the ModelCapability enum.
+     *
+     * @return array{name: string, description: string, capabilities: array<string>, contextLength: int, maxOutputTokens: int, costInput: int, costOutput: int, recommended: bool}
+     */
+    private static function specializedSpec(string $name, string $description, string $capability): array
+    {
+        return [
+            'name' => $name,
+            'description' => $description,
+            'capabilities' => [$capability],
+            'contextLength' => 0,
+            'maxOutputTokens' => 0,
+            'costInput' => 0,
+            'costOutput' => 0,
+            'recommended' => false,
+        ];
     }
 
     /**
@@ -1134,6 +1119,39 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     }
 
     /**
+     * Fetch a Bearer-authenticated `/models` listing and return the decoded
+     * `data` list.
+     *
+     * Returns null when the endpoint answered with a non-200 status (already
+     * logged); network-level failures bubble up as exceptions so callers
+     * keep their provider-specific fallback handling.
+     *
+     *
+     * @throws Throwable when the request fails
+     *
+     * @return array<int|string, mixed>|null
+     */
+    private function fetchBearerModelList(string $adapterType, string $endpoint, string $apiKey): ?array
+    {
+        $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
+            ->withHeader('Authorization', 'Bearer ' . $apiKey);
+
+        $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
+
+        if ($response->getStatusCode() !== 200) {
+            $this->logDiscoveryHttpError($adapterType, $response->getStatusCode());
+
+            return null;
+        }
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return is_array($data) && isset($data['data']) && is_array($data['data'])
+            ? $data['data']
+            : [];
+    }
+
+    /**
      * Discover OpenRouter models.
      *
      * @return array<DiscoveredModel>
@@ -1141,24 +1159,12 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private function discoverOpenRouter(string $endpoint, string $apiKey): array
     {
         try {
-            $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
-                ->withHeader('Authorization', 'Bearer ' . $apiKey);
-
-            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
-
-            if ($response->getStatusCode() !== 200) {
-                $this->logDiscoveryHttpError('openrouter', $response->getStatusCode());
-
+            $modelList = $this->fetchBearerModelList('openrouter', $endpoint, $apiKey);
+            if ($modelList === null) {
                 return [];
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
             $models = [];
-
-            $modelList = is_array($data) && isset($data['data']) && is_array($data['data'])
-                ? $data['data']
-                : [];
-
             foreach ($modelList as $model) {
                 if (!is_array($model)) {
                     continue;
@@ -1212,24 +1218,12 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private function discoverMistral(string $endpoint, string $apiKey): array
     {
         try {
-            $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
-                ->withHeader('Authorization', 'Bearer ' . $apiKey);
-
-            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
-
-            if ($response->getStatusCode() !== 200) {
-                $this->logDiscoveryHttpError('mistral', $response->getStatusCode());
-
+            $modelList = $this->fetchBearerModelList('mistral', $endpoint, $apiKey);
+            if ($modelList === null) {
                 return $this->asFallback($this->getMistralFallbackModels());
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
             $models = [];
-
-            $modelList = is_array($data) && isset($data['data']) && is_array($data['data'])
-                ? $data['data']
-                : [];
-
             foreach ($modelList as $model) {
                 if (!is_array($model)) {
                     continue;
@@ -1301,24 +1295,12 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private function discoverGroq(string $endpoint, string $apiKey): array
     {
         try {
-            $request = $this->requestFactory->createRequest('GET', $endpoint . '/models')
-                ->withHeader('Authorization', 'Bearer ' . $apiKey);
-
-            $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
-
-            if ($response->getStatusCode() !== 200) {
-                $this->logDiscoveryHttpError('groq', $response->getStatusCode());
-
+            $modelList = $this->fetchBearerModelList('groq', $endpoint, $apiKey);
+            if ($modelList === null) {
                 return [];
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
             $models = [];
-
-            $modelList = is_array($data) && isset($data['data']) && is_array($data['data'])
-                ? $data['data']
-                : [];
-
             foreach ($modelList as $model) {
                 if (!is_array($model)) {
                     continue;

--- a/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
+++ b/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
@@ -30,4 +30,14 @@ interface ModelDiscoveryInterface
      * @return array<DiscoveredModel>
      */
     public function discover(DetectedProvider $provider, string $apiKey): array;
+
+    /**
+     * Whether the most recent discover() call substituted a static fallback
+     * catalog for live API data (failed request, unexpected HTTP status, or
+     * malformed/empty response).
+     *
+     * Returns false when no live discovery was attempted at all (e.g. for
+     * adapter types without API-based discovery).
+     */
+    public function wasLastDiscoveryFromFallback(): bool;
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -280,9 +280,55 @@
                 <source>New Snippet</source>
                 <target>Neues Snippet</target>
             </trans-unit>
+            <trans-unit id="btn.task.new">
+                <source>New Task</source>
+                <target>Neue Aufgabe</target>
+            </trans-unit>
             <trans-unit id="btn.refresh">
                 <source>Refresh</source>
                 <target>Aktualisieren</target>
+            </trans-unit>
+
+            <!-- Dashboard overview cards -->
+            <trans-unit id="snippet.card.title">
+                <source>Prompt Snippets</source>
+                <target>Prompt-Snippets</target>
+            </trans-unit>
+            <trans-unit id="snippet.card.subtitle">
+                <source>Reusable prompt fragments</source>
+                <target>Wiederverwendbare Prompt-Fragmente</target>
+            </trans-unit>
+            <trans-unit id="snippet.card.description">
+                <source>Tagged prompt fragments (personas, tones of voice, audiences, styles) for tasks and consuming extensions.</source>
+                <target>Getaggte Prompt-Fragmente (Personas, Tonalitäten, Zielgruppen, Stile) für Aufgaben und nutzende Erweiterungen.</target>
+            </trans-unit>
+            <trans-unit id="snippet.card.button">
+                <source>Manage Snippets</source>
+                <target>Snippets verwalten</target>
+            </trans-unit>
+            <trans-unit id="card.count.snippets">
+                <source>snippet(s) configured</source>
+                <target>Snippet(s) konfiguriert</target>
+            </trans-unit>
+            <trans-unit id="card.count.none.snippets">
+                <source>No snippets configured</source>
+                <target>Keine Snippets konfiguriert</target>
+            </trans-unit>
+            <trans-unit id="analytics.card.title">
+                <source>Usage Analytics</source>
+                <target>Nutzungsstatistik</target>
+            </trans-unit>
+            <trans-unit id="analytics.card.subtitle">
+                <source>Usage and cost dashboard</source>
+                <target>Nutzungs- und Kosten-Dashboard</target>
+            </trans-unit>
+            <trans-unit id="analytics.card.description">
+                <source>Review LLM usage, cost trends, and per-model / per-user breakdowns.</source>
+                <target>LLM-Nutzung, Kostentrends und Auswertungen pro Modell / Benutzer einsehen.</target>
+            </trans-unit>
+            <trans-unit id="analytics.card.button">
+                <source>Open Analytics</source>
+                <target>Statistik öffnen</target>
             </trans-unit>
 
             <!-- Task controller messages -->

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -213,8 +213,43 @@
             <trans-unit id="btn.snippet.new">
                 <source>New Snippet</source>
             </trans-unit>
+            <trans-unit id="btn.task.new">
+                <source>New Task</source>
+            </trans-unit>
             <trans-unit id="btn.refresh">
                 <source>Refresh</source>
+            </trans-unit>
+
+            <!-- Dashboard overview cards -->
+            <trans-unit id="snippet.card.title">
+                <source>Prompt Snippets</source>
+            </trans-unit>
+            <trans-unit id="snippet.card.subtitle">
+                <source>Reusable prompt fragments</source>
+            </trans-unit>
+            <trans-unit id="snippet.card.description">
+                <source>Tagged prompt fragments (personas, tones of voice, audiences, styles) for tasks and consuming extensions.</source>
+            </trans-unit>
+            <trans-unit id="snippet.card.button">
+                <source>Manage Snippets</source>
+            </trans-unit>
+            <trans-unit id="card.count.snippets">
+                <source>snippet(s) configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.none.snippets">
+                <source>No snippets configured</source>
+            </trans-unit>
+            <trans-unit id="analytics.card.title">
+                <source>Usage Analytics</source>
+            </trans-unit>
+            <trans-unit id="analytics.card.subtitle">
+                <source>Usage and cost dashboard</source>
+            </trans-unit>
+            <trans-unit id="analytics.card.description">
+                <source>Review LLM usage, cost trends, and per-model / per-user breakdowns.</source>
+            </trans-unit>
+            <trans-unit id="analytics.card.button">
+                <source>Open Analytics</source>
             </trans-unit>
 
             <!-- Task controller messages -->

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -78,6 +78,10 @@
                     <a href="{be:moduleLink(route: 'nrllm_providers')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.card.button" default="Manage Providers" />
                     </a>
+                    <a href="{newProviderUrl}" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-plus" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.provider.new" default="New Provider" />
+                    </a>
                 </div>
             </div>
 
@@ -111,6 +115,10 @@
                 <div class="card-footer">
                     <a href="{be:moduleLink(route: 'nrllm_models')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.card.button" default="Manage Models" />
+                    </a>
+                    <a href="{newModelUrl}" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-plus" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.model.new" default="New Model" />
                     </a>
                 </div>
             </div>
@@ -146,6 +154,10 @@
                     <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.card.button" default="Manage Configurations" />
                     </a>
+                    <a href="{newConfigurationUrl}" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-plus" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.configuration.new" default="New Configuration" />
+                    </a>
                 </div>
             </div>
 
@@ -180,12 +192,74 @@
                     <a href="{be:moduleLink(route: 'nrllm_tasks')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.card.button" default="Manage Tasks" />
                     </a>
+                    <a href="{newTaskUrl}" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-plus" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.task.new" default="New Task" />
+                    </a>
                     <f:if condition="{dbProviderCount} > 0">
                         <a href="{taskWizardUrl}" class="btn btn-primary btn-sm ms-1">
                             <core:icon identifier="actions-bolt" size="small" />
                             Create with AI
                         </a>
                     </f:if>
+                </div>
+            </div>
+
+            <div class="card card-size-small">
+                <div class="card-header">
+                    <div class="card-icon">
+                        <core:icon identifier="module-nrllm-snippet" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.card.title" default="Prompt Snippets" /></h2>
+                        <span class="card-subtitle"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.card.subtitle" default="Reusable prompt fragments" /></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.card.description" default="Tagged prompt fragments (personas, tones of voice, audiences, styles) for tasks and consuming extensions." /></p>
+                    <f:if condition="{dbSnippetCount} > 0">
+                        <f:then>
+                            <p class="text-success fw-bold mb-0">
+                                <core:icon identifier="actions-check" size="small" />
+                                {dbSnippetCount} <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:card.count.snippets" default="snippet(s) configured" />
+                            </p>
+                        </f:then>
+                        <f:else>
+                            <p class="text-muted fw-bold mb-0">
+                                <core:icon identifier="actions-info" size="small" />
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:card.count.none.snippets" default="No snippets configured" />
+                            </p>
+                        </f:else>
+                    </f:if>
+                </div>
+                <div class="card-footer">
+                    <a href="{be:moduleLink(route: 'nrllm_snippets')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.card.button" default="Manage Snippets" />
+                    </a>
+                    <a href="{newSnippetUrl}" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-plus" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.snippet.new" default="New Snippet" />
+                    </a>
+                </div>
+            </div>
+
+            <div class="card card-size-small">
+                <div class="card-header">
+                    <div class="card-icon">
+                        <core:icon identifier="module-nrllm-analytics" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.card.title" default="Usage Analytics" /></h2>
+                        <span class="card-subtitle"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.card.subtitle" default="Usage and cost dashboard" /></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.card.description" default="Review LLM usage, cost trends, and per-model / per-user breakdowns." /></p>
+                </div>
+                <div class="card-footer">
+                    <a href="{be:moduleLink(route: 'nrllm_analytics')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.card.button" default="Open Analytics" />
+                    </a>
                 </div>
             </div>
         </div>

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -62,23 +62,23 @@ import Notification from '@typo3/backend/notification.js';
      * Create a rich dropdown item for a model.
      */
     function createModelItem(model, onSelect) {
-        var item = document.createElement('button');
+        const item = document.createElement('button');
         item.type = 'button';
         item.className = 'list-group-item list-group-item-action p-2';
         item.style.cursor = 'pointer';
 
         // Top row: model name + recommended badge
-        var topRow = document.createElement('div');
+        const topRow = document.createElement('div');
         topRow.className = 'd-flex justify-content-between align-items-center';
 
-        var nameEl = document.createElement('strong');
+        const nameEl = document.createElement('strong');
         nameEl.className = 'text-truncate';
         nameEl.style.maxWidth = '280px';
         nameEl.textContent = model.name || model.id;
         topRow.appendChild(nameEl);
 
         if (model.recommended) {
-            var badge = document.createElement('span');
+            const badge = document.createElement('span');
             badge.className = 'badge bg-success ms-1';
             badge.textContent = 'recommended';
             badge.style.fontSize = '0.7em';
@@ -89,7 +89,7 @@ import Notification from '@typo3/backend/notification.js';
 
         // Model ID (if different from name)
         if (model.name && model.name !== model.id) {
-            var idEl = document.createElement('div');
+            const idEl = document.createElement('div');
             idEl.className = 'text-muted small font-monospace';
             idEl.textContent = model.id;
             item.appendChild(idEl);
@@ -97,7 +97,7 @@ import Notification from '@typo3/backend/notification.js';
 
         // Description
         if (model.description) {
-            var descEl = document.createElement('div');
+            const descEl = document.createElement('div');
             descEl.className = 'small text-body-secondary';
             descEl.style.whiteSpace = 'nowrap';
             descEl.style.overflow = 'hidden';
@@ -107,19 +107,19 @@ import Notification from '@typo3/backend/notification.js';
         }
 
         // Metadata row: context, output, cost, capabilities
-        var metaParts = [];
-        var ctx = formatTokens(model.contextLength);
+        const metaParts = [];
+        const ctx = formatTokens(model.contextLength);
         if (ctx) metaParts.push('Ctx: ' + ctx);
-        var maxOut = formatTokens(model.maxOutputTokens);
+        const maxOut = formatTokens(model.maxOutputTokens);
         if (maxOut) metaParts.push('Out: ' + maxOut);
-        var costIn = formatCost(model.costInput);
-        var costOut = formatCost(model.costOutput);
+        const costIn = formatCost(model.costInput);
+        const costOut = formatCost(model.costOutput);
         if (costIn && costOut) metaParts.push(costIn + ' / ' + costOut + ' per 1M');
-        var caps = renderCapabilities(model.capabilities);
+        const caps = renderCapabilities(model.capabilities);
         if (caps) metaParts.push(caps);
 
         if (metaParts.length > 0) {
-            var metaRow = document.createElement('div');
+            const metaRow = document.createElement('div');
             metaRow.className = 'small mt-1';
             metaRow.style.color = '#888';
             metaRow.style.fontSize = '0.78em';
@@ -143,29 +143,29 @@ import Notification from '@typo3/backend/notification.js';
         if (!model) return;
 
         if (model.contextLength) {
-            var ctxInput = findFormEngineInput(tableName, inputName, 'context_length');
+            const ctxInput = findFormEngineInput(tableName, inputName, 'context_length');
             if (ctxInput) setFieldValue(ctxInput, String(model.contextLength));
         }
 
         if (model.maxOutputTokens) {
-            var maxInput = findFormEngineInput(tableName, inputName, 'max_output_tokens');
+            const maxInput = findFormEngineInput(tableName, inputName, 'max_output_tokens');
             if (maxInput) setFieldValue(maxInput, String(model.maxOutputTokens));
         }
 
         if (model.costInput) {
-            var costInInput = findFormEngineInput(tableName, inputName, 'cost_input');
+            const costInInput = findFormEngineInput(tableName, inputName, 'cost_input');
             if (costInInput) setFieldValue(costInInput, String(model.costInput));
         }
 
         if (model.costOutput) {
-            var costOutInput = findFormEngineInput(tableName, inputName, 'cost_output');
+            const costOutInput = findFormEngineInput(tableName, inputName, 'cost_output');
             if (costOutInput) setFieldValue(costOutInput, String(model.costOutput));
         }
 
         if (model.capabilities && Array.isArray(model.capabilities)) {
-            var match = inputName.match(/^data\[([^\]]+)\]\[([^\]]+)\]/);
+            let match = inputName.match(/^data\[([^\]]+)\]\[([^\]]+)\]/);
             if (match) {
-                var selector = '[name^="data[' + match[1] + '][' + match[2] + '][capabilities]"]';
+                const selector = '[name^="data[' + match[1] + '][' + match[2] + '][capabilities]"]';
                 document.querySelectorAll(selector).forEach(function (el) {
                     if (el.type === 'checkbox') {
                         el.checked = model.capabilities.includes(el.value);
@@ -182,9 +182,9 @@ import Notification from '@typo3/backend/notification.js';
     function setFieldValue(input, value) {
         input.value = value;
         input.dispatchEvent(new Event('change', { bubbles: true }));
-        var actualName = input.getAttribute('data-formengine-input-name');
+        const actualName = input.getAttribute('data-formengine-input-name');
         if (actualName) {
-            var hidden = document.querySelector('input[name="' + actualName + '"][type="hidden"]');
+            const hidden = document.querySelector('input[name="' + actualName + '"][type="hidden"]');
             if (hidden) hidden.value = value;
         }
     }
@@ -193,9 +193,9 @@ import Notification from '@typo3/backend/notification.js';
      * Show a status message below the input group.
      */
     function showStatus(button, message, type) {
-        var container = button.closest('.form-control-wrap');
+        const container = button.closest('.form-control-wrap');
         if (!container) return;
-        var statusEl = container.querySelector('.js-model-status');
+        const statusEl = container.querySelector('.js-model-status');
         if (!statusEl) return;
         statusEl.textContent = message;
         statusEl.className = 'js-model-status mt-1 text-' + (type === 'error' ? 'danger' : 'success');
@@ -209,11 +209,11 @@ import Notification from '@typo3/backend/notification.js';
      * Create or get the dropdown container for a button.
      */
     function getOrCreateDropdown(button) {
-        var wrap = button.closest('.form-control-wrap');
-        var existing = wrap.querySelector('.js-model-dropdown');
+        const wrap = button.closest('.form-control-wrap');
+        const existing = wrap.querySelector('.js-model-dropdown');
         if (existing) return existing;
 
-        var dropdown = document.createElement('div');
+        const dropdown = document.createElement('div');
         dropdown.className = 'js-model-dropdown list-group shadow-sm border';
         dropdown.style.position = 'absolute';
         dropdown.style.zIndex = '1060';
@@ -223,7 +223,7 @@ import Notification from '@typo3/backend/notification.js';
         dropdown.style.display = 'none';
         dropdown.style.backgroundColor = 'var(--bs-body-bg, #fff)';
 
-        var inputGroup = wrap.querySelector('.input-group');
+        const inputGroup = wrap.querySelector('.input-group');
         if (inputGroup) {
             inputGroup.style.position = 'relative';
             inputGroup.appendChild(dropdown);
@@ -242,21 +242,21 @@ import Notification from '@typo3/backend/notification.js';
     function renderDropdown(dropdown, models, input, button) {
         dropdown.replaceChildren();
 
-        var tableName = button.getAttribute('data-table') || 'tx_nrllm_model';
-        var inputName = input.getAttribute('data-formengine-input-name') || input.name;
+        const tableName = button.getAttribute('data-table') || 'tx_nrllm_model';
+        const inputName = input.getAttribute('data-formengine-input-name') || input.name;
 
         // Filter input
-        var filterWrap = document.createElement('div');
+        const filterWrap = document.createElement('div');
         filterWrap.className = 'p-2 border-bottom sticky-top';
         filterWrap.style.backgroundColor = 'var(--bs-body-bg, #fff)';
 
-        var filterInput = document.createElement('input');
+        const filterInput = document.createElement('input');
         filterInput.type = 'text';
         filterInput.className = 'form-control form-control-sm';
         filterInput.placeholder = 'Filter models...';
         filterWrap.appendChild(filterInput);
 
-        var countEl = document.createElement('div');
+        const countEl = document.createElement('div');
         countEl.className = 'text-muted small mt-1';
         countEl.textContent = models.length + ' models available';
         filterWrap.appendChild(countEl);
@@ -264,7 +264,7 @@ import Notification from '@typo3/backend/notification.js';
         dropdown.appendChild(filterWrap);
 
         // Model list container
-        var listContainer = document.createElement('div');
+        const listContainer = document.createElement('div');
         listContainer.className = 'js-model-list';
         dropdown.appendChild(listContainer);
 
@@ -279,7 +279,7 @@ import Notification from '@typo3/backend/notification.js';
         function renderItems(filteredModels) {
             listContainer.replaceChildren();
             if (filteredModels.length === 0) {
-                var empty = document.createElement('div');
+                const empty = document.createElement('div');
                 empty.className = 'list-group-item text-muted small';
                 empty.textContent = 'No models match filter';
                 listContainer.appendChild(empty);
@@ -294,19 +294,19 @@ import Notification from '@typo3/backend/notification.js';
         renderItems(models);
 
         // Filter handler with debounce
-        var filterTimer;
+        const filterTimer;
         filterInput.addEventListener('input', function () {
             clearTimeout(filterTimer);
             filterTimer = setTimeout(function () {
-                var q = filterInput.value.toLowerCase().trim();
+                const q = filterInput.value.toLowerCase().trim();
                 if (!q) {
                     renderItems(models);
                     return;
                 }
-                var filtered = models.filter(function (m) {
-                    return (m.id && m.id.toLowerCase().includes(q))
-                        || (m.name && m.name.toLowerCase().includes(q))
-                        || (m.description && m.description.toLowerCase().includes(q))
+                const filtered = models.filter(function (m) {
+                    return m.id?.toLowerCase().includes(q)
+                        || m.name?.toLowerCase().includes(q)
+                        || m.description?.toLowerCase().includes(q)
                         || (m.capabilities && m.capabilities.some(function (c) { return c.includes(q); }));
                 });
                 renderItems(filtered);
@@ -329,25 +329,25 @@ import Notification from '@typo3/backend/notification.js';
      * Handle "Fetch Models" button click.
      */
     function handleFetchClick(event) {
-        var button = event.currentTarget;
-        var fetchUrl = button.getAttribute('data-fetch-url');
-        var inputId = button.getAttribute('data-input-id');
-        var tableName = button.getAttribute('data-table');
+        const button = event.currentTarget;
+        const fetchUrl = button.getAttribute('data-fetch-url');
+        const inputId = button.getAttribute('data-input-id');
+        const tableName = button.getAttribute('data-table');
 
-        var input = document.getElementById(inputId);
+        const input = document.getElementById(inputId);
         if (!input) return;
-        var inputName = input.getAttribute('data-formengine-input-name') || input.name;
+        const inputName = input.getAttribute('data-formengine-input-name') || input.name;
 
         // Toggle dropdown if already open
-        var existingDropdown = button.closest('.form-control-wrap').querySelector('.js-model-dropdown');
+        const existingDropdown = button.closest('.form-control-wrap').querySelector('.js-model-dropdown');
         if (existingDropdown && existingDropdown.style.display === 'block') {
             existingDropdown.style.display = 'none';
             return;
         }
 
         // Read current provider_uid
-        var providerUid = parseInt(button.getAttribute('data-provider-uid'), 10) || 0;
-        var providerInput = findFormEngineInput(tableName, inputName, 'provider_uid');
+        let providerUid = parseInt(button.getAttribute('data-provider-uid'), 10) || 0;
+        const providerInput = findFormEngineInput(tableName, inputName, 'provider_uid');
         if (providerInput) {
             providerUid = parseInt(providerInput.value, 10) || providerUid;
         }
@@ -359,16 +359,16 @@ import Notification from '@typo3/backend/notification.js';
 
         // Reuse cached models if same provider
         if (input._fetchedModels && input._fetchedModels.length > 0 && input._fetchedProviderUid === providerUid) {
-            var dropdown = getOrCreateDropdown(button);
+            const dropdown = getOrCreateDropdown(button);
             renderDropdown(dropdown, input._fetchedModels, input, button);
             return;
         }
 
         button.disabled = true;
-        var originalHTML = button.innerHTML;
+        const originalHTML = button.innerHTML;
         button.textContent = 'Fetching\u2026';
 
-        var body = new FormData();
+        const body = new FormData();
         body.append('providerUid', String(providerUid));
 
         fetch(fetchUrl, { method: 'POST', body: body })
@@ -387,7 +387,7 @@ import Notification from '@typo3/backend/notification.js';
                     );
                 }
 
-                var models = data.models || [];
+                const models = data.models || [];
                 input._fetchedModels = models;
                 input._fetchedProviderUid = providerUid;
 
@@ -396,7 +396,7 @@ import Notification from '@typo3/backend/notification.js';
                     return;
                 }
 
-                var dd = getOrCreateDropdown(button);
+                const dd = getOrCreateDropdown(button);
                 renderDropdown(dd, models, input, button);
                 showStatus(button, models.length + ' models from ' + (data.providerName || 'provider'), 'success');
             })
@@ -421,12 +421,12 @@ import Notification from '@typo3/backend/notification.js';
 
     // Invalidate cache when provider changes
     document.addEventListener('change', function (e) {
-        var target = e.target;
+        const target = e.target;
         if (!target || !target.name) return;
         if (!target.name.includes('[provider_uid]')) return;
         document.querySelectorAll('.js-fetch-models').forEach(function (button) {
-            var inputId = button.getAttribute('data-input-id');
-            var input = document.getElementById(inputId);
+            const inputId = button.getAttribute('data-input-id');
+            const input = document.getElementById(inputId);
             if (input) {
                 input._fetchedModels = null;
                 input._fetchedProviderUid = null;

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -5,6 +5,8 @@
  * models from the provider's API, renders a rich dropdown showing model details
  * (context length, capabilities, cost), and auto-fills related fields on selection.
  */
+import Notification from '@typo3/backend/notification.js';
+
 (function () {
     'use strict';
 
@@ -375,6 +377,14 @@
                 if (!data.success) {
                     showStatus(button, 'Error: ' + (data.error || 'Unknown error'), 'error');
                     return;
+                }
+
+                if (data.source === 'fallback') {
+                    Notification.warning(
+                        'Model discovery',
+                        'Live model discovery failed — showing the built-in catalog. See system log.',
+                        10
+                    );
                 }
 
                 var models = data.models || [];

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -15,11 +15,11 @@ import Notification from '@typo3/backend/notification.js';
      * TYPO3 FormEngine names follow the pattern: data[table][uid][column]
      */
     function findFormEngineInput(tableName, inputName, column) {
-        var match = inputName.match(/^data\[([^\]]+)\]\[([^\]]+)\]/);
+        const match = inputName.match(/^data\[([^\]]+)\]\[([^\]]+)\]/);
         if (!match) {
             return null;
         }
-        var fieldName = 'data[' + match[1] + '][' + match[2] + '][' + column + ']';
+        const fieldName = 'data[' + match[1] + '][' + match[2] + '][' + column + ']';
         return document.querySelector('[data-formengine-input-name="' + fieldName + '"]')
             || document.querySelector('[name="' + fieldName + '"]');
     }
@@ -46,8 +46,8 @@ import Notification from '@typo3/backend/notification.js';
      * Render capability badges as text.
      */
     function renderCapabilities(capabilities) {
-        if (!capabilities || !capabilities.length) return '';
-        var labels = {
+        if (!capabilities?.length) return '';
+        const labels = {
             chat: 'Chat', completion: 'Completion', embeddings: 'Embed',
             vision: 'Vision', streaming: 'Stream', tools: 'Tools',
             json_mode: 'JSON', audio: 'Audio', reasoning: 'Reasoning',

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -294,7 +294,7 @@ import Notification from '@typo3/backend/notification.js';
         renderItems(models);
 
         // Filter handler with debounce
-        const filterTimer;
+        let filterTimer;
         filterInput.addEventListener('input', function () {
             clearTimeout(filterTimer);
             filterTimer = setTimeout(function () {

--- a/Tests/Architecture/DomainLayerTest.php
+++ b/Tests/Architecture/DomainLayerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Architecture;
 
 use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrVault\Utility\IdentifierValidator;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
@@ -123,6 +124,9 @@ final class DomainLayerTest
                 Selector::inNamespace('Netresearch\NrLlm\Domain\DTO'),
                 // Vault service (required for API key handling via nr-vault)
                 Selector::inNamespace('Netresearch\NrVault\Service'),
+                // Vault identifier rules (single source of truth for what
+                // counts as a vault identifier — UUID v7 or name-style)
+                Selector::classname(IdentifierValidator::class),
                 // Extbase infrastructure
                 Selector::inNamespace('TYPO3\CMS\Extbase\DomainObject'),
                 Selector::inNamespace('TYPO3\CMS\Extbase\Persistence'),

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -737,6 +737,9 @@ final class ModelControllerTest extends TestCase
             ->expects(self::once())
             ->method('discover')
             ->willReturn($discoveredModels);
+        $this->modelDiscovery
+            ->method('wasLastDiscoveryFromFallback')
+            ->willReturn(false);
 
         $request = $this->createRequest(['providerUid' => 1]);
         $response = $this->subject->fetchAvailableModelsAction($request);
@@ -745,6 +748,7 @@ final class ModelControllerTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertTrue($data['success']);
+        self::assertSame('live', $data['source']);
         self::assertIsArray($data['models']);
         self::assertCount(2, $data['models']);
         self::assertIsArray($data['models'][0]);
@@ -753,6 +757,37 @@ final class ModelControllerTest extends TestCase
         self::assertSame(128000, $data['models'][0]['contextLength']);
         self::assertIsArray($data['models'][0]['capabilities']);
         self::assertContains('vision', $data['models'][0]['capabilities']);
+    }
+
+    #[Test]
+    public function fetchAvailableModelsActionMarksFallbackSource(): void
+    {
+        $provider = $this->createProvider(1);
+
+        $this->providerRepository
+            ->expects(self::once())
+            ->method('findByUid')
+            ->with(1)
+            ->willReturn($provider);
+
+        $this->modelDiscovery
+            ->expects(self::once())
+            ->method('discover')
+            ->willReturn([
+                new DiscoveredModel(modelId: 'gpt-5.5', name: 'GPT-5.5'),
+            ]);
+        $this->modelDiscovery
+            ->method('wasLastDiscoveryFromFallback')
+            ->willReturn(true);
+
+        $request = $this->createRequest(['providerUid' => 1]);
+        $response = $this->subject->fetchAvailableModelsAction($request);
+
+        $data = $this->decodeJsonResponse($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($data['success']);
+        self::assertSame('fallback', $data['source']);
     }
 
     #[Test]

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -35,6 +35,16 @@ final class ProviderTest extends AbstractUnitTestCase
         $this->subject = new Provider();
     }
 
+    protected function tearDown(): void
+    {
+        // The vault-mock tests queue an instance via GeneralUtility::addInstance();
+        // this base class is a plain PHPUnit TestCase (no testing-framework
+        // integrity check), so purge defensively — a failing assertion before the
+        // instance is consumed must not leak it into later tests.
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     // ========================================
     // Basic getter / setter tests
     // ========================================

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -13,9 +13,11 @@ use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\Model\AdapterType;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Unit tests for Provider domain entity.
@@ -259,6 +261,101 @@ final class ProviderTest extends AbstractUnitTestCase
 
         // UUID v4 (version digit is 4, not 7)
         $this->subject->setApiKey('550e8400-e29b-41d4-a716-446655440000');
+    }
+
+    #[Test]
+    public function setApiKeyAcceptsNameStyleVaultIdentifier(): void
+    {
+        // nr-vault also accepts user-friendly name identifiers
+        // (see Netresearch\NrVault\Utility\IdentifierValidator)
+        $this->subject->setApiKey('nr_repurpose_openai');
+        self::assertSame('nr_repurpose_openai', $this->subject->getApiKey());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function plaintextApiKeyProvider(): array
+    {
+        return [
+            'OpenAI project key' => ['sk-proj-abc123xyz'],
+            'Anthropic key' => ['sk-ant-api03-abc123'],
+            'xAI key' => ['xai-abc123xyz'],
+            'Google key (name-style shaped)' => ['AIzaSyDabc123xyz'],
+            'Groq key' => ['gsk_abc123xyz'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('plaintextApiKeyProvider')]
+    public function setApiKeyThrowsForKnownPlaintextKeyPrefixes(string $plaintextKey): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key must be a vault identifier');
+
+        $this->subject->setApiKey($plaintextKey);
+    }
+
+    // ========================================
+    // getDecryptedApiKey
+    // ========================================
+
+    #[Test]
+    public function getDecryptedApiKeyReturnsEmptyStringForEmptyKey(): void
+    {
+        $this->subject->setApiKey('');
+        self::assertSame('', $this->subject->getDecryptedApiKey());
+    }
+
+    #[Test]
+    public function getDecryptedApiKeyRetrievesSecretForNameStyleIdentifier(): void
+    {
+        $vault = $this->createVaultServiceMock(['nr_repurpose_openai' => 'sk-decrypted-secret']);
+        GeneralUtility::addInstance(VaultServiceInterface::class, $vault);
+
+        $this->subject->setApiKey('nr_repurpose_openai');
+
+        self::assertSame('sk-decrypted-secret', $this->subject->getDecryptedApiKey());
+    }
+
+    #[Test]
+    public function getDecryptedApiKeyRetrievesSecretForUuidV7Identifier(): void
+    {
+        $vaultId = '01938f2a-1b2c-7abc-89de-1234567890ab';
+        $vault = $this->createVaultServiceMock([$vaultId => 'sk-decrypted-secret']);
+        GeneralUtility::addInstance(VaultServiceInterface::class, $vault);
+
+        $this->subject->setApiKey($vaultId);
+
+        self::assertSame('sk-decrypted-secret', $this->subject->getDecryptedApiKey());
+    }
+
+    #[Test]
+    public function getDecryptedApiKeyReturnsEmptyAndWarnsForLegacyPlaintextKey(): void
+    {
+        // Legacy plaintext rows are hydrated by Extbase directly into the
+        // property, bypassing setApiKey() validation.
+        $this->subject->_setProperty('apiKey', 'sk-proj-legacy-plaintext');
+
+        $warnings = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$warnings): bool {
+                $warnings[] = $errstr;
+
+                return true;
+            },
+            E_USER_WARNING,
+        );
+
+        try {
+            $result = $this->subject->getDecryptedApiKey();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame('', $result);
+        self::assertCount(1, $warnings);
+        self::assertStringContainsString('plaintext API key', $warnings[0]);
     }
 
     // ========================================

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -342,7 +342,8 @@ final class ProviderTest extends AbstractUnitTestCase
             static function (int $errno, string $errstr) use (&$warnings): bool {
                 $warnings[] = $errstr;
 
-                return true;
+                // Swallow only the user warning under test; let anything else bubble.
+                return $errno === E_USER_WARNING;
             },
             E_USER_WARNING,
         );

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -682,7 +682,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             'data' => [
                 ['id' => 'gpt-5.2'],
                 ['id' => 'text-davinci-003'], // Should be filtered out
-                ['id' => 'whisper-1'], // Should be filtered out
+                ['id' => 'text-embedding-3-large'], // Should be filtered out
+                ['id' => 'gpt-3.5-turbo-instruct'], // Should be filtered out
                 ['id' => 'gpt-image-1'], // Should be included
             ],
         ]);
@@ -697,7 +698,128 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         self::assertContains('gpt-5.2', $modelIds);
         self::assertContains('gpt-image-1', $modelIds);
         self::assertNotContains('text-davinci-003', $modelIds);
-        self::assertNotContains('whisper-1', $modelIds);
+        self::assertNotContains('text-embedding-3-large', $modelIds);
+        self::assertNotContains('gpt-3.5-turbo-instruct', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiIncludesSpecializedModelsWithMatchingCapabilities(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $apiResponse = (string)json_encode([
+            'data' => [
+                ['id' => 'gpt-5.5'],
+                ['id' => 'dall-e-3'],
+                ['id' => 'gpt-image-2'],
+                ['id' => 'tts-1'],
+                ['id' => 'tts-1-hd'],
+                ['id' => 'whisper-1'],
+            ],
+        ]);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, $apiResponse));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $byId = [];
+        foreach ($models as $model) {
+            $byId[$model->modelId] = $model;
+        }
+
+        // Capability values must match the ModelCapability enum
+        assert(isset($byId['dall-e-3'], $byId['gpt-image-2'], $byId['tts-1'], $byId['tts-1-hd'], $byId['whisper-1']));
+        self::assertSame(['image'], $byId['dall-e-3']->capabilities);
+        self::assertSame(['image'], $byId['gpt-image-2']->capabilities);
+        self::assertSame(['text_to_speech'], $byId['tts-1']->capabilities);
+        self::assertSame(['text_to_speech'], $byId['tts-1-hd']->capabilities);
+        self::assertSame(['transcription'], $byId['whisper-1']->capabilities);
+
+        // Specialized models carry no token-based specs
+        self::assertSame(0, $byId['tts-1']->contextLength);
+        self::assertSame(0, $byId['tts-1']->maxOutputTokens);
+
+        // A live result is not flagged as fallback
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
+    }
+
+    #[Test]
+    public function getOpenAiFallbackModelsIncludeGpt55AndSpecializedModels(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        // 401 (e.g. invalid API key) → static fallback catalog
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(401, ''));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $byId = [];
+        foreach ($models as $model) {
+            $byId[$model->modelId] = $model;
+        }
+
+        assert(isset($byId['gpt-5.5'], $byId['gpt-image-2'], $byId['tts-1'], $byId['tts-1-hd'], $byId['whisper-1']));
+        // $5 / $30 per 1M tokens, stored as cents per 1M
+        self::assertSame(500, $byId['gpt-5.5']->costInput);
+        self::assertSame(3000, $byId['gpt-5.5']->costOutput);
+        self::assertTrue($byId['gpt-5.5']->recommended);
+        self::assertSame(['image'], $byId['gpt-image-2']->capabilities);
+        self::assertSame(['text_to_speech'], $byId['tts-1']->capabilities);
+        self::assertSame(['text_to_speech'], $byId['tts-1-hd']->capabilities);
+        self::assertSame(['transcription'], $byId['whisper-1']->capabilities);
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+    }
+
+    #[Test]
+    public function wasLastDiscoveryFromFallbackResetsBetweenCalls(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $liveResponse = $this->createJsonResponseStubForDiscovery(
+            200,
+            (string)json_encode(['data' => [['id' => 'gpt-5.5']]]),
+        );
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls(
+                $this->createJsonResponseStubForDiscovery(401, ''),
+                $liveResponse,
+            );
+
+        $this->subject->discover($provider, 'test-key');
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+
+        $this->subject->discover($provider, 'test-key');
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Three fixes diagnosed live on the sobol review instance:

### 1. Vault identifier handling (root cause of "Fetch models" showing a stale catalog)
`Provider::isVaultIdentifier()` accepted only UUID-v7 strings, but nr-vault identifiers are legitimately name-style (the live instance stores `nr_repurpose_openai`). Consequences:
- `getDecryptedApiKey()` misclassified the identifier as legacy plaintext and returned `''` → ModelDiscovery sent an empty `Bearer` token → OpenAI 401 → silent fallback to the static catalog.
- `setApiKey()` threw an `InvalidArgumentException`, so re-saving the provider record in the backend crashed.

Identifier recognition now delegates to nr-vault's `IdentifierValidator` (UUID v7 **or** name-style). Values starting with known API-key prefixes (`sk-`, `xai-`, `AIza`, `gsk_`) are conservatively treated as plaintext, since some raw keys (e.g. Google `AIza…`) would otherwise match the name-style pattern. The plaintext `trigger_error` warning path is kept.

### 2. ModelDiscovery modernization
- The OpenAI relevance filter no longer excludes `tts-*`/`-tts`, `whisper-*`/`-transcribe`, `dall-e-*` — the model registry has `image`/`text_to_speech`/`transcription` capabilities since #239/#240. Embeddings/babbage/davinci/instruct/realtime/-search stay excluded.
- `enrichOpenAIModel()` tags those capabilities (matching the `ModelCapability` enum) with token specs of 0 where not applicable.
- Static catalog refreshed: `gpt-5.5` ($5/$30 per 1M tokens → 500/3000 cents) plus `gpt-image-2`, `tts-1`, `tts-1-hd`, `whisper-1`.
- **Silent failure killed**: discovery exceptions and unexpected HTTP statuses are now logged as warnings (exception class + sanitized message — never the key) for all providers; this 401 previously hid for weeks. `fetchAvailableModelsAction` reports `'source' => 'live'|'fallback'`, and `ModelIdField.js` shows a backend notification when the built-in catalog is substituted.

### 3. Overview module cards
- Each card gains a "+ New …" action via the existing `FormEngineUrlBuilder` (providers, models, configurations, tasks).
- Missing cards added for the **Snippets** sub-module (with active-snippet count via new `PromptSnippetRepository::countActive()` and "+ New") and the **Analytics** sub-module (open-only — read-only dashboard). EN/DE labels localized.

## Test plan

- [x] `Build/Scripts/runTests.sh -s unit` — 3642 tests, green (new tests: name identifier accepted, UUID v7 accepted, `sk-`/`xai-`/`AIza`/`gsk_` rejected as plaintext incl. warning path, empty key; specialized-model capabilities; gpt-5.5 catalog costs; fallback-source flag reset between calls; AJAX `source` field live/fallback)
- [x] `Build/Scripts/runTests.sh -s phpstan` — green (PHPat allowlist extended for `IdentifierValidator`)
- [x] `Build/Scripts/runTests.sh -s cgl -n` — green
- [x] `Build/Scripts/runTests.sh -s rector -n` — green
- [x] Targeted functional (`ModelControllerTest`, `LlmModuleControllerTest`, `PromptSnippetRepositoryTest`) — identical results to clean main (pre-existing failures verified via stash run, not chased here)
