### PR TITLE
fix(config): hydrate be-group access-control MM relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **BREAKING:** `ToolInterface` now requires a `requiresAdmin(): bool` method. Every implementer must declare it — return `true` for tools exposing system/host/cross-user data (logs, environment, phpinfo, backend-user/group listings), `false` for tools that self-enforce the acting user's TYPO3 permissions. Without it, the tool fatals at runtime on instantiation.
 
+### Fixed
+
+- Per-configuration backend-group access control now works. The `beGroups` MM relation on `LlmConfiguration` had no Extbase mapping, so `LlmConfigurationRepository::findAccessibleForGroups()` raised `MissingColumnMapException` for any backend user in a group, and the in-PHP fallback check always saw an empty group list. The relation is now hydrated via a minimal `be_groups` domain model, and `getAllowedGroups()` is derived from it (the single source of truth). Present since at least v0.13.0.
+
 ### Security
 
 - Gemini provider now sends the API key in the `x-goog-api-key` header instead of the URL query string, so it no longer leaks into server/proxy logs, browser history or the Referer header.

--- a/Classes/Domain/Model/BackendUserGroup.php
+++ b/Classes/Domain/Model/BackendUserGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+/**
+ * Minimal Extbase model for `be_groups`.
+ *
+ * It exists solely as the concrete target of the {@see LlmConfiguration}
+ * `beGroups` MM relation used for per-group access control. TYPO3 core no longer
+ * ships an Extbase model for `be_groups` and ext:beuser is not a dependency, so
+ * Extbase needs a concrete class it can instantiate when hydrating the relation.
+ *
+ * Only `uid` (via AbstractEntity) and the human-readable `title` are mapped — no
+ * permission masks, allowed-table lists or other authorization-bearing columns
+ * are exposed.
+ */
+class BackendUserGroup extends AbstractEntity
+{
+    protected string $title = '';
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -71,13 +71,14 @@ class LlmConfiguration extends AbstractEntity
 
     protected bool $isActive = true;
     protected bool $isDefault = false;
-    protected int $allowedGroups = 0;
     protected int $tstamp = 0;
     protected int $crdate = 0;
     /**
-     * Allowed backend groups (MM relation).
+     * Allowed backend groups (MM relation) — the single source of truth for the
+     * per-group access restriction. Its TCA config lives on the `allowed_groups`
+     * column, where TYPO3 also maintains the relation count.
      *
-     * @var ObjectStorage<AbstractEntity>|null
+     * @var ObjectStorage<BackendUserGroup>|null
      */
     protected ?ObjectStorage $beGroups = null;
 
@@ -342,13 +343,19 @@ class LlmConfiguration extends AbstractEntity
         return $this->getIsDefault();
     }
 
+    /**
+     * Number of backend groups this configuration is restricted to (0 = no
+     * restriction). Derived from the beGroups MM relation, the single source of
+     * truth; TYPO3 also stores this count in the `allowed_groups` column but
+     * Extbase surfaces the relation, not that scalar.
+     */
     public function getAllowedGroups(): int
     {
-        return $this->allowedGroups;
+        return $this->getBeGroups()->count();
     }
 
     /**
-     * @return ObjectStorage<AbstractEntity>
+     * @return ObjectStorage<BackendUserGroup>
      */
     public function getBeGroups(): ObjectStorage
     {
@@ -567,11 +574,6 @@ class LlmConfiguration extends AbstractEntity
         $this->isDefault = $isDefault;
     }
 
-    public function setAllowedGroups(int $allowedGroups): void
-    {
-        $this->allowedGroups = $allowedGroups;
-    }
-
     /**
      * Set fallback chain from raw JSON (used by Extbase when hydrating from DB).
      *
@@ -602,7 +604,7 @@ class LlmConfiguration extends AbstractEntity
     }
 
     /**
-     * @param ObjectStorage<AbstractEntity>|null $beGroups
+     * @param ObjectStorage<BackendUserGroup>|null $beGroups
      */
     public function setBeGroups(?ObjectStorage $beGroups): void
     {
@@ -648,8 +650,7 @@ class LlmConfiguration extends AbstractEntity
      */
     public function hasAccessRestrictions(): bool
     {
-        return $this->allowedGroups > 0
-            || ($this->beGroups !== null && $this->beGroups->count() > 0);
+        return $this->getBeGroups()->count() > 0;
     }
 
     /**

--- a/Classes/Domain/Repository/LlmConfigurationRepository.php
+++ b/Classes/Domain/Repository/LlmConfigurationRepository.php
@@ -94,21 +94,25 @@ class LlmConfigurationRepository extends Repository
     {
         $query = $this->createQuery();
 
-        if (empty($groupUids)) {
-            // No groups: only return configurations without access restrictions
+        // "Unrestricted" = no be-group linked. The beGroups MM relation is
+        // LEFT-joined, so an unlinked configuration has a NULL relation uid.
+        $noRestriction = $query->equals('beGroups.uid', null);
+
+        if ($groupUids === []) {
+            // No groups: only configurations without access restrictions.
             $query->matching(
                 $query->logicalAnd(
                     $query->equals('isActive', true),
-                    $query->equals('allowedGroups', 0),
+                    $noRestriction,
                 ),
             );
         } else {
-            // Return configurations without restrictions OR with matching groups
+            // Configurations without restrictions OR restricted to a matching group.
             $query->matching(
                 $query->logicalAnd(
                     $query->equals('isActive', true),
                     $query->logicalOr(
-                        $query->equals('allowedGroups', 0),
+                        $noRestriction,
                         $query->in('beGroups.uid', $groupUids),
                     ),
                 ),

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Domain\Model\BackendUserGroup;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
@@ -25,6 +26,9 @@ use Netresearch\NrLlm\Domain\Model\UserBudget;
 return [
     Provider::class => [
         'tableName' => 'tx_nrllm_provider',
+    ],
+    BackendUserGroup::class => [
+        'tableName' => 'be_groups',
     ],
     Skill::class => [
         'tableName' => 'tx_nrllm_skill',
@@ -76,7 +80,15 @@ return [
             'isDefault' => [
                 'fieldName' => 'is_default',
             ],
-            'allowedGroups' => [
+            // The be-group access-control MM relation. Its TCA config lives on
+            // the `allowed_groups` column (type=select, MM=…begroups_mm); TYPO3
+            // stores the relation count in that column while the rows live in
+            // tx_nrllm_configuration_begroups_mm. Mapping `beGroups` here gives
+            // the ObjectStorage its ColumnMap so Extbase hydrates the relation
+            // and findAccessibleForGroups() can constrain on `beGroups.uid`.
+            // Without it the relation resolves to a non-existent `be_groups`
+            // column and every group-scoped query raised MissingColumnMapException.
+            'beGroups' => [
                 'fieldName' => 'allowed_groups',
             ],
         ],

--- a/Tests/Functional/Fixtures/BeGroupRelations.csv
+++ b/Tests/Functional/Fixtures/BeGroupRelations.csv
@@ -1,0 +1,11 @@
+"be_groups"
+,"uid","pid","title"
+,5,0,"Editors"
+,6,0,"Authors"
+"tx_nrllm_configuration"
+,"uid","pid","identifier","name","is_active","allowed_groups"
+,130,0,"be-restricted","BE Restricted",1,1
+,131,0,"be-open","BE Open",1,0
+"tx_nrllm_configuration_begroups_mm"
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,130,5,1,0

--- a/Tests/Functional/Fixtures/LlmConfigurations.csv
+++ b/Tests/Functional/Fixtures/LlmConfigurations.csv
@@ -8,3 +8,9 @@
 ,6,0,"restricted-config","Restricted Configuration","Configuration with group access restrictions",1,"","",0.70,1000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,1,1703347200,1703347200,0,0,6
 ,7,0,"reasoning-config","Reasoning Configuration","Configuration using O4 Mini for reasoning tasks",2,"","You are a reasoning assistant. Think step by step.",0.20,8000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,0,1703347200,1703347200,0,0,7
 ,8,0,"no-model-config","No Model Configuration","Configuration without a model assigned",0,"","System prompt.",0.70,1000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,0,1703347200,1703347200,0,0,8
+"be_groups"
+,"uid","pid","title"
+,100,0,"Restricted Access Group"
+"tx_nrllm_configuration_begroups_mm"
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,6,100,1,0

--- a/Tests/Functional/Repository/BeGroupAccessControlTest.php
+++ b/Tests/Functional/Repository/BeGroupAccessControlTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Repository;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Ground-truth coverage for the backend-group access-control path.
+ *
+ * A configuration can be restricted to specific backend user groups via the
+ * `allowed_groups` MM relation (table `tx_nrllm_configuration_begroups_mm`).
+ * Two production consumers rely on it hydrating:
+ *   - LlmConfigurationRepository::findAccessibleForGroups() filters at the DB
+ *     level via `beGroups.uid`;
+ *   - LlmConfigurationService::getConfigurationGroupIds() iterates
+ *     LlmConfiguration::getBeGroups() in PHP.
+ *
+ * Before these tests the whole non-empty-group branch was uncovered — only the
+ * "no groups" and the int-counter (`allowedGroups`) paths were exercised. These
+ * tests assert the security-relevant behaviour end-to-end against a real MM row.
+ */
+#[CoversClass(LlmConfigurationRepository::class)]
+final class BeGroupAccessControlTest extends AbstractFunctionalTestCase
+{
+    private LlmConfigurationRepository $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeGroupRelations.csv');
+
+        /** @var LlmConfigurationRepository $subject */
+        $subject       = $this->get(LlmConfigurationRepository::class);
+        $this->subject = $subject;
+    }
+
+    #[Test]
+    public function beGroupsRelationHydratesFromMmTable(): void
+    {
+        $config = $this->subject->findByUid(130);
+        self::assertInstanceOf(LlmConfiguration::class, $config);
+
+        // The restricting group must be reachable through the ObjectStorage
+        // relation — this is what getConfigurationGroupIds() iterates.
+        self::assertCount(1, $config->getBeGroups());
+
+        $uids = [];
+        foreach ($config->getBeGroups() as $group) {
+            $uids[] = $group->getUid();
+        }
+        self::assertSame([5], $uids);
+    }
+
+    #[Test]
+    public function memberOfRestrictingGroupSeesRestrictedConfiguration(): void
+    {
+        $uids = $this->configUids($this->subject->findAccessibleForGroups([5]));
+
+        self::assertContains(130, $uids, 'a member of the restricting group must see the restricted config');
+        self::assertContains(131, $uids, 'the unrestricted config is always visible');
+    }
+
+    #[Test]
+    public function nonMemberDoesNotSeeRestrictedConfiguration(): void
+    {
+        $uids = $this->configUids($this->subject->findAccessibleForGroups([6]));
+
+        self::assertNotContains(130, $uids, 'a config restricted to group 5 must NOT leak to group 6 (fail-closed)');
+        self::assertContains(131, $uids, 'the unrestricted config stays visible');
+    }
+
+    /**
+     * @param iterable<LlmConfiguration> $configs
+     *
+     * @return list<int>
+     */
+    private function configUids(iterable $configs): array
+    {
+        $uids = [];
+        foreach ($configs as $config) {
+            $uid = $config->getUid();
+            if ($uid !== null) {
+                $uids[] = $uid;
+            }
+        }
+
+        return $uids;
+    }
+}

--- a/Tests/Unit/Domain/Model/LlmConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/LlmConfigurationTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Model;
 
 use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
+use Netresearch\NrLlm\Domain\Model\BackendUserGroup;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
@@ -671,10 +672,15 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function hasAccessRestrictionsReturnsTrueWhenAllowedGroupsSet(): void
+    public function hasAccessRestrictionsReturnsTrueWhenBeGroupAttached(): void
     {
-        $this->subject->setAllowedGroups(1);
+        $groups = new ObjectStorage();
+        $groups->attach(new BackendUserGroup());
+        $this->subject->setBeGroups($groups);
+
         self::assertTrue($this->subject->hasAccessRestrictions());
+        // getAllowedGroups() is derived from the relation, not a separate scalar.
+        self::assertSame(1, $this->subject->getAllowedGroups());
     }
 
     // ========================================


### PR DESCRIPTION
## Summary

The per-configuration **backend-group access control** feature was completely non-functional. `LlmConfiguration` declares a `beGroups` `ObjectStorage` MM relation (used to restrict a configuration to specific backend user groups), but it had **no Extbase persistence mapping** — it resolved by convention to a non-existent `be_groups` column, while the relation's TCA config actually lives on the `allowed_groups` column.

Consequences (present since **≥ v0.13.0**):
- `LlmConfigurationRepository::findAccessibleForGroups()` raised `MissingColumnMapException` for **any backend user in a group** (the `in('beGroups.uid', …)` constraint).
- `LlmConfigurationService::getConfigurationGroupIds()` iterated a relation that never hydrated, so it always saw an **empty** group list.

It failed **closed** (threw / returned empty) rather than leaking access, so there was no security exposure — but the feature simply never worked.

## Root cause

The `allowed_groups` column does double duty: TYPO3 select-MM stores the relation *count* there (read by an int `allowedGroups` property) **and** the actual rows live in `tx_nrllm_configuration_begroups_mm`. Extbase can't map two properties to one column with different semantics.

## Fix (root-cause)

- Add a minimal `be_groups` domain model (`Domain/Model/BackendUserGroup`) — core no longer ships one and `ext:beuser` is not a dependency, so the relation needs a concrete class Extbase can instantiate.
- Map `beGroups` → `allowed_groups` in `Configuration/Extbase/Persistence/Classes.php`, making the relation the **single source of truth**.
- Derive `getAllowedGroups()` from `beGroups->count()` and remove the now-redundant int scalar (`setAllowedGroups()` was DB-maintained, never called in production).
- Rewrite `findAccessibleForGroups()` to express "unrestricted" as an empty relation (`beGroups.uid IS NULL`) for both the empty-groups and matching-groups paths.

No behavior change for *working* released behavior: `getAllowedGroups()` returns the same value (group count) for real persisted data. Only released-but-**broken** behavior (the exception / empty list) is fixed.

## Verification

- New functional test `BeGroupAccessControlTest` seeds a real MM row and asserts: the relation hydrates, a **member** of the restricting group sees the configuration, and a **non-member** does not. This branch had **zero** coverage before.
- Gates (PHP 8.4): PHPStan L10 ✓ · CGL ✓ · functional (48 tests) ✓ · unit `LlmConfigurationTest` (82 tests) ✓.

## Context

This is the single genuine finding from the round-6 24-lens audit; the other 11 "high/critical" findings were verified as false positives, cosmetic, or already-handled.