### PR TITLE
test: restore PHPUnit 13 compatibility for mock with() expectations

### DIFF
--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -45,7 +45,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         parent::setUp();
 
         $this->extensionConfigStub = $this->createMock(ExtensionConfiguration::class);
-        $this->extensionConfigStub->method('get')
+        $this->extensionConfigStub->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'defaultProvider' => 'openai',

--- a/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
@@ -29,7 +29,7 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
     public function processReturnsEarlyWhenManagerNotRegistered(): void
     {
         $containerMock = $this->createMock(ContainerBuilder::class);
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(false);
 
@@ -46,15 +46,15 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([
                 'provider.openai' => [['priority' => 10]],
@@ -79,15 +79,15 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([
                 'provider.low' => [['priority' => 5]],
@@ -118,15 +118,15 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([]);
 
@@ -143,16 +143,16 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
         // Empty tag array means no priority specified
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([
                 'provider.a' => [],
@@ -176,16 +176,16 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
         // Tags with non-array first element
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([
                 'provider.a' => ['not_an_array'],
@@ -208,16 +208,16 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         $containerMock = $this->createMock(ContainerBuilder::class);
         $definitionMock = $this->createMock(Definition::class);
 
-        $containerMock->method('has')
+        $containerMock->expects(self::any())->method('has')
             ->with(LlmServiceManager::class)
             ->willReturn(true);
 
-        $containerMock->method('findDefinition')
+        $containerMock->expects(self::any())->method('findDefinition')
             ->with(LlmServiceManager::class)
             ->willReturn($definitionMock);
 
         // Priority as string, should be treated as 0
-        $containerMock->method('findTaggedServiceIds')
+        $containerMock->expects(self::any())->method('findTaggedServiceIds')
             ->with('nr_llm.provider')
             ->willReturn([
                 'provider.a' => [['priority' => 'high']],

--- a/Tests/Unit/Service/CacheManagerMutationTest.php
+++ b/Tests/Unit/Service/CacheManagerMutationTest.php
@@ -39,7 +39,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
     {
         $cacheFrontend = $this->createMock(FrontendInterface::class);
         $cacheFrontend
-            ->method('has')
+            ->expects(self::any())->method('has')
             ->with('test_key')
             ->willReturn(false);
 
@@ -57,11 +57,11 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
 
         $cacheFrontend = $this->createMock(FrontendInterface::class);
         $cacheFrontend
-            ->method('has')
+            ->expects(self::any())->method('has')
             ->with('test_key')
             ->willReturn(true);
         $cacheFrontend
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('test_key')
             ->willReturn($expectedData);
 

--- a/Tests/Unit/Service/CapabilityPermissionServiceTest.php
+++ b/Tests/Unit/Service/CapabilityPermissionServiceTest.php
@@ -134,7 +134,7 @@ class CapabilityPermissionServiceTest extends AbstractUnitTestCase
     public function fallsBackToGlobalsBeUserWhenNoArgumentPassed(): void
     {
         $user = $this->makeBackendUser(isAdmin: false);
-        $user->method('check')
+        $user->expects(self::any())->method('check')
             ->with('custom_options', 'nrllm:capability_embeddings')
             ->willReturn(true);
         $GLOBALS['BE_USER'] = $user;

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -398,7 +398,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             ));
 
         $this->translatorRegistryMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('llm')
             ->willReturn($translatorStub);
 
@@ -488,7 +488,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
     public function hasTranslatorDelegatesToRegistry(): void
     {
         $this->translatorRegistryMock
-            ->method('has')
+            ->expects(self::any())->method('has')
             ->with('deepl')
             ->willReturn(true);
 
@@ -501,7 +501,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $translatorStub = self::createStub(TranslatorInterface::class);
 
         $this->translatorRegistryMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('deepl')
             ->willReturn($translatorStub);
 
@@ -516,7 +516,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $translatorStub = self::createStub(TranslatorInterface::class);
 
         $this->translatorRegistryMock
-            ->method('findBestTranslator')
+            ->expects(self::any())->method('findBestTranslator')
             ->with('en', 'de')
             ->willReturn($translatorStub);
 
@@ -860,7 +860,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $configurationStub->method('getTranslator')->willReturn('deepl');
 
         $configServiceMock
-            ->method('getConfiguration')
+            ->expects(self::any())->method('getConfiguration')
             ->with('my-preset')
             ->willReturn($configurationStub);
 

--- a/Tests/Unit/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Unit/Service/LlmConfigurationServiceTest.php
@@ -114,7 +114,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
     private function setupNoBackendUser(): void
     {
         $this->contextMock
-            ->method('getAspect')
+            ->expects(self::any())->method('getAspect')
             ->with('backend.user')
             ->willThrowException(new AspectNotFoundException());
     }
@@ -144,7 +144,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
         };
 
         $this->contextMock
-            ->method('getAspect')
+            ->expects(self::any())->method('getAspect')
             ->with('backend.user')
             ->willReturn($aspectStub);
     }
@@ -158,7 +158,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
         $config = $this->createConfigurationStub();
 
         $this->repositoryMock
-            ->method('findOneByIdentifier')
+            ->expects(self::any())->method('findOneByIdentifier')
             ->with('test-config')
             ->willReturn($config);
 
@@ -281,7 +281,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
         $queryResult->method('toArray')->willReturn([$config1]);
 
         $this->repositoryMock
-            ->method('findAccessibleForGroups')
+            ->expects(self::any())->method('findAccessibleForGroups')
             ->with([1, 2, 3])
             ->willReturn($queryResult);
 
@@ -494,7 +494,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
     public function isIdentifierAvailableChecksRepository(): void
     {
         $this->repositoryMock
-            ->method('isIdentifierUnique')
+            ->expects(self::any())->method('isIdentifierUnique')
             ->with('new-identifier', 5)
             ->willReturn(true);
 
@@ -508,7 +508,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
     public function isIdentifierAvailableReturnsFalseWhenTaken(): void
     {
         $this->repositoryMock
-            ->method('isIdentifierUnique')
+            ->expects(self::any())->method('isIdentifierUnique')
             ->with('existing-identifier', null)
             ->willReturn(false);
 
@@ -545,7 +545,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
         $queryResult->method('toArray')->willReturn([]);
 
         $this->repositoryMock
-            ->method('findAccessibleForGroups')
+            ->expects(self::any())->method('findAccessibleForGroups')
             ->with([])
             ->willReturn($queryResult);
 

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -295,7 +295,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
 
         $provider = $this->createMock(ProviderInterface::class);
         $provider->method('getIdentifier')->willReturn('test');
-        $provider->method('supportsFeature')
+        $provider->expects(self::any())->method('supportsFeature')
             ->with('chat')
             ->willReturn(true);
 

--- a/Tests/Unit/Service/PromptTemplateServiceTest.php
+++ b/Tests/Unit/Service/PromptTemplateServiceTest.php
@@ -68,7 +68,7 @@ class PromptTemplateServiceTest extends AbstractUnitTestCase
     {
         $template = $this->createTemplate('my-prompt');
         $this->repositoryMock
-            ->method('findOneByIdentifier')
+            ->expects(self::any())->method('findOneByIdentifier')
             ->with('my-prompt')
             ->willReturn($template);
 
@@ -81,7 +81,7 @@ class PromptTemplateServiceTest extends AbstractUnitTestCase
     public function getPromptThrowsExceptionWhenNotFound(): void
     {
         $this->repositoryMock
-            ->method('findOneByIdentifier')
+            ->expects(self::any())->method('findOneByIdentifier')
             ->with('nonexistent')
             ->willReturn(null);
 
@@ -463,7 +463,7 @@ class PromptTemplateServiceTest extends AbstractUnitTestCase
     {
         $variant = $this->createTemplate('variant-a');
         $this->repositoryMock
-            ->method('findVariant')
+            ->expects(self::any())->method('findVariant')
             ->with('base', 'variant-a')
             ->willReturn($variant);
 
@@ -548,7 +548,7 @@ class PromptTemplateServiceTest extends AbstractUnitTestCase
             ->willReturn([$template1, $template2]);
 
         $this->repositoryMock
-            ->method('findByFeature')
+            ->expects(self::any())->method('findByFeature')
             ->with('translation')
             ->willReturn($queryResultMock);
 

--- a/Tests/Unit/Service/UsageTrackerServiceTest.php
+++ b/Tests/Unit/Service/UsageTrackerServiceTest.php
@@ -92,7 +92,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
         };
 
         $this->contextMock
-            ->method('getAspect')
+            ->expects(self::any())->method('getAspect')
             ->with('backend.user')
             ->willReturn($aspectStub);
     }
@@ -100,7 +100,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
     private function setupNoBackendUser(): void
     {
         $this->contextMock
-            ->method('getAspect')
+            ->expects(self::any())->method('getAspect')
             ->with('backend.user')
             ->willThrowException(new AspectNotFoundException());
     }

--- a/Tests/Unit/Service/WizardGeneratorServiceTest.php
+++ b/Tests/Unit/Service/WizardGeneratorServiceTest.php
@@ -154,7 +154,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
         $defaultConfig = $this->createConfigurationWithModel();
 
         $this->configurationRepository
-            ->method('findByUid')
+            ->expects(self::any())->method('findByUid')
             ->with(999)
             ->willReturn(null);
         $this->stubDefaultConfig($defaultConfig);

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -131,7 +131,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ];
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
@@ -149,7 +149,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     private function createSubjectWithoutApiKey(): DallEImageService
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [],
@@ -390,7 +390,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -443,7 +443,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $record->_setProperty('uid', 42);
 
         $modelRepository = $this->createMock(ModelRepository::class);
-        $modelRepository->method('findOneByModelId')->with('dall-e-3')->willReturn($record);
+        $modelRepository->expects(self::any())->method('findOneByModelId')->with('dall-e-3')->willReturn($record);
 
         $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
         $usageTrackerMock
@@ -459,7 +459,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             );
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
         $this->setupSuccessfulRequest([
@@ -625,7 +625,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $configuration->_setProperty('uid', 23);
 
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::any())->method('findOneByIdentifier')
             ->with('alt-text-images')
             ->willReturn($configuration);
 
@@ -643,7 +643,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             );
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
         $this->setupSuccessfulRequest([
@@ -968,7 +968,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -1060,7 +1060,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -1169,7 +1169,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesInvalidConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
@@ -1318,7 +1318,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
@@ -1395,7 +1395,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             ->willThrowException(new RuntimeException('Connection refused'));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
@@ -1429,7 +1429,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest(['data' => $imageData]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
@@ -1486,7 +1486,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
@@ -1534,7 +1534,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -154,7 +154,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         ];
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(array_replace_recursive($defaultConfig, $config));
 
@@ -171,7 +171,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     private function createSubjectWithoutApiKey(): FalImageService
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'image' => [
@@ -440,7 +440,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'image' => [
@@ -610,7 +610,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         ]);
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'image' => [
@@ -764,7 +764,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesInvalidConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
@@ -784,7 +784,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesMissingImageConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([]);
 
@@ -804,7 +804,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesMissingFalConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['image' => []]);
 
@@ -868,7 +868,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesNumericTypes(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'image' => [
@@ -1082,7 +1082,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willThrowException(new RuntimeException('Connection timeout'));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'image' => [

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -121,7 +121,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         ];
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
@@ -139,7 +139,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     private function createSubjectWithoutApiKey(): TextToSpeechService
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [],
@@ -334,7 +334,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest();
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -385,11 +385,11 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $record->_setProperty('uid', 7);
 
         $modelRepository = $this->createMock(ModelRepository::class);
-        $modelRepository->method('findOneByModelId')->with('tts-1')->willReturn($record);
+        $modelRepository->expects(self::any())->method('findOneByModelId')->with('tts-1')->willReturn($record);
 
         $this->setupSuccessfulRequest();
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
 
@@ -542,13 +542,13 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $configuration->_setProperty('uid', 11);
 
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::any())->method('findOneByIdentifier')
             ->with('podcast-narration')
             ->willReturn($configuration);
 
         $this->setupSuccessfulRequest();
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
 
@@ -820,7 +820,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesInvalidConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
@@ -1039,7 +1039,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesNonArrayConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
@@ -1059,7 +1059,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesNonArrayProviders(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => 'not-an-array',

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -141,7 +141,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         ];
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(array_merge($defaultConfig, $config));
 
@@ -159,7 +159,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private function createSubjectWithoutApiKey(): WhisperTranscriptionService
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [],
@@ -439,7 +439,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $configuration->_setProperty('uid', 31);
 
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::any())->method('findOneByIdentifier')
             ->with('meeting-minutes')
             ->willReturn($configuration);
 
@@ -447,7 +447,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
 
@@ -539,7 +539,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -715,7 +715,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -766,7 +766,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         ]));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [
@@ -860,7 +860,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     public function loadConfigurationHandlesInvalidConfig(): void
     {
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn('not-an-array');
 
@@ -995,7 +995,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->willThrowException(new RuntimeException('Connection refused'));
 
         $this->extensionConfigMock
-            ->method('get')
+            ->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
                 'providers' => [


### PR DESCRIPTION
## Problem

The `ci / PHPStan (8.4, *)` and `(8.5, *)` matrix legs fail with **174 errors** (`method.notFound` / `method.nonObject`), all in `Tests/`:

```
Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().
Cannot call method willReturn() on mixed.
```

PHP 8.2/8.3 pass; 8.4/8.5 fail. Root cause is **dependency drift**, unrelated to any feature change:

| PHP | Resolved phpunit/phpunit |
|-----|--------------------------|
| 8.2 / 8.3 | 12.5.30 ✅ |
| 8.4 / 8.5 | 13.1.14 ❌ |

PHPUnit 13 **removed `with()`** (and `withAnyParameters()`/`id()`/`after()`) from the `InvocationStubber` interface returned by `MockObject::method()`; those matchers now live only on the `InvocationMocker` returned by `expects()`. So stub-style chains `$mock->method('x')->with(...)` no longer type-check. They still **work at runtime** (the unit suite is green on 8.5), so this is a static-analysis incompatibility only.

## Fix

Route every `with()`-bearing chain through `expects(self::any())`, whose return type exposes `with()` on **both** majors:

- PHPUnit 12: `expects()` → `InvocationStubber` (has `with()`)
- PHPUnit 13: `expects()` → `InvocationMocker` (has `with()`)

`any()` keeps stub semantics (no invocation-count expectation), so behaviour is unchanged. 87 chains across 14 test files.

```diff
-        $this->extensionConfigStub->method('get')
+        $this->extensionConfigStub->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([...]);
```

## Verification (local, PHP 8.5)

- ✅ PHPStan level 10 clean against **both** `phpunit/phpunit` 12.5.30 and 13.1.14
- ✅ Unit suite green — 3647 tests, 8193 assertions
- ✅ `php-cs-fixer` and Rector clean

## Follow-up (not in this PR)

`Tests/AGENTS.md` still says "PHPUnit 11/12 (cross-compatible)" — worth updating to 11/12/13 once this lands.
