### PR TITLE
refactor: types, doc accuracy & hygiene (audit round 2, part 2)

### DIFF
--- a/.github/SECURITY_CONTROLS.md
+++ b/.github/SECURITY_CONTROLS.md
@@ -65,8 +65,14 @@ All releases include:
 ### Dependency Management
 
 - Dependabot enabled for automated updates
-- composer.lock committed for reproducible builds
-- All GitHub Actions pinned with SHA hashes
+- No `composer.lock` committed — as a TYPO3 extension (library) the lock file is
+  intentionally git-ignored so the host project resolves compatible versions;
+  reproducibility is enforced by the `composer.json` constraints and the CI matrix
+- Third-party GitHub Actions pinned to full commit SHAs (with a version comment).
+  First-party Netresearch reusable workflows (`netresearch/typo3-ci-workflows`,
+  `netresearch/.github`) are referenced at `@main`: they are org-owned,
+  OpenSSF-Scorecard-monitored, and centrally maintained, so pinning them to a SHA
+  would freeze shared CI fixes across every consuming repository
 - Weekly dependency audits
 
 ## Succession Planning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Three-tier model: **Provider → Model → Configuration**. See `Documentation/A
 ### Directory Structure
 ```
 nr_llm/
-├── Classes/                    # 249 PHP source files
+├── Classes/                    # 264 PHP source files
 │   ├── Attribute/              # #[AsLlmProvider] auto-registration attribute
 │   ├── Controller/Backend/     # Backend controllers, DTOs, Response objects
 │   ├── DependencyInjection/    # Compiler passes (ProviderCompilerPass)

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -4,7 +4,7 @@
 
 <!-- AGENTS-GENERATED:START overview -->
 ## Overview
-PHP 8.2+ source code (249 files) with strict typing, PSR-12, PHPStan level 10. Three-tier domain: Providers -> Models -> Configurations.
+PHP 8.2+ source code (264 files) with strict typing, PSR-12, PHPStan level 10. Three-tier domain: Providers -> Models -> Configurations.
 <!-- AGENTS-GENERATED:END overview -->
 
 <!-- AGENTS-GENERATED:START setup -->

--- a/Classes/Attribute/AsLlmProvider.php
+++ b/Classes/Attribute/AsLlmProvider.php
@@ -15,9 +15,11 @@ use Attribute;
  * Marks a class as an LLM provider for auto-registration with LlmServiceManager.
  *
  * Providers bearing this attribute are automatically tagged `nr_llm.provider`
- * AND made public by ProviderCompilerPass at container compile time. You no
- * longer need to add a `tags:` entry or set `public: true` in Services.yaml
- * for the provider when you use this attribute.
+ * by ProviderCompilerPass at container compile time, so you no longer need to
+ * add a `tags:` entry in Services.yaml. They are deliberately kept private —
+ * nothing resolves a provider by class name from the container; all access is
+ * via `LlmServiceManager::getProvider()` — which keeps the documented public
+ * service set stable (ADR-028 / PublicServicesPolicyTest).
  *
  * Higher priority providers are registered first with the service manager.
  * Priority is an ordering hint only; providers are still resolved by their

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -348,9 +348,9 @@ class LlmConfiguration extends AbstractEntity
     }
 
     /**
-     * @return ObjectStorage<AbstractEntity>|null
+     * @return ObjectStorage<AbstractEntity>
      */
-    public function getBeGroups(): ?ObjectStorage
+    public function getBeGroups(): ObjectStorage
     {
         // Extbase can reconstitute a relation-less entity without the constructor's
         // ObjectStorage init, leaving this property unset/null.

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -278,9 +278,9 @@ class Provider extends AbstractEntity
     }
 
     /**
-     * @return ObjectStorage<Model>|null
+     * @return ObjectStorage<Model>
      */
-    public function getModels(): ?ObjectStorage
+    public function getModels(): ObjectStorage
     {
         // Extbase can reconstitute a relation-less entity without the constructor's
         // ObjectStorage init, leaving this property unset/null.

--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -79,7 +79,7 @@ class Task extends AbstractEntity
     protected string $promptTemplate = '';
     protected string $inputType = TaskInputType::MANUAL->value;
     protected string $inputSource = '';
-    protected string $outputFormat = self::OUTPUT_MARKDOWN;
+    protected string $outputFormat = TaskOutputFormat::MARKDOWN->value;
     protected bool $isActive = true;
     protected bool $isSystem = false;
     protected int $sorting = 0;

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -250,8 +250,13 @@ final class GeminiProvider extends AbstractProvider implements
 
             $functionCall = $this->getArray($partArray, 'functionCall');
             if ($functionCall !== []) {
+                // Gemini does not return tool-call IDs; synthesise a
+                // conversation-unique one. A per-response part index would
+                // reset to 0 each loop turn and collide across turns in
+                // buildToolCallIdToName(); uniqid(more_entropy: true) is
+                // collision-free even for multiple calls in one response.
                 $toolCalls[] = ToolCall::function(
-                    id: 'call_' . uniqid(),
+                    id: uniqid('call_', true),
                     name: $this->getString($functionCall, 'name'),
                     arguments: $this->getArray($functionCall, 'args'),
                 );

--- a/Classes/Service/LlmConfigurationService.php
+++ b/Classes/Service/LlmConfigurationService.php
@@ -252,9 +252,6 @@ final readonly class LlmConfigurationService implements LlmConfigurationServiceI
     private function getConfigurationGroupIds(LlmConfiguration $configuration): array
     {
         $beGroups = $configuration->getBeGroups();
-        if ($beGroups === null) {
-            return [];
-        }
 
         $groupIds = [];
         foreach ($beGroups as $group) {

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -263,14 +263,13 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
             return $a->isDefault() ? -1 : 1; // Default first
         }
 
-        // Fourth priority: sorting order.
-        // NOTE: `sorting` is a TYPO3-managed TCA `ctrl.sortby` field and is NOT
-        // hydrated onto the model by Extbase, so getSorting() returns 0 here and
-        // this comparison is effectively a no-op. Tied candidates therefore keep
-        // their repository order, which PHP's stable sort preserves. The line is
-        // kept intentionally so the intended ordering takes effect automatically
-        // should the field ever become hydrated.
-        return $a->getSorting() <=> $b->getSorting();
+        // Fourth priority: sorting order — handled at the query level.
+        // ModelRepository hydrates candidates already ordered by `sorting, name`
+        // (its $defaultOrderings), and usort() is stable, so equal-priority
+        // candidates keep that order without an explicit tiebreaker here. (A
+        // getSorting() comparison would be a no-op anyway: `sorting` is a TCA
+        // ctrl.sortby field that Extbase does not hydrate onto the model.)
+        return 0;
     }
 
     /**

--- a/Classes/Service/Option/EmbeddingOptions.php
+++ b/Classes/Service/Option/EmbeddingOptions.php
@@ -25,7 +25,7 @@ class EmbeddingOptions extends AbstractOptions implements BudgetAwareOptionsInte
     public function __construct(
         private ?string $model = null,
         private ?int $dimensions = null,
-        private ?int $cacheTtl = self::DEFAULT_CACHE_TTL,
+        private int $cacheTtl = self::DEFAULT_CACHE_TTL,
         private ?string $provider = null,
         ?int $beUserUid = null,
         ?float $plannedCost = null,
@@ -130,7 +130,7 @@ class EmbeddingOptions extends AbstractOptions implements BudgetAwareOptionsInte
         return $this->dimensions;
     }
 
-    public function getCacheTtl(): ?int
+    public function getCacheTtl(): int
     {
         return $this->cacheTtl;
     }
@@ -166,7 +166,7 @@ class EmbeddingOptions extends AbstractOptions implements BudgetAwareOptionsInte
             self::validatePositiveInt($this->dimensions, 'dimensions');
         }
 
-        if ($this->cacheTtl !== null && $this->cacheTtl < 0) {
+        if ($this->cacheTtl < 0) {
             self::validateRange($this->cacheTtl, 0, PHP_INT_MAX, 'cache_ttl');
         }
 

--- a/Documentation/Adr/Adr038ToolRuntime.rst
+++ b/Documentation/Adr/Adr038ToolRuntime.rst
@@ -153,10 +153,13 @@ Consequences
 - ● The allow-list re-validation at both offer and execution time means a
   declared-but-unknown tool name is dropped and an injected prompt cannot
   reach a tool the skills did not grant.
-- ◐ The two shipped example tools (``fetch_logs``, ``read_fal_asset_meta``)
-  are admin-curated, **read-only**, input-bounded and scoped (limit cap + PII
-  redaction; storage-scoped lookup). They are reference implementations of the
-  security contract, not a general capability.
+- ◐ The shipped built-in tools (``fetch_logs``, ``read_fal_asset_meta``, and
+  the later diagnostic/record tools — ``get_php_info``, ``get_env``,
+  ``get_page_tree``, ``get_tca``, ``list_be_users``, ``list_be_groups`` and
+  their secret-redacted/raw variants) are admin-curated, **read-only**,
+  input-bounded and scoped (limit cap + PII redaction; storage-scoped lookup).
+  They are reference implementations of the security contract, not a general
+  capability.
 - ●● Authorization is **per-tool and enforced in the runtime against the
   acting backend user**, not merely the playground gate (§6): admin-only tools
   are filtered out for non-admins (fail-closed), and the user-scoped tools

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x     | :white_check_mark: |
+| 0.13.x  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/Tests/Unit/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Unit/Service/LlmConfigurationServiceTest.php
@@ -86,7 +86,9 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
             }
             $config->method('getBeGroups')->willReturn($groups);
         } else {
-            $config->method('getBeGroups')->willReturn(null);
+            // getBeGroups() never returns null — an unrestricted configuration
+            // exposes an empty ObjectStorage.
+            $config->method('getBeGroups')->willReturn(new ObjectStorage());
         }
 
         return $config;
@@ -521,13 +523,15 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
     // ==================== Edge cases ====================
 
     #[Test]
-    public function hasAccessHandlesNullBeGroups(): void
+    public function hasAccessHandlesEmptyBeGroups(): void
     {
         $this->setupNonAdminUser([1, 2]);
 
         $config = self::createStub(LlmConfiguration::class);
         $config->method('hasAccessRestrictions')->willReturn(true);
-        $config->method('getBeGroups')->willReturn(null);
+        // getBeGroups() never returns null — a restricted config with no groups
+        // assigned exposes an empty ObjectStorage.
+        $config->method('getBeGroups')->willReturn(new ObjectStorage());
 
         $subject = $this->createSubject();
         $result = $subject->hasAccess($config);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,6 +15,11 @@ $EM_CONF[$_EXTKEY] = [
     'state' => 'beta',
     'version' => '0.13.0',
     'constraints' => [
+        // composer.json is the authoritative dependency constraint
+        // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only
+        // supports a single contiguous min-max range and therefore cannot
+        // express the 14.0–14.2 gap; the broad range below is intentional and
+        // never under-claims the supported 13.4 / 14.3 targets.
         'depends' => [
             'typo3' => '13.4.0-14.99.99',
             'php' => '8.2.0-8.99.99',


### PR DESCRIPTION
## Summary

Round-2 audit follow-up — type-safety, documentation accuracy and hygiene. **Stacked on #282** (base will retarget to `main` once #282 merges). Each finding was independently verified before fixing; verified false positives are noted below.

### Documentation accuracy
- **SECURITY_CONTROLS.md**: corrected two false claims — `composer.lock` is intentionally git-ignored (this is a library), not committed; the SHA-pinning statement now correctly scopes to *third-party* actions (first-party Netresearch reusable workflows are referenced at `@main` by design — org-owned, Scorecard-monitored).
- **SECURITY.md**: supported version `1.x` → `0.13.x` (matches `ext_emconf.php` / `composer.json`).
- **ext_emconf.php**: comment clarifying `composer.json` is the authoritative TYPO3 constraint and the TER contiguous-range format cannot express the 14.0–14.2 gap.
- **AsLlmProvider** docblock claimed providers are made public — the compiler pass deliberately keeps them private (ADR-028). Corrected.
- **AGENTS.md** source-file count 249 → 264; **ADR-038** now lists the full built-in tool set.

### Type safety
- `LlmConfiguration::getBeGroups()` / `Provider::getModels()` lazily initialize and never return null — dropped the `?ObjectStorage` return type and the now-dead null check in `LlmConfigurationService`.
- `EmbeddingOptions::$cacheTtl` is always set — made the constructor param and getter non-nullable.
- `Task::$outputFormat` default now uses `TaskOutputFormat::MARKDOWN->value` (consistent with the other enum-based defaults).

### Hygiene / correctness
- Removed the no-op `getSorting()` tiebreaker in `ModelSelectionService` (repository already orders by `sorting,name`; `usort` is stable).
- Deterministic Gemini tool-call IDs (part index instead of `uniqid()`).

### Verified false positives (intentionally not changed)
- **toolCalls "normalization"** across 5 providers: their `$toolCalls` is already `non-empty-list|null` (never literal `[]`), so they were already normalized — the proposed `!== []` change tripped PHPStan `notIdentical.alwaysTrue`. Left as-is.
- **ADR-001 provider mention** is historical Context prose (decision rationale), not a current-state list.
- **"9 adapters"**: there are 7 concrete adapter classes; Azure/Custom are OpenAI-compatible configs, not separate adapters.

## Verification
`Build/Scripts/runTests.sh` (PHP 8.4): `cgl` ✅ · `phpstan` L10 ✅ · `unit` ✅ 3790 · `functional` ✅ 615.