### PR TITLE
fix: round-3 audit remediation — correctness, security hardening, i18n, docs

### DIFF
--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -54,6 +54,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class TaskWizardController extends ActionController
 {
     use SafeCastTrait;
+    use DefensiveLocalizationTrait;
 
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
@@ -91,7 +92,7 @@ final class TaskWizardController extends ActionController
         $moduleTemplate->makeDocHeaderModuleMenu();
         $description = trim($description);
         if ($description === '') {
-            $this->enqueueFlashMessage('Please describe what this task should do.', 'Missing description', ContextualFeedbackSeverity::WARNING);
+            $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.body', 'Please describe what this task should do.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.title', 'Missing description'), ContextualFeedbackSeverity::WARNING);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
         if (mb_strlen($description) > 2000) {
@@ -129,10 +130,10 @@ final class TaskWizardController extends ActionController
                 // REC #8b: provider error text often references endpoints / payloads /
                 // model names that aren't safe to render verbatim into the backend UI.
                 $this->logger->error('Task wizard: single-task generation failed (provider)', ['exception' => $e]);
-                $this->enqueueFlashMessage('Generation failed (LLM provider error). See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             } else {
                 $this->logger->error('Task wizard: single-task generation failed unexpectedly', ['exception' => $e]);
-                $this->enqueueFlashMessage('Generation failed. See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             }
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
@@ -144,7 +145,7 @@ final class TaskWizardController extends ActionController
         $moduleTemplate->makeDocHeaderModuleMenu();
         $description = trim($description);
         if ($description === '') {
-            $this->enqueueFlashMessage('Please describe what this task should do.', 'Missing description', ContextualFeedbackSeverity::WARNING);
+            $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.body', 'Please describe what this task should do.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.title', 'Missing description'), ContextualFeedbackSeverity::WARNING);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
         if (mb_strlen($description) > 2000) {
@@ -175,10 +176,10 @@ final class TaskWizardController extends ActionController
         } catch (Throwable $e) {
             if ($e instanceof ProviderException) {
                 $this->logger->error('Task wizard: chain generation failed (provider)', ['exception' => $e]);
-                $this->enqueueFlashMessage('Generation failed (LLM provider error). See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             } else {
                 $this->logger->error('Task wizard: chain generation failed unexpectedly', ['exception' => $e]);
-                $this->enqueueFlashMessage('Generation failed. See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             }
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
@@ -188,7 +189,7 @@ final class TaskWizardController extends ActionController
     {
         $body = $this->request->getParsedBody();
         if (!is_array($body)) {
-            $this->enqueueFlashMessage('Invalid request.', 'Error', ContextualFeedbackSeverity::ERROR);
+            $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.invalidRequest.body', 'Invalid request.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
 
@@ -248,8 +249,8 @@ final class TaskWizardController extends ActionController
             $this->persistenceManager->persistAll();
 
             $this->enqueueFlashMessage(
-                sprintf('Task "%s" created successfully with dedicated configuration.', $task->getName()),
-                'Task Created',
+                sprintf($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.created.body', 'Task "%s" created successfully with dedicated configuration.'), $task->getName()),
+                $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.created.title', 'Task Created'),
                 ContextualFeedbackSeverity::OK,
             );
 
@@ -274,7 +275,7 @@ final class TaskWizardController extends ActionController
             // schema and connection internals — log and surface a
             // generic message.
             $this->logger->error('Task wizard: failed to persist generated task', ['exception' => $e]);
-            $this->enqueueFlashMessage('Failed to create task. See system log for details.', 'Error', ContextualFeedbackSeverity::ERROR);
+            $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.creationFailed.body', 'Failed to create task. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
     }

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -62,6 +63,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         private readonly ToolLoopService $toolLoopService,
         private readonly ToolAvailabilityServiceInterface $toolAvailability,
         private readonly ToolStateRepository $toolStateRepository,
+        private readonly AllowedToolsResolver $allowedToolsResolver,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -114,7 +116,16 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         // The checked tool boxes restrict this run; absent any selection, fall
         // back to the globally-enabled set. The runtime gate is authoritative
         // regardless (a disabled tool stays off).
-        $allowed = $this->toolNamesFromBody($body) ?? $this->toolAvailability->enabledNames();
+        $selected = $this->toolNamesFromBody($body) ?? $this->toolAvailability->enabledNames();
+
+        // Stay faithful to production (ADR-038 §5): if the configuration's skills
+        // declare an allowed-tools allow-list, intersect the admin's selection
+        // with it so the playground offers only what the config would actually
+        // permit. null = no declaring skill ⇒ no skill-imposed restriction.
+        $skillAllowed = $this->allowedToolsResolver->resolve($config);
+        $allowed      = $skillAllowed !== null
+            ? array_values(array_intersect($selected, $skillAllowed))
+            : $selected;
 
         try {
             $result = $this->toolLoopService->runLoop([ChatMessage::user($prompt)], $config, $allowed, $options);

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -619,12 +619,14 @@ class LlmConfiguration extends AbstractEntity
 
     public function addSkill(Skill $skill): void
     {
-        $this->skills->attach($skill);
+        // Route through the lazy-initializing getter: Extbase reconstitution
+        // skips the constructor, leaving $skills unset on relation-less entities.
+        $this->getSkills()->attach($skill);
     }
 
     public function removeSkill(Skill $skill): void
     {
-        $this->skills->detach($skill);
+        $this->getSkills()->detach($skill);
     }
 
     // ========================================

--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -321,12 +321,14 @@ class Task extends AbstractEntity
 
     public function addSkill(Skill $skill): void
     {
-        $this->skills->attach($skill);
+        // Route through the lazy-initializing getter: Extbase reconstitution
+        // skips the constructor, leaving $skills unset on relation-less entities.
+        $this->getSkills()->attach($skill);
     }
 
     public function removeSkill(Skill $skill): void
     {
-        $this->skills->detach($skill);
+        $this->getSkills()->detach($skill);
     }
 
     // ========================================

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -237,7 +237,12 @@ abstract class AbstractProvider implements ProviderInterface
                 $attempt++;
 
                 if ($attempt < $this->maxRetries) {
-                    usleep((int)(100000 * (2 ** $attempt)));
+                    // Exponential backoff capped at 30s. Short-circuit at
+                    // attempt >= 9 (100000 * 2**9 = 51.2s already exceeds the
+                    // cap) so the 2 ** $attempt term cannot overflow the float→int
+                    // cast into a negative value and make usleep() throw.
+                    $backoffMicros = $attempt >= 9 ? 30_000_000 : (int)(100000 * (2 ** $attempt));
+                    usleep($backoffMicros);
                 }
             }
         }
@@ -404,6 +409,11 @@ abstract class AbstractProvider implements ProviderInterface
 
     protected function createUsageStatistics(int $promptTokens, int $completionTokens): UsageStatistics
     {
+        // Token counts come from untrusted provider responses; a negative value
+        // (malformed payload) would corrupt usage and cost accounting downstream.
+        $promptTokens     = max(0, $promptTokens);
+        $completionTokens = max(0, $completionTokens);
+
         return new UsageStatistics(
             promptTokens: $promptTokens,
             completionTokens: $completionTokens,

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -448,6 +448,10 @@ final class ClaudeProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -461,6 +461,10 @@ final class GeminiProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -260,6 +260,10 @@ final class GroqProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -289,6 +289,10 @@ final class MistralProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -415,6 +415,10 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -334,6 +334,10 @@ final class OpenAiProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -555,6 +555,10 @@ final class OpenRouterProvider extends AbstractProvider implements
      */
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        // Mirror the non-streaming path (sendRequest validates): fail fast with a
+        // typed ProviderConfigurationException instead of a cryptic stream error.
+        $this->validateConfiguration();
+
         $messages = array_map(
             static fn(ChatMessage|array $m): array
                 => $m instanceof ChatMessage ? $m->toArray() : $m,

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Domain\ValueObject\SyncResult;
 use Netresearch\NrLlm\Service\Skill\Exception\GitHubApiException;
 use Netresearch\NrLlm\Service\Skill\Exception\HostNotAllowedException;
 use Netresearch\NrLlm\Service\Skill\Exception\SkillParseException;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
@@ -50,6 +51,7 @@ final class SkillSyncService
         private readonly SkillRepository $skillRepository,
         private readonly SkillSourceRepository $sourceRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly LoggerInterface $logger,
         private readonly int $maxFiles = 500,
         private readonly int $maxSeconds = 120,
     ) {}
@@ -123,6 +125,13 @@ final class SkillSyncService
             }
             $source->setSyncError(implode("\n", $errors));
         } catch (Throwable $e) {
+            // Keep the full stack trace server-side (GitHub rate limits, network
+            // timeouts, DBAL/persistence errors) — the user only sees getMessage().
+            $this->logger->error('Skill sync failed', [
+                'exception'  => $e,
+                'source_uid' => $source->getUid(),
+                'source_url' => $source->getUrl(),
+            ]);
             $status = SyncStatus::ERROR;
             $orphaned = 0;
             $errors[] = $e->getMessage();

--- a/Classes/Service/UsageAnalyticsService.php
+++ b/Classes/Service/UsageAnalyticsService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
@@ -29,6 +30,21 @@ use TYPO3\CMS\Core\SingletonInterface;
 final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInterface, SingletonInterface
 {
     private const TABLE = 'tx_nrllm_service_usage';
+
+    /**
+     * Columns the grouped-by/breakdown queries may select and GROUP BY. All
+     * current callers pass hardcoded literals; this whitelist is a defence in
+     * depth so a future refactor cannot feed untrusted input into the SQL
+     * identifier position (which QueryBuilder does not parameterise).
+     */
+    private const GROUPABLE_COLUMNS = [
+        'service_provider',
+        'model_id',
+        'service_type',
+        'model_uid',
+        'configuration_uid',
+        'task_uid',
+    ];
 
     private const SUM_COST = 'SUM(estimated_cost) AS cost';
 
@@ -105,6 +121,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
 
     public function getTotalsGroupedBy(string $column, DateTimeInterface $from, DateTimeInterface $to): array
     {
+        $this->assertGroupableColumn($column);
         $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $qb->select($column)->from(self::TABLE);
         $this->selectUsageSums($qb, $from, $to);
@@ -281,11 +298,22 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
             );
     }
 
+    private function assertGroupableColumn(string $column): void
+    {
+        if (!in_array($column, self::GROUPABLE_COLUMNS, true)) {
+            throw new InvalidArgumentException(
+                sprintf('Unsupported group column "%s"', $column),
+                1751299200,
+            );
+        }
+    }
+
     /**
      * @return list<array{label: string, cost: float, requests: int, tokens: int}>
      */
     private function breakdown(string $column, DateTimeInterface $from, DateTimeInterface $to): array
     {
+        $this->assertGroupableColumn($column);
         $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $qb->select($column)->from(self::TABLE);
         $this->selectUsageSums($qb, $from, $to);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -55,17 +55,17 @@ services:
     public: true
 
   # ========================================
-  # Providers (PUBLIC)
+  # Providers (private; resolved via LlmServiceManager)
   # ========================================
   # Provider registration and priority are declared via the
   # #[AsLlmProvider(priority: N)] attribute on each provider class.
-  # ProviderCompilerPass scans for the attribute, tags matching
-  # services automatically, AND makes attribute-discovered providers
-  # public so backend diagnostics can resolve them by class name.
-  # Services.yaml `tags:` entries still work for third-party
-  # providers and take precedence if both are present; yaml-tagged
-  # services remain private unless the yaml entry sets
-  # `public: true` explicitly.
+  # ProviderCompilerPass scans for the attribute and tags matching
+  # services automatically. Providers stay PRIVATE — nothing resolves a
+  # provider by class name from the container; all access is via
+  # LlmServiceManager::getProvider(), which keeps the documented public
+  # service set stable (ADR-028 / PublicServicesPolicyTest).
+  # Services.yaml `tags:` entries still work for third-party providers and
+  # take precedence if both are present.
 
   # ========================================
   # Provider Adapter Registry (database-backed providers)

--- a/Documentation/Adr/Adr038ToolRuntime.rst
+++ b/Documentation/Adr/Adr038ToolRuntime.rst
@@ -108,9 +108,10 @@ Decision
    registered-but-not-offered tool.
 
 6. **Authorization is enforced in the runtime, against the acting backend
-   user — not only in the playground.** Because :php:`ToolLoopService` is a
-   public service (a future non-admin consumer could call it), every tool
-   declares :php:`requiresAdmin()`. The loop resolves the acting
+   user — not only in the playground.** Because :php:`ToolLoopService` runs
+   tools on behalf of a backend request (and a future non-admin consumer could
+   be wired to it), every tool declares :php:`requiresAdmin()`. The loop
+   resolves the acting
    ``$GLOBALS['BE_USER']`` and, when it is not an admin, **filters every
    admin-only tool out of the offered set** (fail-closed: an unknown tool name
    is treated as admin-only). Admin-only tools are those exposing system /

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -12,6 +12,7 @@ Sitemap
 
    Introduction/Index
    Installation/Index
+   Administration/Index
    Configuration/Index
    Architecture/Index
    Developer/Index

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1632,6 +1632,44 @@
                 <source>Failed to load records. See system log for details.</source>
                 <target>Datensätze konnten nicht geladen werden. Siehe Systemprotokoll für Details.</target>
             </trans-unit>
+
+            <!-- Task wizard flash messages -->
+            <trans-unit id="flash.task.missingDescription.body">
+                <source>Please describe what this task should do.</source>
+                <target>Bitte beschreiben Sie, was diese Aufgabe tun soll.</target>
+            </trans-unit>
+            <trans-unit id="flash.task.missingDescription.title">
+                <source>Missing description</source>
+                <target>Beschreibung fehlt</target>
+            </trans-unit>
+            <trans-unit id="flash.task.generationFailed.provider">
+                <source>Generation failed (LLM provider error). See system log for details.</source>
+                <target>Generierung fehlgeschlagen (LLM-Provider-Fehler). Siehe Systemprotokoll für Details.</target>
+            </trans-unit>
+            <trans-unit id="flash.task.generationFailed.generic">
+                <source>Generation failed. See system log for details.</source>
+                <target>Generierung fehlgeschlagen. Siehe Systemprotokoll für Details.</target>
+            </trans-unit>
+            <trans-unit id="flash.task.error.title">
+                <source>Error</source>
+                <target>Fehler</target>
+            </trans-unit>
+            <trans-unit id="flash.task.invalidRequest.body">
+                <source>Invalid request.</source>
+                <target>Ungültige Anfrage.</target>
+            </trans-unit>
+            <trans-unit id="flash.task.created.body">
+                <source>Task "%s" created successfully with dedicated configuration.</source>
+                <target>Aufgabe "%s" wurde erfolgreich mit eigener Konfiguration erstellt.</target>
+            </trans-unit>
+            <trans-unit id="flash.task.created.title">
+                <source>Task Created</source>
+                <target>Aufgabe erstellt</target>
+            </trans-unit>
+            <trans-unit id="flash.task.creationFailed.body">
+                <source>Failed to create task. See system log for details.</source>
+                <target>Aufgabe konnte nicht erstellt werden. Siehe Systemprotokoll für Details.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1237,6 +1237,35 @@
             <trans-unit id="error.records.loadFailed">
                 <source>Failed to load records. See system log for details.</source>
             </trans-unit>
+
+            <!-- Task wizard flash messages -->
+            <trans-unit id="flash.task.missingDescription.body">
+                <source>Please describe what this task should do.</source>
+            </trans-unit>
+            <trans-unit id="flash.task.missingDescription.title">
+                <source>Missing description</source>
+            </trans-unit>
+            <trans-unit id="flash.task.generationFailed.provider">
+                <source>Generation failed (LLM provider error). See system log for details.</source>
+            </trans-unit>
+            <trans-unit id="flash.task.generationFailed.generic">
+                <source>Generation failed. See system log for details.</source>
+            </trans-unit>
+            <trans-unit id="flash.task.error.title">
+                <source>Error</source>
+            </trans-unit>
+            <trans-unit id="flash.task.invalidRequest.body">
+                <source>Invalid request.</source>
+            </trans-unit>
+            <trans-unit id="flash.task.created.body">
+                <source>Task "%s" created successfully with dedicated configuration.</source>
+            </trans-unit>
+            <trans-unit id="flash.task.created.title">
+                <source>Task Created</source>
+            </trans-unit>
+            <trans-unit id="flash.task.creationFailed.body">
+                <source>Failed to create task. See system log for details.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Public/Css/Backend/Analytics.css
+++ b/Resources/Public/Css/Backend/Analytics.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 .nrllm-kpi-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/Resources/Public/Css/Backend/SetupWizard.css
+++ b/Resources/Public/Css/Backend/SetupWizard.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Setup Wizard Styles
  */

--- a/Resources/Public/JavaScript/Backend/AjaxError.js
+++ b/Resources/Public/JavaScript/Backend/AjaxError.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Shared AJAX error reader for the nr_llm backend ES modules.
  *

--- a/Resources/Public/JavaScript/Backend/Analytics.js
+++ b/Resources/Public/JavaScript/Backend/Analytics.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * LLM Analytics dashboard charts (ES6 module).
  *

--- a/Resources/Public/JavaScript/Backend/ConfigurationConstraints.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationConstraints.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Configuration parameter constraints based on selected model.
  *

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Configuration list JavaScript module for TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/HtmlEscape.js
+++ b/Resources/Public/JavaScript/Backend/HtmlEscape.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Shared HTML-escaping helper for the nr_llm backend ES modules.
  *

--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * ModelIdField — TCA custom element JS for model_id with fetch + rich dropdown.
  *

--- a/Resources/Public/JavaScript/Backend/ModelList.js
+++ b/Resources/Public/JavaScript/Backend/ModelList.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Model list JavaScript module for TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/ProviderList.js
+++ b/Resources/Public/JavaScript/Backend/ProviderList.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Provider list JavaScript module for TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Setup Wizard JavaScript (ES6 Module)
  *

--- a/Resources/Public/JavaScript/Backend/SkillList.js
+++ b/Resources/Public/JavaScript/Backend/SkillList.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Skill list JavaScript module for TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Task Execute module for handling task execution in the backend.
  */

--- a/Resources/Public/JavaScript/Backend/Test.js
+++ b/Resources/Public/JavaScript/Backend/Test.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Wires the test prompt form to the nrllm_test AJAX endpoint and renders
  * the response (success, error, usage details).

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Tool playground JavaScript module for the TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Tool state JavaScript module for the TYPO3 backend (ES6 Module).
  *

--- a/Resources/Public/JavaScript/Backend/WizardChainPreview.js
+++ b/Resources/Public/JavaScript/Backend/WizardChainPreview.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Toggle visibility of the "new configuration" details panel based on the
  * selected radio in the chain wizard preview.

--- a/Resources/Public/JavaScript/Backend/WizardFormLoading.js
+++ b/Resources/Public/JavaScript/Backend/WizardFormLoading.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /**
  * Loading state handler for the AI wizard form.
  *

--- a/Resources/Public/JavaScript/Vendor/chart.umd.js
+++ b/Resources/Public/JavaScript/Vendor/chart.umd.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /*!
  * Chart.js v4.5.1
  * https://www.chartjs.org

--- a/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Tests\Functional\Service\Skill\Fixtures\FakeGitHubClient;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -58,6 +59,7 @@ final class SkillSourceControllerTest extends AbstractFunctionalTestCase
             $this->get(SkillRepository::class),
             $this->get(SkillSourceRepository::class),
             $this->get(PersistenceManagerInterface::class),
+            new NullLogger(),
         );
         return new SkillSourceController(
             $this->get(ModuleTemplateFactory::class),

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -86,6 +87,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), $availability),
             $availability,
             new ToolStateRepository($this->toolConnectionPool()),
+            $this->get(AllowedToolsResolver::class),
         );
         $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
 
@@ -233,6 +235,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             $toolLoopService,
             $this->availabilityFor($toolRegistry),
             new ToolStateRepository($this->toolConnectionPool()),
+            $this->get(AllowedToolsResolver::class),
         );
     }
 

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Skill\Fixtures\FakeGitHubClient;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 #[CoversClass(SkillSyncService::class)]
@@ -50,6 +51,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
             $this->get(SkillRepository::class),
             $this->get(SkillSourceRepository::class),
             $this->get(PersistenceManagerInterface::class),
+            new NullLogger(),
             $maxFiles,
             $maxSeconds,
         );


### PR DESCRIPTION
## Summary

Third audit round (24 independent lenses + adversarial verification). The audit's raw "high" count over-rates severity (it flagged i18n-completeness, a doc-sitemap entry, and a test gap as high); each finding below was independently verified and fixed at its true severity. **Stacked on #284.**

### Correctness
- **`addSkill()` / `removeSkill()` NPE guard** (`Task`, `LlmConfiguration`): both mutated `$this->skills` directly; an Extbase-reconstituted (relation-less) entity would hit an uninitialized typed property. Routed through the lazy-init `getSkills()` getter (same class of bug as the round-2 `getBeGroups`/`getModels` fix).
- **`createUsageStatistics` clamps negative token counts** to 0 (malformed provider payloads can't corrupt usage/cost accounting); **retry backoff capped at 30s** (large `maxRetries` can't overflow / sleep impractically long).

### Security hardening
- **`streamChatCompletion()` now validates configuration** in all 7 adapters (the streaming path skipped the `validateConfiguration()` the non-streaming path runs via `sendRequest()`), so a misconfigured provider fails with a typed `ProviderConfigurationException` instead of a cryptic stream error.
- **`UsageAnalyticsService` whitelists groupable columns** — `$column` flows into `select()`/`groupBy()` (not parameterised by QueryBuilder); all callers pass literals today, this is defence-in-depth against a future refactor.
- **Tool playground enforces the skill `allowed-tools` allow-list** (ADR-038 §5): it's the only `runLoop` caller and previously offered the selection/enabled-set without consulting the config's skills, leaving `AllowedToolsResolver` unwired. Now resolves + intersects.

### Observability
- **`SkillSyncService` logs the full exception** on sync failure (GitHub rate limits, timeouts, DBAL errors) instead of keeping only `getMessage()`.

### i18n
- **Task wizard flash messages localized** via `DefensiveLocalizationTrait::localize()` with new `flash.task.*` keys (EN + DE).

### Docs & hygiene
- `Sitemap.rst` gains the missing **Administration** entry; ADR-038 / `Services.yaml` provider-visibility wording corrected (providers stay private, ADR-028).
- **SPDX + copyright headers** added to all JS and CSS sources (PHP already had them).

## Verified false positives / won't-fix (transparency)
- `ToolLoopService` "must be public": it's **constructor-injected only** (no `makeInstance`/container fetch) — works private; only the ADR wording needed fixing.
- `ChatMessage::getValidRoles()` "dead code": it's **public back-compat API** (tested) — removing it is a breaking change disproportionate to a cleanup.

## Deferred (tracked, lower-value)
- WizardForm static template labels i18n (dynamic flash/AJAX strings are localized; static labels render correctly in English — MEDIUM, audit over-rated as high).
- Budget-metadata unit assertions on `ToolLoopService` (the path is exercised end-to-end; the gap is a unit assertion).

## Verification
`Build/Scripts/runTests.sh` (PHP 8.4): `cgl` ✅ · `phpstan` L10 ✅ · `unit` ✅ 3790 · targeted `functional` ✅.