### PR TITLE
feat(tools): enforce acting-user RBAC + surface real run errors

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -12,15 +12,18 @@ namespace Netresearch\NrLlm\Controller\Backend;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use ReflectionClass;
 use stdClass;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -49,6 +52,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 {
     use RequiresBackendAdminTrait;
     use LoggerAwareTrait;
+    use ErrorMessageSanitizerTrait;
 
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
@@ -116,7 +120,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             $result = $this->toolLoopService->runLoop([ChatMessage::user($prompt)], $config, $allowed, $options);
         } catch (Throwable $e) {
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
-            return new JsonResponse(['success' => false, 'error' => 'Tool run failed'], 500);
+
+            return new JsonResponse(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
         }
 
         return new JsonResponse([
@@ -230,5 +235,34 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
 
         return $names;
+    }
+
+    /**
+     * Build an actionable error string for a failed run.
+     *
+     * The playground is admin-only ({@see RequiresBackendAdminTrait}), so it
+     * surfaces the concrete failure — exception class + (secret-sanitised)
+     * message, and for an upstream {@see ProviderResponseException} the HTTP
+     * status and a truncated, sanitised response-body snippet — instead of a
+     * generic "Tool run failed". The full exception is still logged separately.
+     */
+    private function diagnoseRunFailure(Throwable $e): string
+    {
+        $class   = (new ReflectionClass($e))->getShortName();
+        $message = $this->sanitizeErrorMessage($e->getMessage());
+        $detail  = sprintf('%s: %s', $class, $message);
+
+        if ($e instanceof ProviderResponseException) {
+            if ($e->httpStatus > 0) {
+                $detail .= sprintf(' (HTTP %d)', $e->httpStatus);
+            }
+            $body = trim($e->responseBody);
+            if ($body !== '') {
+                $snippet = $this->sanitizeErrorMessage(mb_substr($body, 0, 500));
+                $detail .= "\nProvider response: " . $snippet;
+            }
+        }
+
+        return $detail;
     }
 }

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -367,20 +367,27 @@ abstract class AbstractProvider implements ProviderInterface
      */
     protected function extractErrorMessage(array $error): string
     {
-        // Try nested error.message first (OpenAI format)
-        $nestedError = $this->getArray($error, 'error');
-        $message = $nestedError !== [] ? $this->getNullableString($nestedError, 'message') : null;
+        $errorValue = $error['error'] ?? null;
 
-        // Sometimes error is just a string
-        if ($message === null && $nestedError !== []) {
-            $errorValue = $error['error'] ?? null;
-            if (is_string($errorValue)) {
-                return $errorValue;
+        // Nested {"error":{"message":...}} (OpenAI format).
+        if (is_array($errorValue)) {
+            $message = $this->getNullableString($this->asArray($errorValue), 'message');
+            if ($message !== null && $message !== '') {
+                return $message;
             }
         }
 
-        // Try direct message (some providers)
-        $message ??= $this->getNullableString($error, 'message');
+        // Flat {"error":"..."} string (Ollama and others). This must be checked
+        // independently of the nested branch above: when `error` is a string,
+        // getArray() yields [] for it, so guarding the flat case on a non-empty
+        // nested array (the previous bug) silently dropped the real message and
+        // degraded everything to "Unknown provider error".
+        if (is_string($errorValue) && $errorValue !== '') {
+            return $errorValue;
+        }
+
+        // Direct top-level {"message":...} (some providers).
+        $message = $this->getNullableString($error, 'message');
 
         return $message ?? 'Unknown provider error';
     }

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -120,4 +120,10 @@ final readonly class FetchLogsTool implements ToolInterface
     {
         return true;
     }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetEnvRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvRawTool.php
@@ -64,4 +64,10 @@ final readonly class GetEnvRawTool implements ToolInterface
         return false;
     }
 
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
+
 }

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -68,4 +68,10 @@ final readonly class GetEnvTool implements ToolInterface
         return true;
     }
 
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
+
 }

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
  * Return the backend page tree (`pages`) as a depth-indented outline.
@@ -30,6 +31,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  */
 final readonly class GetPageTreeTool implements ToolInterface
 {
+    use ResolvesActingBackendUserTrait;
     use SafeCastTrait;
 
     private const TABLE = 'pages';
@@ -101,6 +103,12 @@ final readonly class GetPageTreeTool implements ToolInterface
         return true;
     }
 
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
+        return false;
+    }
+
     /**
      * Append the live (non-deleted, non-hidden) children of $pid, recursing
      * until the depth or the global node cap is reached.
@@ -113,21 +121,37 @@ final readonly class GetPageTreeTool implements ToolInterface
             return;
         }
 
+        // Respect the acting user's page permissions: a non-admin only sees
+        // pages they may show. No backend user → no pages (fail-closed).
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return;
+        }
+        $permsClause = $user->getPagePermsClause(Permission::PAGE_SHOW);
+
+        // Default restrictions (no removeAll) already drop soft-deleted rows;
+        // the explicit deleted/hidden filters are kept as belt-and-suspenders,
+        // and sys_language_uid is pinned so translated rows do not duplicate the
+        // tree.
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
-        $queryBuilder->getRestrictions()->removeAll();
-        $rows = $queryBuilder
+        $queryBuilder
             ->select('uid', 'title', 'doktype')
             ->from(self::TABLE)
             ->where(
                 $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),
                 $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                 $queryBuilder->expr()->eq('hidden', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
-                // removeAll() above drops the language restriction, so pin to the
-                // default language explicitly — otherwise translated page records
-                // surface as separate nodes and corrupt the tree structure.
                 $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
             )
-            ->orderBy('sorting', 'ASC')
+            ->orderBy('sorting', 'ASC');
+
+        // For an admin getPagePermsClause() yields an empty string; only add it
+        // for non-admins so we never pass an empty constraint to andWhere().
+        if ($permsClause !== '') {
+            $queryBuilder->andWhere($permsClause);
+        }
+
+        $rows = $queryBuilder
             ->executeQuery()
             ->fetchAllAssociative();
 

--- a/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
@@ -68,4 +68,10 @@ final readonly class GetPhpInfoRawTool implements ToolInterface
     {
         return false;
     }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
@@ -71,4 +71,10 @@ final readonly class GetPhpInfoTool implements ToolInterface
     {
         return true;
     }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTcaTool.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Utility\SafeCastTrait;
  */
 final readonly class GetTcaTool implements ToolInterface
 {
+    use ResolvesActingBackendUserTrait;
     use SafeCastTrait;
 
     /** Upper bound on listed tables / columns to keep the egress bounded. */
@@ -70,12 +71,31 @@ final readonly class GetTcaTool implements ToolInterface
         return true;
     }
 
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
+        return false;
+    }
+
     /**
      * @param array<array-key, mixed> $tca
      */
     private function listTables(array $tca): string
     {
+        // Respect the acting user's table-select rights: a non-admin only sees
+        // tables they may read in the backend (admins pass every check). No
+        // backend user → no tables (fail-closed); return early so the whole TCA
+        // is not mapped/filtered for nothing.
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return "TCA tables (0):\n";
+        }
+
         $names = array_map(static fn(int|string $name): string => (string)$name, array_keys($tca));
+        $names = array_values(array_filter(
+            $names,
+            static fn(string $name): bool => $user->check('tables_select', $name),
+        ));
         sort($names);
         $names = array_slice($names, 0, self::MAX_ITEMS);
 
@@ -87,6 +107,14 @@ final readonly class GetTcaTool implements ToolInterface
      */
     private function describeTable(array $tca, string $table): string
     {
+        // A non-admin may only describe tables they can read; an unreadable (or
+        // unknown) table returns the same neutral string so the tool never
+        // confirms a table's existence to someone without access.
+        $user = $this->actingBackendUser();
+        if ($user === null || !$user->check('tables_select', $table)) {
+            return 'Unknown TCA table.';
+        }
+
         $definition = $tca[$table] ?? null;
         if (!is_array($definition) || !isset($definition['columns']) || !is_array($definition['columns'])) {
             return 'Unknown TCA table.';

--- a/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
@@ -82,4 +82,10 @@ final readonly class ListBeGroupsTool implements ToolInterface
     {
         return true;
     }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
@@ -106,6 +106,12 @@ final readonly class ListBeUsersRawTool implements ToolInterface
         return false;
     }
 
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
+
     private function truncate(string $value): string
     {
         if (mb_strlen($value) <= self::MAX_VALUE_LENGTH) {

--- a/Classes/Service/Tool/Builtin/ListBeUsersTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersTool.php
@@ -92,4 +92,10 @@ final readonly class ListBeUsersTool implements ToolInterface
     {
         return true;
     }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
+        return true;
+    }
 }

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -74,6 +74,12 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
             return self::NOT_PERMITTED;
         }
 
+        // sys_file / sys_file_metadata are FAL system tables without enable
+        // columns (no deleted/hidden), so removeAll() is kept; the storage
+        // allow-list ({@see $allowedStorages}) is the access gate, and the
+        // metadata query pins sys_language_uid below. This tool is admin-only
+        // (requiresAdmin() = true) — the runtime never offers it to a non-admin
+        // — so cross-storage file metadata cannot reach a non-admin.
         $fileQuery = $this->connectionPool->getQueryBuilderForTable(self::FILE_TABLE);
         $fileQuery->getRestrictions()->removeAll();
         $file = $fileQuery
@@ -128,6 +134,15 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
 
     public function isEnabledByDefault(): bool
     {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: file metadata can span storages the acting non-admin may
+        // not access, and resolving per-user storage perms here is brittle; the
+        // simpler, stricter gate is admin-only (the runtime never offers it to a
+        // non-admin), with the storage allow-list as a further bound.
         return true;
     }
 }

--- a/Classes/Service/Tool/Builtin/ResolvesActingBackendUserTrait.php
+++ b/Classes/Service/Tool/Builtin/ResolvesActingBackendUserTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Resolves the acting backend user for per-tool RBAC self-enforcement.
+ *
+ * The acting user is the real logged-in {@see BackendUserAuthentication} in
+ * `$GLOBALS['BE_USER']`. Both accessors fail CLOSED: when no backend user is
+ * present (or it is not a {@see BackendUserAuthentication}) the user is null
+ * and {@see actingUserIsAdmin()} is false, so a tool treats the situation as
+ * "no access / not an admin" rather than silently running unscoped.
+ */
+trait ResolvesActingBackendUserTrait
+{
+    /**
+     * The real logged-in backend user, or null when none is present
+     * (fail-closed: callers must treat null as "no access").
+     */
+    private function actingBackendUser(): ?BackendUserAuthentication
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+
+        return $backendUser instanceof BackendUserAuthentication ? $backendUser : null;
+    }
+
+    /**
+     * True only when a real backend user is present AND is an admin. Absent a
+     * backend user this is false (fail-closed), so an admin-only code path
+     * never runs without a verified admin.
+     */
+    private function actingUserIsAdmin(): bool
+    {
+        $backendUser = $this->actingBackendUser();
+
+        return $backendUser !== null && $backendUser->isAdmin();
+    }
+}

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -20,13 +20,20 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * AutoconfigureTag, mirroring ProviderMiddlewareInterface) and collected by
  * ToolRegistry through a tagged iterator.
  *
- * Security contract: a tool runs with full TYPO3 privileges and has NO
- * per-record authorization. Its array `$arguments` are model-chosen and
+ * Security contract: a tool's array `$arguments` are model-chosen and
  * therefore attacker-influenceable (the model is steerable by injected,
  * externally-authored skill prose), and its return value egresses both to
  * the external provider AND the rendered backend DOM. Implementations MUST
- * assume an authorized-admin caller and treat `$arguments` as untrusted:
- * validate and scope them, and never expose secrets.
+ * treat `$arguments` as untrusted: validate and scope them, and never expose
+ * secrets.
+ *
+ * Authorization is enforced at TWO levels (see {@see requiresAdmin()}):
+ * a coarse admin-only tier checked by the runtime ({@see ToolLoopService}
+ * resolves the acting `$GLOBALS['BE_USER']` and never offers an admin-only
+ * tool to a non-admin), and — for tools that touch user-scoped data — a
+ * fine-grained self-enforcement of the ACTING user's TYPO3 permissions
+ * inside `execute()` (page perms / `tables_select` / accessible file
+ * storages). Both fail CLOSED when no `BackendUserAuthentication` is present.
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface ToolInterface
@@ -58,4 +65,23 @@ interface ToolInterface
      * context.
      */
     public function isEnabledByDefault(): bool;
+
+    /**
+     * Whether this tool may only ever be offered to a backend ADMIN.
+     *
+     * `true` for tools exposing system / host / cross-user data that a
+     * non-admin must never reach (logs, environment, phpinfo, the backend
+     * user/group listings). {@see ToolLoopService} resolves the acting
+     * `$GLOBALS['BE_USER']` and filters every admin-only tool out of the
+     * offered set when that user is not an admin — fail-closed when no
+     * backend user is present.
+     *
+     * `false` for tools usable by a non-admin; those that read user-scoped
+     * records additionally self-enforce the acting user's own TYPO3
+     * permissions inside {@see execute()} (page perms / `tables_select` /
+     * accessible file storages), so a non-admin only ever sees what they are
+     * already entitled to in the backend. An admin bypasses that narrowing
+     * (TYPO3 admins see everything).
+     */
+    public function requiresAdmin(): bool;
 }

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesActingBackendUserTrait;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
@@ -50,6 +51,8 @@ use Throwable;
  */
 final readonly class ToolLoopService
 {
+    use ResolvesActingBackendUserTrait;
+
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
@@ -88,6 +91,20 @@ final readonly class ToolLoopService
         $effective = $allowedToolNames === null
             ? $enabled
             : array_values(array_intersect($allowedToolNames, $enabled));
+
+        // Fail-closed RBAC gate: admin-only tools (logs, environment, phpinfo,
+        // backend user/group listings) are never offered unless the ACTING
+        // backend user is an admin — enforced here in the runtime, not just the
+        // (admin-only) playground, so the public service cannot be invoked on a
+        // non-admin's behalf to reach them. An unknown tool name is treated as
+        // admin-only (fail-closed).
+        if (!$this->actingUserIsAdmin()) {
+            $effective = array_values(array_filter(
+                $effective,
+                fn(string $name): bool => $this->registry->get($name)?->requiresAdmin() === false,
+            ));
+        }
+
         $specs = $this->registry->specs($effective);
 
         // No tools offered (an empty allow-list, or nothing registered): a tools

--- a/Documentation/Adr/Adr038ToolRuntime.rst
+++ b/Documentation/Adr/Adr038ToolRuntime.rst
@@ -107,11 +107,25 @@ Decision
    execution time, so a model steered by injected skill prose cannot call a
    registered-but-not-offered tool.
 
-6. **The admin-only playground is the v1 consumer.** The only caller is the
-   ``nrllm_tools`` backend submodule (``access => admin``); its AJAX
-   ``runAction`` calls ``denyNonAdmin()`` first (:ref:`ADR-037 <adr-037>`).
-   Tools have **no per-record authorization** and run with full TYPO3
-   privileges — safe only because the caller is an authenticated admin.
+6. **Authorization is enforced in the runtime, against the acting backend
+   user — not only in the playground.** Because :php:`ToolLoopService` is a
+   public service (a future non-admin consumer could call it), every tool
+   declares :php:`requiresAdmin()`. The loop resolves the acting
+   ``$GLOBALS['BE_USER']`` and, when it is not an admin, **filters every
+   admin-only tool out of the offered set** (fail-closed: an unknown tool name
+   is treated as admin-only). Admin-only tools are those exposing system /
+   host / cross-user data — ``fetch_logs``, ``get_env`` / ``get_env_raw``,
+   ``get_php_info`` / ``get_php_info_raw``, ``list_be_users`` /
+   ``list_be_users_raw``, ``list_be_groups`` and ``read_fal_asset_meta``.
+   Tools that read user-scoped records and are usable by a non-admin instead
+   **self-enforce the acting user's own TYPO3 permissions** inside
+   ``execute()``: ``get_pagetree`` applies
+   ``getPagePermsClause(Permission::PAGE_SHOW)`` and ``get_tca`` filters tables
+   by ``check('tables_select', …)`` (an admin bypasses both — TYPO3 admins see
+   everything). Queries use the default restriction set (no blanket
+   ``removeAll()``) so soft-deleted rows never surface; the admin-only
+   ``be_users`` / ``be_groups`` listings keep ``removeAll()`` plus an explicit
+   ``deleted = 0`` so disabled users remain visible for auditing.
 
 7. **Generic error egress, detail logged server-side.** A thrown tool, an
    unknown or disallowed tool name, and any unexpected provider failure
@@ -143,12 +157,17 @@ Consequences
   are admin-curated, **read-only**, input-bounded and scoped (limit cap + PII
   redaction; storage-scoped lookup). They are reference implementations of the
   security contract, not a general capability.
-- ✕ This is an **authorization (admin-only)** control, not per-record access
-  control: a tool can read what the admin can read. ``allowed_tools``
-  defaulting to "all tools when no skill declares" is acceptable **only** while
-  the consumer is admin-only — **before any non-admin consumer the default
-  must flip to fail-closed and per-tool authorization must be added** (see
-  §6 of the design and :ref:`ADR-035 <adr-035>` for the escalation surface).
+- ●● Authorization is **per-tool and enforced in the runtime against the
+  acting backend user**, not merely the playground gate (§6): admin-only tools
+  are filtered out for non-admins (fail-closed), and the user-scoped tools
+  honour the acting user's page / table permissions. A future non-admin
+  consumer of :php:`ToolLoopService` therefore cannot reach system data or read
+  beyond the user's own TYPO3 rights — closing the escalation surface the
+  earlier admin-only-playground assumption relied on.
+- ◐ ``read_fal_asset_meta`` is gated **admin-only** rather than resolving
+  per-user file-storage permissions: file metadata can span storages a
+  non-admin cannot see, and per-storage resolution is brittle, so the simpler,
+  stricter gate was chosen (with the storage allow-list as a further bound).
 - ✕ Message role is not a trust boundary: a prompt injection in skill prose
   can still steer a tool's arguments. The mitigation is input validation +
   scoping in each tool, the offered allow-list, and the XSS-safe render of

--- a/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
@@ -32,6 +32,12 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
     {
         parent::setUp();
 
+        // get_pagetree self-enforces the acting backend user's page permissions
+        // (ADR-038): set up an admin (BeUsers.csv uid 1) so getPagePermsClause
+        // resolves to "show all" and the tool returns the full live tree here.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
         $connectionPool = $this->get(ConnectionPool::class);
         self::assertInstanceOf(ConnectionPool::class, $connectionPool);
         $this->tool = new GetPageTreeTool($connectionPool);

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -357,6 +357,41 @@ class AbstractProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function flatErrorStringSurfacesInsteadOfUnknownProviderError(): void
+    {
+        // Ollama (and others) return a 4xx body as a FLAT {"error":"<text>"}
+        // string rather than the nested {"error":{"message":...}} form. The real
+        // message must surface — regression guard for the bug where the flat
+        // case was skipped and everything degraded to "Unknown provider error".
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'maxRetries' => 1,
+        ]);
+
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['error' => 'qwen3:0.6b does not support tools'], 400),
+        );
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hello');
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            self::assertStringContainsString('does not support tools', $e->getMessage());
+            self::assertStringNotContainsString('Unknown provider error', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function sanitizeErrorMessageRedactsApiKeyOnConnectionExhaustion(): void
     {
         // When all retries fail, the surfaced "Failed to connect …" message must

--- a/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetTcaTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Unit tests for GetTcaTool.
@@ -27,10 +28,20 @@ final class GetTcaToolTest extends TestCase
     /** @var array<array-key, mixed> */
     private array $tcaBackup = [];
 
+    private mixed $beUserBackup = null;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->tcaBackup = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+
+        // get_tca self-enforces the acting user's tables_select rights; an admin
+        // passes every check (isAdmin() short-circuits), so set one up to assert
+        // the schema-listing contract.
+        $this->beUserBackup = $GLOBALS['BE_USER'] ?? null;
+        $adminUser          = new BackendUserAuthentication();
+        $adminUser->user    = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $adminUser;
 
         $GLOBALS['TCA'] = [
             'pages' => [
@@ -51,6 +62,11 @@ final class GetTcaToolTest extends TestCase
     protected function tearDown(): void
     {
         $GLOBALS['TCA'] = $this->tcaBackup;
+        if ($this->beUserBackup === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->beUserBackup;
+        }
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -25,6 +25,7 @@ final readonly class FakeTool implements ToolInterface
         private string $name,
         private string $result = 'ok',
         private bool $enabledByDefault = true,
+        private bool $requiresAdmin = false,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -47,5 +48,10 @@ final readonly class FakeTool implements ToolInterface
     public function isEnabledByDefault(): bool
     {
         return $this->enabledByDefault;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        return $this->requiresAdmin;
     }
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 #[CoversClass(ToolLoopService::class)]
 final class ToolLoopServiceTest extends TestCase
@@ -119,6 +120,11 @@ final class ToolLoopServiceTest extends TestCase
             {
                 return true;
             }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -162,6 +168,11 @@ final class ToolLoopServiceTest extends TestCase
             public function isEnabledByDefault(): bool
             {
                 return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
             }
         };
 
@@ -369,6 +380,11 @@ final class ToolLoopServiceTest extends TestCase
             {
                 return true;
             }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -531,5 +547,38 @@ final class ToolLoopServiceTest extends TestCase
         self::assertIsArray($value);
 
         return $value;
+    }
+
+    #[Test]
+    public function adminOnlyToolIsNeverOfferedToNonAdmin(): void
+    {
+        $beUserBackup    = $GLOBALS['BE_USER'] ?? null;
+        $nonAdmin        = new BackendUserAuthentication();
+        $nonAdmin->user  = ['uid' => 2, 'admin' => 0];
+        $GLOBALS['BE_USER'] = $nonAdmin;
+
+        try {
+            $mgr = $this->createMock(LlmServiceManagerInterface::class);
+            // The admin-only tool is filtered out for a non-admin ⇒ no tools
+            // offered ⇒ exactly one plain completion, never the tools path.
+            $mgr->expects(self::once())
+                ->method('chatWithConfiguration')
+                ->willReturn($this->response('plain answer'));
+            $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+            // Tool is registered, globally enabled, AND explicitly allowed — but
+            // it requiresAdmin and the acting user is not an admin.
+            $service = new ToolLoopService(
+                $mgr,
+                new ToolRegistry([new FakeTool('fetch_logs', 'ok', true, true)]),
+                new FakeToolAvailability(['fetch_logs']),
+            );
+            $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ['fetch_logs']);
+
+            self::assertSame('plain answer', $result->finalContent);
+            self::assertSame([], $result->trace);
+        } finally {
+            $GLOBALS['BE_USER'] = $beUserBackup;
+        }
     }
 }


### PR DESCRIPTION
## Description

Closes a security gap in the tool subsystem you flagged: tools ran with full **process** privileges and authorization was enforced **only** in the admin-only playground — but `ToolLoopService` is a *public* service, so any future non-admin caller (consuming extension, FE-triggered agent, scheduled job) would reach every tool unrestricted. Authorization now lives in the **runtime + each tool**.

### RBAC (respect the acting backend user)
- **`ToolInterface::requiresAdmin()`** — every tool declares an admin-only tier. `ToolLoopService` resolves the acting `$GLOBALS['BE_USER']` and **filters every admin-only tool out of the offered set** when the user isn't an admin — **fail-closed** (an unknown tool name counts as admin-only), enforced in the runtime, not just the playground.
  - Admin-only: `fetch_logs`, `get_env`(`_raw`), `get_php_info`(`_raw`), `list_be_users`(`_raw`), `list_be_groups`, `read_fal_asset_meta`.
- **User-scoped tools self-enforce the acting user's own TYPO3 permissions** in `execute()` (admins bypass — they see all):
  - `get_pagetree` → `getPagePermsClause(Permission::PAGE_SHOW)`
  - `get_tca` → `check('tables_select', $table)`
- **Default query restrictions** replace blanket `removeAll()` on the page tree; `be_users`/`be_groups` keep `removeAll()` + explicit `deleted=0` so **disabled users stay visible for auditing** (full restrictions would wrongly hide them).
- New `ResolvesActingBackendUserTrait` (fail-closed: no `BackendUserAuthentication` → not admin / no access).

### Run-error visibility (the "Tool run failed" sparseness)
- **`AbstractProvider::extractErrorMessage()`** bug fixed: a flat `{"error":"…"}` body (Ollama) was guarded behind a nested-array check and degraded to *"Unknown provider error"*. Now the real message surfaces (e.g. *"qwen3:0.6b does not support tools"*).
- **`ToolPlaygroundController`** (admin-only) now returns the **real** failure — exception class + sanitised message, and for `ProviderResponseException` the HTTP status + a truncated, secret-sanitised response-body snippet — instead of a generic *"Tool run failed"*. Full detail still logged.

### Docs + tests
- **ADR-038** updated (process-privilege → acting-user RBAC; FAL admin-only rationale).
- Tests: non-admin is **not** offered admin-only tools (runtime filter); flat provider error surfaces; `get_pagetree`/`get_tca` tests set up an admin acting user.

## Type of Change
- [x] Security hardening + bug fix

## Checklist
- [x] Unit 3752 (incl. new RBAC + flat-error tests) · tool functional 17/0 · PHPStan L10 · CGL · Rector clean (PHP 8.4); full functional running
- [x] Fail-closed verified; admins bypass; disabled users still audit-visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
