### PR TITLE
test(functional): clear remaining 73 assertion failures (suite now 0/0)

### DIFF
--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -152,7 +152,11 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         // Verify each configuration has required display information
         foreach ($configurations as $config) {
             self::assertNotEmpty($config->getName(), 'Configuration should have a name');
-            self::assertNotNull($config->getLlmModel(), 'Configuration should have a model');
+            // "no-model-config" (uid 8) is an intentional model-less edge-case
+            // fixture consumed by ConfigurationControllerTest::testConfigurationReturnsErrorForConfigurationWithoutModel.
+            if ($config->getIdentifier() !== 'no-model-config') {
+                self::assertNotNull($config->getLlmModel(), 'Configuration should have a model');
+            }
             // isActive() and isDefault() return bool, getTemperature() returns float, getMaxTokens() returns int
             // Verify values are accessible (types are enforced by domain model)
             $config->isActive();
@@ -338,7 +342,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->testConfigurationAction($request);
 
         // Response should have proper structure
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -366,7 +370,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         ]);
         $response = $this->controller->testConfigurationAction($request);
 
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -1165,7 +1169,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->testConfigurationAction($request);
 
         // Should handle special characters gracefully
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
     }
@@ -1466,7 +1470,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->testConfigurationAction($request);
 
         // Either success or error response
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);

--- a/Tests/E2E/Backend/DashboardE2ETest.php
+++ b/Tests/E2E/Backend/DashboardE2ETest.php
@@ -209,7 +209,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Verify response structure
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -389,7 +389,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             $response = $this->controller->executeTestAction();
 
             // Each provider should return a valid response structure
-            self::assertContains($response->getStatusCode(), [200, 500]);
+            self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
             $body = json_decode((string)$response->getBody(), true);
             self::assertIsArray($body);
@@ -414,7 +414,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Should return error for invalid provider
-        self::assertContains($response->getStatusCode(), [400, 404, 500]);
+        self::assertContains($response->getStatusCode(), [400, 404, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -439,7 +439,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Should handle special characters gracefully
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -465,7 +465,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Should handle long prompts (may succeed or fail with token limit error)
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -488,7 +488,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Should handle whitespace-only prompt (might use default or return error)
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -512,7 +512,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $response = $this->controller->executeTestAction();
 
         // Should handle multiline prompts
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -717,6 +717,11 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $models = $this->modelRepository->findActive()->toArray();
 
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the relationship check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             // Dashboard shows model capabilities
             self::assertNotEmpty($model->getModelId());
             self::assertGreaterThanOrEqual(0, $model->getContextLength());
@@ -808,6 +813,11 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
 
         // Every model should have a valid provider
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the relationship check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             $provider = $model->getProvider();
             self::assertNotNull($provider);
             $providerUid = $provider->getUid();
@@ -872,7 +882,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
 
         // All providers should return valid responses
         foreach ($results as $result) {
-            self::assertContains($result['status'], [200, 500]);
+            self::assertContains($result['status'], [200, 500, 502]);
         }
     }
 
@@ -893,7 +903,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
 
             $response = $this->controller->executeTestAction();
 
-            self::assertContains($response->getStatusCode(), [200, 500]);
+            self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
             $body = json_decode((string)$response->getBody(), true);
             self::assertIsArray($body);
@@ -1033,7 +1043,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $this->setPrivateProperty($this->controller, 'request', $request);
         $response = $this->controller->executeTestAction();
 
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
     }
@@ -1052,7 +1062,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $this->setPrivateProperty($this->controller, 'request', $request);
         $response = $this->controller->executeTestAction();
 
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
     }
@@ -1071,7 +1081,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $this->setPrivateProperty($this->controller, 'request', $request);
         $response = $this->controller->executeTestAction();
 
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
     }
@@ -1274,6 +1284,11 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         $models = $this->modelRepository->findActive()->toArray();
 
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the relationship check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             $provider = $model->getProvider();
             self::assertNotNull($provider, 'Each model must have a provider');
             self::assertNotNull($provider->getUid());
@@ -1402,6 +1417,11 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         self::assertGreaterThanOrEqual(0, $models->count());
 
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the relationship check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             self::assertNotNull($model->getProvider());
         }
     }

--- a/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
+++ b/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
@@ -261,7 +261,7 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
         $response = $this->providerController->testConnectionAction($request);
 
         // Response should be structured (not crash)
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
@@ -356,8 +356,9 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
         $this->setPrivateProperty($this->dashboardController, 'request', $request);
         $response = $this->dashboardController->executeTestAction();
 
-        // Response should be structured
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        // Response should be structured. 502 = upstream provider unreachable
+        // in the test env (Bad Gateway), handled gracefully.
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
 
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);

--- a/Tests/E2E/Backend/ModelManagementE2ETest.php
+++ b/Tests/E2E/Backend/ModelManagementE2ETest.php
@@ -115,7 +115,11 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
             self::assertInstanceOf(Model::class, $model);
             self::assertNotEmpty($model->getName(), 'Model should have a name');
             self::assertNotEmpty($model->getModelId(), 'Model should have a model ID');
-            self::assertNotNull($model->getProvider(), 'Model should have a provider');
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture consumed by ModelControllerTest::testModelReturnsErrorForModelWithoutProvider.
+            if ($model->getIdentifier() !== 'orphan-model') {
+                self::assertNotNull($model->getProvider(), 'Model should have a provider');
+            }
         }
     }
 
@@ -180,8 +184,13 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
 
         self::assertNotEmpty($counts);
 
-        // User sees count for each provider
+        // User sees count for each provider. provider_uid 0 is the intentional
+        // "orphan-model" edge-case fixture (a model with no provider) and is
+        // not a real provider bucket.
         foreach ($counts as $providerUid => $count) {
+            if ($providerUid === 0) {
+                continue;
+            }
             self::assertGreaterThan(0, $providerUid);
             self::assertGreaterThan(0, $count);
         }
@@ -743,6 +752,11 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
 
         foreach ($models as $model) {
             self::assertInstanceOf(Model::class, $model);
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the integrity check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getName()} must have a provider");
             self::assertNotNull($provider->getUid(), 'Provider must have UID');

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -220,7 +220,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $request1 = $this->createFormRequest(self::AJAX_CONFIG_TEST, ['uid' => $config1->getUid()]);
         $response1 = $this->configurationController->testConfigurationAction($request1);
 
-        self::assertContains($response1->getStatusCode(), [200, 500]);
+        self::assertContains($response1->getStatusCode(), [200, 500, 502]);
         $body1 = json_decode((string)$response1->getBody(), true);
         self::assertIsArray($body1);
 
@@ -231,7 +231,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             $request2 = $this->createFormRequest(self::AJAX_CONFIG_TEST, ['uid' => $config2->getUid()]);
             $response2 = $this->configurationController->testConfigurationAction($request2);
 
-            self::assertContains($response2->getStatusCode(), [200, 500]);
+            self::assertContains($response2->getStatusCode(), [200, 500, 502]);
             $body2 = json_decode((string)$response2->getBody(), true);
             self::assertIsArray($body2);
 
@@ -399,7 +399,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $response = $this->configurationController->testConfigurationAction($request);
 
         // Should return a structured response (success or error)
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
 
@@ -1318,6 +1318,11 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $models = $queryResult->toArray();
 
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture for error-path testing; skip the relationship check for it.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getName()} must have a provider");
             self::assertNotNull($provider->getUid());
@@ -1506,6 +1511,12 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $models = $queryResult->toArray();
 
         foreach ($models as $model) {
+            // "orphan-model" (uid 6) is an intentional provider-less edge-case
+            // fixture consumed by ModelControllerTest; it is the one deliberate
+            // orphan and is excluded from this no-orphans integrity sweep.
+            if ($model->getIdentifier() === 'orphan-model') {
+                continue;
+            }
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getIdentifier()} is orphaned");
 

--- a/Tests/E2E/Backend/SetupWizardE2ETest.php
+++ b/Tests/E2E/Backend/SetupWizardE2ETest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -99,6 +100,11 @@ final class SetupWizardE2ETest extends AbstractBackendE2ETestCase
             'modelRepository' => $this->modelRepository,
             'llmConfigurationRepository' => $this->configurationRepository,
             'persistenceManager' => $this->persistenceManager,
+            // The vault's master-key encryption isn't configured in the
+            // functional env, so the real VaultService::store() throws and the
+            // save flow returns 500. Inject a stub (no-op void store(), null
+            // retrieve()) so the wizard's persist path completes as in prod.
+            'vaultService' => self::createStub(VaultServiceInterface::class),
         ]);
     }
 

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -910,12 +910,22 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
         ]);
         $response = $this->recordsController->fetchRecordsAction($request);
 
-        // Should return error for non-existent table
-        self::assertSame(500, $response->getStatusCode());
+        // A non-existent table has no uid column, so the reader short-circuits
+        // to an empty 200 payload on SQLite (listTableColumns() returns []),
+        // while MySQL/MariaDB raises a schema error mapped to 500. Both are
+        // sane, non-crashing outcomes for an unknown table.
+        self::assertContains($response->getStatusCode(), [200, 500]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
-        self::assertFalse($body['success']);
-        self::assertArrayHasKey('error', $body);
+        if ($response->getStatusCode() === 500) {
+            self::assertFalse($body['success']);
+            self::assertArrayHasKey('error', $body);
+        } else {
+            // SQLite: a non-existent table has no columns, the reader
+            // short-circuits to a successful empty result.
+            self::assertTrue($body['success']);
+            self::assertSame([], $body['records']);
+        }
     }
 
     #[Test]

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -358,7 +358,7 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
         $response = $this->controller->testConfigurationAction($request);
 
         // Assert - response is either success or connection failure (expected without real API)
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
         self::assertArrayHasKey('success', $body);

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -241,8 +241,10 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->configController->testConfigurationAction($request);
 
-        // Assert - should return error response without crashing
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        // Assert - should return error response without crashing.
+        // 502 = the upstream provider is unreachable in the test env (handled
+        // gracefully as Bad Gateway), not a crash.
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
         self::assertArrayHasKey('success', $body);
@@ -269,8 +271,9 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->llmModuleController->executeTestAction();
 
-        // Assert - should return structured error response
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        // Assert - should return structured error response.
+        // 502 = upstream provider unreachable in the test env (Bad Gateway).
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
 
@@ -328,8 +331,9 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->configController->testConfigurationAction($request);
 
-        // Assert - should return proper HTTP status
-        self::assertContains($response->getStatusCode(), [200, 400, 500]);
+        // Assert - should return proper HTTP status.
+        // 502 = upstream provider unreachable in the test env (Bad Gateway).
+        self::assertContains($response->getStatusCode(), [200, 400, 500, 502]);
 
         // Body should be valid JSON
         $body = json_decode((string)$response->getBody(), true);
@@ -353,8 +357,9 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->llmModuleController->executeTestAction();
 
-        // Assert - should not throw unhandled exception
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        // Assert - should not throw unhandled exception.
+        // 502 = upstream provider unreachable in the test env (Bad Gateway).
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
 

--- a/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
+++ b/Tests/Functional/Controller/Backend/LlmModuleControllerTest.php
@@ -203,8 +203,9 @@ final class LlmModuleControllerTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->controller->executeTestAction();
 
-        // Assert - either 200 with success or 500 with error (no real API)
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        // Assert - either 200 with success or 500/502 with error (no real API:
+        // 502 = upstream provider unreachable in the test env, Bad Gateway)
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
 
@@ -233,8 +234,9 @@ final class LlmModuleControllerTest extends AbstractFunctionalTestCase
         // Act
         $response = $this->controller->executeTestAction();
 
-        // Assert - either 200 or 500, but not 400 (bad request)
-        self::assertContains($response->getStatusCode(), [200, 500]);
+        // Assert - either 200 or 500/502, but not 400 (bad request);
+        // 502 = upstream provider unreachable in the test env (Bad Gateway)
+        self::assertContains($response->getStatusCode(), [200, 500, 502]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
         // The action should proceed (not return bad request for missing prompt)

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -317,8 +317,8 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $response2 = $this->llmModuleController->executeTestAction();
 
         // Both requests should return valid responses (success or error)
-        self::assertContains($response1->getStatusCode(), [200, 500]);
-        self::assertContains($response2->getStatusCode(), [200, 500]);
+        self::assertContains($response1->getStatusCode(), [200, 500, 502]);
+        self::assertContains($response2->getStatusCode(), [200, 500, 502]);
 
         $body1 = json_decode((string)$response1->getBody(), true);
         $body2 = json_decode((string)$response2->getBody(), true);

--- a/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
@@ -395,12 +395,22 @@ final class TaskExecutionAndRecordsControllerTest extends AbstractFunctionalTest
         // Act
         $response = $this->recordsController->fetchRecordsAction($request);
 
-        // Assert - should return 500 with error message from database layer
-        self::assertSame(500, $response->getStatusCode());
+        // A non-existent table has no uid column, so the reader short-circuits
+        // to an empty 200 payload on SQLite (listTableColumns() returns []),
+        // while MySQL/MariaDB raises a schema error mapped to 500. Both are
+        // sane, non-crashing outcomes for an unknown table.
+        self::assertContains($response->getStatusCode(), [200, 500]);
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
-        self::assertFalse($body['success']);
-        self::assertArrayHasKey('error', $body);
+        if ($response->getStatusCode() === 500) {
+            self::assertFalse($body['success']);
+            self::assertArrayHasKey('error', $body);
+        } else {
+            // SQLite: a non-existent table has no columns, the reader
+            // short-circuits to a successful empty result.
+            self::assertTrue($body['success']);
+            self::assertSame([], $body['records']);
+        }
     }
 
     #[Test]

--- a/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
+++ b/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
@@ -50,7 +50,10 @@ class LlmConfigurationRepositoryTest extends AbstractFunctionalTestCase
     {
         $result = $this->subject->findAll();
 
-        self::assertCount(7, $result);
+        // 8 non-deleted rows incl. the intentional edge-case fixture
+        // "no-model-config" (uid 8, model_uid=0) used by the error-path
+        // controller tests (testConfigurationReturnsErrorForConfigurationWithoutModel).
+        self::assertCount(8, $result);
     }
 
     #[Test]
@@ -78,7 +81,9 @@ class LlmConfigurationRepositoryTest extends AbstractFunctionalTestCase
     {
         $result = $this->subject->findActive();
 
-        self::assertCount(6, $result);
+        // 7 active rows: 6 fully-wired configs + the intentional edge-case
+        // fixture "no-model-config" (uid 8, active but model_uid=0).
+        self::assertCount(7, $result);
 
         foreach ($result as $config) {
             self::assertTrue($config->isActive());

--- a/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
+++ b/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
@@ -122,14 +122,15 @@ final class PromptSnippetRepositoryTest extends AbstractFunctionalTestCase
     {
         $snippets = $this->repository->findActiveByTag('tone_of_voice');
 
-        // tone-formal (sorting 10) before tone-casual (sorting 20),
-        // although 'Casual tone' sorts before 'Formal tone' by name
+        // tone-formal (sorting 10) comes before tone-casual (sorting 20),
+        // although by name 'Casual tone' sorts before 'Formal tone' — proving
+        // the query's `sorting ASC, name ASC` ordering puts sorting first.
+        // Assert the resulting identifier order (the repository's contract);
+        // `sorting` is a TCA `ctrl.sortby` field which Extbase uses for the
+        // query ordering but does not hydrate back onto the domain property.
         self::assertSame(
-            [10, 20],
-            array_map(
-                static fn(PromptSnippet $snippet): int => $snippet->getSorting(),
-                $snippets,
-            ),
+            ['tone-formal', 'tone-casual'],
+            $this->identifiersOf($snippets),
         );
     }
 

--- a/Tests/Functional/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Functional/Service/LlmConfigurationServiceTest.php
@@ -124,8 +124,10 @@ class LlmConfigurationServiceTest extends AbstractFunctionalTestCase
 
         $configs = $this->subject->getAccessibleConfigurations();
 
-        // Should return all active configurations for admin
-        self::assertCount(6, $configs);
+        // Should return all active configurations for admin: 6 fully-wired
+        // configs + the intentional edge-case fixture "no-model-config"
+        // (uid 8, active but model_uid=0) = 7.
+        self::assertCount(7, $configs);
     }
 
     #[Test]


### PR DESCRIPTION
## Description

Follow-up to #267 (which took the functional+e2e-backend suite from 188 errors → 0). This clears the remaining **73 assertion failures** → the full suite is now **905 tests, 0 errors, 0 failures**. **Test-only — zero production-code and zero fixture changes** (15 test files).

Three patterns:

1. **Stub the vault (30 tests)** — `SetupWizardE2ETest::createController` now injects `self::createStub(VaultServiceInterface::class)`. nr-vault's master-key encryption isn't configured in the functional env, so `saveAction`'s real `vaultService->store()` 500'd; the wizard-save tests don't test nr-vault, so stubbing is the correct test fix.
2. **Accept upstream 502 (~30 asserts)** — provider-connection actions make a real outbound call to an unreachable provider in-test, which the controllers deliberately map to a **502 Bad Gateway** (confirmed: caught `ProviderException` → 502, generic `Throwable` → 500). Broadened only the lenient `assertContains($status, [200,500])` smoke asserts (which verify the action handles the call sanely, not a specific value) to include 502. Specific `assertSame(400, …)` asserts were left untouched.
3. **Varied fixture/assert fixes (~9)** — config counts (8 total / 7 active incl. the `no-model-config` edge fixture), `fetchRecords`-on-missing-table (SQLite returns an empty 200, not MySQL's 500 → `assertContains([200,500])`), a PromptSnippet sorting assert (Extbase doesn't hydrate the `sortby` field → assert the order contract instead), and data-integrity sweeps that skip the intentional `orphan-model`/`no-model-config` fixtures by identifier. The intentional fixtures are **unchanged** (error-path tests consume them by uid).

These tests are not run by CI's merge_group functional check, so this debt accumulated silently since the #256 refactor.

## Known limitation (separate)
The 502 smoke tests make real outbound HTTPS calls that wait out timeouts → the full suite is slow (~35 min) locally; per-class runs are fast. A future improvement could mock the provider HTTP client. Also flagged for separate triage: `ModelSelectionService:267` sorts via `Model::getSorting()` which Extbase never hydrates (effectively a no-op).

## Type of Change
- [x] Test fix (no production code change)

## Checklist
- [x] Full functional+e2e suite: 905 tests, 0 errors, 0 failures
- [x] PHPStan L10, Rector, CGL clean (PHP 8.4); spot-checked classes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
