### PR TITLE
feat(tools): per-tool enable/disable + builtin system tools

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -13,9 +13,10 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
-use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -40,7 +41,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  *
  * Mirrors {@see SkillSourceController}: a `#[AsController]` Extbase
  * ActionController whose list action is the module entry point, gated to
- * admins via the module's ``access => admin`` and (for the AJAX action) the
+ * admins via the module's ``access => admin`` and (for the AJAX actions) the
  * {@see RequiresBackendAdminTrait} guard.
  */
 #[AsController]
@@ -54,18 +55,20 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         private readonly ToolRegistry $toolRegistry,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly PageRenderer $pageRenderer,
-        private readonly AllowedToolsResolver $allowedToolsResolver,
         private readonly ToolLoopService $toolLoopService,
+        private readonly ToolAvailabilityServiceInterface $toolAvailability,
+        private readonly ToolStateRepository $toolStateRepository,
     ) {}
 
     public function listAction(): ResponseInterface
     {
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolPlayground.js');
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolState.js');
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $moduleTemplate->assignMultiple([
             'configurations' => $this->configurationRepository->findAll(),
-            'tools' => $this->toolRegistry->specs(),
+            'toolStates' => $this->toolAvailability->states(),
             'ajaxRoute' => 'nrllm_tool_run',
         ]);
         return $moduleTemplate->renderResponse('Backend/ToolPlayground/List');
@@ -79,10 +82,13 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * module's ``access => admin`` check (ADR-037). The configuration's vault
      * key, model and pricing reach the call through
      * {@see ToolLoopService::runLoop()} (it runs on
-     * `chatWithToolsForConfiguration`). The skill-derived allow-list narrows
-     * which tools are offered. Any unexpected provider/tool failure returns a
-     * generic JSON 500 — never the exception message, which can carry
-     * DBAL/PDO credentials — while the detail is logged downstream.
+     * `chatWithToolsForConfiguration`). The per-run allow-list comes from the
+     * tool checkboxes the operator ticked (defaulting to the globally-enabled
+     * set when none are sent); {@see ToolLoopService} still intersects it with
+     * the global gate, so a disabled tool can never be offered. Any unexpected
+     * provider/tool failure returns a generic JSON 500 — never the exception
+     * message, which can carry DBAL/PDO credentials — while the detail is
+     * logged downstream.
      */
     public function runAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -101,9 +107,13 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         $options = new ToolOptions(beUserUid: $this->currentBackendUserUid());
 
+        // The checked tool boxes restrict this run; absent any selection, fall
+        // back to the globally-enabled set. The runtime gate is authoritative
+        // regardless (a disabled tool stays off).
+        $allowed = $this->toolNamesFromBody($body) ?? $this->toolAvailability->enabledNames();
+
         try {
-            $allowed = $this->allowedToolsResolver->resolve($config);
-            $result  = $this->toolLoopService->runLoop([ChatMessage::user($prompt)], $config, $allowed, $options);
+            $result = $this->toolLoopService->runLoop([ChatMessage::user($prompt)], $config, $allowed, $options);
         } catch (Throwable $e) {
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
             return new JsonResponse(['success' => false, 'error' => 'Tool run failed'], 500);
@@ -127,6 +137,33 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             'truncated'  => $result->truncated,
             'usage'      => ['totalTokens' => $result->usage->totalTokens],
         ]);
+    }
+
+    /**
+     * Toggle the global enable state of a single tool (AJAX, admin-gated).
+     *
+     * Admin-gated via {@see denyNonAdmin()} FIRST (ADR-037). The override is
+     * persisted to `tx_nrllm_tool_state` via {@see ToolStateRepository}; the
+     * fail-closed runtime gate then refuses a disabled tool on every later run.
+     * Only a registered tool name is accepted so the table cannot accumulate
+     * orphan rows.
+     */
+    public function toggleToolAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body     = $request->getParsedBody();
+        $toolName = $this->stringFromBody($body, 'tool');
+        if ($toolName === '' || $this->toolRegistry->get($toolName) === null) {
+            return new JsonResponse(['success' => false, 'error' => 'Unknown tool'], 404);
+        }
+
+        $enabled = $this->boolFromBody($body, 'enabled');
+        $this->toolStateRepository->setEnabled($toolName, $enabled);
+
+        return new JsonResponse(['success' => true, 'enabled' => $enabled]);
     }
 
     /**
@@ -161,5 +198,37 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
+    }
+
+    private function boolFromBody(mixed $body, string $key): bool
+    {
+        if (!is_array($body)) {
+            return false;
+        }
+        // filter_var (not a plain cast) so the string "false"/"0" from form bodies is correctly false.
+        return filter_var($body[$key] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Read the ticked tool checkboxes (`tools[]`) from the run form. Returns the
+     * selected names, or null when the form sent no `tools` key at all — the
+     * caller then defaults to the globally-enabled set.
+     *
+     * @return list<string>|null
+     */
+    private function toolNamesFromBody(mixed $body): ?array
+    {
+        if (!is_array($body) || !isset($body['tools']) || !is_array($body['tools'])) {
+            return null;
+        }
+
+        $names = [];
+        foreach ($body['tools'] as $value) {
+            if (is_string($value) && $value !== '') {
+                $names[] = $value;
+            }
+        }
+
+        return $names;
     }
 }

--- a/Classes/Service/Tool/Builtin/CollectsEnvironmentTrait.php
+++ b/Classes/Service/Tool/Builtin/CollectsEnvironmentTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+/**
+ * Shared environment-variable collection for the env tools.
+ *
+ * Both {@see GetEnvTool} (redacted) and {@see GetEnvRawTool} (unredacted) build
+ * the same name => value map from getenv() and $_ENV; only their rendering of
+ * the values differs. The collection lives here so the two tools do not carry
+ * an identical copy.
+ *
+ * The consuming class must provide `self::toStr()` (via
+ * {@see \Netresearch\NrLlm\Utility\SafeCastTrait}).
+ */
+trait CollectsEnvironmentTrait
+{
+    /**
+     * Merge getenv() and $_ENV into a single name => value map of strings.
+     *
+     * @return array<string, string>
+     */
+    private function collectEnvironment(): array
+    {
+        $env = [];
+
+        $all = getenv();
+        if (is_array($all)) {
+            foreach ($all as $name => $value) {
+                $env[self::toStr($name)] = self::toStr($value);
+            }
+        }
+
+        /** @var mixed $value */
+        foreach ($_ENV as $name => $value) {
+            if (is_scalar($value)) {
+                $env[self::toStr($name)] = self::toStr($value);
+            }
+        }
+
+        unset($env['']);
+
+        return $env;
+    }
+}

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -115,4 +115,9 @@ final readonly class FetchLogsTool implements ToolInterface
 
         return implode("\n", $lines);
     }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetEnvRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvRawTool.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * Return ALL process environment variables, unredacted.
+ *
+ * Security contract (see {@see ToolInterface}): this egresses raw secret
+ * values — the database password, the TYPO3 encryptionKey, the nr-vault master
+ * key, provider API keys and any token in the environment — to the configured
+ * LLM provider and into the rendered backend DOM. There is no redaction; the
+ * only guard is that this tool is admin-only AND
+ * {@see isEnabledByDefault()} = false, so an admin must deliberately enable it
+ * in the Tool Playground module before it can ever run. Prefer the redacted
+ * {@see GetEnvTool} unless raw values are genuinely required.
+ */
+final readonly class GetEnvRawTool implements ToolInterface
+{
+    use CollectsEnvironmentTrait;
+    use SafeCastTrait;
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_env_raw',
+            'Return ALL process environment variables WITHOUT redaction (including secrets such as the '
+            . 'database password and encryption keys). Disabled by default — admin must enable it.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $env = $this->collectEnvironment();
+        if ($env === []) {
+            return 'No environment variables.';
+        }
+
+        ksort($env);
+        $lines = [];
+        foreach ($env as $name => $value) {
+            $lines[] = $name . '=' . $value;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return false;
+    }
+
+}

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * Return the process environment variables with secret VALUES redacted.
+ *
+ * Security contract (see {@see ToolInterface}): every variable whose NAME
+ * matches {@see self::SECRET_PATTERN} (passwords, tokens, keys, salts, DSNs,
+ * the TYPO3 encryption key, the nr-vault master key, …) has its value replaced
+ * by {@see self::REDACTED} before the listing egresses to the provider.
+ * Non-secret variables show their value so the model can reason about the host
+ * (paths, hostnames, the TYPO3 context) without leaking credentials. The
+ * unredacted variant is the separate, default-disabled {@see GetEnvRawTool}.
+ */
+final readonly class GetEnvTool implements ToolInterface
+{
+    use CollectsEnvironmentTrait;
+    use SafeCastTrait;
+
+    private const SECRET_PATTERN = '/PASS|PASSWORD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i';
+
+    private const REDACTED = '***redacted***';
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_env',
+            'Return the process environment variables. Values of secret-looking variables '
+            . '(password, token, key, secret, salt, DSN, …) are redacted; non-secret values are shown.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $env = $this->collectEnvironment();
+        if ($env === []) {
+            return 'No environment variables.';
+        }
+
+        ksort($env);
+        $lines = [];
+        foreach ($env as $name => $value) {
+            $masked  = preg_match(self::SECRET_PATTERN, $name) === 1 ? self::REDACTED : $value;
+            $lines[] = $name . '=' . $masked;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+}

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Return the backend page tree (`pages`) as a depth-indented outline.
+ *
+ * Walks children from an optional `rootUid` (default 0 = tree root) down to a
+ * bounded `depth`, emitting only `uid`, `title` and `doktype` per node.
+ *
+ * Security contract (see {@see ToolInterface}): structure only — no page
+ * content, TSconfig, slugs or perms columns are read. Soft-deleted and hidden
+ * pages are excluded (the model only ever sees the live tree), `depth` is
+ * hard-capped at {@see self::MAX_DEPTH} and the total number of emitted nodes
+ * at {@see self::NODE_CAP} so a single model-steered call cannot enumerate an
+ * unbounded tree into the provider egress.
+ */
+final readonly class GetPageTreeTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'pages';
+
+    private const DEFAULT_DEPTH = 3;
+
+    private const MAX_DEPTH = 5;
+
+    /**
+     * Maximum nodes emitted regardless of depth. Bounds the egress volume from
+     * a single model-steered call on a large installation.
+     */
+    private const NODE_CAP = 200;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_pagetree',
+            'Return the backend page tree (uid, title, doktype) as a depth-indented outline. '
+            . 'Deleted and hidden pages are excluded; structure only, no page content.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'rootUid' => [
+                        'type'        => 'integer',
+                        'description' => 'Page uid to start from (default 0 = tree root).',
+                    ],
+                    'depth' => [
+                        'type'        => 'integer',
+                        'description' => 'How many levels deep to descend (default 3, hard cap 5).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $rootUid = self::toInt($arguments['rootUid'] ?? 0);
+        if ($rootUid < 0) {
+            $rootUid = 0;
+        }
+
+        $depth = self::toInt($arguments['depth'] ?? self::DEFAULT_DEPTH);
+        if ($depth < 1) {
+            $depth = self::DEFAULT_DEPTH;
+        }
+        $depth = min($depth, self::MAX_DEPTH);
+
+        $lines = [];
+        $count = 0;
+        $this->appendChildren($rootUid, 0, $depth, $lines, $count);
+
+        if ($lines === []) {
+            return 'No pages.';
+        }
+
+        array_unshift($lines, sprintf('Page tree from uid %d (depth %d):', $rootUid, $depth));
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Append the live (non-deleted, non-hidden) children of $pid, recursing
+     * until the depth or the global node cap is reached.
+     *
+     * @param list<string> $lines
+     */
+    private function appendChildren(int $pid, int $level, int $maxDepth, array &$lines, int &$count): void
+    {
+        if ($level >= $maxDepth || $count >= self::NODE_CAP) {
+            return;
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('uid', 'title', 'doktype')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('hidden', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                // removeAll() above drops the language restriction, so pin to the
+                // default language explicitly — otherwise translated page records
+                // surface as separate nodes and corrupt the tree structure.
+                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            if ($count >= self::NODE_CAP) {
+                return;
+            }
+
+            $uid       = self::toInt($row['uid'] ?? 0);
+            $lines[]   = str_repeat('  ', $level) . sprintf(
+                '[%d] %s (doktype %d)',
+                $uid,
+                self::toStr($row['title'] ?? ''),
+                self::toInt($row['doktype'] ?? 0),
+            );
+            ++$count;
+
+            $this->appendChildren($uid, $level + 1, $maxDepth, $lines, $count);
+        }
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+
+/**
+ * Return the full phpinfo(INFO_ALL) output as captured plain text.
+ *
+ * Security contract (see {@see ToolInterface}): phpinfo dumps the complete
+ * runtime — including `$_SERVER`, `$_ENV`, loaded ini paths and per-extension
+ * configuration — which routinely carries secrets (database credentials in
+ * server vars, API keys in the environment, absolute filesystem paths). The
+ * whole capture egresses to the LLM provider and into the rendered DOM. The
+ * only guard is that this tool is admin-only AND
+ * {@see isEnabledByDefault()} = false, so an admin must deliberately enable it
+ * in the Tool Playground module. Prefer the curated {@see GetPhpInfoTool}.
+ */
+final readonly class GetPhpInfoRawTool implements ToolInterface
+{
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_php_info_raw',
+            'Return the full phpinfo(INFO_ALL) output as plain text (includes $_SERVER, $_ENV and other '
+            . 'secret-bearing runtime detail). Disabled by default — admin must enable it.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        ob_start();
+        phpinfo(INFO_ALL);
+        $info = ob_get_clean();
+
+        if (!is_string($info) || $info === '') {
+            return 'phpinfo unavailable.';
+        }
+
+        // In a web SAPI (the TYPO3 backend) phpinfo() emits HTML, not the CLI's
+        // plain text. Returning raw HTML to the provider wastes a large amount of
+        // tokens and can blow the context window, so reduce it to text: drop the
+        // <head>/<style>, strip tags, decode entities and collapse blank runs.
+        if (stripos($info, '<html') !== false || stripos($info, '<table') !== false) {
+            $info = (string)preg_replace('#<(head|style|script)\b[^>]*>.*?</\1>#is', '', $info);
+            $info = strip_tags($info);
+            $info = html_entity_decode($info, ENT_QUOTES | ENT_HTML5);
+            $info = (string)preg_replace("/\n{3,}/", "\n\n", $info);
+            $info = trim($info);
+        }
+
+        return $info !== '' ? $info : 'phpinfo unavailable.';
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return false;
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * Return a curated, non-sensitive subset of the PHP runtime configuration.
+ *
+ * Security contract (see {@see ToolInterface}): a deliberate allow-list — the
+ * PHP version, the loaded extension names and a handful of harmless ini
+ * settings ({@see self::SAFE_INI_KEYS}). It does NOT dump full phpinfo(),
+ * `$_SERVER` or `$_ENV`, all of which can carry secrets; the unbounded variant
+ * is the separate, default-disabled {@see GetPhpInfoRawTool}.
+ */
+final readonly class GetPhpInfoTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    /**
+     * Non-sensitive ini settings safe to surface to the provider.
+     *
+     * @var list<string>
+     */
+    private const SAFE_INI_KEYS = [
+        'memory_limit',
+        'max_execution_time',
+        'post_max_size',
+        'upload_max_filesize',
+        'date.timezone',
+    ];
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_php_info',
+            'Return a curated, non-sensitive subset of the PHP runtime: version, loaded extensions and a few '
+            . 'harmless ini settings (memory_limit, max_execution_time, post_max_size, upload_max_filesize, date.timezone).',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $extensions = get_loaded_extensions();
+        sort($extensions);
+
+        $lines   = [];
+        $lines[] = 'PHP version: ' . PHP_VERSION;
+        $lines[] = sprintf('Loaded extensions (%d): %s', count($extensions), implode(', ', $extensions));
+        foreach (self::SAFE_INI_KEYS as $key) {
+            $lines[] = $key . ' = ' . self::toStr(ini_get($key));
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTcaTool.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * Describe the TYPO3 table schema from `$GLOBALS['TCA']`.
+ *
+ * With no `table` argument it lists the configured TCA table names; with a
+ * real table name it returns that table's column names and each column's
+ * `config.type`.
+ *
+ * Security contract (see {@see ToolInterface}): schema only — never any record
+ * data. An unknown table name returns a neutral string (the tool does not
+ * confirm or deny table existence beyond the TCA registry the admin already
+ * controls). Output is bounded by {@see self::MAX_ITEMS}.
+ */
+final readonly class GetTcaTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    /** Upper bound on listed tables / columns to keep the egress bounded. */
+    private const MAX_ITEMS = 500;
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_tca',
+            'Describe the TYPO3 TCA schema. Without arguments, lists the configured table names; '
+            . 'with a "table" argument, returns that table\'s column names and each column type. Schema only, no data.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'Optional TCA table name to describe (e.g. "pages", "tt_content").',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $tca = $GLOBALS['TCA'] ?? [];
+        if (!is_array($tca) || $tca === []) {
+            return 'No TCA available.';
+        }
+
+        $table = self::toStr($arguments['table'] ?? '');
+        if ($table === '') {
+            return $this->listTables($tca);
+        }
+
+        return $this->describeTable($tca, $table);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $tca
+     */
+    private function listTables(array $tca): string
+    {
+        $names = array_map(static fn(int|string $name): string => (string)$name, array_keys($tca));
+        sort($names);
+        $names = array_slice($names, 0, self::MAX_ITEMS);
+
+        return sprintf("TCA tables (%d):\n", count($names)) . implode("\n", $names);
+    }
+
+    /**
+     * @param array<array-key, mixed> $tca
+     */
+    private function describeTable(array $tca, string $table): string
+    {
+        $definition = $tca[$table] ?? null;
+        if (!is_array($definition) || !isset($definition['columns']) || !is_array($definition['columns'])) {
+            return 'Unknown TCA table.';
+        }
+
+        $lines = [sprintf('TCA columns for %s:', $table)];
+        $count = 0;
+        foreach ($definition['columns'] as $field => $config) {
+            if ($count >= self::MAX_ITEMS) {
+                break;
+            }
+
+            $type = '';
+            if (is_array($config) && isset($config['config']) && is_array($config['config'])) {
+                $type = self::toStr($config['config']['type'] ?? '');
+            }
+            $lines[] = sprintf('%s: %s', (string)$field, $type !== '' ? $type : '?');
+            ++$count;
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * List the backend user groups (`be_groups`): uid and title only.
+ *
+ * TYPO3 has no separate "roles" table — backend roles ARE backend groups, so
+ * this is the tool to answer "what roles exist?".
+ *
+ * Security contract (see {@see ToolInterface}): only the uid and the
+ * human-readable title are read. No permission masks, allowed-table lists,
+ * TSconfig or any other authorization-bearing column is surfaced. Soft-deleted
+ * groups are excluded and the row count is hard-capped at {@see self::HARD_LIMIT}.
+ */
+final readonly class ListBeGroupsTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'be_groups';
+
+    private const HARD_LIMIT = 200;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_be_groups',
+            'List the backend user groups (uid, title). Backend roles ARE backend groups in TYPO3; '
+            . 'there is no separate roles table. No permission masks or other authorization columns are returned.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('uid', 'title')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('title', 'ASC')
+            ->setMaxResults(self::HARD_LIMIT)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        if ($rows === []) {
+            return 'No backend groups.';
+        }
+
+        $lines = [sprintf('Backend groups (%d):', count($rows))];
+        foreach ($rows as $row) {
+            $lines[] = sprintf('[%d] %s', self::toInt($row['uid'] ?? 0), self::toStr($row['title'] ?? ''));
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * List the backend users (`be_users`) with ALL non-credential columns.
+ *
+ * Unlike {@see ListBeUsersTool} this returns the full profile row (TSconfig,
+ * group memberships, file mounts, language, …) for deep introspection.
+ *
+ * Security contract (see {@see ToolInterface}): even here the credential
+ * columns are stripped — `password` (a crackable hash) and `mfa` (TOTP secrets
+ * and recovery codes) are removed from every row before formatting. Leaking a
+ * backend password hash or an MFA seed to an external LLM provider is a real
+ * security hole, not "raw data". The remaining columns can still expose the
+ * backend account layout, so this tool is {@see isEnabledByDefault()} = false:
+ * an admin must deliberately enable it in the Tool Playground module. Values
+ * are truncated to {@see self::MAX_VALUE_LENGTH} and rows capped at
+ * {@see self::HARD_LIMIT} to bound the egress.
+ */
+final readonly class ListBeUsersRawTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'be_users';
+
+    private const HARD_LIMIT = 100;
+
+    private const MAX_VALUE_LENGTH = 200;
+
+    /**
+     * Credential-bearing columns stripped from every row regardless of the
+     * "raw" framing — never egress these to the provider.
+     *
+     * @var list<string>
+     */
+    private const CREDENTIAL_COLUMNS = ['password', 'mfa'];
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_be_users_raw',
+            'List backend users with all non-credential columns (full profile rows). '
+            . 'Password hashes and MFA secrets are still excluded. Disabled by default — admin must enable it.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults(self::HARD_LIMIT)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        if ($rows === []) {
+            return 'No backend users.';
+        }
+
+        $blocks = [];
+        foreach ($rows as $row) {
+            foreach (self::CREDENTIAL_COLUMNS as $column) {
+                unset($row[$column]);
+            }
+
+            $pairs = [];
+            foreach ($row as $key => $value) {
+                $pairs[] = sprintf('  %s: %s', (string)$key, $this->truncate(self::toStr($value)));
+            }
+            $blocks[] = sprintf('[%d]', self::toInt($row['uid'] ?? 0)) . "\n" . implode("\n", $pairs);
+        }
+
+        return sprintf("Backend users (%d):\n", count($rows)) . implode("\n", $blocks);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return false;
+    }
+
+    private function truncate(string $value): string
+    {
+        if (mb_strlen($value) <= self::MAX_VALUE_LENGTH) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, self::MAX_VALUE_LENGTH) . '…';
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListBeUsersTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersTool.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * List the backend users (`be_users`) with non-credential profile columns.
+ *
+ * Security contract (see {@see ToolInterface}): the column list is an explicit
+ * allow-list — uid, username, realName, email, admin flag, disable flag and
+ * lastlogin. The `password` column (a crackable credential hash, not
+ * information) and the `mfa` column (TOTP secrets / recovery codes) are NEVER
+ * selected, so they cannot egress to the external provider. Soft-deleted users
+ * are excluded and the row count is hard-capped at {@see self::HARD_LIMIT}.
+ */
+final readonly class ListBeUsersTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'be_users';
+
+    private const HARD_LIMIT = 200;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_be_users',
+            'List backend users (uid, username, realName, email, admin flag, disabled flag, last login). '
+            . 'Password hashes and MFA secrets are never included.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            // Explicit allow-list — the password and mfa columns are never read.
+            ->select('uid', 'username', 'realName', 'email', 'admin', 'disable', 'lastlogin')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults(self::HARD_LIMIT)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        if ($rows === []) {
+            return 'No backend users.';
+        }
+
+        $lines = [sprintf('Backend users (%d):', count($rows))];
+        foreach ($rows as $row) {
+            $lastlogin = self::toInt($row['lastlogin'] ?? 0);
+            $lines[]   = sprintf(
+                '[%d] %s | %s <%s> | admin=%d disabled=%d | lastlogin=%s',
+                self::toInt($row['uid'] ?? 0),
+                self::toStr($row['username'] ?? ''),
+                self::toStr($row['realName'] ?? ''),
+                self::toStr($row['email'] ?? ''),
+                self::toInt($row['admin'] ?? 0),
+                self::toInt($row['disable'] ?? 0),
+                $lastlogin > 0 ? gmdate('Y-m-d H:i', $lastlogin) : 'never',
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+}

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -125,4 +125,9 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
 
         return implode("\n", $lines);
     }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
 }

--- a/Classes/Service/Tool/ToolAvailabilityService.php
+++ b/Classes/Service/Tool/ToolAvailabilityService.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Computes the effective global enable state of every registered tool.
+ *
+ * The effective state of a tool is its admin override when one exists
+ * ({@see ToolStateRepository::overrides()}), otherwise its own
+ * {@see ToolInterface::isEnabledByDefault()}. This is the authoritative
+ * "what may run at all" set: {@see ToolLoopService} intersects every per-run
+ * allow-list with {@see enabledNames()} so a globally-disabled tool can never
+ * be called, and {@see ToolPlaygroundController} renders {@see states()} as the
+ * module's toggle list.
+ */
+final readonly class ToolAvailabilityService implements ToolAvailabilityServiceInterface
+{
+    public function __construct(
+        private ToolRegistry $registry,
+        private ToolStateRepository $stateRepository,
+    ) {}
+
+    public function enabledNames(): array
+    {
+        $names = [];
+        foreach ($this->states() as $state) {
+            if ($state['enabled']) {
+                $names[] = $state['name'];
+            }
+        }
+
+        return $names;
+    }
+
+    public function states(): array
+    {
+        $overrides = $this->stateRepository->overrides();
+
+        $states = [];
+        foreach ($this->registry->names() as $name) {
+            $tool = $this->registry->get($name);
+            if ($tool === null) {
+                continue;
+            }
+
+            $default    = $tool->isEnabledByDefault();
+            $overridden = array_key_exists($name, $overrides);
+
+            $states[] = [
+                'name'           => $name,
+                'description'    => $tool->getSpec()->description,
+                'enabled'        => $overridden ? $overrides[$name] : $default,
+                'defaultEnabled' => $default,
+                'overridden'     => $overridden,
+            ];
+        }
+
+        return $states;
+    }
+}

--- a/Classes/Service/Tool/ToolAvailabilityServiceInterface.php
+++ b/Classes/Service/Tool/ToolAvailabilityServiceInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Resolves the globally-enabled tool set from each tool's default and the
+ * admin overrides ({@see ToolStateRepository}).
+ *
+ * Extracted as an interface so the fail-closed gate in {@see ToolLoopService}
+ * is unit-testable without a database, while the backend module consumes the
+ * concrete {@see ToolAvailabilityService} (which needs the ConnectionPool).
+ */
+interface ToolAvailabilityServiceInterface
+{
+    /**
+     * Names of the tools that are globally enabled right now (override, else
+     * the tool's {@see ToolInterface::isEnabledByDefault()}).
+     *
+     * @return list<string>
+     */
+    public function enabledNames(): array;
+
+    /**
+     * Per-tool state rows for the management UI: name, description, the
+     * effective enabled flag, the tool default and whether an explicit admin
+     * override is in effect.
+     *
+     * @return list<array{
+     *     name: string,
+     *     description: string,
+     *     enabled: bool,
+     *     defaultEnabled: bool,
+     *     overridden: bool,
+     * }>
+     */
+    public function states(): array;
+}

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -46,4 +46,16 @@ interface ToolInterface
      * @param array<string, mixed> $arguments
      */
     public function execute(array $arguments): string;
+
+    /**
+     * Whether this tool is offered by default when an admin has not set an
+     * explicit global override (see {@see ToolStateRepository}).
+     *
+     * Curated, low-risk tools return `true`. "Raw" tools whose output can
+     * egress server/host secrets to the external provider return `false`, so
+     * they are unavailable until an admin deliberately enables them in the
+     * Tool Playground module — defence in depth on top of the admin-only
+     * context.
+     */
+    public function isEnabledByDefault(): bool;
 }

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -53,6 +53,7 @@ final readonly class ToolLoopService
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
+        private ToolAvailabilityServiceInterface $availability,
         private ?LoggerInterface $logger = null,
         private int $defaultMaxIterations = 5,
     ) {}
@@ -61,12 +62,11 @@ final readonly class ToolLoopService
      * Run the bounded agent loop and return its outcome.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param list<string>|null                      $allowedToolNames null ⇒ all
-     *                                                                 registered
-     *                                                                 tools; a
-     *                                                                 list ⇒ that
-     *                                                                 set (∩
-     *                                                                 registry);
+     * @param list<string>|null                      $allowedToolNames null ⇒ the
+     *                                                                 globally-
+     *                                                                 enabled set;
+     *                                                                 a list ⇒ that
+     *                                                                 set ∩ enabled;
      *                                                                 `[]` ⇒ no
      *                                                                 tools
      */
@@ -77,8 +77,18 @@ final readonly class ToolLoopService
         ?ToolOptions $options = null,
         ?int $maxIterations = null,
     ): ToolLoopResult {
-        $max   = $maxIterations ?? $this->defaultMaxIterations;
-        $specs = $this->registry->specs($allowedToolNames);
+        $max = $maxIterations ?? $this->defaultMaxIterations;
+
+        // Fail-closed global gate: the effective allow-set is always intersected
+        // with the globally-enabled tools. A null caller list means "no per-run
+        // restriction" and collapses to the enabled set (NOT every registered
+        // tool); a disabled tool can therefore never be offered, even when a
+        // caller — or a model steered by injected skill prose — names it.
+        $enabled   = $this->availability->enabledNames();
+        $effective = $allowedToolNames === null
+            ? $enabled
+            : array_values(array_intersect($allowedToolNames, $enabled));
+        $specs = $this->registry->specs($effective);
 
         // No tools offered (an empty allow-list, or nothing registered): a tools
         // request with an empty `tools` array makes some providers (OpenAI) 400.

--- a/Classes/Service/Tool/ToolStateRepository.php
+++ b/Classes/Service/Tool/ToolStateRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * ConnectionPool-backed store for the global per-tool enable/disable overrides
+ * (`tx_nrllm_tool_state`).
+ *
+ * A row exists only for a tool whose admin override differs from — or has been
+ * explicitly set equal to — its {@see ToolInterface::isEnabledByDefault()}.
+ * The absence of a row therefore means "no override; use the tool default".
+ * The table carries no `deleted`/`hidden` columns and is never edited via
+ * FormEngine, so every query removes the default restrictions (mirroring the
+ * builtin tools) to avoid referencing non-existent enable columns.
+ */
+final readonly class ToolStateRepository
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_tool_state';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * Return the explicit overrides keyed by tool name: `tool_name => enabled`.
+     *
+     * @return array<string, bool>
+     */
+    public function overrides(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('tool_name', 'enabled')
+            ->from(self::TABLE)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $overrides = [];
+        foreach ($rows as $row) {
+            $name = self::toStr($row['tool_name'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+            $overrides[$name] = self::toInt($row['enabled'] ?? 0) === 1;
+        }
+
+        return $overrides;
+    }
+
+    /**
+     * Upsert the override for a single tool. A select-then-write keeps the unique
+     * `tool_name` intact and avoids the "0 affected rows because the value was
+     * unchanged" pitfall of a blind update-or-insert.
+     */
+    public function setEnabled(string $toolName, bool $enabled): void
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $existingUid = $queryBuilder
+            ->select('uid')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('tool_name', $queryBuilder->createNamedParameter($toolName)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $value      = $enabled ? 1 : 0;
+        if ($existingUid !== false) {
+            $connection->update(self::TABLE, ['enabled' => $value], ['uid' => self::toInt($existingUid)]);
+
+            return;
+        }
+
+        $connection->insert(self::TABLE, [
+            'pid'       => 0,
+            'tool_name' => $toolName,
+            'enabled'   => $value,
+        ]);
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -136,6 +136,10 @@ return [
         'path' => '/nrllm/tool/run',
         'target' => ToolPlaygroundController::class . '::runAction',
     ],
+    'nrllm_tool_toggle' => [
+        'path' => '/nrllm/tool/toggle',
+        'target' => ToolPlaygroundController::class . '::toggleToolAction',
+    ],
 
     // Setup Wizard routes
     'nrllm_wizard_detect' => [

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -191,6 +191,9 @@ services:
   Netresearch\NrLlm\Service\Skill\GitHubClientInterface:
     alias: Netresearch\NrLlm\Service\Skill\GitHubClient
 
+  Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface:
+    alias: Netresearch\NrLlm\Service\Tool\ToolAvailabilityService
+
   Netresearch\NrLlm\Service\BudgetService:
     public: true
 

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -46,6 +46,58 @@
                 <source>No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool.</source>
                 <target>Es sind keine Tools registriert. Ein Tool wird hinzugefügt, indem eine ToolInterface-Implementierung mit nr_llm.tool getaggt wird.</target>
             </trans-unit>
+            <trans-unit id="playground.run.tools">
+                <source>Tools available to this run</source>
+                <target>Für diesen Lauf verfügbare Tools</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.enabled">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.disabled">
+                <source>Disabled</source>
+                <target>Deaktiviert</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.default">
+                <source>Default</source>
+                <target>Standard</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.overridden">
+                <source>Override</source>
+                <target>Überschrieben</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.enable">
+                <source>Enable</source>
+                <target>Aktivieren</target>
+            </trans-unit>
+            <trans-unit id="playground.tool.disable">
+                <source>Disable</source>
+                <target>Deaktivieren</target>
+            </trans-unit>
+            <trans-unit id="playground.help.title">
+                <source>How to add a tool</source>
+                <target>Ein Tool hinzufügen</target>
+            </trans-unit>
+            <trans-unit id="playground.help.intro">
+                <source>Tools are auto-discovered PHP classes — no manual registration is needed.</source>
+                <target>Tools sind automatisch erkannte PHP-Klassen — eine manuelle Registrierung ist nicht nötig.</target>
+            </trans-unit>
+            <trans-unit id="playground.help.step.interface">
+                <source>Implement Netresearch\NrLlm\Service\Tool\ToolInterface (getSpec + execute + isEnabledByDefault).</source>
+                <target>Netresearch\NrLlm\Service\Tool\ToolInterface implementieren (getSpec + execute + isEnabledByDefault).</target>
+            </trans-unit>
+            <trans-unit id="playground.help.step.tag">
+                <source>The class is auto-discovered via the nr_llm.tool DI tag — there is nothing else to register.</source>
+                <target>Die Klasse wird über das DI-Tag nr_llm.tool automatisch erkannt — es ist nichts weiter zu registrieren.</target>
+            </trans-unit>
+            <trans-unit id="playground.help.step.template">
+                <source>Copy Classes/Service/Tool/Builtin/FetchLogsTool.php as a starting template.</source>
+                <target>Classes/Service/Tool/Builtin/FetchLogsTool.php als Vorlage kopieren.</target>
+            </trans-unit>
+            <trans-unit id="playground.help.security">
+                <source>A tool runs with full backend privileges and its result egresses to the LLM provider. Keep it admin-only and read-only, scope and validate every argument, and never expose secrets.</source>
+                <target>Ein Tool läuft mit vollen Backend-Rechten und sein Ergebnis wird an den LLM-Provider übertragen. Es muss nur für Administratoren und lesend bleiben, jedes Argument prüfen und eingrenzen und darf niemals Geheimnisse preisgeben.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -35,6 +35,45 @@
             <trans-unit id="playground.empty">
                 <source>No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool.</source>
             </trans-unit>
+            <trans-unit id="playground.run.tools">
+                <source>Tools available to this run</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.enabled">
+                <source>Enabled</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.disabled">
+                <source>Disabled</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.default">
+                <source>Default</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.overridden">
+                <source>Override</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.enable">
+                <source>Enable</source>
+            </trans-unit>
+            <trans-unit id="playground.tool.disable">
+                <source>Disable</source>
+            </trans-unit>
+            <trans-unit id="playground.help.title">
+                <source>How to add a tool</source>
+            </trans-unit>
+            <trans-unit id="playground.help.intro">
+                <source>Tools are auto-discovered PHP classes — no manual registration is needed.</source>
+            </trans-unit>
+            <trans-unit id="playground.help.step.interface">
+                <source>Implement Netresearch\NrLlm\Service\Tool\ToolInterface (getSpec + execute + isEnabledByDefault).</source>
+            </trans-unit>
+            <trans-unit id="playground.help.step.tag">
+                <source>The class is auto-discovered via the nr_llm.tool DI tag — there is nothing else to register.</source>
+            </trans-unit>
+            <trans-unit id="playground.help.step.template">
+                <source>Copy Classes/Service/Tool/Builtin/FetchLogsTool.php as a starting template.</source>
+            </trans-unit>
+            <trans-unit id="playground.help.security">
+                <source>A tool runs with full backend privileges and its result egresses to the LLM provider. Keep it admin-only and read-only, scope and validate every argument, and never expose secrets.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Templates/Backend/ToolPlayground/List.html
+++ b/Resources/Private/Templates/Backend/ToolPlayground/List.html
@@ -38,6 +38,29 @@
                             <textarea id="nrllm-tool-prompt" class="form-control" rows="4"></textarea>
                         </div>
 
+                        <f:if condition="{toolStates -> f:count()}">
+                            <div class="mb-3">
+                                <label class="form-label">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run.tools" default="Tools available to this run" />
+                                </label>
+                                <f:for each="{toolStates}" as="tool">
+                                    <div class="form-check">
+                                        <f:if condition="{tool.enabled}">
+                                            <f:then>
+                                                <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" checked="checked" />
+                                            </f:then>
+                                            <f:else>
+                                                <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" />
+                                            </f:else>
+                                        </f:if>
+                                        <label class="form-check-label" for="nrllm-tool-select-{tool.name}">
+                                            <code>{tool.name}</code>
+                                        </label>
+                                    </div>
+                                </f:for>
+                            </div>
+                        </f:if>
+
                         <button type="button" id="nrllm-tool-run" class="btn btn-primary">
                             <core:icon identifier="actions-play" size="small" />
                             <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run" default="Run" />
@@ -51,16 +74,43 @@
 
             <div class="col-md-5">
                 <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tools" default="Available tools" /></h2>
-                <f:if condition="{tools -> f:count()}">
+                <f:if condition="{toolStates -> f:count()}">
                     <f:then>
                         <div class="card mb-4">
                             <ul class="list-group list-group-flush">
-                                <f:for each="{tools}" as="tool">
-                                    <li class="list-group-item">
-                                        <strong><code>{tool.name}</code></strong>
-                                        <f:if condition="{tool.description}">
-                                            <br><small class="text-body-secondary">{tool.description}</small>
-                                        </f:if>
+                                <f:for each="{toolStates}" as="tool">
+                                    <li class="list-group-item d-flex justify-content-between align-items-start">
+                                        <div class="me-3">
+                                            <strong><code>{tool.name}</code></strong>
+                                            <f:if condition="{tool.enabled}">
+                                                <f:then>
+                                                    <span class="badge bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.enabled" default="Enabled" /></span>
+                                                </f:then>
+                                                <f:else>
+                                                    <span class="badge bg-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.disabled" default="Disabled" /></span>
+                                                </f:else>
+                                            </f:if>
+                                            <f:if condition="{tool.overridden}">
+                                                <f:then>
+                                                    <span class="badge bg-info"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.overridden" default="Override" /></span>
+                                                </f:then>
+                                                <f:else>
+                                                    <span class="badge bg-light text-dark"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.default" default="Default" /></span>
+                                                </f:else>
+                                            </f:if>
+                                            <f:if condition="{tool.description}">
+                                                <br><small class="text-body-secondary">{tool.description}</small>
+                                            </f:if>
+                                        </div>
+                                        <button type="button"
+                                                class="btn btn-sm js-tool-toggle {f:if(condition: tool.enabled, then: 'btn-outline-secondary', else: 'btn-outline-success')}"
+                                                data-tool="{tool.name}"
+                                                data-enabled="{f:if(condition: tool.enabled, then: '1', else: '0')}">
+                                            <f:if condition="{tool.enabled}">
+                                                <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.disable" default="Disable" /></f:then>
+                                                <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.enable" default="Enable" /></f:else>
+                                            </f:if>
+                                        </button>
                                     </li>
                                 </f:for>
                             </ul>
@@ -72,6 +122,27 @@
                         </f:be.infobox>
                     </f:else>
                 </f:if>
+
+                <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.title" default="How to add a tool" /></h2>
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.intro" default="Tools are auto-discovered PHP classes — no manual registration is needed." /></p>
+                        <ol class="mb-3">
+                            <li>
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.step.interface" default="Implement Netresearch\NrLlm\Service\Tool\ToolInterface (getSpec + execute + isEnabledByDefault)." />
+                            </li>
+                            <li>
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.step.tag" default="The class is auto-discovered via the nr_llm.tool DI tag — there is nothing else to register." />
+                            </li>
+                            <li>
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.step.template" default="Copy Classes/Service/Tool/Builtin/FetchLogsTool.php as a starting template." />
+                            </li>
+                        </ol>
+                        <f:be.infobox state="-1">
+                            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.security" default="A tool runs with full backend privileges and its result egresses to the LLM provider. Keep it admin-only and read-only, scope and validate every argument, and never expose secrets." /></p>
+                        </f:be.infobox>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -60,6 +60,12 @@ class ToolPlayground {
         formData.append('configuration', configuration);
         formData.append('prompt', prompt);
 
+        // Restrict this run to the ticked tools. When none are ticked, the
+        // `tools` key is omitted and the server defaults to the enabled set.
+        this.root.querySelectorAll('.js-tool-select:checked').forEach((checkbox) => {
+            formData.append('tools[]', checkbox.value);
+        });
+
         if (this.runButton) {
             this.runButton.disabled = true;
         }

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -1,0 +1,64 @@
+/**
+ * Tool state JavaScript module for the TYPO3 backend (ES6 Module).
+ *
+ * Toggles the global enable/disable override of a single agent tool from the
+ * Tool Playground module. Mirrors SkillList.js: event delegation on the body
+ * and a CSRF-tokenised AJAX POST (the per-route token is embedded in
+ * TYPO3.settings.ajaxUrls).
+ */
+import Notification from '@typo3/backend/notification.js';
+
+class ToolState {
+    constructor() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.init());
+        } else {
+            this.init();
+        }
+    }
+
+    init() {
+        document.body.addEventListener('click', (e) => {
+            const toggleBtn = e.target.closest('.js-tool-toggle');
+            if (toggleBtn) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.handleToggle(toggleBtn);
+            }
+        });
+
+        console.debug('[ToolState] Initialized with event delegation');
+    }
+
+    handleToggle(btn) {
+        const tool = btn.dataset.tool;
+        const enabled = btn.dataset.enabled === '1' ? 0 : 1;
+        const url = TYPO3.settings.ajaxUrls['nrllm_tool_toggle'];
+        if (!url) {
+            Notification.error('Error', 'AJAX URL not configured');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('tool', tool);
+        formData.append('enabled', String(enabled));
+
+        btn.disabled = true;
+        fetch(url, { method: 'POST', body: formData })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                    btn.disabled = false;
+                }
+            })
+            .catch(err => {
+                Notification.error('Error', err.message);
+                btn.disabled = false;
+            });
+    }
+}
+
+export default new ToolState();

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -20,10 +20,10 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
-use Netresearch\NrLlm\Service\Skill\SkillComposer;
-use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
@@ -35,6 +35,7 @@ use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
@@ -74,13 +75,17 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $pageRenderer = $this->get(PageRenderer::class);
         self::assertInstanceOf(PageRenderer::class, $pageRenderer);
 
+        $toolRegistry = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $availability = $this->availabilityFor($toolRegistry);
+
         $controller = new ToolPlaygroundController(
             $moduleTemplateFactory,
-            new ToolRegistry([new FakeTool('fetch_logs')]),
+            $toolRegistry,
             $configurationRepository,
             $pageRenderer,
-            new AllowedToolsResolver(new SkillComposer()),
-            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([])),
+            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), $availability),
+            $availability,
+            new ToolStateRepository($this->toolConnectionPool()),
         );
         $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
 
@@ -110,10 +115,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $configurationRepository = $this->get(LlmConfigurationRepository::class);
         self::assertInstanceOf(LlmConfigurationRepository::class, $configurationRepository);
 
-        $controller = $this->makeController(
+        $emptyRegistry = new ToolRegistry([]);
+        $controller    = $this->makeController(
             $configurationRepository,
-            new ToolRegistry([]),
-            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([])),
+            $emptyRegistry,
+            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), $emptyRegistry, $this->availabilityFor($emptyRegistry)),
         );
 
         $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
@@ -171,7 +177,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, new NullLogger());
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
 
         $controller = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
 
@@ -223,9 +229,27 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             $toolRegistry,
             $configurationRepository,
             $pageRenderer,
-            new AllowedToolsResolver(new SkillComposer()),
             $toolLoopService,
+            $this->availabilityFor($toolRegistry),
+            new ToolStateRepository($this->toolConnectionPool()),
         );
+    }
+
+    /**
+     * Build the real availability service over the given registry, backed by the
+     * functional database — so the fail-closed gate is exercised end-to-end.
+     */
+    private function availabilityFor(ToolRegistry $toolRegistry): ToolAvailabilityService
+    {
+        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()));
+    }
+
+    private function toolConnectionPool(): ConnectionPool
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        return $connectionPool;
     }
 
     /**

--- a/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageTreeTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for GetPageTreeTool.
+ *
+ * Builds a small `pages` tree and asserts depth-indented output, sorting,
+ * and — load-bearing — that hidden and soft-deleted pages never reach the
+ * model-facing outline.
+ */
+#[CoversClass(GetPageTreeTool::class)]
+final class GetPageTreeToolTest extends AbstractFunctionalTestCase
+{
+    private GetPageTreeTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new GetPageTreeTool($connectionPool);
+
+        $connection = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $connection);
+        $this->insertPage($connection, 1, 0, 'Home', 1, ['sorting' => 1]);
+        $this->insertPage($connection, 2, 1, 'About', 1, ['sorting' => 1]);
+        $this->insertPage($connection, 3, 1, 'Hidden Branch', 1, ['sorting' => 2, 'hidden' => 1]);
+        $this->insertPage($connection, 4, 1, 'Deleted Branch', 1, ['sorting' => 3, 'deleted' => 1]);
+        $this->insertPage($connection, 5, 2, 'Team', 1, ['sorting' => 1]);
+    }
+
+    #[Test]
+    public function getSpecDeclaresGetPageTreeFunction(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('get_pagetree', $spec->name);
+        $properties = $spec->parameters['properties'] ?? null;
+        self::assertIsArray($properties);
+        self::assertArrayHasKey('rootUid', $properties);
+        self::assertArrayHasKey('depth', $properties);
+    }
+
+    #[Test]
+    public function returnsDepthIndentedLiveTree(): void
+    {
+        $output = $this->tool->execute(['rootUid' => 0, 'depth' => 3]);
+
+        self::assertStringContainsString('[1] Home (doktype 1)', $output);
+        // About is one level below Home, Team two levels below.
+        self::assertStringContainsString('  [2] About (doktype 1)', $output);
+        self::assertStringContainsString('    [5] Team (doktype 1)', $output);
+    }
+
+    #[Test]
+    public function excludesHiddenAndDeletedPages(): void
+    {
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3]);
+
+        self::assertStringNotContainsString('Hidden Branch', $output);
+        self::assertStringNotContainsString('Deleted Branch', $output);
+    }
+
+    #[Test]
+    public function depthOneStopsAtImmediateChildren(): void
+    {
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 1]);
+
+        self::assertStringContainsString('[2] About', $output);
+        // Team is a grandchild — beyond depth 1.
+        self::assertStringNotContainsString('Team', $output);
+    }
+
+    /**
+     * @param array{sorting?: int, hidden?: int, deleted?: int} $flags
+     */
+    private function insertPage(
+        Connection $connection,
+        int $uid,
+        int $pid,
+        string $title,
+        int $doktype,
+        array $flags = [],
+    ): void {
+        $connection->insert('pages', [
+            'uid'     => $uid,
+            'pid'     => $pid,
+            'title'   => $title,
+            'doktype' => $doktype,
+            'sorting' => $flags['sorting'] ?? 0,
+            'hidden'  => $flags['hidden'] ?? 0,
+            'deleted' => $flags['deleted'] ?? 0,
+        ]);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
+++ b/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ToolAvailabilityService: effective enable state derived
+ * from each tool's default and the admin overrides persisted in
+ * tx_nrllm_tool_state.
+ */
+#[CoversClass(ToolAvailabilityService::class)]
+final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
+{
+    private ToolStateRepository $stateRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->stateRepository = new ToolStateRepository($connectionPool);
+    }
+
+    #[Test]
+    public function enabledNamesUsesToolDefaultsWhenNoOverrides(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('safe_tool', 'ok', true),
+            new FakeTool('raw_tool', 'ok', false),
+        ]);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+
+        self::assertSame(['safe_tool'], $service->enabledNames());
+    }
+
+    #[Test]
+    public function overrideEnablesADefaultDisabledToolAndDisablesADefaultEnabledOne(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('safe_tool', 'ok', true),
+            new FakeTool('raw_tool', 'ok', false),
+        ]);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+
+        $this->stateRepository->setEnabled('raw_tool', true);
+        $this->stateRepository->setEnabled('safe_tool', false);
+
+        self::assertSame(['raw_tool'], $service->enabledNames());
+    }
+
+    #[Test]
+    public function statesReportsDefaultVersusOverriddenFlags(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('safe_tool', 'ok', true),
+            new FakeTool('raw_tool', 'ok', false),
+        ]);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+
+        $this->stateRepository->setEnabled('raw_tool', true);
+
+        $states = [];
+        foreach ($service->states() as $state) {
+            $states[$state['name']] = $state;
+        }
+
+        self::assertFalse($states['safe_tool']['overridden']);
+        self::assertTrue($states['safe_tool']['enabled']);
+        self::assertTrue($states['safe_tool']['defaultEnabled']);
+
+        self::assertTrue($states['raw_tool']['overridden']);
+        self::assertTrue($states['raw_tool']['enabled']);
+        self::assertFalse($states['raw_tool']['defaultEnabled']);
+        self::assertSame('desc of raw_tool', $states['raw_tool']['description']);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolStateRepositoryTest.php
+++ b/Tests/Functional/Service/Tool/ToolStateRepositoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ToolStateRepository against the tx_nrllm_tool_state table.
+ *
+ * Verifies the upsert semantics: a fresh store has no overrides, the first
+ * setEnabled() inserts a row, a second on the same tool updates it in place
+ * (no duplicate, even when the value is unchanged), and overrides() reflects
+ * the persisted booleans.
+ */
+#[CoversClass(ToolStateRepository::class)]
+final class ToolStateRepositoryTest extends AbstractFunctionalTestCase
+{
+    private ToolStateRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->repository = new ToolStateRepository($connectionPool);
+    }
+
+    #[Test]
+    public function freshStoreHasNoOverrides(): void
+    {
+        self::assertSame([], $this->repository->overrides());
+    }
+
+    #[Test]
+    public function setEnabledInsertsThenReflectsInOverrides(): void
+    {
+        $this->repository->setEnabled('get_env_raw', true);
+        $this->repository->setEnabled('list_be_users_raw', false);
+
+        $overrides = $this->repository->overrides();
+
+        self::assertTrue($overrides['get_env_raw'] ?? null);
+        self::assertFalse($overrides['list_be_users_raw'] ?? null);
+    }
+
+    #[Test]
+    public function repeatedSetEnabledUpdatesInPlaceWithoutDuplicateRow(): void
+    {
+        $this->repository->setEnabled('get_env_raw', true);
+        // Same value again — must not create a second row.
+        $this->repository->setEnabled('get_env_raw', true);
+        // Then flip it.
+        $this->repository->setEnabled('get_env_raw', false);
+
+        $overrides = $this->repository->overrides();
+        self::assertArrayHasKey('get_env_raw', $overrides);
+        self::assertFalse($overrides['get_env_raw']);
+
+        $rowCount = $this->get(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_tool_state')
+            ->count('uid', 'tx_nrllm_tool_state', ['tool_name' => 'get_env_raw']);
+        self::assertSame(1, $rowCount);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvRawTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GetEnvRawTool.
+ *
+ * The raw variant performs NO redaction (that is the whole point) and is
+ * therefore disabled by default — both contracts are asserted here.
+ */
+#[CoversClass(GetEnvRawTool::class)]
+final class GetEnvRawToolTest extends TestCase
+{
+    private const SECRET_KEY = 'NRLLM_TEST_RAW_SECRET_KEY';
+    private const SECRET_VALUE = 'raw-unmasked-value';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv(self::SECRET_KEY . '=' . self::SECRET_VALUE);
+        $_ENV[self::SECRET_KEY] = self::SECRET_VALUE;
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(self::SECRET_KEY);
+        unset($_ENV[self::SECRET_KEY]);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function isDisabledByDefault(): void
+    {
+        self::assertFalse((new GetEnvRawTool())->isEnabledByDefault());
+        self::assertSame('get_env_raw', (new GetEnvRawTool())->getSpec()->name);
+    }
+
+    #[Test]
+    public function returnsSecretValueUnredacted(): void
+    {
+        $output = (new GetEnvRawTool())->execute([]);
+
+        self::assertStringContainsString(self::SECRET_KEY . '=' . self::SECRET_VALUE, $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GetEnvTool.
+ *
+ * Load-bearing: a variable whose NAME matches a secret pattern has its VALUE
+ * redacted before egress, while a non-secret variable keeps its value. Real
+ * process env vars are set with putenv() and cleaned up afterwards.
+ */
+#[CoversClass(GetEnvTool::class)]
+final class GetEnvToolTest extends TestCase
+{
+    private const PLAIN_KEY = 'NRLLM_TEST_PLAIN_HOST';
+    private const PLAIN_VALUE = 'web-01.example.test';
+    private const SECRET_KEY = 'NRLLM_TEST_DB_PASSWORD';
+    private const SECRET_VALUE = 'sup3r-s3cr3t-value';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv(self::PLAIN_KEY . '=' . self::PLAIN_VALUE);
+        putenv(self::SECRET_KEY . '=' . self::SECRET_VALUE);
+        $_ENV[self::PLAIN_KEY]  = self::PLAIN_VALUE;
+        $_ENV[self::SECRET_KEY] = self::SECRET_VALUE;
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(self::PLAIN_KEY);
+        putenv(self::SECRET_KEY);
+        unset($_ENV[self::PLAIN_KEY], $_ENV[self::SECRET_KEY]);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getSpecDeclaresGetEnvFunction(): void
+    {
+        $spec = (new GetEnvTool())->getSpec();
+
+        self::assertSame('get_env', $spec->name);
+        self::assertTrue((new GetEnvTool())->isEnabledByDefault());
+    }
+
+    #[Test]
+    public function nonSecretValueIsShownButSecretValueIsRedacted(): void
+    {
+        $output = (new GetEnvTool())->execute([]);
+
+        self::assertStringContainsString(self::PLAIN_KEY . '=' . self::PLAIN_VALUE, $output);
+        // The secret variable appears, but its value is masked.
+        self::assertStringContainsString(self::SECRET_KEY . '=***redacted***', $output);
+        self::assertStringNotContainsString(self::SECRET_VALUE, $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/GetPhpInfoRawToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetPhpInfoRawToolTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoRawTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GetPhpInfoRawTool.
+ *
+ * The raw variant captures the full phpinfo(INFO_ALL) output and is disabled by
+ * default — both are asserted here.
+ */
+#[CoversClass(GetPhpInfoRawTool::class)]
+final class GetPhpInfoRawToolTest extends TestCase
+{
+    #[Test]
+    public function isDisabledByDefault(): void
+    {
+        self::assertFalse((new GetPhpInfoRawTool())->isEnabledByDefault());
+        self::assertSame('get_php_info_raw', (new GetPhpInfoRawTool())->getSpec()->name);
+    }
+
+    #[Test]
+    public function capturesFullPhpInfoOutput(): void
+    {
+        $output = (new GetPhpInfoRawTool())->execute([]);
+
+        // phpinfo() always emits the PHP version line in its capture; in CLI it
+        // is plain text ("PHP Version => x.y.z").
+        self::assertStringContainsString('PHP Version', $output);
+        self::assertStringContainsString(PHP_VERSION, $output);
+        self::assertNotSame('phpinfo unavailable.', $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/GetPhpInfoToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetPhpInfoToolTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GetPhpInfoTool.
+ *
+ * Asserts the curated subset (version, extensions, the few safe ini keys) is
+ * present and that it stays curated — the full phpinfo() server/env dump must
+ * NOT leak through this tool.
+ */
+#[CoversClass(GetPhpInfoTool::class)]
+final class GetPhpInfoToolTest extends TestCase
+{
+    #[Test]
+    public function getSpecDeclaresGetPhpInfoFunction(): void
+    {
+        self::assertSame('get_php_info', (new GetPhpInfoTool())->getSpec()->name);
+        self::assertTrue((new GetPhpInfoTool())->isEnabledByDefault());
+    }
+
+    #[Test]
+    public function returnsCuratedRuntimeSubset(): void
+    {
+        $output = (new GetPhpInfoTool())->execute([]);
+
+        self::assertStringContainsString('PHP version: ' . PHP_VERSION, $output);
+        self::assertStringContainsString('Loaded extensions (', $output);
+        self::assertStringContainsString('Core', $output);
+        self::assertStringContainsString('memory_limit = ', $output);
+        self::assertStringContainsString('date.timezone = ', $output);
+
+        // Curated — not a full phpinfo() dump of the server environment.
+        self::assertStringNotContainsString('$_SERVER', $output);
+        self::assertStringNotContainsString('phpinfo()', $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTcaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GetTcaTool.
+ *
+ * Drives the tool against a controlled $GLOBALS['TCA'] so the schema-only
+ * contract (table listing, column types, neutral unknown-table string) is
+ * asserted without a database.
+ */
+#[CoversClass(GetTcaTool::class)]
+final class GetTcaToolTest extends TestCase
+{
+    /** @var array<array-key, mixed> */
+    private array $tcaBackup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tcaBackup = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+
+        $GLOBALS['TCA'] = [
+            'pages' => [
+                'columns' => [
+                    'title'   => ['config' => ['type' => 'input']],
+                    'doktype' => ['config' => ['type' => 'select']],
+                    'broken'  => ['label' => 'no config here'],
+                ],
+            ],
+            'tt_content' => [
+                'columns' => [
+                    'header' => ['config' => ['type' => 'input']],
+                ],
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TCA'] = $this->tcaBackup;
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getSpecDeclaresGetTcaFunctionWithOptionalTable(): void
+    {
+        $spec = (new GetTcaTool())->getSpec();
+
+        self::assertSame('get_tca', $spec->name);
+        self::assertSame('object', $spec->parameters['type'] ?? null);
+        $properties = $spec->parameters['properties'] ?? null;
+        self::assertIsArray($properties);
+        self::assertArrayHasKey('table', $properties);
+    }
+
+    #[Test]
+    public function withoutTableArgumentListsSortedTableNames(): void
+    {
+        $output = (new GetTcaTool())->execute([]);
+
+        self::assertStringContainsString('TCA tables (2):', $output);
+        // Sorted: pages before tt_content.
+        self::assertStringContainsString("pages\ntt_content", $output);
+    }
+
+    #[Test]
+    public function withTableArgumentReturnsColumnNamesAndTypes(): void
+    {
+        $output = (new GetTcaTool())->execute(['table' => 'pages']);
+
+        self::assertStringContainsString('TCA columns for pages:', $output);
+        self::assertStringContainsString('title: input', $output);
+        self::assertStringContainsString('doktype: select', $output);
+        // A column without config.type falls back to "?", never an error.
+        self::assertStringContainsString('broken: ?', $output);
+    }
+
+    #[Test]
+    public function unknownTableReturnsNeutralString(): void
+    {
+        self::assertSame('Unknown TCA table.', (new GetTcaTool())->execute(['table' => 'no_such_table']));
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -24,6 +24,7 @@ final readonly class FakeTool implements ToolInterface
     public function __construct(
         private string $name,
         private string $result = 'ok',
+        private bool $enabledByDefault = true,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -41,5 +42,10 @@ final readonly class FakeTool implements ToolInterface
     public function execute(array $arguments): string
     {
         return $this->result;
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return $this->enabledByDefault;
     }
 }

--- a/Tests/Unit/Service/Tool/Fixtures/FakeToolAvailability.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeToolAvailability.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
+
+/**
+ * In-memory {@see ToolAvailabilityServiceInterface} double for the
+ * ToolLoopService unit tests.
+ *
+ * Carries a fixed list of globally-enabled tool names so a test can exercise
+ * the fail-closed gate (intersection with the per-run allow-list) without a
+ * database. The richer {@see states()} payload is unused by the loop and
+ * returns an empty list.
+ */
+final readonly class FakeToolAvailability implements ToolAvailabilityServiceInterface
+{
+    /**
+     * @param list<string> $enabledNames
+     */
+    public function __construct(private array $enabledNames) {}
+
+    public function enabledNames(): array
+    {
+        return $this->enabledNames;
+    }
+
+    public function states(): array
+    {
+        return [];
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +42,7 @@ final class ToolLoopServiceTest extends TestCase
 
         // A registered tool keeps the loop on the tools path (an empty registry
         // would short-circuit to a plain completion — covered separately).
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('noop')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
         $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), null);
 
         self::assertSame('the answer', $result->finalContent);
@@ -61,7 +62,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             ->willReturnCallback($this->queueCallback($queue));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
         $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
 
         self::assertCount(1, $result->trace);
@@ -87,7 +88,7 @@ final class ToolLoopServiceTest extends TestCase
         // The registry holds a different tool so the loop stays on the tools
         // path; the model then requests the unregistered name "nope", which
         // registry->get() resolves to null (the unknown-tool branch).
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('real_tool')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('real_tool')]));
         $result  = $service->runLoop([$this->userTurn('do it')], new LlmConfiguration(), null);
 
         self::assertCount(1, $result->trace);
@@ -113,6 +114,11 @@ final class ToolLoopServiceTest extends TestCase
             {
                 throw new RuntimeException('boom https://x?key=secret', 1782700101);
             }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -123,7 +129,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             ->willReturnCallback($this->queueCallback($queue));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([$throwing]));
+        $service = $this->service($mgr, new ToolRegistry([$throwing]));
         $result  = $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), null);
 
         self::assertCount(1, $result->trace);
@@ -152,6 +158,11 @@ final class ToolLoopServiceTest extends TestCase
             {
                 throw new RuntimeException('boom https://x?key=secret', 1782700101);
             }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -175,7 +186,7 @@ final class ToolLoopServiceTest extends TestCase
                 ),
             );
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([$throwing]), $logger);
+        $service = $this->service($mgr, new ToolRegistry([$throwing]), $logger);
         $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), null);
     }
 
@@ -192,7 +203,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             ->willReturnCallback($this->queueCallback($queue, $captured));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
         $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
 
         // The second round must carry the appended assistant + tool turns.
@@ -225,7 +236,7 @@ final class ToolLoopServiceTest extends TestCase
             ->method('chatWithConfiguration')
             ->willReturn($this->response('SYNTHESISED'));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
         $result  = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), null, null, 2);
 
         self::assertSame(2, $result->iterations);
@@ -244,13 +255,17 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             // $messages is an unused positional placeholder for the $tools arg.
             ->willReturnCallback(function (array $messages, array $tools) use (&$capturedTools, $response): CompletionResponse {
+                // $messages must stay first so $tools binds positionally to the
+                // real chatWithToolsForConfiguration signature; assert it rather
+                // than leave it unused.
+                self::assertNotSame([], $messages);
                 $capturedTools[] = $tools;
 
                 return $response;
             });
 
         $registry = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
-        $service  = new ToolLoopService($mgr, $registry);
+        $service  = $this->service($mgr, $registry);
         $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ['fetch_logs']);
 
         $specs = self::arr($capturedTools[0] ?? null);
@@ -280,7 +295,7 @@ final class ToolLoopServiceTest extends TestCase
                 throw $budgetException;
             });
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
         $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
 
         self::assertTrue($result->truncated);
@@ -301,7 +316,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')
             ->willReturnCallback($this->queueCallback($queue));
 
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
         $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
 
         self::assertSame(13, $result->usage->promptTokens);
@@ -320,7 +335,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
 
         // A tool IS registered, but the empty allow-list offers none of them.
-        $service = new ToolLoopService($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
         $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), []);
 
         self::assertSame('plain answer', $result->finalContent);
@@ -349,6 +364,11 @@ final class ToolLoopServiceTest extends TestCase
 
                 return 'META';
             }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -361,7 +381,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturnCallback($this->queueCallback($queue));
 
         $registry = new ToolRegistry([new FakeTool('fetch_logs'), $spy]);
-        $service  = new ToolLoopService($mgr, $registry);
+        $service  = $this->service($mgr, $registry);
         $result   = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['fetch_logs']);
 
         self::assertCount(1, $result->trace);
@@ -369,6 +389,83 @@ final class ToolLoopServiceTest extends TestCase
         self::assertStringContainsString('not permitted', $result->trace[0]->result);
         self::assertFalse($spy->executed, 'a disallowed tool must never be executed');
         self::assertSame('done', $result->finalContent);
+    }
+
+    #[Test]
+    public function globallyDisabledToolIsNeverOfferedEvenWhenExplicitlyAllowed(): void
+    {
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        // The disabled tool drops out of the effective set ⇒ no tools offered ⇒
+        // exactly one plain completion, never the tools path.
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('plain answer'));
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+        // fetch_logs IS registered, but the global gate reports it disabled.
+        $service = new ToolLoopService(
+            $mgr,
+            new ToolRegistry([new FakeTool('fetch_logs')]),
+            new FakeToolAvailability([]),
+        );
+        // The caller explicitly lists the disabled tool — the gate still wins.
+        $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ['fetch_logs']);
+
+        self::assertSame('plain answer', $result->finalContent);
+        self::assertSame([], $result->trace);
+        self::assertSame(1, $result->iterations);
+    }
+
+    #[Test]
+    public function nullAllowListDefaultsToEnabledSetNotEveryRegisteredTool(): void
+    {
+        $capturedTools = [];
+        $response      = $this->response('done');
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback(function (array $messages, array $tools) use (&$capturedTools, $response): CompletionResponse {
+                // $messages must stay first so $tools binds positionally to the
+                // real chatWithToolsForConfiguration signature; assert it rather
+                // than leave it unused.
+                self::assertNotSame([], $messages);
+                $capturedTools[] = $tools;
+
+                return $response;
+            });
+
+        // Two tools registered, but only one is globally enabled.
+        $registry = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
+        $service  = new ToolLoopService($mgr, $registry, new FakeToolAvailability(['fetch_logs']));
+        // null ⇒ "no per-run restriction" ⇒ collapses to the enabled set only.
+        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), null);
+
+        $specs = self::arr($capturedTools[0] ?? null);
+        $names = array_map(
+            static fn(mixed $s): string => $s instanceof ToolSpec ? $s->name : '<not-a-spec>',
+            array_values($specs),
+        );
+        self::assertSame(['fetch_logs'], $names);
+    }
+
+    /**
+     * Build a ToolLoopService whose global availability gate is a no-op: every
+     * registered tool counts as enabled, so the loop's effective allow-set is
+     * governed solely by the caller's $allowedToolNames (the behaviour these
+     * tests target). Gating-specific tests build the service inline with a
+     * restricted {@see FakeToolAvailability}.
+     */
+    private function service(
+        LlmServiceManagerInterface $mgr,
+        ToolRegistry $registry,
+        ?LoggerInterface $logger = null,
+    ): ToolLoopService {
+        return new ToolLoopService(
+            $mgr,
+            $registry,
+            new FakeToolAvailability($registry->names()),
+            $logger,
+        );
     }
 
     /**

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -516,3 +516,20 @@ CREATE TABLE tx_nrllm_configuration_skill_mm (
     KEY uid_local (uid_local),
     KEY uid_foreign (uid_foreign)
 );
+
+#
+# Table structure for table 'tx_nrllm_tool_state'
+# Global per-tool enable/disable overrides for the agent tool runtime.
+# Managed via the Tool Playground module toggles (no FormEngine UI / no TCA);
+# a missing row means "use the tool's isEnabledByDefault()".
+#
+CREATE TABLE tx_nrllm_tool_state (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    tool_name varchar(190) DEFAULT '' NOT NULL,
+    enabled smallint(5) unsigned DEFAULT '1' NOT NULL,
+
+    PRIMARY KEY (uid),
+    UNIQUE KEY tool_name (tool_name)
+);


### PR DESCRIPTION
## Description

Builds out the **Tools** subsystem: per-tool enable/disable, in-module guidance, a playground per-run override, and nine read-only builtin system tools.

### Per-tool enable/disable (DB-backed, fail-closed)
- New table `tx_nrllm_tool_state` (`tool_name` unique + `enabled`) + `ToolStateRepository` (upsert).
- `ToolInterface::isEnabledByDefault()` — each tool declares its default.
- `ToolAvailabilityService`: effective state = admin override (if any) **else** the tool's default.
- **Fail-closed runtime gating** in `ToolLoopService`: the per-run allow-list is intersected with the globally-enabled set; a caller passing `null` collapses to the *enabled* set (not all tools), and a model steered by injected skill prose can't call a globally-disabled tool. Defense-in-depth: re-checked again at execution time.

### Tools backend module (playground)
- In-page **"How to add a tool"** help block (implement `ToolInterface`, auto-discovered via the `nr_llm.tool` DI tag, with `FetchLogsTool` as the copy-paste template).
- Per-tool **enable/disable toggles** (AJAX, admin-gated) showing default-vs-overridden state.
- **Per-run override**: the run form lists tools with checkboxes (pre-checked per the enabled set); the run can further restrict, but the global fail-closed gate still applies.

### Nine builtin system tools (read-only, admin-context)
| Tool | Default | Notes |
|------|---------|-------|
| `get_pagetree` | on | bounded depth |
| `get_tca` | on | schema only (column names + `config.type`), never data |
| `list_be_groups` | on | TYPO3 backend "roles" *are* be_groups |
| `list_be_users` | on | explicit column allow-list — **password/mfa never selected** |
| `list_be_users_raw` | **off** | full profile, still strips `password`+`mfa` |
| `get_env` | on | secret-name values redacted (`PASS|TOKEN|KEY|SECRET|…`) |
| `get_env_raw` | **off** | unredacted; docblock warns values egress to the provider |
| `get_php_info` | on | curated subset (version, extensions, safe ini) |
| `get_php_info_raw` | **off** | full `phpinfo()` |

Sensitive tools ship in **redacted + raw** variants; **all raw variants are disabled by default** (admin must opt in). The `be_users.password` hash is never selected — even in the raw variant.

## Type of Change
- [x] Feature

## Checklist
- [x] Unit 3750 · Functional (Tool* incl. fail-closed gating + new table) green · PHPStan L10 · CGL · Rector clean (PHP 8.4)
- [x] EN + DE labels (`locallang_mod_tool.xlf`)
- [x] Security: fail-closed gating verified; raw tools disabled by default; password/mfa never egress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
