### PR TITLE
fix(backend): i18n, accessibility & hygiene findings from the audit

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 | Task | Command |
 |------|---------|
 | Unit tests | `./Build/Scripts/runTests.sh -s unit` |
+| Integration tests | `./Build/Scripts/runTests.sh -s integration` |
 | Functional tests | `./Build/Scripts/runTests.sh -s functional` |
 | Static analysis (PHPStan level 10) | `./Build/Scripts/runTests.sh -s phpstan` |
 | Code style (fix) | `./Build/Scripts/runTests.sh -s cgl` |

--- a/Build/FunctionalTestsBootstrap.php
+++ b/Build/FunctionalTestsBootstrap.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/Build/fractor/fractor.php
+++ b/Build/fractor/fractor.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 /**

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -186,7 +186,11 @@ final class ConfigurationController extends ActionController
     {
         $description = trim($description);
         if ($description === '') {
-            $this->addFlashMessage('Please describe what this configuration should do.', 'Missing description', ContextualFeedbackSeverity::WARNING);
+            $this->addFlashMessage(
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.configuration.missingDescription.body', 'NrLlm') ?? 'Please describe what this configuration should do.',
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.configuration.missingDescription.title', 'NrLlm') ?? 'Missing description',
+                ContextualFeedbackSeverity::WARNING,
+            );
             return $this->redirect('wizardForm');
         }
         if (mb_strlen($description) > 2000) {
@@ -209,10 +213,18 @@ final class ConfigurationController extends ActionController
             return $this->moduleTemplate->renderResponse('Backend/Configuration/WizardPreview');
         } catch (ProviderException $e) {
             $this->logger->error('Configuration wizard: provider error', ['exception' => $e]);
-            $this->addFlashMessage('Generation failed (LLM provider error). See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+            $this->addFlashMessage(
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.configuration.generationFailed.provider', 'NrLlm') ?? 'Generation failed (LLM provider error). See system log for details.',
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error', 'NrLlm') ?? 'Error',
+                ContextualFeedbackSeverity::ERROR,
+            );
         } catch (Throwable $e) {
             $this->logger->error('Configuration wizard: unexpected error', ['exception' => $e]);
-            $this->addFlashMessage('Generation failed. See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+            $this->addFlashMessage(
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.configuration.generationFailed.generic', 'NrLlm') ?? 'Generation failed. See system log for details.',
+                LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error', 'NrLlm') ?? 'Error',
+                ContextualFeedbackSeverity::ERROR,
+            );
         }
 
         return $this->redirect('wizardForm');

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 #[AsController]
 final class LlmModuleController extends ActionController
@@ -205,7 +206,7 @@ final class LlmModuleController extends ActionController
         $menu->setIdentifier('LlmModuleMenu');
 
         $dashboardItem = $menu->makeMenuItem()
-            ->setTitle('Dashboard')
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tab.dashboard', 'NrLlm') ?? 'Dashboard')
             ->setHref((string)$this->backendUriBuilder->buildUriFromRoute('nrllm_overview'));
         if ($activeTab === 'dashboard') {
             $dashboardItem->setActive(true);
@@ -213,7 +214,7 @@ final class LlmModuleController extends ActionController
         $menu->addMenuItem($dashboardItem);
 
         $helpItem = $menu->makeMenuItem()
-            ->setTitle('Help')
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tab.help', 'NrLlm') ?? 'Help')
             ->setHref($this->uriBuilder->reset()->uriFor('help'));
         if ($activeTab === 'help') {
             $helpItem->setActive(true);

--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Backend controller for the Task catalog (list view).
@@ -109,7 +110,7 @@ final class TaskListController extends ActionController
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
         $createButton = $buttonBar->makeLinkButton()
             ->setIcon($this->iconFactory->getIcon('actions-plus', IconSize::SMALL))
-            ->setTitle('New Task')
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:btn.task.new', 'NrLlm') ?? 'New Task')
             ->setShowLabelText(true)
             ->setHref($this->buildNewUrl());
         $buttonBar->addButton($createButton);
@@ -125,7 +126,7 @@ final class TaskListController extends ActionController
         ]);
         $aiButton = $buttonBar->makeLinkButton()
             ->setIcon($this->iconFactory->getIcon('actions-bolt', IconSize::SMALL))
-            ->setTitle('Create with AI')
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.createWithAi', 'NrLlm') ?? 'Create with AI')
             ->setShowLabelText(true)
             ->setHref($wizardUrl);
         $buttonBar->addButton($aiButton, ButtonBar::BUTTON_POSITION_LEFT, 2);

--- a/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
+++ b/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
@@ -29,8 +29,9 @@ sensitive — provider/model/configuration state mutations (toggle-active,
 set-default), provider and model *test* calls that decrypt vault-stored API
 keys and reach out to upstream LLMs, task execution (which spends budget and
 runs the configured prompt), reading of arbitrary TYPO3 records via the task
-record picker, and the setup wizard's *save* which creates providers and stores
-new API keys in the vault.
+record picker, the tool playground's *run* (which executes the agent loop,
+spending budget and invoking registered tools) and tool *toggle*, and the setup
+wizard's *save* which creates providers and stores new API keys in the vault.
 
 Only :php:`SkillSourceController` enforced an admin check, via a private
 ``denyNonAdmin()`` method duplicated nowhere else. Every other backend AJAX
@@ -56,9 +57,10 @@ Decision
    type-compatible. The guard covers
    :php:`LlmModuleController`, :php:`ProviderController`, :php:`ModelController`,
    :php:`ConfigurationController`, :php:`TaskRecordsController`,
-   :php:`TaskExecutionController`, :php:`SetupWizardController` and the
-   already-guarded :php:`SkillSourceController` — 27 actions in total, matching
-   the route table exactly.
+   :php:`TaskExecutionController`, :php:`SetupWizardController`,
+   :php:`ToolPlaygroundController` and the already-guarded
+   :php:`SkillSourceController` — 29 actions in total, matching the route table
+   exactly.
 
 3. **Non-AJAX module actions are left untouched.** Extbase module actions
    (``listAction``, ``indexAction``, ``executeFormAction``,

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -297,6 +297,16 @@
                 <target>Aktualisieren</target>
             </trans-unit>
 
+            <!-- Docheader tab menu -->
+            <trans-unit id="tab.dashboard">
+                <source>Dashboard</source>
+                <target>Dashboard</target>
+            </trans-unit>
+            <trans-unit id="tab.help">
+                <source>Help</source>
+                <target>Hilfe</target>
+            </trans-unit>
+
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">
                 <source>Prompt Snippets</source>
@@ -410,6 +420,22 @@
                 <source>(not configured)</source>
                 <target>(nicht konfiguriert)</target>
             </trans-unit>
+            <trans-unit id="flash.configuration.missingDescription.title">
+                <source>Missing description</source>
+                <target>Beschreibung fehlt</target>
+            </trans-unit>
+            <trans-unit id="flash.configuration.missingDescription.body">
+                <source>Please describe what this configuration should do.</source>
+                <target>Bitte beschreiben Sie, was diese Konfiguration tun soll.</target>
+            </trans-unit>
+            <trans-unit id="flash.configuration.generationFailed.provider">
+                <source>Generation failed (LLM provider error). See system log for details.</source>
+                <target>Generierung fehlgeschlagen (LLM-Anbieterfehler). Details siehe Systemlog.</target>
+            </trans-unit>
+            <trans-unit id="flash.configuration.generationFailed.generic">
+                <source>Generation failed. See system log for details.</source>
+                <target>Generierung fehlgeschlagen. Details siehe Systemlog.</target>
+            </trans-unit>
 
             <!-- Model test results -->
             <trans-unit id="model.test.responded">
@@ -505,6 +531,10 @@
             <trans-unit id="analytics.budget.of">
                 <source>of</source>
                 <target>von</target>
+            </trans-unit>
+            <trans-unit id="analytics.budget.barAria">
+                <source>Budget usage</source>
+                <target>Budgetnutzung</target>
             </trans-unit>
             <trans-unit id="analytics.empty.title">
                 <source>No usage recorded</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -226,6 +226,14 @@
                 <source>Refresh</source>
             </trans-unit>
 
+            <!-- Docheader tab menu -->
+            <trans-unit id="tab.dashboard">
+                <source>Dashboard</source>
+            </trans-unit>
+            <trans-unit id="tab.help">
+                <source>Help</source>
+            </trans-unit>
+
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">
                 <source>Prompt Snippets</source>
@@ -312,6 +320,18 @@
             <trans-unit id="configuration.notConfigured">
                 <source>(not configured)</source>
             </trans-unit>
+            <trans-unit id="flash.configuration.missingDescription.title">
+                <source>Missing description</source>
+            </trans-unit>
+            <trans-unit id="flash.configuration.missingDescription.body">
+                <source>Please describe what this configuration should do.</source>
+            </trans-unit>
+            <trans-unit id="flash.configuration.generationFailed.provider">
+                <source>Generation failed (LLM provider error). See system log for details.</source>
+            </trans-unit>
+            <trans-unit id="flash.configuration.generationFailed.generic">
+                <source>Generation failed. See system log for details.</source>
+            </trans-unit>
 
             <!-- Model test results -->
             <trans-unit id="model.test.responded">
@@ -384,6 +404,9 @@
             </trans-unit>
             <trans-unit id="analytics.budget.of">
                 <source>of</source>
+            </trans-unit>
+            <trans-unit id="analytics.budget.barAria">
+                <source>Budget usage</source>
             </trans-unit>
             <trans-unit id="analytics.empty.title">
                 <source>No usage recorded</source>

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -23,7 +23,8 @@
         <div class="btn-group mb-3" role="group" aria-label="Date range">
             <f:for each="{presets}" as="p">
                 <a href="{rangeLinks.{p}}"
-                   class="btn btn-sm {f:if(condition: '{p} == {preset}', then: 'btn-primary', else: 'btn-default')}">
+                   class="btn btn-sm {f:if(condition: '{p} == {preset}', then: 'btn-primary', else: 'btn-default')}"
+                   aria-current="{f:if(condition: '{p} == {preset}', then: 'true', else: 'false')}">
                     <f:switch expression="{p}">
                         <f:case value="7d"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.range.7d" /></f:case>
                         <f:case value="30d"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.range.30d" /></f:case>
@@ -88,7 +89,12 @@
                                         <f:if condition="{u.budget}">
                                             <f:then>
                                                 <div class="d-flex align-items-center gap-2">
-                                                    <span class="nrllm-budget-bar"><span style="width: {u.budget.percent -> f:format.number(decimals: 0)}%"></span></span>
+                                                    <span class="nrllm-budget-bar"
+                                                          role="progressbar"
+                                                          aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.budget.barAria')}"
+                                                          aria-valuenow="{u.budget.percent -> f:format.number(decimals: 0)}"
+                                                          aria-valuemin="0"
+                                                          aria-valuemax="100"><span style="width: {u.budget.percent -> f:format.number(decimals: 0)}%"></span></span>
                                                     <span>{u.budget.percent -> f:format.number(decimals: 0)}% <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.budget.of" /> ${u.budget.limitCost -> f:format.number(decimals: 2)}</span>
                                                 </div>
                                             </f:then>

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -91,14 +91,15 @@
                                     <td>{tokByConfig.{config.uid}}</td>
                                     <td class="col-control">
                                         <div class="btn-group" role="group">
-                                            <a href="{editUrls.{config.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
+                                            <a href="{editUrls.{config.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}" aria-label="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
                                                 <core:icon identifier="actions-open" size="small" />
                                             </a>
                                             <f:if condition="{config.llmModel}">
                                                 <f:then>
                                                     <button type="button" class="btn btn-secondary btn-sm js-toggle-active"
                                                             data-uid="{config.uid}"
-                                                            title="{f:if(condition: config.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
+                                                            title="{f:if(condition: config.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}"
+                                                            aria-label="{f:if(condition: config.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
                                                         <f:if condition="{config.isActive}">
                                                             <f:then><core:icon identifier="actions-toggle-on" size="small" /></f:then>
                                                             <f:else><core:icon identifier="actions-toggle-off" size="small" /></f:else>
@@ -107,7 +108,8 @@
                                                 </f:then>
                                                 <f:else>
                                                     <button type="button" class="btn btn-secondary btn-sm" disabled
-                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.title')}">
+                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.title')}"
+                                                            aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.noModel.title')}">
                                                         <core:icon identifier="actions-toggle-off" size="small" />
                                                     </button>
                                                 </f:else>
@@ -115,14 +117,16 @@
                                             <f:if condition="!{config.isDefault}">
                                                 <button type="button" class="btn btn-secondary btn-sm js-set-default"
                                                         data-uid="{config.uid}"
-                                                        title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:setDefault')}">
+                                                        title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:setDefault')}"
+                                                        aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:setDefault')}">
                                                     <core:icon identifier="actions-star" size="small" />
                                                 </button>
                                             </f:if>
                                             <button type="button" class="btn btn-secondary btn-sm js-test-config"
                                                     data-uid="{config.uid}"
                                                     data-name="{config.name}"
-                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConfiguration')}">
+                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConfiguration')}"
+                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConfiguration')}">
                                                 <core:icon identifier="actions-play" size="small" />
                                             </button>
                                         </div>

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -109,12 +109,13 @@
                                                     <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.reassignProvider" default="Reassign Provider" />
                                                 </a>
                                             </f:if>
-                                            <a href="{editUrls.{model.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
+                                            <a href="{editUrls.{model.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}" aria-label="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
                                                 <core:icon identifier="actions-open" size="small" />
                                             </a>
                                             <button type="button" class="btn btn-secondary btn-sm js-toggle-active"
                                                     data-uid="{model.uid}"
-                                                    title="{f:if(condition: model.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
+                                                    title="{f:if(condition: model.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}"
+                                                    aria-label="{f:if(condition: model.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
                                                 <f:if condition="{model.isActive}">
                                                     <f:then><core:icon identifier="actions-toggle-on" size="small" /></f:then>
                                                     <f:else><core:icon identifier="actions-toggle-off" size="small" /></f:else>
@@ -123,13 +124,15 @@
                                             <button type="button" class="btn btn-secondary btn-sm js-set-default"
                                                     data-uid="{model.uid}"
                                                     title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:setDefault')}"
+                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:setDefault')}"
                                                     {f:if(condition: model.isDefault, then: 'disabled')}>
                                                 <core:icon identifier="actions-star" size="small" />
                                             </button>
                                             <button type="button" class="btn btn-secondary btn-sm js-test-model"
                                                     data-uid="{model.uid}"
                                                     data-name="{model.name}"
-                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testModel')}">
+                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testModel')}"
+                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testModel')}">
                                                 <core:icon identifier="actions-play" size="small" />
                                             </button>
                                         </div>

--- a/Resources/Private/Templates/Backend/PromptSnippet/List.html
+++ b/Resources/Private/Templates/Backend/PromptSnippet/List.html
@@ -84,7 +84,7 @@
                                         </td>
                                         <td>
                                             <div class="btn-group btn-group-sm">
-                                                <a href="{editUrls.{snippet.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
+                                                <a href="{editUrls.{snippet.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
                                                     <core:icon identifier="actions-open" size="small" />
                                                 </a>
                                             </div>

--- a/Resources/Private/Templates/Backend/Provider/List.html
+++ b/Resources/Private/Templates/Backend/Provider/List.html
@@ -92,12 +92,13 @@
                                     <td>{tokByProvider.{provider.adapterType}}</td>
                                     <td class="col-control">
                                         <div class="btn-group" role="group">
-                                            <a href="{editUrls.{provider.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
+                                            <a href="{editUrls.{provider.uid}}" class="btn btn-secondary btn-sm" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}" aria-label="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:edit')}">
                                                 <core:icon identifier="actions-open" size="small" />
                                             </a>
                                             <button type="button" class="btn btn-secondary btn-sm js-toggle-active"
                                                     data-uid="{provider.uid}"
-                                                    title="{f:if(condition: provider.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
+                                                    title="{f:if(condition: provider.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}"
+                                                    aria-label="{f:if(condition: provider.isActive, then: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:deactivate\')}', else: '{f:translate(key: \'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:activate\')}')}">
                                                 <f:if condition="{provider.isActive}">
                                                     <f:then><core:icon identifier="actions-toggle-on" size="small" /></f:then>
                                                     <f:else><core:icon identifier="actions-toggle-off" size="small" /></f:else>
@@ -106,7 +107,8 @@
                                             <button type="button" class="btn btn-secondary btn-sm js-test-connection"
                                                     data-uid="{provider.uid}"
                                                     data-name="{provider.name}"
-                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConnection')}">
+                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConnection')}"
+                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:testConnection')}">
                                                 <core:icon identifier="actions-play" size="small" />
                                             </button>
                                         </div>

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -121,7 +121,7 @@
                                                             <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.run" default="Run" />
                                                         </f:link.action>
                                                     </f:if>
-                                                    <a href="{editUrls.{task.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
+                                                    <a href="{editUrls.{task.uid}}" class="btn btn-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.action.edit')}">
                                                         <core:icon identifier="actions-open" size="small" />
                                                     </a>
                                                 </div>


### PR DESCRIPTION
## Description

Resolves the **i18n / accessibility / hygiene / docs** findings from the comprehensive audit (round 1). No production logic changes.

- **i18n** — `TaskListController` docheader buttons, `LlmModuleController` Dashboard/Help tab items, and `ConfigurationController` wizard flash messages now use `locallang` (EN+DE) instead of hardcoded English.
- **a11y** — every icon-only action/toggle button across the five backend list templates gains a translated `aria-label`; Analytics budget bars get `role="progressbar"` + `aria-value*`, the date-range selector `aria-current`.
- **hygiene** — SPDX/copyright headers added to `Build/FunctionalTestsBootstrap.php`, `Build/rector/rector.php`, `Build/fractor/fractor.php`, `.php-cs-fixer.dist.php`; **ADR-037** guarded-controller/action counts corrected (8→9 controllers, 27→29 actions incl. ToolPlayground); integration suite documented in `AGENTS.md`.

## Type of Change
- [x] i18n / a11y / docs / chore

## Checklist
- [x] Unit 3752 · functional (TaskList/LlmModule/Configuration) · PHPStan L10 · CGL clean (PHP 8.4)
- [x] All new locallang keys EN + DE; no production-logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge
