### PR TITLE
security(backend): require admin for all backend AJAX endpoints

### DIFF
--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -55,6 +55,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 #[AsController]
 final class ConfigurationController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     private const TABLE_NAME = 'tx_nrllm_configuration';
 
     private const ERROR_NO_UID = 'No configuration UID specified';
@@ -221,6 +223,9 @@ final class ConfigurationController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -251,6 +256,9 @@ final class ConfigurationController extends ActionController
      */
     public function setDefaultAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -278,6 +286,9 @@ final class ConfigurationController extends ActionController
      */
     public function getModelsAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $providerKey = $this->extractStringFromBody($body, 'provider');
 
@@ -322,6 +333,9 @@ final class ConfigurationController extends ActionController
      */
     public function testConfigurationAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -387,6 +401,9 @@ final class ConfigurationController extends ActionController
      */
     public function getModelConstraintsAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $modelUid = $this->extractIntFromBody($body, 'modelUid');
 

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -32,6 +32,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 #[AsController]
 final class LlmModuleController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly LlmServiceManagerInterface $llmServiceManager,
@@ -137,6 +139,9 @@ final class LlmModuleController extends ActionController
 
     public function executeTestAction(): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $this->request->getParsedBody();
         $provider = $this->extractStringFromBody($body, 'provider');
         $prompt = $this->extractStringFromBody($body, 'prompt', $this->testPromptResolver->resolve());

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -53,6 +53,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 #[AsController]
 final class ModelController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     private const TABLE_NAME = 'tx_nrllm_model';
 
     private const ERROR_NO_MODEL_UID = 'No model UID specified';
@@ -160,6 +162,9 @@ final class ModelController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -192,6 +197,9 @@ final class ModelController extends ActionController
      */
     public function setDefaultAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -220,6 +228,9 @@ final class ModelController extends ActionController
      */
     public function getByProviderAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
 
@@ -246,6 +257,9 @@ final class ModelController extends ActionController
      */
     public function testModelAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -343,6 +357,9 @@ final class ModelController extends ActionController
      */
     public function fetchAvailableModelsAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
 
@@ -429,6 +446,9 @@ final class ModelController extends ActionController
      */
     public function detectLimitsAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
         $modelId = $this->extractStringFromBody($body, 'modelId');

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -47,6 +47,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 #[AsController]
 final class ProviderController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     private const TABLE_NAME = 'tx_nrllm_provider';
 
     private ModuleTemplate $moduleTemplate;
@@ -140,6 +142,9 @@ final class ProviderController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -189,6 +194,9 @@ final class ProviderController extends ActionController
      */
     public function testConnectionAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 

--- a/Classes/Controller/Backend/RequiresBackendAdminTrait.php
+++ b/Classes/Controller/Backend/RequiresBackendAdminTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Shared admin guard for the backend module's standalone AJAX endpoints.
+ *
+ * The nrllm backend module is registered with ``access => admin``, but the
+ * AJAX routes in ``Configuration/Backend/AjaxRoutes.php`` are dispatched
+ * outside the module route and therefore bypass that access check. Any
+ * authenticated backend user could otherwise reach state-mutating actions,
+ * provider test-calls that decrypt vault keys, task execution, and arbitrary
+ * record reads. Each AJAX action calls {@see denyNonAdmin()} at its very top
+ * so only a backend admin proceeds. See ADR-037.
+ */
+trait RequiresBackendAdminTrait
+{
+    /**
+     * Returns a 403 JSON response for non-admins, or null when the current backend user is an admin.
+     */
+    private function denyNonAdmin(): ?ResponseInterface
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if ($backendUser instanceof BackendUserAuthentication && $backendUser->isAdmin()) {
+            return null;
+        }
+        return new JsonResponse(['success' => false, 'error' => 'Forbidden'], 403);
+    }
+}

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -53,6 +53,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 #[AsController]
 final class SetupWizardController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     private const ERROR_ENDPOINT_REQUIRED = 'Endpoint URL is required';
 
     private ModuleTemplate $moduleTemplate;
@@ -132,6 +134,9 @@ final class SetupWizardController extends ActionController
      */
     public function detectAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
 
@@ -154,6 +159,9 @@ final class SetupWizardController extends ActionController
      */
     public function testAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
@@ -184,6 +192,9 @@ final class SetupWizardController extends ActionController
      */
     public function discoverAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
@@ -216,6 +227,9 @@ final class SetupWizardController extends ActionController
      */
     public function generateAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $this->parseRequestBody($request);
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
@@ -254,6 +268,9 @@ final class SetupWizardController extends ActionController
      */
     public function saveAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $body = $this->parseRequestBody($request);
         $providerData = $this->extractArrayFromBody($body, 'provider');
         $modelsData = $this->extractArrayFromBody($body, 'models');

--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -18,7 +18,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\StringUtility;
@@ -28,6 +27,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 #[AsController]
 final class SkillSourceController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly SkillSourceRepository $sourceRepository,
@@ -124,19 +125,6 @@ final class SkillSourceController extends ActionController
         $this->sourceRepository->update($source);
         $this->persistenceManager->persistAll();
         return new JsonResponse(['success' => true]);
-    }
-
-    /**
-     * Guard the AJAX endpoints: only an authenticated backend admin may sync, toggle or set tokens.
-     * Skill source/skill management is admin-only (see Modules.php access => admin).
-     */
-    private function denyNonAdmin(): ?ResponseInterface
-    {
-        $backendUser = $GLOBALS['BE_USER'] ?? null;
-        if ($backendUser instanceof BackendUserAuthentication && $backendUser->isAdmin()) {
-            return null;
-        }
-        return new JsonResponse(['success' => false, 'error' => 'Forbidden'], 403);
     }
 
     private function intFromBody(mixed $body, string $key): int

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -65,6 +65,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 #[AsController]
 final class TaskExecutionController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     private const TABLE_NAME = 'tx_nrllm_task';
 
     public function __construct(
@@ -182,6 +184,9 @@ final class TaskExecutionController extends ActionController
      */
     public function executeAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $dto = ExecuteTaskRequest::fromRequest($request);
 
         $task = $this->taskRepository->findByUid($dto->uid);
@@ -253,6 +258,9 @@ final class TaskExecutionController extends ActionController
      */
     public function refreshInputAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $dto = RefreshInputRequest::fromRequest($request);
 
         $task = $this->taskRepository->findByUid($dto->uid);

--- a/Classes/Controller/Backend/TaskRecordsController.php
+++ b/Classes/Controller/Backend/TaskRecordsController.php
@@ -49,6 +49,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 #[AsController]
 final class TaskRecordsController extends ActionController
 {
+    use RequiresBackendAdminTrait;
+
     public function __construct(
         private readonly RecordTableReaderInterface $recordTableReader,
         private readonly LoggerInterface $logger,
@@ -59,6 +61,9 @@ final class TaskRecordsController extends ActionController
      */
     public function listTablesAction(): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         try {
             return new JsonResponse((new TableListResponse(
                 tables: $this->recordTableReader->listAllowedTables(),
@@ -78,6 +83,9 @@ final class TaskRecordsController extends ActionController
      */
     public function fetchRecordsAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $dto = FetchRecordsRequest::fromRequest($request);
 
         if (!$dto->isValid()) {
@@ -142,6 +150,9 @@ final class TaskRecordsController extends ActionController
      */
     public function loadRecordDataAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
         $dto = LoadRecordDataRequest::fromRequest($request);
 
         if (!$dto->isValid()) {

--- a/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
+++ b/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
@@ -1,0 +1,103 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-037:
+
+==================================================================
+ADR-037: Backend AJAX admin guard
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-28
+:Authors: Netresearch DTT GmbH
+
+.. _adr-037-context:
+
+Context
+=======
+
+The nrllm backend module is registered with ``access => admin``, so TYPO3's
+module dispatcher only renders its controllers for backend administrators.
+The module's interactive features, however, are driven by standalone AJAX
+routes declared in ``Configuration/Backend/AjaxRoutes.php`` (``ajax_nrllm_*``).
+These routes are dispatched by the generic backend AJAX route handler, **not**
+through the module route — so the module's ``access => admin`` check never runs
+for them.
+
+The practical effect: any authenticated backend user (including a low-privilege
+editor) could call these endpoints directly. The exposed surface is broad and
+sensitive — provider/model/configuration state mutations (toggle-active,
+set-default), provider and model *test* calls that decrypt vault-stored API
+keys and reach out to upstream LLMs, task execution (which spends budget and
+runs the configured prompt), reading of arbitrary TYPO3 records via the task
+record picker, and the setup wizard's *save* which creates providers and stores
+new API keys in the vault.
+
+Only :php:`SkillSourceController` enforced an admin check, via a private
+``denyNonAdmin()`` method duplicated nowhere else. Every other backend AJAX
+controller was unguarded.
+
+.. _adr-037-decision:
+
+Decision
+========
+
+1. **One shared guard trait.** :php:`RequiresBackendAdminTrait`
+   (``Classes/Controller/Backend/``) exposes a single private
+   ``denyNonAdmin(): ?ResponseInterface`` that returns ``null`` for an admin
+   and a ``403`` ``{"success": false, "error": "Forbidden"}`` JSON response
+   otherwise. :php:`SkillSourceController` now uses the trait; its identical
+   private copy was deleted.
+
+2. **Guard every AJAX-routed action, at the very top.** Each action listed in
+   ``AjaxRoutes.php`` begins with
+   ``if (($deny = $this->denyNonAdmin()) !== null) { return $deny; }`` before
+   any body parse, repository read, or side effect. All AJAX actions already
+   return :php:`ResponseInterface`, so the :php:`JsonResponse` is
+   type-compatible. The guard covers
+   :php:`LlmModuleController`, :php:`ProviderController`, :php:`ModelController`,
+   :php:`ConfigurationController`, :php:`TaskRecordsController`,
+   :php:`TaskExecutionController`, :php:`SetupWizardController` and the
+   already-guarded :php:`SkillSourceController` — 27 actions in total, matching
+   the route table exactly.
+
+3. **Non-AJAX module actions are left untouched.** Extbase module actions
+   (``listAction``, ``indexAction``, ``executeFormAction``,
+   ``wizardFormAction``, …) are reached through the ``access => admin`` module
+   route and are already protected; adding the guard there would be redundant.
+
+4. **The standard accessor is ``$GLOBALS['BE_USER']``.** The guard reads the
+   current backend user from ``$GLOBALS['BE_USER']`` and checks
+   :php:`instanceof BackendUserAuthentication` plus :php:`isAdmin()`. This is
+   the conventional accessor for the authenticated backend user in this
+   context — the AJAX route handler has already established the backend user
+   session by the time the controller action runs, and using the global keeps
+   the guard a zero-dependency trait that any controller can adopt without
+   constructor changes.
+
+.. _adr-037-consequences:
+
+Consequences
+============
+
+- ●● Every backend AJAX endpoint now requires a backend admin; a
+  non-admin receives a uniform ``403`` and no state is mutated, no vault key
+  is decrypted, no upstream LLM is called, and no arbitrary record is read.
+- ● A single shared trait removes the duplicated guard and makes "add the
+  guard" the obvious, one-line step for any future backend AJAX action.
+- ● The guard short-circuits before request-body parsing, so it is cheap and
+  cannot be bypassed by malformed input.
+- ◐ Tests that exercise these actions must now set up an admin
+  ``$GLOBALS['BE_USER']`` (functional: ``setUpBackendUser(1)``; unit: an admin
+  ``BackendUserAuthentication`` stub). This is a one-time, mechanical update to
+  the existing controller test suites.
+- ◐ ``$GLOBALS['BE_USER']`` is a global accessor rather than an injected
+  dependency. It matches existing project usage and keeps the trait
+  dependency-free, but it is global state and is set/reset explicitly in tests.
+- ✕ This is an authorization (admin-only) control, **not** per-record or
+  per-table access control: an admin retains full access to every endpoint,
+  including reading arbitrary records through the task picker. Finer-grained
+  authorization is out of scope.
+
+See :ref:`ADR-023 <adr-023>` for backend capability permissions and
+:ref:`ADR-012 <adr-012>` for API-key encryption (the keys these endpoints
+would otherwise expose).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -230,6 +230,14 @@ Modern architecture (v0.4+)
       .. card-footer:: :ref:`Read <adr-020>`
          :button-style: btn btn-secondary stretched-link
 
+   .. card:: ADR-037: Backend AJAX admin guard
+
+      Shared trait requires a backend admin on every
+      backend AJAX endpoint (403 otherwise).
+
+      .. card-footer:: :ref:`Read <adr-037>`
+         :button-style: btn btn-secondary stretched-link
+
 .. _adr-skills:
 
 Skills
@@ -298,3 +306,4 @@ Skills
    Adr034RemoveExtensionConfigDefaultProvider
    Adr035SkillIngest
    Adr036SkillInjection
+   Adr037BackendAjaxAdminGuard

--- a/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
+++ b/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
+use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
+use Netresearch\NrLlm\Controller\Backend\ModelController;
+use Netresearch\NrLlm\Controller\Backend\ProviderController;
+use Netresearch\NrLlm\Controller\Backend\SetupWizardController;
+use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
+use Netresearch\NrLlm\Controller\Backend\TaskRecordsController;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
+
+/**
+ * Verifies that every newly-guarded backend AJAX endpoint refuses a
+ * non-admin backend user with HTTP 403 and performs no state mutation.
+ *
+ * The nrllm backend module is registered ``access => admin``, but the
+ * standalone AJAX routes in ``Configuration/Backend/AjaxRoutes.php`` are
+ * dispatched outside the module route and bypass that check. The shared
+ * RequiresBackendAdminTrait closes that gap (ADR-037). This test mirrors the
+ * non-admin pattern from {@see SkillSourceControllerTest}: a non-admin BE user
+ * plus a backend request, controller resolved via the container, asserting 403.
+ *
+ * One representative action per guarded controller is exercised here; the
+ * remaining actions share the identical first-line guard.
+ */
+#[CoversClass(ProviderController::class)]
+#[CoversClass(ModelController::class)]
+#[CoversClass(ConfigurationController::class)]
+#[CoversClass(TaskRecordsController::class)]
+#[CoversClass(TaskExecutionController::class)]
+#[CoversClass(SetupWizardController::class)]
+#[CoversClass(LlmModuleController::class)]
+final class BackendAjaxAdminGuardTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+        $this->importFixture('LlmConfigurations.csv');
+        $this->importFixture('Tasks.csv');
+
+        // uid 2 is a non-admin editor (admin=0).
+        $this->setUpBackendUser(2);
+
+        // Resolving an Extbase ActionController from the container triggers
+        // injectConfigurationManager(), which reads settings from the current
+        // request. Provide a backend request so resolution succeeds.
+        $GLOBALS['TYPO3_REQUEST'] = (new Typo3ServerRequest())
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    /**
+     * Assert a denied (403, success:false) JSON response.
+     */
+    private function assertForbidden(ResponseInterface $response): void
+    {
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertSame('Forbidden', $payload['error']);
+    }
+
+    #[Test]
+    public function providerToggleActiveDeniedForNonAdmin(): void
+    {
+        $providerRepository = $this->get(ProviderRepository::class);
+        self::assertInstanceOf(ProviderRepository::class, $providerRepository);
+        $before = $providerRepository->findByUid(1);
+        self::assertNotNull($before);
+        self::assertTrue($before->isActive());
+
+        $controller = $this->get(ProviderController::class);
+        self::assertInstanceOf(ProviderController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/provider/toggle-active'))
+            ->withParsedBody(['uid' => 1]);
+        $this->assertForbidden($controller->toggleActiveAction($request));
+
+        // The denied call must not have toggled the provider.
+        $reloaded = $providerRepository->findByUid(1);
+        self::assertNotNull($reloaded);
+        self::assertTrue($reloaded->isActive(), 'a denied toggle must leave the provider active');
+    }
+
+    #[Test]
+    public function modelSetDefaultDeniedForNonAdmin(): void
+    {
+        $modelRepository = $this->get(ModelRepository::class);
+        self::assertInstanceOf(ModelRepository::class, $modelRepository);
+        $before = $modelRepository->findByUid(3);
+        self::assertNotNull($before);
+        self::assertFalse($before->isDefault());
+
+        $controller = $this->get(ModelController::class);
+        self::assertInstanceOf(ModelController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/model/set-default'))
+            ->withParsedBody(['uid' => 3]);
+        $this->assertForbidden($controller->setDefaultAction($request));
+
+        // The denied call must not have promoted model 3 to default.
+        $reloaded = $modelRepository->findByUid(3);
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isDefault(), 'a denied set-default must not change the default model');
+    }
+
+    #[Test]
+    public function configurationSetDefaultDeniedForNonAdmin(): void
+    {
+        $configurationRepository = $this->get(LlmConfigurationRepository::class);
+        self::assertInstanceOf(LlmConfigurationRepository::class, $configurationRepository);
+        $before = $configurationRepository->findByUid(2);
+        self::assertNotNull($before);
+        self::assertFalse($before->isDefault());
+
+        $controller = $this->get(ConfigurationController::class);
+        self::assertInstanceOf(ConfigurationController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/config/set-default'))
+            ->withParsedBody(['uid' => 2]);
+        $this->assertForbidden($controller->setDefaultAction($request));
+
+        // The denied call must not have promoted configuration 2 to default.
+        $reloaded = $configurationRepository->findByUid(2);
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isDefault(), 'a denied set-default must not change the default configuration');
+    }
+
+    #[Test]
+    public function taskRecordsFetchRecordsDeniedForNonAdmin(): void
+    {
+        $controller = $this->get(TaskRecordsController::class);
+        self::assertInstanceOf(TaskRecordsController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/task/fetch-records'))
+            ->withParsedBody(['table' => 'tx_nrllm_task']);
+        // Reading arbitrary records is admin-only; a non-admin must be refused
+        // before any table read happens.
+        $this->assertForbidden($controller->fetchRecordsAction($request));
+    }
+
+    #[Test]
+    public function taskExecuteDeniedForNonAdmin(): void
+    {
+        $controller = $this->get(TaskExecutionController::class);
+        self::assertInstanceOf(TaskExecutionController::class, $controller);
+
+        // Task uid=1 is active in the fixture; a non-admin must not be able to
+        // execute it (no LLM call, no execution).
+        $request = (new ServerRequest('POST', '/ajax/nrllm/task/execute'))
+            ->withParsedBody(['uid' => 1, 'input' => 'should not run']);
+        $this->assertForbidden($controller->executeAction($request));
+    }
+
+    #[Test]
+    public function setupWizardGenerateDeniedForNonAdmin(): void
+    {
+        $controller = $this->get(SetupWizardController::class);
+        self::assertInstanceOf(SetupWizardController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/wizard/generate'))
+            ->withParsedBody([
+                'endpoint' => 'https://api.openai.com/v1',
+                'apiKey' => 'sk-should-not-be-used',
+                'models' => [['modelId' => 'gpt-5', 'name' => 'GPT-5']],
+            ]);
+        $this->assertForbidden($controller->generateAction($request));
+    }
+
+    #[Test]
+    public function llmModuleExecuteTestDeniedForNonAdmin(): void
+    {
+        $controller = $this->get(LlmModuleController::class);
+        self::assertInstanceOf(LlmModuleController::class, $controller);
+
+        // The guard short-circuits before $this->request is touched, so the
+        // non-admin call is refused without dispatching an Extbase request.
+        $this->assertForbidden($controller->executeTestAction());
+    }
+}

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -63,6 +63,12 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
         $this->importFixture('Models.csv');
         $this->importFixture('LlmConfigurations.csv');
 
+        // The backend AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the success paths.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get real services from container
         $repository = $this->get(LlmConfigurationRepository::class);
         self::assertInstanceOf(LlmConfigurationRepository::class, $repository);

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -74,6 +74,12 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $this->importFixture('LlmConfigurations.csv');
         $this->importFixture('Tasks.csv');
 
+        // The backend AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the error-handling paths rather than the admin guard.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get services from container
         $configurationRepository = $this->get(LlmConfigurationRepository::class);
         self::assertInstanceOf(LlmConfigurationRepository::class, $configurationRepository);

--- a/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
+++ b/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
@@ -49,6 +49,12 @@ final class LlmModuleControllerTest extends AbstractFunctionalTestCase
         $this->importFixture('LlmConfigurations.csv');
         $this->importFixture('Tasks.csv');
 
+        // executeTestAction now requires an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the success paths.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get real services from container
         $llmServiceManager = $this->get(LlmServiceManager::class);
         self::assertInstanceOf(LlmServiceManager::class, $llmServiceManager);

--- a/Tests/Functional/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ModelControllerTest.php
@@ -57,6 +57,12 @@ final class ModelControllerTest extends AbstractFunctionalTestCase
         $this->importFixture('Providers.csv');
         $this->importFixture('Models.csv');
 
+        // The backend AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the success paths.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get real services from container
         $repository = $this->get(ModelRepository::class);
         self::assertInstanceOf(ModelRepository::class, $repository);

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -77,6 +77,12 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $this->importFixture('LlmConfigurations.csv');
         $this->importFixture('Tasks.csv');
 
+        // The backend AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so the workflow
+        // exercises the multi-provider paths rather than the admin guard.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get repositories
         $providerRepository = $this->get(ProviderRepository::class);
         self::assertInstanceOf(ProviderRepository::class, $providerRepository);

--- a/Tests/Functional/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ProviderControllerTest.php
@@ -47,6 +47,12 @@ final class ProviderControllerTest extends AbstractFunctionalTestCase
 
         $this->importFixture('Providers.csv');
 
+        // The backend AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the success paths.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get real services from container
         $repository = $this->get(ProviderRepository::class);
         self::assertInstanceOf(ProviderRepository::class, $repository);

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -52,6 +52,13 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     {
         parent::setUp();
 
+        // Every wizard AJAX endpoint now requires an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037). saveAction additionally needs
+        // an authorized actor for the nr-vault store() call. Set up an admin so
+        // the detect/test/discover/generate/save success + validation paths run.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         // Get real services from container
         $providerDetector = $this->get(ProviderDetector::class);
         self::assertInstanceOf(ProviderDetector::class, $providerDetector);
@@ -445,13 +452,8 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function saveActionCreatesProviderAndModels(): void
     {
-        // saveAction stores the API key through nr-vault, which since
-        // nr-vault 0.6.0 requires an authorized actor (VaultService::store()
-        // calls canCreate()). The wizard's AJAX save route is backend-only in
-        // production, so set up the authenticated backend user it relies on.
-        $this->importFixture('BeUsers.csv');
-        $this->setUpBackendUser(1);
-
+        // The admin backend user (required by both the admin guard and the
+        // nr-vault store() call) is set up in setUp().
         $request = new ServerRequest('POST', self::AJAX_NRLLM_WIZARD_SAVE);
         $request = $request->withHeader('Content-Type', self::APPLICATION_JSON);
         $request = $request->withBody(Utils::streamFor(json_encode([
@@ -496,11 +498,8 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function saveActionCreatesProviderWithConfigurations(): void
     {
-        // Authenticated backend user required for the nr-vault store() call
-        // (see saveActionCreatesProviderAndModels).
-        $this->importFixture('BeUsers.csv');
-        $this->setUpBackendUser(1);
-
+        // The admin backend user (required by both the admin guard and the
+        // nr-vault store() call) is set up in setUp().
         $request = new ServerRequest('POST', self::AJAX_NRLLM_WIZARD_SAVE);
         $request = $request->withHeader('Content-Type', self::APPLICATION_JSON);
         $request = $request->withBody(Utils::streamFor(json_encode([

--- a/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
@@ -61,6 +61,12 @@ final class TaskExecutionAndRecordsControllerTest extends AbstractFunctionalTest
         $this->importFixture('LlmConfigurations.csv');
         $this->importFixture('Tasks.csv');
 
+        // The Task AJAX endpoints now require an authenticated admin
+        // (RequiresBackendAdminTrait — ADR-037); set one up so these tests
+        // exercise the success paths.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+
         $taskRepository = $this->get(TaskRepository::class);
         self::assertInstanceOf(TaskRepository::class, $taskRepository);
         $this->taskRepository = $taskRepository;

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -30,6 +30,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
 use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
 /**
@@ -48,10 +49,18 @@ final class ConfigurationControllerTest extends TestCase
     private ModelRepository&MockObject $modelRepository;
     private TestPromptResolverInterface&MockObject $testPromptResolver;
     private ConfigurationController $subject;
+    private mixed $previousBeUser;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        // The AJAX actions are guarded by RequiresBackendAdminTrait (ADR-037);
+        // provide an admin backend user so these tests reach the action body.
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
 
         $this->configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $this->configurationService = $this->createMock(LlmConfigurationServiceInterface::class);
@@ -63,6 +72,16 @@ final class ConfigurationControllerTest extends TestCase
 
         // Create controller using reflection to inject only required dependencies
         $this->subject = $this->createControllerWithDependencies();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
     }
 
     /**

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
@@ -50,10 +51,18 @@ final class ModelControllerTest extends TestCase
     private ModelDiscoveryInterface&MockObject $modelDiscovery;
     private TestPromptResolverInterface&MockObject $testPromptResolver;
     private ModelController $subject;
+    private mixed $previousBeUser;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        // The AJAX actions are guarded by RequiresBackendAdminTrait (ADR-037);
+        // provide an admin backend user so these tests reach the action body.
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
 
         $this->modelRepository = $this->createMock(ModelRepository::class);
         $this->providerRepository = $this->createMock(ProviderRepository::class);
@@ -65,6 +74,16 @@ final class ModelControllerTest extends TestCase
 
         // Create controller using reflection to inject only required dependencies
         $this->subject = $this->createControllerWithDependencies();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
     }
 
     /**

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
 use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -37,10 +38,18 @@ final class ProviderControllerTest extends TestCase
     private PersistenceManagerInterface&MockObject $persistenceManager;
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ProviderController $subject;
+    private mixed $previousBeUser;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        // The AJAX actions are guarded by RequiresBackendAdminTrait (ADR-037);
+        // provide an admin backend user so these tests reach the action body.
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
 
         $this->providerRepository = $this->createMock(ProviderRepository::class);
         $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
@@ -48,6 +57,16 @@ final class ProviderControllerTest extends TestCase
 
         // Create controller using reflection to inject only required dependencies
         $this->subject = $this->createControllerWithDependencies();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
     }
 
     /**

--- a/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
+++ b/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\RequiresBackendAdminTrait;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Unit tests for the shared backend-admin guard trait.
+ *
+ * The trait method is private; an anonymous class `using` the trait exposes it
+ * so the guard can be exercised directly against the three relevant
+ * `$GLOBALS['BE_USER']` states: admin, non-admin, and absent.
+ */
+#[CoversNothing]
+final class RequiresBackendAdminTraitTest extends TestCase
+{
+    private mixed $previousBeUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Run the guard via an anonymous class that `uses` the trait and exposes
+     * the otherwise-private method.
+     */
+    private function guardResult(): ?ResponseInterface
+    {
+        $subject = new class {
+            use RequiresBackendAdminTrait;
+
+            public function expose(): ?ResponseInterface
+            {
+                return $this->denyNonAdmin();
+            }
+        };
+
+        return $subject->expose();
+    }
+
+    #[Test]
+    public function denyNonAdminReturnsNullForAdminUser(): void
+    {
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertNull($this->guardResult());
+    }
+
+    #[Test]
+    public function denyNonAdminReturnsForbiddenForNonAdminUser(): void
+    {
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 2, 'admin' => 0];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->guardResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertSame('Forbidden', $payload['error']);
+    }
+
+    #[Test]
+    public function denyNonAdminReturnsForbiddenWhenNoBackendUserIsPresent(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->guardResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+    }
+}


### PR DESCRIPTION
## Description

Security hardening: **require a backend admin on every nr-llm backend AJAX endpoint.**

The `nrllm` backend module is registered `access => admin`, but its standalone AJAX routes (`Configuration/Backend/AjaxRoutes.php`) are dispatched outside the module route, so they **bypass that access check** — any authenticated backend user (e.g. an editor) could call them. Surfaced while reviewing the Skills PRs (the skills controller was already guarded; its siblings were not).

This adds a shared `RequiresBackendAdminTrait::denyNonAdmin()` (403 JSON for non-admins) called at the top of **all 27 AJAX-routed actions** across 8 controllers, and refactors `SkillSourceController` onto the shared trait.

**Why it matters** — the previously-open endpoints include state mutations (`toggle-active`, `set-default`), provider/model/config **test calls that decrypt vault API keys**, **task execution** (runs LLM calls / spends budget), **arbitrary TYPO3 record reads** (`task/fetch-records`, `load-record-data`), and the setup wizard's **`save` (creates a provider + stores a new API key in the vault)**.

**Guarded (27 = every AjaxRoutes target):** LlmModule(1), Provider(2), Model(6), Configuration(5), TaskRecords(3), TaskExecution(2), SetupWizard(5 incl. `save`), Skills(3, refactored onto the trait).

## Related Issue

Follow-up hardening from the Skills feature reviews (#259, #261).

## Type of Change

- [x] Bug fix (non-breaking change that fixes a security issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [x] PHPStan level 10, Rector, CGL all clean (PHP 8.4)
- [x] Tests added: a trait unit test (admin→pass / non-admin→403) + 7 functional non-admin-403 tests (one representative action per controller); existing controller tests updated to run as admin so they still reach their assertions
- [x] Documentation updated (ADR-037 + index)
- [x] No new warnings

## Note

The `Tests/Functional/Controller/Backend` suite has a pre-existing local (WSL2) error baseline unrelated to this change (verified identical on `main` via a controlled before/after — same 32 err / 2 fail; this change adds only the 7 passing guard tests). CI's `merge_group` functional job is authoritative.
