### PR TITLE
docs: add 0.12.0 changelog link references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -857,7 +857,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
The 0.12.0 release section was added without extending the link-reference block: `[0.12.0]` had no definition and `[Unreleased]` still compared against v0.11.1. Adds the 0.12.0 compare link and points Unreleased at v0.12.0...HEAD.