### PR TITLE
fix(specialized): apply per-service request timeouts on the secure-client path

### DIFF
--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -243,6 +243,13 @@ abstract class AbstractSpecializedService
      * and placement. It resolves the secret inside the vault, injects it,
      * audits the access, and scrubs the plaintext — the secret never
      * surfaces in this extension's code. Mirrors `AbstractProvider`.
+     *
+     * Also pushes the service's configured request timeout down to the wire
+     * via the per-request `withTimeout()` wither when the installed nr-vault
+     * exposes it. Without it, plain PSR-18 `sendRequest()` runs under the
+     * host's global `HTTP.timeout` (TYPO3 default) and long-running calls —
+     * large image generations in particular — get cut off there no matter
+     * what `$this->timeout` says.
      */
     protected function getSecureClient(): ClientInterface
     {
@@ -250,13 +257,26 @@ abstract class AbstractSpecializedService
             return $this->configuredHttpClient;
         }
 
-        return $this->vault->http()
+        $client = $this->vault->http()
             ->withAuthentication(
                 $this->apiKeyIdentifier,
                 $this->getSecretPlacement(),
                 $this->getSecretPlacementOptions(),
             )
             ->withReason($this->getAuditReason());
+
+        // Non-positive timeout = no override, per the wither's contract. The
+        // method_exists() guard keeps the extension installable against an
+        // nr-vault without the wither yet — drop the guard once nr-vault's
+        // per-request timeout is merged and required.
+        if ($this->timeout > 0 && method_exists($client, 'withTimeout')) {
+            $timeoutClient = $client->withTimeout($this->timeout);
+            if ($timeoutClient instanceof ClientInterface) {
+                return $timeoutClient;
+            }
+        }
+
+        return $client;
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -346,9 +346,18 @@ final class DallEImageService extends AbstractSpecializedService
         return self::API_URL;
     }
 
+    /**
+     * Image generation is the slowest specialised call by far: gpt-image-2
+     * at its larger sizes (e.g. 768x2160) routinely takes 2-3+ minutes per
+     * image, so the previous 120s default — and the 180s global
+     * `HTTP.timeout` it silently fell back to — produced live timeouts on
+     * perfectly healthy generations. 300s gives those renders headroom;
+     * deployments can still tune it via the `image.dalle.timeout`
+     * extension-configuration override.
+     */
     protected function getDefaultTimeout(): int
     {
-        return 120;
+        return 300;
     }
 
     /**

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -205,6 +205,84 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function getSecureClientAppliesDefaultTimeoutWhenVaultClientSupportsIt(): void
+    {
+        // Without an ext-conf override, the wire timeout must be the
+        // service's getDefaultTimeout() (42 for the testable fixture) —
+        // previously $this->timeout never reached the secure client and
+        // the host's global HTTP.timeout silently applied instead.
+        $capturedSeconds = null;
+        $client = $this->createTimeoutCapableVaultClientStub($capturedSeconds);
+
+        $subject = $this->createSubjectWithVaultClient(
+            $client,
+            ['apiKeyIdentifier' => 'vault-id', 'baseUrl' => 'https://api.test/v1'],
+        );
+
+        $subject->callSendJsonRequest('endpoint', []);
+
+        self::assertSame(42, $capturedSeconds);
+    }
+
+    #[Test]
+    public function getSecureClientPrefersExtensionConfiguredTimeoutOverDefault(): void
+    {
+        // The ext-conf per-service timeout override must win over
+        // getDefaultTimeout() AND reach the wire via withTimeout().
+        $capturedSeconds = null;
+        $client = $this->createTimeoutCapableVaultClientStub($capturedSeconds);
+
+        $subject = $this->createSubjectWithVaultClient(
+            $client,
+            ['apiKeyIdentifier' => 'vault-id', 'baseUrl' => 'https://api.test/v1', 'timeout' => 300],
+        );
+
+        $subject->callSendJsonRequest('endpoint', []);
+
+        self::assertSame(300, $capturedSeconds);
+    }
+
+    #[Test]
+    public function getSecureClientSkipsTimeoutWitherForNonPositiveTimeout(): void
+    {
+        // Non-positive = "no override" per the wither's contract: the
+        // wither must not be called at all, even on a capable client.
+        $client = $this->createMock(TimeoutCapableVaultHttpClientInterface::class);
+        $client->expects(self::never())->method('withTimeout');
+        $client->method('withAuthentication')->willReturn($client);
+        $client->method('withReason')->willReturn($client);
+        $client->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+
+        $subject = $this->createSubjectWithVaultClient(
+            $client,
+            ['apiKeyIdentifier' => 'vault-id', 'baseUrl' => 'https://api.test/v1', 'timeout' => 0],
+        );
+
+        $subject->callSendJsonRequest('endpoint', []);
+    }
+
+    #[Test]
+    public function getSecureClientToleratesVaultClientWithoutTimeoutSupport(): void
+    {
+        // Installability guard: against an nr-vault whose client does not
+        // expose withTimeout() yet, the request must still go through —
+        // just without the per-request timeout override.
+        $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
+        $vaultHttpClient->method('withAuthentication')->willReturn($vaultHttpClient);
+        $vaultHttpClient->method('withReason')->willReturn($vaultHttpClient);
+        $vaultHttpClient->method('sendRequest')->willReturnCallback(
+            fn() => $this->createJsonResponseMock(['result' => 'ok'], 200),
+        );
+
+        $subject = $this->createSubjectWithVaultClient(
+            $vaultHttpClient,
+            ['apiKeyIdentifier' => 'vault-id', 'baseUrl' => 'https://api.test/v1'],
+        );
+
+        self::assertSame(['result' => 'ok'], $subject->callSendJsonRequest('endpoint', []));
+    }
+
+    #[Test]
     public function auditReasonDefaultsToProviderLabelApiCall(): void
     {
         $subject = $this->createSubject();
@@ -965,6 +1043,56 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         return $subject;
     }
 
+    /**
+     * Timeout-capable vault client stub whose `withTimeout()` argument is
+     * captured into `$capturedSeconds` (stays null when never called).
+     */
+    private function createTimeoutCapableVaultClientStub(?int &$capturedSeconds): TimeoutCapableVaultHttpClientInterface
+    {
+        $client = self::createStub(TimeoutCapableVaultHttpClientInterface::class);
+        $client->method('withAuthentication')->willReturn($client);
+        $client->method('withReason')->willReturn($client);
+        $client->method('withTimeout')->willReturnCallback(
+            static function (int $seconds) use (&$capturedSeconds, $client): TimeoutCapableVaultHttpClientInterface {
+                $capturedSeconds = $seconds;
+                return $client;
+            },
+        );
+        $client->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+
+        return $client;
+    }
+
+    /**
+     * Build a subject whose vault `http()` returns the given client and that
+     * deliberately does NOT use `setHttpClient()` — the test seam bypasses
+     * `getSecureClient()` entirely, so timeout behaviour must be asserted on
+     * the vault path.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function createSubjectWithVaultClient(
+        VaultHttpClientInterface $vaultHttpClient,
+        array $config,
+    ): TestableSpecializedService {
+        $vault = self::createStub(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('http')->willReturn($vaultHttpClient);
+
+        $extConf = self::createStub(ExtensionConfiguration::class);
+        $extConf->method('get')->willReturn($config);
+
+        return new TestableSpecializedService(
+            vault: $vault,
+            requestFactory: $this->passthroughRequestFactory(),
+            streamFactory: $this->passthroughStreamFactory(),
+            extensionConfiguration: $extConf,
+            usageTracker: self::createStub(UsageTrackerServiceInterface::class),
+            logger: self::createStub(LoggerInterface::class),
+            costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+    }
+
     private function passthroughRequestFactory(): RequestFactoryInterface
     {
         $stub = self::createStub(RequestFactoryInterface::class);
@@ -1082,7 +1210,24 @@ final class TestableSpecializedService extends AbstractSpecializedService
     {
         $this->apiKeyIdentifier = is_string($config['apiKeyIdentifier'] ?? null) ? $config['apiKeyIdentifier'] : '';
         $this->baseUrl          = is_string($config['baseUrl'] ?? null) ? $config['baseUrl'] : $this->getDefaultBaseUrl();
+        // Timeout override semantics mirror the real services
+        // (ServiceConfigurationTrait::loadOpenAiServiceConfiguration()).
+        $timeout       = $config['timeout'] ?? null;
+        $this->timeout = is_numeric($timeout) ? (int)$timeout : $this->getDefaultTimeout();
     }
+}
+
+/**
+ * Test-local extension of the vault client contract declaring the frozen
+ * `withTimeout()` wither nr-vault is gaining, so the suite can stub a
+ * timeout-capable client while the installed nr-vault does not declare it
+ * on `VaultHttpClientInterface` yet. The signature mirrors the frozen
+ * nr-vault contract (non-positive = no override); delete this interface
+ * once nr-vault's per-request timeout is merged and required.
+ */
+interface TimeoutCapableVaultHttpClientInterface extends VaultHttpClientInterface
+{
+    public function withTimeout(int $seconds): static;
 }
 
 /**

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -37,6 +37,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -1204,6 +1205,42 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject($config);
 
         self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function defaultTimeoutIsFiveMinutesForLargeImageGeneration(): void
+    {
+        // gpt-image-2 at its larger sizes routinely takes 2-3+ minutes per
+        // image; the previous 120s default produced live timeouts on healthy
+        // generations. Without an ext-conf override the service must come up
+        // with the 300s default.
+        $subject = $this->createSubject();
+
+        self::assertSame(300, $this->readTimeout($subject));
+    }
+
+    #[Test]
+    public function extensionConfiguredTimeoutOverridesImageDefault(): void
+    {
+        // The image.dalle.timeout ext-conf override must keep winning over
+        // getDefaultTimeout().
+        $subject = $this->createSubject([
+            'image' => [
+                'dalle' => [
+                    'timeout' => 600,
+                ],
+            ],
+        ]);
+
+        self::assertSame(600, $this->readTimeout($subject));
+    }
+
+    private function readTimeout(DallEImageService $subject): int
+    {
+        $timeout = (new ReflectionClass($subject))->getProperty('timeout')->getValue($subject);
+        self::assertIsInt($timeout);
+
+        return $timeout;
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -43,8 +43,8 @@ speech.tts.defaultModel = tts-1
 # cat=image; type=string; label=DALL-E Base URL: Custom base URL for DALL-E API (leave empty for OpenAI default)
 image.dalle.baseUrl =
 
-# cat=image; type=int+; label=DALL-E Timeout: Request timeout in seconds (image generation can take time)
-image.dalle.timeout = 120
+# cat=image; type=int+; label=DALL-E Timeout: Request timeout in seconds (large gpt-image-2 sizes routinely take 2-3+ minutes)
+image.dalle.timeout = 300
 
 # cat=image; type=options[dall-e-2,dall-e-3]; label=DALL-E Default Model: Default model for image generation
 image.dalle.defaultModel = dall-e-3


### PR DESCRIPTION
## Description

The specialized services (DALL-E, FAL, Whisper, TTS, DeepL) carry a per-service `$this->timeout` (default from `getDefaultTimeout()`, overridable via extension configuration), but it never reached the wire: `getSecureClient()` returned a plain PSR-18 client, so every request ran under the host's global `HTTP.timeout` instead. On an instance with the TYPO3 default of 180s, a 768x2160 gpt-image-2 generation timed out at exactly 180s mid-render.

**Changes:**

- `AbstractSpecializedService::getSecureClient()` now chains nr-vault's per-request `withTimeout()` wither onto the secure client. The call is guarded with `method_exists()` so the extension stays installable against an nr-vault release that does not expose the wither yet; the guard is marked for removal once nr-vault's per-request timeout is merged and required. Non-positive timeouts mean "no override" per the wither's contract.
- DALL-E default timeout raised from 120s to 300s — gpt-image-2 at its larger sizes routinely takes 2-3+ minutes per image. Both the code default and the `ext_conf_template.txt` default move together (the template value is what real installations resolve). TTS/Whisper/DeepL defaults are unchanged.
- The extension-configuration override path is intact: `loadServiceConfiguration()` still overrides the default per service, and the configured value now actually reaches the wire — covered by unit tests on the vault path (the `setHttpClient()` test seam bypasses `getSecureClient()`, so the tests stub the vault to return a timeout-capable spy client).

**New tests:**

- `getSecureClient` applies the default timeout via `withTimeout()` when the vault client supports it
- ext-conf timeout override wins over the default and reaches `withTimeout()`
- non-positive timeout skips the wither (contract: no override)
- a vault client *without* `withTimeout()` still works (installability guard)
- DALL-E default is 300s; `image.dalle.timeout` override still wins

## Related Issue

Diagnosed on a live review instance: large gpt-image-2 generation cut off at exactly the global 180s `HTTP.timeout` despite the service's own timeout configuration.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the CI suites (`runTests.sh -s unit / cgl -n / phpstan / rector -n`) and all checks pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
