### PR TITLE
feat(tools): tool runtime — agent loop, registry, Ollama tools, allow-list gating (PR-A)

### DIFF
--- a/Classes/Domain/Model/Skill.php
+++ b/Classes/Domain/Model/Skill.php
@@ -165,6 +165,26 @@ class Skill extends AbstractEntity
         $this->allowedTools = $allowedTools;
     }
 
+    /**
+     * Decode the stored allow-list into tool names.
+     *
+     * Returns null when the skill expresses no opinion (stored value is the
+     * empty string, i.e. the front-matter declared no `allowed-tools` key, or
+     * the stored JSON is not an array). Returns the decoded list of string
+     * names otherwise — including the empty list `[]`, which is a deliberate
+     * fail-closed declaration of "no tools".
+     *
+     * @return list<string>|null
+     */
+    public function getAllowedToolsList(): ?array
+    {
+        if ($this->allowedTools === '') {
+            return null;
+        }
+        $decoded = json_decode($this->allowedTools, true);
+        return is_array($decoded) ? array_values(array_filter($decoded, is_string(...))) : null;
+    }
+
     public function isOrphaned(): bool
     {
         return $this->orphaned;

--- a/Classes/Domain/ValueObject/ToolInvocation.php
+++ b/Classes/Domain/ValueObject/ToolInvocation.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One executed tool call recorded during a {@see ToolLoopService} run.
+ *
+ * Captures the model-requested tool name, the arguments it supplied, the
+ * string the PHP tool returned, and whether that turn was an error (unknown
+ * tool or a caught, sanitised exception). The collected list of invocations
+ * forms the {@see ToolLoopResult::$trace} audit trail.
+ */
+final readonly class ToolInvocation
+{
+    /**
+     * @param array<string, mixed> $arguments The arguments the model supplied for the call.
+     */
+    public function __construct(
+        public string $name,
+        public array $arguments,
+        public string $result,
+        public bool $isError,
+    ) {}
+}

--- a/Classes/Domain/ValueObject/ToolLoopResult.php
+++ b/Classes/Domain/ValueObject/ToolLoopResult.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+
+/**
+ * Outcome of a bounded function-calling agent loop ({@see ToolLoopService}).
+ *
+ * Bundles the final assistant answer with the ordered trace of every tool
+ * the model invoked, the number of model round-trips spent, whether the
+ * loop hit its iteration cap (or budget limit) before the model stopped
+ * requesting tools, and the summed token usage across all round-trips.
+ */
+final readonly class ToolLoopResult
+{
+    /**
+     * @param list<ToolInvocation> $trace Ordered record of every executed tool call.
+     */
+    public function __construct(
+        public string $finalContent,
+        public array $trace,
+        public int $iterations,
+        public bool $truncated,
+        public UsageStatistics $usage,
+    ) {}
+}

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -15,7 +15,10 @@ use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
+use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
@@ -28,7 +31,7 @@ use Throwable;
  * @see https://ollama.com/
  */
 #[AsLlmProvider(priority: 40)]
-final class OllamaProvider extends AbstractProvider implements StreamingCapableInterface
+final class OllamaProvider extends AbstractProvider implements StreamingCapableInterface, ToolCapableInterface
 {
     /** @var array<string> */
     protected array $supportedFeatures = [
@@ -198,6 +201,170 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             ),
             finishReason: $this->getString($response, 'done_reason', 'stop'),
         );
+    }
+
+    /**
+     * Ollama exposes OpenAI-style function calling on the same `/api/chat`
+     * endpoint: tools are declared under a top-level `tools` key and the model
+     * answers with `message.tool_calls`. Unlike OpenAI it returns no call id and
+     * expects replayed turns in its own native shape, both reconciled here.
+     *
+     * `tool_choice` / `parallel_tool_calls` options are intentionally ignored —
+     * Ollama does not understand them.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
+     */
+    public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
+    {
+        $messages = array_map(
+            static fn(ChatMessage|array $m): array
+                => $m instanceof ChatMessage ? $m->toArray() : $m,
+            $messages,
+        );
+
+        $messages = $this->normaliseToolTurnsForOllama($messages);
+
+        $model = $this->getString($options, 'model', $this->getDefaultModel());
+
+        /** @var array<string, mixed> $payloadOptions */
+        $payloadOptions = [];
+
+        if (isset($options['temperature'])) {
+            $payloadOptions['temperature'] = $this->getFloat($options, 'temperature');
+        }
+
+        if (isset($options['top_p'])) {
+            $payloadOptions['top_p'] = $this->getFloat($options, 'top_p');
+        }
+
+        if (isset($options['num_predict']) || isset($options['max_tokens'])) {
+            $payloadOptions['num_predict'] = $this->getInt($options, 'num_predict', $this->getInt($options, 'max_tokens', 4096));
+        }
+
+        $payload = [
+            'model' => $model,
+            'messages' => $messages,
+            'stream' => false,
+            'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
+        ];
+
+        if ($payloadOptions !== []) {
+            $payload['options'] = $payloadOptions;
+        }
+
+        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload);
+
+        $message = $this->getArray($response, 'message');
+
+        $toolCalls    = null;
+        $rawToolCalls = $this->getArray($message, 'tool_calls');
+        if ($rawToolCalls !== []) {
+            $toolCalls = [];
+            $index     = 0;
+            foreach ($rawToolCalls as $rawToolCall) {
+                $callData = $this->asArray($rawToolCall);
+                // Ollama returns no call id; synthesise a stable, non-empty one
+                // (ToolCall rejects an empty id). `function.arguments` already
+                // arrives as an object, which ToolCall normalises straight
+                // through.
+                $callData['id'] = 'call_' . $index;
+                $toolCalls[]    = ToolCall::fromArray($callData);
+                ++$index;
+            }
+        }
+
+        return new CompletionResponse(
+            content: $this->getString($message, 'content'),
+            model: $this->getString($response, 'model', $model),
+            usage: $this->createUsageStatistics(
+                promptTokens: $this->getInt($response, 'prompt_eval_count'),
+                completionTokens: $this->getInt($response, 'eval_count'),
+            ),
+            finishReason: $this->getString($response, 'done_reason', 'stop'),
+            provider: $this->getIdentifier(),
+            toolCalls: $toolCalls,
+        );
+    }
+
+    public function supportsTools(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Translate replayed OpenAI-shape conversation turns into Ollama's native
+     * chat shape before they go back on the wire.
+     *
+     * The agent loop replays canonical OpenAI-shaped turns: an assistant turn
+     * carries `tool_calls` whose `function.arguments` is a JSON *string*, and a
+     * tool result arrives as a `{role:'tool', tool_call_id, content}` turn.
+     * Ollama wants `function.arguments` as a decoded object and keys tool
+     * results by role/position rather than id, so:
+     *
+     *  - assistant turns: each `function.arguments` JSON string is decoded to an
+     *    object/array;
+     *  - `tool` turns: the `tool_call_id` key is dropped.
+     *
+     * Plain `{role, content}` turns pass through untouched.
+     *
+     * @param list<array<string, mixed>> $messages
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normaliseToolTurnsForOllama(array $messages): array
+    {
+        $normalised = [];
+        foreach ($messages as $message) {
+            if (($message['role'] ?? null) === 'tool') {
+                unset($message['tool_call_id']);
+                $normalised[] = $message;
+                continue;
+            }
+
+            if (isset($message['tool_calls']) && is_array($message['tool_calls'])) {
+                $calls = [];
+                foreach ($message['tool_calls'] as $call) {
+                    $calls[] = $this->decodeToolCallArguments($call);
+                }
+                $message['tool_calls'] = $calls;
+            }
+
+            $normalised[] = $message;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * Decode a single replayed assistant tool-call's `function.arguments` from
+     * the OpenAI JSON-string form into Ollama's object form. Anything that is
+     * not a tool-call array with a string `arguments` is returned untouched.
+     */
+    private function decodeToolCallArguments(mixed $call): mixed
+    {
+        if (!is_array($call)) {
+            return $call;
+        }
+
+        $function = $call['function'] ?? null;
+        if (!is_array($function)) {
+            return $call;
+        }
+
+        $arguments = $function['arguments'] ?? null;
+        if (!is_string($arguments)) {
+            return $call;
+        }
+
+        $decoded = json_decode($arguments, true);
+        if (is_array($decoded)) {
+            $function['arguments'] = $decoded;
+            $call['function']      = $function;
+        }
+
+        return $call;
     }
 
     /**

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -160,6 +160,12 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $messages,
         );
 
+        // The truncation-synthesis path replays prior tool turns through this
+        // plain endpoint, so apply the same OpenAI->Ollama shape translation as
+        // chatCompletionWithTools(). It is a no-op for plain {role,content}
+        // turns, so it is safe for every caller.
+        $messages = $this->normaliseToolTurnsForOllama($messages);
+
         $model = $this->getString($options, 'model', $this->getDefaultModel());
 
         /** @var array<string, mixed> $payloadOptions */

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -491,6 +491,60 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
+     * Chat completion with tool calling against a specific LLM configuration.
+     *
+     * Mirrors {@see self::chatWithConfiguration()} — resolves the adapter via
+     * {@see self::getAdapterFromConfiguration()} (so the configuration's vault
+     * key + model + params drive the call) and runs through the middleware
+     * pipeline (so Budget/Usage see the real Model and record real cost) — but
+     * guards `ToolCapableInterface` and dispatches `chatCompletionWithTools()`.
+     *
+     * This is the keystone for the tool runtime: the keyed
+     * {@see self::chatWithTools()} path cannot reach a DB-backed configuration's
+     * vault key/model/pricing (it resolves a provider from ExtensionConfiguration
+     * against a model-less transient configuration), so a tool loop that must
+     * run on a selected configuration uses this entry point instead.
+     *
+     * The per-call {@see ToolOptions} take precedence over the configuration's
+     * stored defaults, matching `chatWithConfiguration()`'s override semantics.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
+     */
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse
+    {
+        $options ??= new ToolOptions();
+        $optionOverrides = $options->toArray();
+        unset($optionOverrides['provider']);
+
+        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedTools    = array_values(array_map(
+            static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
+            $tools,
+        ));
+
+        return $this->runThroughPipeline(
+            $configuration,
+            ProviderOperation::Tools,
+            function (LlmConfiguration $config) use ($normalisedMessages, $normalisedTools, $optionOverrides): CompletionResponse {
+                $adapter = $this->getAdapterFromConfiguration($config);
+                if (!$adapter instanceof ToolCapableInterface) {
+                    throw new UnsupportedFeatureException(
+                        sprintf('Provider "%s" does not support tool calling', $adapter->getIdentifier()),
+                        1782748801,
+                    );
+                }
+
+                $callOptions = array_merge($config->toOptionsArray(), $optionOverrides);
+                unset($callOptions['provider']);
+
+                return $adapter->chatCompletionWithTools($normalisedMessages, $normalisedTools, $callOptions);
+            },
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+        );
+    }
+
+    /**
      * Check if a specific feature is supported by a provider.
      */
     public function supportsFeature(string $feature, ?string $provider = null): bool

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -134,6 +134,22 @@ interface LlmServiceManagerInterface
      */
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse;
 
+    /**
+     * Chat completion with tool calling against a specific LLM configuration.
+     *
+     * Unlike {@see self::chatWithTools()} — which resolves a provider from
+     * ExtensionConfiguration against a model-less transient configuration —
+     * this entry point resolves the adapter from the configuration's model
+     * (vault key + model + pricing) so the middleware pipeline records real
+     * cost and budget. Legacy array-shaped message and tool fixtures are
+     * accepted for back-compat and normalised via `ChatMessage::fromArray()`
+     * / `ToolSpec::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
+     */
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse;
+
     public function supportsFeature(string $feature, ?string $provider = null): bool;
 
     /**

--- a/Classes/Service/Skill/SkillComposer.php
+++ b/Classes/Service/Skill/SkillComposer.php
@@ -112,12 +112,16 @@ final readonly class SkillComposer
      * Union of config-then-task, deduped by (source, identifier) with config winning,
      * keeping only enabled and non-orphaned skills.
      *
+     * This is the single source of truth for "which skills are in effect" — both the
+     * injection path (via selectCandidates()) and the allowed-tools gating path
+     * (AllowedToolsResolver) consume it, so the selection stays consistent.
+     *
      * @param list<Skill> $configSkills
      * @param list<Skill> $taskSkills
      *
      * @return list<Skill>
      */
-    private function selectCandidates(array $configSkills, array $taskSkills): array
+    public function effectiveSkills(array $configSkills, array $taskSkills): array
     {
         $candidates = [];
         $seen       = [];
@@ -136,6 +140,17 @@ final readonly class SkillComposer
         }
 
         return $candidates;
+    }
+
+    /**
+     * @param list<Skill> $configSkills
+     * @param list<Skill> $taskSkills
+     *
+     * @return list<Skill>
+     */
+    private function selectCandidates(array $configSkills, array $taskSkills): array
+    {
+        return $this->effectiveSkills($configSkills, $taskSkills);
     }
 
     /**

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -360,8 +360,15 @@ final class SkillSyncService
         $skill->setRawFrontmatter((string)json_encode($parsed->rawFrontmatter));
         $skill->setSupportStatus($parsed->supportStatus->value);
         $skill->setUnsupportedNotes($parsed->unsupportedNotes);
-        $tools = $parsed->rawFrontmatter['allowed-tools'] ?? $parsed->rawFrontmatter['allowed_tools'] ?? [];
-        $skill->setAllowedTools((string)json_encode(is_array($tools) ? $tools : []));
+        // Distinguish "no opinion" (key absent → store '') from a present declaration (store its JSON,
+        // including '[]' for a declared-empty fail-closed list). The accessor treats '' as null/no-opinion.
+        $frontmatter = $parsed->rawFrontmatter;
+        if (!array_key_exists('allowed-tools', $frontmatter) && !array_key_exists('allowed_tools', $frontmatter)) {
+            $skill->setAllowedTools('');
+        } else {
+            $tools = $frontmatter['allowed-tools'] ?? $frontmatter['allowed_tools'] ?? [];
+            $skill->setAllowedTools((string)json_encode(is_array($tools) ? $tools : []));
+        }
     }
 
     /**

--- a/Classes/Service/Tool/AllowedToolsResolver.php
+++ b/Classes/Service/Tool/AllowedToolsResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Skill;
+use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+
+/**
+ * Resolves the effective allowed-tools allow-list for a run.
+ *
+ * Semantics (fail-closed on declaration): the allow-list is the UNION of the
+ * declared lists of every effective skill (config + task, enabled, non-orphaned,
+ * deduped — exactly the set SkillComposer composes into the prompt). A skill that
+ * declares no `allowed-tools` key (its accessor returns null) contributes no
+ * opinion. When NO effective skill declares anything, this returns null meaning
+ * "no skill-imposed restriction" (all registry tools are permitted). When at least
+ * one skill declares, the union is returned — and a lone declared empty list yields
+ * `[]`, i.e. no tools at all.
+ */
+final readonly class AllowedToolsResolver
+{
+    public function __construct(
+        private SkillComposer $composer,
+    ) {}
+
+    /**
+     * @return list<string>|null null = no declaring skill (all tools); a list = the declared union
+     */
+    public function resolve(LlmConfiguration $config, ?Task $task = null): ?array
+    {
+        $configSkills = $this->toList($config->getSkills());
+        $taskSkills   = $task !== null ? $this->toList($task->getSkills()) : [];
+
+        $declared = [];
+        $any      = false;
+        foreach ($this->composer->effectiveSkills($configSkills, $taskSkills) as $skill) {
+            $list = $skill->getAllowedToolsList();
+            if ($list === null) {
+                continue;
+            }
+            $any = true;
+            foreach ($list as $name) {
+                $declared[$name] = true;
+            }
+        }
+
+        return $any ? array_keys($declared) : null;
+    }
+
+    /**
+     * @param iterable<Skill> $skills
+     *
+     * @return list<Skill>
+     */
+    private function toList(iterable $skills): array
+    {
+        $list = [];
+        foreach ($skills as $skill) {
+            $list[] = $skill;
+        }
+
+        return $list;
+    }
+}

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Example tool: return the most recent TYPO3 system log entries.
+ *
+ * Reads `sys_log` newest-first, bounded by a model-supplied `limit` that is
+ * hard-capped at {@see self::HARD_LIMIT}, with an optional PSR `level`
+ * filter.
+ *
+ * Security contract (see {@see ToolInterface}): the formatted result
+ * egresses to an external LLM provider, so every personally-identifying or
+ * payload field is redacted by omission. Only the timestamp, type/action
+ * codes, the level and the `details` *template* are surfaced — the raw
+ * client `IP`, the backend `userid` and the serialized `log_data` payload
+ * (which may carry usernames or further PII substituted into the template)
+ * are never read into the output.
+ */
+final readonly class FetchLogsTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'sys_log';
+
+    /**
+     * Maximum rows returned regardless of the requested limit. Bounds the
+     * egress volume from a single model-steered call.
+     */
+    private const HARD_LIMIT = 50;
+
+    private const DEFAULT_LIMIT = 20;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'fetch_logs',
+            'Return the most recent TYPO3 system log (sys_log) entries, newest first. '
+            . 'Personally-identifying fields (client IP, backend user id, payload) are redacted.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'level' => [
+                        'type'        => 'string',
+                        'description' => 'Optional PSR log level to filter by (e.g. "info", "error", "warning").',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum number of entries to return (default 20, hard cap 50).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        if ($limit < 1) {
+            $limit = self::DEFAULT_LIMIT;
+        }
+        $limit = min($limit, self::HARD_LIMIT);
+
+        $level = self::toStr($arguments['level'] ?? '');
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder
+            ->select('tstamp', 'type', 'action', 'level', 'details')
+            ->from(self::TABLE)
+            ->orderBy('tstamp', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($level !== '') {
+            $queryBuilder->where(
+                $queryBuilder->expr()->eq(
+                    'level',
+                    $queryBuilder->createNamedParameter($level),
+                ),
+            );
+        }
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        if ($rows === []) {
+            return 'No log entries.';
+        }
+
+        $lines = [sprintf('Recent sys_log entries (showing %d):', count($rows))];
+        foreach ($rows as $row) {
+            $lines[] = sprintf(
+                '[%s] %d.%d %s: %s',
+                gmdate('Y-m-d H:i', self::toInt($row['tstamp'] ?? 0)),
+                self::toInt($row['type'] ?? 0),
+                self::toInt($row['action'] ?? 0),
+                self::toStr($row['level'] ?? ''),
+                self::toStr($row['details'] ?? ''),
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -102,6 +102,12 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
             ->from(self::METADATA_TABLE)
             ->where(
                 $metaQuery->expr()->eq('file', $metaQuery->createNamedParameter($uid, Connection::PARAM_INT)),
+                // sys_file_metadata is language-aware: removeAll() above drops the
+                // language restriction, so pin to the default language explicitly —
+                // otherwise an arbitrary translated row could replace the original
+                // metadata. (The table has no soft-delete capability, hence no
+                // `deleted` column to filter.)
+                $metaQuery->expr()->eq('sys_language_uid', $metaQuery->createNamedParameter(0, Connection::PARAM_INT)),
             )
             ->executeQuery()
             ->fetchAssociative();

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Example tool: return read-only metadata for a single managed file (FAL).
+ *
+ * Loads one `sys_file` row by its uid and returns name, MIME type and size,
+ * plus title/alternative text from `sys_file_metadata` when present.
+ *
+ * Security contract (see {@see ToolInterface}): the `uid` argument is
+ * model-chosen and therefore injection-steerable, so the lookup is
+ * **storage-scoped** — a file whose `storage` is not in
+ * {@see $allowedStorages} is treated exactly like a missing file. Both a
+ * non-permitted storage and an absent uid return the same neutral
+ * {@see self::NOT_PERMITTED} string (never an exception and never a
+ * storage-specific signal), so the model cannot enumerate arbitrary
+ * storages or distinguish "exists elsewhere" from "does not exist".
+ */
+final readonly class ReadFalAssetMetaTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Asset not found or not permitted.';
+
+    private const FILE_TABLE = 'sys_file';
+
+    private const METADATA_TABLE = 'sys_file_metadata';
+
+    /**
+     * @param list<int> $allowedStorages sys_file_storage uids this tool may read from
+     */
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+        protected array $allowedStorages = [1],
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'read_fal_asset_meta',
+            'Return read-only metadata (file name, MIME type, size, title, alternative text) for a single '
+            . 'managed file (sys_file) identified by its uid, scoped to permitted storages.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'The sys_file uid of the asset to inspect.',
+                    ],
+                ],
+                'required' => ['uid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid < 1) {
+            return self::NOT_PERMITTED;
+        }
+
+        $fileQuery = $this->connectionPool->getQueryBuilderForTable(self::FILE_TABLE);
+        $fileQuery->getRestrictions()->removeAll();
+        $file = $fileQuery
+            ->select('storage', 'name', 'mime_type', 'size')
+            ->from(self::FILE_TABLE)
+            ->where(
+                $fileQuery->expr()->eq('uid', $fileQuery->createNamedParameter($uid, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($file) || !in_array(self::toInt($file['storage'] ?? 0), $this->allowedStorages, true)) {
+            return self::NOT_PERMITTED;
+        }
+
+        $lines = [
+            'file: ' . self::toStr($file['name'] ?? ''),
+            'mime: ' . self::toStr($file['mime_type'] ?? ''),
+            'size: ' . self::toInt($file['size'] ?? 0) . ' bytes',
+        ];
+
+        $metaQuery = $this->connectionPool->getQueryBuilderForTable(self::METADATA_TABLE);
+        $metaQuery->getRestrictions()->removeAll();
+        $meta = $metaQuery
+            ->select('title', 'alternative')
+            ->from(self::METADATA_TABLE)
+            ->where(
+                $metaQuery->expr()->eq('file', $metaQuery->createNamedParameter($uid, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (is_array($meta)) {
+            $title = self::toStr($meta['title'] ?? '');
+            if ($title !== '') {
+                $lines[] = 'title: ' . $title;
+            }
+            $alt = self::toStr($meta['alternative'] ?? '');
+            if ($alt !== '') {
+                $lines[] = 'alt: ' . $alt;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A PHP "tool" the model may call mid-generation during the agent loop.
+ *
+ * Implementations are admin-curated, read-only, and return a plain string.
+ * They are discovered via the `nr_llm.tool` DI tag (auto-applied by
+ * AutoconfigureTag, mirroring ProviderMiddlewareInterface) and collected by
+ * ToolRegistry through a tagged iterator.
+ *
+ * Security contract: a tool runs with full TYPO3 privileges and has NO
+ * per-record authorization. Its array `$arguments` are model-chosen and
+ * therefore attacker-influenceable (the model is steerable by injected,
+ * externally-authored skill prose), and its return value egresses both to
+ * the external provider AND the rendered backend DOM. Implementations MUST
+ * assume an authorized-admin caller and treat `$arguments` as untrusted:
+ * validate and scope them, and never expose secrets.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface ToolInterface
+{
+    public const TAG_NAME = 'nr_llm.tool';
+
+    /**
+     * The tool declaration (name, description, JSON-Schema parameters) the
+     * model receives and points back at by name via a ToolCall.
+     */
+    public function getSpec(): ToolSpec;
+
+    /**
+     * Execute the tool with the model-provided arguments and return a string
+     * result that is fed back into the conversation as a tool turn.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments): string;
+}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use stdClass;
+use Throwable;
+
+/**
+ * Bounded function-calling agent loop over a DB-backed {@see LlmConfiguration}.
+ *
+ * Each round calls {@see LlmServiceManagerInterface::chatWithToolsForConfiguration()}
+ * (so the run uses the configuration's vault key, model, and pricing — the
+ * provider-key path of `chatWithTools()` cannot reach those). When the model
+ * answers with tool calls, they are executed in PHP, appended back as raw
+ * assistant + tool turns, and the conversation is re-sent — bounded by a
+ * configurable max-iteration cap.
+ *
+ * Failure handling is fail-soft so the admin always sees what ran:
+ * - a tool that throws, or an unknown/disallowed tool name, becomes a sanitised
+ *   error tool-result and the loop continues;
+ * - hitting the iteration cap with tools still pending triggers one final plain
+ *   completion via {@see LlmServiceManagerInterface::chatWithConfiguration()}
+ *   (no tools at all) to synthesise a closing answer, marking the result
+ *   truncated;
+ * - a mid-loop {@see BudgetExceededException} returns the partial result
+ *   gathered so far (tools are read-only, so the state stays consistent).
+ *
+ * Token usage is summed across every round-trip (including the synthesis call);
+ * per-iteration monetary cost is recorded downstream by the middleware pipeline.
+ */
+final readonly class ToolLoopService
+{
+    use ErrorMessageSanitizerTrait;
+
+    public function __construct(
+        private LlmServiceManagerInterface $mgr,
+        private ToolRegistry $registry,
+        private int $defaultMaxIterations = 5,
+    ) {}
+
+    /**
+     * Run the bounded agent loop and return its outcome.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<string>|null                      $allowedToolNames null ⇒ all
+     *                                                                 registered
+     *                                                                 tools; a
+     *                                                                 list ⇒ that
+     *                                                                 set (∩
+     *                                                                 registry);
+     *                                                                 `[]` ⇒ no
+     *                                                                 tools
+     */
+    public function runLoop(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?array $allowedToolNames,
+        ?ToolOptions $options = null,
+        ?int $maxIterations = null,
+    ): ToolLoopResult {
+        $max   = $maxIterations ?? $this->defaultMaxIterations;
+        $specs = $this->registry->specs($allowedToolNames);
+
+        $trace            = [];
+        $promptTokens     = 0;
+        $completionTokens = 0;
+        $iterations       = 0;
+
+        try {
+            for ($i = 0; $i < $max; $i++) {
+                $iterations++;
+                $resp = $this->mgr->chatWithToolsForConfiguration($messages, $specs, $configuration, $options);
+                $promptTokens     += $resp->usage->promptTokens;
+                $completionTokens += $resp->usage->completionTokens;
+
+                if (!$resp->hasToolCalls()) {
+                    return new ToolLoopResult(
+                        $resp->content,
+                        $trace,
+                        $iterations,
+                        false,
+                        UsageStatistics::fromTokens($promptTokens, $completionTokens),
+                    );
+                }
+
+                $messages[] = $this->assistantTurn($resp);
+                foreach ($resp->toolCalls ?? [] as $call) {
+                    [$result, $isError] = $this->invoke($call);
+                    $messages[]         = [
+                        'role'         => 'tool',
+                        'tool_call_id' => $call->id,
+                        'content'      => $result,
+                    ];
+                    $trace[] = new ToolInvocation($call->name, $call->arguments, $result, $isError);
+                }
+            }
+
+            // Cap hit with tools still pending: synthesise a closing answer with
+            // NO tools. A plain completion yields a real finalContent uniformly
+            // across OpenAI, Claude and Ollama — unlike toolChoice='none' or an
+            // empty tools array (see design §4.3).
+            $final = $this->mgr->chatWithConfiguration(
+                $messages,
+                $configuration,
+                $this->budgetMetadata($options),
+            );
+            $promptTokens     += $final->usage->promptTokens;
+            $completionTokens += $final->usage->completionTokens;
+
+            return new ToolLoopResult(
+                $final->content,
+                $trace,
+                $iterations,
+                true,
+                UsageStatistics::fromTokens($promptTokens, $completionTokens),
+            );
+        } catch (BudgetExceededException) {
+            // Budget fires pre-flight and tools are read-only, so the partial
+            // trace is consistent. Surface what ran rather than aborting.
+            return new ToolLoopResult(
+                '',
+                $trace,
+                $iterations,
+                true,
+                UsageStatistics::fromTokens($promptTokens, $completionTokens),
+            );
+        }
+    }
+
+    /**
+     * Build the raw OpenAI-compatible assistant turn carrying the model's tool
+     * calls. Empty arguments serialise to `{}` (an object), never `[]`.
+     *
+     * @return array{
+     *     role: string,
+     *     content: string,
+     *     tool_calls: list<array{id: string, type: string, function: array{name: string, arguments: string}}>,
+     * }
+     */
+    private function assistantTurn(CompletionResponse $resp): array
+    {
+        $calls = array_map(
+            static fn(ToolCall $c): array => [
+                'id'       => $c->id,
+                'type'     => 'function',
+                'function' => [
+                    'name'      => $c->name,
+                    'arguments' => json_encode($c->arguments !== [] ? $c->arguments : new stdClass(), JSON_THROW_ON_ERROR),
+                ],
+            ],
+            $resp->toolCalls ?? [],
+        );
+
+        return [
+            'role'       => 'assistant',
+            'content'    => $resp->content,
+            'tool_calls' => $calls,
+        ];
+    }
+
+    /**
+     * Resolve and execute a single tool call. A missing tool or a thrown
+     * exception becomes a sanitised error result (`isError = true`) so the loop
+     * can continue instead of aborting or leaking internals.
+     *
+     * @return array{0: string, 1: bool} [result, isError]
+     */
+    private function invoke(ToolCall $call): array
+    {
+        $tool = $this->registry->get($call->name);
+        if ($tool === null) {
+            return [sprintf('Error: unknown tool "%s"', $call->name), true];
+        }
+
+        try {
+            return [$tool->execute($call->arguments), false];
+        } catch (Throwable $e) {
+            return ['Error: ' . $this->sanitizeErrorMessage($e->getMessage()), true];
+        }
+    }
+
+    /**
+     * Forward the budget pre-flight context (BE-user uid, planned cost) onto the
+     * synthesis completion so the cap-hit final call stays budget-gated and
+     * cost-attributed, matching the per-iteration tool calls.
+     *
+     * @return array<string, mixed>
+     */
+    private function budgetMetadata(?ToolOptions $options): array
+    {
+        if ($options === null) {
+            return [];
+        }
+
+        $metadata  = [];
+        $beUserUid = $options->getBeUserUid();
+        if ($beUserUid !== null) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
+
+        $plannedCost = $options->getPlannedCost();
+        if ($plannedCost !== null) {
+            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
+        }
+
+        return $metadata;
+    }
+}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -16,11 +16,11 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use stdClass;
 use Throwable;
 
@@ -35,7 +35,7 @@ use Throwable;
  * configurable max-iteration cap.
  *
  * Failure handling is fail-soft so the admin always sees what ran:
- * - a tool that throws, or an unknown/disallowed tool name, becomes a sanitised
+ * - a tool that throws, or an unknown/disallowed tool name, becomes a generic
  *   error tool-result and the loop continues;
  * - hitting the iteration cap with tools still pending triggers one final plain
  *   completion via {@see LlmServiceManagerInterface::chatWithConfiguration()}
@@ -49,8 +49,6 @@ use Throwable;
  */
 final readonly class ToolLoopService
 {
-    use ErrorMessageSanitizerTrait;
-
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
@@ -80,6 +78,26 @@ final readonly class ToolLoopService
         $max   = $maxIterations ?? $this->defaultMaxIterations;
         $specs = $this->registry->specs($allowedToolNames);
 
+        // No tools offered (an empty allow-list, or nothing registered): a tools
+        // request with an empty `tools` array makes some providers (OpenAI) 400.
+        // The design (§4.3) maps "no tools" to a single plain completion.
+        if ($specs === []) {
+            $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options));
+
+            return new ToolLoopResult(
+                $resp->content,
+                [],
+                1,
+                false,
+                UsageStatistics::fromTokens($resp->usage->promptTokens, $resp->usage->completionTokens),
+            );
+        }
+
+        // Enforce the offered set at execution time too: a model steered by
+        // injected skill prose must not be able to call a registered-but-not-
+        // offered tool.
+        $allowedNames = array_map(static fn(ToolSpec $s): string => $s->name, $specs);
+
         $trace            = [];
         $promptTokens     = 0;
         $completionTokens = 0;
@@ -104,7 +122,7 @@ final readonly class ToolLoopService
 
                 $messages[] = $this->assistantTurn($resp);
                 foreach ($resp->toolCalls ?? [] as $call) {
-                    [$result, $isError] = $this->invoke($call);
+                    [$result, $isError] = $this->invoke($call, $allowedNames);
                     $messages[]         = [
                         'role'         => 'tool',
                         'tool_call_id' => $call->id,
@@ -178,23 +196,37 @@ final readonly class ToolLoopService
     }
 
     /**
-     * Resolve and execute a single tool call. A missing tool or a thrown
-     * exception becomes a sanitised error result (`isError = true`) so the loop
-     * can continue instead of aborting or leaking internals.
+     * Resolve and execute a single tool call. A missing tool, a tool not in the
+     * offered allow-list, or a thrown exception becomes a generic error result
+     * (`isError = true`) so the loop can continue instead of aborting or leaking
+     * internals.
+     *
+     * The thrown-exception branch returns a generic message rather than the
+     * exception text: the tool name is a known registered name (safe), but the
+     * exception body may carry DBAL/PDO credentials ('Access denied for user
+     * X@host') that URL-sanitising would not strip, so it must never reach the
+     * provider.
+     *
+     * @param list<string> $allowedNames Names of the tools actually offered this
+     *                                   run; a call to any other registered tool
+     *                                   is rejected unexecuted.
      *
      * @return array{0: string, 1: bool} [result, isError]
      */
-    private function invoke(ToolCall $call): array
+    private function invoke(ToolCall $call, array $allowedNames): array
     {
         $tool = $this->registry->get($call->name);
         if ($tool === null) {
             return [sprintf('Error: unknown tool "%s"', $call->name), true];
         }
+        if (!in_array($call->name, $allowedNames, true)) {
+            return [sprintf('Error: tool "%s" not permitted', $call->name), true];
+        }
 
         try {
             return [$tool->execute($call->arguments), false];
-        } catch (Throwable $e) {
-            return ['Error: ' . $this->sanitizeErrorMessage($e->getMessage()), true];
+        } catch (Throwable) {
+            return [sprintf('Error: tool "%s" failed.', $call->name), true];
         }
     }
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
 
@@ -52,6 +53,7 @@ final readonly class ToolLoopService
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
+        private ?LoggerInterface $logger = null,
         private int $defaultMaxIterations = 5,
     ) {}
 
@@ -225,7 +227,12 @@ final readonly class ToolLoopService
 
         try {
             return [$tool->execute($call->arguments), false];
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            $this->logger?->error(
+                sprintf('Tool "%s" failed: %s', $call->name, $e->getMessage()),
+                ['exception' => $e],
+            );
+
             return [sprintf('Error: tool "%s" failed.', $call->name), true];
         }
     }

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Collects every DI-tagged ToolInterface and exposes it to the agent loop.
+ *
+ * Tools are injected through the `nr_llm.tool` tagged iterator and indexed by
+ * their spec name; a duplicate name is a developer error and fails fast with a
+ * LogicException at construction time.
+ *
+ * The registry is the authoritative allow-set: `specs()` filters the declared
+ * tool specs against an optional allow-list, dropping any name that does not
+ * map to a registered tool. An explicit empty allow-list therefore yields no
+ * tools, while `null` means "no restriction" and returns every registered
+ * spec.
+ */
+final class ToolRegistry
+{
+    /** @var array<string, ToolInterface> */
+    private array $byName = [];
+
+    /**
+     * @param iterable<ToolInterface> $tools
+     */
+    public function __construct(
+        #[AutowireIterator(ToolInterface::TAG_NAME)]
+        iterable $tools,
+    ) {
+        foreach ($tools as $tool) {
+            $name = $tool->getSpec()->name;
+            if (isset($this->byName[$name])) {
+                throw new LogicException(
+                    sprintf('Duplicate tool name "%s".', $name),
+                    1782700001,
+                );
+            }
+            $this->byName[$name] = $tool;
+        }
+    }
+
+    public function get(string $name): ?ToolInterface
+    {
+        return $this->byName[$name] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return array_keys($this->byName);
+    }
+
+    /**
+     * Return the specs of all registered tools, or only those whose name is in
+     * `$allowedNames`. Unknown declared names are dropped (the registry is the
+     * authoritative allow-set); `[]` yields no specs, `null` yields all.
+     *
+     * @param list<string>|null $allowedNames
+     *
+     * @return list<ToolSpec>
+     */
+    public function specs(?array $allowedNames = null): array
+    {
+        $specs = [];
+        foreach ($this->byName as $name => $tool) {
+            if ($allowedNames !== null && !in_array($name, $allowedNames, true)) {
+                continue;
+            }
+            $specs[] = $tool->getSpec();
+        }
+
+        return $specs;
+    }
+}

--- a/Tests/Functional/Fixtures/sys_file_metadata_tools.csv
+++ b/Tests/Functional/Fixtures/sys_file_metadata_tools.csv
@@ -1,3 +1,3 @@
 "sys_file_metadata"
-,"uid","pid","file","title","alternative"
-,1,0,1,"Company Logo","Logo alt text"
+,"uid","pid","file","sys_language_uid","title","alternative"
+,1,0,1,0,"Company Logo","Logo alt text"

--- a/Tests/Functional/Fixtures/sys_file_metadata_tools.csv
+++ b/Tests/Functional/Fixtures/sys_file_metadata_tools.csv
@@ -1,0 +1,3 @@
+"sys_file_metadata"
+,"uid","pid","file","title","alternative"
+,1,0,1,"Company Logo","Logo alt text"

--- a/Tests/Functional/Fixtures/sys_file_tools.csv
+++ b/Tests/Functional/Fixtures/sys_file_tools.csv
@@ -1,0 +1,4 @@
+"sys_file"
+,"uid","pid","storage","type","mime_type","name","identifier","size"
+,1,0,1,2,"image/png","logo.png","/logo.png",2048
+,2,0,2,2,"image/jpeg","secret.jpg","/secret.jpg",4096

--- a/Tests/Functional/Fixtures/sys_log_tools.csv
+++ b/Tests/Functional/Fixtures/sys_log_tools.csv
@@ -1,0 +1,6 @@
+"sys_log"
+,"uid","userid","action","recuid","tablename","recpid","error","details","type","channel","IP","log_data","event_pid","level","tstamp"
+,9001,4242,1,0,"",0,0,"User authenticated",255,"default","203.0.113.55","a:1:{i:0;s:11:\"secretadmin\";}",0,"info",1799990001
+,9002,4242,1,0,"",0,0,"Page content updated",1,"default","203.0.113.55","a:0:{}",0,"info",1799990002
+,9003,4242,5,0,"",0,1,"Login failed",255,"default","203.0.113.55","a:0:{}",0,"error",1799990003
+,9004,4242,3,0,"",0,0,"Cache cleared",1,"default","203.0.113.55","a:0:{}",0,"info",1799990004

--- a/Tests/Functional/Service/Fixtures/RecordingToolAdapter.php
+++ b/Tests/Functional/Service/Fixtures/RecordingToolAdapter.php
@@ -73,7 +73,11 @@ final class RecordingToolAdapter implements ProviderInterface, ToolCapableInterf
         return 'recording-fake';
     }
 
-    public function configure(array $config): void {}
+    public function configure(array $config): void
+    {
+        // intentional no-op: this double is resolved directly via a mocked
+        // createAdapterFromModel(), so configure() is never invoked by the test.
+    }
 
     public function isAvailable(): bool
     {

--- a/Tests/Functional/Service/Fixtures/RecordingToolAdapter.php
+++ b/Tests/Functional/Service/Fixtures/RecordingToolAdapter.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Fixtures;
+
+use BadMethodCallException;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
+
+/**
+ * In-memory provider adapter double that is BOTH a {@see ProviderInterface}
+ * and a {@see ToolCapableInterface}.
+ *
+ * Used by {@see \Netresearch\NrLlm\Tests\Functional\Service\LlmServiceManagerToolsConfigurationTest}
+ * to prove `LlmServiceManager::chatWithToolsForConfiguration()` resolves the
+ * adapter from the run's configuration and forwards through
+ * `chatCompletionWithTools()`. It records the tools/options the manager
+ * forwards and answers with a single canned `ToolCall` so the round trip can
+ * be asserted without a real provider or HTTP traffic. Methods the test does
+ * not exercise throw so an accidental call is loud rather than silent.
+ */
+final class RecordingToolAdapter implements ProviderInterface, ToolCapableInterface
+{
+    /** @var list<ToolSpec>|null */
+    public ?array $recordedTools = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $recordedOptions = null;
+
+    public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
+    {
+        $this->recordedTools   = $tools;
+        $this->recordedOptions = $options;
+
+        return new CompletionResponse(
+            content: '',
+            model: is_string($options['model'] ?? null) ? $options['model'] : 'unknown',
+            usage: new UsageStatistics(7, 3, 10),
+            finishReason: 'tool_calls',
+            provider: 'recording-fake',
+            toolCalls: [ToolCall::function('call_0', 'fetch_logs', ['limit' => 5])],
+        );
+    }
+
+    public function supportsTools(): bool
+    {
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    // ProviderInterface methods not exercised by the test
+    // ------------------------------------------------------------------
+
+    public function getName(): string
+    {
+        return 'Recording Fake';
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'recording-fake';
+    }
+
+    public function configure(array $config): void {}
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function supportsFeature(string|ModelCapability $feature): bool
+    {
+        return true;
+    }
+
+    public function chatCompletion(array $messages, array $options = []): CompletionResponse
+    {
+        throw new BadMethodCallException('chatCompletion() is not used in this test', 1782748810);
+    }
+
+    public function complete(string $prompt, array $options = []): CompletionResponse
+    {
+        throw new BadMethodCallException('complete() is not used in this test', 1782748811);
+    }
+
+    public function embeddings(string|array $input, array $options = []): EmbeddingResponse
+    {
+        throw new BadMethodCallException('embeddings() is not used in this test', 1782748812);
+    }
+
+    public function getAvailableModels(): array
+    {
+        return [];
+    }
+
+    public function getDefaultModel(): string
+    {
+        return 'recording-default-model';
+    }
+
+    public function testConnection(): array
+    {
+        return ['success' => true, 'message' => 'ok'];
+    }
+}

--- a/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
+++ b/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
@@ -67,8 +67,9 @@ final class LlmServiceManagerToolsConfigurationTest extends AbstractFunctionalTe
         $resolvedFromModel = null;
         $adapterRegistry   = $this->createMock(ProviderAdapterRegistryInterface::class);
         $adapterRegistry->expects(self::once())->method('createAdapterFromModel')->willReturnCallback(
-            function (Model $passedModel, bool $useCache = true) use ($adapter, &$resolvedFromModel): RecordingToolAdapter {
+            function (Model $passedModel) use ($adapter, &$resolvedFromModel): RecordingToolAdapter {
                 $resolvedFromModel = $passedModel;
+
                 return $adapter;
             },
         );

--- a/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
+++ b/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\RecordingToolAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Functional coverage for the config-aware tool entry point
+ * {@see LlmServiceManager::chatWithToolsForConfiguration()} (design §4.3a).
+ *
+ * Unlike the keyed {@see LlmServiceManager::chatWithTools()} path — which
+ * resolves a provider from ExtensionConfiguration against a model-less
+ * transient configuration — this entry point MUST resolve its adapter from
+ * the run's DB-backed {@see LlmConfiguration} via `getAdapterFromConfiguration()`
+ * so the configuration's vault key, model and pricing reach the call.
+ */
+#[CoversClass(LlmServiceManager::class)]
+final class LlmServiceManagerToolsConfigurationTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function chatWithToolsForConfigurationResolvesAdapterFromConfigurationAndReturnsToolCall(): void
+    {
+        // A DB-backed configuration: a provider carrying a vault key identifier
+        // and a priced model the configuration points at.
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+        $model->setCostInputDollars(1.5);
+        $model->setCostOutputDollars(3.0);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-tools');
+        $configuration->setLlmModel($model);
+
+        $adapter = new RecordingToolAdapter();
+
+        // Capture the model the manager resolves the adapter from. A keyed/default
+        // path would never call createAdapterFromModel(), so a captured model that
+        // is the configuration's own model proves config-driven resolution.
+        $resolvedFromModel = null;
+        $adapterRegistry   = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->expects(self::once())->method('createAdapterFromModel')->willReturnCallback(
+            function (Model $passedModel, bool $useCache = true) use ($adapter, &$resolvedFromModel): RecordingToolAdapter {
+                $resolvedFromModel = $passedModel;
+                return $adapter;
+            },
+        );
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = new LlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $messages = [['role' => 'user', 'content' => 'Show me the last logs.']];
+        $tools    = [ToolSpec::function('fetch_logs', 'Read recent log rows', ['type' => 'object', 'properties' => []])];
+
+        $response = $manager->chatWithToolsForConfiguration($messages, $tools, $configuration, ToolOptions::auto());
+
+        // 1. The configuration's model — not a default — drove adapter resolution,
+        //    and the provider's vault key is reachable from that model.
+        self::assertInstanceOf(Model::class, $resolvedFromModel);
+        self::assertSame($model, $resolvedFromModel);
+        self::assertSame('priced-model-x', $resolvedFromModel->getModelId());
+        self::assertSame('nr_tools_vault_key', $resolvedFromModel->getProvider()?->getApiKey());
+
+        // 2. The tool call the adapter emitted is returned to the caller verbatim.
+        self::assertInstanceOf(CompletionResponse::class, $response);
+        self::assertTrue($response->hasToolCalls());
+        $toolCalls = $response->toolCalls;
+        self::assertIsArray($toolCalls);
+        self::assertCount(1, $toolCalls);
+        self::assertSame('fetch_logs', $toolCalls[0]->name);
+        self::assertSame(['limit' => 5], $toolCalls[0]->arguments);
+
+        // 3. The configuration's model id and the declared tool reached the call.
+        $recordedOptions = $adapter->recordedOptions;
+        self::assertIsArray($recordedOptions);
+        self::assertSame('priced-model-x', $recordedOptions['model'] ?? null);
+        $recordedTools = $adapter->recordedTools;
+        self::assertIsArray($recordedTools);
+        self::assertCount(1, $recordedTools);
+        self::assertSame('fetch_logs', $recordedTools[0]->name);
+    }
+}

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -105,6 +105,17 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         return sprintf("---\nname: %s\ndescription: %s\n---\n%s", $name, $description, $body);
     }
 
+    private function mdWithTools(string $name, string $allowedToolsYaml, string $body, string $description = 'd'): string
+    {
+        return sprintf(
+            "---\nname: %s\ndescription: %s\nallowed-tools: %s\n---\n%s",
+            $name,
+            $description,
+            $allowedToolsYaml,
+            $body,
+        );
+    }
+
     /**
      * Build a marketplace client whose index lists the given owner/repo plugin slugs and whose child
      * repos each expose a single skill at SKILL_A_PATH. Optionally force a child (owner,repo) to fail.
@@ -146,6 +157,33 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         foreach ($skills as $skill) {
             self::assertFalse($skill->isEnabled(), 'multi-skill discovery must default disabled');
         }
+    }
+
+    #[Test]
+    public function syncStoresAbsentAllowedToolsAsEmptyAndDeclaredAsJson(): void
+    {
+        // Absent front-matter key → '' (no opinion); a present declaration → its JSON,
+        // including '[]' for a declared-empty fail-closed list.
+        $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH, self::SKILL_B_PATH, 'skills/c/SKILL.md'], [
+            self::SKILL_A_PATH    => $this->md('A', 'body a'),
+            self::SKILL_B_PATH    => $this->mdWithTools('B', '[]', 'body b'),
+            'skills/c/SKILL.md'   => $this->mdWithTools('C', '[x]', 'body c'),
+        ]);
+        $this->service($gitHub)->sync($this->repoSource());
+
+        $repo = $this->get(SkillRepository::class);
+
+        $absent = $repo->findBySourceAndIdentifier(10, self::SKILL_A_ID);
+        self::assertNotNull($absent);
+        self::assertSame('', $absent->getAllowedTools(), 'absent allowed-tools front-matter stores empty string');
+
+        $declaredEmpty = $repo->findBySourceAndIdentifier(10, self::SKILL_B_ID);
+        self::assertNotNull($declaredEmpty);
+        self::assertSame('[]', $declaredEmpty->getAllowedTools(), 'declared-empty allowed-tools stores "[]"');
+
+        $declaredList = $repo->findBySourceAndIdentifier(10, '10:skills/c/SKILL.md');
+        self::assertNotNull($declaredList);
+        self::assertSame('["x"]', $declaredList->getAllowedTools(), 'a declared list stores its JSON encoding');
     }
 
     #[Test]

--- a/Tests/Functional/Service/Tool/FetchLogsToolTest.php
+++ b/Tests/Functional/Service/Tool/FetchLogsToolTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for FetchLogsTool.
+ *
+ * Verifies the sys_log read path: newest-first ordering, the hard 50-row
+ * cap, the optional level filter and — load-bearing — that PII fields
+ * (raw IP, backend user id, serialized payload) never reach the formatted
+ * output that egresses to an external LLM.
+ */
+#[CoversClass(FetchLogsTool::class)]
+final class FetchLogsToolTest extends AbstractFunctionalTestCase
+{
+    private const RAW_IP = '203.0.113.55';
+    private const USER_ID = '4242';
+    private const PAYLOAD_USERNAME = 'secretadmin';
+
+    private FetchLogsTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new FetchLogsTool($connectionPool);
+    }
+
+    #[Test]
+    public function getSpecDeclaresFetchLogsFunction(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('fetch_logs', $spec->name);
+        self::assertSame('object', $spec->parameters['type'] ?? null);
+
+        $properties = $spec->parameters['properties'] ?? null;
+        self::assertIsArray($properties);
+        self::assertArrayHasKey('level', $properties);
+        self::assertArrayHasKey('limit', $properties);
+    }
+
+    #[Test]
+    public function returnsNewestEntriesCappedByLimit(): void
+    {
+        $this->importFixture('sys_log_tools.csv');
+
+        $output = $this->tool->execute(['limit' => 2]);
+
+        self::assertStringContainsString('Cache cleared', $output);
+        self::assertStringContainsString('Login failed', $output);
+        self::assertStringNotContainsString('User authenticated', $output);
+        self::assertStringNotContainsString('Page content updated', $output);
+        self::assertCount(2, $this->entryLines($output));
+    }
+
+    #[Test]
+    public function redactsRawIpUserIdAndPayloadUsername(): void
+    {
+        $this->importFixture('sys_log_tools.csv');
+
+        $output = $this->tool->execute(['limit' => 10]);
+
+        self::assertStringNotContainsString(self::RAW_IP, $output);
+        self::assertStringNotContainsString(self::USER_ID, $output);
+        self::assertStringNotContainsString(self::PAYLOAD_USERNAME, $output);
+    }
+
+    #[Test]
+    public function levelFilterRestrictsToMatchingEntries(): void
+    {
+        $this->importFixture('sys_log_tools.csv');
+
+        $output = $this->tool->execute(['level' => 'error']);
+
+        self::assertStringContainsString('Login failed', $output);
+        self::assertStringNotContainsString('Cache cleared', $output);
+    }
+
+    #[Test]
+    public function hardCapsResultsAtFiftyEvenWhenLimitHigher(): void
+    {
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('sys_log');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        for ($i = 1; $i <= 60; ++$i) {
+            $connection->insert('sys_log', [
+                'tstamp'   => 1799990000 + $i,
+                'userid'   => 0,
+                'type'     => 1,
+                'action'   => 1,
+                'error'    => 0,
+                'level'    => 'info',
+                'details'  => 'bulk entry ' . $i,
+                'IP'       => '',
+                'log_data' => '',
+            ]);
+        }
+
+        $output = $this->tool->execute(['limit' => 9999]);
+
+        self::assertCount(50, $this->entryLines($output));
+    }
+
+    #[Test]
+    public function returnsPlaceholderWhenNoEntriesMatch(): void
+    {
+        $output = $this->tool->execute(['level' => 'no-such-level']);
+
+        self::assertSame('No log entries.', $output);
+    }
+
+    /**
+     * Formatted log rows each begin with a "[" date bracket; the header line
+     * does not. Counting them yields the number of returned entries.
+     *
+     * @return list<string>
+     */
+    private function entryLines(string $output): array
+    {
+        return array_values(array_filter(
+            explode("\n", $output),
+            static fn(string $line): bool => str_starts_with($line, '['),
+        ));
+    }
+}

--- a/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ReadFalAssetMetaTool.
+ *
+ * Verifies the storage-scoped sys_file metadata read: an asset in an
+ * allowed storage returns name/MIME/size (+ title/alt), while an asset in
+ * a non-allowed storage and a missing uid both return the same neutral
+ * "not found or not permitted" string — the model-chosen uid must never be
+ * able to enumerate arbitrary storages, and a missing row must not throw.
+ */
+#[CoversClass(ReadFalAssetMetaTool::class)]
+final class ReadFalAssetMetaToolTest extends AbstractFunctionalTestCase
+{
+    private const NOT_PERMITTED = 'Asset not found or not permitted.';
+
+    private ReadFalAssetMetaTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new ReadFalAssetMetaTool($connectionPool);
+    }
+
+    #[Test]
+    public function getSpecDeclaresReadFalAssetMetaFunction(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('read_fal_asset_meta', $spec->name);
+        self::assertSame(['uid'], $spec->parameters['required'] ?? null);
+
+        $properties = $spec->parameters['properties'] ?? null;
+        self::assertIsArray($properties);
+        self::assertArrayHasKey('uid', $properties);
+    }
+
+    #[Test]
+    public function returnsMetadataForAssetInAllowedStorage(): void
+    {
+        $this->importFixture('sys_file_tools.csv');
+        $this->importFixture('sys_file_metadata_tools.csv');
+
+        $output = $this->tool->execute(['uid' => 1]);
+
+        self::assertStringContainsString('logo.png', $output);
+        self::assertStringContainsString('image/png', $output);
+        self::assertStringContainsString('2048', $output);
+        self::assertStringContainsString('Company Logo', $output);
+        self::assertStringContainsString('Logo alt text', $output);
+    }
+
+    #[Test]
+    public function rejectsAssetOutsideAllowedStorage(): void
+    {
+        $this->importFixture('sys_file_tools.csv');
+
+        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 2]));
+    }
+
+    #[Test]
+    public function returnsNotFoundForMissingUidWithoutThrowing(): void
+    {
+        $this->importFixture('sys_file_tools.csv');
+
+        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 999999]));
+    }
+}

--- a/Tests/Unit/Domain/Model/SkillAllowedToolsTest.php
+++ b/Tests/Unit/Domain/Model/SkillAllowedToolsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;
+
+use Netresearch\NrLlm\Domain\Model\Skill;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Skill::getAllowedToolsList().
+ *
+ * Note: Domain models are excluded from coverage in phpunit.xml.
+ */
+#[CoversNothing]
+final class SkillAllowedToolsTest extends TestCase
+{
+    #[Test]
+    public function emptyStoredValueMeansNoOpinion(): void
+    {
+        $skill = new Skill();
+        $skill->setAllowedTools('');
+
+        self::assertNull($skill->getAllowedToolsList());
+    }
+
+    #[Test]
+    public function declaredEmptyListFailsClosedToEmptyArray(): void
+    {
+        $skill = new Skill();
+        $skill->setAllowedTools('[]');
+
+        self::assertSame([], $skill->getAllowedToolsList());
+    }
+
+    #[Test]
+    public function declaredListReturnsStringNames(): void
+    {
+        $skill = new Skill();
+        $skill->setAllowedTools('["a","b"]');
+
+        self::assertSame(['a', 'b'], $skill->getAllowedToolsList());
+    }
+
+    #[Test]
+    public function invalidJsonMeansNoOpinion(): void
+    {
+        $skill = new Skill();
+        $skill->setAllowedTools('garbage');
+
+        self::assertNull($skill->getAllowedToolsList());
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/ToolLoopResultTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolLoopResultTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ToolLoopResultTest extends TestCase
+{
+    #[Test]
+    public function toolInvocationExposesPublicProperties(): void
+    {
+        $invocation = new ToolInvocation(
+            name: 'fetch_logs',
+            arguments: ['limit' => 5],
+            result: 'LOGS',
+            isError: false,
+        );
+
+        self::assertSame('fetch_logs', $invocation->name);
+        self::assertSame(['limit' => 5], $invocation->arguments);
+        self::assertSame('LOGS', $invocation->result);
+        self::assertFalse($invocation->isError);
+    }
+
+    #[Test]
+    public function toolLoopResultExposesPublicProperties(): void
+    {
+        $trace = [
+            new ToolInvocation('fetch_logs', ['limit' => 5], 'LOGS', false),
+            new ToolInvocation('nope', [], 'Error: unknown tool "nope"', true),
+        ];
+        $usage = UsageStatistics::fromTokens(10, 5);
+
+        $result = new ToolLoopResult(
+            finalContent: 'done',
+            trace: $trace,
+            iterations: 2,
+            truncated: true,
+            usage: $usage,
+        );
+
+        self::assertSame('done', $result->finalContent);
+        self::assertSame($trace, $result->trace);
+        self::assertSame(2, $result->iterations);
+        self::assertTrue($result->truncated);
+        self::assertSame($usage, $result->usage);
+        self::assertSame(15, $result->usage->totalTokens);
+    }
+
+    #[Test]
+    public function traceHoldsToolInvocationInstances(): void
+    {
+        $result = new ToolLoopResult(
+            finalContent: '',
+            trace: [new ToolInvocation('fetch_logs', [], 'LOGS', false)],
+            iterations: 1,
+            truncated: false,
+            usage: UsageStatistics::fromTokens(0, 0),
+        );
+
+        self::assertContainsOnlyInstancesOf(ToolInvocation::class, $result->trace);
+        self::assertCount(1, $result->trace);
+        self::assertSame('fetch_logs', $result->trace[0]->name);
+    }
+}

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\OllamaProvider;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Covers the `ToolCapableInterface` slice of {@see OllamaProvider}: tool
+ * serialisation into the `/api/chat` payload, id synthesis on the parsed
+ * `message.tool_calls`, and the inbound translation of replayed OpenAI-shape
+ * turns into Ollama's native shape.
+ */
+#[CoversClass(OllamaProvider::class)]
+class OllamaProviderToolsTest extends AbstractUnitTestCase
+{
+    /**
+     * Captures the JSON request body the provider hands to the stream factory
+     * so the outbound payload shaping can be asserted directly.
+     */
+    private ?string $capturedBody = null;
+
+    #[Test]
+    public function supportsToolsReturnsTrue(): void
+    {
+        self::assertTrue($this->buildSubject([])->supportsTools());
+    }
+
+    #[Test]
+    public function serialisesToolsIntoPayload(): void
+    {
+        $subject = $this->buildSubject($this->plainAssistantResponse('done'));
+
+        $tool = ToolSpec::function('fetch_logs', 'Fetch recent log entries', [
+            'type'       => 'object',
+            'properties' => ['limit' => ['type' => 'integer']],
+        ]);
+
+        $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'show logs']], [$tool]);
+
+        $payload = $this->capturedRequest();
+        self::assertArrayHasKey('tools', $payload);
+
+        $tools = $payload['tools'];
+        self::assertIsArray($tools);
+        $first = $tools[0] ?? null;
+        self::assertIsArray($first);
+        $function = $first['function'] ?? null;
+        self::assertIsArray($function);
+        self::assertSame('fetch_logs', $function['name'] ?? null);
+    }
+
+    #[Test]
+    public function parsesToolCallsAndSynthesisesIds(): void
+    {
+        $subject = $this->buildSubject([
+            'model'   => 'llama3.2',
+            'message' => [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    ['function' => ['name' => 'fetch_logs', 'arguments' => ['limit' => 5]]],
+                ],
+            ],
+            'done'              => true,
+            'done_reason'       => 'stop',
+            'prompt_eval_count' => 3,
+            'eval_count'        => 4,
+        ]);
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'logs']], []);
+
+        self::assertTrue($result->hasToolCalls());
+        self::assertNotNull($result->toolCalls);
+
+        $call = $result->toolCalls[0];
+        self::assertSame('call_0', $call->id);
+        self::assertSame('fetch_logs', $call->name);
+        self::assertSame(['limit' => 5], $call->arguments);
+    }
+
+    #[Test]
+    public function translatesReplayedAssistantAndToolTurnsToNativeShape(): void
+    {
+        $subject = $this->buildSubject($this->plainAssistantResponse('ok'));
+
+        $messages = [
+            ['role' => 'user', 'content' => 'show logs'],
+            [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    [
+                        'id'       => 'call_0',
+                        'type'     => 'function',
+                        'function' => ['name' => 'fetch_logs', 'arguments' => '{"limit":5}'],
+                    ],
+                ],
+            ],
+            ['role' => 'tool', 'tool_call_id' => 'call_0', 'content' => 'LOGS'],
+        ];
+
+        $subject->chatCompletionWithTools($messages, []);
+
+        $payload = $this->capturedRequest();
+        $sent    = $payload['messages'];
+        self::assertIsArray($sent);
+
+        // Assistant turn: the JSON-string arguments are decoded to an object.
+        $assistant = $sent[1] ?? null;
+        self::assertIsArray($assistant);
+        $calls = $assistant['tool_calls'] ?? null;
+        self::assertIsArray($calls);
+        $firstCall = $calls[0] ?? null;
+        self::assertIsArray($firstCall);
+        $function = $firstCall['function'] ?? null;
+        self::assertIsArray($function);
+        self::assertSame(['limit' => 5], $function['arguments'] ?? null);
+
+        // Tool turn: the OpenAI-only tool_call_id key is dropped.
+        $toolTurn = $sent[2] ?? null;
+        self::assertIsArray($toolTurn);
+        self::assertArrayNotHasKey('tool_call_id', $toolTurn);
+        self::assertSame('LOGS', $toolTurn['content'] ?? null);
+    }
+
+    #[Test]
+    public function nonToolResponseReturnsPlainContent(): void
+    {
+        $subject = $this->buildSubject($this->plainAssistantResponse('plain answer'));
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'hi']], []);
+
+        self::assertFalse($result->hasToolCalls());
+        self::assertSame('plain answer', $result->content);
+    }
+
+    /**
+     * Build an Ollama provider whose stream factory records the outgoing JSON
+     * request body and whose HTTP client returns the given canned response.
+     *
+     * @param array<string, mixed> $apiResponse
+     */
+    private function buildSubject(array $apiResponse): OllamaProvider
+    {
+        $this->capturedBody = null;
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content): StreamInterface {
+                $this->capturedBody = $content;
+                $stream             = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel'     => 'llama3.2',
+            'baseUrl'          => 'http://localhost:11434',
+            'timeout'          => 30,
+        ]);
+
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturn($this->createJsonResponseMock($apiResponse));
+
+        // setHttpClient must be called AFTER configure(), which resets the client.
+        $subject->setHttpClient($httpClient);
+
+        return $subject;
+    }
+
+    /**
+     * Decode the captured outbound request body.
+     *
+     * @return array<string, mixed>
+     */
+    private function capturedRequest(): array
+    {
+        self::assertIsString($this->capturedBody);
+        $decoded = json_decode($this->capturedBody, true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * A successful `/api/chat` response that carries only assistant content.
+     *
+     * @return array<string, mixed>
+     */
+    private function plainAssistantResponse(string $content): array
+    {
+        return [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => $content],
+            'done'              => true,
+            'done_reason'       => 'stop',
+            'prompt_eval_count' => 2,
+            'eval_count'        => 3,
+        ];
+    }
+}

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -137,6 +137,54 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function plainChatCompletionTranslatesReplayedToolTurns(): void
+    {
+        // The truncation-synthesis path replays prior tool turns through the
+        // plain chatCompletion() endpoint, so it must perform the same
+        // OpenAI->Ollama shape translation as chatCompletionWithTools().
+        $subject = $this->buildSubject($this->plainAssistantResponse('ok'));
+
+        $messages = [
+            ['role' => 'user', 'content' => 'show logs'],
+            [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    [
+                        'id'       => 'call_0',
+                        'type'     => 'function',
+                        'function' => ['name' => 'fetch_logs', 'arguments' => '{"limit":5}'],
+                    ],
+                ],
+            ],
+            ['role' => 'tool', 'tool_call_id' => 'call_0', 'content' => 'LOGS'],
+        ];
+
+        $subject->chatCompletion($messages);
+
+        $payload = $this->capturedRequest();
+        $sent    = $payload['messages'];
+        self::assertIsArray($sent);
+
+        // Assistant turn: the JSON-string arguments are decoded to an object.
+        $assistant = $sent[1] ?? null;
+        self::assertIsArray($assistant);
+        $calls = $assistant['tool_calls'] ?? null;
+        self::assertIsArray($calls);
+        $firstCall = $calls[0] ?? null;
+        self::assertIsArray($firstCall);
+        $function = $firstCall['function'] ?? null;
+        self::assertIsArray($function);
+        self::assertSame(['limit' => 5], $function['arguments'] ?? null);
+
+        // Tool turn: the OpenAI-only tool_call_id key is dropped.
+        $toolTurn = $sent[2] ?? null;
+        self::assertIsArray($toolTurn);
+        self::assertArrayNotHasKey('tool_call_id', $toolTurn);
+        self::assertSame('LOGS', $toolTurn['content'] ?? null);
+    }
+
+    #[Test]
     public function nonToolResponseReturnsPlainContent(): void
     {
         $subject = $this->buildSubject($this->plainAssistantResponse('plain answer'));

--- a/Tests/Unit/Service/Tool/AllowedToolsResolverTest.php
+++ b/Tests/Unit/Service/Tool/AllowedToolsResolverTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Skill;
+use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AllowedToolsResolver::class)]
+final class AllowedToolsResolverTest extends TestCase
+{
+    private function resolver(): AllowedToolsResolver
+    {
+        // A real (pure) SkillComposer: effectiveSkills() has no side effects, so the
+        // resolver is exercised against the genuine enabled/non-orphaned/dedup selection.
+        return new AllowedToolsResolver(new SkillComposer());
+    }
+
+    private function skill(
+        string $identifier,
+        string $allowedTools,
+        bool $enabled = true,
+        bool $orphaned = false,
+        int $source = 1,
+    ): Skill {
+        $skill = new Skill();
+        $skill->setSource($source);
+        $skill->setIdentifier($identifier);
+        $skill->setAllowedTools($allowedTools);
+        $skill->setEnabled($enabled);
+        $skill->setOrphaned($orphaned);
+
+        return $skill;
+    }
+
+    #[Test]
+    public function returnsNullWhenNoEffectiveSkillDeclares(): void
+    {
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', ''));
+        $config->addSkill($this->skill('b', ''));
+
+        self::assertNull($this->resolver()->resolve($config));
+    }
+
+    #[Test]
+    public function returnsDeclaredNamesWhenOneDeclaresAndAnotherIsAbsent(): void
+    {
+        // Declarer on the configuration, an absent (no-opinion) skill on the task:
+        // exercises both the config and the task skill-list paths.
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', '["fetch_logs"]'));
+
+        $task = new Task();
+        $task->addSkill($this->skill('b', ''));
+
+        self::assertSame(['fetch_logs'], $this->resolver()->resolve($config, $task));
+    }
+
+    #[Test]
+    public function loneDeclaredEmptyListFailsClosedToEmptyArray(): void
+    {
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', '[]'));
+
+        self::assertSame([], $this->resolver()->resolve($config));
+    }
+
+    #[Test]
+    public function disabledDeclarerIsExcludedSoNoOpinionRemains(): void
+    {
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', '["x"]', enabled: false));
+        $config->addSkill($this->skill('b', '', enabled: true));
+
+        self::assertNull($this->resolver()->resolve($config));
+    }
+
+    #[Test]
+    public function unionsDeclaredNamesAcrossDeclarers(): void
+    {
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', '["a"]'));
+        $config->addSkill($this->skill('b', '["a","b"]'));
+
+        $result = $this->resolver()->resolve($config);
+        self::assertNotNull($result);
+        sort($result);
+        self::assertSame(['a', 'b'], $result);
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+
+/**
+ * Minimal in-memory ToolInterface double used by the ToolRegistry unit tests.
+ *
+ * Carries a configurable name (the registry index key) and a canned result so
+ * a test can assert both the lookup-by-name path and the execute() contract
+ * without touching the database or a real provider.
+ */
+final readonly class FakeTool implements ToolInterface
+{
+    public function __construct(
+        private string $name,
+        private string $result = 'ok',
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            $this->name,
+            'desc of ' . $this->name,
+            ['type' => 'object', 'properties' => []],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments): string
+    {
+        return $this->result;
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -17,7 +17,6 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
-use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -25,7 +24,9 @@ use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Throwable;
 
 #[CoversClass(ToolLoopService::class)]
 final class ToolLoopServiceTest extends TestCase
@@ -136,6 +137,49 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function toolFailureIsLoggedServerSideWithFullDetail(): void
+    {
+        $throwing = new class implements ToolInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('boom_tool', 'throws', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments): string
+            {
+                throw new RuntimeException('boom https://x?key=secret', 1782700101);
+            }
+        };
+
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'boom_tool', [])]),
+            $this->response('recovered'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        // The provider-facing result is generic (no egress of internals), but the
+        // server-side logger MUST still receive the real exception detail.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('boom_tool'),
+                self::callback(
+                    static fn(mixed $context): bool => is_array($context)
+                        && ($context['exception'] ?? null) instanceof Throwable,
+                ),
+            );
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([$throwing]), $logger);
+        $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), null);
+    }
+
+    #[Test]
     public function assistantTurnShapeIsOpenAiCompatible(): void
     {
         $captured = [];
@@ -198,12 +242,8 @@ final class ToolLoopServiceTest extends TestCase
 
         $mgr = self::createStub(LlmServiceManagerInterface::class);
         $mgr->method('chatWithToolsForConfiguration')
-            ->willReturnCallback(function (
-                array $messages,
-                array $tools,
-                LlmConfiguration $configuration,
-                ?ToolOptions $options,
-            ) use (&$capturedTools, $response): CompletionResponse {
+            // $messages is an unused positional placeholder for the $tools arg.
+            ->willReturnCallback(function (array $messages, array $tools) use (&$capturedTools, $response): CompletionResponse {
                 $capturedTools[] = $tools;
 
                 return $response;
@@ -365,16 +405,11 @@ final class ToolLoopServiceTest extends TestCase
      * @param list<CompletionResponse>     $queue
      * @param list<array<int, mixed>>|null $captured
      *
-     * @return callable(array<int, mixed>, array<int, mixed>, LlmConfiguration, ?ToolOptions): CompletionResponse
+     * @return callable(array<int, mixed>): CompletionResponse
      */
     private function queueCallback(array $queue, ?array &$captured = null): callable
     {
-        return function (
-            array $messages,
-            array $tools,
-            LlmConfiguration $configuration,
-            ?ToolOptions $options,
-        ) use (&$queue, &$captured): CompletionResponse {
+        return function (array $messages) use (&$queue, &$captured): CompletionResponse {
             if ($captured !== null) {
                 $captured[] = $messages;
             }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1,0 +1,334 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(ToolLoopService::class)]
+final class ToolLoopServiceTest extends TestCase
+{
+    #[Test]
+    public function returnsContentWhenNoToolCalls(): void
+    {
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('the answer'));
+        $mgr->expects(self::never())->method('chatWithConfiguration');
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([]));
+        $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), null);
+
+        self::assertSame('the answer', $result->finalContent);
+        self::assertSame([], $result->trace);
+        self::assertSame(1, $result->iterations);
+        self::assertFalse($result->truncated);
+    }
+
+    #[Test]
+    public function executesToolAndFeedsResultThenFinishes(): void
+    {
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'fetch_logs', [])]),
+            $this->response('all done'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
+
+        self::assertCount(1, $result->trace);
+        self::assertSame('fetch_logs', $result->trace[0]->name);
+        self::assertSame('LOGS', $result->trace[0]->result);
+        self::assertFalse($result->trace[0]->isError);
+        self::assertSame('all done', $result->finalContent);
+        self::assertSame(2, $result->iterations);
+        self::assertFalse($result->truncated);
+    }
+
+    #[Test]
+    public function unknownToolYieldsErrorResultNotCrash(): void
+    {
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'nope', [])]),
+            $this->response('recovered'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([]));
+        $result  = $service->runLoop([$this->userTurn('do it')], new LlmConfiguration(), null);
+
+        self::assertCount(1, $result->trace);
+        self::assertTrue($result->trace[0]->isError);
+        self::assertStringStartsWith('Error: unknown tool', $result->trace[0]->result);
+        self::assertStringContainsString('"nope"', $result->trace[0]->result);
+        self::assertSame('recovered', $result->finalContent);
+    }
+
+    #[Test]
+    public function toolExecuteThrowsIsCaughtAndSanitised(): void
+    {
+        $throwing = new class implements ToolInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('boom_tool', 'throws', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments): string
+            {
+                throw new RuntimeException('boom https://x?key=secret', 1782700101);
+            }
+        };
+
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'boom_tool', [])]),
+            $this->response('recovered'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([$throwing]));
+        $result  = $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), null);
+
+        self::assertCount(1, $result->trace);
+        self::assertTrue($result->trace[0]->isError);
+        self::assertStringContainsString('key=***', $result->trace[0]->result);
+        self::assertStringNotContainsString('secret', $result->trace[0]->result);
+        self::assertSame('recovered', $result->finalContent);
+        self::assertFalse($result->truncated);
+    }
+
+    #[Test]
+    public function assistantTurnShapeIsOpenAiCompatible(): void
+    {
+        $captured = [];
+        $queue    = [
+            $this->response('', [new ToolCall('call_1', 'fetch_logs', [])]),
+            $this->response('done'),
+        ];
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue, $captured));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
+
+        // The second round must carry the appended assistant + tool turns.
+        $round2    = self::arr($captured[1] ?? null);
+        $assistant = self::arr($round2[1] ?? null);
+        self::assertSame('assistant', $assistant['role'] ?? null);
+
+        $calls    = self::arr($assistant['tool_calls'] ?? null);
+        $function = self::arr(self::arr($calls[0] ?? null)['function'] ?? null);
+        self::assertSame('call_1', self::arr($calls[0] ?? null)['id'] ?? null);
+        self::assertSame('function', self::arr($calls[0] ?? null)['type'] ?? null);
+        // Empty arguments MUST serialise to an object, not an array.
+        self::assertSame('{}', $function['arguments'] ?? null);
+
+        $toolTurn = self::arr($round2[2] ?? null);
+        self::assertSame('tool', $toolTurn['role'] ?? null);
+        self::assertSame('call_1', $toolTurn['tool_call_id'] ?? null);
+        self::assertSame('LOGS', $toolTurn['content'] ?? null);
+    }
+
+    #[Test]
+    public function capHitSynthesisesFinalAnswerAndMarksTruncated(): void
+    {
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        // The model never stops requesting tools.
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_x', 'loop_tool', [])]));
+        // Exactly one no-tools synthesis completion closes the loop.
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('SYNTHESISED'));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
+        $result  = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), null, null, 2);
+
+        self::assertSame(2, $result->iterations);
+        self::assertTrue($result->truncated);
+        self::assertSame('SYNTHESISED', $result->finalContent);
+        self::assertCount(2, $result->trace);
+    }
+
+    #[Test]
+    public function allowListIsForwardedToRegistry(): void
+    {
+        $capturedTools = [];
+        $response      = $this->response('done');
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback(function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options,
+            ) use (&$capturedTools, $response): CompletionResponse {
+                $capturedTools[] = $tools;
+
+                return $response;
+            });
+
+        $registry = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
+        $service  = new ToolLoopService($mgr, $registry);
+        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ['fetch_logs']);
+
+        $specs = self::arr($capturedTools[0] ?? null);
+        $names = array_map(
+            static fn(mixed $s): string => $s instanceof ToolSpec ? $s->name : '<not-a-spec>',
+            array_values($specs),
+        );
+        self::assertSame(['fetch_logs'], $names);
+    }
+
+    #[Test]
+    public function budgetExceededMidLoopReturnsPartialTruncated(): void
+    {
+        $budgetException = new BudgetExceededException(
+            BudgetCheckResult::denied(BudgetCheckResult::LIMIT_MONTHLY_COST, 10.0, 5.0),
+        );
+
+        $calls = 0;
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback(function () use (&$calls, $budgetException): CompletionResponse {
+                ++$calls;
+                if ($calls === 1) {
+                    return $this->response('', [new ToolCall('call_1', 'fetch_logs', [])]);
+                }
+
+                throw $budgetException;
+            });
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
+
+        self::assertTrue($result->truncated);
+        self::assertSame('', $result->finalContent);
+        self::assertCount(1, $result->trace);
+        self::assertSame('fetch_logs', $result->trace[0]->name);
+        self::assertSame('LOGS', $result->trace[0]->result);
+    }
+
+    #[Test]
+    public function usageTokensSummedAcrossIterations(): void
+    {
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'fetch_logs', [])], 10, 5),
+            $this->response('done', null, 3, 2),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
+
+        self::assertSame(13, $result->usage->promptTokens);
+        self::assertSame(7, $result->usage->completionTokens);
+        self::assertSame(20, $result->usage->totalTokens);
+    }
+
+    /**
+     * Build a CompletionResponse fixture with optional tool calls and usage.
+     *
+     * @param list<ToolCall>|null $toolCalls
+     */
+    private function response(
+        string $content,
+        ?array $toolCalls = null,
+        int $promptTokens = 0,
+        int $completionTokens = 0,
+    ): CompletionResponse {
+        return new CompletionResponse(
+            content: $content,
+            model: 'test-model',
+            usage: UsageStatistics::fromTokens($promptTokens, $completionTokens),
+            toolCalls: $toolCalls,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function userTurn(string $content): array
+    {
+        return ['role' => 'user', 'content' => $content];
+    }
+
+    /**
+     * Script a queue of CompletionResponses for chatWithToolsForConfiguration,
+     * recording each call's $messages argument into $captured.
+     *
+     * @param list<CompletionResponse>     $queue
+     * @param list<array<int, mixed>>|null $captured
+     *
+     * @return callable(array<int, mixed>, array<int, mixed>, LlmConfiguration, ?ToolOptions): CompletionResponse
+     */
+    private function queueCallback(array $queue, ?array &$captured = null): callable
+    {
+        return function (
+            array $messages,
+            array $tools,
+            LlmConfiguration $configuration,
+            ?ToolOptions $options,
+        ) use (&$queue, &$captured): CompletionResponse {
+            if ($captured !== null) {
+                $captured[] = $messages;
+            }
+
+            $next = array_shift($queue);
+            if (!$next instanceof CompletionResponse) {
+                throw new RuntimeException('Scripted response queue underflow.', 1782700100);
+            }
+
+            return $next;
+        };
+    }
+
+    /**
+     * Assert a mixed value is an array and return it narrowed (PHPStan-clean
+     * deep access into captured raw-array message turns).
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function arr(mixed $value): array
+    {
+        self::assertIsArray($value);
+
+        return $value;
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -38,7 +38,9 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturn($this->response('the answer'));
         $mgr->expects(self::never())->method('chatWithConfiguration');
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([]));
+        // A registered tool keeps the loop on the tools path (an empty registry
+        // would short-circuit to a plain completion — covered separately).
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('noop')]));
         $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), null);
 
         self::assertSame('the answer', $result->finalContent);
@@ -81,7 +83,10 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             ->willReturnCallback($this->queueCallback($queue));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([]));
+        // The registry holds a different tool so the loop stays on the tools
+        // path; the model then requests the unregistered name "nope", which
+        // registry->get() resolves to null (the unknown-tool branch).
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('real_tool')]));
         $result  = $service->runLoop([$this->userTurn('do it')], new LlmConfiguration(), null);
 
         self::assertCount(1, $result->trace);
@@ -92,7 +97,7 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
-    public function toolExecuteThrowsIsCaughtAndSanitised(): void
+    public function toolExecuteThrowsIsCaughtAsGenericError(): void
     {
         $throwing = new class implements ToolInterface {
             public function getSpec(): ToolSpec
@@ -122,8 +127,10 @@ final class ToolLoopServiceTest extends TestCase
 
         self::assertCount(1, $result->trace);
         self::assertTrue($result->trace[0]->isError);
-        self::assertStringContainsString('key=***', $result->trace[0]->result);
+        // Generic message only: no exception text (URL / credentials / DBAL).
+        self::assertSame('Error: tool "boom_tool" failed.', $result->trace[0]->result);
         self::assertStringNotContainsString('secret', $result->trace[0]->result);
+        self::assertStringNotContainsString('https', $result->trace[0]->result);
         self::assertSame('recovered', $result->finalContent);
         self::assertFalse($result->truncated);
     }
@@ -260,6 +267,68 @@ final class ToolLoopServiceTest extends TestCase
         self::assertSame(13, $result->usage->promptTokens);
         self::assertSame(7, $result->usage->completionTokens);
         self::assertSame(20, $result->usage->totalTokens);
+    }
+
+    #[Test]
+    public function emptyAllowListDoesSinglePlainCompletion(): void
+    {
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        // No tools offered ⇒ exactly one plain completion, never the tools path.
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('plain answer'));
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+        // A tool IS registered, but the empty allow-list offers none of them.
+        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
+        $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), []);
+
+        self::assertSame('plain answer', $result->finalContent);
+        self::assertSame([], $result->trace);
+        self::assertSame(1, $result->iterations);
+        self::assertFalse($result->truncated);
+    }
+
+    #[Test]
+    public function disallowedButRegisteredToolIsRejectedAndNotExecuted(): void
+    {
+        $spy = new class implements ToolInterface {
+            public bool $executed = false;
+
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('read_meta', 'reads meta', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments): string
+            {
+                $this->executed = true;
+
+                return 'META';
+            }
+        };
+
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            // The model calls a registered tool that is NOT in the allow-list.
+            $this->response('', [new ToolCall('call_1', 'read_meta', [])]),
+            $this->response('done'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback($this->queueCallback($queue));
+
+        $registry = new ToolRegistry([new FakeTool('fetch_logs'), $spy]);
+        $service  = new ToolLoopService($mgr, $registry);
+        $result   = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['fetch_logs']);
+
+        self::assertCount(1, $result->trace);
+        self::assertTrue($result->trace[0]->isError);
+        self::assertStringContainsString('not permitted', $result->trace[0]->result);
+        self::assertFalse($spy->executed, 'a disallowed tool must never be executed');
+        self::assertSame('done', $result->finalContent);
     }
 
     /**

--- a/Tests/Unit/Service/Tool/ToolRegistryTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolRegistry::class)]
+final class ToolRegistryTest extends TestCase
+{
+    #[Test]
+    public function collectsAndLooksUpByName(): void
+    {
+        $a = new FakeTool('alpha');
+        $b = new FakeTool('beta');
+        $r = new ToolRegistry([$a, $b]);
+
+        self::assertSame($a, $r->get('alpha'));
+        self::assertNull($r->get('missing'));
+        self::assertSame(['alpha', 'beta'], $r->names());
+    }
+
+    #[Test]
+    public function specsReturnsAllOrFilteredByAllowList(): void
+    {
+        $r = new ToolRegistry([new FakeTool('alpha'), new FakeTool('beta')]);
+
+        self::assertSame(['alpha', 'beta'], array_map(static fn(ToolSpec $s): string => $s->name, $r->specs()));
+        self::assertSame(['beta'], array_map(static fn(ToolSpec $s): string => $s->name, $r->specs(['beta'])));
+        self::assertSame([], $r->specs(['unknown'])); // unknown declared names dropped
+        self::assertSame([], $r->specs([]));          // explicit empty allow-list => no tools
+    }
+
+    #[Test]
+    public function duplicateToolNameThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        new ToolRegistry([new FakeTool('dup'), new FakeTool('dup')]);
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolRegistryTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryTest.php
@@ -47,6 +47,6 @@ final class ToolRegistryTest extends TestCase
     public function duplicateToolNameThrows(): void
     {
         $this->expectException(LogicException::class);
-        new ToolRegistry([new FakeTool('dup'), new FakeTool('dup')]);
+        self::assertInstanceOf(ToolRegistry::class, new ToolRegistry([new FakeTool('dup'), new FakeTool('dup')]));
     }
 }


### PR DESCRIPTION
## Description

**Unit 2 — Tools, PR-A: the tool runtime.** A bounded function-calling **agent loop** (the codebase is otherwise single-shot), a DI-tagged tool registry, two example tools, **Ollama tool support**, and skill-driven allowed-tools gating. **No UI** — the admin playground is PR-B. The loop is exercised end-to-end by unit + functional tests.

Design + plan (two adversarial review rounds, 5 reviewers, no blockers): `docs/superpowers/specs/2026-06-29-tools-agent-runtime-design.md` (v2.1), `docs/superpowers/plans/2026-06-29-tools-runtime-pr-a.md`.

### What's here (8 commits)
- **`ToolInterface` + `ToolRegistry`** — tools self-register via the `nr_llm.tool` DI tag (`#[AutowireIterator]`); dependent extensions add tools by tagging, no central change.
- **`chatWithToolsForConfiguration()`** on `LlmServiceManager` — the keystone: runs tools on the **DB-backed `LlmConfiguration`'s adapter** (vault key + model + pricing), which the existing provider-key `chatWithTools()` cannot reach (it resolves a model-less transient config → unauthenticated providers + zero-cost usage).
- **`ToolLoopService`** — call → execute tool calls in PHP → append assistant+tool turns → re-call, bounded by a configurable **max-iteration cap** (default 5). Truncation synthesizes a real answer via a no-tools `chatWithConfiguration()`. Fail-soft: unknown/disallowed/throwing tools become error tool-results; mid-loop `BudgetExceededException` returns a partial result.
- **`FetchLogsTool`** (sys_log, PII-redacted, limit ≤50) + **`ReadFalAssetMetaTool`** (sys_file, storage-scoped).
- **`OllamaProvider`** implements `ToolCapableInterface` (outbound tools, inbound replay-turn translation, synthesized tool-call ids).
- **`Skill.allowed_tools`** as a **fail-closed-on-declaration** allow-list (`AllowedToolsResolver` over effective — enabled, non-orphaned — skills; sync distinguishes absent from declared-empty).

### Security posture (admin-only consumer in PR-B)
Tools are admin-curated PHP, read-only; allow-list enforced at **both offer and execution** (a model steered by injected skill prose cannot call a registered-but-not-allowed tool); thrown-exception text never egresses (generic error); tool args validated + scoped.

## Type of Change
- [x] New feature (tool runtime)

## Checklist
- [x] PHPStan L10, Rector, CGL, **PHPat architecture** clean (PHP 8.4)
- [x] Unit + functional tests per component (registry, loop incl. cap/truncation/error/budget, both tools over CSV fixtures, Ollama tool calls, allow-list resolver, config-aware entry)
- [x] Pre-push integration + security review (3 majors found & fixed: empty-allow short-circuit, Ollama replay on the plain path, allow-list enforced at execution)

## Note
The `SetupWizardE2ETest::pathway1_1_firstTimeProviderSetup_ollama` E2E test is **pre-existing red on `main`** (403≠200, from the #262 admin-gate) — unrelated to this PR; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
