### PR TITLE
test: backend-user tool coverage + O(1) skill-loop membership (audit round 2, part 3)

### DIFF
--- a/Classes/Service/Skill/SkillComposer.php
+++ b/Classes/Service/Skill/SkillComposer.php
@@ -93,9 +93,11 @@ final readonly class SkillComposer
         // candidate before returning.
         $includedKeys = array_column($rendered, 'key');
         $includedIds  = array_column($rendered, 'id');
-        $droppedIds   = [];
+        // Keyed set for O(1) membership instead of in_array() per candidate.
+        $includedKeySet = array_fill_keys($includedKeys, true);
+        $droppedIds     = [];
         foreach ($candidates as $skill) {
-            if (!in_array($this->skillKey($skill), $includedKeys, true)) {
+            if (!isset($includedKeySet[$this->skillKey($skill)])) {
                 $droppedIds[] = $skill->getIdentifier();
             }
         }

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -249,17 +249,22 @@ final class SkillSyncService
         $discovered = [];
         $reachedPrefixes = [];
         $listedPrefixes = [];
+        // Keyed set mirroring $listedPrefixes: O(1) duplicate detection instead
+        // of in_array() over the growing list (the $listedPrefixes list is kept
+        // because it is part of this method's return contract).
+        $listedPrefixSet = [];
         foreach ($this->marketplaceParser->parse($index) as $entry) {
             // Namespace marketplace skills by repo to avoid path collisions across plugins.
             $prefix = $entry->owner . '/' . $entry->repo . '/';
             // Dedup duplicate plugin entries (same owner/repo): first wins.
-            if (in_array($prefix, $listedPrefixes, true)) {
+            if (isset($listedPrefixSet[$prefix])) {
                 $errors[] = sprintf('duplicate marketplace plugin "%s/%s", first wins', $entry->owner, $entry->repo);
                 continue;
             }
             // "Listed" = present in the parsed index this run, even if unreached below. A skill whose
             // prefix is no longer listed (plugin de-listed) IS orphaned; one listed-but-unreached is not.
-            $listedPrefixes[] = $prefix;
+            $listedPrefixes[]          = $prefix;
+            $listedPrefixSet[$prefix]  = true;
 
             // A bound hit leaves the remaining plugins listed (protected) but unvisited this run.
             if ($this->limitReached($errors)) {

--- a/Tests/Functional/Service/Tool/ListBeGroupsToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeGroupsToolTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeGroupsTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ListBeGroupsTool.
+ *
+ * Backend roles ARE backend groups in TYPO3; the tool returns only uid + title
+ * (no permission masks), title-ordered, soft-deleted groups excluded.
+ */
+#[CoversClass(ListBeGroupsTool::class)]
+final class ListBeGroupsToolTest extends AbstractFunctionalTestCase
+{
+    private ListBeGroupsTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new ListBeGroupsTool($connectionPool);
+
+        $connection = $connectionPool->getConnectionForTable('be_groups');
+        self::assertInstanceOf(Connection::class, $connection);
+        // Insert out of alphabetical order to prove title ASC ordering.
+        $this->insertGroup($connection, 1, 'Editors', ['non_exclude_fields' => 'pages:title']);
+        $this->insertGroup($connection, 2, 'Administrators');
+        $this->insertGroup($connection, 3, 'Deleted Group', ['deleted' => 1]);
+    }
+
+    #[Test]
+    public function getSpecDeclaresListBeGroupsFunction(): void
+    {
+        self::assertSame('list_be_groups', $this->tool->getSpec()->name);
+    }
+
+    #[Test]
+    public function executeListsLiveGroupsTitleOrdered(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Backend groups (2):', $output);
+        // Title ASC: Administrators before Editors.
+        $adminPos  = strpos($output, '[2] Administrators');
+        $editorPos = strpos($output, '[1] Editors');
+        self::assertIsInt($adminPos);
+        self::assertIsInt($editorPos);
+        self::assertLessThan($editorPos, $adminPos);
+    }
+
+    #[Test]
+    public function executeExcludesSoftDeletedGroupsAndPermissionMasks(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringNotContainsString('Deleted Group', $output);
+        // Only uid + title are emitted — never authorization columns.
+        self::assertStringNotContainsString('non_exclude_fields', $output);
+        self::assertStringNotContainsString('pages:title', $output);
+    }
+
+    #[Test]
+    public function isAdminOnlyAndEnabledByDefault(): void
+    {
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertTrue($this->tool->isEnabledByDefault());
+    }
+
+    /**
+     * @param array<string, int|string> $overrides
+     */
+    private function insertGroup(Connection $connection, int $uid, string $title, array $overrides = []): void
+    {
+        $connection->insert('be_groups', [
+            'uid'                => $uid,
+            'pid'                => 0,
+            'title'              => $title,
+            'non_exclude_fields' => $overrides['non_exclude_fields'] ?? '',
+            'deleted'            => $overrides['deleted'] ?? 0,
+        ]);
+    }
+}

--- a/Tests/Functional/Service/Tool/ListBeUsersRawToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersRawToolTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersRawTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ListBeUsersRawTool — the full-column variant.
+ *
+ * It selects `*` but still strips the credential columns (`password`, `mfa`)
+ * before emitting, and ships disabled-by-default because the wide column set
+ * reveals the backend account layout. The credential-exclusion assertion is
+ * the load-bearing one: even with `SELECT *`, no hash or MFA seed may egress.
+ */
+#[CoversClass(ListBeUsersRawTool::class)]
+final class ListBeUsersRawToolTest extends AbstractFunctionalTestCase
+{
+    private const SECRET_HASH = '$2y$12$THISisAcrackableHASHmarker0000000000000000000000000';
+
+    private const SECRET_MFA = '{"totp":"JBSWY3DPEHPK3PXP-secret-seed-marker"}';
+
+    private ListBeUsersRawTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new ListBeUsersRawTool($connectionPool);
+
+        $connection = $connectionPool->getConnectionForTable('be_users');
+        self::assertInstanceOf(Connection::class, $connection);
+        $connection->insert('be_users', [
+            'uid'      => 20,
+            'pid'      => 0,
+            'username' => 'dave',
+            'password' => self::SECRET_HASH,
+            'mfa'      => self::SECRET_MFA,
+            'realName' => 'Dave Raw',
+            'email'    => 'dave@example.com',
+            'admin'    => 1,
+            'deleted'  => 0,
+        ]);
+    }
+
+    #[Test]
+    public function getSpecDeclaresRawFunction(): void
+    {
+        self::assertSame('list_be_users_raw', $this->tool->getSpec()->name);
+    }
+
+    #[Test]
+    public function executeEmitsWideColumnSet(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Backend users (1):', $output);
+        self::assertStringContainsString('[20]', $output);
+        self::assertStringContainsString('username: dave', $output);
+        self::assertStringContainsString('realName: Dave Raw', $output);
+        // A column the redacted variant never selects, proving "raw" really is wide.
+        self::assertStringContainsString('email: dave@example.com', $output);
+    }
+
+    #[Test]
+    public function executeStripsCredentialColumnsEvenWithSelectStar(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringNotContainsString(self::SECRET_HASH, $output);
+        self::assertStringNotContainsString(self::SECRET_MFA, $output);
+        self::assertStringNotContainsString('password:', $output);
+        self::assertStringNotContainsString('mfa:', $output);
+    }
+
+    #[Test]
+    public function isAdminOnlyAndDisabledByDefault(): void
+    {
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertFalse($this->tool->isEnabledByDefault());
+    }
+}

--- a/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ListBeUsersTool.
+ *
+ * Load-bearing security assertion: the `password` hash and `mfa` secret of a
+ * backend user MUST NEVER reach the tool output (and therefore the LLM
+ * provider), and soft-deleted users must be excluded.
+ */
+#[CoversClass(ListBeUsersTool::class)]
+final class ListBeUsersToolTest extends AbstractFunctionalTestCase
+{
+    private const SECRET_HASH = '$2y$12$THISisAcrackableHASHmarker0000000000000000000000000';
+
+    private const SECRET_MFA = '{"totp":"JBSWY3DPEHPK3PXP-secret-seed-marker"}';
+
+    private ListBeUsersTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new ListBeUsersTool($connectionPool);
+
+        $connection = $connectionPool->getConnectionForTable('be_users');
+        self::assertInstanceOf(Connection::class, $connection);
+        $this->insertUser($connection, 10, 'alice', [
+            'realName' => 'Alice Admin',
+            'email'    => 'alice@example.com',
+            'admin'    => 1,
+            'lastlogin' => 1700000000,
+        ]);
+        $this->insertUser($connection, 11, 'bob', [
+            'realName' => 'Bob Editor',
+            'email'    => 'bob@example.com',
+            'admin'    => 0,
+            'disable'  => 1,
+        ]);
+        // Soft-deleted — must be excluded from the listing.
+        $this->insertUser($connection, 12, 'carol', ['deleted' => 1]);
+    }
+
+    #[Test]
+    public function getSpecDeclaresListBeUsersFunctionWithoutParameters(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('list_be_users', $spec->name);
+        self::assertSame([], $spec->parameters['properties'] ?? null);
+    }
+
+    #[Test]
+    public function executeListsLiveUsersWithProfileColumns(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Backend users (2):', $output);
+        self::assertStringContainsString('[10] alice | Alice Admin <alice@example.com> | admin=1 disabled=0', $output);
+        self::assertStringContainsString('[11] bob | Bob Editor <bob@example.com> | admin=0 disabled=1', $output);
+        self::assertStringContainsString('lastlogin=2023-11-14 22:13', $output);
+        self::assertStringContainsString('lastlogin=never', $output);
+    }
+
+    #[Test]
+    public function executeExcludesSoftDeletedUsers(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringNotContainsString('carol', $output);
+    }
+
+    #[Test]
+    public function executeNeverLeaksPasswordHashOrMfaSecret(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringNotContainsString(self::SECRET_HASH, $output);
+        self::assertStringNotContainsString(self::SECRET_MFA, $output);
+        self::assertStringNotContainsString('$2y$', $output);
+    }
+
+    #[Test]
+    public function isAdminOnlyAndEnabledByDefault(): void
+    {
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertTrue($this->tool->isEnabledByDefault());
+    }
+
+    /**
+     * @param array<string, int|string> $overrides
+     */
+    private function insertUser(Connection $connection, int $uid, string $username, array $overrides = []): void
+    {
+        $connection->insert('be_users', [
+            'uid'       => $uid,
+            'pid'       => 0,
+            'username'  => $username,
+            'password'  => self::SECRET_HASH,
+            'mfa'       => self::SECRET_MFA,
+            'realName'  => $overrides['realName'] ?? '',
+            'email'     => $overrides['email'] ?? '',
+            'admin'     => $overrides['admin'] ?? 0,
+            'disable'   => $overrides['disable'] ?? 0,
+            'lastlogin' => $overrides['lastlogin'] ?? 0,
+            'deleted'   => $overrides['deleted'] ?? 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Round-2 audit follow-up — test coverage and a perf cleanup. **Stacked on #283** (retargets up the chain as the stack merges).

### Test coverage (closes the last untested HIGH finding)
`ListBeUsersTool`, `ListBeUsersRawTool` and `ListBeGroupsTool` had no direct tests. New functional tests cover each tool's `execute()` output, soft-delete exclusion, and the admin-only / enabled-by-default contract — and, **load-bearing**, that the `password` hash and `mfa` secret never reach the output, including the raw variant's `SELECT *` path (it strips credential columns before emitting).

### Performance
Replaced the remaining `in_array()` membership scans over growing lists with keyed sets (the O(1) pattern already used elsewhere in `SkillSyncService`): marketplace duplicate-prefix detection and `SkillComposer` dropped-candidate classification.

## Verification
`Build/Scripts/runTests.sh` (PHP 8.4): `cgl` ✅ · `phpstan` L10 ✅ · `unit` ✅ · the 3 new tool tests ✅ (13 tests / 61 assertions).

## Round-2 findings triage (transparency)
Several round-2 "lowImpactUnverified" frontend findings were **verified false positives** and intentionally left unchanged:
- JS modal markup already escapes user data via `escapeHtml()` and uses the Modal text-title API — no XSS vector.
- `Task/Execute` output-format group already has `aria-label`; `Model/List` already has a "Status" `<th>`; the Analytics progressbar already has `aria-valuemin/max`.
- Analytics `chartData` is already `json_encode`d with `JSON_HEX_TAG|AMP|APOS|QUOT` and a documented trust-boundary comment.

Genuinely deferred (low value / not automatically verifiable here), to be reconsidered in the next audit round:
- `SkillList.js` GitHub-token entry via `prompt()` — low risk (encrypted at rest, HTTPS, admin-only); a masked Modal input is the right fix but is interactive UI not covered by an automated test in this context.
- `WizardGeneratorService` 4× `findAll()` — a small config table on an interactive (non-hot) path; threading a shared list through the call chain is churn for negligible gain.