### PR TITLE
fix: round-4 audit — Gemini key leak, input clamps, secret hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Function-calling tool runtime (agent loop) with an admin-curated, RBAC-gated built-in tool set and a backend tool playground (ADR-038).
+
+### Changed
+
+- **BREAKING:** `ToolInterface` now requires a `requiresAdmin(): bool` method. Every implementer must declare it — return `true` for tools exposing system/host/cross-user data (logs, environment, phpinfo, backend-user/group listings), `false` for tools that self-enforce the acting user's TYPO3 permissions. Without it, the tool fatals at runtime on instantiation.
+
+### Security
+
+- Gemini provider now sends the API key in the `x-goog-api-key` header instead of the URL query string, so it no longer leaks into server/proxy logs, browser history or the Referer header.
+
 ## [0.13.0] - 2026-06-26
 
 ### Changed

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -462,8 +462,11 @@ final class SetupWizardController extends ActionController
             $configIdentifier = is_string($configData['identifier'] ?? null) ? $configData['identifier'] : '';
             $configDescription = is_string($configData['description'] ?? null) ? $configData['description'] : '';
             $systemPrompt = is_string($configData['systemPrompt'] ?? null) ? $configData['systemPrompt'] : '';
-            $temperature = is_numeric($configData['temperature'] ?? null) ? (float)$configData['temperature'] : 0.7;
-            $maxTokens = is_numeric($configData['maxTokens'] ?? null) ? (int)$configData['maxTokens'] : 4096;
+            // Clamp to valid ranges (mirrors TaskWizardController): temperature
+            // 0.0–2.0, maxTokens 1–128000, so the wizard cannot persist
+            // out-of-range values that the providers would reject.
+            $temperature = max(0.0, min(2.0, is_numeric($configData['temperature'] ?? null) ? (float)$configData['temperature'] : 0.7));
+            $maxTokens = max(1, min(128000, is_numeric($configData['maxTokens'] ?? null) ? (int)$configData['maxTokens'] : 4096));
 
             $config = new LlmConfiguration();
             $config->setIdentifier($configIdentifier !== '' ? $configIdentifier : $this->generateIdentifier($configName));

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -25,7 +25,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
-use Psr\Http\Message\RequestInterface;
+use Netresearch\NrVault\Http\SecretPlacement;
 
 #[AsLlmProvider(priority: 80)]
 final class GeminiProvider extends AbstractProvider implements
@@ -91,9 +91,9 @@ final class GeminiProvider extends AbstractProvider implements
      * getAvailableModels() returns a static list and never touches the
      * network, so the AbstractProvider default would report success even
      * when the endpoint is unreachable or the key is invalid. Make a real
-     * lightweight GET to the models endpoint (Gemini carries the key in the
-     * URL) and let any failure surface as the typed exception sendRequest()
-     * raises.
+     * lightweight GET to the models endpoint (the key travels in the
+     * x-goog-api-key header) and let any failure surface as the typed
+     * exception sendRequest() raises.
      *
      * @throws ProviderConnectionException on connection failure
      *
@@ -102,7 +102,7 @@ final class GeminiProvider extends AbstractProvider implements
     public function testConnection(): array
     {
         // Real HTTP request to the models endpoint — do NOT catch exceptions.
-        $response = $this->sendRequest('models?key=' . $this->retrieveApiKey(), [], 'GET');
+        $response = $this->sendRequest('models', [], 'GET');
         $list = $this->getList($response, 'models');
 
         $models = [];
@@ -164,7 +164,7 @@ final class GeminiProvider extends AbstractProvider implements
         }
 
         $response = $this->sendRequest(
-            "models/{$model}:generateContent?key=" . $this->retrieveApiKey(),
+            "models/{$model}:generateContent",
             $payload,
         );
 
@@ -229,7 +229,7 @@ final class GeminiProvider extends AbstractProvider implements
         }
 
         $response = $this->sendRequest(
-            "models/{$model}:generateContent?key=" . $this->retrieveApiKey(),
+            "models/{$model}:generateContent",
             $payload,
         );
 
@@ -309,7 +309,7 @@ final class GeminiProvider extends AbstractProvider implements
             ];
 
             $response = $this->sendRequest(
-                "models/{$model}:embedContent?key=" . $this->retrieveApiKey(),
+                "models/{$model}:embedContent",
                 $payload,
             );
 
@@ -399,7 +399,7 @@ final class GeminiProvider extends AbstractProvider implements
         }
 
         $response = $this->sendRequest(
-            "models/{$model}:generateContent?key=" . $this->retrieveApiKey(),
+            "models/{$model}:generateContent",
             $payload,
         );
 
@@ -487,8 +487,11 @@ final class GeminiProvider extends AbstractProvider implements
             $payload['systemInstruction'] = $geminiContents['systemInstruction'];
         }
 
-        $url = rtrim($this->baseUrl, '/') . "/models/{$model}:streamGenerateContent?key=" . $this->retrieveApiKey() . '&alt=sse';
+        $url = rtrim($this->baseUrl, '/') . "/models/{$model}:streamGenerateContent?alt=sse";
 
+        // The vault HTTP client injects the API key as the x-goog-api-key header
+        // (SecretPlacement::Header) — the key is never decrypted into provider
+        // memory here.
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
@@ -554,10 +557,23 @@ final class GeminiProvider extends AbstractProvider implements
         return true;
     }
 
-    protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
+    protected function getSecretPlacement(): SecretPlacement
     {
-        // Gemini uses API key in URL, not headers
-        return $request->withoutHeader('Authorization');
+        // Inject the API key as the x-goog-api-key header via the vault HTTP
+        // client. The key never enters the URL (no ?key= leak to logs/referrer)
+        // and is never decrypted into this provider's memory.
+        return SecretPlacement::Header;
+    }
+
+    /**
+     * @return array{headerName: string, reason: string}
+     */
+    protected function getSecretPlacementOptions(): array
+    {
+        return [
+            'headerName' => 'x-goog-api-key',
+            'reason' => sprintf('LLM API call to %s', $this->getName()),
+        ];
     }
 
     /**

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -263,13 +263,11 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
             return $a->isDefault() ? -1 : 1; // Default first
         }
 
-        // Fourth priority: sorting order — handled at the query level.
-        // ModelRepository hydrates candidates already ordered by `sorting, name`
-        // (its $defaultOrderings), and usort() is stable, so equal-priority
-        // candidates keep that order without an explicit tiebreaker here. (A
-        // getSorting() comparison would be a no-op anyway: `sorting` is a TCA
-        // ctrl.sortby field that Extbase does not hydrate onto the model.)
-        return 0;
+        // Fourth priority: explicit sorting-order tiebreak. Extbase maps the
+        // ctrl.sortby `sorting` column onto the model, and ModelRepository
+        // already pre-orders by `sorting, name`, so this yields a deterministic
+        // result without relying on usort() input-order preservation.
+        return $a->getSorting() <=> $b->getSorting();
     }
 
     /**

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -590,6 +590,17 @@ class SetupWizard {
             document.getElementById('save-error-message').textContent = 'Network error: ' + saveError;
             document.getElementById('save-footer').style.display = 'flex';
             Notification.error('Network Error', saveError, 10);
+        } finally {
+            // The key has been transmitted (encrypted server-side via the vault).
+            // Drop it from this module-level singleton's memory AND from the DOM
+            // input so it cannot be read back via the console or an XSS payload
+            // after the save.
+            this.data.apiKey = '';
+            providerData.apiKey = '';
+            const apiKeyInput = document.getElementById('wizard-apikey');
+            if (apiKeyInput) {
+                apiKeyInput.value = '';
+            }
         }
     }
 

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -24,6 +24,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -144,6 +146,50 @@ class GeminiProviderTest extends AbstractUnitTestCase
         self::assertEquals('Gemini response content', $result->content);
         self::assertEquals('gemini-3-flash-preview', $result->model);
         self::assertEquals('stop', $result->finishReason);
+    }
+
+    #[Test]
+    public function chatCompletionNeverPutsApiKeyInTheUrl(): void
+    {
+        // Security regression guard: the Gemini API key must travel in the
+        // x-goog-api-key header, never the URL query string (which leaks into
+        // server/proxy logs, browser history and the Referer header).
+        $capturedUri = null;
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')
+            ->willReturnCallback(function (string $method, string $uri) use (&$capturedUri): RequestInterface {
+                $capturedUri = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            });
+
+        $subject = new GeminiProvider(
+            $requestFactory,
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gemini-3-flash-preview',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+        ]));
+        $subject->setHttpClient($httpClientMock);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertIsString($capturedUri);
+        self::assertStringNotContainsString('key=', $capturedUri);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Fourth audit round. The standout finding is a **genuine security bug the loop surfaced**. **Stacked on #285.**

### Security (high)
- **Gemini API key no longer placed in the URL at any call site.** `GeminiProvider` embedded `?key=<apiKey>` in every request (models list, generateContent, embedContent, streamGenerateContent) — leaking it into server/proxy logs, browser history and the Referer header. Round 2 only fixed the separate `ModelDiscovery` path; this moves auth to the `x-goog-api-key` header in the provider itself (+ regression test asserting no `key=` in the URL).
- **Setup-wizard JS clears the API key from singleton memory after save** (it lingered on a module-level singleton, readable via console/XSS).

### Correctness
- **Collision-free Gemini tool-call IDs** (addresses a reviewer-flagged multi-turn bug from #283): a per-response part index resets to 0 each loop turn and would collide in `buildToolCallIdToName()`; use `uniqid(more_entropy: true)`.
- **Deterministic model-sort tiebreak** restored (`getSorting()` spaceship; Extbase maps the column and the repository pre-orders by `sorting,name`).

### Input validation
- **Setup wizard clamps `temperature` (0–2) and `maxTokens` (1–128000)** before persisting (mirrors the task wizard).

### Docs
- CHANGELOG `[Unreleased]`: the tool runtime, the **BREAKING** `ToolInterface::requiresAdmin()` addition with migration guidance, and the Gemini key fix.

## Verification
`Build/Scripts/runTests.sh` (PHP 8.4): `cgl` ✅ · `phpstan` L10 ✅ · `unit` ✅ 3791 · targeted `functional` ✅.

## Round-4 triage (transparency)
- **SSRF on keyless-provider `endpoint_url`**: a real hardening, but keyless Ollama legitimately targets `localhost`, which the SSRF allowlist rejects — gating it risks breaking working Ollama installs and needs an ADR + functional coverage. Deferred (not a rush-fix).
- **Branch-protection "no required checks"**: false positive — required checks are enforced via the repo **ruleset** (`required_status_checks`), not classic branch protection.
- **Wizard-template static-label i18n + backend-controller JSON error i18n**: legitimate but MEDIUM (dynamic strings are localized; static labels render in English). Tracked for a focused i18n-completion pass.