### PR TITLE
feat: TYPO3 v15 forward-compat (ext_emconf) + version-drift guard

### DIFF
--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -263,7 +263,13 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
             return $a->isDefault() ? -1 : 1; // Default first
         }
 
-        // Fourth priority: sorting order
+        // Fourth priority: sorting order.
+        // NOTE: `sorting` is a TYPO3-managed TCA `ctrl.sortby` field and is NOT
+        // hydrated onto the model by Extbase, so getSorting() returns 0 here and
+        // this comparison is effectively a no-op. Tied candidates therefore keep
+        // their repository order, which PHP's stable sort preserves. The line is
+        // kept intentionally so the intended ordering takes effect automatically
+        // should the field ever become hydrated.
         return $a->getSorting() <=> $b->getSorting();
     }
 

--- a/Tests/Unit/VersionConsistencyTest.php
+++ b/Tests/Unit/VersionConsistencyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the (manually maintained) extension version surfaces against drift.
+ *
+ * The version number lives in several files that are bumped by hand on every
+ * release: ext_emconf.php (authoritative in-repo), composer.json
+ * (extra.typo3/cms.version — required since the TYPO3 v14.2 ext_emconf
+ * deprecation #108345 to silence it while staying v13.4-compatible), and
+ * Documentation/guides.xml. The release workflow derives the published version
+ * from the git tag and does NOT validate these in-repo files, so this test is
+ * the safety net: if a release bump forgets one surface, CI fails here.
+ */
+#[CoversNothing]
+final class VersionConsistencyTest extends AbstractUnitTestCase
+{
+    private function repoRoot(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    private function extEmConfVersion(): string
+    {
+        $contents = file_get_contents($this->repoRoot() . '/ext_emconf.php');
+        self::assertIsString($contents, 'ext_emconf.php must be readable');
+        self::assertSame(
+            1,
+            preg_match("/'version'\\s*=>\\s*'([^']+)'/", $contents, $matches),
+            'ext_emconf.php must declare a version',
+        );
+
+        return $matches[1];
+    }
+
+    #[Test]
+    public function composerJsonVersionMatchesExtEmconf(): void
+    {
+        $composer = json_decode((string)file_get_contents($this->repoRoot() . '/composer.json'), true);
+        self::assertIsArray($composer);
+
+        $composerVersion = $composer['extra']['typo3/cms']['version'] ?? null;
+
+        self::assertSame(
+            $this->extEmConfVersion(),
+            $composerVersion,
+            'composer.json extra.typo3/cms.version must match ext_emconf.php version '
+            . '(TYPO3 v14.2 ext_emconf deprecation #108345 — keep both in sync on every release bump).',
+        );
+    }
+
+    #[Test]
+    public function guidesXmlVersionMatchesExtEmconf(): void
+    {
+        $version = $this->extEmConfVersion();
+        $guides = (string)file_get_contents($this->repoRoot() . '/Documentation/guides.xml');
+
+        self::assertStringContainsString(
+            'version="' . $version . '"',
+            $guides,
+            'Documentation/guides.xml version attribute must match ext_emconf.php version.',
+        );
+        self::assertStringContainsString(
+            'release="' . $version . '"',
+            $guides,
+            'Documentation/guides.xml release attribute must match ext_emconf.php version.',
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,11 @@
         },
         "typo3/cms": {
             "extension-key": "nr_llm",
-            "web-dir": ".Build/Web"
+            "web-dir": ".Build/Web",
+            "version": "0.13.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
## Description

Addresses the **`ext_emconf.php` TYPO3 v14.2 deprecation (#108345)** in a way that **stays compatible with both TYPO3 13.4 and 14.3**, plus a guard against version-surface drift and an honest cleanup.

### 1. ext_emconf forward-compat (cross-version)
The deprecation fires when `composer.json` lacks `version`/`providesPackages` — *explicitly designed so an extension can satisfy both v14 and v15 at once*. So this keeps `ext_emconf.php` (required by 13.4) and adds to `composer.json`:
```json
"extra": { "typo3/cms": { "version": "0.13.0", "Package": { "providesPackages": {} } } }
```
13.4 ignores the `extra.typo3/cms` additions; 14.x reads them and stops emitting the deprecation. **Verified:** a functional run shows the `nr_llm` ext_emconf deprecation gone (only the `nr_vault` dependency one and the TCA-`searchFields` notice remain — see below).

### 2. Version-consistency guard (`VersionConsistencyTest`)
`extra.typo3/cms.version` is a **new manual version surface** alongside `ext_emconf.php` and `Documentation/guides.xml`. The release workflow derives the published version from the git tag and does **not** validate these in-repo files, so this unit test asserts all three stay equal to `ext_emconf.php` — CI fails if a release bump forgets one. No external release-workflow change is required.

### 3. ModelSelectionService — document the no-op tiebreaker
`getSorting() <=> getSorting()` is effectively a no-op (Extbase doesn't hydrate the `ctrl.sortby` field), so tied candidates keep repository order (PHP stable sort). Behaviour unchanged; the misleading line is now documented (per the dead-code-flag rule, the line is kept, not removed).

### Deliberately NOT changed (cannot, while supporting 13.4)
- **TCA `ctrl.searchFields`** — the replacement `searchable` field config and the `searchFields` removal both landed in **TYPO3 14.0** (`Feature-106972` / `Breaking-106972`). 13.4 needs `searchFields`; removing it would break 13.4 search. The 14.x notice is a harmless auto-migration and unavoidable until 13.4 is dropped.
- **`nr_vault` ext_emconf** — dependency; fix belongs upstream.

## Type of Change
- [x] Forward-compat / packaging metadata (no runtime behaviour change)
- [x] Test (drift guard)

## Checklist
- [x] TYPO3 13.4 + 14.3 both unaffected (additions live under `extra.typo3/cms`, ignored by 13.4)
- [x] `-s unit` 3736 pass (incl. new VersionConsistencyTest) · CGL · PHPStan L10 clean (PHP 8.4)
- [x] Functional run confirms the nr_llm ext_emconf deprecation is silenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
