### PR TITLE
test: cover budget pipeline, tool RBAC/execution, PSR-18 mapping & configure edges

### DIFF
--- a/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\BudgetService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end budget gate: a real {@see LlmConfiguration} dispatched through the
+ * REAL {@see MiddlewarePipeline} + REAL {@see BudgetMiddleware} + REAL
+ * {@see BudgetService}, with the per-user ceiling and existing usage read from
+ * the actual database (`tx_nrllm_user_budget` + `tx_nrllm_service_usage`).
+ *
+ * The unit-level {@see \Netresearch\NrLlm\Tests\Unit\Provider\Middleware\BudgetMiddlewareTest}
+ * stubs BudgetServiceInterface, so the wiring from a DB budget through the real
+ * service's aggregation and the typed denial was never exercised. Here only the
+ * terminal provider call is a no-op closure (no network); everything between the
+ * pipeline entry and the budget decision is production code resolved from the DI
+ * container.
+ */
+#[CoversClass(BudgetMiddleware::class)]
+#[CoversClass(BudgetExceededException::class)]
+final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
+{
+    private const TABLE_BUDGET = 'tx_nrllm_user_budget';
+    private const TABLE_USAGE  = 'tx_nrllm_service_usage';
+
+    private const BE_USER_UID = 42;
+
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+    }
+
+    #[Test]
+    public function withinBudgetRequestReachesTerminalAndReturnsResult(): void
+    {
+        // Monthly ceiling of 10.0; only 1.0 spent so far. A 0.5 planned cost on
+        // the next call (10.0 - 1.0 - 0.5 still positive) must be allowed.
+        $this->insertBudget(maxCostPerMonth: 10.0);
+        $this->insertUsageRow(estimatedCost: 1.0);
+
+        $terminalRan = false;
+        $result = $this->pipeline()->run(
+            context: $this->contextFor(plannedCost: 0.5),
+            configuration: $this->configuration(),
+            terminal: static function (LlmConfiguration $config) use (&$terminalRan): string {
+                $terminalRan = true;
+
+                // The middleware must forward the SAME configuration untouched.
+                return $config->getIdentifier();
+            },
+        );
+
+        self::assertTrue($terminalRan, 'A within-budget request must reach the terminal provider call.');
+        self::assertSame('primary', $result, 'The terminal receives the dispatched configuration.');
+    }
+
+    #[Test]
+    public function overBudgetRequestIsBlockedWithTypedException(): void
+    {
+        // Monthly ceiling of 10.0 already fully consumed (10.0 spent). The next
+        // call's projected total (10.0 + 0.5) overflows the monthly-cost bucket.
+        $this->insertBudget(maxCostPerMonth: 10.0);
+        $this->insertUsageRow(estimatedCost: 10.0);
+
+        $terminalRan = false;
+
+        try {
+            $this->pipeline()->run(
+                context: $this->contextFor(plannedCost: 0.5),
+                configuration: $this->configuration(),
+                terminal: static function () use (&$terminalRan): string {
+                    $terminalRan = true;
+
+                    return 'should-never-run';
+                },
+            );
+            self::fail('Expected BudgetExceededException for an over-budget request.');
+        } catch (BudgetExceededException $e) {
+            self::assertFalse($terminalRan, 'An over-budget request must NOT reach the terminal call.');
+            // The real BudgetService named the monthly-cost bucket as the one
+            // that tripped, with the genuine current usage read from the DB.
+            self::assertFalse($e->result->allowed);
+            self::assertSame(BudgetCheckResult::LIMIT_MONTHLY_COST, $e->result->exceededLimit);
+            self::assertEqualsWithDelta(10.0, $e->result->currentUsage, 0.0001);
+            self::assertEqualsWithDelta(10.0, $e->result->limit, 0.0001);
+        }
+    }
+
+    #[Test]
+    public function requestForUserWithoutBudgetRecordProceeds(): void
+    {
+        // No budget row at all for this user: the real service returns allowed()
+        // (BudgetService::check short-circuits on a missing record), so the call
+        // must reach the terminal even with a non-trivial planned cost.
+        $terminalRan = false;
+        $this->pipeline()->run(
+            context: $this->contextFor(plannedCost: 99.0),
+            configuration: $this->configuration(),
+            terminal: static function () use (&$terminalRan): string {
+                $terminalRan = true;
+
+                return 'ok';
+            },
+        );
+
+        self::assertTrue($terminalRan, 'A user with no budget record is unconstrained and proceeds.');
+    }
+
+    /**
+     * Build a real pipeline containing ONLY the container-resolved
+     * BudgetMiddleware (which itself wraps the real BudgetService + DB-backed
+     * usage windows). Isolating the single middleware keeps the assertions about
+     * the budget gate's behaviour, not the full default stack ordering (covered
+     * by MiddlewarePipelineOrderTest).
+     */
+    private function pipeline(): MiddlewarePipeline
+    {
+        $budgetService = $this->get(BudgetService::class);
+        self::assertInstanceOf(BudgetService::class, $budgetService);
+
+        $middleware = $this->get(BudgetMiddleware::class);
+        self::assertInstanceOf(BudgetMiddleware::class, $middleware);
+
+        return new MiddlewarePipeline([$middleware]);
+    }
+
+    private function contextFor(float $plannedCost): ProviderCallContext
+    {
+        return new ProviderCallContext(
+            operation: ProviderOperation::Chat,
+            correlationId: 'functional-budget-test',
+            metadata: [
+                BudgetMiddleware::METADATA_BE_USER_UID  => self::BE_USER_UID,
+                BudgetMiddleware::METADATA_PLANNED_COST => $plannedCost,
+            ],
+        );
+    }
+
+    private function configuration(): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier('primary');
+
+        return $config;
+    }
+
+    private function insertBudget(float $maxCostPerMonth): void
+    {
+        $now = (new DateTimeImmutable('now'))->getTimestamp();
+        $this->connectionPool->getConnectionForTable(self::TABLE_BUDGET)->insert(self::TABLE_BUDGET, [
+            'pid'                     => 0,
+            'be_user'                 => self::BE_USER_UID,
+            'max_requests_per_day'    => 0,
+            'max_tokens_per_day'      => 0,
+            'max_cost_per_day'        => 0.0,
+            'max_requests_per_month'  => 0,
+            'max_tokens_per_month'    => 0,
+            'max_cost_per_month'      => $maxCostPerMonth,
+            'is_active'               => 1,
+            'tstamp'                  => $now,
+            'crdate'                  => $now,
+            'deleted'                 => 0,
+            'hidden'                  => 0,
+        ]);
+    }
+
+    /**
+     * Insert a usage row dated to "now" so it falls inside the current monthly
+     * window the BudgetService aggregates over.
+     */
+    private function insertUsageRow(float $estimatedCost): void
+    {
+        $now = (new DateTimeImmutable('now'))->getTimestamp();
+        $this->connectionPool->getConnectionForTable(self::TABLE_USAGE)->insert(self::TABLE_USAGE, [
+            'pid'                => 0,
+            'service_type'       => 'chat',
+            'service_provider'   => 'openai',
+            'configuration_uid'  => 0,
+            'model_uid'          => 1,
+            'model_id'           => 'gpt-4o',
+            'be_user'            => self::BE_USER_UID,
+            'request_count'      => 1,
+            'tokens_used'        => 100,
+            'prompt_tokens'      => 60,
+            'completion_tokens'  => 40,
+            'characters_used'    => 0,
+            'audio_seconds_used' => 0,
+            'images_generated'   => 0,
+            'estimated_cost'     => $estimatedCost,
+            'request_date'       => $now,
+            'tstamp'             => $now,
+            'crdate'             => $now,
+        ]);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end agent loop over a REAL builtin tool.
+ *
+ * The unit {@see \Netresearch\NrLlm\Tests\Unit\Service\Tool\ToolLoopServiceTest}
+ * drives the loop with an in-memory FakeTool and a hand-written availability
+ * double. Here the loop runs the actual admin-curated {@see FetchLogsTool}
+ * through the REAL {@see ToolRegistry} and the REAL DB-backed
+ * {@see ToolAvailabilityService} (its `tx_nrllm_tool_state` overrides), with the
+ * acting admin resolved from `$GLOBALS['BE_USER']`. Only the LLM manager is
+ * stubbed (it scripts one tool call followed by a final answer — no network);
+ * everything from the availability gate through the admin gate down into
+ * `FetchLogsTool::execute()` reading real `sys_log` rows is production code, and
+ * the trace is asserted to carry the tool's REAL formatted output.
+ */
+#[CoversClass(ToolLoopService::class)]
+final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
+{
+    private ConnectionPool $connectionPool;
+
+    /** @var BackendUserAuthentication|object|null */
+    private mixed $beUserBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        // FetchLogsTool is admin-only; the runtime RBAC gate reads the acting
+        // backend user from $GLOBALS['BE_USER'] and fails closed when absent.
+        $this->beUserBackup = $GLOBALS['BE_USER'] ?? null;
+        $admin              = new BackendUserAuthentication();
+        $admin->user        = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $admin;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['BE_USER'] = $this->beUserBackup;
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function realFetchLogsToolExecutesThroughLoopAndTraceRecordsItsOutput(): void
+    {
+        $this->importFixture('sys_log_tools.csv');
+
+        // Script the LLM: round 1 asks for the tool, round 2 (after the real tool
+        // result is fed back) gives the final answer.
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'fetch_logs', ['limit' => 2])]),
+            $this->response('Here is a summary of the recent logs.'),
+        ];
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback(function () use (&$queue): CompletionResponse {
+                $next = array_shift($queue);
+                if (!$next instanceof CompletionResponse) {
+                    throw new RuntimeException('Scripted response queue underflow.', 1799990001);
+                }
+
+                return $next;
+            });
+
+        $service = $this->buildService($mgr);
+        $result  = $service->runLoop([$this->userTurn('show me the logs')], new LlmConfiguration(), null);
+
+        // The real builtin tool ran exactly once and its REAL output is in the trace.
+        self::assertCount(1, $result->trace);
+        self::assertSame('fetch_logs', $result->trace[0]->name);
+        self::assertFalse($result->trace[0]->isError, 'the real tool executed without error');
+
+        $toolOutput = $result->trace[0]->result;
+        // FetchLogsTool formats newest-first; the limit=2 it was called with
+        // surfaces the two newest fixture rows (see FetchLogsToolTest).
+        self::assertStringContainsString('Cache cleared', $toolOutput);
+        self::assertStringContainsString('Login failed', $toolOutput);
+        // PII redaction in the real tool still holds end-to-end.
+        self::assertStringNotContainsString('203.0.113.55', $toolOutput);
+
+        self::assertSame('Here is a summary of the recent logs.', $result->finalContent);
+        self::assertFalse($result->truncated);
+    }
+
+    #[Test]
+    public function adminOnlyBuiltinToolIsNotOfferedToNonAdminEndToEnd(): void
+    {
+        // Flip the acting user to a non-admin: the REAL admin gate must drop the
+        // admin-only FetchLogsTool, leaving no tools ⇒ a single plain completion,
+        // and the LLM's tools path is never taken.
+        $nonAdmin           = new BackendUserAuthentication();
+        $nonAdmin->user     = ['uid' => 2, 'admin' => 0];
+        $GLOBALS['BE_USER'] = $nonAdmin;
+
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('plain answer'));
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+        $service = $this->buildService($mgr);
+        // The caller even explicitly allows the tool — the admin gate still wins.
+        $result = $service->runLoop([$this->userTurn('show me the logs')], new LlmConfiguration(), ['fetch_logs']);
+
+        self::assertSame('plain answer', $result->finalContent);
+        self::assertSame([], $result->trace);
+        self::assertSame(1, $result->iterations);
+    }
+
+    /**
+     * Wire the loop with the real registry + real DB-backed availability service
+     * over the single real {@see FetchLogsTool}.
+     */
+    private function buildService(LlmServiceManagerInterface $mgr): ToolLoopService
+    {
+        $registry     = new ToolRegistry([new FetchLogsTool($this->connectionPool)]);
+        $availability = new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool));
+
+        return new ToolLoopService($mgr, $registry, $availability);
+    }
+
+    /**
+     * @param list<ToolCall>|null $toolCalls
+     */
+    private function response(string $content, ?array $toolCalls = null): CompletionResponse
+    {
+        return new CompletionResponse(
+            content: $content,
+            model: 'test-model',
+            usage: UsageStatistics::fromTokens(0, 0),
+            toolCalls: $toolCalls,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function userTurn(string $content): array
+    {
+        return ['role' => 'user', 'content' => $content];
+    }
+}

--- a/Tests/Unit/Provider/AbstractProviderConfigureTest.php
+++ b/Tests/Unit/Provider/AbstractProviderConfigureTest.php
@@ -341,4 +341,152 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
         // Provider should report as not available due to empty API key
         self::assertFalse($provider->isAvailable());
     }
+
+    #[Test]
+    public function configureWithEmptyArrayAppliesAllDefaults(): void
+    {
+        // An entirely empty config must leave every field at its safe default:
+        // empty api key (⇒ not available), timeout 30, maxRetries 3, the
+        // provider's own default base URL and model. No exception is thrown
+        // (validation is lazy, deferred to the first real request).
+        $provider = $this->geminiProvider();
+
+        $provider->configure([]);
+
+        self::assertFalse($provider->isAvailable());
+        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
+
+        $baseUrl = $this->stringProperty($provider, 'baseUrl');
+        self::assertStringContainsString('generativelanguage.googleapis.com', $baseUrl);
+        self::assertNotEmpty($provider->getDefaultModel());
+    }
+
+    #[Test]
+    public function configureWithOnlyApiKeyLeavesEverythingElseAtDefaults(): void
+    {
+        // A partial config carrying just the api key identifier: the provider
+        // becomes available, but the unspecified numeric fields keep their
+        // defaults rather than collapsing to zero.
+        $provider = $this->geminiProvider();
+
+        $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
+
+        self::assertTrue($provider->isAvailable());
+        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
+        self::assertNotEmpty($provider->getDefaultModel());
+    }
+
+    #[Test]
+    public function configureCoercesNumericStringTimeoutAndMaxRetriesToInt(): void
+    {
+        // A numeric string (e.g. from a YAML/ext-conf scalar) is coerced to int
+        // by the SafeCast getter rather than discarded.
+        $provider = $this->geminiProvider();
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'timeout' => '60',
+            'maxRetries' => '5',
+        ]);
+
+        self::assertSame(60, $this->intProperty($provider, 'timeout'));
+        self::assertSame(5, $this->intProperty($provider, 'maxRetries'));
+    }
+
+    #[Test]
+    public function configureFallsBackToDefaultsForNonNumericStringNumerics(): void
+    {
+        // A non-numeric string cannot be coerced and must fall back to the
+        // default (30 / 3) rather than casting to 0, which would disable the
+        // timeout / retry behaviour.
+        $provider = $this->geminiProvider();
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'timeout' => 'soon',
+            'maxRetries' => 'lots',
+        ]);
+
+        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
+    }
+
+    #[Test]
+    public function configureFallsBackToDefaultBaseUrlForNonStringValue(): void
+    {
+        // A type-mismatched baseUrl (an array, not a string) must fall back to
+        // the provider's default base URL — never an empty or malformed URL.
+        $provider = $this->geminiProvider();
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'baseUrl' => ['not', 'a', 'string'],
+        ]);
+
+        $baseUrl = $this->stringProperty($provider, 'baseUrl');
+        self::assertStringContainsString('generativelanguage.googleapis.com', $baseUrl);
+    }
+
+    #[Test]
+    public function reconfiguringResetsTheConfiguredHttpClient(): void
+    {
+        // configure() resets the lazily-built HTTP client (so a re-config with a
+        // new key/base URL does not keep dispatching through the old client).
+        // Assert the reset directly on the private property: a client injected
+        // after the first configure() is cleared by the second configure().
+        $provider = $this->geminiProvider();
+        $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        self::assertNotNull($this->configuredHttpClient($provider), 'client present after setHttpClient');
+
+        $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
+
+        self::assertNull(
+            $this->configuredHttpClient($provider),
+            'reconfiguration must clear the previously configured HTTP client',
+        );
+    }
+
+    private function geminiProvider(): GeminiProvider
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        return $provider;
+    }
+
+    private function intProperty(GeminiProvider $provider, string $name): int
+    {
+        $value = (new ReflectionClass($provider))->getProperty($name)->getValue($provider);
+        self::assertIsInt($value);
+
+        return $value;
+    }
+
+    private function stringProperty(GeminiProvider $provider, string $name): string
+    {
+        $value = (new ReflectionClass($provider))->getProperty($name)->getValue($provider);
+        self::assertIsString($value);
+
+        return $value;
+    }
+
+    private function configuredHttpClient(GeminiProvider $provider): mixed
+    {
+        // configuredHttpClient is a private property declared on AbstractProvider;
+        // a child-class ReflectionClass does not expose a parent's private prop,
+        // so reflect on the declaring class.
+        return (new ReflectionClass(AbstractProvider::class))
+            ->getProperty('configuredHttpClient')
+            ->getValue($provider);
+    }
 }

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -26,6 +26,9 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 
 /**
@@ -595,5 +598,82 @@ class AbstractProviderTest extends AbstractUnitTestCase
         $provider->complete('hello, do not leak me');
 
         self::assertSame(['LLM chat call to OpenAI (gpt-4o)'], $capturedReasons);
+    }
+
+    #[Test]
+    public function clientExceptionMapsToProviderConnectionExceptionWithSanitisedMessage(): void
+    {
+        // A PSR-18 ClientExceptionInterface raised by the HTTP client is a
+        // transport failure; sendRequest() exhausts its retries and rethrows the
+        // typed ProviderConnectionException, scrubbing any `?key=<secret>` the
+        // underlying message carried. This is the unit-suite counterpart of the
+        // mapping previously only exercised by the mutation suite.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'maxRetries' => 1,
+        ]);
+
+        $clientException = new class ('Client error reaching https://api.openai.com/v1/chat/completions?key=sk-secret123', 1799990100) extends RuntimeException implements ClientExceptionInterface {};
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willThrowException($clientException);
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hello');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('key=***', $e->getMessage());
+            self::assertStringNotContainsString('sk-secret123', $e->getMessage());
+            // The transport failure is mapped, not swallowed: the original
+            // ClientException is preserved as the cause.
+            self::assertSame($clientException, $e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function networkExceptionMapsToProviderConnectionExceptionWithSanitisedMessage(): void
+    {
+        // A PSR-18 NetworkExceptionInterface (a connection-level failure that
+        // carries the originating request) follows the same retry/rethrow path
+        // as a ClientException: it maps to a sanitised ProviderConnectionException.
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'maxRetries' => 1,
+        ]);
+
+        $networkException = new class ('DNS lookup failed for https://api.openai.com/v1/chat/completions?token=sk-secret456', 1799990101) extends RuntimeException implements NetworkExceptionInterface {
+            public function getRequest(): RequestInterface
+            {
+                throw new RuntimeException('not needed for this test', 1799990102);
+            }
+        };
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willThrowException($networkException);
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hello');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('token=***', $e->getMessage());
+            self::assertStringNotContainsString('sk-secret456', $e->getMessage());
+            self::assertSame($networkException, $e->getPrevious());
+        }
     }
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -581,4 +581,81 @@ final class ToolLoopServiceTest extends TestCase
             $GLOBALS['BE_USER'] = $beUserBackup;
         }
     }
+
+    #[Test]
+    public function adminIsOfferedAdminOnlyToolAndItExecutesThroughTheLoop(): void
+    {
+        // Positive RBAC case (mirror of adminOnlyToolIsNeverOfferedToNonAdmin):
+        // when the acting user IS an admin, the admin-only tool survives the
+        // runtime filter, is offered on the tools path, executes, and its real
+        // result is recorded in the trace.
+        $beUserBackup       = $GLOBALS['BE_USER'] ?? null;
+        $admin              = new BackendUserAuthentication();
+        $admin->user        = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $admin;
+
+        try {
+            $mgr   = self::createStub(LlmServiceManagerInterface::class);
+            $queue = [
+                // The model calls the admin-only tool, then answers.
+                $this->response('', [new ToolCall('call_1', 'fetch_logs', [])]),
+                $this->response('logs reviewed'),
+            ];
+            $mgr->method('chatWithToolsForConfiguration')
+                ->willReturnCallback($this->queueCallback($queue));
+
+            // requiresAdmin = true; globally enabled; explicitly allowed.
+            $service = new ToolLoopService(
+                $mgr,
+                new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]),
+                new FakeToolAvailability(['fetch_logs']),
+            );
+            $result = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ['fetch_logs']);
+
+            self::assertCount(1, $result->trace);
+            self::assertSame('fetch_logs', $result->trace[0]->name);
+            self::assertSame('LOGS', $result->trace[0]->result, 'the admin-only tool actually executed');
+            self::assertFalse($result->trace[0]->isError);
+            self::assertSame('logs reviewed', $result->finalContent);
+            self::assertFalse($result->truncated);
+        } finally {
+            $GLOBALS['BE_USER'] = $beUserBackup;
+        }
+    }
+
+    #[Test]
+    public function disabledGateComposesWithAdminGateForAdminUser(): void
+    {
+        // The two fail-closed gates compose: an admin-only tool that the global
+        // availability gate reports as DISABLED is dropped by the disabled gate
+        // BEFORE the admin gate ever sees it, so even an admin is not offered it
+        // ⇒ no tools ⇒ exactly one plain completion.
+        $beUserBackup       = $GLOBALS['BE_USER'] ?? null;
+        $admin              = new BackendUserAuthentication();
+        $admin->user        = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $admin;
+
+        try {
+            $mgr = $this->createMock(LlmServiceManagerInterface::class);
+            $mgr->expects(self::once())
+                ->method('chatWithConfiguration')
+                ->willReturn($this->response('plain answer'));
+            $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+            // Tool requiresAdmin AND is registered, but the global gate reports
+            // NO enabled tools — the caller even explicitly allows it.
+            $service = new ToolLoopService(
+                $mgr,
+                new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]),
+                new FakeToolAvailability([]),
+            );
+            $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ['fetch_logs']);
+
+            self::assertSame('plain answer', $result->finalContent);
+            self::assertSame([], $result->trace);
+            self::assertSame(1, $result->iterations);
+        } finally {
+            $GLOBALS['BE_USER'] = $beUserBackup;
+        }
+    }
 }


### PR DESCRIPTION
Adds the **test-gap findings** from the comprehensive audit — test-only, no production change (no bugs found; edge cases behave per contract).

- **BudgetMiddlewarePipelineTest** (functional) — real `LlmConfiguration` + real `BudgetService` + real `MiddlewarePipeline` with DB-backed budget/usage rows: within-budget proceeds, over-budget → `BudgetExceededException`, no-budget short-circuits.
- **ToolLoopService** — admin *is* offered admin-only tools and one executes through the loop (trace records the real result); the disabled/host-allowlist gate composes with the admin gate; + a functional test driving the real `FetchLogsTool` (PII redaction holds end-to-end).
- **AbstractProvider PSR-18** — `ClientException`/`NetworkException` map to the typed provider exceptions with sanitised messages (unit, not just mutation).
- **configure() edges** — empty/partial/type-mismatch/reconfigure.

15 new tests. Unit 3783 · functional (Budget/Middleware/ToolLoop/Tool) · PHPStan L10 · CGL green (PHP 8.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nNzWq4gaZad2FXcTSge