### PR TITLE
feat(backend): module UX, help, glossary, readiness & enablement overhaul

### DIFF
--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -133,6 +133,7 @@ final class ModelController extends ActionController
             'editUrls' => $editUrls,
             'newUrl' => $this->buildNewUrl(),
             'wizardUrl' => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_wizard'),
+            'hasDefaultModel' => $this->modelRepository->findDefault() !== null,
             'costByModel' => $usage['cost'],
             'reqByModel' => $usage['requests'],
             'tokByModel' => $usage['tokens'],

--- a/Classes/Controller/Backend/RequiresBackendAdminTrait.php
+++ b/Classes/Controller/Backend/RequiresBackendAdminTrait.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend;
 
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Shared admin guard for the backend module's standalone AJAX endpoints.
@@ -35,6 +37,20 @@ trait RequiresBackendAdminTrait
         if ($backendUser instanceof BackendUserAuthentication && $backendUser->isAdmin()) {
             return null;
         }
-        return new JsonResponse(['success' => false, 'error' => 'Forbidden'], 403);
+
+        $fallback = 'This action requires backend administrator privileges. Please contact your site administrator.';
+
+        try {
+            $message = LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.adminRequired',
+                'NrLlm',
+            ) ?? $fallback;
+        } catch (Throwable) {
+            // Outside a full TYPO3 request (e.g. an isolated unit context) the
+            // language service may be unavailable; fall back to the English message.
+            $message = $fallback;
+        }
+
+        return new JsonResponse(['success' => false, 'error' => $message], 403);
     }
 }

--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -60,8 +60,23 @@ final class SkillSourceController extends ActionController
             ->setHref($this->formEngineUrlBuilder->buildNewUrl('tx_nrllm_skill_source', 'nrllm_skills'));
         $buttonBar->addButton($createButton);
 
+        $sources = $this->sourceRepository->findAll();
+
+        // FormEngine edit URLs per source, returning to this module after save/close
+        // (mirrors the docheader "Add source" button's buildNewUrl pattern).
+        /** @var array<int, string> $sourceEditUrls */
+        $sourceEditUrls = [];
+        foreach ($sources as $source) {
+            $uid = $source->getUid();
+            if ($uid === null) {
+                continue;
+            }
+            $sourceEditUrls[$uid] = $this->formEngineUrlBuilder->buildEditUrl('tx_nrllm_skill_source', $uid, 'nrllm_skills');
+        }
+
         $moduleTemplate->assignMultiple([
-            'sources' => $this->sourceRepository->findAll(),
+            'sources' => $sources,
+            'sourceEditUrls' => $sourceEditUrls,
             'skills' => $this->skillRepository->findAll(),
         ]);
         return $moduleTemplate->renderResponse('Backend/Skill/List');

--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -97,6 +97,7 @@ final class TaskListController extends ActionController
         $moduleTemplate->assignMultiple([
             'groupedTasks' => $groupedTasks,
             'totalCount'   => $tasks->count(),
+            'activeCount'  => $this->taskRepository->countActive(),
             'editUrls'     => $editUrls,
             'newUrl'       => $this->buildNewUrl(),
             'wizardUrl'    => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_wizard'),

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -230,6 +230,10 @@
                 <source>Error</source>
                 <target>Fehler</target>
             </trans-unit>
+            <trans-unit id="error.adminRequired">
+                <source>This action requires backend administrator privileges. Please contact your site administrator to enable LLM management for your account.</source>
+                <target>Diese Aktion erfordert Backend-Administratorrechte. Bitte wenden Sie sich an Ihren Website-Administrator, um die LLM-Verwaltung für Ihr Konto zu aktivieren.</target>
+            </trans-unit>
             <trans-unit id="provider">
                 <source>Provider</source>
                 <target>Anbieter</target>
@@ -627,6 +631,854 @@
             <trans-unit id="skill.skills.empty.message">
                 <source>No skills have been ingested yet. Add a source and run a sync.</source>
                 <target>Es wurden noch keine Skills importiert. Fügen Sie eine Quelle hinzu und starten Sie eine Synchronisierung.</target>
+            </trans-unit>
+
+            <!-- Glossary partial -->
+            <trans-unit id="glossary.title">
+                <source>Terms &amp; Parameters</source>
+                <target>Begriffe &amp; Parameter</target>
+            </trans-unit>
+            <trans-unit id="glossary.intro">
+                <source>A quick reference for the terms and numeric parameters used across these modules.</source>
+                <target>Eine Kurzreferenz der Begriffe und numerischen Parameter, die in diesen Modulen verwendet werden.</target>
+            </trans-unit>
+            <trans-unit id="glossary.section.terms">
+                <source>Terms</source>
+                <target>Begriffe</target>
+            </trans-unit>
+            <trans-unit id="glossary.section.params">
+                <source>Numeric parameters</source>
+                <target>Numerische Parameter</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.provider.label">
+                <source>Provider</source>
+                <target>Anbieter</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.provider.text">
+                <source>An API connection to an LLM service (OpenAI, Claude, Gemini, Ollama, …). Stores endpoint, adapter type and the encrypted API key.</source>
+                <target>Eine API-Verbindung zu einem LLM-Dienst (OpenAI, Claude, Gemini, Ollama, …). Speichert Endpunkt, Adaptertyp und den verschlüsselten API-Schlüssel.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.adapter.label">
+                <source>Adapter type</source>
+                <target>Adaptertyp</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.adapter.text">
+                <source>The protocol dialect a provider speaks (e.g. OpenAI-compatible, Anthropic, Gemini). Determines how requests are formatted.</source>
+                <target>Der Protokolldialekt, den ein Anbieter spricht (z. B. OpenAI-kompatibel, Anthropic, Gemini). Bestimmt, wie Anfragen formatiert werden.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.model.label">
+                <source>Model</source>
+                <target>Modell</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.model.text">
+                <source>A specific model offered by a provider (e.g. gpt-4o, claude-sonnet). Carries its capabilities, context window and cost.</source>
+                <target>Ein bestimmtes Modell, das ein Anbieter bereitstellt (z. B. gpt-4o, claude-sonnet). Trägt seine Fähigkeiten, sein Kontextfenster und seine Kosten.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.configuration.label">
+                <source>Configuration</source>
+                <target>Konfiguration</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.configuration.text">
+                <source>A reusable preset that bundles a model with default parameters and a system prompt. Tasks and consuming extensions reference it.</source>
+                <target>Eine wiederverwendbare Vorlage, die ein Modell mit Standardparametern und einem System-Prompt bündelt. Aufgaben und verwendende Erweiterungen verweisen darauf.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.capabilities.label">
+                <source>Capabilities</source>
+                <target>Fähigkeiten</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.capabilities.text">
+                <source>What a model can do: chat, vision (image input), tool_use (function calling) and embeddings (vector representations).</source>
+                <target>Was ein Modell kann: chat, vision (Bildeingabe), tool_use (Funktionsaufrufe) und embeddings (Vektordarstellungen).</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.fallback.label">
+                <source>Fallback chain</source>
+                <target>Fallback-Kette</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.fallback.text">
+                <source>An ordered list of providers tried in turn: if one fails, the next is used automatically.</source>
+                <target>Eine geordnete Liste von Anbietern, die nacheinander versucht werden: Schlägt einer fehl, wird automatisch der nächste verwendet.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.priority.label">
+                <source>Priority</source>
+                <target>Priorität</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.priority.text">
+                <source>Ordering weight when several providers qualify. Lower number = higher priority (tried first).</source>
+                <target>Gewichtung der Reihenfolge, wenn mehrere Anbieter infrage kommen. Niedrigere Zahl = höhere Priorität (zuerst versucht).</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.vault.label">
+                <source>Vault UUID</source>
+                <target>Vault-UUID</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.vault.text">
+                <source>A reference to an API key stored encrypted by the nr-vault extension. The key itself is never kept in the database in plain text.</source>
+                <target>Ein Verweis auf einen API-Schlüssel, der von der Erweiterung nr-vault verschlüsselt gespeichert wird. Der Schlüssel selbst wird nie im Klartext in der Datenbank abgelegt.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.token.label">
+                <source>Token</source>
+                <target>Token</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.token.text">
+                <source>The unit LLMs read and write in — roughly a word fragment. Usage and cost are measured in tokens.</source>
+                <target>Die Einheit, in der LLMs lesen und schreiben — etwa ein Wortfragment. Nutzung und Kosten werden in Token gemessen.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.context.label">
+                <source>Context window</source>
+                <target>Kontextfenster</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.context.text">
+                <source>The maximum number of tokens (input plus output) a model can handle in a single request.</source>
+                <target>Die maximale Anzahl an Token (Eingabe plus Ausgabe), die ein Modell in einer einzelnen Anfrage verarbeiten kann.</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.budget.label">
+                <source>Budget</source>
+                <target>Budget</target>
+            </trans-unit>
+            <trans-unit id="glossary.term.budget.text">
+                <source>A per-user spending ceiling. Requests are blocked once the ceiling for the period is reached.</source>
+                <target>Eine Ausgabenobergrenze pro Benutzer. Anfragen werden blockiert, sobald die Grenze für den Zeitraum erreicht ist.</target>
+            </trans-unit>
+            <trans-unit id="glossary.param.temperature">
+                <source>Randomness of the output (typically 0–2). Lower = more focused and deterministic, higher = more creative.</source>
+                <target>Zufälligkeit der Ausgabe (typisch 0–2). Niedriger = fokussierter und deterministischer, höher = kreativer.</target>
+            </trans-unit>
+            <trans-unit id="glossary.param.maxTokens">
+                <source>Upper limit on the number of tokens the model may generate in its response.</source>
+                <target>Obergrenze für die Anzahl der Token, die das Modell in seiner Antwort erzeugen darf.</target>
+            </trans-unit>
+            <trans-unit id="glossary.param.topP">
+                <source>Nucleus sampling (0–1): only the most probable tokens whose cumulative probability reaches top_p are considered. An alternative to temperature.</source>
+                <target>Nucleus-Sampling (0–1): Es werden nur die wahrscheinlichsten Token berücksichtigt, deren kumulierte Wahrscheinlichkeit top_p erreicht. Eine Alternative zu temperature.</target>
+            </trans-unit>
+            <trans-unit id="glossary.param.frequencyPenalty">
+                <source>Discourages repeating the same tokens (typically -2 to 2). Higher values reduce verbatim repetition.</source>
+                <target>Verringert das Wiederholen derselben Token (typisch -2 bis 2). Höhere Werte reduzieren wörtliche Wiederholungen.</target>
+            </trans-unit>
+            <trans-unit id="glossary.param.presencePenalty">
+                <source>Encourages introducing new topics (typically -2 to 2). Higher values push the model toward novelty.</source>
+                <target>Fördert das Einbringen neuer Themen (typisch -2 bis 2). Höhere Werte drängen das Modell zu mehr Abwechslung.</target>
+            </trans-unit>
+
+            <!-- Per-module help / admin / see-also -->
+            <trans-unit id="module.adminOnly">
+                <source>This module is admin-only. Records and actions here affect every editor using LLM features.</source>
+                <target>Dieses Modul ist nur für Administratoren. Datensätze und Aktionen hier wirken sich auf alle Redakteure aus, die LLM-Funktionen nutzen.</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.heading">
+                <source>See also</source>
+                <target>Siehe auch</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.next.models">
+                <source>Next: register Models</source>
+                <target>Weiter: Modelle anlegen</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.next.configurations">
+                <source>Next: create Configurations</source>
+                <target>Weiter: Konfigurationen erstellen</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.providers">
+                <source>Providers</source>
+                <target>Anbieter</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.models">
+                <source>Models</source>
+                <target>Modelle</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.docs">
+                <source>Read the documentation</source>
+                <target>Dokumentation lesen</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.help">
+                <source>Open Help</source>
+                <target>Hilfe öffnen</target>
+            </trans-unit>
+
+            <!-- Readiness (overview) -->
+            <trans-unit id="readiness.title">
+                <source>Setup readiness</source>
+                <target>Einrichtungsstatus</target>
+            </trans-unit>
+            <trans-unit id="readiness.ready">
+                <source>Ready</source>
+                <target>Bereit</target>
+            </trans-unit>
+            <trans-unit id="readiness.incomplete">
+                <source>Setup incomplete</source>
+                <target>Einrichtung unvollständig</target>
+            </trans-unit>
+            <trans-unit id="readiness.step.provider">
+                <source>At least one Provider</source>
+                <target>Mindestens ein Anbieter</target>
+            </trans-unit>
+            <trans-unit id="readiness.step.model">
+                <source>At least one Model</source>
+                <target>Mindestens ein Modell</target>
+            </trans-unit>
+            <trans-unit id="readiness.step.configuration">
+                <source>At least one Configuration</source>
+                <target>Mindestens eine Konfiguration</target>
+            </trans-unit>
+            <trans-unit id="readiness.hint">
+                <source>Set up Provider → Model → Configuration in that order, then create Tasks.</source>
+                <target>Richten Sie Anbieter → Modell → Konfiguration in dieser Reihenfolge ein und erstellen Sie anschließend Aufgaben.</target>
+            </trans-unit>
+            <trans-unit id="help.card.title">
+                <source>Help &amp; Documentation</source>
+                <target>Hilfe &amp; Dokumentation</target>
+            </trans-unit>
+            <trans-unit id="help.card.subtitle">
+                <source>Guides and reference</source>
+                <target>Anleitungen und Referenz</target>
+            </trans-unit>
+            <trans-unit id="skill.card.title">
+                <source>Skills</source>
+                <target>Skills</target>
+            </trans-unit>
+            <trans-unit id="skill.card.subtitle">
+                <source>Agent skill library</source>
+                <target>Skill-Bibliothek für den Agenten</target>
+            </trans-unit>
+            <trans-unit id="skill.card.description">
+                <source>Sync GitHub-hosted SKILL.md sources and enable the skills available to the agent.</source>
+                <target>Auf GitHub gehostete SKILL.md-Quellen synchronisieren und die für den Agenten verfügbaren Skills aktivieren.</target>
+            </trans-unit>
+            <trans-unit id="skill.card.button">
+                <source>Manage Skills</source>
+                <target>Skills verwalten</target>
+            </trans-unit>
+            <trans-unit id="tool.card.title">
+                <source>Tools</source>
+                <target>Werkzeuge</target>
+            </trans-unit>
+            <trans-unit id="tool.card.subtitle">
+                <source>Function-calling tools</source>
+                <target>Werkzeuge für Funktionsaufrufe</target>
+            </trans-unit>
+            <trans-unit id="tool.card.description">
+                <source>Function-calling tools available to the agent, with an admin playground to test them.</source>
+                <target>Werkzeuge für Funktionsaufrufe, die dem Agenten zur Verfügung stehen, mit einem Administrator-Playground zum Testen.</target>
+            </trans-unit>
+            <trans-unit id="tool.card.button">
+                <source>Open Tool Playground</source>
+                <target>Werkzeug-Playground öffnen</target>
+            </trans-unit>
+            <trans-unit id="help.card.description">
+                <source>Read the in-module help and the online documentation for setup guidance and troubleshooting.</source>
+                <target>Lesen Sie die Hilfe im Modul und die Online-Dokumentation für Einrichtungshinweise und Fehlerbehebung.</target>
+            </trans-unit>
+            <trans-unit id="help.card.button">
+                <source>Open Help</source>
+                <target>Hilfe öffnen</target>
+            </trans-unit>
+
+            <!-- Readiness signals (lists) -->
+            <trans-unit id="configuration.noModel.badge">
+                <source>No model assigned</source>
+                <target>Kein Modell zugewiesen</target>
+            </trans-unit>
+            <trans-unit id="configuration.noModel.title">
+                <source>This configuration has no model and cannot be activated. Edit it and assign a model first.</source>
+                <target>Diese Konfiguration hat kein Modell und kann nicht aktiviert werden. Bearbeiten Sie sie und weisen Sie zuerst ein Modell zu.</target>
+            </trans-unit>
+            <trans-unit id="configuration.intro.modelNote">
+                <source>Every configuration needs a model assigned before it can be activated and used.</source>
+                <target>Jeder Konfiguration muss ein Modell zugewiesen sein, bevor sie aktiviert und verwendet werden kann.</target>
+            </trans-unit>
+            <trans-unit id="model.noDefault.warning">
+                <source>No default model is set. Tasks and features that do not specify a model will fail until you mark one model as default.</source>
+                <target>Es ist kein Standardmodell festgelegt. Aufgaben und Funktionen, die kein Modell angeben, schlagen fehl, bis Sie ein Modell als Standard markieren.</target>
+            </trans-unit>
+            <trans-unit id="model.orphaned.title">
+                <source>This model has no provider and cannot be used. Reassign a provider to it.</source>
+                <target>Dieses Modell hat keinen Anbieter und kann nicht verwendet werden. Weisen Sie ihm erneut einen Anbieter zu.</target>
+            </trans-unit>
+            <trans-unit id="model.reassignProvider">
+                <source>Reassign Provider</source>
+                <target>Anbieter neu zuweisen</target>
+            </trans-unit>
+            <trans-unit id="task.noActive.warning">
+                <source>No active tasks. Only active tasks appear in the CKEditor cowriter dialog and the API. Activate a task to make it available.</source>
+                <target>Keine aktiven Aufgaben. Nur aktive Aufgaben erscheinen im CKEditor-Cowriter-Dialog und in der API. Aktivieren Sie eine Aufgabe, um sie verfügbar zu machen.</target>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.never">
+                <source>Never synced</source>
+                <target>Nie synchronisiert</target>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.syncing">
+                <source>Syncing</source>
+                <target>Synchronisiert gerade</target>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.ok">
+                <source>Synced</source>
+                <target>Synchronisiert</target>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.partial">
+                <source>Partial</source>
+                <target>Teilweise</target>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.error">
+                <source>Failed</source>
+                <target>Fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="skill.source.edit">
+                <source>Edit source</source>
+                <target>Quelle bearbeiten</target>
+            </trans-unit>
+
+            <!-- Empty-state standardization -->
+            <trans-unit id="provider.empty.hint">
+                <source>Providers are the first tier of setup (Provider → Model → Configuration). Launch the Setup Wizard to add one.</source>
+                <target>Anbieter sind die erste Stufe der Einrichtung (Anbieter → Modell → Konfiguration). Starten Sie den Einrichtungsassistenten, um einen anzulegen.</target>
+            </trans-unit>
+            <trans-unit id="model.empty.hint">
+                <source>Models are the second tier of setup and require a Provider first (Provider → Model → Configuration).</source>
+                <target>Modelle sind die zweite Stufe der Einrichtung und erfordern zuerst einen Anbieter (Anbieter → Modell → Konfiguration).</target>
+            </trans-unit>
+            <trans-unit id="configuration.empty.hint">
+                <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
+                <target>Konfigurationen sind die dritte Stufe der Einrichtung und erfordern zuerst ein Modell (Anbieter → Modell → Konfiguration).</target>
+            </trans-unit>
+            <trans-unit id="task.empty.title">
+                <source>No Tasks Configured</source>
+                <target>Keine Aufgaben konfiguriert</target>
+            </trans-unit>
+            <trans-unit id="task.empty.message">
+                <source>Tasks are one-shot prompt templates. They require a Configuration first. Launch the Setup Wizard to get started, or create a task manually.</source>
+                <target>Aufgaben sind einmalige Prompt-Vorlagen. Sie erfordern zuerst eine Konfiguration. Starten Sie den Einrichtungsassistenten oder legen Sie eine Aufgabe manuell an.</target>
+            </trans-unit>
+            <trans-unit id="skill.sources.empty.admin">
+                <source>Administrators: add a source record, then run a sync. Discovered skills start disabled — enable the ones you want to use.</source>
+                <target>Administratoren: Legen Sie einen Quelldatensatz an und starten Sie eine Synchronisierung. Gefundene Skills sind zunächst deaktiviert — aktivieren Sie die, die Sie verwenden möchten.</target>
+            </trans-unit>
+            <trans-unit id="skill.sources.empty.developer">
+                <source>Developers: a source points at a GitHub-hosted SKILL.md file, repository or marketplace index.</source>
+                <target>Entwickler: Eine Quelle verweist auf eine auf GitHub gehostete SKILL.md-Datei, ein Repository oder einen Marketplace-Index.</target>
+            </trans-unit>
+            <trans-unit id="skill.skills.empty.admin">
+                <source>Administrators: once a source is synced, enable a skill here to make it available.</source>
+                <target>Administratoren: Sobald eine Quelle synchronisiert ist, aktivieren Sie hier einen Skill, um ihn verfügbar zu machen.</target>
+            </trans-unit>
+            <trans-unit id="playground.empty.admin">
+                <source>Administrators: enable a tool below, pick a configuration and run a prompt to try the agent loop.</source>
+                <target>Administratoren: Aktivieren Sie unten ein Werkzeug, wählen Sie eine Konfiguration und führen Sie einen Prompt aus, um die Agentenschleife auszuprobieren.</target>
+            </trans-unit>
+            <trans-unit id="playground.empty.developer">
+                <source>Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool.</source>
+                <target>Entwickler: Implementieren Sie Netresearch\NrLlm\Service\Tool\ToolInterface und versehen Sie die Klasse mit dem Tag nr_llm.tool, um ein neues Werkzeug zu registrieren.</target>
+            </trans-unit>
+
+            <!-- Tasks list (translation sweep) -->
+            <trans-unit id="task.list.title">
+                <source>Tasks</source>
+                <target>Aufgaben</target>
+            </trans-unit>
+            <trans-unit id="task.col.name">
+                <source>Name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="task.col.identifier">
+                <source>Identifier</source>
+                <target>Bezeichner</target>
+            </trans-unit>
+            <trans-unit id="task.col.input">
+                <source>Input</source>
+                <target>Eingabe</target>
+            </trans-unit>
+            <trans-unit id="task.col.output">
+                <source>Output</source>
+                <target>Ausgabe</target>
+            </trans-unit>
+            <trans-unit id="task.badge.system">
+                <source>System</source>
+                <target>System</target>
+            </trans-unit>
+            <trans-unit id="task.title.system">
+                <source>System task</source>
+                <target>Systemaufgabe</target>
+            </trans-unit>
+            <trans-unit id="task.title.active">
+                <source>Active</source>
+                <target>Aktiv</target>
+            </trans-unit>
+            <trans-unit id="task.title.inactive">
+                <source>Inactive</source>
+                <target>Inaktiv</target>
+            </trans-unit>
+            <trans-unit id="task.action.execute">
+                <source>Execute</source>
+                <target>Ausführen</target>
+            </trans-unit>
+            <trans-unit id="task.action.run">
+                <source>Run</source>
+                <target>Starten</target>
+            </trans-unit>
+            <trans-unit id="task.action.edit">
+                <source>Edit</source>
+                <target>Bearbeiten</target>
+            </trans-unit>
+            <trans-unit id="task.intro.line1">
+                <source>Tasks define &lt;strong&gt;what&lt;/strong&gt; the AI should do: a prompt template with placeholders for input data. Each task is a one-shot prompt — for example, "Summarize this text" or "Check for grammar errors". Tasks receive input, send it to the LLM, and return the result.</source>
+                <target>Aufgaben legen fest, &lt;strong&gt;was&lt;/strong&gt; die KI tun soll: eine Prompt-Vorlage mit Platzhaltern für Eingabedaten. Jede Aufgabe ist ein einmaliger Prompt — zum Beispiel „Diesen Text zusammenfassen“ oder „Auf Grammatikfehler prüfen“. Aufgaben erhalten eine Eingabe, senden sie an das LLM und geben das Ergebnis zurück.</target>
+            </trans-unit>
+            <trans-unit id="task.intro.line2">
+                <source>Each task uses a &lt;strong&gt;Configuration&lt;/strong&gt; that defines &lt;strong&gt;how&lt;/strong&gt; the AI behaves (model, temperature, system prompt). You can assign different configurations to tasks depending on the use case — a translation task might use a precise, low-temperature configuration, while a creative writing task uses a high-temperature one.</source>
+                <target>Jede Aufgabe verwendet eine &lt;strong&gt;Konfiguration&lt;/strong&gt;, die festlegt, &lt;strong&gt;wie&lt;/strong&gt; sich die KI verhält (Modell, Temperatur, System-Prompt). Je nach Anwendungsfall können Sie Aufgaben unterschiedliche Konfigurationen zuweisen — eine Übersetzungsaufgabe nutzt vielleicht eine präzise Konfiguration mit niedriger Temperatur, während eine kreative Schreibaufgabe eine mit hoher Temperatur verwendet.</target>
+            </trans-unit>
+
+            <!-- Overview AI task callout (translation sweep) -->
+            <trans-unit id="taskAi.callout.title">
+                <source>Create Tasks with AI</source>
+                <target>Aufgaben mit KI erstellen</target>
+            </trans-unit>
+            <trans-unit id="taskAi.callout.message">
+                <source>Use the AI Task Wizard to describe what a task should do in plain language. The AI generates a complete task setup — prompt template, dedicated configuration, and model recommendation — in one step.</source>
+                <target>Beschreiben Sie mit dem KI-Aufgabenassistenten in einfacher Sprache, was eine Aufgabe tun soll. Die KI erzeugt eine vollständige Aufgabe — Prompt-Vorlage, eigene Konfiguration und Modellempfehlung — in einem Schritt.</target>
+            </trans-unit>
+            <trans-unit id="taskAi.callout.button">
+                <source>Create Task with AI</source>
+                <target>Aufgabe mit KI erstellen</target>
+            </trans-unit>
+            <trans-unit id="taskAi.createWithAi">
+                <source>Create with AI</source>
+                <target>Mit KI erstellen</target>
+            </trans-unit>
+
+            <!-- Configuration list intro (translation sweep) -->
+            <trans-unit id="configuration.intro.line1">
+                <source>Configurations define &lt;strong&gt;how&lt;/strong&gt; the AI behaves: which model to use, creativity level (temperature), response length, and a system prompt that sets the AI's role. Each configuration is a reusable preset — for example, a "Translator" config with low temperature and a translation-focused system prompt.</source>
+                <target>Konfigurationen legen fest, &lt;strong&gt;wie&lt;/strong&gt; sich die KI verhält: welches Modell verwendet wird, der Grad an Kreativität (Temperatur), die Antwortlänge und ein System-Prompt, der die Rolle der KI festlegt. Jede Konfiguration ist eine wiederverwendbare Vorlage — zum Beispiel eine „Übersetzer“-Konfiguration mit niedriger Temperatur und einem auf Übersetzung ausgerichteten System-Prompt.</target>
+            </trans-unit>
+            <trans-unit id="configuration.intro.line2">
+                <source>Configurations are shared across &lt;strong&gt;Tasks&lt;/strong&gt;. A Task defines &lt;strong&gt;what&lt;/strong&gt; to do (the prompt template), while a Configuration defines &lt;strong&gt;how&lt;/strong&gt; to do it (model, temperature, system prompt). One configuration can power many different tasks.</source>
+                <target>Konfigurationen werden von mehreren &lt;strong&gt;Aufgaben&lt;/strong&gt; gemeinsam genutzt. Eine Aufgabe legt fest, &lt;strong&gt;was&lt;/strong&gt; zu tun ist (die Prompt-Vorlage), während eine Konfiguration festlegt, &lt;strong&gt;wie&lt;/strong&gt; es zu tun ist (Modell, Temperatur, System-Prompt). Eine Konfiguration kann viele verschiedene Aufgaben antreiben.</target>
+            </trans-unit>
+
+            <!-- Prompt snippet list intro + empty (translation sweep) -->
+            <trans-unit id="snippet.list.title">
+                <source>Prompt Snippets</source>
+                <target>Prompt-Snippets</target>
+            </trans-unit>
+            <trans-unit id="snippet.intro.line1">
+                <source>Prompt snippets are small reusable prompt &lt;strong&gt;fragments&lt;/strong&gt; — personas, tones of voice, target audiences, image styles, layouts — managed centrally in one place. Consuming extensions query them by tag and compose them into their prompts.</source>
+                <target>Prompt-Snippets sind kleine, wiederverwendbare Prompt-&lt;strong&gt;Fragmente&lt;/strong&gt; — Personas, Tonalitäten, Zielgruppen, Bildstile, Layouts — die zentral an einer Stelle verwaltet werden. Verwendende Erweiterungen fragen sie per Tag ab und setzen sie in ihre Prompts ein.</target>
+            </trans-unit>
+            <trans-unit id="snippet.intro.line2">
+                <source>Tag snippets with comma-separated free-form tags. Established tags: &lt;code&gt;audience&lt;/code&gt;, &lt;code&gt;tone_of_voice&lt;/code&gt;, &lt;code&gt;persona&lt;/code&gt;, &lt;code&gt;layout&lt;/code&gt;, &lt;code&gt;style&lt;/code&gt;. Snippets are not prompt templates: templates are complete prompts with model parameters, snippets are building blocks.</source>
+                <target>Versehen Sie Snippets mit kommagetrennten freien Tags. Etablierte Tags: &lt;code&gt;audience&lt;/code&gt;, &lt;code&gt;tone_of_voice&lt;/code&gt;, &lt;code&gt;persona&lt;/code&gt;, &lt;code&gt;layout&lt;/code&gt;, &lt;code&gt;style&lt;/code&gt;. Snippets sind keine Prompt-Vorlagen: Vorlagen sind vollständige Prompts mit Modellparametern, Snippets sind Bausteine.</target>
+            </trans-unit>
+            <trans-unit id="snippet.empty.title">
+                <source>No Prompt Snippets Configured</source>
+                <target>Keine Prompt-Snippets konfiguriert</target>
+            </trans-unit>
+            <trans-unit id="snippet.empty.message">
+                <source>No prompt snippets have been created yet.</source>
+                <target>Es wurden noch keine Prompt-Snippets erstellt.</target>
+            </trans-unit>
+            <trans-unit id="snippet.col.name">
+                <source>Name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="snippet.col.identifier">
+                <source>Identifier</source>
+                <target>Bezeichner</target>
+            </trans-unit>
+            <trans-unit id="snippet.col.tags">
+                <source>Tags</source>
+                <target>Tags</target>
+            </trans-unit>
+
+            <!-- Setup wizard (translation sweep) -->
+            <trans-unit id="wizard.step.connect">
+                <source>Connect</source>
+                <target>Verbinden</target>
+            </trans-unit>
+            <trans-unit id="wizard.step.verify">
+                <source>Verify</source>
+                <target>Prüfen</target>
+            </trans-unit>
+            <trans-unit id="wizard.step.models">
+                <source>Models</source>
+                <target>Modelle</target>
+            </trans-unit>
+            <trans-unit id="wizard.step.configure">
+                <source>Configure</source>
+                <target>Konfigurieren</target>
+            </trans-unit>
+            <trans-unit id="wizard.step.save">
+                <source>Save</source>
+                <target>Speichern</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.endpoint">
+                <source>API Endpoint URL *</source>
+                <target>API-Endpunkt-URL *</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.endpoint.hint">
+                <source>Examples: https://api.openai.com/v1, https://api.anthropic.com/v1, http://localhost:11434</source>
+                <target>Beispiele: https://api.openai.com/v1, https://api.anthropic.com/v1, http://localhost:11434</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey">
+                <source>API Key</source>
+                <target>API-Schlüssel</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey.toggle">
+                <source>Toggle API key visibility</source>
+                <target>Sichtbarkeit des API-Schlüssels umschalten</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey.hint">
+                <source>Leave empty for local providers like Ollama that don't require authentication.</source>
+                <target>Bei lokalen Anbietern wie Ollama, die keine Authentifizierung benötigen, leer lassen.</target>
+            </trans-unit>
+            <trans-unit id="wizard.detected.label">
+                <source>Detected:</source>
+                <target>Erkannt:</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter">
+                <source>Provider Type (override)</source>
+                <target>Anbietertyp (überschreiben)</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter.select">
+                <source>Select provider type</source>
+                <target>Anbietertyp auswählen</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter.hint">
+                <source>Only change this if auto-detection is incorrect.</source>
+                <target>Ändern Sie dies nur, wenn die automatische Erkennung falsch ist.</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.overrideAdapter">
+                <source>Override provider type</source>
+                <target>Anbietertyp überschreiben</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.detect">
+                <source>Detect &amp; Continue</source>
+                <target>Erkennen &amp; fortfahren</target>
+            </trans-unit>
+            <trans-unit id="wizard.testing.hidden">
+                <source>Testing connection...</source>
+                <target>Verbindung wird getestet …</target>
+            </trans-unit>
+            <trans-unit id="wizard.connectionFailed">
+                <source>Connection Failed</source>
+                <target>Verbindung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="wizard.connectionFailed.hint">
+                <source>Please check your endpoint URL and API key, then try again.</source>
+                <target>Bitte prüfen Sie Endpunkt-URL und API-Schlüssel und versuchen Sie es erneut.</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.back">
+                <source>Back</source>
+                <target>Zurück</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.discover">
+                <source>Discover Models</source>
+                <target>Modelle ermitteln</target>
+            </trans-unit>
+            <trans-unit id="wizard.discovering.hidden">
+                <source>Discovering models...</source>
+                <target>Modelle werden ermittelt …</target>
+            </trans-unit>
+            <trans-unit id="wizard.col.model">
+                <source>Model</source>
+                <target>Modell</target>
+            </trans-unit>
+            <trans-unit id="wizard.col.context">
+                <source>Context</source>
+                <target>Kontext</target>
+            </trans-unit>
+            <trans-unit id="wizard.col.capabilities">
+                <source>Capabilities</source>
+                <target>Fähigkeiten</target>
+            </trans-unit>
+            <trans-unit id="wizard.col.recommended">
+                <source>Recommended</source>
+                <target>Empfohlen</target>
+            </trans-unit>
+            <trans-unit id="wizard.selectAll">
+                <source>Select all models</source>
+                <target>Alle Modelle auswählen</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.generate">
+                <source>Generate Configurations</source>
+                <target>Konfigurationen erzeugen</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.review">
+                <source>Review &amp; Save</source>
+                <target>Prüfen &amp; speichern</target>
+            </trans-unit>
+            <trans-unit id="wizard.section.provider">
+                <source>Provider</source>
+                <target>Anbieter</target>
+            </trans-unit>
+            <trans-unit id="wizard.section.models">
+                <source>Models</source>
+                <target>Modelle</target>
+            </trans-unit>
+            <trans-unit id="wizard.section.configurations">
+                <source>Configurations</source>
+                <target>Konfigurationen</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.pid">
+                <source>Storage Folder (Page ID)</source>
+                <target>Ablageordner (Seiten-ID)</target>
+            </trans-unit>
+            <trans-unit id="wizard.field.pid.hint">
+                <source>The page ID where records will be stored. Use 0 for root level.</source>
+                <target>Die Seiten-ID, unter der die Datensätze gespeichert werden. 0 für die Wurzelebene.</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.goProviders">
+                <source>View Providers</source>
+                <target>Anbieter ansehen</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.restart">
+                <source>Add Another Provider</source>
+                <target>Weiteren Anbieter hinzufügen</target>
+            </trans-unit>
+            <trans-unit id="wizard.saveFailed">
+                <source>Save Failed</source>
+                <target>Speichern fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="wizard.btn.save">
+                <source>Save Configuration</source>
+                <target>Konfiguration speichern</target>
+            </trans-unit>
+            <trans-unit id="wizard.progress.aria">
+                <source>Setup wizard progress</source>
+                <target>Fortschritt des Einrichtungsassistenten</target>
+            </trans-unit>
+
+            <!-- Test page (translation sweep) -->
+            <trans-unit id="test.page.title">
+                <source>Test LLM Provider</source>
+                <target>LLM-Anbieter testen</target>
+            </trans-unit>
+            <trans-unit id="test.info.title">
+                <source>Raw provider test</source>
+                <target>Direkter Anbietertest</target>
+            </trans-unit>
+            <trans-unit id="test.info.body">
+                <source>This page sends a single prompt directly to the selected provider, bypassing tasks and configurations. Use it to confirm a provider connection works. Results are not stored.</source>
+                <target>Diese Seite sendet einen einzelnen Prompt direkt an den ausgewählten Anbieter und umgeht dabei Aufgaben und Konfigurationen. Nutzen Sie sie, um zu bestätigen, dass eine Anbieterverbindung funktioniert. Ergebnisse werden nicht gespeichert.</target>
+            </trans-unit>
+            <trans-unit id="test.card.send">
+                <source>Send Test Request</source>
+                <target>Testanfrage senden</target>
+            </trans-unit>
+            <trans-unit id="test.field.provider">
+                <source>Provider</source>
+                <target>Anbieter</target>
+            </trans-unit>
+            <trans-unit id="test.field.prompt">
+                <source>Prompt</source>
+                <target>Prompt</target>
+            </trans-unit>
+            <trans-unit id="test.btn.run">
+                <source>Run Test</source>
+                <target>Test ausführen</target>
+            </trans-unit>
+            <trans-unit id="test.btn.back">
+                <source>Back to Overview</source>
+                <target>Zurück zur Übersicht</target>
+            </trans-unit>
+            <trans-unit id="test.card.response">
+                <source>Response</source>
+                <target>Antwort</target>
+            </trans-unit>
+            <trans-unit id="test.response.success">
+                <source>Success!</source>
+                <target>Erfolg!</target>
+            </trans-unit>
+            <trans-unit id="test.response.error">
+                <source>Error:</source>
+                <target>Fehler:</target>
+            </trans-unit>
+            <trans-unit id="test.response.content">
+                <source>Content</source>
+                <target>Inhalt</target>
+            </trans-unit>
+            <trans-unit id="test.response.usage">
+                <source>Usage</source>
+                <target>Nutzung</target>
+            </trans-unit>
+            <trans-unit id="test.usage.model">
+                <source>Model</source>
+                <target>Modell</target>
+            </trans-unit>
+            <trans-unit id="test.usage.promptTokens">
+                <source>Prompt Tokens</source>
+                <target>Prompt-Token</target>
+            </trans-unit>
+            <trans-unit id="test.usage.completionTokens">
+                <source>Completion Tokens</source>
+                <target>Completion-Token</target>
+            </trans-unit>
+            <trans-unit id="test.usage.totalTokens">
+                <source>Total Tokens</source>
+                <target>Token gesamt</target>
+            </trans-unit>
+            <trans-unit id="test.loading">
+                <source>Sending request...</source>
+                <target>Anfrage wird gesendet …</target>
+            </trans-unit>
+
+            <!-- Help page (translation sweep) -->
+            <trans-unit id="help.page.title">
+                <source>LLM Management Help</source>
+                <target>Hilfe zur LLM-Verwaltung</target>
+            </trans-unit>
+            <trans-unit id="help.lead">
+                <source>This guide explains how to set up LLM providers, configure models, create task pipelines, and troubleshoot common issues.</source>
+                <target>Diese Anleitung erklärt, wie Sie LLM-Anbieter einrichten, Modelle konfigurieren, Aufgaben-Pipelines erstellen und häufige Probleme beheben.</target>
+            </trans-unit>
+            <trans-unit id="help.gettingStarted">
+                <source>Getting started</source>
+                <target>Erste Schritte</target>
+            </trans-unit>
+            <trans-unit id="help.intro">
+                <source>The LLM extension connects your TYPO3 installation to large language model APIs (OpenAI, Anthropic, Google, local Ollama, etc.). Follow these steps for initial setup:</source>
+                <target>Die LLM-Erweiterung verbindet Ihre TYPO3-Installation mit APIs großer Sprachmodelle (OpenAI, Anthropic, Google, lokales Ollama usw.). Folgen Sie diesen Schritten für die Ersteinrichtung:</target>
+            </trans-unit>
+            <trans-unit id="help.step1.title">
+                <source>Step 1 — Run the Setup Wizard</source>
+                <target>Schritt 1 — Einrichtungsassistenten ausführen</target>
+            </trans-unit>
+            <trans-unit id="help.step1.text">
+                <source>The fastest way to get started is the Setup Wizard. Paste your API endpoint URL and key, and the wizard will auto-detect the provider type, discover available models, and generate a ready-to-use configuration.</source>
+                <target>Am schnellsten gelingt der Einstieg mit dem Einrichtungsassistenten. Fügen Sie Ihre API-Endpunkt-URL und den Schlüssel ein, und der Assistent erkennt den Anbietertyp automatisch, ermittelt verfügbare Modelle und erzeugt eine einsatzbereite Konfiguration.</target>
+            </trans-unit>
+            <trans-unit id="help.step2.title">
+                <source>Step 2 — Create a Provider</source>
+                <target>Schritt 2 — Anbieter anlegen</target>
+            </trans-unit>
+            <trans-unit id="help.step2.text">
+                <source>A provider represents an API connection. Each provider stores the endpoint URL, API key (encrypted via nr-vault), and adapter type. You can create providers manually or via the Setup Wizard.</source>
+                <target>Ein Anbieter steht für eine API-Verbindung. Jeder Anbieter speichert die Endpunkt-URL, den API-Schlüssel (über nr-vault verschlüsselt) und den Adaptertyp. Sie können Anbieter manuell oder über den Einrichtungsassistenten anlegen.</target>
+            </trans-unit>
+            <trans-unit id="help.step3.title">
+                <source>Step 3 — Register Models</source>
+                <target>Schritt 3 — Modelle anlegen</target>
+            </trans-unit>
+            <trans-unit id="help.step3.text">
+                <source>Each provider can host multiple models. Models define capabilities (chat, completion, vision, embeddings, tools), context window limits, and cost information. The wizard can discover models automatically from the provider's API.</source>
+                <target>Jeder Anbieter kann mehrere Modelle bereitstellen. Modelle legen Fähigkeiten (chat, completion, vision, embeddings, tools), Grenzen des Kontextfensters und Kosteninformationen fest. Der Assistent kann Modelle automatisch über die API des Anbieters ermitteln.</target>
+            </trans-unit>
+            <trans-unit id="help.step4.title">
+                <source>Step 4 — Create Configurations</source>
+                <target>Schritt 4 — Konfigurationen erstellen</target>
+            </trans-unit>
+            <trans-unit id="help.step4.text">
+                <source>A configuration ties a provider and model together with default parameters (temperature, max tokens, system prompt). Extensions like Cowriter reference configurations by identifier.</source>
+                <target>Eine Konfiguration verknüpft einen Anbieter und ein Modell mit Standardparametern (Temperatur, max. Token, System-Prompt). Erweiterungen wie Cowriter verweisen über den Bezeichner auf Konfigurationen.</target>
+            </trans-unit>
+            <trans-unit id="help.step5.title">
+                <source>Step 5 — Define Tasks (optional)</source>
+                <target>Schritt 5 — Aufgaben definieren (optional)</target>
+            </trans-unit>
+            <trans-unit id="help.step5.text">
+                <source>Tasks are one-shot prompt templates that appear in the Cowriter dialog. They are simple utility prompts — not multi-step AI agents.</source>
+                <target>Aufgaben sind einmalige Prompt-Vorlagen, die im Cowriter-Dialog erscheinen. Es sind einfache Hilfs-Prompts — keine mehrstufigen KI-Agenten.</target>
+            </trans-unit>
+            <trans-unit id="help.arch.title">
+                <source>Architecture overview</source>
+                <target>Architekturübersicht</target>
+            </trans-unit>
+            <trans-unit id="help.arch.intro">
+                <source>The extension follows a layered architecture:</source>
+                <target>Die Erweiterung folgt einer geschichteten Architektur:</target>
+            </trans-unit>
+            <trans-unit id="help.arch.provider">
+                <source>&lt;strong&gt;Provider layer&lt;/strong&gt; — Adapters for each API (OpenAI, Anthropic, Google Gemini, Ollama). Each adapter translates the unified interface into provider-specific HTTP calls.</source>
+                <target>&lt;strong&gt;Anbieterschicht&lt;/strong&gt; — Adapter für jede API (OpenAI, Anthropic, Google Gemini, Ollama). Jeder Adapter übersetzt die einheitliche Schnittstelle in anbieterspezifische HTTP-Aufrufe.</target>
+            </trans-unit>
+            <trans-unit id="help.arch.service">
+                <source>&lt;strong&gt;Service layer&lt;/strong&gt; — &lt;code&gt;LlmServiceManager&lt;/code&gt; provides feature-based services (chat, translation, vision) that automatically route to the correct provider and model.</source>
+                <target>&lt;strong&gt;Dienstschicht&lt;/strong&gt; — &lt;code&gt;LlmServiceManager&lt;/code&gt; stellt funktionsbasierte Dienste (chat, translation, vision) bereit, die automatisch an den passenden Anbieter und das passende Modell weiterleiten.</target>
+            </trans-unit>
+            <trans-unit id="help.arch.configuration">
+                <source>&lt;strong&gt;Configuration layer&lt;/strong&gt; — Database-backed configurations with encrypted API keys via nr-vault's envelope encryption.</source>
+                <target>&lt;strong&gt;Konfigurationsschicht&lt;/strong&gt; — Datenbankgestützte Konfigurationen mit über die Envelope-Verschlüsselung von nr-vault verschlüsselten API-Schlüsseln.</target>
+            </trans-unit>
+            <trans-unit id="help.secret.title">
+                <source>Secret management</source>
+                <target>Verwaltung von Geheimnissen</target>
+            </trans-unit>
+            <trans-unit id="help.secret.text">
+                <source>API keys are stored using the &lt;code&gt;nr-vault&lt;/code&gt; extension which provides envelope encryption. Keys are never stored in plain text. The vault reveal endpoint allows viewing keys temporarily in the backend with proper authentication.</source>
+                <target>API-Schlüssel werden über die Erweiterung &lt;code&gt;nr-vault&lt;/code&gt; gespeichert, die eine Envelope-Verschlüsselung bietet. Schlüssel werden nie im Klartext gespeichert. Der Reveal-Endpunkt des Vaults erlaubt es, Schlüssel mit entsprechender Authentifizierung vorübergehend im Backend anzuzeigen.</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.title">
+                <source>Troubleshooting</source>
+                <target>Fehlerbehebung</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.title">
+                <source>Connection test fails with "Unknown error"</source>
+                <target>Verbindungstest schlägt mit „Unbekannter Fehler“ fehl</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.text">
+                <source>This usually means the API returned an unexpected response. Check:</source>
+                <target>Das bedeutet meist, dass die API eine unerwartete Antwort zurückgegeben hat. Prüfen Sie:</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item1">
+                <source>The endpoint URL is correct and includes the API path (e.g., &lt;code&gt;/v1&lt;/code&gt; for OpenAI/Anthropic)</source>
+                <target>Die Endpunkt-URL ist korrekt und enthält den API-Pfad (z. B. &lt;code&gt;/v1&lt;/code&gt; für OpenAI/Anthropic)</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item2">
+                <source>The API key is valid and not expired</source>
+                <target>Der API-Schlüssel ist gültig und nicht abgelaufen</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item3">
+                <source>The server can reach the API endpoint (firewall, proxy settings)</source>
+                <target>Der Server kann den API-Endpunkt erreichen (Firewall, Proxy-Einstellungen)</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.models.title">
+                <source>Models not discovered</source>
+                <target>Modelle werden nicht ermittelt</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.models.text">
+                <source>Some providers (e.g., Anthropic) do not expose a model listing API. For these providers, models must be added manually. The Setup Wizard will warn you when auto-discovery is not available.</source>
+                <target>Manche Anbieter (z. B. Anthropic) stellen keine API zum Auflisten von Modellen bereit. Bei diesen Anbietern müssen Modelle manuell hinzugefügt werden. Der Einrichtungsassistent weist Sie darauf hin, wenn die automatische Ermittlung nicht verfügbar ist.</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.500.title">
+                <source>Translation or task execution returns 500</source>
+                <target>Übersetzung oder Aufgabenausführung gibt 500 zurück</target>
+            </trans-unit>
+            <trans-unit id="help.trouble.500.text">
+                <source>Ensure a &lt;strong&gt;default configuration&lt;/strong&gt; is set. Feature services like translation require a default provider to be configured. Check the Configurations module and mark one configuration as default.</source>
+                <target>Stellen Sie sicher, dass eine &lt;strong&gt;Standardkonfiguration&lt;/strong&gt; festgelegt ist. Funktionsdienste wie die Übersetzung erfordern einen konfigurierten Standardanbieter. Prüfen Sie das Modul Konfigurationen und markieren Sie eine Konfiguration als Standard.</target>
+            </trans-unit>
+            <trans-unit id="help.faq.title">
+                <source>Frequently asked questions</source>
+                <target>Häufig gestellte Fragen</target>
+            </trans-unit>
+            <trans-unit id="help.faq.q1">
+                <source>Can I use multiple providers at the same time?</source>
+                <target>Kann ich mehrere Anbieter gleichzeitig verwenden?</target>
+            </trans-unit>
+            <trans-unit id="help.faq.a1">
+                <source>Yes. You can register as many providers as you need. Each configuration references a specific provider and model. Different features (chat, translation, vision) can use different providers.</source>
+                <target>Ja. Sie können so viele Anbieter anlegen, wie Sie benötigen. Jede Konfiguration verweist auf einen bestimmten Anbieter und ein bestimmtes Modell. Verschiedene Funktionen (chat, translation, vision) können verschiedene Anbieter nutzen.</target>
+            </trans-unit>
+            <trans-unit id="help.faq.q2">
+                <source>How are API keys stored?</source>
+                <target>Wie werden API-Schlüssel gespeichert?</target>
+            </trans-unit>
+            <trans-unit id="help.faq.a2">
+                <source>API keys are encrypted using the &lt;code&gt;nr-vault&lt;/code&gt; extension's envelope encryption. Each key is encrypted with a unique data encryption key (DEK), which is itself encrypted with a master key (KEK). Keys are never stored in plain text in the database.</source>
+                <target>API-Schlüssel werden mit der Envelope-Verschlüsselung der Erweiterung &lt;code&gt;nr-vault&lt;/code&gt; verschlüsselt. Jeder Schlüssel wird mit einem eindeutigen Datenschlüssel (DEK) verschlüsselt, der wiederum mit einem Hauptschlüssel (KEK) verschlüsselt ist. Schlüssel werden nie im Klartext in der Datenbank gespeichert.</target>
+            </trans-unit>
+            <trans-unit id="help.faq.q3">
+                <source>Can I use a local LLM (e.g., Ollama)?</source>
+                <target>Kann ich ein lokales LLM (z. B. Ollama) verwenden?</target>
+            </trans-unit>
+            <trans-unit id="help.faq.a3">
+                <source>Yes. The Ollama adapter supports local LLM instances. Set the endpoint to your Ollama server URL (e.g., &lt;code&gt;http://localhost:11434&lt;/code&gt;) and the wizard will auto-detect it. No API key is needed for local instances.</source>
+                <target>Ja. Der Ollama-Adapter unterstützt lokale LLM-Instanzen. Setzen Sie den Endpunkt auf die URL Ihres Ollama-Servers (z. B. &lt;code&gt;http://localhost:11434&lt;/code&gt;), und der Assistent erkennt ihn automatisch. Für lokale Instanzen ist kein API-Schlüssel erforderlich.</target>
+            </trans-unit>
+            <trans-unit id="help.faq.q4">
+                <source>What is the difference between tasks and the Cowriter dialog?</source>
+                <target>Was ist der Unterschied zwischen Aufgaben und dem Cowriter-Dialog?</target>
+            </trans-unit>
+            <trans-unit id="help.faq.a4">
+                <source>&lt;strong&gt;Tasks&lt;/strong&gt; are simple one-shot prompts defined here in the LLM module. They appear as preset options in the Cowriter dialog. The &lt;strong&gt;Cowriter dialog&lt;/strong&gt; is the CKEditor plugin that editors use to interact with the AI. Editors can pick a task or write a custom instruction.</source>
+                <target>&lt;strong&gt;Aufgaben&lt;/strong&gt; sind einfache einmalige Prompts, die hier im LLM-Modul definiert werden. Sie erscheinen als vorgegebene Optionen im Cowriter-Dialog. Der &lt;strong&gt;Cowriter-Dialog&lt;/strong&gt; ist das CKEditor-Plugin, mit dem Redakteure mit der KI interagieren. Redakteure können eine Aufgabe auswählen oder eine eigene Anweisung schreiben.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -175,6 +175,9 @@
             <trans-unit id="error">
                 <source>Error</source>
             </trans-unit>
+            <trans-unit id="error.adminRequired">
+                <source>This action requires backend administrator privileges. Please contact your site administrator to enable LLM management for your account.</source>
+            </trans-unit>
             <trans-unit id="provider">
                 <source>Provider</source>
             </trans-unit>
@@ -476,6 +479,648 @@
             </trans-unit>
             <trans-unit id="skill.skills.empty.message">
                 <source>No skills have been ingested yet. Add a source and run a sync.</source>
+            </trans-unit>
+
+            <!-- Glossary partial -->
+            <trans-unit id="glossary.title">
+                <source>Terms &amp; Parameters</source>
+            </trans-unit>
+            <trans-unit id="glossary.intro">
+                <source>A quick reference for the terms and numeric parameters used across these modules.</source>
+            </trans-unit>
+            <trans-unit id="glossary.section.terms">
+                <source>Terms</source>
+            </trans-unit>
+            <trans-unit id="glossary.section.params">
+                <source>Numeric parameters</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.provider.label">
+                <source>Provider</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.provider.text">
+                <source>An API connection to an LLM service (OpenAI, Claude, Gemini, Ollama, …). Stores endpoint, adapter type and the encrypted API key.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.adapter.label">
+                <source>Adapter type</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.adapter.text">
+                <source>The protocol dialect a provider speaks (e.g. OpenAI-compatible, Anthropic, Gemini). Determines how requests are formatted.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.model.label">
+                <source>Model</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.model.text">
+                <source>A specific model offered by a provider (e.g. gpt-4o, claude-sonnet). Carries its capabilities, context window and cost.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.configuration.label">
+                <source>Configuration</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.configuration.text">
+                <source>A reusable preset that bundles a model with default parameters and a system prompt. Tasks and consuming extensions reference it.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.capabilities.label">
+                <source>Capabilities</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.capabilities.text">
+                <source>What a model can do: chat, vision (image input), tool_use (function calling) and embeddings (vector representations).</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.fallback.label">
+                <source>Fallback chain</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.fallback.text">
+                <source>An ordered list of providers tried in turn: if one fails, the next is used automatically.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.priority.label">
+                <source>Priority</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.priority.text">
+                <source>Ordering weight when several providers qualify. Lower number = higher priority (tried first).</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.vault.label">
+                <source>Vault UUID</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.vault.text">
+                <source>A reference to an API key stored encrypted by the nr-vault extension. The key itself is never kept in the database in plain text.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.token.label">
+                <source>Token</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.token.text">
+                <source>The unit LLMs read and write in — roughly a word fragment. Usage and cost are measured in tokens.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.context.label">
+                <source>Context window</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.context.text">
+                <source>The maximum number of tokens (input plus output) a model can handle in a single request.</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.budget.label">
+                <source>Budget</source>
+            </trans-unit>
+            <trans-unit id="glossary.term.budget.text">
+                <source>A per-user spending ceiling. Requests are blocked once the ceiling for the period is reached.</source>
+            </trans-unit>
+            <trans-unit id="glossary.param.temperature">
+                <source>Randomness of the output (typically 0–2). Lower = more focused and deterministic, higher = more creative.</source>
+            </trans-unit>
+            <trans-unit id="glossary.param.maxTokens">
+                <source>Upper limit on the number of tokens the model may generate in its response.</source>
+            </trans-unit>
+            <trans-unit id="glossary.param.topP">
+                <source>Nucleus sampling (0–1): only the most probable tokens whose cumulative probability reaches top_p are considered. An alternative to temperature.</source>
+            </trans-unit>
+            <trans-unit id="glossary.param.frequencyPenalty">
+                <source>Discourages repeating the same tokens (typically -2 to 2). Higher values reduce verbatim repetition.</source>
+            </trans-unit>
+            <trans-unit id="glossary.param.presencePenalty">
+                <source>Encourages introducing new topics (typically -2 to 2). Higher values push the model toward novelty.</source>
+            </trans-unit>
+
+            <!-- Per-module help / admin / see-also -->
+            <trans-unit id="module.adminOnly">
+                <source>This module is admin-only. Records and actions here affect every editor using LLM features.</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.heading">
+                <source>See also</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.next.models">
+                <source>Next: register Models</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.next.configurations">
+                <source>Next: create Configurations</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.providers">
+                <source>Providers</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.models">
+                <source>Models</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.docs">
+                <source>Read the documentation</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.help">
+                <source>Open Help</source>
+            </trans-unit>
+
+            <!-- Readiness (overview) -->
+            <trans-unit id="readiness.title">
+                <source>Setup readiness</source>
+            </trans-unit>
+            <trans-unit id="readiness.ready">
+                <source>Ready</source>
+            </trans-unit>
+            <trans-unit id="readiness.incomplete">
+                <source>Setup incomplete</source>
+            </trans-unit>
+            <trans-unit id="readiness.step.provider">
+                <source>At least one Provider</source>
+            </trans-unit>
+            <trans-unit id="readiness.step.model">
+                <source>At least one Model</source>
+            </trans-unit>
+            <trans-unit id="readiness.step.configuration">
+                <source>At least one Configuration</source>
+            </trans-unit>
+            <trans-unit id="readiness.hint">
+                <source>Set up Provider → Model → Configuration in that order, then create Tasks.</source>
+            </trans-unit>
+            <trans-unit id="help.card.title">
+                <source>Help &amp; Documentation</source>
+            </trans-unit>
+            <trans-unit id="help.card.subtitle">
+                <source>Guides and reference</source>
+            </trans-unit>
+            <trans-unit id="skill.card.title">
+                <source>Skills</source>
+            </trans-unit>
+            <trans-unit id="skill.card.subtitle">
+                <source>Agent skill library</source>
+            </trans-unit>
+            <trans-unit id="skill.card.description">
+                <source>Sync GitHub-hosted SKILL.md sources and enable the skills available to the agent.</source>
+            </trans-unit>
+            <trans-unit id="skill.card.button">
+                <source>Manage Skills</source>
+            </trans-unit>
+            <trans-unit id="tool.card.title">
+                <source>Tools</source>
+            </trans-unit>
+            <trans-unit id="tool.card.subtitle">
+                <source>Function-calling tools</source>
+            </trans-unit>
+            <trans-unit id="tool.card.description">
+                <source>Function-calling tools available to the agent, with an admin playground to test them.</source>
+            </trans-unit>
+            <trans-unit id="tool.card.button">
+                <source>Open Tool Playground</source>
+            </trans-unit>
+            <trans-unit id="help.card.description">
+                <source>Read the in-module help and the online documentation for setup guidance and troubleshooting.</source>
+            </trans-unit>
+            <trans-unit id="help.card.button">
+                <source>Open Help</source>
+            </trans-unit>
+
+            <!-- Readiness signals (lists) -->
+            <trans-unit id="configuration.noModel.badge">
+                <source>No model assigned</source>
+            </trans-unit>
+            <trans-unit id="configuration.noModel.title">
+                <source>This configuration has no model and cannot be activated. Edit it and assign a model first.</source>
+            </trans-unit>
+            <trans-unit id="configuration.intro.modelNote">
+                <source>Every configuration needs a model assigned before it can be activated and used.</source>
+            </trans-unit>
+            <trans-unit id="model.noDefault.warning">
+                <source>No default model is set. Tasks and features that do not specify a model will fail until you mark one model as default.</source>
+            </trans-unit>
+            <trans-unit id="model.orphaned.title">
+                <source>This model has no provider and cannot be used. Reassign a provider to it.</source>
+            </trans-unit>
+            <trans-unit id="model.reassignProvider">
+                <source>Reassign Provider</source>
+            </trans-unit>
+            <trans-unit id="task.noActive.warning">
+                <source>No active tasks. Only active tasks appear in the CKEditor cowriter dialog and the API. Activate a task to make it available.</source>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.never">
+                <source>Never synced</source>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.syncing">
+                <source>Syncing</source>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.ok">
+                <source>Synced</source>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.partial">
+                <source>Partial</source>
+            </trans-unit>
+            <trans-unit id="skill.syncStatus.error">
+                <source>Failed</source>
+            </trans-unit>
+            <trans-unit id="skill.source.edit">
+                <source>Edit source</source>
+            </trans-unit>
+
+            <!-- Empty-state standardization -->
+            <trans-unit id="provider.empty.hint">
+                <source>Providers are the first tier of setup (Provider → Model → Configuration). Launch the Setup Wizard to add one.</source>
+            </trans-unit>
+            <trans-unit id="model.empty.hint">
+                <source>Models are the second tier of setup and require a Provider first (Provider → Model → Configuration).</source>
+            </trans-unit>
+            <trans-unit id="configuration.empty.hint">
+                <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
+            </trans-unit>
+            <trans-unit id="task.empty.title">
+                <source>No Tasks Configured</source>
+            </trans-unit>
+            <trans-unit id="task.empty.message">
+                <source>Tasks are one-shot prompt templates. They require a Configuration first. Launch the Setup Wizard to get started, or create a task manually.</source>
+            </trans-unit>
+            <trans-unit id="skill.sources.empty.admin">
+                <source>Administrators: add a source record, then run a sync. Discovered skills start disabled — enable the ones you want to use.</source>
+            </trans-unit>
+            <trans-unit id="skill.sources.empty.developer">
+                <source>Developers: a source points at a GitHub-hosted SKILL.md file, repository or marketplace index.</source>
+            </trans-unit>
+            <trans-unit id="skill.skills.empty.admin">
+                <source>Administrators: once a source is synced, enable a skill here to make it available.</source>
+            </trans-unit>
+            <trans-unit id="playground.empty.admin">
+                <source>Administrators: enable a tool below, pick a configuration and run a prompt to try the agent loop.</source>
+            </trans-unit>
+            <trans-unit id="playground.empty.developer">
+                <source>Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool.</source>
+            </trans-unit>
+
+            <!-- Tasks list (translation sweep) -->
+            <trans-unit id="task.list.title">
+                <source>Tasks</source>
+            </trans-unit>
+            <trans-unit id="task.col.name">
+                <source>Name</source>
+            </trans-unit>
+            <trans-unit id="task.col.identifier">
+                <source>Identifier</source>
+            </trans-unit>
+            <trans-unit id="task.col.input">
+                <source>Input</source>
+            </trans-unit>
+            <trans-unit id="task.col.output">
+                <source>Output</source>
+            </trans-unit>
+            <trans-unit id="task.badge.system">
+                <source>System</source>
+            </trans-unit>
+            <trans-unit id="task.title.system">
+                <source>System task</source>
+            </trans-unit>
+            <trans-unit id="task.title.active">
+                <source>Active</source>
+            </trans-unit>
+            <trans-unit id="task.title.inactive">
+                <source>Inactive</source>
+            </trans-unit>
+            <trans-unit id="task.action.execute">
+                <source>Execute</source>
+            </trans-unit>
+            <trans-unit id="task.action.run">
+                <source>Run</source>
+            </trans-unit>
+            <trans-unit id="task.action.edit">
+                <source>Edit</source>
+            </trans-unit>
+            <trans-unit id="task.intro.line1">
+                <source>Tasks define &lt;strong&gt;what&lt;/strong&gt; the AI should do: a prompt template with placeholders for input data. Each task is a one-shot prompt — for example, "Summarize this text" or "Check for grammar errors". Tasks receive input, send it to the LLM, and return the result.</source>
+            </trans-unit>
+            <trans-unit id="task.intro.line2">
+                <source>Each task uses a &lt;strong&gt;Configuration&lt;/strong&gt; that defines &lt;strong&gt;how&lt;/strong&gt; the AI behaves (model, temperature, system prompt). You can assign different configurations to tasks depending on the use case — a translation task might use a precise, low-temperature configuration, while a creative writing task uses a high-temperature one.</source>
+            </trans-unit>
+
+            <!-- Overview AI task callout (translation sweep) -->
+            <trans-unit id="taskAi.callout.title">
+                <source>Create Tasks with AI</source>
+            </trans-unit>
+            <trans-unit id="taskAi.callout.message">
+                <source>Use the AI Task Wizard to describe what a task should do in plain language. The AI generates a complete task setup — prompt template, dedicated configuration, and model recommendation — in one step.</source>
+            </trans-unit>
+            <trans-unit id="taskAi.callout.button">
+                <source>Create Task with AI</source>
+            </trans-unit>
+            <trans-unit id="taskAi.createWithAi">
+                <source>Create with AI</source>
+            </trans-unit>
+
+            <!-- Configuration list intro (translation sweep) -->
+            <trans-unit id="configuration.intro.line1">
+                <source>Configurations define &lt;strong&gt;how&lt;/strong&gt; the AI behaves: which model to use, creativity level (temperature), response length, and a system prompt that sets the AI's role. Each configuration is a reusable preset — for example, a "Translator" config with low temperature and a translation-focused system prompt.</source>
+            </trans-unit>
+            <trans-unit id="configuration.intro.line2">
+                <source>Configurations are shared across &lt;strong&gt;Tasks&lt;/strong&gt;. A Task defines &lt;strong&gt;what&lt;/strong&gt; to do (the prompt template), while a Configuration defines &lt;strong&gt;how&lt;/strong&gt; to do it (model, temperature, system prompt). One configuration can power many different tasks.</source>
+            </trans-unit>
+
+            <!-- Prompt snippet list intro + empty (translation sweep) -->
+            <trans-unit id="snippet.list.title">
+                <source>Prompt Snippets</source>
+            </trans-unit>
+            <trans-unit id="snippet.intro.line1">
+                <source>Prompt snippets are small reusable prompt &lt;strong&gt;fragments&lt;/strong&gt; — personas, tones of voice, target audiences, image styles, layouts — managed centrally in one place. Consuming extensions query them by tag and compose them into their prompts.</source>
+            </trans-unit>
+            <trans-unit id="snippet.intro.line2">
+                <source>Tag snippets with comma-separated free-form tags. Established tags: &lt;code&gt;audience&lt;/code&gt;, &lt;code&gt;tone_of_voice&lt;/code&gt;, &lt;code&gt;persona&lt;/code&gt;, &lt;code&gt;layout&lt;/code&gt;, &lt;code&gt;style&lt;/code&gt;. Snippets are not prompt templates: templates are complete prompts with model parameters, snippets are building blocks.</source>
+            </trans-unit>
+            <trans-unit id="snippet.empty.title">
+                <source>No Prompt Snippets Configured</source>
+            </trans-unit>
+            <trans-unit id="snippet.empty.message">
+                <source>No prompt snippets have been created yet.</source>
+            </trans-unit>
+            <trans-unit id="snippet.col.name">
+                <source>Name</source>
+            </trans-unit>
+            <trans-unit id="snippet.col.identifier">
+                <source>Identifier</source>
+            </trans-unit>
+            <trans-unit id="snippet.col.tags">
+                <source>Tags</source>
+            </trans-unit>
+
+            <!-- Setup wizard (translation sweep) -->
+            <trans-unit id="wizard.step.connect">
+                <source>Connect</source>
+            </trans-unit>
+            <trans-unit id="wizard.step.verify">
+                <source>Verify</source>
+            </trans-unit>
+            <trans-unit id="wizard.step.models">
+                <source>Models</source>
+            </trans-unit>
+            <trans-unit id="wizard.step.configure">
+                <source>Configure</source>
+            </trans-unit>
+            <trans-unit id="wizard.step.save">
+                <source>Save</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.endpoint">
+                <source>API Endpoint URL *</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.endpoint.hint">
+                <source>Examples: https://api.openai.com/v1, https://api.anthropic.com/v1, http://localhost:11434</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey">
+                <source>API Key</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey.toggle">
+                <source>Toggle API key visibility</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.apikey.hint">
+                <source>Leave empty for local providers like Ollama that don't require authentication.</source>
+            </trans-unit>
+            <trans-unit id="wizard.detected.label">
+                <source>Detected:</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter">
+                <source>Provider Type (override)</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter.select">
+                <source>Select provider type</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.adapter.hint">
+                <source>Only change this if auto-detection is incorrect.</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.overrideAdapter">
+                <source>Override provider type</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.detect">
+                <source>Detect &amp; Continue</source>
+            </trans-unit>
+            <trans-unit id="wizard.testing.hidden">
+                <source>Testing connection...</source>
+            </trans-unit>
+            <trans-unit id="wizard.connectionFailed">
+                <source>Connection Failed</source>
+            </trans-unit>
+            <trans-unit id="wizard.connectionFailed.hint">
+                <source>Please check your endpoint URL and API key, then try again.</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.back">
+                <source>Back</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.discover">
+                <source>Discover Models</source>
+            </trans-unit>
+            <trans-unit id="wizard.discovering.hidden">
+                <source>Discovering models...</source>
+            </trans-unit>
+            <trans-unit id="wizard.col.model">
+                <source>Model</source>
+            </trans-unit>
+            <trans-unit id="wizard.col.context">
+                <source>Context</source>
+            </trans-unit>
+            <trans-unit id="wizard.col.capabilities">
+                <source>Capabilities</source>
+            </trans-unit>
+            <trans-unit id="wizard.col.recommended">
+                <source>Recommended</source>
+            </trans-unit>
+            <trans-unit id="wizard.selectAll">
+                <source>Select all models</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.generate">
+                <source>Generate Configurations</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.review">
+                <source>Review &amp; Save</source>
+            </trans-unit>
+            <trans-unit id="wizard.section.provider">
+                <source>Provider</source>
+            </trans-unit>
+            <trans-unit id="wizard.section.models">
+                <source>Models</source>
+            </trans-unit>
+            <trans-unit id="wizard.section.configurations">
+                <source>Configurations</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.pid">
+                <source>Storage Folder (Page ID)</source>
+            </trans-unit>
+            <trans-unit id="wizard.field.pid.hint">
+                <source>The page ID where records will be stored. Use 0 for root level.</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.goProviders">
+                <source>View Providers</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.restart">
+                <source>Add Another Provider</source>
+            </trans-unit>
+            <trans-unit id="wizard.saveFailed">
+                <source>Save Failed</source>
+            </trans-unit>
+            <trans-unit id="wizard.btn.save">
+                <source>Save Configuration</source>
+            </trans-unit>
+            <trans-unit id="wizard.progress.aria">
+                <source>Setup wizard progress</source>
+            </trans-unit>
+
+            <!-- Test page (translation sweep) -->
+            <trans-unit id="test.page.title">
+                <source>Test LLM Provider</source>
+            </trans-unit>
+            <trans-unit id="test.info.title">
+                <source>Raw provider test</source>
+            </trans-unit>
+            <trans-unit id="test.info.body">
+                <source>This page sends a single prompt directly to the selected provider, bypassing tasks and configurations. Use it to confirm a provider connection works. Results are not stored.</source>
+            </trans-unit>
+            <trans-unit id="test.card.send">
+                <source>Send Test Request</source>
+            </trans-unit>
+            <trans-unit id="test.field.provider">
+                <source>Provider</source>
+            </trans-unit>
+            <trans-unit id="test.field.prompt">
+                <source>Prompt</source>
+            </trans-unit>
+            <trans-unit id="test.btn.run">
+                <source>Run Test</source>
+            </trans-unit>
+            <trans-unit id="test.btn.back">
+                <source>Back to Overview</source>
+            </trans-unit>
+            <trans-unit id="test.card.response">
+                <source>Response</source>
+            </trans-unit>
+            <trans-unit id="test.response.success">
+                <source>Success!</source>
+            </trans-unit>
+            <trans-unit id="test.response.error">
+                <source>Error:</source>
+            </trans-unit>
+            <trans-unit id="test.response.content">
+                <source>Content</source>
+            </trans-unit>
+            <trans-unit id="test.response.usage">
+                <source>Usage</source>
+            </trans-unit>
+            <trans-unit id="test.usage.model">
+                <source>Model</source>
+            </trans-unit>
+            <trans-unit id="test.usage.promptTokens">
+                <source>Prompt Tokens</source>
+            </trans-unit>
+            <trans-unit id="test.usage.completionTokens">
+                <source>Completion Tokens</source>
+            </trans-unit>
+            <trans-unit id="test.usage.totalTokens">
+                <source>Total Tokens</source>
+            </trans-unit>
+            <trans-unit id="test.loading">
+                <source>Sending request...</source>
+            </trans-unit>
+
+            <!-- Help page (translation sweep) -->
+            <trans-unit id="help.page.title">
+                <source>LLM Management Help</source>
+            </trans-unit>
+            <trans-unit id="help.lead">
+                <source>This guide explains how to set up LLM providers, configure models, create task pipelines, and troubleshoot common issues.</source>
+            </trans-unit>
+            <trans-unit id="help.gettingStarted">
+                <source>Getting started</source>
+            </trans-unit>
+            <trans-unit id="help.intro">
+                <source>The LLM extension connects your TYPO3 installation to large language model APIs (OpenAI, Anthropic, Google, local Ollama, etc.). Follow these steps for initial setup:</source>
+            </trans-unit>
+            <trans-unit id="help.step1.title">
+                <source>Step 1 — Run the Setup Wizard</source>
+            </trans-unit>
+            <trans-unit id="help.step1.text">
+                <source>The fastest way to get started is the Setup Wizard. Paste your API endpoint URL and key, and the wizard will auto-detect the provider type, discover available models, and generate a ready-to-use configuration.</source>
+            </trans-unit>
+            <trans-unit id="help.step2.title">
+                <source>Step 2 — Create a Provider</source>
+            </trans-unit>
+            <trans-unit id="help.step2.text">
+                <source>A provider represents an API connection. Each provider stores the endpoint URL, API key (encrypted via nr-vault), and adapter type. You can create providers manually or via the Setup Wizard.</source>
+            </trans-unit>
+            <trans-unit id="help.step3.title">
+                <source>Step 3 — Register Models</source>
+            </trans-unit>
+            <trans-unit id="help.step3.text">
+                <source>Each provider can host multiple models. Models define capabilities (chat, completion, vision, embeddings, tools), context window limits, and cost information. The wizard can discover models automatically from the provider's API.</source>
+            </trans-unit>
+            <trans-unit id="help.step4.title">
+                <source>Step 4 — Create Configurations</source>
+            </trans-unit>
+            <trans-unit id="help.step4.text">
+                <source>A configuration ties a provider and model together with default parameters (temperature, max tokens, system prompt). Extensions like Cowriter reference configurations by identifier.</source>
+            </trans-unit>
+            <trans-unit id="help.step5.title">
+                <source>Step 5 — Define Tasks (optional)</source>
+            </trans-unit>
+            <trans-unit id="help.step5.text">
+                <source>Tasks are one-shot prompt templates that appear in the Cowriter dialog. They are simple utility prompts — not multi-step AI agents.</source>
+            </trans-unit>
+            <trans-unit id="help.arch.title">
+                <source>Architecture overview</source>
+            </trans-unit>
+            <trans-unit id="help.arch.intro">
+                <source>The extension follows a layered architecture:</source>
+            </trans-unit>
+            <trans-unit id="help.arch.provider">
+                <source>&lt;strong&gt;Provider layer&lt;/strong&gt; — Adapters for each API (OpenAI, Anthropic, Google Gemini, Ollama). Each adapter translates the unified interface into provider-specific HTTP calls.</source>
+            </trans-unit>
+            <trans-unit id="help.arch.service">
+                <source>&lt;strong&gt;Service layer&lt;/strong&gt; — &lt;code&gt;LlmServiceManager&lt;/code&gt; provides feature-based services (chat, translation, vision) that automatically route to the correct provider and model.</source>
+            </trans-unit>
+            <trans-unit id="help.arch.configuration">
+                <source>&lt;strong&gt;Configuration layer&lt;/strong&gt; — Database-backed configurations with encrypted API keys via nr-vault's envelope encryption.</source>
+            </trans-unit>
+            <trans-unit id="help.secret.title">
+                <source>Secret management</source>
+            </trans-unit>
+            <trans-unit id="help.secret.text">
+                <source>API keys are stored using the &lt;code&gt;nr-vault&lt;/code&gt; extension which provides envelope encryption. Keys are never stored in plain text. The vault reveal endpoint allows viewing keys temporarily in the backend with proper authentication.</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.title">
+                <source>Troubleshooting</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.title">
+                <source>Connection test fails with "Unknown error"</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.text">
+                <source>This usually means the API returned an unexpected response. Check:</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item1">
+                <source>The endpoint URL is correct and includes the API path (e.g., &lt;code&gt;/v1&lt;/code&gt; for OpenAI/Anthropic)</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item2">
+                <source>The API key is valid and not expired</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.conn.item3">
+                <source>The server can reach the API endpoint (firewall, proxy settings)</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.models.title">
+                <source>Models not discovered</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.models.text">
+                <source>Some providers (e.g., Anthropic) do not expose a model listing API. For these providers, models must be added manually. The Setup Wizard will warn you when auto-discovery is not available.</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.500.title">
+                <source>Translation or task execution returns 500</source>
+            </trans-unit>
+            <trans-unit id="help.trouble.500.text">
+                <source>Ensure a &lt;strong&gt;default configuration&lt;/strong&gt; is set. Feature services like translation require a default provider to be configured. Check the Configurations module and mark one configuration as default.</source>
+            </trans-unit>
+            <trans-unit id="help.faq.title">
+                <source>Frequently asked questions</source>
+            </trans-unit>
+            <trans-unit id="help.faq.q1">
+                <source>Can I use multiple providers at the same time?</source>
+            </trans-unit>
+            <trans-unit id="help.faq.a1">
+                <source>Yes. You can register as many providers as you need. Each configuration references a specific provider and model. Different features (chat, translation, vision) can use different providers.</source>
+            </trans-unit>
+            <trans-unit id="help.faq.q2">
+                <source>How are API keys stored?</source>
+            </trans-unit>
+            <trans-unit id="help.faq.a2">
+                <source>API keys are encrypted using the &lt;code&gt;nr-vault&lt;/code&gt; extension's envelope encryption. Each key is encrypted with a unique data encryption key (DEK), which is itself encrypted with a master key (KEK). Keys are never stored in plain text in the database.</source>
+            </trans-unit>
+            <trans-unit id="help.faq.q3">
+                <source>Can I use a local LLM (e.g., Ollama)?</source>
+            </trans-unit>
+            <trans-unit id="help.faq.a3">
+                <source>Yes. The Ollama adapter supports local LLM instances. Set the endpoint to your Ollama server URL (e.g., &lt;code&gt;http://localhost:11434&lt;/code&gt;) and the wizard will auto-detect it. No API key is needed for local instances.</source>
+            </trans-unit>
+            <trans-unit id="help.faq.q4">
+                <source>What is the difference between tasks and the Cowriter dialog?</source>
+            </trans-unit>
+            <trans-unit id="help.faq.a4">
+                <source>&lt;strong&gt;Tasks&lt;/strong&gt; are simple one-shot prompts defined here in the LLM module. They appear as preset options in the Cowriter dialog. The &lt;strong&gt;Cowriter dialog&lt;/strong&gt; is the CKEditor plugin that editors use to interact with the AI. Editors can pick a task or write a custom instruction.</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Partials/Backend/Glossary.html
+++ b/Resources/Private/Partials/Backend/Glossary.html
@@ -1,0 +1,82 @@
+<f:comment>
+    Shared "Terms &amp; Parameters" glossary card. Collapsed by default so it
+    does not clutter list views. Included via <f:render partial="Backend/Glossary" />.
+    All copy is translated (glossary.term.* / glossary.param.*).
+</f:comment>
+<f:comment>Partial (no &lt;html&gt; page wrapper): declare only the non-default namespace.</f:comment>
+{namespace core=TYPO3\CMS\Core\ViewHelpers}
+<div class="card mb-4">
+    <div class="card-header py-2">
+        <button type="button" class="btn btn-link text-decoration-none p-0 collapsed"
+                data-bs-toggle="collapse" data-bs-target="#nrllm-glossary"
+                aria-expanded="false" aria-controls="nrllm-glossary">
+            <core:icon identifier="actions-info" size="small" />
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.title" default="Terms &amp; Parameters" />
+        </button>
+    </div>
+    <div class="collapse" id="nrllm-glossary">
+        <div class="card-body">
+            <p class="text-body-secondary">
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.intro" default="A quick reference for the terms and numeric parameters used across these modules." />
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <h4><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.section.terms" default="Terms" /></h4>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.provider.label" default="Provider" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.provider.text" default="An API connection to an LLM service (OpenAI, Claude, Gemini, Ollama, …). Stores endpoint, adapter type and the encrypted API key." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.adapter.label" default="Adapter type" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.adapter.text" default="The protocol dialect a provider speaks (e.g. OpenAI-compatible, Anthropic, Gemini). Determines how requests are formatted." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.model.label" default="Model" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.model.text" default="A specific model offered by a provider (e.g. gpt-4o, claude-sonnet). Carries its capabilities, context window and cost." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.configuration.label" default="Configuration" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.configuration.text" default="A reusable preset that bundles a model with default parameters and a system prompt. Tasks and consuming extensions reference it." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.capabilities.label" default="Capabilities" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.capabilities.text" default="What a model can do: chat, vision (image input), tool_use (function calling) and embeddings (vector representations)." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.fallback.label" default="Fallback chain" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.fallback.text" default="An ordered list of providers tried in turn: if one fails, the next is used automatically." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.priority.label" default="Priority" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.priority.text" default="Ordering weight when several providers qualify. Lower number = higher priority (tried first)." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.vault.label" default="Vault UUID" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.vault.text" default="A reference to an API key stored encrypted by the nr-vault extension. The key itself is never kept in the database in plain text." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.token.label" default="Token" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.token.text" default="The unit LLMs read and write in — roughly a word fragment. Usage and cost are measured in tokens." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.context.label" default="Context window" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.context.text" default="The maximum number of tokens (input plus output) a model can handle in a single request." /></dd>
+
+                        <dt class="col-sm-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.budget.label" default="Budget" /></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.budget.text" default="A per-user spending ceiling. Requests are blocked once the ceiling for the period is reached." /></dd>
+                    </dl>
+                </div>
+                <div class="col-md-6">
+                    <h4><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.section.params" default="Numeric parameters" /></h4>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4"><code>temperature</code></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.param.temperature" default="Randomness of the output (typically 0–2). Lower = more focused and deterministic, higher = more creative." /></dd>
+
+                        <dt class="col-sm-4"><code>max_tokens</code></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.param.maxTokens" default="Upper limit on the number of tokens the model may generate in its response." /></dd>
+
+                        <dt class="col-sm-4"><code>top_p</code></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.param.topP" default="Nucleus sampling (0–1): only the most probable tokens whose cumulative probability reaches top_p are considered. An alternative to temperature." /></dd>
+
+                        <dt class="col-sm-4"><code>frequency_penalty</code></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.param.frequencyPenalty" default="Discourages repeating the same tokens (typically -2 to 2). Higher values reduce verbatim repetition." /></dd>
+
+                        <dt class="col-sm-4"><code>presence_penalty</code></dt>
+                        <dd class="col-sm-8"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.param.presencePenalty" default="Encourages introducing new topics (typically -2 to 2). Higher values push the model toward novelty." /></dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -1,4 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
 <f:layout name="Module" />
@@ -7,6 +8,17 @@
     <div class="nrllm-analytics">
         <script type="application/json" id="nrllm-analytics-data">{chartData -> f:format.raw()}</script>
         <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.title" /></h1>
+
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_providers')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.providers" default="Providers" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
 
         <div class="btn-group mb-3" role="group" aria-label="Date range">
             <f:for each="{presets}" as="p">

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -9,10 +9,25 @@
     <div>
         <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.list.title" default="LLM Configurations" /></h1>
 
-        <f:be.infobox state="-2">
-            <p>Configurations define <strong>how</strong> the AI behaves: which model to use, creativity level (temperature), response length, and a system prompt that sets the AI's role. Each configuration is a reusable preset — for example, a "Translator" config with low temperature and a translation-focused system prompt.</p>
-            <p class="mb-0">Configurations are shared across <strong>Tasks</strong>. A Task defines <strong>what</strong> to do (the prompt template), while a Configuration defines <strong>how</strong> to do it (model, temperature, system prompt). One configuration can power many different tasks.</p>
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
         </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_providers')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.providers" default="Providers" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_models')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.models" default="Models" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:be.infobox state="-2">
+            <p><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.intro.line1" default="Configurations define &lt;strong&gt;how&lt;/strong&gt; the AI behaves." /></f:format.raw></p>
+            <p><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.intro.line2" default="Configurations are shared across Tasks." /></f:format.raw></p>
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.intro.modelNote" default="Every configuration needs a model assigned before it can be activated and used." /></p>
+        </f:be.infobox>
+
+        <f:render partial="Backend/Glossary" />
 
         <f:if condition="{configurations -> f:count()}">
             <f:then>
@@ -57,7 +72,7 @@
                                                 <br /><span class="text-body-secondary">{config.llmModel.modelId}</span>
                                             </f:then>
                                             <f:else>
-                                                <span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:notConfigured" default="Not configured" /></span>
+                                                <span class="badge text-bg-danger" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.title')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.badge" default="No model assigned" /></span>
                                             </f:else>
                                         </f:if>
                                     </td>
@@ -79,14 +94,24 @@
                                             <a href="{editUrls.{config.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
                                                 <core:icon identifier="actions-open" size="small" />
                                             </a>
-                                            <button type="button" class="btn btn-secondary btn-sm js-toggle-active"
-                                                    data-uid="{config.uid}"
-                                                    title="{f:if(condition: config.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
-                                                <f:if condition="{config.isActive}">
-                                                    <f:then><core:icon identifier="actions-toggle-on" size="small" /></f:then>
-                                                    <f:else><core:icon identifier="actions-toggle-off" size="small" /></f:else>
-                                                </f:if>
-                                            </button>
+                                            <f:if condition="{config.llmModel}">
+                                                <f:then>
+                                                    <button type="button" class="btn btn-secondary btn-sm js-toggle-active"
+                                                            data-uid="{config.uid}"
+                                                            title="{f:if(condition: config.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
+                                                        <f:if condition="{config.isActive}">
+                                                            <f:then><core:icon identifier="actions-toggle-on" size="small" /></f:then>
+                                                            <f:else><core:icon identifier="actions-toggle-off" size="small" /></f:else>
+                                                        </f:if>
+                                                    </button>
+                                                </f:then>
+                                                <f:else>
+                                                    <button type="button" class="btn btn-secondary btn-sm" disabled
+                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.title')}">
+                                                        <core:icon identifier="actions-toggle-off" size="small" />
+                                                    </button>
+                                                </f:else>
+                                            </f:if>
                                             <f:if condition="!{config.isDefault}">
                                                 <button type="button" class="btn btn-secondary btn-sm js-set-default"
                                                         data-uid="{config.uid}"
@@ -114,6 +139,7 @@
                     state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.empty.message" default="No LLM configurations found yet. Create your first configuration to get started." /></p>
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.empty.hint" default="Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration)." /></p>
                     <p><a href="{wizardUrl}" class="btn btn-primary btn-sm"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.launch" default="Launch Setup Wizard" /></a></p>
                 </f:be.infobox>
             </f:else>

--- a/Resources/Private/Templates/Backend/Help.html
+++ b/Resources/Private/Templates/Backend/Help.html
@@ -10,59 +10,45 @@
 -->
 <f:layout name="Module" />
 <f:section name="Content">
-    <h1>LLM Management Help</h1>
+    <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.page.title" default="LLM Management Help" /></h1>
     <p class="lead">
-        This guide explains how to set up LLM providers, configure models,
-        create task pipelines, and troubleshoot common issues.
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.lead" default="This guide explains how to set up LLM providers, configure models, create task pipelines, and troubleshoot common issues." />
     </p>
 
     <!-- Section 1: Getting started -->
     <div class="card mb-3">
         <div class="card-header">
-            <h2 class="card-title mb-0">Getting started</h2>
+            <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.gettingStarted" default="Getting started" /></h2>
         </div>
         <div class="card-body">
             <p>
-                The LLM extension connects your TYPO3 installation to large language
-                model APIs (OpenAI, Anthropic, Google, local Ollama, etc.). Follow
-                these steps for initial setup:
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.intro" default="The LLM extension connects your TYPO3 installation to large language model APIs (OpenAI, Anthropic, Google, local Ollama, etc.). Follow these steps for initial setup:" />
             </p>
 
-            <h3>Step 1 &mdash; Run the Setup Wizard</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step1.title" default="Step 1 — Run the Setup Wizard" /></h3>
             <p>
-                The fastest way to get started is the
-                <a href="{wizardUrl}">Setup Wizard</a>. Paste your API endpoint
-                URL and key, and the wizard will auto-detect the provider type,
-                discover available models, and generate a ready-to-use configuration.
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step1.text" default="The fastest way to get started is the Setup Wizard. Paste your API endpoint URL and key, and the wizard will auto-detect the provider type, discover available models, and generate a ready-to-use configuration." />
+            </p>
+            <p><a href="{wizardUrl}" class="btn btn-primary btn-sm"><core:icon identifier="actions-bolt" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.launch" default="Launch Setup Wizard" /></a></p>
+
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step2.title" default="Step 2 — Create a Provider" /></h3>
+            <p>
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step2.text" default="A provider represents an API connection. Each provider stores the endpoint URL, API key (encrypted via nr-vault), and adapter type. You can create providers manually or via the Setup Wizard." />
             </p>
 
-            <h3>Step 2 &mdash; Create a Provider</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step3.title" default="Step 3 — Register Models" /></h3>
             <p>
-                A <strong>provider</strong> represents an API connection. Each provider
-                stores the endpoint URL, API key (encrypted via nr-vault), and adapter
-                type. You can create providers manually or via the Setup Wizard.
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step3.text" default="Each provider can host multiple models. Models define capabilities (chat, completion, vision, embeddings, tools), context window limits, and cost information. The wizard can discover models automatically from the provider's API." />
             </p>
 
-            <h3>Step 3 &mdash; Register Models</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step4.title" default="Step 4 — Create Configurations" /></h3>
             <p>
-                Each provider can host multiple <strong>models</strong>. Models define
-                capabilities (chat, completion, vision, embeddings, tools), context
-                window limits, and cost information. The wizard can discover models
-                automatically from the provider's API.
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step4.text" default="A configuration ties a provider and model together with default parameters (temperature, max tokens, system prompt). Extensions like Cowriter reference configurations by identifier." />
             </p>
 
-            <h3>Step 4 &mdash; Create Configurations</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step5.title" default="Step 5 — Define Tasks (optional)" /></h3>
             <p>
-                A <strong>configuration</strong> ties a provider and model together
-                with default parameters (temperature, max tokens, system prompt).
-                Extensions like Cowriter reference configurations by identifier.
-            </p>
-
-            <h3>Step 5 &mdash; Define Tasks (optional)</h3>
-            <p>
-                <strong>Tasks</strong> are one-shot prompt templates that appear in
-                the Cowriter dialog. They are simple utility prompts &mdash; not
-                multi-step AI agents.
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.step5.text" default="Tasks are one-shot prompt templates that appear in the Cowriter dialog. They are simple utility prompts — not multi-step AI agents." />
             </p>
         </div>
     </div>
@@ -70,34 +56,25 @@
     <!-- Section 2: Architecture -->
     <div class="card mb-3">
         <div class="card-header">
-            <h2 class="card-title mb-0">Architecture overview</h2>
+            <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.arch.title" default="Architecture overview" /></h2>
         </div>
         <div class="card-body">
-            <p>The extension follows a layered architecture:</p>
+            <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.arch.intro" default="The extension follows a layered architecture:" /></p>
             <ul>
                 <li>
-                    <strong>Provider layer</strong> &mdash; Adapters for each API
-                    (OpenAI, Anthropic, Google Gemini, Ollama). Each adapter translates
-                    the unified interface into provider-specific HTTP calls.
+                    <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.arch.provider" default="Provider layer — Adapters for each API." /></f:format.raw>
                 </li>
                 <li>
-                    <strong>Service layer</strong> &mdash; <code>LlmServiceManager</code>
-                    provides feature-based services (chat, translation, vision) that
-                    automatically route to the correct provider and model.
+                    <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.arch.service" default="Service layer — LlmServiceManager." /></f:format.raw>
                 </li>
                 <li>
-                    <strong>Configuration layer</strong> &mdash; Database-backed
-                    configurations with encrypted API keys via nr-vault's envelope
-                    encryption.
+                    <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.arch.configuration" default="Configuration layer — Database-backed configurations." /></f:format.raw>
                 </li>
             </ul>
 
-            <h3>Secret management</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.secret.title" default="Secret management" /></h3>
             <p>
-                API keys are stored using the <code>nr-vault</code> extension which
-                provides envelope encryption. Keys are never stored in plain text.
-                The vault reveal endpoint allows viewing keys temporarily in the
-                backend with proper authentication.
+                <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.secret.text" default="API keys are stored using the nr-vault extension which provides envelope encryption. Keys are never stored in plain text." /></f:format.raw>
             </p>
         </div>
     </div>
@@ -105,31 +82,27 @@
     <!-- Section 3: Troubleshooting -->
     <div class="card mb-3">
         <div class="card-header">
-            <h2 class="card-title mb-0">Troubleshooting</h2>
+            <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.title" default="Troubleshooting" /></h2>
         </div>
         <div class="card-body">
-            <h3>Connection test fails with "Unknown error"</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.conn.title" default="Connection test fails with &quot;Unknown error&quot;" /></h3>
             <p>
-                This usually means the API returned an unexpected response. Check:
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.conn.text" default="This usually means the API returned an unexpected response. Check:" />
             </p>
             <ul>
-                <li>The endpoint URL is correct and includes the API path (e.g., <code>/v1</code> for OpenAI/Anthropic)</li>
-                <li>The API key is valid and not expired</li>
-                <li>The server can reach the API endpoint (firewall, proxy settings)</li>
+                <li><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.conn.item1" default="The endpoint URL is correct and includes the API path." /></f:format.raw></li>
+                <li><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.conn.item2" default="The API key is valid and not expired" /></li>
+                <li><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.conn.item3" default="The server can reach the API endpoint (firewall, proxy settings)" /></li>
             </ul>
 
-            <h3>Models not discovered</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.models.title" default="Models not discovered" /></h3>
             <p>
-                Some providers (e.g., Anthropic) do not expose a model listing API.
-                For these providers, models must be added manually. The Setup Wizard
-                will warn you when auto-discovery is not available.
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.models.text" default="Some providers (e.g., Anthropic) do not expose a model listing API. For these providers, models must be added manually. The Setup Wizard will warn you when auto-discovery is not available." />
             </p>
 
-            <h3>Translation or task execution returns 500</h3>
+            <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.500.title" default="Translation or task execution returns 500" /></h3>
             <p>
-                Ensure a <strong>default configuration</strong> is set. Feature services
-                like translation require a default provider to be configured. Check the
-                Configurations module and mark one configuration as default.
+                <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.trouble.500.text" default="Ensure a default configuration is set." /></f:format.raw>
             </p>
         </div>
     </div>
@@ -137,7 +110,7 @@
     <!-- Section 4: FAQ -->
     <div class="card mb-3">
         <div class="card-header">
-            <h2 class="card-title mb-0">Frequently asked questions</h2>
+            <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.title" default="Frequently asked questions" /></h2>
         </div>
         <div class="card-body">
             <div class="accordion" id="faqAccordion">
@@ -147,17 +120,14 @@
                         <button class="accordion-button collapsed" type="button"
                                 data-bs-toggle="collapse" data-bs-target="#faqCollapse1"
                                 aria-expanded="false" aria-controls="faqCollapse1">
-                            Can I use multiple providers at the same time?
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.q1" default="Can I use multiple providers at the same time?" />
                         </button>
                     </h3>
                     <div id="faqCollapse1" class="accordion-collapse collapse"
                          aria-labelledby="faqHeading1" data-bs-parent="#faqAccordion">
                         <div class="accordion-body">
                             <p>
-                                Yes. You can register as many providers as you need.
-                                Each configuration references a specific provider and model.
-                                Different features (chat, translation, vision) can use
-                                different providers.
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.a1" default="Yes. You can register as many providers as you need. Each configuration references a specific provider and model. Different features (chat, translation, vision) can use different providers." />
                             </p>
                         </div>
                     </div>
@@ -168,18 +138,14 @@
                         <button class="accordion-button collapsed" type="button"
                                 data-bs-toggle="collapse" data-bs-target="#faqCollapse2"
                                 aria-expanded="false" aria-controls="faqCollapse2">
-                            How are API keys stored?
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.q2" default="How are API keys stored?" />
                         </button>
                     </h3>
                     <div id="faqCollapse2" class="accordion-collapse collapse"
                          aria-labelledby="faqHeading2" data-bs-parent="#faqAccordion">
                         <div class="accordion-body">
                             <p>
-                                API keys are encrypted using the <code>nr-vault</code>
-                                extension's envelope encryption. Each key is encrypted with
-                                a unique data encryption key (DEK), which is itself encrypted
-                                with a master key (KEK). Keys are never stored in plain text
-                                in the database.
+                                <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.a2" default="API keys are encrypted using the nr-vault extension's envelope encryption." /></f:format.raw>
                             </p>
                         </div>
                     </div>
@@ -190,17 +156,14 @@
                         <button class="accordion-button collapsed" type="button"
                                 data-bs-toggle="collapse" data-bs-target="#faqCollapse3"
                                 aria-expanded="false" aria-controls="faqCollapse3">
-                            Can I use a local LLM (e.g., Ollama)?
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.q3" default="Can I use a local LLM (e.g., Ollama)?" />
                         </button>
                     </h3>
                     <div id="faqCollapse3" class="accordion-collapse collapse"
                          aria-labelledby="faqHeading3" data-bs-parent="#faqAccordion">
                         <div class="accordion-body">
                             <p>
-                                Yes. The Ollama adapter supports local LLM instances. Set the
-                                endpoint to your Ollama server URL (e.g.,
-                                <code>http://localhost:11434</code>) and the wizard will
-                                auto-detect it. No API key is needed for local instances.
+                                <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.a3" default="Yes. The Ollama adapter supports local LLM instances." /></f:format.raw>
                             </p>
                         </div>
                     </div>
@@ -211,18 +174,14 @@
                         <button class="accordion-button collapsed" type="button"
                                 data-bs-toggle="collapse" data-bs-target="#faqCollapse4"
                                 aria-expanded="false" aria-controls="faqCollapse4">
-                            What is the difference between tasks and the Cowriter dialog?
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.q4" default="What is the difference between tasks and the Cowriter dialog?" />
                         </button>
                     </h3>
                     <div id="faqCollapse4" class="accordion-collapse collapse"
                          aria-labelledby="faqHeading4" data-bs-parent="#faqAccordion">
                         <div class="accordion-body">
                             <p>
-                                <strong>Tasks</strong> are simple one-shot prompts defined
-                                here in the LLM module. They appear as preset options in the
-                                Cowriter dialog. The <strong>Cowriter dialog</strong> is the
-                                CKEditor plugin that editors use to interact with the AI.
-                                Editors can pick a task or write a custom instruction.
+                                <f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.faq.a4" default="Tasks are simple one-shot prompts defined here in the LLM module." /></f:format.raw>
                             </p>
                         </div>
                     </div>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -29,19 +29,58 @@
             <f:if condition="{dbProviderCount} > 0">
                 <div class="col-md-6">
                     <f:be.infobox
-                        title="Create Tasks with AI"
+                        title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.callout.title', default: 'Create Tasks with AI')}"
                         state="-2"
                     >
                         <p>
-                            Use the AI Task Wizard to describe what a task should do in plain language. The AI generates a complete task setup — prompt template, dedicated configuration, and model recommendation — in one step.
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.callout.message" default="Use the AI Task Wizard to describe what a task should do in plain language. The AI generates a complete task setup — prompt template, dedicated configuration, and model recommendation — in one step." />
                         </p>
                         <a href="{taskWizardUrl}" class="btn btn-primary">
                             <core:icon identifier="actions-bolt" size="small" />
-                            Create Task with AI
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.callout.button" default="Create Task with AI" />
                         </a>
                     </f:be.infobox>
                 </div>
             </f:if>
+        </div>
+
+        <f:comment>Setup readiness checklist (Provider → Model → Configuration)</f:comment>
+        <f:comment>Attribute-form f:if so the &amp;&amp; entities decode — inline {f:if(...)} does not decode them.</f:comment>
+        <f:variable name="setupReady"><f:if condition="{dbProviderCount} > 0 &amp;&amp; {dbModelCount} > 0 &amp;&amp; {dbConfigurationCount} > 0"><f:then>1</f:then><f:else>0</f:else></f:if></f:variable>
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.title" default="Setup readiness" /></h2>
+                <f:if condition="{setupReady}">
+                    <f:then><span class="badge text-bg-success"><core:icon identifier="actions-check" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.ready" default="Ready" /></span></f:then>
+                    <f:else><span class="badge text-bg-warning"><core:icon identifier="actions-exclamation-triangle" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.incomplete" default="Setup incomplete" /></span></f:else>
+                </f:if>
+            </div>
+            <div class="card-body">
+                <ul class="list-unstyled mb-2">
+                    <li>
+                        <f:if condition="{dbProviderCount} > 0">
+                            <f:then><span class="text-success"><core:icon identifier="actions-check" size="small" /></span></f:then>
+                            <f:else><span class="text-warning"><core:icon identifier="actions-close" size="small" /></span></f:else>
+                        </f:if>
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.step.provider" default="At least one Provider" />
+                    </li>
+                    <li>
+                        <f:if condition="{dbModelCount} > 0">
+                            <f:then><span class="text-success"><core:icon identifier="actions-check" size="small" /></span></f:then>
+                            <f:else><span class="text-warning"><core:icon identifier="actions-close" size="small" /></span></f:else>
+                        </f:if>
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.step.model" default="At least one Model" />
+                    </li>
+                    <li>
+                        <f:if condition="{dbConfigurationCount} > 0">
+                            <f:then><span class="text-success"><core:icon identifier="actions-check" size="small" /></span></f:then>
+                            <f:else><span class="text-warning"><core:icon identifier="actions-close" size="small" /></span></f:else>
+                        </f:if>
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.step.configuration" default="At least one Configuration" />
+                    </li>
+                </ul>
+                <p class="text-body-secondary mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.hint" default="Set up Provider → Model → Configuration in that order, then create Tasks." /></p>
+            </div>
         </div>
 
         <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.management" default="LLM Management" /></h2>
@@ -183,7 +222,7 @@
                         <f:else>
                             <p class="text-muted fw-bold mb-0">
                                 <core:icon identifier="actions-info" size="small" />
-                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:card.count.none.tasks" default="No tasks configured - use seed data" />
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:card.count.none.tasks" default="No tasks yet" />
                             </p>
                         </f:else>
                     </f:if>
@@ -199,7 +238,7 @@
                     <f:if condition="{dbProviderCount} > 0">
                         <a href="{taskWizardUrl}" class="btn btn-primary btn-sm ms-1">
                             <core:icon identifier="actions-bolt" size="small" />
-                            Create with AI
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.createWithAi" default="Create with AI" />
                         </a>
                     </f:if>
                 </div>
@@ -246,6 +285,46 @@
             <div class="card card-size-small">
                 <div class="card-header">
                     <div class="card-icon">
+                        <core:icon identifier="module-nrllm-skill" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.card.title" default="Skills" /></h2>
+                        <span class="card-subtitle"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.card.subtitle" default="Agent skill library" /></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.card.description" default="Sync GitHub-hosted SKILL.md sources and enable the skills available to the agent." /></p>
+                </div>
+                <div class="card-footer">
+                    <a href="{be:moduleLink(route: 'nrllm_skills')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.card.button" default="Manage Skills" />
+                    </a>
+                </div>
+            </div>
+
+            <div class="card card-size-small">
+                <div class="card-header">
+                    <div class="card-icon">
+                        <core:icon identifier="module-nrllm-tool" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tool.card.title" default="Tools" /></h2>
+                        <span class="card-subtitle"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tool.card.subtitle" default="Function-calling tools" /></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tool.card.description" default="Function-calling tools available to the agent, with an admin playground to test them." /></p>
+                </div>
+                <div class="card-footer">
+                    <a href="{be:moduleLink(route: 'nrllm_tools')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tool.card.button" default="Open Tool Playground" />
+                    </a>
+                </div>
+            </div>
+
+            <div class="card card-size-small">
+                <div class="card-header">
+                    <div class="card-icon">
                         <core:icon identifier="module-nrllm-analytics" size="medium" />
                     </div>
                     <div class="card-header-body">
@@ -259,6 +338,31 @@
                 <div class="card-footer">
                     <a href="{be:moduleLink(route: 'nrllm_analytics')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.card.button" default="Open Analytics" />
+                    </a>
+                </div>
+            </div>
+
+            <f:comment>Help &amp; Documentation card (readiness task D)</f:comment>
+            <div class="card card-size-small">
+                <div class="card-header">
+                    <div class="card-icon">
+                        <core:icon identifier="actions-info" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.card.title" default="Help &amp; Documentation" /></h2>
+                        <span class="card-subtitle"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.card.subtitle" default="Guides and reference" /></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.card.description" default="Read the in-module help and the online documentation for setup guidance and troubleshooting." /></p>
+                </div>
+                <div class="card-footer">
+                    <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.card.button" default="Open Help" />
+                    </a>
+                    <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="btn btn-default btn-sm ms-1">
+                        <core:icon identifier="actions-open" size="small" />
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" />
                     </a>
                 </div>
             </div>

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -9,6 +9,27 @@
     <div>
         <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.list.title" default="LLM Models" /></h1>
 
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.next.configurations" default="Next: create Configurations" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_providers')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.providers" default="Providers" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:render partial="Backend/Glossary" />
+
+        <f:if condition="{models -> f:count()} &gt; 0 &amp;&amp; !{hasDefaultModel}">
+            <div class="alert alert-warning">
+                <core:icon identifier="actions-exclamation-triangle" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.noDefault.warning" default="No default model is set. Tasks and features that do not specify a model will fail until you mark one model as default." />
+            </div>
+        </f:if>
+
         <f:if condition="{models -> f:count()}">
             <f:then>
                 <div class="table-fit">
@@ -47,7 +68,7 @@
                                                 <span class="badge text-bg-info">{model.provider.name}</span>
                                             </f:then>
                                             <f:else>
-                                                <span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:noProvider" default="No provider" /></span>
+                                                <span class="badge text-bg-warning" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.orphaned.title')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:noProvider" default="No provider" /></span>
                                             </f:else>
                                         </f:if>
                                     </td>
@@ -82,6 +103,12 @@
                                     <td>{tokByModel.{model.uid}}</td>
                                     <td class="col-control">
                                         <div class="btn-group" role="group">
+                                            <f:if condition="!{model.provider}">
+                                                <a href="{editUrls.{model.uid}}" class="btn btn-warning btn-sm" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.orphaned.title')}">
+                                                    <core:icon identifier="actions-link" size="small" />
+                                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.reassignProvider" default="Reassign Provider" />
+                                                </a>
+                                            </f:if>
                                             <a href="{editUrls.{model.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
                                                 <core:icon identifier="actions-open" size="small" />
                                             </a>
@@ -119,6 +146,7 @@
                     state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.empty.message" default="No models configured yet. Create your first model to start using LLM services." /></p>
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.empty.hint" default="Models are the second tier of setup and require a Provider first (Provider → Model → Configuration)." /></p>
                     <f:if condition="{providers -> f:count()} == 0">
                         <p class="mb-0">
                             <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:note" default="Note" />:</strong>

--- a/Resources/Private/Templates/Backend/PromptSnippet/List.html
+++ b/Resources/Private/Templates/Backend/PromptSnippet/List.html
@@ -9,21 +9,34 @@
     <div>
         <h1>
             <core:icon identifier="module-nrllm-snippet" size="medium" />
-            Prompt Snippets ({totalCount})
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.list.title" default="Prompt Snippets" /> ({totalCount})
         </h1>
 
-        <f:be.infobox state="-2">
-            <p>Prompt snippets are small reusable prompt <strong>fragments</strong> — personas, tones of voice, target audiences, image styles, layouts — managed centrally in one place. Consuming extensions query them by tag and compose them into their prompts.</p>
-            <p class="mb-0">Tag snippets with comma-separated free-form tags. Established tags: <code>audience</code>, <code>tone_of_voice</code>, <code>persona</code>, <code>layout</code>, <code>style</code>. Snippets are not prompt templates: templates are complete prompts with model parameters, snippets are building blocks.</p>
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
         </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_tasks')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.list.title" default="Tasks" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:be.infobox state="-2">
+            <p><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.intro.line1" default="Prompt snippets are small reusable prompt fragments." /></f:format.raw></p>
+            <p class="mb-0"><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.intro.line2" default="Tag snippets with comma-separated free-form tags." /></f:format.raw></p>
+        </f:be.infobox>
+
+        <f:render partial="Backend/Glossary" />
 
         <f:if condition="{totalCount} == 0">
             <f:then>
                 <f:be.infobox
-                    title="No Prompt Snippets Configured"
+                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.empty.title', default: 'No Prompt Snippets Configured')}"
                     state="-1"
                 >
-                    <p>No prompt snippets have been created yet.</p>
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.empty.message" default="No prompt snippets have been created yet." /></p>
                     <p><a href="{newUrl}" class="btn btn-primary btn-sm"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.snippet.new" default="New Snippet" /></a></p>
                 </f:be.infobox>
             </f:then>
@@ -34,10 +47,10 @@
                             <thead>
                                 <tr>
                                     <th style="width: 40px;"></th>
-                                    <th>Name</th>
-                                    <th>Identifier</th>
-                                    <th>Tags</th>
-                                    <th style="width: 120px;">Actions</th>
+                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.name" default="Name" /></th>
+                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.identifier" default="Identifier" /></th>
+                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.tags" default="Tags" /></th>
+                                    <th style="width: 120px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -46,12 +59,12 @@
                                         <td>
                                             <f:if condition="{snippet.isActive}">
                                                 <f:then>
-                                                    <span class="badge text-bg-success" title="Active">
+                                                    <span class="badge text-bg-success" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.active')}">
                                                         <core:icon identifier="actions-check" size="small" />
                                                     </span>
                                                 </f:then>
                                                 <f:else>
-                                                    <span class="badge text-bg-secondary" title="Inactive">
+                                                    <span class="badge text-bg-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.inactive')}">
                                                         <core:icon identifier="actions-close" size="small" />
                                                     </span>
                                                 </f:else>
@@ -71,7 +84,7 @@
                                         </td>
                                         <td>
                                             <div class="btn-group btn-group-sm">
-                                                <a href="{editUrls.{snippet.uid}}" class="btn btn-secondary" title="Edit">
+                                                <a href="{editUrls.{snippet.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
                                                     <core:icon identifier="actions-open" size="small" />
                                                 </a>
                                             </div>

--- a/Resources/Private/Templates/Backend/Provider/List.html
+++ b/Resources/Private/Templates/Backend/Provider/List.html
@@ -9,6 +9,19 @@
     <div>
         <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.list.title" default="LLM Providers" /></h1>
 
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_models')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.next.models" default="Next: register Models" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:render partial="Backend/Glossary" />
+
         <f:if condition="{providers -> f:count()}">
             <f:then>
                 <div class="table-fit">
@@ -19,7 +32,7 @@
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.identifier" default="Identifier" /></th>
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.adapterType" default="Adapter Type" /></th>
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.endpoint" default="Endpoint" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.apiKey" default="API Key" /></th>
+                                <th title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.vault.text')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.apiKey" default="API Key" /></th>
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.status" default="Status" /></th>
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.priority" default="Priority" /></th>
                                 <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
@@ -110,6 +123,7 @@
                     state="-1"
                 >
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.empty.message" default="No API providers configured yet. Create your first provider to connect to LLM services." /></p>
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.empty.hint" default="Providers are the first tier of setup (Provider → Model → Configuration). Launch the Setup Wizard to add one." /></p>
                     <p><a href="{wizardUrl}" class="btn btn-primary btn-sm"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.launch" default="Launch Setup Wizard" /></a></p>
                 </f:be.infobox>
             </f:else>

--- a/Resources/Private/Templates/Backend/SetupWizard/Index.html
+++ b/Resources/Private/Templates/Backend/SetupWizard/Index.html
@@ -14,34 +14,34 @@
                     <div class="step-icon">
                         <core:icon identifier="actions-link" size="small" />
                     </div>
-                    <div class="step-label">Connect</div>
+                    <div class="step-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.step.connect" default="Connect" /></div>
                 </div>
                 <div class="wizard-step" data-step="2">
                     <div class="step-icon">
                         <core:icon identifier="actions-check" size="small" />
                     </div>
-                    <div class="step-label">Verify</div>
+                    <div class="step-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.step.verify" default="Verify" /></div>
                 </div>
                 <div class="wizard-step" data-step="3">
                     <div class="step-icon">
                         <core:icon identifier="apps-pagetree-folder-contains-board" size="small" />
                     </div>
-                    <div class="step-label">Models</div>
+                    <div class="step-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.step.models" default="Models" /></div>
                 </div>
                 <div class="wizard-step" data-step="4">
                     <div class="step-icon">
                         <core:icon identifier="actions-cog" size="small" />
                     </div>
-                    <div class="step-label">Configure</div>
+                    <div class="step-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.step.configure" default="Configure" /></div>
                 </div>
                 <div class="wizard-step" data-step="5">
                     <div class="step-icon">
                         <core:icon identifier="actions-database" size="small" />
                     </div>
-                    <div class="step-label">Save</div>
+                    <div class="step-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.step.save" default="Save" /></div>
                 </div>
             </div>
-            <div class="wizard-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Setup wizard progress">
+            <div class="wizard-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.progress.aria')}">
                 <div class="wizard-progress-fill" style="width: 0%"></div>
             </div>
         </div>
@@ -61,26 +61,26 @@
                     </p>
 
                     <div class="mb-3">
-                        <label for="wizard-endpoint" class="form-label">API Endpoint URL *</label>
+                        <label for="wizard-endpoint" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.endpoint" default="API Endpoint URL *" /></label>
                         <input type="url" class="form-control" id="wizard-endpoint"
                                placeholder="https://api.openai.com/v1" required>
                         <div class="form-text">
-                            Examples: https://api.openai.com/v1, https://api.anthropic.com/v1, http://localhost:11434
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.endpoint.hint" default="Examples: https://api.openai.com/v1, https://api.anthropic.com/v1, http://localhost:11434" />
                         </div>
                     </div>
 
                     <div class="mb-3">
-                        <label for="wizard-apikey" class="form-label">API Key</label>
+                        <label for="wizard-apikey" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.apikey" default="API Key" /></label>
                         <div class="input-group">
                             <input type="password" class="form-control" id="wizard-apikey"
                                    placeholder="sk-...">
                             <button type="button" class="btn btn-outline-secondary" id="toggle-apikey"
-                                    aria-label="Toggle API key visibility">
+                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.apikey.toggle')}">
                                 <core:icon identifier="actions-preview" size="small" />
                             </button>
                         </div>
                         <div class="form-text">
-                            Leave empty for local providers like Ollama that don't require authentication.
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.apikey.hint" default="Leave empty for local providers like Ollama that don't require authentication." />
                         </div>
                     </div>
 
@@ -90,7 +90,7 @@
                                 <core:icon identifier="information" size="small" />
                             </div>
                             <div>
-                                <strong>Detected:</strong> <span id="detected-name"></span>
+                                <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.detected.label" default="Detected:" /></strong> <span id="detected-name"></span>
                                 <span class="badge text-bg-secondary ms-2" id="detected-adapter"></span>
                                 <div class="small text-body-secondary" id="detected-confidence"></div>
                             </div>
@@ -98,27 +98,27 @@
                     </div>
 
                     <div class="mb-3" id="adapter-override" style="display: none;">
-                        <label for="wizard-adapter" class="form-label">Provider Type (override)</label>
-                        <select class="form-select" id="wizard-adapter" aria-label="Select provider type">
+                        <label for="wizard-adapter" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.adapter" default="Provider Type (override)" /></label>
+                        <select class="form-select" id="wizard-adapter" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.adapter.select')}">
                             <f:for each="{adapterTypes}" as="label" key="value">
                                 <option value="{value}">{label}</option>
                             </f:for>
                         </select>
                         <div class="form-text">
-                            Only change this if auto-detection is incorrect.
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.adapter.hint" default="Only change this if auto-detection is incorrect." />
                         </div>
                     </div>
 
                     <button type="button" class="btn btn-link btn-sm" id="show-adapter-override">
                         <core:icon identifier="actions-cog" size="small" />
-                        Override provider type
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.overrideAdapter" default="Override provider type" />
                     </button>
                 </div>
                 <div class="card-footer">
                     <div class="d-flex justify-content-end">
                         <button type="button" class="btn btn-primary" id="btn-detect">
                             <core:icon identifier="actions-search" size="small" />
-                            Detect &amp; Continue
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.detect" default="Detect &amp; Continue" />
                         </button>
                     </div>
                 </div>
@@ -137,7 +137,7 @@
                 <div class="card-body">
                     <div id="test-loading" class="text-center py-5">
                         <div class="spinner-border text-primary mb-3" role="status">
-                            <span class="visually-hidden">Testing connection...</span>
+                            <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.testing.hidden" default="Testing connection..." /></span>
                         </div>
                         <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testingConnection" default="Testing connection to provider..." /></p>
                     </div>
@@ -155,22 +155,22 @@
                     <div id="test-error" class="alert alert-danger" style="display: none;">
                         <h4 class="alert-heading">
                             <core:icon identifier="actions-ban" size="small" />
-                            Connection Failed
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.connectionFailed" default="Connection Failed" />
                         </h4>
                         <p id="test-error-message"></p>
                         <hr>
-                        <p class="mb-0">Please check your endpoint URL and API key, then try again.</p>
+                        <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.connectionFailed.hint" default="Please check your endpoint URL and API key, then try again." /></p>
                     </div>
                 </div>
                 <div class="card-footer">
                     <div class="d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="btn-back-1">
                             <core:icon identifier="actions-chevron-left" size="small" />
-                            Back
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.back" default="Back" />
                         </button>
                         <button type="button" class="btn btn-primary" id="btn-discover" disabled>
                             <core:icon identifier="actions-refresh" size="small" />
-                            Discover Models
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.discover" default="Discover Models" />
                         </button>
                     </div>
                 </div>
@@ -189,7 +189,7 @@
                 <div class="card-body">
                     <div id="models-loading" class="text-center py-5">
                         <div class="spinner-border text-primary mb-3" role="status">
-                            <span class="visually-hidden">Discovering models...</span>
+                            <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.discovering.hidden" default="Discovering models..." /></span>
                         </div>
                         <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:discoveringModels" default="Discovering available models..." /></p>
                     </div>
@@ -204,12 +204,12 @@
                                     <tr>
                                         <th style="width: 40px;">
                                             <input type="checkbox" class="form-check-input" id="select-all-models"
-                                                   aria-label="Select all models">
+                                                   aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.selectAll')}">
                                         </th>
-                                        <th>Model</th>
-                                        <th>Context</th>
-                                        <th>Capabilities</th>
-                                        <th style="width: 100px;">Recommended</th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.model" default="Model" /></th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.context" default="Context" /></th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.capabilities" default="Capabilities" /></th>
+                                        <th style="width: 100px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.recommended" default="Recommended" /></th>
                                     </tr>
                                 </thead>
                                 <tbody></tbody>
@@ -221,11 +221,11 @@
                     <div class="d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="btn-back-2">
                             <core:icon identifier="actions-chevron-left" size="small" />
-                            Back
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.back" default="Back" />
                         </button>
                         <button type="button" class="btn btn-primary" id="btn-generate" disabled>
                             <core:icon identifier="actions-bolt" size="small" />
-                            Generate Configurations
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.generate" default="Generate Configurations" />
                         </button>
                     </div>
                 </div>
@@ -262,11 +262,11 @@
                     <div class="d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="btn-back-3">
                             <core:icon identifier="actions-chevron-left" size="small" />
-                            Back
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.back" default="Back" />
                         </button>
                         <button type="button" class="btn btn-primary" id="btn-review">
                             <core:icon identifier="actions-preview" size="small" />
-                            Review &amp; Save
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.review" default="Review &amp; Save" />
                         </button>
                     </div>
                 </div>
@@ -284,26 +284,26 @@
                 </div>
                 <div class="card-body">
                     <div id="review-content">
-                        <h5>Provider</h5>
+                        <h5><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.section.provider" default="Provider" /></h5>
                         <div class="card mb-3">
                             <div class="card-body" id="review-provider"></div>
                         </div>
 
-                        <h5>Models (<span id="review-models-count">0</span>)</h5>
+                        <h5><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.section.models" default="Models" /> (<span id="review-models-count">0</span>)</h5>
                         <div class="card mb-3">
                             <ul class="list-group list-group-flush" id="review-models"></ul>
                         </div>
 
-                        <h5>Configurations (<span id="review-configs-count">0</span>)</h5>
+                        <h5><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.section.configurations" default="Configurations" /> (<span id="review-configs-count">0</span>)</h5>
                         <div class="card mb-3">
                             <ul class="list-group list-group-flush" id="review-configs"></ul>
                         </div>
 
                         <div class="mb-3">
-                            <label for="wizard-pid" class="form-label">Storage Folder (Page ID)</label>
+                            <label for="wizard-pid" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.pid" default="Storage Folder (Page ID)" /></label>
                             <input type="number" class="form-control" id="wizard-pid" value="0" min="0">
                             <div class="form-text">
-                                The page ID where records will be stored. Use 0 for root level.
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.field.pid.hint" default="The page ID where records will be stored. Use 0 for root level." />
                             </div>
                         </div>
                     </div>
@@ -326,11 +326,11 @@
                         <div class="mt-4">
                             <a href="#" class="btn btn-primary" id="btn-go-providers">
                                 <core:icon identifier="actions-open" size="small" />
-                                View Providers
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.goProviders" default="View Providers" />
                             </a>
                             <button type="button" class="btn btn-secondary" id="btn-restart">
                                 <core:icon identifier="actions-refresh" size="small" />
-                                Add Another Provider
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.restart" default="Add Another Provider" />
                             </button>
                         </div>
                     </div>
@@ -338,7 +338,7 @@
                     <div id="save-error" class="alert alert-danger" style="display: none;">
                         <h4 class="alert-heading">
                             <core:icon identifier="actions-ban" size="small" />
-                            Save Failed
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.saveFailed" default="Save Failed" />
                         </h4>
                         <p id="save-error-message"></p>
                     </div>
@@ -347,11 +347,11 @@
                     <div class="d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="btn-back-4">
                             <core:icon identifier="actions-chevron-left" size="small" />
-                            Back
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.back" default="Back" />
                         </button>
                         <button type="button" class="btn btn-success" id="btn-save">
                             <core:icon identifier="actions-check" size="small" />
-                            Save Configuration
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.btn.save" default="Save Configuration" />
                         </button>
                     </div>
                 </div>

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -12,6 +12,19 @@
             <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.list.title" default="Skills" />
         </h1>
 
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_tools')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:render partial="Backend/Glossary" />
+
         <f:be.infobox state="-2">
             <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.intro.line1" default="Add GitHub-hosted skill sources (a single SKILL.md file, a repository, or a marketplace index), then synchronise them. Skills are fetched by immutable commit SHA, integrity-checksummed and host-allowlisted." /></p>
             <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.intro.line2" default="Skills discovered from repositories and marketplaces are materialised disabled by default. Re-syncing an enabled skill whose body changed upstream auto-disables it for review." /></p>
@@ -37,7 +50,16 @@
                                     <tr data-source-uid="{source.uid}">
                                         <td><strong>{source.title}</strong></td>
                                         <td><span class="badge text-bg-info">{source.type.value}</span></td>
-                                        <td><code>{source.syncStatus.value}</code></td>
+                                        <td>
+                                            <f:switch expression="{source.syncStatus.value}">
+                                                <f:case value="ok"><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.ok" default="Synced" /></span></f:case>
+                                                <f:case value="never_synced"><span class="badge text-bg-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.never" default="Never synced" /></span></f:case>
+                                                <f:case value="syncing"><span class="badge text-bg-info"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.syncing" default="Syncing" /></span></f:case>
+                                                <f:case value="partial"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.partial" default="Partial" /></span></f:case>
+                                                <f:case value="error"><span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.error" default="Failed" /></span></f:case>
+                                                <f:defaultCase><code>{source.syncStatus.value}</code></f:defaultCase>
+                                            </f:switch>
+                                        </td>
                                         <td>
                                             <f:if condition="{source.lastSynced} > 0">
                                                 <f:then><f:format.date date="@{source.lastSynced}" format="Y-m-d H:i" /></f:then>
@@ -46,6 +68,9 @@
                                         </td>
                                         <td>
                                             <div class="btn-group btn-group-sm">
+                                                <a href="{sourceEditUrls.{source.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.source.edit', default: 'Edit source')}">
+                                                    <core:icon identifier="actions-open" size="small" />
+                                                </a>
                                                 <button type="button" class="btn btn-secondary js-skill-sync"
                                                         data-source="{source.uid}" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.action.sync', default: 'Sync')}">
                                                     <core:icon identifier="actions-refresh" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.action.sync" default="Sync" />
@@ -66,6 +91,8 @@
             <f:else>
                 <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.sources.empty.title', default: 'No skill sources configured')}" state="-1">
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.sources.empty.message" default="No skill sources have been added yet. Create a source record to ingest skills from GitHub." /></p>
+                    <p class="mb-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.sources.empty.admin" default="Administrators: add a source record, then run a sync. Discovered skills start disabled — enable the ones you want to use." /></p>
+                    <p class="mb-0 text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.sources.empty.developer" default="Developers: a source points at a GitHub-hosted SKILL.md file, repository or marketplace index." /></p>
                 </f:be.infobox>
             </f:else>
         </f:if>
@@ -131,6 +158,7 @@
             <f:else>
                 <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.skills.empty.title', default: 'No skills ingested')}" state="-1">
                     <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.skills.empty.message" default="No skills have been ingested yet. Add a source and run a sync." /></p>
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.skills.empty.admin" default="Administrators: once a source is synced, enable a skill here to make it available." /></p>
                 </f:be.infobox>
             </f:else>
         </f:if>

--- a/Resources/Private/Templates/Backend/Task/Execute.html
+++ b/Resources/Private/Templates/Backend/Task/Execute.html
@@ -34,6 +34,8 @@
             </div>
         </f:if>
 
+        <f:render partial="Backend/Glossary" />
+
         <f:comment>Configuration & Model Details Panel</f:comment>
         <div class="card mb-4">
             <div class="card-header d-flex justify-content-between align-items-center">

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -9,21 +9,41 @@
     <div>
         <h1>
             <core:icon identifier="actions-bolt" size="medium" />
-            Tasks ({totalCount})
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.list.title" default="Tasks" /> ({totalCount})
         </h1>
 
-        <f:be.infobox state="-2">
-            <p>Tasks define <strong>what</strong> the AI should do: a prompt template with placeholders for input data. Each task is a one-shot prompt — for example, "Summarize this text" or "Check for grammar errors". Tasks receive input, send it to the LLM, and return the result.</p>
-            <p class="mb-0">Each task uses a <strong>Configuration</strong> that defines <strong>how</strong> the AI behaves (model, temperature, system prompt). You can assign different configurations to tasks depending on the use case — a translation task might use a precise, low-temperature configuration, while a creative writing task uses a high-temperature one.</p>
+        <f:be.infobox state="-1">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
         </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.list.title" default="Configurations" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:be.infobox state="-2">
+            <p><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.intro.line1" default="Tasks define what the AI should do." /></f:format.raw></p>
+            <p class="mb-0"><f:format.raw><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.intro.line2" default="Each task uses a Configuration." /></f:format.raw></p>
+        </f:be.infobox>
+
+        <f:render partial="Backend/Glossary" />
+
+        <f:if condition="{totalCount} &gt; 0 &amp;&amp; {activeCount} == 0">
+            <div class="alert alert-warning">
+                <core:icon identifier="actions-exclamation-triangle" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.noActive.warning" default="No active tasks. Only active tasks appear in the CKEditor cowriter dialog and the API. Activate a task to make it available." />
+            </div>
+        </f:if>
 
         <f:if condition="{totalCount} == 0">
             <f:then>
                 <f:be.infobox
-                    title="No Tasks Configured"
+                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.empty.title', default: 'No Tasks Configured')}"
                     state="-1"
                 >
-                    <p>No tasks have been created yet. Use the seed data or create your first task.</p>
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.empty.message" default="Tasks are one-shot prompt templates. They require a Configuration first. Launch the Setup Wizard to get started, or create a task manually." /></p>
                     <p><a href="{wizardUrl}" class="btn btn-primary btn-sm"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.launch" default="Launch Setup Wizard" /></a></p>
                 </f:be.infobox>
             </f:then>
@@ -47,14 +67,14 @@
                                 <thead>
                                     <tr>
                                         <th style="width: 40px;"></th>
-                                        <th>Name</th>
-                                        <th>Identifier</th>
-                                        <th>Input</th>
-                                        <th>Output</th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.name" default="Name" /></th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.identifier" default="Identifier" /></th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.input" default="Input" /></th>
+                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.output" default="Output" /></th>
                                         <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
                                         <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
                                         <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
-                                        <th style="width: 200px;">Actions</th>
+                                        <th style="width: 200px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -63,12 +83,12 @@
                                             <td>
                                                 <f:if condition="{task.isActive}">
                                                     <f:then>
-                                                        <span class="badge text-bg-success" title="Active">
+                                                        <span class="badge text-bg-success" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.active')}">
                                                             <core:icon identifier="actions-check" size="small" />
                                                         </span>
                                                     </f:then>
                                                     <f:else>
-                                                        <span class="badge text-bg-secondary" title="Inactive">
+                                                        <span class="badge text-bg-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.inactive')}">
                                                             <core:icon identifier="actions-close" size="small" />
                                                         </span>
                                                     </f:else>
@@ -77,7 +97,7 @@
                                             <td>
                                                 <strong>{task.name}</strong>
                                                 <f:if condition="{task.isSystem}">
-                                                    <span class="badge text-bg-info ms-1" title="System task">System</span>
+                                                    <span class="badge text-bg-info ms-1" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.system')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.badge.system" default="System" /></span>
                                                 </f:if>
                                                 <f:if condition="{task.description}">
                                                     <br><small class="text-muted">{task.description}</small>
@@ -96,12 +116,12 @@
                                             <td>
                                                 <div class="btn-group btn-group-sm">
                                                     <f:if condition="{task.isActive}">
-                                                        <f:link.action action="executeForm" arguments="{uid: task.uid}" class="btn btn-success" title="Execute">
+                                                        <f:link.action action="executeForm" arguments="{uid: task.uid}" class="btn btn-success" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.execute')}">
                                                             <core:icon identifier="actions-play" size="small" />
-                                                            Run
+                                                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.run" default="Run" />
                                                         </f:link.action>
                                                     </f:if>
-                                                    <a href="{editUrls.{task.uid}}" class="btn btn-secondary" title="Edit">
+                                                    <a href="{editUrls.{task.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
                                                         <core:icon identifier="actions-open" size="small" />
                                                     </a>
                                                 </div>

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -9,19 +9,23 @@
 </f:section>
 
 <f:section name="Content">
-    <h1>Test LLM Provider</h1>
+    <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.page.title" default="Test LLM Provider" /></h1>
+
+    <f:be.infobox state="-1" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.info.title', default: 'Raw provider test')}">
+        <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.info.body" default="This page sends a single prompt directly to the selected provider, bypassing tasks and configurations. Use it to confirm a provider connection works. Results are not stored." /></p>
+    </f:be.infobox>
 
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-6">
                 <div class="card">
                     <div class="card-header">
-                        <h2 class="card-title">Send Test Request</h2>
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.card.send" default="Send Test Request" /></h2>
                     </div>
                     <div class="card-body">
                         <form id="testForm">
                             <div class="mb-3">
-                                <label for="provider" class="form-label">Provider</label>
+                                <label for="provider" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.provider" default="Provider" /></label>
                                 <select id="provider" name="provider" class="form-select">
                                     <f:for each="{providers}" as="provider">
                                         <option value="{provider.identifier}">{provider.name}</option>
@@ -30,16 +34,16 @@
                             </div>
 
                             <div class="mb-3">
-                                <label for="prompt" class="form-label">Prompt</label>
+                                <label for="prompt" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.prompt" default="Prompt" /></label>
                                 <textarea id="prompt" name="prompt" class="form-control" rows="4">Hello, please respond with a brief greeting to test the connection.</textarea>
                             </div>
 
                             <button type="submit" class="btn btn-primary mt-3">
-                                Run Test
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.btn.run" default="Run Test" />
                             </button>
 
                             <f:link.action action="index" class="btn btn-secondary mt-3">
-                                Back to Overview
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.btn.back" default="Back to Overview" />
                             </f:link.action>
                         </form>
                     </div>
@@ -49,37 +53,37 @@
             <div class="col-md-6">
                 <div class="card">
                     <div class="card-header">
-                        <h2 class="card-title">Response</h2>
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.card.response" default="Response" /></h2>
                     </div>
                     <div class="card-body">
                         <div id="responseContainer" style="display: none;">
                             <div id="responseSuccess" class="alert alert-success" style="display: none;">
-                                <strong>Success!</strong>
+                                <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.response.success" default="Success!" /></strong>
                             </div>
                             <div id="responseError" class="alert alert-danger" style="display: none;">
-                                <strong>Error:</strong> <span id="errorMessage"></span>
+                                <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.response.error" default="Error:" /></strong> <span id="errorMessage"></span>
                             </div>
 
                             <div id="responseDetails" style="display: none;">
-                                <h4>Content</h4>
+                                <h4><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.response.content" default="Content" /></h4>
                                 <pre id="responseContent" class="bg-light p-3"></pre>
 
-                                <h4>Usage</h4>
+                                <h4><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.response.usage" default="Usage" /></h4>
                                 <table class="table table-sm">
                                     <tr>
-                                        <td>Model</td>
+                                        <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.usage.model" default="Model" /></td>
                                         <td id="responseModel"></td>
                                     </tr>
                                     <tr>
-                                        <td>Prompt Tokens</td>
+                                        <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.usage.promptTokens" default="Prompt Tokens" /></td>
                                         <td id="promptTokens"></td>
                                     </tr>
                                     <tr>
-                                        <td>Completion Tokens</td>
+                                        <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.usage.completionTokens" default="Completion Tokens" /></td>
                                         <td id="completionTokens"></td>
                                     </tr>
                                     <tr>
-                                        <td>Total Tokens</td>
+                                        <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.usage.totalTokens" default="Total Tokens" /></td>
                                         <td id="totalTokens"></td>
                                     </tr>
                                 </table>
@@ -88,9 +92,9 @@
 
                         <div id="loadingIndicator" style="display: none;">
                             <div class="spinner-border text-primary" role="status">
-                                <span class="visually-hidden">Loading...</span>
+                                <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.loading" default="Sending request..." /></span>
                             </div>
-                            <span class="ms-2">Sending request...</span>
+                            <span class="ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.loading" default="Sending request..." /></span>
                         </div>
                     </div>
                 </div>

--- a/Resources/Private/Templates/Backend/ToolPlayground/List.html
+++ b/Resources/Private/Templates/Backend/ToolPlayground/List.html
@@ -16,6 +16,16 @@
             <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.intro" default="Pick an LLM configuration, enter a prompt and run the agent loop. Each tool call, its result and the final answer are shown below. Tools run with full backend privileges and their results egress to the configured provider — this module is admin-only." /></p>
         </f:be.infobox>
 
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.list.title" default="Configurations" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_skills')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.list.title" default="Skills" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:render partial="Backend/Glossary" />
+
         <div class="row">
             <div class="col-md-7">
                 <div class="card mb-4">
@@ -118,7 +128,9 @@
                     </f:then>
                     <f:else>
                         <f:be.infobox state="-1">
-                            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.empty" default="No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool." /></p>
+                            <p class="mb-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.empty" default="No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool." /></p>
+                            <p class="mb-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:playground.empty.admin" default="Administrators: enable a tool below, pick a configuration and run a prompt to try the agent loop." /></p>
+                            <p class="mb-0 text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:playground.empty.developer" default="Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool." /></p>
                         </f:be.infobox>
                     </f:else>
                 </f:if>

--- a/Tests/E2E/Playwright/action-buttons.spec.ts
+++ b/Tests/E2E/Playwright/action-buttons.spec.ts
@@ -17,7 +17,7 @@ test.describe('Action Buttons', () => {
       } else {
         // No providers configured - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
       }
     });
 
@@ -126,7 +126,7 @@ test.describe('Action Buttons', () => {
       } else {
         // No models configured - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
       }
     });
   });
@@ -152,7 +152,7 @@ test.describe('Action Buttons', () => {
       } else {
         // No configurations - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
       }
     });
 

--- a/Tests/E2E/Playwright/ajax-controllers.spec.ts
+++ b/Tests/E2E/Playwright/ajax-controllers.spec.ts
@@ -33,7 +33,7 @@ test.describe('Provider AJAX Actions', () => {
       if (count === 0) {
         // No providers - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -69,7 +69,7 @@ test.describe('Provider AJAX Actions', () => {
       if (count === 0) {
         // No providers - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -124,7 +124,7 @@ test.describe('Provider AJAX Actions', () => {
       if (count === 0) {
         // No providers - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -156,7 +156,7 @@ test.describe('Provider AJAX Actions', () => {
       if (count === 0) {
         // No providers - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -189,7 +189,7 @@ test.describe('Model AJAX Actions', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -211,7 +211,7 @@ test.describe('Model AJAX Actions', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -234,7 +234,7 @@ test.describe('Model AJAX Actions', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -255,7 +255,7 @@ test.describe('Model AJAX Actions', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -278,7 +278,7 @@ test.describe('Model AJAX Actions', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -372,7 +372,7 @@ test.describe('Configuration AJAX Actions', () => {
       if (count === 0) {
         // No configurations - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -431,7 +431,7 @@ test.describe('Configuration AJAX Actions', () => {
       if (count === 0) {
         // No configurations - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -463,7 +463,7 @@ test.describe('Configuration AJAX Actions', () => {
       if (count === 0) {
         // No configurations - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 
@@ -510,7 +510,7 @@ test.describe('AJAX Error Handling', () => {
     if (count === 0) {
       // No AJAX buttons - verify empty state is shown
       const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-      await expect(emptyState).toBeVisible();
+      await expect(emptyState.first()).toBeVisible();
       return;
     }
 

--- a/Tests/E2E/Playwright/backend-module.spec.ts
+++ b/Tests/E2E/Playwright/backend-module.spec.ts
@@ -35,8 +35,8 @@ test.describe('LLM Backend Module - Multi-Tier Architecture', () => {
 
       // Check for expected content: either providers table or empty state callout
       const hasTable = await moduleFrame.locator('table').isVisible();
-      const hasCallout = await moduleFrame.locator('.callout').isVisible();
-      const hasInfoBox = await moduleFrame.locator('.t3js-infobox, [class*="infobox"]').isVisible();
+      const hasCallout = await moduleFrame.locator('.callout').first().isVisible();
+      const hasInfoBox = await moduleFrame.locator('.t3js-infobox, [class*="infobox"]').first().isVisible();
 
       expect(hasTable || hasCallout || hasInfoBox).toBe(true);
     });
@@ -155,7 +155,7 @@ test.describe('LLM Backend Module - Multi-Tier Architecture', () => {
         expect(buttonCount).toBeGreaterThan(0);
       } else {
         // No providers - verify empty state message exists
-        const hasEmptyState = await moduleFrame.locator('.callout, [class*="infobox"]').isVisible();
+        const hasEmptyState = await moduleFrame.locator('.callout, [class*="infobox"]').first().isVisible();
         expect(hasEmptyState).toBe(true);
       }
     });

--- a/Tests/E2E/Playwright/model-list.spec.ts
+++ b/Tests/E2E/Playwright/model-list.spec.ts
@@ -82,7 +82,7 @@ test.describe('Model List Module', () => {
       if (count === 0) {
         // No models - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 

--- a/Tests/E2E/Playwright/task-execute.spec.ts
+++ b/Tests/E2E/Playwright/task-execute.spec.ts
@@ -397,7 +397,7 @@ test.describe('Task Execute Module', () => {
       if (count === 0) {
         // No tasks - verify empty state is shown
         const emptyState = moduleFrame.locator('.callout-info, .alert-info, [class*="infobox"]');
-        await expect(emptyState).toBeVisible();
+        await expect(emptyState.first()).toBeVisible();
         return;
       }
 

--- a/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
+++ b/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
@@ -85,7 +85,10 @@ final class BackendAjaxAdminGuardTest extends AbstractFunctionalTestCase
         $payload = json_decode((string)$response->getBody(), true);
         self::assertIsArray($payload);
         self::assertFalse($payload['success']);
-        self::assertSame('Forbidden', $payload['error']);
+        // The denial carries an actionable, admin-oriented message (translated;
+        // falls back to the English source) rather than a bare "Forbidden".
+        self::assertIsString($payload['error']);
+        self::assertStringContainsStringIgnoringCase('administrator', $payload['error']);
     }
 
     #[Test]

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -130,7 +130,8 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $payload = json_decode((string)$response->getBody(), true);
         self::assertIsArray($payload);
         self::assertFalse($payload['success']);
-        self::assertSame('Forbidden', $payload['error']);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsStringIgnoringCase('administrator', $payload['error']);
     }
 
     #[Test]

--- a/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
+++ b/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
@@ -86,7 +86,10 @@ final class RequiresBackendAdminTraitTest extends TestCase
         $payload = json_decode((string)$response->getBody(), true);
         self::assertIsArray($payload);
         self::assertFalse($payload['success']);
-        self::assertSame('Forbidden', $payload['error']);
+        // Actionable, admin-oriented message (translated when a language service
+        // is available, else the English fallback) rather than a bare "Forbidden".
+        self::assertIsString($payload['error']);
+        self::assertStringContainsStringIgnoringCase('administrator', $payload['error']);
     }
 
     #[Test]


### PR DESCRIPTION
## Description

Implements the consolidated findings of a **6-lens independent UX/help audit** (context-help/glossary, onboarding, roles/enablement, see-also, readiness, consistency/a11y/i18n) across **all backend modules**. 85 raw findings → 6 themes; this PR addresses them (the audit's own verification rejected two reviewer errors — a non-existent `nrllm_help` route and an API-key false-positive — which are correctly **not** acted on here).

### Help & glossary
- A docheader **Help** affordance + **"Read docs"** links on every module (targeting the Overview `help` action — there is no `nrllm_help` route — and the online docs).
- A shared collapsible **glossary partial** (`Partials/Backend/Glossary.html`) — core terms + numeric params (temperature/max_tokens/top_p/penalties) — reused across the data modules.

### Onboarding & empty states
- Standardized empty states: *what-it-is + setup-order (Provider → Model → Configuration → Task) + primary CTA*. Skills/Tools empty states split into **admin vs developer** guidance (no more dev-jargon-only).

### Readiness signals
- Overview **readiness checklist** (Provider/Model/Configuration ✓). Configuration: **"No model assigned"** danger badge + activation disabled when no model. Model: **"no default model"** banner. Task: **"no active tasks"** banner. Skills: colored **sync-status badges** (real `SyncStatus` enum values).

### Enablement
- `denyNonAdmin()` now returns an **actionable, translated** admin-required message (was bare `Forbidden`) — resilient (falls back to English outside a request context). Admin-only infoboxes added for parity.

### Dashboard
- Added the **missing Skills, Tools and Help & Documentation cards** (the overview only had 6 cards; Skills/Tools shipped later without dashboard cards).

### Skills
- Per-source **"Add source"** (docheader) and **"Edit"** (per row) FormEngine buttons — there was previously no way to add/edit a source from the module.

### i18n
- Full **EN + DE** translation sweep of previously-hardcoded templates (Task list, Setup Wizard, Index, Configuration/Snippet intros, Help, Test). EN/DE parity verified.

## Type of Change
- [x] Feature (backend UX / help / i18n)

## Checklist
- [x] Unit 3750 · Functional 915 · PHPStan L10 · CGL clean (PHP 8.4)
- [x] Every new label EN + DE; `<f:be.infobox>` (not `<be:infobox>`); no invented `nrllm_help` route; `hasApiKey()` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
