### PR TITLE
refactor!: remove ExtensionConfiguration default-provider fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** `setDefaultProvider()` and `getDefaultProvider()` removed from
+  `LlmServiceManagerInterface` (and its implementation), and the
+  `ExtensionConfiguration['nr_llm']['defaultProvider']` setting is no longer
+  read. These were a vestige of the pre-database provider-centric design and
+  had no effect in production (the key was never exposed in
+  `ext_conf_template.txt`). See ADR-034.
+
+### Changed
+
+- **BREAKING:** `LlmServiceManager::getProvider(null)` now throws
+  `ProviderException` (4867297358) instead of falling back to an
+  extension-config default provider.
+
+  **Migration:** select a provider in one of the two supported ways —
+  pin it per call via the options object's `provider` field
+  (`new ChatOptions(provider: 'openai')`, likewise `EmbeddingOptions`/
+  `VisionOptions`/`ToolOptions`), or mark a Configuration *active* and
+  *default* in the LLM backend module so the generic `chat()`/`complete()`/
+  `embed()` entry points resolve it automatically. To read the configured
+  default programmatically, use
+  `LlmConfigurationService::getDefaultConfiguration()` (access-checked) or
+  `LlmConfigurationRepository::findDefault()` (raw).
+
 ## [0.12.0] - 2026-06-11
 
 ### Added

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -63,7 +63,6 @@ final class LlmModuleController extends ActionController
 
         $providers = $this->llmServiceManager->getProviderList();
         $availableProviders = $this->llmServiceManager->getAvailableProviders();
-        $defaultProvider = $this->llmServiceManager->getDefaultProvider();
 
         $providerDetails = [];
         foreach ($providers as $identifier => $name) {
@@ -74,7 +73,6 @@ final class LlmModuleController extends ActionController
                 'name' => $name,
                 'identifier' => $identifier,
                 'available' => $isAvailable,
-                'isDefault' => $identifier === $defaultProvider,
                 'models' => $provider?->getAvailableModels() ?? [],
                 'defaultModel' => $provider?->getDefaultModel() ?? '',
                 'features' => $this->getProviderFeatures($provider),
@@ -90,7 +88,6 @@ final class LlmModuleController extends ActionController
 
         $moduleTemplate->assignMultiple([
             'providers' => $providerDetails,
-            'defaultProvider' => $defaultProvider,
             'dbProviderCount' => $dbProviderCount,
             'dbModelCount' => $dbModelCount,
             'dbConfigurationCount' => $dbConfigurationCount,

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -45,8 +45,6 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     /** @var array<string, ProviderInterface> */
     private array $providers = [];
 
-    private ?string $defaultProvider = null;
-
     /** @var array<string, mixed> */
     private array $configuration = [];
 
@@ -65,8 +63,9 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      * Resolve the backend-module-managed default configuration for a generic
      * (provider-agnostic) completion/chat call. Returns null when the caller
      * pinned an explicit provider, when no repository is wired (unit tests), or
-     * when no active default configuration exists — in which case the caller
-     * falls back to the extension-config default provider.
+     * when no active default configuration exists — in which case the generic
+     * path requires a per-call pinned provider and otherwise throws (there is
+     * no extension-config default-provider fallback; see ADR-034).
      *
      * Uses the repository directly rather than LlmConfigurationService, whose
      * getDefaultConfiguration() enforces a backend-user access check that the
@@ -80,9 +79,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
         $configuration = $this->configurationRepository?->findDefault();
 
-        // Treat as "no default" — preserving the extension-config fallback — when the default
-        // configuration is missing, has no model (getAdapterFromConfiguration() would throw), or
-        // is access-restricted to specific BE groups. The generic chat()/complete()/streamChat()
+        // Treat as "no default" when the default configuration is missing, has no model
+        // (getAdapterFromConfiguration() would throw), or is access-restricted to specific BE
+        // groups. Returning null here means the generic call needs a per-call pinned provider —
+        // otherwise getProvider(null) throws. The generic chat()/complete()/streamChat()
         // path has no backend-user context to enforce group membership against (notably the CLI
         // worker), so an access-restricted default must not be auto-applied to arbitrary callers.
         if ($configuration === null
@@ -101,8 +101,6 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             /** @var array<string, mixed> $config */
             $config = $this->extensionConfiguration->get('nr_llm');
             $this->configuration = $config;
-            $defaultProvider = $config['defaultProvider'] ?? null;
-            $this->defaultProvider = is_string($defaultProvider) ? $defaultProvider : null;
         } catch (Exception $e) {
             $this->logger->warning('Failed to load extension configuration', ['exception' => $e]);
             $this->configuration = [];
@@ -127,8 +125,6 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
     public function getProvider(?string $identifier = null): ProviderInterface
     {
-        $identifier ??= $this->defaultProvider;
-
         if ($identifier === null) {
             throw new ProviderException(
                 'No provider specified and no default provider configured. '
@@ -177,19 +173,6 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         return $list;
     }
 
-    public function setDefaultProvider(string $identifier): void
-    {
-        if (!isset($this->providers[$identifier])) {
-            throw new ProviderException(sprintf('Cannot set default: Provider "%s" not found', $identifier), 7808641575);
-        }
-        $this->defaultProvider = $identifier;
-    }
-
-    public function getDefaultProvider(): ?string
-    {
-        return $this->defaultProvider;
-    }
-
     /**
      * Send a chat completion request.
      *
@@ -207,8 +190,9 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
         // Single source of truth: with no explicit provider pinned, prefer the
         // backend-module-managed default DB configuration so it drives generation.
-        // The per-call options override the configuration's stored defaults; falls
-        // back to the extension-config default provider when no default exists.
+        // The per-call options override the configuration's stored defaults. When
+        // no default configuration resolves and no provider is pinned, the call
+        // throws (no extension-config fallback; see ADR-034).
         $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
         if ($defaultConfiguration !== null) {
             return $this->chatWithConfiguration(
@@ -278,7 +262,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
         $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
         if ($cacheTtl > 0) {
-            $resolvedProvider = $providerKey ?? $this->defaultProvider ?? 'default';
+            $resolvedProvider = $providerKey ?? 'default';
             $metadata += [
                 CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
                     $resolvedProvider,
@@ -698,7 +682,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $identifier = sprintf(
             'ad-hoc:%s:%s',
             $operation->value,
-            $providerKey ?? ($this->defaultProvider ?? 'default'),
+            $providerKey ?? 'default',
         );
 
         $configuration = new LlmConfiguration();

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -46,10 +46,6 @@ interface LlmServiceManagerInterface
      */
     public function getProviderList(): array;
 
-    public function setDefaultProvider(string $identifier): void;
-
-    public function getDefaultProvider(): ?string;
-
     /**
      * Legacy array-shaped message fixtures are accepted for back-compat
      * and normalised via `ChatMessage::fromArray()` before dispatch.

--- a/Documentation/Adr/Adr034RemoveExtensionConfigDefaultProvider.rst
+++ b/Documentation/Adr/Adr034RemoveExtensionConfigDefaultProvider.rst
@@ -1,0 +1,97 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-034:
+
+======================================================================
+ADR-034: Remove the ExtensionConfiguration default-provider fallback
+======================================================================
+
+:Status: Accepted
+:Date: 2026-06-24
+:Authors: Netresearch DTT GmbH
+
+.. _adr-034-context:
+
+Context
+=======
+
+:php:`LlmServiceManager` carried a session-level *default provider*: a
+nullable ``defaultProvider`` string seeded from
+``ExtensionConfiguration['nr_llm']['defaultProvider']`` and mutable at
+runtime through :php:`setDefaultProvider()` / :php:`getDefaultProvider()`
+(both on the public :php:`LlmServiceManagerInterface`). When a generic
+:php:`chat()` / :php:`complete()` / :php:`streamChat()` call pinned no
+provider, :php:`getProvider(null)` fell back to that string.
+
+This is a remnant of the original provider-centric design that predates
+the database-backed three-tier model (:ref:`adr-013`,
+:ref:`adr-001`). Since :ref:`adr-021` / :ref:`adr-026`, the generic
+entry points resolve the **active default** ``tx_nrllm_configuration``
+record first (``isActive = 1 AND isDefault = 1``, via
+:php:`LlmConfigurationRepository::findDefault()`); the
+``ExtensionConfiguration`` fallback was only ever reached when no such
+record existed.
+
+In practice the fallback was inert: the ``defaultProvider`` key was
+never exposed in ``ext_conf_template.txt``, so it was always ``null`` in
+production unless an integrator set it by hand in ``additional.php``. It
+was also misleading — together with the orphaned ``plugin.tx_nrllm``
+TypoScript (removed in `#255
+<https://github.com/netresearch/t3x-nr-llm/pull/255>`__, answering
+`discussion #254
+<https://github.com/netresearch/t3x-nr-llm/discussions/254>`__) it
+suggested a second, config-driven way to choose a provider that no code
+path honoured as the source of truth.
+
+.. _adr-034-decision:
+
+Decision
+========
+
+Remove the default-provider concept from :php:`LlmServiceManager`
+entirely. The database is the single source of truth for provider
+selection.
+
+1. **Drop the state and its seed.** The ``defaultProvider`` property and
+   the ``ExtensionConfiguration['nr_llm']['defaultProvider']`` read in
+   :php:`loadConfiguration()` are removed. The rest of the extension
+   configuration (provider-specific settings consumed by
+   :php:`registerProvider()`) is unaffected.
+
+2. **Remove the public accessors.** :php:`setDefaultProvider()` and
+   :php:`getDefaultProvider()` are removed from
+   :php:`LlmServiceManagerInterface` and its implementation. **This is a
+   breaking change** to the public service contract.
+
+3. **`getProvider(null)` throws.** With no fallback,
+   :php:`getProvider()` requires an explicit identifier; called with
+   ``null`` it throws :php:`ProviderException` (code ``4867297358``)
+   with guidance to configure a default Configuration in the backend
+   module. The signature keeps the nullable parameter for callers that
+   pass a possibly-null pinned provider.
+
+.. _adr-034-consequences:
+
+Consequences
+============
+
+- ● One way to choose a provider: pin it per call (the ``provider``
+  option on :php:`ChatOptions` / :php:`EmbeddingOptions`) or let the
+  generic path resolve the active default Configuration. No silent,
+  inert third path.
+- ● The :php:`LlmServiceManagerInterface` shrinks by two methods that
+  no production code consumed.
+- ◐ **Breaking:** integrators that called
+  :php:`setDefaultProvider()` / :php:`getDefaultProvider()`, or relied
+  on the ``defaultProvider`` extension-config key, must instead create
+  an active+default Configuration record or pin the provider per call.
+  No production deployment used the key (it was never exposed in
+  ``ext_conf_template.txt``), so real-world impact is expected to be
+  nil.
+- ● No production behaviour change in practice: the generic entry
+  points already resolved the database default first, and the fallback
+  was never populated in production.
+- ◐ Supersedes the provider-default resolution steps of :ref:`adr-007`
+  ("Default provider from configuration" / "First configured provider by
+  priority"): provider selection is now per-call or via the active default
+  Configuration only, with no extension-config or priority fallback.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -266,3 +266,4 @@ Modern architecture (v0.4+)
    Adr031PromptSnippetLibrary
    Adr032SpecializedUsageAndPricingCatalog
    Adr033SpecializedModelRegistry
+   Adr034RemoveExtensionConfigDefaultProvider

--- a/Documentation/Api/LlmServiceManager.rst
+++ b/Documentation/Api/LlmServiceManager.rst
@@ -82,10 +82,14 @@ The central service for all LLM operations.
 
    .. php:method:: getProvider(?string $identifier = null): ProviderInterface
 
-      Get a specific provider by identifier.
+      Get a specific provider by identifier. An explicit identifier is
+      required; passing ``null`` throws ``ProviderException`` (code
+      4867297358). To select a provider without naming one, pin it per
+      call via the options object's ``provider`` field, or configure an
+      active default Configuration in the backend module (see ADR-034).
 
       :param string|null $identifier: Provider identifier
-         (openai, claude, gemini); null for default
+         (openai, claude, gemini); ``null`` is rejected
       :returns: ProviderInterface
       :throws: ProviderException
 

--- a/Documentation/Testing/EndToEndTesting.rst
+++ b/Documentation/Testing/EndToEndTesting.rst
@@ -81,7 +81,7 @@ E2E test example
                ExtensionConfiguration::class
            );
            $extConfig->method('get')->willReturn([
-               'defaultProvider' => 'openai',
+               'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
            ]);
 
            $registry = self::createStub(

--- a/Documentation/Testing/UnitTesting.rst
+++ b/Documentation/Testing/UnitTesting.rst
@@ -141,8 +141,7 @@ Unit test example
            $mockProvider->method('isConfigured')->willReturn(true);
 
            $this->subject = new LlmServiceManager(
-               providers: [$mockProvider],
-               defaultProvider: 'test'
+               providers: [$mockProvider]
            );
        }
 

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -56,7 +56,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -65,12 +64,11 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
 
         $completionService = new CompletionService($serviceManager);
 
-        // Act: Execute complete workflow
-        $result = $completionService->complete('Hello!');
+        // Act: Execute complete workflow (provider pinned per-call)
+        $result = $completionService->complete('Hello!', new ChatOptions(provider: 'openai'));
 
         // Assert: Verify complete response
         self::assertInstanceOf(CompletionResponse::class, $result);
@@ -104,7 +102,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'claude',
             'providers' => ['claude' => ['apiKeyIdentifier' => '019650a0-1234-7abc-8def-0123456789ab']],
         ]);
 
@@ -113,12 +110,11 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('claude');
 
         $completionService = new CompletionService($serviceManager);
 
-        // Act
-        $result = $completionService->complete('Hello Claude!');
+        // Act (provider pinned per-call)
+        $result = $completionService->complete('Hello Claude!', new ChatOptions(provider: 'claude'));
 
         // Assert
         self::assertInstanceOf(CompletionResponse::class, $result);
@@ -150,7 +146,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -159,9 +154,8 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
-        $serviceManager->setDefaultProvider('openai');
 
-        // Act: Multi-turn conversation via service manager directly
+        // Act: Multi-turn conversation via service manager directly (provider pinned per-call)
         $messages = [
             ['role' => 'system', 'content' => 'You are a helpful geography assistant.'],
             ['role' => 'user', 'content' => 'What is the capital of France?'],
@@ -169,7 +163,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
             ['role' => 'user', 'content' => 'Can you confirm that?'],
         ];
 
-        $result = $serviceManager->chat($messages);
+        $result = $serviceManager->chat($messages, new ChatOptions(provider: 'openai'));
 
         // Assert
         self::assertInstanceOf(CompletionResponse::class, $result);
@@ -207,7 +201,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -216,14 +209,13 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
-        $serviceManager->setDefaultProvider('openai');
 
         $completionService = new CompletionService($serviceManager);
 
-        // Act: Request with specific options (use gpt-4o which supports sampling params)
+        // Act: Request with specific options (provider pinned per-call; gpt-4o supports sampling params)
         $result = $completionService->complete(
             'Generate JSON',
-            new ChatOptions(model: 'gpt-4o', temperature: 0.1, maxTokens: 500),
+            new ChatOptions(provider: 'openai', model: 'gpt-4o', temperature: 0.1, maxTokens: 500),
         );
 
         // Assert
@@ -261,7 +253,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -270,12 +261,11 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
 
         $completionService = new CompletionService($serviceManager);
 
-        // Act
-        $result = $completionService->complete('Write a very long essay');
+        // Act (provider pinned per-call)
+        $result = $completionService->complete('Write a very long essay', new ChatOptions(provider: 'openai'));
 
         // Assert
         self::assertTrue($result->wasTruncated());
@@ -307,7 +297,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -316,12 +305,11 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
 
         $completionService = new CompletionService($serviceManager);
 
-        // Act
-        $result = $completionService->complete('Track my usage');
+        // Act (provider pinned per-call)
+        $result = $completionService->complete('Track my usage', new ChatOptions(provider: 'openai'));
 
         // Assert usage is correctly tracked
         self::assertEquals(25, $result->usage->promptTokens);
@@ -367,7 +355,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => [
                 'openai' => ['apiKeyIdentifier' => 'sk-openai-test'],
                 'claude' => ['apiKeyIdentifier' => '019650a0-1234-7abc-8def-0123456789ab'],
@@ -381,7 +368,6 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $openAiProvider->setHttpClient($openAiClient);
         $claudeProvider->setHttpClient($claudeClient);
-        $serviceManager->setDefaultProvider('openai');
 
         $completionService = new CompletionService($serviceManager);
 

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -10,12 +10,15 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\E2E;
 
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -50,7 +53,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -59,8 +61,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
-
         // Mock cache manager
         $cacheManager = self::createStub(CacheManagerInterface::class);
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
@@ -69,7 +69,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $embeddingService = new EmbeddingService($serviceManager);
 
         // Act
-        $result = $embeddingService->embedFull('Test text for embedding');
+        $result = $embeddingService->embedFull('Test text for embedding', new EmbeddingOptions(provider: 'openai'));
 
         // Assert
         self::assertInstanceOf(EmbeddingResponse::class, $result);
@@ -81,35 +81,43 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
     #[Test]
     public function embeddingWithCacheHitWorkflow(): void
     {
-        // Arrange - No HTTP client needed when cache hits
+        // Arrange: a cache hit short-circuits the middleware pipeline in
+        // CacheMiddleware BEFORE the terminal provider call, so no provider
+        // needs to be registered. The cached value is stored in
+        // EmbeddingResponse::toArray() shape (what the terminal returns and
+        // CacheMiddleware persists) and is reconstructed via fromArray().
+        $cachedResponse = (new EmbeddingResponse(
+            embeddings: [
+                array_map(fn() => $this->faker->randomFloat(8, -1, 1), range(1, 1536)),
+            ],
+            model: 'text-embedding-3-small',
+            usage: new UsageStatistics(10, 0, 10),
+            provider: 'openai',
+        ))->toArray();
+
+        // The SAME cache manager backs both embed()'s key generation and
+        // CacheMiddleware's lookup; get() returning a non-null value is the hit.
+        $cacheManager = self::createStub(CacheManagerInterface::class);
+        $cacheManager->method('generateCacheKey')->willReturn('emb-cache-key');
+        $cacheManager->method('get')->willReturn($cachedResponse);
+
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
-
-        // Mock cache manager returning cached embeddings with full structure
-        $cachedData = [
-            'embeddings' => [
-                array_map(fn() => $this->faker->randomFloat(8, -1, 1), range(1, 1536)),
-            ],
-            'model' => 'text-embedding-3-small',
-            'usage' => [
-                'promptTokens' => 10,
-                'totalTokens' => 10,
-            ],
-        ];
-
-        $cacheManager = self::createStub(CacheManagerInterface::class);
-        $cacheManager->method('getCachedEmbeddings')
-            ->willReturn($cachedData);
+        $serviceManager = new LlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([new CacheMiddleware($cacheManager)]),
+            $cacheManager,
+        );
 
         $embeddingService = new EmbeddingService($serviceManager);
 
-        // Act - Should hit cache, not make HTTP request
+        // Act - cache hit returns without any HTTP request or registered provider
         $result = $embeddingService->embedFull('Cached text');
 
         // Assert
@@ -168,7 +176,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -177,8 +184,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
-
         $cacheManager = self::createStub(CacheManagerInterface::class);
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
         $cacheManager->method('cacheEmbeddings')->willReturn('cache-key');
@@ -190,7 +195,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
             'First text',
             'Second text',
             'Third text',
-        ]);
+        ], new EmbeddingOptions(provider: 'openai'));
 
         // Assert: embedBatch returns array of vectors directly
         self::assertCount(3, $result);
@@ -235,7 +240,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
 
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([
-            'defaultProvider' => 'openai',
             'providers' => ['openai' => ['apiKeyIdentifier' => 'sk-test']],
         ]);
 
@@ -244,8 +248,6 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $serviceManager->setDefaultProvider('openai');
-
         $cacheManager = self::createStub(CacheManagerInterface::class);
         $cacheManager->method('getCachedEmbeddings')->willReturn(null);
         $cacheManager->method('cacheEmbeddings')->willReturn('cache-key');
@@ -253,8 +255,8 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         $embeddingService = new EmbeddingService($serviceManager);
 
         // Act: Get embedding vectors (not full responses)
-        $vector1 = $embeddingService->embed('Hello world');
-        $vector2 = $embeddingService->embed('Hello world!');
+        $vector1 = $embeddingService->embed('Hello world', new EmbeddingOptions(provider: 'openai'));
+        $vector2 = $embeddingService->embed('Hello world!', new EmbeddingOptions(provider: 'openai'));
 
         // Assert: Both should return valid embedding vectors
         self::assertCount(1536, $vector1);

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Integration\Service;
 
-use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
@@ -48,7 +47,6 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         $this->extensionConfigStub->expects(self::any())->method('get')
             ->with('nr_llm')
             ->willReturn([
-                'defaultProvider' => 'openai',
                 'providers' => [
                     'openai' => [
                         'apiKeyIdentifier' => 'sk-test-openai',
@@ -147,29 +145,6 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
     }
 
     #[Test]
-    public function defaultProviderIsUsedWhenNoProviderSpecified(): void
-    {
-        /** @var array<string, mixed> $responseData */
-        $responseData = $this->getOpenAiChatResponse(content: 'OpenAI response');
-
-        ['provider' => $openAiProvider, 'httpClient' => $httpClient] = $this->createConfiguredOpenAiProvider([
-            $this->createSuccessResponse($responseData),
-        ]);
-
-        $this->subject->registerProvider($openAiProvider);
-        // setHttpClient must be called AFTER registerProvider() since it calls configure()
-        $openAiProvider->setHttpClient($httpClient);
-        $this->subject->setDefaultProvider('openai');
-
-        $result = $this->subject->chat([
-            ['role' => 'user', 'content' => 'Hello'],
-        ]);
-
-        self::assertInstanceOf(CompletionResponse::class, $result);
-        self::assertEquals('OpenAI response', $result->content);
-    }
-
-    #[Test]
     public function specificProviderCanBeRequestedInOptions(): void
     {
         /** @var array<string, mixed> $openAiResponse */
@@ -189,7 +164,6 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $openAiProvider->setHttpClient($openAiClient);
         $claudeProvider->setHttpClient($claudeClient);
-        $this->subject->setDefaultProvider('openai');
 
         // Request Claude specifically
         $result = $this->subject->chat(
@@ -293,11 +267,10 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         $this->subject->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
-        $this->subject->setDefaultProvider('openai');
 
         $this->subject->chat(
             [['role' => 'user', 'content' => 'Hello']],
-            new ChatOptions(temperature: 0.5, maxTokens: 100),
+            new ChatOptions(provider: 'openai', temperature: 0.5, maxTokens: 100),
         );
 
         self::assertCount(1, $clientSetup['requests']);
@@ -338,9 +311,8 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         $this->subject->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
-        $this->subject->setDefaultProvider('openai');
 
-        $result = $this->subject->complete('Tell me a joke');
+        $result = $this->subject->complete('Tell me a joke', new ChatOptions(provider: 'openai'));
 
         self::assertEquals('Completed prompt', $result->content);
     }

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -75,24 +75,12 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
     #[Test]
     public function getProviderThrowsWhenProviderNotFound(): void
     {
-        $manager = $this->createManager(['defaultProvider' => 'nonexistent']);
+        $manager = $this->createManager();
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Provider "nonexistent" not found');
 
-        $manager->getProvider();
-    }
-
-    #[Test]
-    public function getProviderUsesDefaultWhenNullPassed(): void
-    {
-        $manager = $this->createManager(['defaultProvider' => 'test']);
-        $provider = $this->createProviderStub('test');
-        $manager->registerProvider($provider);
-
-        $result = $manager->getProvider(null);
-
-        self::assertSame($provider, $result);
+        $manager->getProvider('nonexistent');
     }
 
     #[Test]
@@ -151,45 +139,6 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
             'openai' => 'OpenAI',
             'claude' => 'Anthropic Claude',
         ], $result);
-    }
-
-    #[Test]
-    public function setDefaultProviderThrowsWhenProviderNotFound(): void
-    {
-        $manager = $this->createManager();
-
-        $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Cannot set default: Provider "nonexistent" not found');
-
-        $manager->setDefaultProvider('nonexistent');
-    }
-
-    #[Test]
-    public function setDefaultProviderUpdatesDefault(): void
-    {
-        $manager = $this->createManager();
-        $provider = $this->createProviderStub('test');
-        $manager->registerProvider($provider);
-
-        $manager->setDefaultProvider('test');
-
-        self::assertEquals('test', $manager->getDefaultProvider());
-    }
-
-    #[Test]
-    public function getDefaultProviderReturnsNullWhenNotSet(): void
-    {
-        $manager = $this->createManager();
-
-        self::assertNull($manager->getDefaultProvider());
-    }
-
-    #[Test]
-    public function getDefaultProviderReturnsConfiguredDefault(): void
-    {
-        $manager = $this->createManager(['defaultProvider' => 'configured']);
-
-        self::assertEquals('configured', $manager->getDefaultProvider());
     }
 
     #[Test]
@@ -291,7 +240,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
     #[Test]
     public function supportsFeatureReturnsTrueWhenProviderSupports(): void
     {
-        $manager = $this->createManager(['defaultProvider' => 'test']);
+        $manager = $this->createManager();
 
         $provider = $this->createMock(ProviderInterface::class);
         $provider->method('getIdentifier')->willReturn('test');
@@ -301,7 +250,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
 
         $manager->registerProvider($provider);
 
-        $result = $manager->supportsFeature('chat');
+        $result = $manager->supportsFeature('chat', 'test');
 
         self::assertTrue($result);
     }

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -65,7 +65,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $this->extensionConfigStub
             ->method('get')
             ->willReturn([
-                'defaultProvider' => 'openai',
                 'providers' => [],
             ]);
 
@@ -98,14 +97,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function getProviderReturnsRegisteredProvider(): void
     {
         $provider = $this->subject->getProvider('openai');
-
-        self::assertSame($this->provider, $provider);
-    }
-
-    #[Test]
-    public function getProviderUsesDefaultWhenNoneSpecified(): void
-    {
-        $provider = $this->subject->getProvider();
 
         self::assertSame($this->provider, $provider);
     }
@@ -148,7 +139,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             provider: 'openai',
         ));
 
-        $result = $this->subject->chat($messages);
+        $result = $this->subject->chat($messages, new ChatOptions(provider: 'openai'));
 
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertEquals('Hi there', $result->content);
@@ -166,7 +157,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             provider: 'openai',
         ));
 
-        $result = $this->subject->complete($prompt);
+        $result = $this->subject->complete($prompt, new ChatOptions(provider: 'openai'));
 
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertEquals('I am fine, thank you!', $result->content);
@@ -185,7 +176,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             provider: 'openai',
         ));
 
-        $result = $this->subject->embed($text);
+        $result = $this->subject->embed($text, new EmbeddingOptions(provider: 'openai'));
 
         self::assertInstanceOf(EmbeddingResponse::class, $result);
         self::assertCount(1536, $result->embeddings[0]);
@@ -218,25 +209,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function setDefaultProviderChangesDefault(): void
-    {
-        $claudeProvider = new TestableProvider('claude', 'Claude', true);
-        $this->subject->registerProvider($claudeProvider);
-        $this->subject->setDefaultProvider('claude');
-
-        self::assertEquals('claude', $this->subject->getDefaultProvider());
-    }
-
-    #[Test]
-    public function setDefaultProviderThrowsForNonexistent(): void
-    {
-        $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Cannot set default: Provider "nonexistent" not found');
-
-        $this->subject->setDefaultProvider('nonexistent');
-    }
-
-    #[Test]
     public function supportsFeatureReturnsTrueWhenSupported(): void
     {
         self::assertTrue($this->subject->supportsFeature('chat', 'openai'));
@@ -261,6 +233,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $options = new ChatOptions(
             temperature: 0.7,
             maxTokens: 1000,
+            provider: 'openai',
             model: 'gpt-4-turbo',
         );
 
@@ -287,7 +260,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $extensionConfigStub
             ->method('get')
             ->willReturn([
-                'defaultProvider' => 'openai',
                 'providers' => [
                     'openai' => [
                         'apiKeyIdentifier' => 'sk-test',
@@ -366,14 +338,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             provider: 'openai',
         ));
         $this->subject->registerProvider($visionProvider);
-        $this->subject->setDefaultProvider('openai-vision');
 
         $content = [
             ['type' => 'text', 'text' => 'Describe this image'],
             ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']],
         ];
 
-        $result = $this->subject->vision($content);
+        $result = $this->subject->vision($content, new VisionOptions(provider: 'openai-vision'));
 
         self::assertInstanceOf(VisionResponse::class, $result);
         self::assertEquals('Image shows a cat', $result->description);
@@ -382,11 +353,11 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     #[Test]
     public function visionThrowsWhenProviderDoesNotSupportVision(): void
     {
-        // Use the default provider which doesn't implement VisionCapableInterface
+        // Pin the registered provider (openai), which doesn't implement VisionCapableInterface
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support vision');
 
-        $this->subject->vision([['type' => 'text', 'text' => 'test']]);
+        $this->subject->vision([['type' => 'text', 'text' => 'test']], new VisionOptions(provider: 'openai'));
     }
 
     #[Test]
@@ -395,11 +366,10 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // Create streaming-capable provider
         $streamProvider = new TestableStreamingProvider();
         $this->subject->registerProvider($streamProvider);
-        $this->subject->setDefaultProvider('openai-stream');
 
         $messages = [['role' => 'user', 'content' => 'Hello']];
         $chunks = [];
-        foreach ($this->subject->streamChat($messages) as $chunk) {
+        foreach ($this->subject->streamChat($messages, new ChatOptions(provider: 'openai-stream')) as $chunk) {
             $chunks[] = $chunk;
         }
 
@@ -412,7 +382,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support streaming');
 
-        foreach ($this->subject->streamChat([['role' => 'user', 'content' => 'test']]) as $chunk) {
+        foreach ($this->subject->streamChat([['role' => 'user', 'content' => 'test']], new ChatOptions(provider: 'openai')) as $chunk) {
             // Should not reach here
         }
     }
@@ -433,14 +403,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ],
         ));
         $this->subject->registerProvider($toolProvider);
-        $this->subject->setDefaultProvider('openai-tools');
 
         $messages = [['role' => 'user', 'content' => 'What is the weather?']];
         $tools = [
             ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => []]]),
         ];
 
-        $result = $this->subject->chatWithTools($messages, $tools);
+        $result = $this->subject->chatWithTools($messages, $tools, new ToolOptions(provider: 'openai-tools'));
 
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
@@ -462,14 +431,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             toolCalls: [ToolCall::function('call_1', 'echo', [])],
         ));
         $this->subject->registerProvider($toolProvider);
-        $this->subject->setDefaultProvider('openai-tools');
 
         $messages    = [['role' => 'user', 'content' => 'echo back']];
         $legacyTools = [
             ['type' => 'function', 'function' => ['name' => 'echo', 'description' => 'echoes input', 'parameters' => []]],
         ];
 
-        $result = $this->subject->chatWithTools($messages, $legacyTools);
+        $result = $this->subject->chatWithTools($messages, $legacyTools, new ToolOptions(provider: 'openai-tools'));
 
         self::assertNotNull($result->toolCalls);
         self::assertCount(1, $result->toolCalls);
@@ -493,7 +461,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $messages = [['role' => 'user', 'content' => 'test']];
         $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'test', 'parameters' => []]])];
 
-        $this->subject->chatWithTools($messages, $tools);
+        $this->subject->chatWithTools($messages, $tools, new ToolOptions(provider: 'openai'));
     }
 
     #[Test]
@@ -515,28 +483,21 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // Should not throw, but log warning
         $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
-        // Manager should work without configuration
-        self::assertNull($manager->getDefaultProvider());
+        // Manager should construct and operate without configuration: no
+        // providers registered yet, so the provider list is empty.
+        self::assertSame([], $manager->getProviderList());
     }
 
     #[Test]
     public function embedThrowsWhenProviderDoesNotSupportEmbeddings(): void
     {
-        // Create provider that doesn't support embeddings
-        $noEmbeddingsProvider = new TestableProvider('no-embed', 'No Embed', true);
-        $this->subject->registerProvider($noEmbeddingsProvider);
-        $this->subject->setDefaultProvider('no-embed');
-
-        // Override supportsFeature to return false for embeddings
-        // Actually the TestableProvider already supports embeddings, so let's use a different approach
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support embeddings');
 
         $limitedProvider = new TestableNoEmbeddingsProvider();
         $this->subject->registerProvider($limitedProvider);
-        $this->subject->setDefaultProvider('limited');
 
-        $this->subject->embed('test');
+        $this->subject->embed('test', new EmbeddingOptions(provider: 'limited'));
     }
 
     #[Test]
@@ -546,7 +507,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $extensionConfigStub
             ->method('get')
             ->willReturn([
-                'defaultProvider' => 'test',
                 'providers' => [
                     'configurable' => [
                         'apiKey' => 'test-key',
@@ -781,7 +741,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function chatFallsBackToDefaultProviderWhenNoDefaultConfigurationExists(): void
+    public function chatThrowsWhenNoDefaultConfigurationAndNoProviderPinned(): void
     {
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn(null);
@@ -796,13 +756,17 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         );
         $manager->registerProvider($this->provider);
 
-        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+        // No active default configuration and no per-call provider: with the
+        // extension-config default-provider fallback removed, the generic path
+        // must throw rather than silently pick a provider.
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
 
-        self::assertInstanceOf(CompletionResponse::class, $result);
+        $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
 
     #[Test]
-    public function chatFallsBackToDefaultProviderWhenDefaultConfigurationHasNoModel(): void
+    public function chatThrowsWhenDefaultConfigurationHasNoModelAndNoProviderPinned(): void
     {
         $config = self::createStub(LlmConfiguration::class);
         $config->method('getLlmModel')->willReturn(null);
@@ -821,14 +785,17 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager->registerProvider($this->provider);
 
         // A model-less default config must not route into *WithConfiguration()
-        // (which would throw) — the extension-config provider handles it instead.
-        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+        // (which would throw a different "no model" error): resolveDefaultConfiguration()
+        // returns null, so with no pinned provider the generic path throws the
+        // no-provider error — asserting that distinguishes the gate from a misroute.
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
 
-        self::assertInstanceOf(CompletionResponse::class, $result);
+        $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
 
     #[Test]
-    public function chatFallsBackToDefaultProviderWhenDefaultConfigurationIsAccessRestricted(): void
+    public function chatThrowsWhenDefaultConfigurationIsAccessRestrictedAndNoProviderPinned(): void
     {
         $model = self::createStub(Model::class);
         $config = self::createStub(LlmConfiguration::class);
@@ -849,10 +816,12 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager->registerProvider($this->provider);
 
         // A group-restricted default must not be auto-applied without a BE-user
-        // context to enforce membership — the extension-config provider handles it.
-        $result = $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+        // context to enforce membership: resolveDefaultConfiguration() returns
+        // null, so with no pinned provider the generic path throws.
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
 
-        self::assertInstanceOf(CompletionResponse::class, $result);
+        $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
 
     #[Test]
@@ -930,7 +899,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function completeFallsBackToDefaultProviderWhenNoDefaultConfigurationExists(): void
+    public function completeThrowsWhenNoDefaultConfigurationAndNoProviderPinned(): void
     {
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn(null);
@@ -945,9 +914,11 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         );
         $manager->registerProvider($this->provider);
 
-        $result = $manager->complete('Prompt');
+        // Mirror of the chat() no-fallback contract for the complete() entry point.
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
 
-        self::assertInstanceOf(CompletionResponse::class, $result);
+        $manager->complete('Prompt');
     }
 
     #[Test]
@@ -1054,7 +1025,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->chat([['role' => 'user', 'content' => 'Hello']]);
+        $manager->chat([['role' => 'user', 'content' => 'Hello']], new ChatOptions(provider: 'openai'));
 
         self::assertCount(1, $spy->calls);
         self::assertSame(ProviderOperation::Chat, $spy->calls[0]['operation']);
@@ -1069,7 +1040,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->complete('prompt');
+        $manager->complete('prompt', new ChatOptions(provider: 'openai'));
 
         self::assertCount(1, $spy->calls);
         self::assertSame(ProviderOperation::Completion, $spy->calls[0]['operation']);
@@ -1081,7 +1052,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->embed('text');
+        $manager->embed('text', new EmbeddingOptions(provider: 'openai'));
 
         self::assertCount(1, $spy->calls);
         self::assertSame(ProviderOperation::Embedding, $spy->calls[0]['operation']);
@@ -1096,7 +1067,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         $manager->vision([
             ['type' => 'image_url', 'image_url' => ['url' => 'https://example.test/i.png']],
-        ]);
+        ], new VisionOptions(provider: 'openai-vision'));
 
         self::assertCount(1, $spy->calls);
         self::assertSame(ProviderOperation::Vision, $spy->calls[0]['operation']);
@@ -1112,6 +1083,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager->chatWithTools(
             [['role' => 'user', 'content' => 'hi']],
             [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'noop', 'description' => '', 'parameters' => []]])],
+            new ToolOptions(provider: 'openai-tools'),
         );
 
         self::assertCount(1, $spy->calls);
@@ -1126,7 +1098,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         // EmbeddingOptions defaults to cacheTtl = 86400, so cache metadata
         // should be set on the ProviderCallContext the middleware sees.
-        $manager->embed('text');
+        $manager->embed('text', new EmbeddingOptions(provider: 'openai'));
 
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
@@ -1141,7 +1113,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->embed('text', EmbeddingOptions::noCache());
+        $manager->embed('text', EmbeddingOptions::noCache()->withProvider('openai'));
 
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
@@ -1158,6 +1130,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
         $options = (new ChatOptions())
+            ->withProvider('openai')
             ->withBeUserUid(7)
             ->withPlannedCost(0.42);
 
@@ -1178,7 +1151,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $manager->chat([['role' => 'user', 'content' => 'hi']]);
+        $manager->chat([['role' => 'user', 'content' => 'hi']], new ChatOptions(provider: 'openai'));
 
         self::assertCount(1, $spy->calls);
         $metadata = $spy->calls[0]['metadata'];
@@ -1197,6 +1170,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
         $options = (new ChatOptions())
+            ->withProvider('openai')
             ->withBeUserUid(13)
             ->withPlannedCost(0.17);
 
@@ -1219,6 +1193,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
 
         $options = new ToolOptions(
+            provider: 'openai-tools',
             beUserUid: 21,
             plannedCost: 0.05,
         );
@@ -1246,6 +1221,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
         $options = (new EmbeddingOptions(cacheTtl: 0))
+            ->withProvider('openai')
             ->withBeUserUid(7)
             ->withPlannedCost(0.42);
 
@@ -1267,6 +1243,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
         $options = (new EmbeddingOptions())
+            ->withProvider('openai')
             ->withBeUserUid(11)
             ->withPlannedCost(0.05);
 
@@ -1288,6 +1265,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager  = $this->buildManagerWithMiddleware([$spy], $provider);
 
         $options = (new VisionOptions())
+            ->withProvider('openai-vision')
             ->withBeUserUid(21)
             ->withPlannedCost(0.10);
 
@@ -1312,7 +1290,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $spy     = new RecordingMiddleware();
         $manager = $this->buildManagerWithMiddleware([$spy]);
 
-        $options = (new ChatOptions())->withBeUserUid(11);
+        $options = (new ChatOptions())->withProvider('openai')->withBeUserUid(11);
 
         $manager->chat([['role' => 'user', 'content' => 'hi']], $options);
 
@@ -1363,7 +1341,6 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ));
         }
         $manager->registerProvider($testProvider);
-        $manager->setDefaultProvider($testProvider->getIdentifier());
 
         return $manager;
     }

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -11,7 +11,10 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
@@ -44,12 +47,35 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         $extensionConfigStub
             ->method('get')
             ->willReturn([
-                'defaultProvider' => 'openai',
                 'providers' => [],
             ]);
 
         $loggerStub = self::createStub(LoggerInterface::class);
+
+        $this->provider = new TranslatorTestProvider();
+
+        // Default DB configuration (flow 2): a provider-agnostic chat() — used
+        // by detectLanguage() and the auto-detect path of translate() — has no
+        // pinned provider, so the manager resolves the backend-module default
+        // configuration. A bare config with a Model assigned and no access
+        // restrictions satisfies resolveDefaultConfiguration()'s gate
+        // (getLlmModel() !== null && !hasAccessRestrictions()).
+        $defaultModel = new Model();
+        $defaultModel->setModelId('gpt-5.2');
+
+        $defaultConfiguration = new LlmConfiguration();
+        $defaultConfiguration->setIdentifier('test-default');
+        $defaultConfiguration->setLlmModel($defaultModel);
+
+        $configurationRepositoryStub = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepositoryStub->method('findDefault')->willReturn($defaultConfiguration);
+
+        // The default configuration resolves its adapter through the registry;
+        // route it back to the same in-memory test provider the pinned
+        // (per-call ['provider' => 'openai']) flow uses, so both paths share
+        // one response source.
         $adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
+        $adapterRegistryStub->method('createAdapterFromModel')->willReturn($this->provider);
 
         $this->llmManager = new LlmServiceManager(
             $extensionConfigStub,
@@ -57,9 +83,9 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             $adapterRegistryStub,
             $this->emptyMiddlewarePipeline(),
             self::createStub(CacheManagerInterface::class),
+            $configurationRepositoryStub,
         );
 
-        $this->provider = new TranslatorTestProvider();
         $this->llmManager->registerProvider($this->provider);
 
         $this->usageTrackerStub = self::createStub(UsageTrackerServiceInterface::class);
@@ -128,7 +154,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     {
         $this->setResponse('Hallo Welt');
 
-        $result = $this->subject->translate('Hello World', 'de', 'en');
+        $result = $this->subject->translate('Hello World', 'de', 'en', ['provider' => 'openai']);
 
         self::assertInstanceOf(TranslatorResult::class, $result);
         self::assertEquals('Hallo Welt', $result->translatedText);
@@ -167,7 +193,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             $usageTrackerMock,
         );
 
-        $subject->translate('Test text', 'de', 'en');
+        $subject->translate('Test text', 'de', 'en', ['provider' => 'openai']);
     }
 
     #[Test]
@@ -175,7 +201,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     {
         $this->setResponse('Result', 'stop');
 
-        $result = $this->subject->translate('Test', 'de', 'en');
+        $result = $this->subject->translate('Test', 'de', 'en', ['provider' => 'openai']);
 
         self::assertEquals(0.9, $result->confidence);
     }
@@ -185,7 +211,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     {
         $this->setResponse('Result', 'length');
 
-        $result = $this->subject->translate('Test', 'de', 'en');
+        $result = $this->subject->translate('Test', 'de', 'en', ['provider' => 'openai']);
 
         self::assertEquals(0.6, $result->confidence);
     }
@@ -195,7 +221,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     {
         $this->setResponse('Result', 'unknown');
 
-        $result = $this->subject->translate('Test', 'de', 'en');
+        $result = $this->subject->translate('Test', 'de', 'en', ['provider' => 'openai']);
 
         self::assertEquals(0.5, $result->confidence);
     }
@@ -205,7 +231,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     {
         $this->setResponse('Translated');
 
-        $result = $this->subject->translate('Test', 'de', 'en');
+        $result = $this->subject->translate('Test', 'de', 'en', ['provider' => 'openai']);
 
         self::assertNotNull($result->metadata);
         self::assertArrayHasKey('model', $result->metadata);
@@ -227,7 +253,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             new CompletionResponse('Translated', 'gpt-5.2', new UsageStatistics(100, 50, 150), 'stop', 'openai'),
         ];
 
-        $result = $this->subject->translate('Das ist ein Test', 'en');
+        $result = $this->subject->translate('Das ist ein Test', 'en', null, ['provider' => 'openai']);
 
         self::assertEquals('de', $result->sourceLanguage);
         self::assertEquals('Translated', $result->translatedText);
@@ -252,7 +278,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             new CompletionResponse('Third', 'gpt-5.2', new UsageStatistics(10, 5, 15), 'stop', 'openai'),
         ];
 
-        $result = $this->subject->translateBatch(['Text 1', 'Text 2', 'Text 3'], 'de', 'en');
+        $result = $this->subject->translateBatch(['Text 1', 'Text 2', 'Text 3'], 'de', 'en', ['provider' => 'openai']);
 
         self::assertCount(3, $result);
     }
@@ -510,7 +536,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             'Dear Sir or Madam',
             'de',
             'en',
-            ['formality' => 'formal'],
+            ['formality' => 'formal', 'provider' => 'openai'],
         );
 
         self::assertInstanceOf(TranslatorResult::class, $result);
@@ -526,7 +552,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             'Test medical text',
             'de',
             'en',
-            ['domain' => 'medical'],
+            ['domain' => 'medical', 'provider' => 'openai'],
         );
 
         self::assertInstanceOf(TranslatorResult::class, $result);
@@ -541,7 +567,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             'Original text',
             'de',
             'en',
-            ['glossary' => ['term1' => 'Begriff1', 'term2' => 'Begriff2']],
+            ['glossary' => ['term1' => 'Begriff1', 'term2' => 'Begriff2'], 'provider' => 'openai'],
         );
 
         self::assertInstanceOf(TranslatorResult::class, $result);
@@ -556,7 +582,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             'Text to translate',
             'de',
             'en',
-            ['context' => 'This is an informal chat message'],
+            ['context' => 'This is an informal chat message', 'provider' => 'openai'],
         );
 
         self::assertInstanceOf(TranslatorResult::class, $result);
@@ -571,7 +597,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             '<p>Text with HTML</p>',
             'de',
             'en',
-            ['preserve_formatting' => false],
+            ['preserve_formatting' => false, 'provider' => 'openai'],
         );
 
         self::assertInstanceOf(TranslatorResult::class, $result);
@@ -615,6 +641,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             [
                 'temperature' => 'invalid',
                 'max_tokens' => 'invalid',
+                'provider' => 'openai',
             ],
         );
 
@@ -630,6 +657,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             'Hello',
             'xyz', // Unknown language code
             'abc', // Unknown language code
+            ['provider' => 'openai'],
         );
 
         self::assertEquals('abc', $result->sourceLanguage);


### PR DESCRIPTION
## Summary

Follow-up to #255 / discussion #254. Removes the manager-level **default provider** mechanism from `LlmServiceManager` — a remnant of the original provider-centric design that predates the database-backed three-tier model.

It was **never functional in production**: the only ways to populate it were the `defaultProvider` extension-config key (never exposed in `ext_conf_template.txt`, so always `null`) or `setDefaultProvider()` (zero production callers); `getDefaultProvider()`'s sole consumer was a dashboard view variable the `Index` template never rendered. Together with the orphaned TypoScript removed in #255, it advertised a config-driven provider selection that no code path honoured — the exact confusion behind discussion #254.

## Type of change

- [x] **Breaking change** (removes public interface methods)
- [x] Refactoring / dead-code removal
- [x] Documentation (ADR-034)

## ⚠️ Breaking change

`setDefaultProvider()` and `getDefaultProvider()` are removed from `LlmServiceManagerInterface` and `LlmServiceManager`, and `ExtensionConfiguration['nr_llm']['defaultProvider']` is no longer read.

Provider selection now has exactly two real flows:

1. **Per call** — pin the provider via the options object's `provider` field.
2. **DB default** — the generic entry points resolve the active default `tx_nrllm_configuration` record.

With neither, `getProvider(null)` throws `ProviderException` (4867297358) with actionable guidance. See **ADR-034**.

## Production change

- `LlmServiceManager`: drop the `$defaultProvider` property + its ext-config read, `get`/`setDefaultProvider()`, and the `getProvider()` null-fallback; simplify two provider-label spots to `$providerKey ?? 'default'`.
- `LlmServiceManagerInterface`: drop the two method declarations.
- `LlmModuleController`: drop the dead `defaultProvider`/`isDefault` dashboard view data (never rendered).

## Test migration

All affected tests moved to real production flows (per-call provider or a stubbed DB default configuration). Tests of the removed feature deleted. Four edge-case tests that covered the `resolveDefaultConfiguration` gate (null / model-less / access-restricted default) were converted to assert the new *throw-when-no-provider* contract — preserving the gate coverage while reflecting the new behaviour.

**Bonus fix:** `embeddingWithCacheHitWorkflow` was a long-broken e2e test — it stubbed the wrong cache method (`getCachedEmbeddings` instead of `CacheManager::get`) on an empty middleware pipeline, so it never exercised a cache hit (it errored on `Provider "openai" not found`; the PHP `e2e` suite is not run in CI, so it never failed). It now wires a real `CacheMiddleware` and genuinely short-circuits on a hit.

## Verification

Run via `Build/Scripts/runTests.sh` (Docker, **PHP 8.5**):

| Check | Result |
|---|---|
| `cgl -n` | ✅ SUCCESS |
| `phpstan` (level 10) | ✅ SUCCESS |
| `unit` | ✅ SUCCESS |
| `integration` | ✅ SUCCESS |
| `e2e` (PHP suite, incl. the rebuilt cache-hit test) | ✅ 26 tests / 95 assertions OK |

Independently adversarially reviewed (removal correctness + test soundness): no missed fallback-dependent tests anywhere in `Tests/`, the converted gate-tests are non-vacuous, and the cache-hit test genuinely hits the cache.

Refs: #254, #255