### PR TITLE
test(functional): repair backend controller test construction after #256 refactor

### DIFF
--- a/Tests/E2E/Backend/DashboardE2ETest.php
+++ b/Tests/E2E/Backend/DashboardE2ETest.php
@@ -17,8 +17,10 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
@@ -69,12 +71,18 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $llmServiceManager = $this->get(LlmServiceManager::class);
         self::assertInstanceOf(LlmServiceManager::class, $llmServiceManager);
 
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
+
         return $this->createControllerWithReflection(LlmModuleController::class, [
             'llmServiceManager' => $llmServiceManager,
             'providerRepository' => $this->providerRepository,
             'modelRepository' => $this->modelRepository,
             'configurationRepository' => $this->configurationRepository,
             'taskRepository' => $this->taskRepository,
+            // executeTest resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 

--- a/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
+++ b/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
@@ -29,10 +29,11 @@ use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
@@ -118,6 +119,8 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
             'providerRepository' => $this->providerRepository,
             'providerAdapterRegistry' => $providerAdapterRegistry,
             'persistenceManager' => $this->persistenceManager,
+            // toggleActive/testConnection log failures via LoggerInterface.
+            'logger' => new NullLogger(),
         ]);
     }
 
@@ -129,8 +132,8 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
         $modelDiscovery = $this->get(ModelDiscoveryInterface::class);
         self::assertInstanceOf(ModelDiscoveryInterface::class, $modelDiscovery);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return $this->createControllerWithReflection(ModelController::class, [
             'modelRepository' => $this->modelRepository,
@@ -138,7 +141,9 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
             'providerAdapterRegistry' => $providerAdapterRegistry,
             'modelDiscovery' => $modelDiscovery,
             'persistenceManager' => $this->persistenceManager,
-            'extensionConfiguration' => $extensionConfiguration,
+            // testModel resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 
@@ -153,15 +158,17 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
         $configurationService = $this->get(LlmConfigurationService::class);
         self::assertInstanceOf(LlmConfigurationService::class, $configurationService);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return $this->createControllerWithReflection(ConfigurationController::class, [
             'configurationService' => $configurationService,
             'configurationRepository' => $this->configurationRepository,
             'llmServiceManager' => $llmServiceManager,
             'providerAdapterRegistry' => $providerAdapterRegistry,
-            'extensionConfiguration' => $extensionConfiguration,
+            // testConfiguration resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 
@@ -177,6 +184,8 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
             'taskRepository'       => $this->taskRepository,
             'taskExecutionService' => $taskExecutionService,
             'taskInputResolver'    => $taskInputResolver,
+            // executeAction logs provider/unexpected errors via LoggerInterface.
+            'logger'               => new NullLogger(),
         ]);
     }
 
@@ -191,8 +200,8 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
         $taskRepository = $this->get(TaskRepository::class);
         self::assertInstanceOf(TaskRepository::class, $taskRepository);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return $this->createControllerWithReflection(LlmModuleController::class, [
             'llmServiceManager' => $llmServiceManager,
@@ -200,7 +209,9 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
             'modelRepository' => $this->modelRepository,
             'configurationRepository' => $configurationRepository,
             'taskRepository' => $taskRepository,
-            'extensionConfiguration' => $extensionConfiguration,
+            // executeTest resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 

--- a/Tests/E2E/Backend/ModelManagementE2ETest.php
+++ b/Tests/E2E/Backend/ModelManagementE2ETest.php
@@ -16,8 +16,10 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -79,12 +81,18 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
         $modelDiscovery = $this->get(ModelDiscoveryInterface::class);
         self::assertInstanceOf(ModelDiscoveryInterface::class, $modelDiscovery);
 
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
+
         return $this->createControllerWithReflection(ModelController::class, [
             'modelRepository' => $this->modelRepository,
             'providerRepository' => $this->providerRepository,
             'providerAdapterRegistry' => $providerAdapterRegistry,
             'modelDiscovery' => $modelDiscovery,
             'persistenceManager' => $this->persistenceManager,
+            // testModel resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -21,9 +21,10 @@ use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -84,15 +85,17 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $providerAdapterRegistry = $this->get(ProviderAdapterRegistry::class);
         self::assertInstanceOf(ProviderAdapterRegistry::class, $providerAdapterRegistry);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         return $this->createControllerWithReflection(ConfigurationController::class, [
             'configurationService' => $configurationService,
             'configurationRepository' => $this->configurationRepository,
             'llmServiceManager' => $llmServiceManager,
             'providerAdapterRegistry' => $providerAdapterRegistry,
-            'extensionConfiguration' => $extensionConfiguration,
+            // testConfiguration resolves a default prompt; error paths log.
+            'testPromptResolver' => $testPromptResolver,
+            'logger' => new NullLogger(),
         ]);
     }
 

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -74,10 +75,14 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
             'taskRepository'       => $this->taskRepository,
             'taskExecutionService' => $taskExecutionService,
             'taskInputResolver'    => $taskInputResolver,
+            // executeAction logs provider/unexpected errors via LoggerInterface.
+            'logger'               => new NullLogger(),
         ]);
 
         $this->recordsController = $this->createControllerWithReflection(TaskRecordsController::class, [
             'recordTableReader' => $recordTableReader,
+            // record actions log failures via LoggerInterface.
+            'logger'            => new NullLogger(),
         ]);
     }
 

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -33,7 +33,6 @@ use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -185,8 +184,8 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $taskRepository = $this->get(TaskRepository::class);
         self::assertInstanceOf(TaskRepository::class, $taskRepository);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         $reflection = new ReflectionClass(LlmModuleController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
@@ -196,7 +195,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'modelRepository', $modelRepository);
         $this->setPrivateProperty($controller, 'configurationRepository', $configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
-        $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
+        $this->setPrivateProperty($controller, 'testPromptResolver', $testPromptResolver);
         $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;

--- a/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
+++ b/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
@@ -15,9 +15,11 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
@@ -101,6 +103,13 @@ final class LlmModuleControllerTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'modelRepository', $modelRepository);
         $this->setPrivateProperty($controller, 'configurationRepository', $configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
+
+        // executeTestAction resolves a default prompt and logs provider
+        // errors via LoggerInterface — initialise both typed properties.
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
+        $this->setPrivateProperty($controller, 'testPromptResolver', $testPromptResolver);
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ModelControllerTest.php
@@ -15,9 +15,11 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
+use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -112,6 +114,14 @@ final class ModelControllerTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'persistenceManager', $persistenceManager);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'modelDiscovery', $modelDiscovery);
+
+        // The test AJAX action resolves a default prompt and the typed
+        // catch blocks log via LoggerInterface — initialise both so the
+        // exercised actions don't hit an uninitialised typed property.
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
+        $this->setPrivateProperty($controller, 'testPromptResolver', $testPromptResolver);
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -32,7 +32,6 @@ use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -199,16 +198,12 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $providerAdapterRegistry = $this->get(ProviderAdapterRegistry::class);
         self::assertInstanceOf(ProviderAdapterRegistry::class, $providerAdapterRegistry);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
-
         $reflection = new ReflectionClass(ModelController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
 
         $this->setPrivateProperty($controller, 'modelRepository', $modelRepository);
         $this->setPrivateProperty($controller, 'providerRepository', $this->providerRepository);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $providerAdapterRegistry);
-        $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
         // REC #8b: typed catches log via LoggerInterface — initialise
         // the new property so any exercised exception path doesn't
         // hit an uninitialised typed property error.
@@ -228,8 +223,8 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $taskRepository = $this->get(TaskRepository::class);
         self::assertInstanceOf(TaskRepository::class, $taskRepository);
 
-        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
-        self::assertInstanceOf(ExtensionConfiguration::class, $extensionConfiguration);
+        $testPromptResolver = $this->get(TestPromptResolverInterface::class);
+        self::assertInstanceOf(TestPromptResolverInterface::class, $testPromptResolver);
 
         $reflection = new ReflectionClass(LlmModuleController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
@@ -239,7 +234,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'modelRepository', $modelRepository);
         $this->setPrivateProperty($controller, 'configurationRepository', $this->configurationRepository);
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
-        $this->setPrivateProperty($controller, 'extensionConfiguration', $extensionConfiguration);
+        $this->setPrivateProperty($controller, 'testPromptResolver', $testPromptResolver);
         $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;

--- a/Tests/Functional/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ProviderControllerTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -90,6 +91,8 @@ final class ProviderControllerTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'providerRepository', $providerRepository);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'persistenceManager', $persistenceManager);
+        // toggleActive/testConnection log failures via LoggerInterface.
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }

--- a/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -102,6 +103,8 @@ final class TaskExecutionAndRecordsControllerTest extends AbstractFunctionalTest
         $this->setPrivateProperty($controller, 'taskRepository', $taskRepository);
         $this->setPrivateProperty($controller, 'taskExecutionService', $taskExecutionService);
         $this->setPrivateProperty($controller, 'taskInputResolver', $taskInputResolver);
+        // executeAction logs provider/unexpected errors via LoggerInterface.
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }
@@ -113,6 +116,8 @@ final class TaskExecutionAndRecordsControllerTest extends AbstractFunctionalTest
         $controller = $reflection->newInstanceWithoutConstructor();
 
         $this->setPrivateProperty($controller, 'recordTableReader', $recordTableReader);
+        // All record actions log failures via LoggerInterface.
+        $this->setPrivateProperty($controller, 'logger', new NullLogger());
 
         return $controller;
     }


### PR DESCRIPTION
## Description

The backend-controller **functional + e2e-backend** tests build controllers via `newInstanceWithoutConstructor()` + partial reflection injection. Two merged refactors silently broke them (these tests are not run by CI's merge_group functional check, so it went unnoticed):

1. **#256 removed the `extensionConfiguration` property** from the controllers, but ~146 test sites still `setPrivateProperty($controller, 'extensionConfiguration', …)` → `ReflectionException: Property … does not exist`.
2. Controller AJAX actions now use `$this->logger` / `$this->testPromptResolver`, but the test helpers never injected them → ~42× `Typed property … must not be accessed before initialization`.

This repairs the construction across **11 files** (6 functional + 5 e2e-backend, all sharing the `AbstractBackendE2ETestCase` pattern): inject the now-required deps (`new NullLogger()`, the real `TestPromptResolverInterface` via the container) and delete the dead `extensionConfiguration` sets. (DI resolution `$this->get(Controller)` was rejected — Extbase controllers need a request → `NoServerRequestGivenException`.)

**Result: functional suite 188 errors → 0.** (The remaining assertion *failures* are a separate, pre-existing matter, addressed next.)

## Type of Change
- [x] Test fix (no production code change)

## Checklist
- [x] PHPStan L10, Rector, CGL clean (PHP 8.4)
- [x] All construction-pattern errors (ReflectionException + uninitialized-property) eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
