### PR TITLE
feat(skills): add 'Add source' button to the Skills module

### DIFF
--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -19,10 +19,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 #[AsController]
 final class SkillSourceController extends ActionController
@@ -37,6 +40,8 @@ final class SkillSourceController extends ActionController
         private readonly VaultServiceInterface $vault,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly PageRenderer $pageRenderer,
+        private readonly IconFactory $iconFactory,
+        private readonly FormEngineUrlBuilder $formEngineUrlBuilder,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -44,6 +49,17 @@ final class SkillSourceController extends ActionController
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/SkillList.js');
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
+
+        // "Add source" button in the docheader → FormEngine new-record form for
+        // tx_nrllm_skill_source, returning to this module after save/close.
+        $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
+        $createButton = $buttonBar->makeLinkButton()
+            ->setIcon($this->iconFactory->getIcon('actions-plus', IconSize::SMALL))
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.skill.source.new', 'NrLlm') ?? 'Add source')
+            ->setShowLabelText(true)
+            ->setHref($this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_skill_source', 'nrllm_skills'));
+        $buttonBar->addButton($createButton);
+
         $moduleTemplate->assignMultiple([
             'sources' => $this->sourceRepository->findAll(),
             'skills' => $this->skillRepository->findAll(),

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -268,6 +268,10 @@
                 <source>New Provider</source>
                 <target>Neuer Anbieter</target>
             </trans-unit>
+            <trans-unit id="btn.skill.source.new">
+                <source>Add source</source>
+                <target>Quelle hinzufügen</target>
+            </trans-unit>
             <trans-unit id="btn.model.new">
                 <source>New Model</source>
                 <target>Neues Modell</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -204,6 +204,9 @@
             <trans-unit id="btn.provider.new">
                 <source>New Provider</source>
             </trans-unit>
+            <trans-unit id="btn.skill.source.new">
+                <source>Add source</source>
+            </trans-unit>
             <trans-unit id="btn.model.new">
                 <source>New Model</source>
             </trans-unit>

--- a/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
+use Netresearch\NrLlm\Controller\Backend\FormEngineUrlBuilder;
 use Netresearch\NrLlm\Controller\Backend\SkillSourceController;
 use Netresearch\NrLlm\Domain\Enum\SkillSourceType;
 use Netresearch\NrLlm\Domain\Model\SkillSource;
@@ -26,6 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -65,6 +67,8 @@ final class SkillSourceControllerTest extends AbstractFunctionalTestCase
             $vault,
             $this->get(PersistenceManagerInterface::class),
             $this->get(PageRenderer::class),
+            $this->get(IconFactory::class),
+            $this->get(FormEngineUrlBuilder::class),
         );
     }
 


### PR DESCRIPTION
## Description

The **Skills** backend module (`SkillSourceController`) rendered only **sync / token / toggle** buttons — there was **no discoverable way to add a skill source**. Skill sources are `tx_nrllm_skill_source` records (rootLevel `-1`), so the only fallback was the generic *Web › List* module, which users can't reasonably find.

This adds an **"Add source"** button to the module docheader that opens the FormEngine new-record form for `tx_nrllm_skill_source` and returns to the module after save/close — mirroring the existing create-button pattern in the Provider/Model/Configuration modules (via the shared `FormEngineUrlBuilder`).

- `SkillSourceController::listAction()` now adds the docheader create button.
- EN + DE labels (`btn.skill.source.new`).
- Functional test updated for the 2 new constructor deps (`IconFactory`, `FormEngineUrlBuilder`).

## Type of Change
- [x] Feature (backend UX)

## Checklist
- [x] PHPStan L10 · CGL clean (PHP 8.4)
- [x] `SkillSourceControllerTest` green (5 tests)
- [x] EN + DE translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
