### PR TITLE
a11y + test coverage: table-header scope, status sr-text, stale-lock & budget-metadata unit tests

### DIFF
--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -59,13 +59,7 @@ final class SkillSyncService
     public function sync(SkillSource $source): SyncResult
     {
         $now = time();
-        // Concurrency guard with stale-lock recovery: a SYNCING source is only treated as locked
-        // when its heartbeat (lastSynced) is recent; an old or never-set heartbeat is stale.
-        if (
-            $source->getSyncStatusEnum() === SyncStatus::SYNCING
-            && $source->getLastSynced() !== 0
-            && ($now - $source->getLastSynced()) <= self::STALE_LOCK_SECONDS
-        ) {
+        if ($this->isLockActive($source, $now)) {
             return new SyncResult(SyncStatus::SYNCING, errors: ['A sync is already running for this source.']);
         }
 
@@ -144,6 +138,22 @@ final class SkillSyncService
         $this->persistSource($source);
 
         return new SyncResult($status, $created, $updated, $disabledOnChange, $orphaned, $errors);
+    }
+
+    /**
+     * Concurrency guard with stale-lock recovery: a SYNCING source is only an
+     * active lock when its heartbeat (lastSynced) is within STALE_LOCK_SECONDS
+     * of now. An old or never-set (0) heartbeat is stale and reclaimable, so a
+     * crashed sync does not wedge the source forever. The window is measured
+     * with abs() so a heartbeat written under clock skew / a backwards NTP
+     * correction (a future timestamp) cannot lock the source indefinitely — a
+     * far-future timestamp is treated as stale, a small skew as still active.
+     */
+    private function isLockActive(SkillSource $source, int $now): bool
+    {
+        return $source->getSyncStatusEnum() === SyncStatus::SYNCING
+            && $source->getLastSynced() !== 0
+            && abs($now - $source->getLastSynced()) <= self::STALE_LOCK_SECONDS;
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1838,6 +1838,10 @@
                 <source>Name</source>
                 <target>Name</target>
             </trans-unit>
+            <trans-unit id="field.status">
+                <source>Status</source>
+                <target>Status</target>
+            </trans-unit>
             <trans-unit id="field.identifier">
                 <source>Identifier</source>
                 <target>Bezeichner</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1392,6 +1392,9 @@
             <trans-unit id="field.name">
                 <source>Name</source>
             </trans-unit>
+            <trans-unit id="field.status">
+                <source>Status</source>
+            </trans-unit>
             <trans-unit id="field.identifier">
                 <source>Identifier</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -76,7 +76,7 @@
                 <div class="table-fit">
                     <table class="table table-striped">
                         <thead>
-                            <tr><th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.user" /></th><th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.cost" /></th><th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.requests" /></th><th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.tokens" /></th><th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.budget" /></th></tr>
+                            <tr><th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.user" /></th><th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.cost" /></th><th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.requests" /></th><th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.tokens" /></th><th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.table.budget" /></th></tr>
                         </thead>
                         <tbody>
                             <f:for each="{perUser}" as="u">

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -35,15 +35,15 @@
                     <table class="table table-striped table-hover">
                         <thead>
                             <tr>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.name" default="Name" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.identifier" default="Identifier" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.provider" default="Provider" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.model" default="Model" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.status" default="Status" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
-                                <th class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.name" default="Name" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.identifier" default="Identifier" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.provider" default="Provider" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.model" default="Model" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.status" default="Status" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
+                                <th scope="col" class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -36,17 +36,17 @@
                     <table class="table table-striped table-hover">
                         <thead>
                             <tr>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.name" default="Name" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.identifier" default="Identifier" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.provider" default="Provider" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.modelId" default="Model ID" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.capabilities" default="Capabilities" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.context" default="Context" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.status" default="Status" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
-                                <th class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.name" default="Name" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.identifier" default="Identifier" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.provider" default="Provider" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.modelId" default="Model ID" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.capabilities" default="Capabilities" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.context" default="Context" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.field.status" default="Status" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
+                                <th scope="col" class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/Resources/Private/Templates/Backend/PromptSnippet/List.html
+++ b/Resources/Private/Templates/Backend/PromptSnippet/List.html
@@ -46,11 +46,11 @@
                         <table class="table table-striped table-hover mb-0">
                             <thead>
                                 <tr>
-                                    <th style="width: 40px;"></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.name" default="Name" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.identifier" default="Identifier" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.tags" default="Tags" /></th>
-                                    <th style="width: 120px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                    <th scope="col" style="width: 40px;"><span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:field.status" default="Status" /></span></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.name" default="Name" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.identifier" default="Identifier" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:snippet.col.tags" default="Tags" /></th>
+                                    <th scope="col" style="width: 120px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -61,11 +61,13 @@
                                                 <f:then>
                                                     <span class="badge text-bg-success" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.active')}">
                                                         <core:icon identifier="actions-check" size="small" />
+                                                        <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.active" /></span>
                                                     </span>
                                                 </f:then>
                                                 <f:else>
                                                     <span class="badge text-bg-secondary" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.inactive')}">
                                                         <core:icon identifier="actions-close" size="small" />
+                                                        <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.title.inactive" /></span>
                                                     </span>
                                                 </f:else>
                                             </f:if>

--- a/Resources/Private/Templates/Backend/Provider/List.html
+++ b/Resources/Private/Templates/Backend/Provider/List.html
@@ -28,17 +28,17 @@
                     <table class="table table-striped table-hover">
                         <thead>
                             <tr>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.name" default="Name" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.identifier" default="Identifier" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.adapterType" default="Adapter Type" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.endpoint" default="Endpoint" /></th>
-                                <th title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.vault.text')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.apiKey" default="API Key" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.status" default="Status" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.priority" default="Priority" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
-                                <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
-                                <th class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.name" default="Name" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.identifier" default="Identifier" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.adapterType" default="Adapter Type" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.endpoint" default="Endpoint" /></th>
+                                <th scope="col" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:glossary.term.vault.text')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.apiKey" default="API Key" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.status" default="Status" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:provider.field.priority" default="Priority" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
+                                <th scope="col" class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/Resources/Private/Templates/Backend/SetupWizard/Index.html
+++ b/Resources/Private/Templates/Backend/SetupWizard/Index.html
@@ -202,14 +202,14 @@
                             <table class="table table-hover" id="models-table">
                                 <thead>
                                     <tr>
-                                        <th style="width: 40px;">
+                                        <th scope="col" style="width: 40px;">
                                             <input type="checkbox" class="form-check-input" id="select-all-models"
                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.selectAll')}">
                                         </th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.model" default="Model" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.context" default="Context" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.capabilities" default="Capabilities" /></th>
-                                        <th style="width: 100px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.recommended" default="Recommended" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.model" default="Model" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.context" default="Context" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.capabilities" default="Capabilities" /></th>
+                                        <th scope="col" style="width: 100px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.col.recommended" default="Recommended" /></th>
                                     </tr>
                                 </thead>
                                 <tbody></tbody>

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -38,11 +38,11 @@
                         <table class="table table-striped table-hover mb-0">
                             <thead>
                                 <tr>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.title" default="Title" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.type" default="Type" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.syncStatus" default="Sync status" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.lastSynced" default="Last synced" /></th>
-                                    <th style="width: 200px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.title" default="Title" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.type" default="Type" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.syncStatus" default="Sync status" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.lastSynced" default="Last synced" /></th>
+                                    <th scope="col" style="width: 200px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -105,10 +105,10 @@
                         <table class="table table-striped table-hover mb-0">
                             <thead>
                                 <tr>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.name" default="Name" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.support" default="Support" /></th>
-                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.state" default="State" /></th>
-                                    <th style="width: 160px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.name" default="Name" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.support" default="Support" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.field.state" default="State" /></th>
+                                    <th scope="col" style="width: 160px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -66,15 +66,15 @@
                             <table class="table table-striped table-hover mb-0">
                                 <thead>
                                     <tr>
-                                        <th style="width: 40px;"></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.name" default="Name" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.identifier" default="Identifier" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.input" default="Input" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.output" default="Output" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
-                                        <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
-                                        <th style="width: 200px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                        <th scope="col" style="width: 40px;"><span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:field.status" default="Status" /></span></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.name" default="Name" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.identifier" default="Identifier" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.input" default="Input" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.col.output" default="Output" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.cost" default="Cost (30d)" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.requests" default="Requests (30d)" /></th>
+                                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.col.tokens" default="Tokens (30d)" /></th>
+                                        <th scope="col" style="width: 200px;"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/Tests/Unit/Service/Skill/SkillSyncServiceOrphanEligibilityTest.php
+++ b/Tests/Unit/Service/Skill/SkillSyncServiceOrphanEligibilityTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Skill;
 
+use Netresearch\NrLlm\Domain\Enum\SyncStatus;
+use Netresearch\NrLlm\Domain\Model\SkillSource;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillSourceRepository;
 use Netresearch\NrLlm\Service\Skill\GitHubClientInterface;
@@ -74,6 +76,52 @@ final class SkillSyncServiceOrphanEligibilityTest extends AbstractUnitTestCase
         $method = (new ReflectionClass($this->subject))->getMethod('orphanEligible');
 
         return (bool)$method->invoke($this->subject, $identifier, $reachedPrefixes, $listedPrefixes);
+    }
+
+    private function isLockActive(SkillSource $source, int $now): bool
+    {
+        $method = (new ReflectionClass($this->subject))->getMethod('isLockActive');
+
+        return (bool)$method->invoke($this->subject, $source, $now);
+    }
+
+    private function sourceWith(SyncStatus $status, int $lastSynced): SkillSource
+    {
+        $source = new SkillSource();
+        $source->setSyncStatus($status->value);
+        $source->setLastSynced($lastSynced);
+
+        return $source;
+    }
+
+    #[Test]
+    public function recentSyncingHeartbeatIsAnActiveLock(): void
+    {
+        // SYNCING with a heartbeat inside the stale window => a concurrent sync is running.
+        self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_000));
+        self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_500));
+        // Small clock skew / backwards NTP nudge (heartbeat slightly in the
+        // future) is still an active lock, not a permanent wedge.
+        self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 995));
+    }
+
+    #[Test]
+    public function staleOrNeverSetSyncingHeartbeatIsReclaimable(): void
+    {
+        // Heartbeat older than STALE_LOCK_SECONDS (600) => a crashed sync, reclaimable.
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_601));
+        // Never-set heartbeat (0) => reclaimable regardless of "now".
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 0), 1_000));
+        // Heartbeat FAR in the future (large clock correction / corruption) is
+        // treated as stale, so it cannot lock the source indefinitely.
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 300));
+    }
+
+    #[Test]
+    public function nonSyncingStatusIsNeverALock(): void
+    {
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::OK, 1_000), 1_000));
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::ERROR, 1_000), 1_000));
     }
 
     /**

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -16,7 +16,9 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -26,6 +28,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -657,5 +660,48 @@ final class ToolLoopServiceTest extends TestCase
         } finally {
             $GLOBALS['BE_USER'] = $beUserBackup;
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function budgetMetadata(?ToolOptions $options): array
+    {
+        $service = new ToolLoopService(
+            self::createStub(LlmServiceManagerInterface::class),
+            new ToolRegistry([]),
+            new FakeToolAvailability([]),
+        );
+        /** @var array<string, mixed> $result */
+        $result = (new ReflectionClass($service))->getMethod('budgetMetadata')->invoke($service, $options);
+
+        return $result;
+    }
+
+    #[Test]
+    public function budgetMetadataForwardsBeUserUidAndPlannedCost(): void
+    {
+        // The billing contract: ToolOptions budget fields must reach the
+        // BudgetMiddleware metadata that chatWithConfiguration() receives.
+        $meta = $this->budgetMetadata(new ToolOptions(beUserUid: 42, plannedCost: 0.05));
+
+        self::assertSame(42, $meta[BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
+        self::assertSame(0.05, $meta[BudgetMiddleware::METADATA_PLANNED_COST] ?? null);
+    }
+
+    #[Test]
+    public function budgetMetadataIsEmptyForNullOptions(): void
+    {
+        self::assertSame([], $this->budgetMetadata(null));
+    }
+
+    #[Test]
+    public function budgetMetadataOmitsUnsetFields(): void
+    {
+        // Only beUserUid set → the plannedCost key must be absent, not null/0.
+        $meta = $this->budgetMetadata(new ToolOptions(beUserUid: 7));
+
+        self::assertSame(7, $meta[BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
+        self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $meta);
     }
 }


### PR DESCRIPTION
## Summary

Clears the deferred low-value tail from the audit loop (deferred for velocity, not blocked). No behavior changes beyond the a11y additions.

### Accessibility
- `scope="col"` on **all backend list-table headers** (8 templates) so screen readers associate cells with their column header.
- Visually-hidden status text on the **PromptSnippet** active/inactive badge (was colour + icon + `title` only) — mirrors the earlier Task/List fix.

### Test coverage (moved into blocking CI)
- **SkillSync stale-lock guard**: extracted the SYNCING/stale-heartbeat decision into `isLockActive()` and unit-tested it — recent heartbeat = active lock (reject), stale (>600s) or never-set (0) heartbeat = reclaimable, non-SYNCING status = never a lock. The data-integrity guard was previously only exercised by the functional suite (not the blocking job).
- **ToolLoopService budget-metadata**: unit test asserting `budgetMetadata()` forwards `ToolOptions` `beUserUid`/`plannedCost` into the `BudgetMiddleware` metadata (and omits unset fields / is empty for null) — the billing contract the pipeline relies on.

## Not changed (verified non-issues, not deferrals)
- **SSRF on keyless `endpoint_url`**: false positive — `SecureHttpClientFactory::create()` already installs the SSRF-defence middleware (default-deny private/metadata + DNS-rebinding pin) for the keyless path too.
- **Glossary `{namespace}`**: deliberate + documented for a partial (no `<html>` root); valid Fluid, not "legacy".
- **"Tautological" E2E `isComplete()`/`wasTruncated()`**: the derivation is fully unit-covered (both branches) in `CompletionResponseTest`; the E2E assertions are harmless.

## Verification
`Build/Scripts/runTests.sh` (PHP 8.4): `cgl` ✅ · `phpstan` L10 ✅ · `unit` ✅ · targeted `functional` ✅ (SkillSync behavior preserved after the `isLockActive` extraction; templates render).