### PR TITLE
fix(security): CSRF tokens on backend AJAX, pin middleware order, harden providers

### DIFF
--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -72,6 +73,7 @@ final class SetupWizardController extends ActionController
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly IconFactory $iconFactory,
         private readonly VaultServiceInterface $vaultService,
+        private readonly LoggerInterface $logger,
     ) {}
 
     protected function initializeAction(): void
@@ -287,8 +289,9 @@ final class SetupWizardController extends ActionController
         try {
             return $this->persistWizardResult($providerData, $modelsData, $configurationsData, $pid);
         } catch (Throwable $e) {
+            $this->logger->error('Setup wizard: failed to persist wizard result', ['exception' => $e]);
             return new JsonResponse(
-                (new ErrorResponse('Failed to save: ' . $e->getMessage()))->jsonSerialize(),
+                (new ErrorResponse('Failed to save. See the system log for details.'))->jsonSerialize(),
                 500,
             );
         }
@@ -320,8 +323,9 @@ final class SetupWizardController extends ActionController
                     'source' => 'setup_wizard',
                 ]);
             } catch (Throwable $e) {
+                $this->logger->error('Setup wizard: failed to store API key in vault', ['exception' => $e]);
                 return new JsonResponse(
-                    (new ErrorResponse('Failed to store API key securely: ' . $e->getMessage()))->jsonSerialize(),
+                    (new ErrorResponse('Failed to store the API key securely. See the system log for details.'))->jsonSerialize(),
                     500,
                 );
             }

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -486,4 +486,34 @@ abstract class AbstractProvider implements ProviderInterface
             'models' => $models,
         ];
     }
+
+    /**
+     * Shared real-connectivity check for OpenAI-compatible providers: a GET to
+     * the `models` endpoint, parsing the `data[].id` list. Exceptions are NOT
+     * caught — a connection/HTTP failure must propagate so testConnection()
+     * reports failure per ProviderInterface. The static-model-list providers
+     * (Claude/Groq/Mistral/OpenRouter) override testConnection() to call this.
+     *
+     * @return array{success: bool, message: string, models: array<string, string>}
+     */
+    protected function testConnectionViaModelsList(): array
+    {
+        $response = $this->sendRequest('models', [], 'GET');
+        $data = $this->getList($response, 'data');
+
+        $models = [];
+        foreach ($data as $model) {
+            $modelArray = $this->asArray($model);
+            $id = $this->getString($modelArray, 'id');
+            if ($id !== '') {
+                $models[$id] = $id;
+            }
+        }
+
+        return [
+            'success' => true,
+            'message' => sprintf('Connection successful. Found %d models.', count($models)),
+            'models' => $models,
+        ];
+    }
 }

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Psr\Http\Message\RequestInterface;
@@ -101,6 +102,24 @@ final class ClaudeProvider extends AbstractProvider implements
             'claude-3-5-sonnet-20241022' => 'Claude 3.5 Sonnet (Legacy)',
             'claude-3-5-haiku-20241022' => 'Claude 3.5 Haiku (Legacy)',
         ];
+    }
+
+    /**
+     * Test the connection to Anthropic.
+     *
+     * getAvailableModels() returns a static list and never touches the
+     * network, so the AbstractProvider default would report success even
+     * when the endpoint is unreachable or the key is invalid. Make a real
+     * lightweight GET to the models endpoint and let any failure surface as
+     * the typed exception sendRequest() raises.
+     *
+     * @throws ProviderConnectionException on connection failure
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testConnection(): array
+    {
+        return $this->testConnectionViaModelsList();
     }
 
     protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -23,6 +23,8 @@ use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Psr\Http\Message\RequestInterface;
 
 #[AsLlmProvider(priority: 80)]
@@ -84,6 +86,44 @@ final class GeminiProvider extends AbstractProvider implements
     }
 
     /**
+     * Test the connection to Google Gemini.
+     *
+     * getAvailableModels() returns a static list and never touches the
+     * network, so the AbstractProvider default would report success even
+     * when the endpoint is unreachable or the key is invalid. Make a real
+     * lightweight GET to the models endpoint (Gemini carries the key in the
+     * URL) and let any failure surface as the typed exception sendRequest()
+     * raises.
+     *
+     * @throws ProviderConnectionException on connection failure
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testConnection(): array
+    {
+        // Real HTTP request to the models endpoint — do NOT catch exceptions.
+        $response = $this->sendRequest('models?key=' . $this->retrieveApiKey(), [], 'GET');
+        $list = $this->getList($response, 'models');
+
+        $models = [];
+        foreach ($list as $model) {
+            $modelArray = $this->asArray($model);
+            // Gemini reports names as `models/gemini-...`; strip the prefix.
+            $name = $this->getString($modelArray, 'name');
+            if ($name !== '') {
+                $id = str_starts_with($name, 'models/') ? substr($name, 7) : $name;
+                $models[$id] = $id;
+            }
+        }
+
+        return [
+            'success' => true,
+            'message' => sprintf('Connection successful. Found %d models.', count($models)),
+            'models' => $models,
+        ];
+    }
+
+    /**
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $options
      */
@@ -96,6 +136,7 @@ final class GeminiProvider extends AbstractProvider implements
         );
 
         $model = $this->getString($options, 'model', $this->getDefaultModel());
+        $this->assertValidModelId($model);
         $geminiContents = $this->convertToGeminiFormat($messages);
 
         $payload = [
@@ -162,6 +203,7 @@ final class GeminiProvider extends AbstractProvider implements
         );
 
         $model = $this->getString($options, 'model', $this->getDefaultModel());
+        $this->assertValidModelId($model);
         $geminiContents = $this->convertToGeminiFormat($messages);
 
         // Convert OpenAI-shaped ToolSpec into Gemini's `functionDeclarations` format.
@@ -246,6 +288,7 @@ final class GeminiProvider extends AbstractProvider implements
     {
         $inputs = is_array($input) ? $input : [$input];
         $model = $this->getString($options, 'model', self::EMBEDDING_MODEL);
+        $this->assertValidModelId($model);
 
         /** @var array<int, array<int, float>> $embeddings */
         $embeddings = [];
@@ -290,6 +333,7 @@ final class GeminiProvider extends AbstractProvider implements
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
         $model = $this->getString($options, 'model', 'gemini-3-flash-preview');
+        $this->assertValidModelId($model);
 
         $parts = [];
         foreach ($content as $item) {
@@ -419,6 +463,7 @@ final class GeminiProvider extends AbstractProvider implements
         );
 
         $model = $this->getString($options, 'model', $this->getDefaultModel());
+        $this->assertValidModelId($model);
         $geminiContents = $this->convertToGeminiFormat($messages);
 
         $payload = [
@@ -726,5 +771,27 @@ final class GeminiProvider extends AbstractProvider implements
             'RECITATION' => 'content_filter',
             default => strtolower($reason),
         };
+    }
+
+    /**
+     * Guard against path-traversal / query injection through the model id.
+     *
+     * The model id is interpolated raw into the request path
+     * (`models/{model}:generateContent`); without this guard a value such as
+     * `../../foo` or `gemini?evil=1&` would escape the intended endpoint or
+     * smuggle extra query parameters. All official Gemini model names match
+     * `[A-Za-z0-9._-]+`, so anything outside that alphabet is rejected.
+     *
+     * @throws ProviderConfigurationException when the model id is empty or
+     *                                        contains illegal characters
+     */
+    private function assertValidModelId(string $model): void
+    {
+        if ($model === '' || preg_match('/^[A-Za-z0-9._-]+$/', $model) !== 1) {
+            throw new ProviderConfigurationException(
+                sprintf('Invalid Gemini model identifier: %s', $model),
+                1751280000,
+            );
+        }
     }
 }

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 
 /**
@@ -99,6 +100,24 @@ final class GroqProvider extends AbstractProvider implements
     public function getAvailableModels(): array
     {
         return self::MODELS;
+    }
+
+    /**
+     * Test the connection to Groq.
+     *
+     * getAvailableModels() returns a static list and never touches the
+     * network, so the AbstractProvider default would report success even
+     * when the endpoint is unreachable or the key is invalid. Make a real
+     * lightweight GET to the OpenAI-compatible models endpoint and let any
+     * failure surface as the typed exception sendRequest() raises.
+     *
+     * @throws ProviderConnectionException on connection failure
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testConnection(): array
+    {
+        return $this->testConnectionViaModelsList();
     }
 
     /**

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Pre-flight budget check middleware (ADR-025).
@@ -49,7 +50,11 @@ use Netresearch\NrLlm\Service\BudgetServiceInterface;
  *
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.
+ *
+ * The default pipeline order is pinned via tag priority (Cache outermost at
+ * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
  */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 75])]
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_BE_USER_UID  = 'beUserUid';

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Array-payload cache middleware.
@@ -47,22 +48,24 @@ use Netresearch\NrLlm\Service\CacheManagerInterface;
  * opinion-free on response shape is what lets it work for any future
  * operation without a per-type codec.
  *
- * Pipeline ordering recommendation
- * --------------------------------
- * Outer of Fallback (so a cache hit skips even the fallback attempt)
- * and outer of Budget (so a free cache hit is not counted against a
- * user's budget):
+ * Pipeline ordering
+ * -----------------
+ * Cache must be the OUTERMOST layer so a cache hit skips even the fallback
+ * attempt and is NOT counted against a user's budget. This order is pinned
+ * via the tag priority below (highest priority = first in the autowired
+ * iterator = outermost in the pipeline):
  *
- *   CacheMiddleware          <-- outermost; short-circuits on hit
- *     BudgetMiddleware       <-- pre-flight only on miss
- *       FallbackMiddleware   <-- swaps config on retryable failure
- *         UsageMiddleware    <-- records the call that actually ran
+ *   CacheMiddleware          <-- outermost; short-circuits on hit (priority 100)
+ *     BudgetMiddleware       <-- pre-flight only on miss            (priority 75)
+ *       FallbackMiddleware   <-- swaps config on retryable failure  (priority 50)
+ *         UsageMiddleware    <-- records the call that actually ran (priority 25)
  *           <terminal>
  *
  * Callers who want cache accounting (count hits against budget / usage)
- * should put Cache *inside* those layers — it is a pipeline-assembly
- * choice, not a property of this middleware.
+ * should assemble a custom pipeline with Cache *inside* those layers — it is
+ * a pipeline-assembly choice, not a property of this middleware.
  */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 100])]
 final readonly class CacheMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_CACHE_KEY  = 'cacheKey';

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Throwable;
 
 /**
@@ -35,7 +36,11 @@ use Throwable;
  *
  * Fallback is shallow: a fallback configuration's own chain is ignored to
  * prevent recursion and cycles.
+ *
+ * The default pipeline order is pinned via tag priority (Cache outermost at
+ * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
  */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 50])]
 final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
 {
     public function __construct(

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Records usage to tx_nrllm_service_usage after a successful provider call.
@@ -52,7 +53,11 @@ use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
  * The middleware never runs when $next throws: failed calls are not
  * tracked here. If failure-rate telemetry is needed later, a dedicated
  * middleware can wrap and record regardless of outcome.
+ *
+ * The default pipeline order is pinned via tag priority (Cache outermost at
+ * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
  */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 25])]
 final readonly class UsageMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_TASK_UID = 'task_uid';

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 
 /**
  * Mistral AI Provider.
@@ -91,6 +92,24 @@ final class MistralProvider extends AbstractProvider implements
     public function getAvailableModels(): array
     {
         return self::MODELS;
+    }
+
+    /**
+     * Test the connection to Mistral AI.
+     *
+     * getAvailableModels() returns a static list and never touches the
+     * network, so the AbstractProvider default would report success even
+     * when the endpoint is unreachable or the key is invalid. Make a real
+     * lightweight GET to the OpenAI-compatible models endpoint and let any
+     * failure surface as the typed exception sendRequest() raises.
+     *
+     * @throws ProviderConnectionException on connection failure
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testConnection(): array
+    {
+        return $this->testConnectionViaModelsList();
     }
 
     /**

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -181,6 +181,24 @@ final class OpenRouterProvider extends AbstractProvider implements
     }
 
     /**
+     * Test the connection to OpenRouter.
+     *
+     * getAvailableModels() returns a static list and never touches the
+     * network, so the AbstractProvider default would report success even
+     * when the endpoint is unreachable or the key is invalid. Make a real
+     * lightweight GET to the models endpoint and let any failure surface as
+     * the typed exception sendRequest() raises.
+     *
+     * @throws ProviderConnectionException on connection failure
+     *
+     * @return array{success: bool, message: string, models?: array<string, string>}
+     */
+    public function testConnection(): array
+    {
+        return $this->testConnectionViaModelsList();
+    }
+
+    /**
      * Fetch live model list from OpenRouter API.
      *
      * @param bool $forceRefresh Bypass cache and fetch fresh data

--- a/Resources/Public/JavaScript/Backend/AjaxError.js
+++ b/Resources/Public/JavaScript/Backend/AjaxError.js
@@ -1,0 +1,19 @@
+/**
+ * Shared AJAX error reader for the nr_llm backend ES modules.
+ *
+ * TYPO3's AjaxRequest rejects on a non-2xx response with an AjaxResponse object
+ * (which exposes resolve()), and on a genuine network failure with a plain
+ * Error. This normalises both into a human-readable message, preferring the
+ * JSON body's `error`/`message` field when one is present. Extracted so every
+ * backend module shares one implementation instead of duplicating it.
+ *
+ * @param {unknown} err the value an AjaxRequest promise rejected with
+ * @returns {Promise<string>} a message suitable for Notification.error()
+ */
+export async function readAjaxError(err) {
+    if (err && typeof err.resolve === 'function') {
+        const data = await err.resolve().catch(() => ({}));
+        return data.error || data.message || 'Unknown error';
+    }
+    return err?.message || 'Unknown error';
+}

--- a/Resources/Public/JavaScript/Backend/ConfigurationConstraints.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationConstraints.js
@@ -4,7 +4,11 @@
  * Watches model_uid select changes and adjusts parameter fields
  * (temperature, top_p, frequency_penalty, presence_penalty) based
  * on the adapter type and model characteristics.
+ *
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+
 (function () {
     'use strict';
 
@@ -171,26 +175,20 @@
         }
 
         try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: 'modelUid=' + encodeURIComponent(modelUid),
-            });
+            const response = await new AjaxRequest(url).post(
+                'modelUid=' + encodeURIComponent(modelUid),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+            );
 
-            if (!response.ok) {
-                resetConstraints();
-                return;
-            }
-
-            const data = await response.json();
+            const data = await response.resolve();
             if (data.success && data.constraints) {
                 applyConstraints(data.constraints);
             } else {
                 resetConstraints();
             }
         } catch (e) {
+            // AjaxRequest rejects on a non-OK HTTP status — treat it the same
+            // as the previous `!response.ok` branch and reset the constraints.
             resetConstraints();
         }
     }

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -3,10 +3,21 @@
  *
  * Uses TYPO3 Backend Notification API and Modal.
  * Uses event delegation for reliable event handling in TYPO3 v14+ iframe modules.
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+
+/**
+ * Read the JSON error body from a rejected AjaxRequest response.
+ *
+ * AjaxRequest rejects with an AjaxResponse on HTTP error status; resolve it
+ * to recover the `{ success: false, error: ... }` payload the controllers
+ * emit. Falls back to a thrown Error's message for genuine network failures.
+ */
 
 class ConfigurationList {
     constructor() {
@@ -64,21 +75,19 @@ class ConfigurationList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                location.reload();
-            } else {
-                Notification.error('Error', data.error || 'Unknown error');
-            }
-        })
-        .catch(err => {
-            Notification.error('Error', err.message);
-        });
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleSetDefault(btn) {
@@ -93,21 +102,19 @@ class ConfigurationList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                location.reload();
-            } else {
-                Notification.error('Error', data.error || 'Unknown error');
-            }
-        })
-        .catch(err => {
-            Notification.error('Error', err.message);
-        });
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleTestConfig(btn) {
@@ -179,11 +186,9 @@ class ConfigurationList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
+        new AjaxRequest(url)
+        .post(formData)
+        .then(response => response.resolve())
         .then(data => {
             console.debug('[ConfigurationList] Test response:', data);
             // Use container reference instead of document.getElementById()
@@ -198,7 +203,7 @@ class ConfigurationList {
                 this.renderTestError(container, data.error || data.message || 'Unknown error');
             }
         })
-        .catch(err => {
+        .catch(async err => {
             console.error('[ConfigurationList] Test error:', err);
             // Use container reference instead of document.getElementById()
             const loadingDiv = container.querySelector('#config-test-loading');
@@ -208,7 +213,7 @@ class ConfigurationList {
             if (errorDiv) {
                 errorDiv.style.display = 'block';
                 const msgEl = container.querySelector('#config-test-error-message');
-                if (msgEl) msgEl.textContent = err.message;
+                if (msgEl) msgEl.textContent = await readAjaxError(err);
             }
         });
     }

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -4,8 +4,12 @@
  * Attaches click handler to ".js-fetch-models" buttons, fetches available
  * models from the provider's API, renders a rich dropdown showing model details
  * (context length, capabilities, cost), and auto-fills related fields on selection.
+ *
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 (function () {
     'use strict';
@@ -386,8 +390,9 @@ import Notification from '@typo3/backend/notification.js';
         const body = new FormData();
         body.append('providerUid', String(providerUid));
 
-        fetch(fetchUrl, { method: 'POST', body: body })
-            .then(function (response) { return response.json(); })
+        new AjaxRequest(fetchUrl)
+            .post(body)
+            .then(function (response) { return response.resolve(); })
             .then(function (data) {
                 if (!data.success) {
                     showStatus(button, 'Error: ' + (data.error || 'Unknown error'), 'error');
@@ -416,7 +421,9 @@ import Notification from '@typo3/backend/notification.js';
                 showStatus(button, models.length + ' models from ' + (data.providerName || 'provider'), 'success');
             })
             .catch(function (err) {
-                showStatus(button, 'Fetch failed: ' + err.message, 'error');
+                readAjaxError(err).then(function (message) {
+                    showStatus(button, 'Fetch failed: ' + message, 'error');
+                });
             })
             .finally(function () {
                 button.disabled = false;

--- a/Resources/Public/JavaScript/Backend/ModelList.js
+++ b/Resources/Public/JavaScript/Backend/ModelList.js
@@ -3,10 +3,13 @@
  *
  * Uses TYPO3 Backend Notification API and Modal.
  * Uses event delegation for reliable event handling in TYPO3 v14+ iframe modules.
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class ModelList {
     constructor() {
@@ -64,21 +67,19 @@ class ModelList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                location.reload();
-            } else {
-                Notification.error('Error', data.error || 'Unknown error');
-            }
-        })
-        .catch(err => {
-            Notification.error('Error', err.message);
-        });
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleSetDefault(btn) {
@@ -93,21 +94,19 @@ class ModelList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                location.reload();
-            } else {
-                Notification.error('Error', data.error || 'Unknown error');
-            }
-        })
-        .catch(err => {
-            Notification.error('Error', err.message);
-        });
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleTestModel(btn) {
@@ -240,11 +239,9 @@ class ModelList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
+        new AjaxRequest(url)
+        .post(formData)
+        .then(response => response.resolve())
         .then(data => {
             clearInterval(timerInterval);
             const elapsed = Math.floor((Date.now() - startTime) / 1000);
@@ -259,14 +256,14 @@ class ModelList {
                 this.showTestError(container, data.error || data.message || 'Unknown error', elapsed);
             }
         })
-        .catch(err => {
+        .catch(async err => {
             clearInterval(timerInterval);
             const elapsed = Math.floor((Date.now() - startTime) / 1000);
 
             console.error('[ModelList] Test error:', err);
             // Use container reference instead of document.getElementById()
             this.hideTestLoading(container);
-            this.showTestError(container, err.message, elapsed);
+            this.showTestError(container, await readAjaxError(err), elapsed);
         });
     }
 

--- a/Resources/Public/JavaScript/Backend/ProviderList.js
+++ b/Resources/Public/JavaScript/Backend/ProviderList.js
@@ -3,10 +3,13 @@
  *
  * Uses TYPO3 Backend Notification API and Bootstrap Modal.
  * Uses event delegation for reliable event handling in TYPO3 v14+ iframe modules.
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class ProviderList {
     constructor() {
@@ -55,21 +58,19 @@ class ProviderList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                location.reload();
-            } else {
-                Notification.error('Error', data.error || 'Unknown error');
-            }
-        })
-        .catch(err => {
-            Notification.error('Error', err.message);
-        });
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleTestConnection(btn) {
@@ -131,11 +132,9 @@ class ProviderList {
         const formData = new FormData();
         formData.append('uid', uid);
 
-        fetch(url, {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
+        new AjaxRequest(url)
+        .post(formData)
+        .then(response => response.resolve())
         .then(data => {
             console.debug('[ProviderList] Test response:', data);
             // Use container reference instead of document.getElementById()
@@ -158,7 +157,7 @@ class ProviderList {
                 if (msgEl) msgEl.textContent = data.error || data.message || 'Unknown error';
             }
         })
-        .catch(err => {
+        .catch(async err => {
             console.error('[ProviderList] Test error:', err);
             // Use container reference instead of document.getElementById()
             const loadingDiv = container.querySelector('#provider-test-loading');
@@ -168,7 +167,7 @@ class ProviderList {
             if (errorDiv) {
                 errorDiv.style.display = 'block';
                 const msgEl = container.querySelector('#provider-test-error-message');
-                if (msgEl) msgEl.textContent = err.message;
+                if (msgEl) msgEl.textContent = await readAjaxError(err);
             }
         });
     }

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -3,8 +3,11 @@
  *
  * Handles the multi-step wizard flow for LLM provider configuration.
  * Uses TYPO3 Backend Notification API for user feedback.
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class SetupWizard {
     currentStep = 1;
@@ -119,13 +122,12 @@ class SetupWizard {
 
     async detectProviderSilent(endpoint) {
         try {
-            const response = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_detect'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ endpoint }),
-            });
+            const response = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_detect']).post(
+                new URLSearchParams({ endpoint }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+            );
 
-            const result = await response.json();
+            const result = await response.resolve();
 
             if (result.success && result.provider) {
                 this.showDetectedProvider(result.provider);
@@ -202,13 +204,12 @@ class SetupWizard {
 
         try {
             // First detect provider
-            const detectResponse = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_detect'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ endpoint }),
-            });
+            const detectResponse = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_detect']).post(
+                new URLSearchParams({ endpoint }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+            );
 
-            const detectResult = await detectResponse.json();
+            const detectResult = await detectResponse.resolve();
 
             if (detectResult.success && detectResult.provider) {
                 this.data.provider = detectResult.provider;
@@ -216,17 +217,16 @@ class SetupWizard {
             }
 
             // Test connection
-            const testResponse = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_test'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({
+            const testResponse = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_test']).post(
+                new URLSearchParams({
                     endpoint: this.data.endpoint,
                     apiKey: this.data.apiKey,
                     adapterType: this.data.adapterType,
-                }),
-            });
+                }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+            );
 
-            const testResult = await testResponse.json();
+            const testResult = await testResponse.resolve();
 
             document.getElementById('test-loading').style.display = 'none';
 
@@ -241,7 +241,7 @@ class SetupWizard {
         } catch (e) {
             document.getElementById('test-loading').style.display = 'none';
             document.getElementById('test-error').style.display = 'block';
-            document.getElementById('test-error-message').textContent = 'Network error: ' + e.message;
+            document.getElementById('test-error-message').textContent = 'Network error: ' + await readAjaxError(e);
         }
     }
 
@@ -254,17 +254,16 @@ class SetupWizard {
         document.getElementById('btn-generate').disabled = true;
 
         try {
-            const response = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_discover'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({
+            const response = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_discover']).post(
+                new URLSearchParams({
                     endpoint: this.data.endpoint,
                     apiKey: this.data.apiKey,
                     adapterType: this.data.adapterType,
-                }),
-            });
+                }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+            );
 
-            const result = await response.json();
+            const result = await response.resolve();
 
             document.getElementById('models-loading').style.display = 'none';
             document.getElementById('models-list').style.display = 'block';
@@ -276,9 +275,10 @@ class SetupWizard {
             }
         } catch (e) {
             document.getElementById('models-loading').style.display = 'none';
-            // SECURITY: Escape error message to prevent XSS
+            // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
+            const discoverError = this.escapeHtml(await readAjaxError(e));
             document.getElementById('models-list').innerHTML =
-                '<div class="alert alert-danger">Failed to discover models: ' + this.escapeHtml(e.message) + '</div>';
+                '<div class="alert alert-danger">Failed to discover models: ' + discoverError + '</div>';
         }
     }
 
@@ -371,18 +371,17 @@ class SetupWizard {
         document.getElementById('configs-list').style.display = 'none';
 
         try {
-            const response = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_generate'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
+            const response = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_generate']).post(
+                JSON.stringify({
                     endpoint: this.data.endpoint,
                     apiKey: this.data.apiKey,
                     adapterType: this.data.adapterType,
                     models: selectedModels,
                 }),
-            });
+                { headers: { 'Content-Type': 'application/json' } },
+            );
 
-            const result = await response.json();
+            const result = await response.resolve();
 
             document.getElementById('configs-loading').style.display = 'none';
             document.getElementById('configs-list').style.display = 'block';
@@ -393,9 +392,10 @@ class SetupWizard {
             }
         } catch (e) {
             document.getElementById('configs-loading').style.display = 'none';
-            // SECURITY: Escape error message to prevent XSS
+            // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
+            const generateError = this.escapeHtml(await readAjaxError(e));
             document.getElementById('configs-list').innerHTML =
-                '<div class="alert alert-danger">Failed to generate configurations: ' + this.escapeHtml(e.message) + '</div>';
+                '<div class="alert alert-danger">Failed to generate configurations: ' + generateError + '</div>';
         }
     }
 
@@ -546,18 +546,17 @@ class SetupWizard {
         document.getElementById('save-footer').style.display = 'none';
 
         try {
-            const response = await fetch(TYPO3.settings.ajaxUrls['nrllm_wizard_save'], {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
+            const response = await new AjaxRequest(TYPO3.settings.ajaxUrls['nrllm_wizard_save']).post(
+                JSON.stringify({
                     provider: providerData,
                     models: selectedModels,
                     configurations: selectedConfigs,
                     pid: pid,
                 }),
-            });
+                { headers: { 'Content-Type': 'application/json' } },
+            );
 
-            const result = await response.json();
+            const result = await response.resolve();
 
             document.getElementById('save-loading').style.display = 'none';
 
@@ -580,11 +579,12 @@ class SetupWizard {
                 Notification.error('Error', result.error, 10);
             }
         } catch (e) {
+            const saveError = await readAjaxError(e);
             document.getElementById('save-loading').style.display = 'none';
             document.getElementById('save-error').style.display = 'block';
-            document.getElementById('save-error-message').textContent = 'Network error: ' + e.message;
+            document.getElementById('save-error-message').textContent = 'Network error: ' + saveError;
             document.getElementById('save-footer').style.display = 'flex';
-            Notification.error('Network Error', e.message, 10);
+            Notification.error('Network Error', saveError, 10);
         }
     }
 

--- a/Resources/Public/JavaScript/Backend/SkillList.js
+++ b/Resources/Public/JavaScript/Backend/SkillList.js
@@ -5,9 +5,12 @@
  * skills, and storing a GitHub token (as a vault UUID) for a source.
  *
  * Uses TYPO3 Backend Notification API and event delegation for reliable
- * handling inside TYPO3 v14+ iframe modules.
+ * handling inside TYPO3 v14+ iframe modules. State-changing AJAX uses
+ * AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class SkillList {
     constructor() {
@@ -59,8 +62,9 @@ class SkillList {
         formData.append('source', source);
 
         btn.disabled = true;
-        fetch(url, { method: 'POST', body: formData })
-            .then(response => response.json())
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
             .then(data => {
                 if (data.success) {
                     Notification.success(
@@ -73,8 +77,8 @@ class SkillList {
                     btn.disabled = false;
                 }
             })
-            .catch(err => {
-                Notification.error('Error', err.message);
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
                 btn.disabled = false;
             });
     }
@@ -92,8 +96,9 @@ class SkillList {
         formData.append('skill', skill);
         formData.append('enabled', String(enabled));
 
-        fetch(url, { method: 'POST', body: formData })
-            .then(response => response.json())
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
             .then(data => {
                 if (data.success) {
                     location.reload();
@@ -101,8 +106,8 @@ class SkillList {
                     Notification.error('Error', data.error || 'Unknown error');
                 }
             })
-            .catch(err => {
-                Notification.error('Error', err.message);
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
             });
     }
 
@@ -123,8 +128,9 @@ class SkillList {
         formData.append('source', source);
         formData.append('token', token);
 
-        fetch(url, { method: 'POST', body: formData })
-            .then(response => response.json())
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
             .then(data => {
                 if (data.success) {
                     Notification.success('Token stored', 'The GitHub token was stored securely.');
@@ -132,8 +138,8 @@ class SkillList {
                     Notification.error('Error', data.error || 'Unknown error');
                 }
             })
-            .catch(err => {
-                Notification.error('Error', err.message);
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
             });
     }
 }

--- a/Resources/Public/JavaScript/Backend/Test.js
+++ b/Resources/Public/JavaScript/Backend/Test.js
@@ -6,7 +6,12 @@
  * The script is included via HeaderAssets, so it runs before <body> is
  * parsed — wrap in DOMContentLoaded and bail out if required elements
  * or the AJAX URL are missing.
+ *
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+
 document.addEventListener('DOMContentLoaded', function () {
     const testForm = document.getElementById('testForm');
     const ajaxUrl = TYPO3?.settings?.ajaxUrls?.['nrllm_test'];
@@ -24,15 +29,12 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('responseContainer').style.display = 'none';
 
         try {
-            const response = await fetch(ajaxUrl, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ provider, prompt }),
-            });
+            const response = await new AjaxRequest(ajaxUrl).post(
+                JSON.stringify({ provider, prompt }),
+                { headers: { 'Content-Type': 'application/json' } },
+            );
 
-            const data = await response.json();
+            const data = await response.resolve();
 
             document.getElementById('loadingIndicator').style.display = 'none';
             document.getElementById('responseContainer').style.display = 'block';
@@ -59,7 +61,7 @@ document.addEventListener('DOMContentLoaded', function () {
             document.getElementById('responseSuccess').style.display = 'none';
             document.getElementById('responseError').style.display = 'block';
             document.getElementById('responseDetails').style.display = 'none';
-            document.getElementById('errorMessage').textContent = error.message;
+            document.getElementById('errorMessage').textContent = await readAjaxError(error);
         }
     });
 });

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -12,9 +12,14 @@
  * preview lives inside a fully sandboxed iframe whose srcdoc is built from
  * escapeHtml() output. This module never assigns a server/LLM string to
  * innerHTML.
+ *
+ * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
+
 import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class ToolPlayground {
     constructor() {
@@ -71,12 +76,14 @@ class ToolPlayground {
         }
         this.renderStatus('Running…');
 
-        fetch(url, { method: 'POST', body: formData })
-            .then(response => response.json())
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
             .then(data => this.renderResult(data))
-            .catch(err => {
-                this.renderError(err.message || 'Request failed');
-                Notification.error('Error', err.message || 'Request failed');
+            .catch(async err => {
+                const message = await readAjaxError(err);
+                this.renderError(message);
+                Notification.error('Error', message);
             })
             .finally(() => {
                 if (this.runButton) {

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -3,10 +3,12 @@
  *
  * Toggles the global enable/disable override of a single agent tool from the
  * Tool Playground module. Mirrors SkillList.js: event delegation on the body
- * and a CSRF-tokenised AJAX POST (the per-route token is embedded in
- * TYPO3.settings.ajaxUrls).
+ * and a state-changing AJAX POST via AjaxRequest, which injects TYPO3's CSRF
+ * token (and sets the request content-type) automatically.
  */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 class ToolState {
     constructor() {
@@ -44,8 +46,9 @@ class ToolState {
         formData.append('enabled', String(enabled));
 
         btn.disabled = true;
-        fetch(url, { method: 'POST', body: formData })
-            .then(response => response.json())
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
             .then(data => {
                 if (data.success) {
                     location.reload();
@@ -54,8 +57,8 @@ class ToolState {
                     btn.disabled = false;
                 }
             })
-            .catch(err => {
-                Notification.error('Error', err.message);
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
                 btn.disabled = false;
             });
     }

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -22,6 +22,8 @@ use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -97,6 +99,7 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
             $llmConfigurationRepository,
             $persistenceManager,
             $vaultService,
+            new NullLogger(),
         );
     }
 
@@ -119,6 +122,7 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
         LlmConfigurationRepository $llmConfigurationRepository,
         PersistenceManagerInterface $persistenceManager,
         VaultServiceInterface $vaultService,
+        LoggerInterface $logger,
     ): SetupWizardController {
         $reflection = new ReflectionClass(SetupWizardController::class);
         $controller = $reflection->newInstanceWithoutConstructor();
@@ -132,6 +136,7 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
         $this->setPrivateProperty($controller, 'llmConfigurationRepository', $llmConfigurationRepository);
         $this->setPrivateProperty($controller, 'persistenceManager', $persistenceManager);
         $this->setPrivateProperty($controller, 'vaultService', $vaultService);
+        $this->setPrivateProperty($controller, 'logger', $logger);
 
         return $controller;
     }

--- a/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
+++ b/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * Verifies that the provider middleware pipeline is assembled in the
+ * documented order via the autowired tagged iterator.
+ *
+ * The order is security-relevant: CacheMiddleware must be the OUTERMOST
+ * layer so that a cache hit short-circuits the pipeline before any budget
+ * is consumed (CacheMiddleware / BudgetMiddleware docblocks). Symfony orders
+ * a tagged iterator by descending tag priority; this test resolves the real
+ * MiddlewarePipeline from the DI container and asserts the resolved order
+ * empirically, so the priority *direction* is proven rather than assumed.
+ */
+#[CoversClass(MiddlewarePipeline::class)]
+final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function pipelineIsAssembledCacheBudgetFallbackUsage(): void
+    {
+        $pipeline = $this->get(MiddlewarePipeline::class);
+        self::assertInstanceOf(MiddlewarePipeline::class, $pipeline);
+
+        $order = $this->resolveMiddlewareOrder($pipeline);
+
+        self::assertSame(
+            [
+                CacheMiddleware::class,    // outermost: a cache hit short-circuits
+                BudgetMiddleware::class,   // pre-flight budget gate on a miss
+                FallbackMiddleware::class, // swaps configuration on retryable failure
+                UsageMiddleware::class,    // innermost: records the call that ran
+            ],
+            $order,
+        );
+    }
+
+    /**
+     * Read the resolved middleware list (a private property of the pipeline)
+     * and return the concrete class names in pipeline order.
+     *
+     * @return list<class-string<ProviderMiddlewareInterface>>
+     */
+    private function resolveMiddlewareOrder(MiddlewarePipeline $pipeline): array
+    {
+        $reflection = new ReflectionClass($pipeline);
+        $property   = $reflection->getProperty('middleware');
+        $middleware = $property->getValue($pipeline);
+        self::assertIsArray($middleware);
+
+        $order = [];
+        foreach ($middleware as $instance) {
+            self::assertInstanceOf(ProviderMiddlewareInterface::class, $instance);
+            $order[] = $instance::class;
+        }
+
+        return $order;
+    }
+}

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
@@ -209,22 +212,13 @@ class AbstractProviderTest extends AbstractUnitTestCase
     #[Test]
     public function testConnectionReturnsSuccessWithModelCount(): void
     {
-        // Use a provider with static model list (Gemini returns static list from getAvailableModels).
-        // AbstractProvider::testConnection() calls getAvailableModels() and wraps result.
-        $httpClientStub = $this->createHttpClientMock();
-
-        $provider = new GeminiProvider(
-            $this->createRequestFactoryMock(),
-            $this->createStreamFactoryMock(),
-            $this->createLoggerMock(),
-            $this->createVaultServiceMock(),
-            $this->createSecureHttpClientFactoryMock(),
-        );
-        $provider->configure([
-            'apiKeyIdentifier' => $this->randomApiKey(),
-            'defaultModel' => 'gemini-2.5-flash',
-        ]);
-        $provider->setHttpClient($httpClientStub);
+        // AbstractProvider::testConnection() default behaviour: it wraps the
+        // static getAvailableModels() list without performing any HTTP call.
+        // All bundled providers now OVERRIDE testConnection() with a real
+        // connectivity request (so an unreachable endpoint can no longer
+        // report success), so the abstract default is exercised here through
+        // a throwaway subclass that intentionally does NOT override it.
+        $provider = $this->makeStaticListProvider();
 
         $result = $provider->testConnection();
 
@@ -233,6 +227,71 @@ class AbstractProviderTest extends AbstractUnitTestCase
         self::assertArrayHasKey('models', $result);
         assert(isset($result['models']));
         self::assertNotEmpty($result['models']);
+    }
+
+    /**
+     * A minimal concrete AbstractProvider that returns a static model list and
+     * does NOT override testConnection() — used to test the abstract default.
+     */
+    private function makeStaticListProvider(): AbstractProvider
+    {
+        $provider = new class (
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        ) extends AbstractProvider {
+            public function getName(): string
+            {
+                return 'Static List Test Provider';
+            }
+
+            public function getIdentifier(): string
+            {
+                return 'static-list-test';
+            }
+
+            protected function getDefaultBaseUrl(): string
+            {
+                return 'https://example.invalid/v1';
+            }
+
+            /**
+             * @return array<string, string>
+             */
+            public function getAvailableModels(): array
+            {
+                return ['model-a' => 'Model A', 'model-b' => 'Model B'];
+            }
+
+            public function chatCompletion(array $messages, array $options = []): CompletionResponse
+            {
+                return new CompletionResponse(
+                    content: '',
+                    model: 'model-a',
+                    usage: new UsageStatistics(0, 0, 0),
+                    finishReason: 'stop',
+                    provider: $this->getIdentifier(),
+                );
+            }
+
+            public function embeddings(string|array $input, array $options = []): EmbeddingResponse
+            {
+                return new EmbeddingResponse(
+                    embeddings: [],
+                    model: 'model-a',
+                    usage: new UsageStatistics(0, 0, 0),
+                    provider: $this->getIdentifier(),
+                );
+            }
+        };
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+        ]);
+
+        return $provider;
     }
 
     #[Test]

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -1276,4 +1276,43 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertEquals('Response', $result->content);
     }
+
+    #[Test]
+    public function testConnectionReturnsSuccessWithModelList(): void
+    {
+        $apiResponse = [
+            'data' => [
+                ['id' => 'claude-opus-4-5-20251124', 'type' => 'model'],
+                ['id' => 'claude-sonnet-4-5-20250929', 'type' => 'model'],
+            ],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->testConnection();
+
+        self::assertTrue($result['success']);
+        self::assertStringContainsString('Connection successful', $result['message']);
+        self::assertStringContainsString('2 models', $result['message']);
+        self::assertArrayHasKey('models', $result);
+        assert(isset($result['models']));
+        self::assertArrayHasKey('claude-opus-4-5-20251124', $result['models']);
+    }
+
+    #[Test]
+    public function testConnectionThrowsOnHttpError(): void
+    {
+        // A static-list provider must NOT silently report success on an
+        // unreachable / unauthorized endpoint: the real HTTP call surfaces
+        // the typed exception instead.
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createErrorResponseMock(401, 'invalid x-api-key'));
+
+        $this->expectException(ProviderResponseException::class);
+
+        $this->subject->testConnection();
+    }
 }

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -14,10 +14,12 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
@@ -1422,5 +1424,83 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $result = $this->subject->chatCompletionWithTools($messages, $tools);
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertEquals('Hamburg is 12C.', $result->content);
+    }
+
+    /**
+     * A model id interpolated raw into the request path must be rejected when
+     * it could escape the endpoint (path traversal) or inject query parameters.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function maliciousModelIdProvider(): iterable
+    {
+        yield 'path traversal' => ['../../v1/models/secret'];
+        yield 'query injection' => ['gemini-3-flash-preview?evil=1'];
+        yield 'query ampersand' => ['gemini-3-flash-preview&key=leak'];
+        yield 'slash' => ['models/gemini-3-flash-preview'];
+        yield 'whitespace' => ['gemini 3 flash'];
+        yield 'empty' => [''];
+    }
+
+    #[Test]
+    #[DataProvider('maliciousModelIdProvider')]
+    public function chatCompletionRejectsInvalidModelId(string $model): void
+    {
+        // The guard fires before any HTTP call, so the default stub
+        // (which would otherwise return a stubbed JSON body) is never reached.
+        $this->expectException(ProviderConfigurationException::class);
+
+        $this->subject->chatCompletion(
+            [['role' => 'user', 'content' => 'hi']],
+            ['model' => $model],
+        );
+    }
+
+    #[Test]
+    public function embeddingsRejectsInvalidModelId(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+
+        $this->subject->embeddings('hi', ['model' => '../../secret']);
+    }
+
+    #[Test]
+    public function testConnectionReturnsSuccessWithModelList(): void
+    {
+        $apiResponse = [
+            'models' => [
+                ['name' => 'models/gemini-3-flash-preview'],
+                ['name' => 'models/gemini-3-pro'],
+            ],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->testConnection();
+
+        self::assertTrue($result['success']);
+        self::assertStringContainsString('Connection successful', $result['message']);
+        self::assertStringContainsString('2 models', $result['message']);
+        self::assertArrayHasKey('models', $result);
+        assert(isset($result['models']));
+        // The `models/` prefix is stripped from the reported id.
+        self::assertArrayHasKey('gemini-3-flash-preview', $result['models']);
+    }
+
+    #[Test]
+    public function testConnectionThrowsOnHttpError(): void
+    {
+        // A static-list provider must NOT silently report success on an
+        // unreachable / unauthorized endpoint: the real HTTP call surfaces
+        // the typed exception instead.
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createErrorResponseMock(403, 'API key not valid'));
+
+        $this->expectException(ProviderResponseException::class);
+
+        $this->subject->testConnection();
     }
 }

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -863,4 +863,44 @@ class GroqProviderTest extends AbstractUnitTestCase
 
         self::assertEquals(['Content'], $chunks);
     }
+
+    #[Test]
+    public function testConnectionReturnsSuccessWithModelList(): void
+    {
+        $apiResponse = [
+            'object' => 'list',
+            'data' => [
+                ['id' => 'llama-3.3-70b-versatile', 'object' => 'model'],
+                ['id' => 'mixtral-8x7b-32768', 'object' => 'model'],
+            ],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->testConnection();
+
+        self::assertTrue($result['success']);
+        self::assertStringContainsString('Connection successful', $result['message']);
+        self::assertStringContainsString('2 models', $result['message']);
+        self::assertArrayHasKey('models', $result);
+        assert(isset($result['models']));
+        self::assertArrayHasKey('llama-3.3-70b-versatile', $result['models']);
+    }
+
+    #[Test]
+    public function testConnectionThrowsOnHttpError(): void
+    {
+        // A static-list provider must NOT silently report success on an
+        // unreachable / unauthorized endpoint: the real HTTP call surfaces
+        // the typed exception instead.
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createErrorResponseMock(401, 'Invalid API Key'));
+
+        $this->expectException(ProviderResponseException::class);
+
+        $this->subject->testConnection();
+    }
 }

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -737,4 +737,44 @@ class MistralProviderTest extends AbstractUnitTestCase
 
         self::assertEquals(['Test'], $chunks);
     }
+
+    #[Test]
+    public function testConnectionReturnsSuccessWithModelList(): void
+    {
+        $apiResponse = [
+            'object' => 'list',
+            'data' => [
+                ['id' => 'mistral-large-latest', 'object' => 'model'],
+                ['id' => 'mistral-small-latest', 'object' => 'model'],
+            ],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->testConnection();
+
+        self::assertTrue($result['success']);
+        self::assertStringContainsString('Connection successful', $result['message']);
+        self::assertStringContainsString('2 models', $result['message']);
+        self::assertArrayHasKey('models', $result);
+        assert(isset($result['models']));
+        self::assertArrayHasKey('mistral-large-latest', $result['models']);
+    }
+
+    #[Test]
+    public function testConnectionThrowsOnHttpError(): void
+    {
+        // A static-list provider must NOT silently report success on an
+        // unreachable / unauthorized endpoint: the real HTTP call surfaces
+        // the typed exception instead.
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createErrorResponseMock(401, 'Unauthorized'));
+
+        $this->expectException(ProviderResponseException::class);
+
+        $this->subject->testConnection();
+    }
 }

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -1333,4 +1333,43 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
 
         self::assertInstanceOf(CompletionResponse::class, $result);
     }
+
+    #[Test]
+    public function testConnectionReturnsSuccessWithModelList(): void
+    {
+        $apiResponse = [
+            'data' => [
+                ['id' => 'anthropic/claude-sonnet-4-5', 'name' => 'Claude Sonnet 4.5'],
+                ['id' => 'openai/gpt-5.2', 'name' => 'GPT-5.2'],
+            ],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->testConnection();
+
+        self::assertTrue($result['success']);
+        self::assertStringContainsString('Connection successful', $result['message']);
+        self::assertStringContainsString('2 models', $result['message']);
+        self::assertArrayHasKey('models', $result);
+        assert(isset($result['models']));
+        self::assertArrayHasKey('anthropic/claude-sonnet-4-5', $result['models']);
+    }
+
+    #[Test]
+    public function testConnectionThrowsOnHttpError(): void
+    {
+        // A static-list provider must NOT silently report success on an
+        // unreachable / unauthorized endpoint: the real HTTP call surfaces
+        // the typed exception instead.
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createErrorResponseMock(401, 'No auth credentials found'));
+
+        $this->expectException(ProviderException::class);
+
+        $this->subject->testConnection();
+    }
 }


### PR DESCRIPTION
## Description

Resolves the **critical/high security findings** from the comprehensive multi-lens audit (round 1), each adversarially verified.

### CSRF — backend AJAX (CRITICAL)
Every state-changing backend AJAX POST used plain `fetch()`, which does **not** attach TYPO3's CSRF token (incl. the SetupWizard API-key save, the SkillList GitHub-token POST, and the ToolPlayground run loop). Converted **22 call sites across 10 JS files** to `AjaxRequest` (`@typo3/core/ajax/ajax-request.js`) — the pattern already used correctly in `TaskExecute.js`, which auto-injects the token. Error branches preserved (AjaxRequest rejects on HTTP error → a small helper reads the rejected response body where the old code read `data.error`).

### Gemini `$model` URL injection (CRITICAL)
`GeminiProvider` interpolated a config/criteria-supplied model id raw into endpoint URLs (path/query-injection via `../` or `?`). Added `assertValidModelId()` (`^[A-Za-z0-9._-]+$`) at every URL-building method + tests rejecting traversal/query/whitespace ids.

### Middleware pipeline order (CRITICAL)
The 4 provider middleware registered with no priority → Symfony ordered them **alphabetically** (Budget→Cache→Fallback→Usage), contradicting the design (Cache must be outermost so hits short-circuit and aren't budget-counted). Pinned via tag priority — Cache 100, Budget 75, Fallback 50, Usage 25 — + a functional test that resolves the **real** pipeline from the container and asserts the order.

### `testConnection()` false success (HIGH)
The 5 static-model-list providers (Claude/Gemini/Groq/Mistral/OpenRouter) returned a hardcoded list without an HTTP call, so `testConnection()` reported success even when unreachable. Each now makes a real connectivity request and throws per `ProviderInterface` (mocked tests, no real network).

### SetupWizard exception leak (HIGH)
`SetupWizardController` no longer concatenates raw exception text into JSON responses — logs the exception, returns a generic message (mirrors ProviderController).

## Type of Change
- [x] Security fix

## Checklist
- [x] Unit 3769 · functional (incl. new middleware-order test) · PHPStan L10 · CGL · Rector clean (PHP 8.4)
- [x] No plain `fetch()` POST remains in backend JS; middleware order test-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
