### PR TITLE
refactor(skills): marketplace git-URL form + defensive enum properties

### DIFF
--- a/Classes/Domain/Model/Skill.php
+++ b/Classes/Domain/Model/Skill.php
@@ -22,7 +22,7 @@ class Skill extends AbstractEntity
     protected string $bodyChecksum = '';
     protected string $sourceSha = '';
     protected string $rawFrontmatter = '';
-    protected SupportStatus $supportStatus = SupportStatus::FULL;
+    protected string $supportStatus = SupportStatus::FULL->value;
     protected string $unsupportedNotes = '';
     protected string $allowedTools = '';
     protected bool $orphaned = false;
@@ -127,12 +127,20 @@ class Skill extends AbstractEntity
         return $out;
     }
 
-    public function getSupportStatus(): SupportStatus
+    public function getSupportStatus(): string
     {
         return $this->supportStatus;
     }
 
-    public function setSupportStatus(SupportStatus $supportStatus): void
+    /**
+     * Get support status as enum.
+     */
+    public function getSupportStatusEnum(): ?SupportStatus
+    {
+        return SupportStatus::tryFrom($this->supportStatus);
+    }
+
+    public function setSupportStatus(string $supportStatus): void
     {
         $this->supportStatus = $supportStatus;
     }

--- a/Classes/Domain/Model/SkillSource.php
+++ b/Classes/Domain/Model/SkillSource.php
@@ -16,12 +16,12 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class SkillSource extends AbstractEntity
 {
     protected string $title = '';
-    protected SkillSourceType $type = SkillSourceType::SINGLE_FILE;
+    protected string $type = SkillSourceType::SINGLE_FILE->value;
     protected string $url = '';
     protected string $ref = '';
     protected string $pinnedSha = '';
     protected string $githubToken = '';
-    protected SyncStatus $syncStatus = SyncStatus::NEVER_SYNCED;
+    protected string $syncStatus = SyncStatus::NEVER_SYNCED->value;
     protected string $syncError = '';
     protected int $lastSynced = 0;
     protected bool $enabled = true;
@@ -36,12 +36,20 @@ class SkillSource extends AbstractEntity
         $this->title = $title;
     }
 
-    public function getType(): SkillSourceType
+    public function getType(): string
     {
         return $this->type;
     }
 
-    public function setType(SkillSourceType $type): void
+    /**
+     * Get type as enum.
+     */
+    public function getTypeEnum(): ?SkillSourceType
+    {
+        return SkillSourceType::tryFrom($this->type);
+    }
+
+    public function setType(string $type): void
     {
         $this->type = $type;
     }
@@ -86,12 +94,20 @@ class SkillSource extends AbstractEntity
         $this->githubToken = $githubToken;
     }
 
-    public function getSyncStatus(): SyncStatus
+    public function getSyncStatus(): string
     {
         return $this->syncStatus;
     }
 
-    public function setSyncStatus(SyncStatus $syncStatus): void
+    /**
+     * Get sync status as enum.
+     */
+    public function getSyncStatusEnum(): ?SyncStatus
+    {
+        return SyncStatus::tryFrom($this->syncStatus);
+    }
+
+    public function setSyncStatus(string $syncStatus): void
     {
         $this->syncStatus = $syncStatus;
     }

--- a/Classes/Service/Skill/MarketplaceParser.php
+++ b/Classes/Service/Skill/MarketplaceParser.php
@@ -52,12 +52,47 @@ final class MarketplaceParser
             $slug = $source;
         } elseif (is_array($source) && isset($source['repo']) && is_string($source['repo'])) {
             $slug = $source['repo'];
+        } elseif (is_array($source) && isset($source['url']) && is_string($source['url'])) {
+            return $this->extractFromGitUrl($source['url']);
         }
         if ($slug === null || !str_contains($slug, '/')) {
             return null;
         }
         [$owner, $repo] = explode('/', $slug, 2);
         if ($owner === '' || $repo === '') {
+            return null;
+        }
+        return [$owner, $repo];
+    }
+
+    /**
+     * Resolve a `{source: git, url: ...}` plugin to an owner/repo pair.
+     *
+     * Only GitHub-hosted URLs are resolved; non-GitHub git URLs are skipped
+     * (the host allowlist would reject them anyway).
+     *
+     * @return array{0:string,1:string}|null
+     */
+    private function extractFromGitUrl(string $url): ?array
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || !in_array(strtolower($host), ['github.com', 'www.github.com'], true)) {
+            return null;
+        }
+        $path = parse_url($url, PHP_URL_PATH);
+        if (!is_string($path)) {
+            return null;
+        }
+        $segments = array_values(array_filter(explode('/', $path), static fn(string $s): bool => $s !== ''));
+        if (count($segments) < 2) {
+            return null;
+        }
+        $owner = $segments[0];
+        $repo = $segments[1];
+        if (str_ends_with($repo, '.git')) {
+            $repo = substr($repo, 0, -4);
+        }
+        if ($repo === '') {
             return null;
         }
         return [$owner, $repo];

--- a/Classes/Service/Skill/MarketplaceParser.php
+++ b/Classes/Service/Skill/MarketplaceParser.php
@@ -75,11 +75,15 @@ final class MarketplaceParser
      */
     private function extractFromGitUrl(string $url): ?array
     {
-        $host = parse_url($url, PHP_URL_HOST);
+        $parts = parse_url($url);
+        if (!is_array($parts)) {
+            return null;
+        }
+        $host = $parts['host'] ?? null;
         if (!is_string($host) || !in_array(strtolower($host), ['github.com', 'www.github.com'], true)) {
             return null;
         }
-        $path = parse_url($url, PHP_URL_PATH);
+        $path = $parts['path'] ?? null;
         if (!is_string($path)) {
             return null;
         }

--- a/Classes/Service/Skill/SkillComposer.php
+++ b/Classes/Service/Skill/SkillComposer.php
@@ -156,7 +156,7 @@ final readonly class SkillComposer
     private function renderSection(Skill $skill): string
     {
         $body = $skill->getBody();
-        if ($skill->getSupportStatus() === SupportStatus::PARTIAL) {
+        if ($skill->getSupportStatusEnum() === SupportStatus::PARTIAL) {
             $body = $this->stripAssetReferences($body);
         }
 

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -57,7 +57,7 @@ final class SkillSyncService
         // Concurrency guard with stale-lock recovery: a SYNCING source is only treated as locked
         // when its heartbeat (lastSynced) is recent; an old or never-set heartbeat is stale.
         if (
-            $source->getSyncStatus() === SyncStatus::SYNCING
+            $source->getSyncStatusEnum() === SyncStatus::SYNCING
             && $source->getLastSynced() !== 0
             && ($now - $source->getLastSynced()) <= self::STALE_LOCK_SECONDS
         ) {
@@ -65,7 +65,7 @@ final class SkillSyncService
         }
 
         // Acquire the lock and write a heartbeat BEFORE the work so a crash leaves a reclaimable lock.
-        $source->setSyncStatus(SyncStatus::SYNCING);
+        $source->setSyncStatus(SyncStatus::SYNCING->value);
         $source->setLastSynced($now);
         $this->persistSource($source);
 
@@ -126,7 +126,7 @@ final class SkillSyncService
         }
 
         // Always persist the final state so the lock is never left stuck.
-        $source->setSyncStatus($status);
+        $source->setSyncStatus($status->value);
         $source->setLastSynced(time());
         $this->persistSource($source);
 
@@ -146,13 +146,13 @@ final class SkillSyncService
      */
     private function collect(SkillSource $source, array &$errors): array
     {
-        if ($source->getType() === SkillSourceType::MARKETPLACE) {
+        if ($source->getTypeEnum() === SkillSourceType::MARKETPLACE) {
             return $this->collectMarketplace($source, $errors);
         }
         // Non-marketplace sources address a single GitHub repo; an unparseable URL is fatal and
         // surfaces as a clear ERROR rather than a malformed API call against an empty owner/repo.
         [$owner, $repo] = $this->requireOwnerRepo($source->getUrl());
-        return $source->getType() === SkillSourceType::SINGLE_FILE
+        return $source->getTypeEnum() === SkillSourceType::SINGLE_FILE
             ? $this->collectSingleFile($source, $owner, $repo, $errors)
             : $this->collectRepo($source, $owner, $repo, $source->getRef(), $errors);
     }
@@ -326,7 +326,7 @@ final class SkillSyncService
             $skill->setSource($source->getUid());
             $skill->setIdentifier($identifier);
             $this->apply($skill, $parsed, $sha, $checksum);
-            $skill->setEnabled($source->getType() === SkillSourceType::SINGLE_FILE);
+            $skill->setEnabled($source->getTypeEnum() === SkillSourceType::SINGLE_FILE);
             $skill->setOrphaned(false);
             $this->skillRepository->add($skill);
             return 'created';
@@ -353,7 +353,7 @@ final class SkillSyncService
         $skill->setBodyChecksum($checksum);
         $skill->setSourceSha($sha);
         $skill->setRawFrontmatter((string)json_encode($parsed->rawFrontmatter));
-        $skill->setSupportStatus($parsed->supportStatus);
+        $skill->setSupportStatus($parsed->supportStatus->value);
         $skill->setUnsupportedNotes($parsed->unsupportedNotes);
         $tools = $parsed->rawFrontmatter['allowed-tools'] ?? $parsed->rawFrontmatter['allowed_tools'] ?? [];
         $skill->setAllowedTools((string)json_encode(is_array($tools) ? $tools : []));

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -146,13 +146,18 @@ final class SkillSyncService
      */
     private function collect(SkillSource $source, array &$errors): array
     {
-        if ($source->getTypeEnum() === SkillSourceType::MARKETPLACE) {
+        // Resolve the type once and fail closed on an unknown/invalid stored value:
+        // a malformed type must surface as a clear ERROR, never be silently treated as a repo.
+        $type = $source->getTypeEnum()
+            ?? throw new RuntimeException(sprintf('Unknown skill source type "%s".', $source->getType()), 4636357234);
+
+        if ($type === SkillSourceType::MARKETPLACE) {
             return $this->collectMarketplace($source, $errors);
         }
         // Non-marketplace sources address a single GitHub repo; an unparseable URL is fatal and
         // surfaces as a clear ERROR rather than a malformed API call against an empty owner/repo.
         [$owner, $repo] = $this->requireOwnerRepo($source->getUrl());
-        return $source->getTypeEnum() === SkillSourceType::SINGLE_FILE
+        return $type === SkillSourceType::SINGLE_FILE
             ? $this->collectSingleFile($source, $owner, $repo, $errors)
             : $this->collectRepo($source, $owner, $repo, $source->getRef(), $errors);
     }

--- a/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
@@ -72,7 +72,7 @@ final class SkillSourceControllerTest extends AbstractFunctionalTestCase
     {
         $source = new SkillSource();
         $source->setTitle('Acme');
-        $source->setType(SkillSourceType::SINGLE_FILE);
+        $source->setType(SkillSourceType::SINGLE_FILE->value);
         $source->setUrl('https://github.com/acme/skills/blob/main/SKILL.md');
         $repository = $this->get(SkillSourceRepository::class);
         $repository->add($source);

--- a/Tests/Functional/Repository/SkillRepositoryTest.php
+++ b/Tests/Functional/Repository/SkillRepositoryTest.php
@@ -35,7 +35,7 @@ final class SkillRepositoryTest extends AbstractFunctionalTestCase
         $skill = $this->repository->findBySourceAndIdentifier(1, '1:SKILL.md');
         self::assertNotNull($skill);
         self::assertSame('Example', $skill->getName());
-        self::assertSame(SupportStatus::FULL, $skill->getSupportStatus());
+        self::assertSame(SupportStatus::FULL, $skill->getSupportStatusEnum());
     }
 
     #[Test]

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -55,6 +55,22 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         );
     }
 
+    #[Test]
+    public function unknownStoredTypeYieldsErrorStatus(): void
+    {
+        // A malformed/unsupported type column must fail closed (clear ERROR), not be
+        // silently treated as a repo — the point of the defensive getTypeEnum() pattern.
+        $source = new SkillSource();
+        $source->_setProperty('uid', 40);
+        $source->setType('bogus-type');
+        $source->setUrl(self::REPO_URL);
+
+        $result = $this->service($this->marketGitHub([]))->sync($source);
+
+        self::assertSame(SyncStatus::ERROR, $result->status);
+        self::assertNotSame([], $result->errors);
+    }
+
     private function repoSource(int $uid = 10): SkillSource
     {
         $source = new SkillSource();

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -59,7 +59,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     {
         $source = new SkillSource();
         $source->_setProperty('uid', $uid);
-        $source->setType(SkillSourceType::REPO);
+        $source->setType(SkillSourceType::REPO->value);
         $source->setUrl(self::REPO_URL);
         $source->setRef('main');
         return $source;
@@ -69,7 +69,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     {
         $source = new SkillSource();
         $source->_setProperty('uid', $uid);
-        $source->setType(SkillSourceType::SINGLE_FILE);
+        $source->setType(SkillSourceType::SINGLE_FILE->value);
         $source->setUrl(self::SINGLE_FILE_URL);
         $source->setRef('main');
         return $source;
@@ -79,7 +79,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     {
         $source = new SkillSource();
         $source->_setProperty('uid', $uid);
-        $source->setType(SkillSourceType::MARKETPLACE);
+        $source->setType(SkillSourceType::MARKETPLACE->value);
         $source->setUrl(self::MARKET_URL);
         return $source;
     }
@@ -195,7 +195,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     public function refusesConcurrentSync(): void
     {
         $source = $this->repoSource();
-        $source->setSyncStatus(SyncStatus::SYNCING);
+        $source->setSyncStatus(SyncStatus::SYNCING->value);
         $source->setLastSynced(time()); // fresh heartbeat → lock is considered active
         $result = $this->service(new FakeGitHubClient('sha1', [], []))->sync($source);
         self::assertSame(SyncStatus::SYNCING, $result->status);
@@ -206,7 +206,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     public function recoversFromStaleLock(): void
     {
         $source = $this->repoSource();
-        $source->setSyncStatus(SyncStatus::SYNCING);
+        $source->setSyncStatus(SyncStatus::SYNCING->value);
         $source->setLastSynced(time() - 3600); // older than STALE_LOCK_SECONDS → stale, proceed
         $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH], [
             self::SKILL_A_PATH => $this->md('A', 'body'),
@@ -242,7 +242,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     public function persistsSyncStateForRealSource(): void
     {
         $source = new SkillSource();
-        $source->setType(SkillSourceType::REPO);
+        $source->setType(SkillSourceType::REPO->value);
         $source->setUrl(self::REPO_URL);
         $source->setRef('main');
         $sourceRepository = $this->get(SkillSourceRepository::class);
@@ -260,7 +260,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         $this->get(PersistenceManagerInterface::class)->persistAll();
         $reloaded = $sourceRepository->findByUid($uid);
         self::assertNotNull($reloaded);
-        self::assertSame(SyncStatus::OK, $reloaded->getSyncStatus());
+        self::assertSame(SyncStatus::OK, $reloaded->getSyncStatusEnum());
         self::assertSame('cafe1234', $reloaded->getPinnedSha());
         self::assertGreaterThan(0, $reloaded->getLastSynced());
     }

--- a/Tests/Unit/Service/Skill/MarketplaceParserTest.php
+++ b/Tests/Unit/Service/Skill/MarketplaceParserTest.php
@@ -37,6 +37,24 @@ final class MarketplaceParserTest extends TestCase
     }
 
     #[Test]
+    public function parsesGitUrlSource(): void
+    {
+        $json = '{"plugins":[{"name":"c","source":{"source":"git","url":"https://github.com/acme/repo-c.git"}}]}';
+        $entries = $this->parser->parse($json);
+        self::assertCount(1, $entries);
+        self::assertSame('acme', $entries[0]->owner);
+        self::assertSame('repo-c', $entries[0]->repo);
+    }
+
+    #[Test]
+    public function skipsNonGithubGitUrlSource(): void
+    {
+        $json = '{"plugins":[{"name":"y","source":{"source":"git","url":"https://gitlab.com/x/y.git"}}]}';
+        $entries = $this->parser->parse($json);
+        self::assertCount(0, $entries);
+    }
+
+    #[Test]
     public function ignoresUnknownKeysAndUnresolvableEntries(): void
     {
         $json = '{"plugins":[{"name":"a","source":"acme/repo-a","extra":true},{"name":"bad"}]}';

--- a/Tests/Unit/Service/Skill/SkillComposerTest.php
+++ b/Tests/Unit/Service/Skill/SkillComposerTest.php
@@ -169,7 +169,7 @@ final class SkillComposerTest extends TestCase
         $skill->setName($name);
         $skill->setBody($body);
         $skill->setBodyChecksum(hash('sha256', $body));
-        $skill->setSupportStatus($support);
+        $skill->setSupportStatus($support->value);
         $skill->setEnabled($enabled);
         $skill->setOrphaned($orphaned);
 

--- a/Tests/Unit/Service/Skill/SkillInjectionServiceTest.php
+++ b/Tests/Unit/Service/Skill/SkillInjectionServiceTest.php
@@ -172,7 +172,7 @@ final class SkillInjectionServiceTest extends TestCase
         $skill->setName($name);
         $skill->setBody($body);
         $skill->setBodyChecksum($checksum ?? hash('sha256', $body));
-        $skill->setSupportStatus($support);
+        $skill->setSupportStatus($support->value);
         $skill->setEnabled(true);
         $skill->setOrphaned(false);
 

--- a/Tests/Unit/Service/SkillConfigInjectionTest.php
+++ b/Tests/Unit/Service/SkillConfigInjectionTest.php
@@ -229,7 +229,7 @@ final class SkillConfigInjectionTest extends AbstractUnitTestCase
         $skill->setName('Config Skill');
         $skill->setBody('Always answer in JSON.');
         $skill->setBodyChecksum(hash('sha256', 'Always answer in JSON.'));
-        $skill->setSupportStatus(SupportStatus::FULL);
+        $skill->setSupportStatus(SupportStatus::FULL->value);
         $skill->setEnabled(true);
         $skill->setOrphaned(false);
         $configuration->addSkill($skill);

--- a/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
+++ b/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
@@ -145,7 +145,7 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
         $skill->setName($name);
         $skill->setBody($body);
         $skill->setBodyChecksum(hash('sha256', $body));
-        $skill->setSupportStatus(SupportStatus::FULL);
+        $skill->setSupportStatus(SupportStatus::FULL->value);
         $skill->setEnabled(true);
         $skill->setOrphaned(false);
 


### PR DESCRIPTION
## Description

Two deferred follow-up refactors from the Skills feature reviews (#259/#261).

**1. Marketplace `{source: "git", url}` plugin form.** `MarketplaceParser` now parses the `git`-URL plugin form (previously silently dropped). GitHub-hosted git URLs (`github.com` / `www.github.com`, trailing `.git` stripped) resolve to owner/repo; non-GitHub git URLs are skipped (the app-level GitHub host allowlist would reject them anyway). The string and `{source:"github", repo}` forms are unchanged.

**2. Defensive string-backed enum properties.** `Skill::$supportStatus`, `SkillSource::$type`, and `SkillSource::$syncStatus` move from native-enum-typed properties to the project's defensive string-backed pattern (mirroring `Task.php`): a `string` property + `getX(): string` + `getXEnum(): ?Enum` (`tryFrom`) + `setX(string)`. A native-enum property hydrates via `Enum::from()` and **throws on any unexpected DB value** (manual edit / future migration), crashing `findAll()`; the string-backed pattern degrades gracefully. Consumers updated to `getXEnum()` / `setX(...->value)`.

## Related Issue

Follow-ups from #259 / #261 (Skills feature).

## Type of Change

- [ ] Bug fix
- [x] New feature (marketplace git-URL form)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (defensive enum properties)

## Checklist

- [x] PHPStan level 10, Rector, CGL clean (PHP 8.4)
- [x] Tests added/updated: marketplace git-URL parse (GitHub + non-GitHub-skipped); enum consumers updated
- [x] **Hydration verified** — the functional repository/sync tests assert `getXEnum()` after DB hydrate + persist/reload (21/21), proving Extbase still maps the string columns correctly
- [x] No new warnings

## Note

`getSupportStatus()`/`getType()`/`getSyncStatus()` now return the raw string; the enum is via `getSupportStatusEnum()` etc. — matching the established `Task.php` convention. These models are only consumed internally (no external API break).
