### PR TITLE
test(e2e): authenticate backend E2E tests as admin (fix #262 403 regression)

### DIFF
--- a/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
+++ b/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
@@ -36,6 +36,13 @@ abstract class AbstractBackendE2ETestCase extends AbstractFunctionalTestCase
         $this->importFixture('Models.csv');
         $this->importFixture('LlmConfigurations.csv');
         $this->importFixture('Tasks.csv');
+
+        // Authenticate as an admin backend user: the backend controllers these
+        // E2E tests drive are admin-gated (RequiresBackendAdminTrait, ADR-037),
+        // so without an admin BE user their actions return 403. uid 1 in
+        // BeUsers.csv is an admin (admin=1).
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
     }
 
     /**


### PR DESCRIPTION
## Description

The backend controllers the E2E tests drive (`Tests/E2E/Backend/`) are admin-gated via `RequiresBackendAdminTrait::denyNonAdmin()` (ADR-037, #262). But `AbstractBackendE2ETestCase` never sets up a backend user, so **every gated action returned 403** (e.g. `SetupWizardE2ETest::pathway1_1_firstTimeProviderSetup_ollama` asserted 200, got 403).

This imports `BeUsers.csv` + `setUpBackendUser(1)` (uid 1 = admin) in the E2E base `setUp()` — exactly the pattern the merged functional controller tests use. This greens the **45** E2E tests that don't store secrets.

## Known remaining (separate, pre-existing — NOT this PR)

The other **30** E2E tests (`SetupWizard saveAction…`) still fail with **500** because they store an API key via **nr-vault**, whose encryption (master-key/sodium) isn't configured in the local functional bootstrap. That's a separate nr-vault test-env concern (the documented "missing-vaultService" issue) and is out of scope here. These E2E tests are not part of the blocking merge-queue functional check.

## Type of Change
- [x] Test fix (no production code change)

## Checklist
- [x] PHPStan L10, Rector, CGL clean (PHP 8.4)
- [x] The originally-403 `_ollama` E2E test now passes; 45 of 75 E2E backend tests green (was ~all-403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
