### PR TITLE
fix: resolve round-6 audit medium/low findings

### DIFF
--- a/Classes/Controller/Backend/DTO/ExecuteTaskRequest.php
+++ b/Classes/Controller/Backend/DTO/ExecuteTaskRequest.php
@@ -50,6 +50,9 @@ final readonly class ExecuteTaskRequest
     private static function extractInt(array $data, string $key, int $default = 0): int
     {
         $value = $data[$key] ?? $default;
-        return is_numeric($value) ? (int)$value : $default;
+        // The only field extracted here is the record uid, which must be a
+        // positive identifier — reject non-positive values so a negative id
+        // never reaches findByUid().
+        return (is_numeric($value) && (int)$value > 0) ? (int)$value : $default;
     }
 }

--- a/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
+++ b/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
@@ -37,7 +37,7 @@ final readonly class FetchRecordsRequest
 
         return new self(
             table: self::extractString($data, 'table'),
-            limit: min($rawLimit, self::MAX_LIMIT),
+            limit: max(1, min($rawLimit, self::MAX_LIMIT)),
             labelField: self::extractString($data, 'labelField'),
         );
     }

--- a/Classes/Controller/Backend/DTO/RefreshInputRequest.php
+++ b/Classes/Controller/Backend/DTO/RefreshInputRequest.php
@@ -39,6 +39,9 @@ final readonly class RefreshInputRequest
     private static function extractInt(array $data, string $key, int $default = 0): int
     {
         $value = $data[$key] ?? $default;
-        return is_numeric($value) ? (int)$value : $default;
+        // The only field extracted here is the record uid, which must be a
+        // positive identifier — reject non-positive values so a negative id
+        // never reaches findByUid().
+        return (is_numeric($value) && (int)$value > 0) ? (int)$value : $default;
     }
 }

--- a/Classes/Controller/Backend/Response/ErrorResponse.php
+++ b/Classes/Controller/Backend/Response/ErrorResponse.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend\Response;
 
 use JsonSerializable;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 
 /**
  * Response DTO for error AJAX responses.
@@ -18,10 +19,19 @@ use JsonSerializable;
  */
 final readonly class ErrorResponse implements JsonSerializable
 {
+    use ErrorMessageSanitizerTrait;
+
+    public string $error;
+
     public function __construct(
-        public string $error,
+        string $error,
         public bool $success = false,
-    ) {}
+    ) {
+        // Defence at the response boundary: controllers pass raw
+        // `$e->getMessage()` here, so redact credential-bearing URL params
+        // (e.g. a provider's `?key=…`) before the message reaches the client.
+        $this->error = $this->sanitizeErrorMessage($error);
+    }
 
     /**
      * @return array{success: bool, error: string}

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -400,7 +400,12 @@ final class SetupWizardController extends ActionController
             $modelName = is_string($modelData['name'] ?? null) ? $modelData['name'] : 'model';
             $modelId = is_string($modelData['modelId'] ?? null) ? $modelData['modelId'] : '';
             $modelDescription = is_string($modelData['description'] ?? null) ? $modelData['description'] : '';
-            $modelCapabilities = is_array($modelData['capabilities'] ?? null) ? $modelData['capabilities'] : ['chat'];
+            // Keep only string capabilities so a malformed payload (nested or
+            // non-string entries) can never reach the model as a bad list.
+            $modelCapabilities = array_values(array_filter(
+                is_array($modelData['capabilities'] ?? null) ? $modelData['capabilities'] : ['chat'],
+                is_string(...),
+            ));
             $contextLength = is_numeric($modelData['contextLength'] ?? null) ? (int)$modelData['contextLength'] : 0;
             $maxOutputTokens = is_numeric($modelData['maxOutputTokens'] ?? null) ? (int)$modelData['maxOutputTokens'] : 0;
 
@@ -462,7 +467,9 @@ final class SetupWizardController extends ActionController
             }
 
             $recommendedModelId = is_string($configData['recommendedModelId'] ?? null) ? $configData['recommendedModelId'] : '';
-            $model = $savedModels[$recommendedModelId] ?? reset($savedModels) ?: null;
+            // Prefer the recommended model; otherwise fall back to the first
+            // saved model, or null when none were saved.
+            $model = $savedModels[$recommendedModelId] ?? (empty($savedModels) ? null : reset($savedModels));
 
             if ($model === null) {
                 continue;

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -40,7 +40,6 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -288,13 +287,8 @@ final class TaskExecutionController extends ActionController
         string $title,
         ContextualFeedbackSeverity $severity,
     ): void {
-        $flashMessage = GeneralUtility::makeInstance(
-            FlashMessage::class,
-            $message,
-            $title,
-            $severity,
-            true,
-        );
+        // FlashMessage is a plain value object, not a service — instantiate directly.
+        $flashMessage = new FlashMessage($message, $title, $severity, true);
         $this->flashMessageService
             ->getMessageQueueByIdentifier()
             ->addMessage($flashMessage);

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -313,13 +312,8 @@ final class TaskWizardController extends ActionController
         string $title,
         ContextualFeedbackSeverity $severity,
     ): void {
-        $flashMessage = GeneralUtility::makeInstance(
-            FlashMessage::class,
-            $message,
-            $title,
-            $severity,
-            true,
-        );
+        // FlashMessage is a plain value object, not a service — instantiate directly.
+        $flashMessage = new FlashMessage($message, $title, $severity, true);
         $this->flashMessageService
             ->getMessageQueueByIdentifier()
             ->addMessage($flashMessage);

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrLlm\Domain\Repository;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
@@ -27,6 +29,13 @@ class ModelRepository extends Repository
         'sorting' => QueryInterface::ORDER_ASCENDING,
         'name' => QueryInterface::ORDER_ASCENDING,
     ];
+
+    private ConnectionPool $connectionPool;
+
+    public function injectConnectionPool(ConnectionPool $connectionPool): void
+    {
+        $this->connectionPool = $connectionPool;
+    }
 
     /**
      * Initialize repository for backend module use.
@@ -258,20 +267,32 @@ class ModelRepository extends Repository
      */
     public function countByProvider(): array
     {
-        $counts = [];
-        $models = $this->findActive();
+        // Aggregate in a single grouped query on the provider FK rather than
+        // hydrating every active model and lazy-loading its Provider (N+1).
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrllm_model');
+        $rows = $queryBuilder
+            ->select('provider_uid')
+            ->addSelectLiteral(
+                $queryBuilder->expr()->count('*', 'model_count'),
+            )
+            ->from('tx_nrllm_model')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'is_active',
+                    $queryBuilder->createNamedParameter(1, Connection::PARAM_INT),
+                ),
+            )
+            ->groupBy('provider_uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
 
-        foreach ($models as $model) {
-            // @phpstan-ignore instanceof.alwaysTrue (defensive check for QueryResult)
-            if (!$model instanceof Model) {
-                continue;
+        $counts = [];
+        foreach ($rows as $row) {
+            $providerUid = $row['provider_uid'];
+            $modelCount = $row['model_count'];
+            if (is_numeric($providerUid) && is_numeric($modelCount)) {
+                $counts[(int)$providerUid] = (int)$modelCount;
             }
-            $provider = $model->getProvider();
-            $providerUid = $provider?->getUid() ?? 0;
-            if (!isset($counts[$providerUid])) {
-                $counts[$providerUid] = 0;
-            }
-            $counts[$providerUid]++;
         }
 
         return $counts;

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
@@ -270,6 +271,11 @@ class ModelRepository extends Repository
         // Aggregate in a single grouped query on the provider FK rather than
         // hydrating every active model and lazy-loading its Provider (N+1).
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrllm_model');
+        // Match findActive(): the repository ignores enable-fields
+        // (initializeObject → setIgnoreEnableFields), so hidden active models
+        // must still be counted. The DeletedRestriction stays (deleted rows are
+        // excluded there too).
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         $rows = $queryBuilder
             ->select('provider_uid')
             ->addSelectLiteral(

--- a/Classes/Service/PromptTemplateService.php
+++ b/Classes/Service/PromptTemplateService.php
@@ -23,6 +23,29 @@ use Netresearch\NrLlm\Exception\PromptTemplateNotFoundException;
  */
 final readonly class PromptTemplateService implements PromptTemplateServiceInterface
 {
+    /**
+     * Fields a new version may legitimately override via createVersion(). Guards
+     * the dynamic setter dispatch against mass-assignment to identity/metadata
+     * setters (uid, version, parentUid, usageCount, stats, …).
+     *
+     * @var list<string>
+     */
+    private const VERSIONABLE_FIELDS = [
+        'title',
+        'description',
+        'feature',
+        'systemPrompt',
+        'userPromptTemplate',
+        'provider',
+        'model',
+        'temperature',
+        'maxTokens',
+        'topP',
+        'variables',
+        'exampleOutput',
+        'tags',
+    ];
+
     public function __construct(
         private PromptTemplateRepository $repository,
     ) {}
@@ -131,8 +154,12 @@ final readonly class PromptTemplateService implements PromptTemplateServiceInter
             $newTemplate->setParentUid($parentUid);
         }
 
-        // Apply updates
+        // Apply updates — only whitelisted content fields, never identity or
+        // metadata setters (prevents mass-assignment via the dynamic dispatch).
         foreach ($updates as $field => $value) {
+            if (!in_array($field, self::VERSIONABLE_FIELDS, true)) {
+                continue;
+            }
             $setter = 'set' . ucfirst($field);
             if (method_exists($newTemplate, $setter)) {
                 $newTemplate->$setter($value);

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Domain\ValueObject\SyncResult;
 use Netresearch\NrLlm\Service\Skill\Exception\GitHubApiException;
 use Netresearch\NrLlm\Service\Skill\Exception\HostNotAllowedException;
 use Netresearch\NrLlm\Service\Skill\Exception\SkillParseException;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
@@ -28,6 +29,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 final class SkillSyncService
 {
+    use ErrorMessageSanitizerTrait;
+
     /** A SYNCING lock older than this many seconds is considered stale and may be reclaimed. */
     private const STALE_LOCK_SECONDS = 600;
 
@@ -117,7 +120,7 @@ final class SkillSyncService
             if ($collected['rootSha'] !== null) {
                 $source->setPinnedSha($collected['rootSha']);
             }
-            $source->setSyncError(implode("\n", $errors));
+            $source->setSyncError($this->sanitizeErrorMessage(implode("\n", $errors)));
         } catch (Throwable $e) {
             // Keep the full stack trace server-side (GitHub rate limits, network
             // timeouts, DBAL/persistence errors) — the user only sees getMessage().
@@ -129,7 +132,7 @@ final class SkillSyncService
             $status = SyncStatus::ERROR;
             $orphaned = 0;
             $errors[] = $e->getMessage();
-            $source->setSyncError($e->getMessage());
+            $source->setSyncError($this->sanitizeErrorMessage($e->getMessage()));
         }
 
         // Always persist the final state so the lock is never left stuck.

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -286,8 +286,13 @@ final readonly class ToolLoopService
             return $result;
         }
 
-        return mb_strcut($result, 0, self::MAX_TOOL_RESULT_BYTES)
-            . "\n…[tool result truncated at " . self::MAX_TOOL_RESULT_BYTES . ' bytes]';
+        // Reserve the marker's bytes from the budget so the returned string
+        // (content + marker) never exceeds the cap. mb_strcut with an explicit
+        // UTF-8 encoding cuts on a byte boundary without splitting a character.
+        $marker = "\n…[tool result truncated at " . self::MAX_TOOL_RESULT_BYTES . ' bytes]';
+        $budget = self::MAX_TOOL_RESULT_BYTES - strlen($marker);
+
+        return mb_strcut($result, 0, max(0, $budget), 'UTF-8') . $marker;
     }
 
     /**

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -53,6 +53,13 @@ final readonly class ToolLoopService
 {
     use ResolvesActingBackendUserTrait;
 
+    /**
+     * Hard cap on a single tool result appended to the message list. A buggy or
+     * malicious tool returning multi-megabyte output would otherwise blow the
+     * provider payload limit, bypass the token budget and pressure memory.
+     */
+    private const MAX_TOOL_RESULT_BYTES = 50000;
+
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
@@ -253,15 +260,34 @@ final readonly class ToolLoopService
         }
 
         try {
-            return [$tool->execute($call->arguments), false];
+            return [$this->capResult($tool->execute($call->arguments)), false];
         } catch (Throwable $e) {
+            // Keep the logged summary generic — the exception body may embed
+            // DBAL/PDO credentials that URL-sanitising would not strip. The full
+            // Throwable (message + trace) is preserved in the log context for
+            // server-side forensics.
             $this->logger?->error(
-                sprintf('Tool "%s" failed: %s', $call->name, $e->getMessage()),
+                sprintf('Tool "%s" failed.', $call->name),
                 ['exception' => $e],
             );
 
             return [sprintf('Error: tool "%s" failed.', $call->name), true];
         }
+    }
+
+    /**
+     * Bound a tool result to {@see self::MAX_TOOL_RESULT_BYTES}. Uses mb_strcut
+     * so the byte cap never splits a multibyte character (which would corrupt
+     * the later JSON encoding), and appends a visible truncation marker.
+     */
+    private function capResult(string $result): string
+    {
+        if (strlen($result) <= self::MAX_TOOL_RESULT_BYTES) {
+            return $result;
+        }
+
+        return mb_strcut($result, 0, self::MAX_TOOL_RESULT_BYTES)
+            . "\n…[tool result truncated at " . self::MAX_TOOL_RESULT_BYTES . ' bytes]';
     }
 
     /**

--- a/Classes/Service/WizardGeneratorService.php
+++ b/Classes/Service/WizardGeneratorService.php
@@ -87,8 +87,9 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if ($parsed !== null) {
                 return $this->normalizeConfigurationResult($parsed, $description);
             }
-        } catch (Throwable) {
-            // Fall through to fallback
+        } catch (Throwable $e) {
+            // Fall through to fallback, but keep the cause for debugging.
+            $this->logger->warning('Wizard configuration generation failed; using fallback', ['exception' => $e]);
         }
 
         return $this->fallbackConfiguration($description);
@@ -122,8 +123,9 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if ($parsed !== null) {
                 return $this->normalizeTaskResult($parsed, $description);
             }
-        } catch (Throwable) {
-            // Fall through to fallback
+        } catch (Throwable $e) {
+            // Fall through to fallback, but keep the cause for debugging.
+            $this->logger->warning('Wizard task generation failed; using fallback', ['exception' => $e]);
         }
 
         return $this->fallbackTask($description);
@@ -160,8 +162,9 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if ($parsed !== null) {
                 return $this->normalizeFullChainResult($parsed, $description);
             }
-        } catch (Throwable) {
-            // Fall through to fallback
+        } catch (Throwable $e) {
+            // Fall through to fallback, but keep the cause for debugging.
+            $this->logger->warning('Wizard task-chain generation failed; using fallback', ['exception' => $e]);
         }
 
         return $this->fallbackTaskChain($description);

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -469,12 +469,13 @@ final class TextToSpeechService extends AbstractSpecializedService
         } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->logger->error('TTS API connection error', [
-                'exception' => $e->getMessage(),
-            ]);
+            // Log the full Throwable server-side (the chained cause below carries
+            // the detail); surface only a static message so connection details,
+            // endpoint URLs or SSL state never reach the caller.
+            $this->logger->error('TTS API connection error', ['exception' => $e]);
 
             throw new ServiceUnavailableException(
-                'Failed to connect to TTS API: ' . $e->getMessage(),
+                'Failed to connect to TTS API',
                 'speech',
                 ['provider' => 'tts'],
                 0,

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -423,12 +423,13 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->logger->error('Whisper API connection error', [
-                'exception' => $e->getMessage(),
-            ]);
+            // Log the full Throwable server-side (the chained cause below carries
+            // the detail); surface only a static message so connection details,
+            // endpoint URLs or SSL state never reach the caller.
+            $this->logger->error('Whisper API connection error', ['exception' => $e]);
 
             throw new ServiceUnavailableException(
-                'Failed to connect to Whisper API: ' . $e->getMessage(),
+                'Failed to connect to Whisper API',
                 'speech',
                 ['provider' => 'whisper'],
                 0,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -145,20 +145,25 @@ services:
   # ========================================
   # Aliases that let consumers wire against the interface rather than the
   # concrete class. The concrete services are auto-registered as private
-  # by the namespace resource block above; these aliases match that
-  # visibility (REC #9b — supporting interface extraction).
+  # by the namespace resource block above; these aliases declare the same
+  # visibility explicitly (REC #9b — supporting interface extraction) so it
+  # stays private regardless of the target service's own visibility.
 
   Netresearch\NrLlm\Service\ModelSelectionServiceInterface:
     alias: Netresearch\NrLlm\Service\ModelSelectionService
+    public: false
 
   Netresearch\NrLlm\Service\CapabilityPermissionServiceInterface:
     alias: Netresearch\NrLlm\Service\CapabilityPermissionService
+    public: false
 
   Netresearch\NrLlm\Service\WizardGeneratorServiceInterface:
     alias: Netresearch\NrLlm\Service\WizardGeneratorService
+    public: false
 
   Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface:
     alias: Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator
+    public: false
 
   # ========================================
   # Repositories (PUBLIC)

--- a/Configuration/TCA/tx_nrllm_model.php
+++ b/Configuration/TCA/tx_nrllm_model.php
@@ -110,7 +110,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'tx_nrllm_provider',
-                'foreign_table_where' => 'AND {#tx_nrllm_provider}.{#hidden} = 0 AND {#tx_nrllm_provider}.{#deleted} = 0 ORDER BY tx_nrllm_provider.priority DESC, tx_nrllm_provider.name',
+                'foreign_table_where' => 'AND {#tx_nrllm_provider}.{#hidden} = 0 AND {#tx_nrllm_provider}.{#deleted} = 0 ORDER BY {#tx_nrllm_provider}.{#priority} DESC, {#tx_nrllm_provider}.{#name}',
                 'items' => [
                     ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_model.provider_uid.select', 'value' => 0],
                 ],

--- a/Configuration/TCA/tx_nrllm_task.php
+++ b/Configuration/TCA/tx_nrllm_task.php
@@ -211,7 +211,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',
                 'foreign_table' => 'tx_nrllm_skill',
-                'foreign_table_where' => 'AND tx_nrllm_skill.enabled = 1 AND tx_nrllm_skill.orphaned = 0 ORDER BY tx_nrllm_skill.name',
+                'foreign_table_where' => 'AND {#tx_nrllm_skill}.{#enabled} = 1 AND {#tx_nrllm_skill}.{#orphaned} = 0 ORDER BY {#tx_nrllm_skill}.{#name}',
                 'MM' => 'tx_nrllm_task_skill_mm',
                 'size' => 5,
                 'minitems' => 0,

--- a/Configuration/TCA/tx_nrllm_user_budget.php
+++ b/Configuration/TCA/tx_nrllm_user_budget.php
@@ -62,7 +62,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'be_users',
-                'foreign_table_where' => 'AND {#be_users}.{#hidden} = 0 AND {#be_users}.{#deleted} = 0 ORDER BY be_users.username',
+                'foreign_table_where' => 'AND {#be_users}.{#hidden} = 0 AND {#be_users}.{#deleted} = 0 ORDER BY {#be_users}.{#username}',
                 'minitems' => 1,
                 'maxitems' => 1,
                 'required' => true,

--- a/Documentation/Adr/Adr038ToolRuntime.rst
+++ b/Documentation/Adr/Adr038ToolRuntime.rst
@@ -47,8 +47,13 @@ Decision
 ========
 
 1. **A DI-tagged tool registry.** :php:`ToolInterface`
-   (``Classes/Service/Tool/``) declares ``getSpec(): ToolSpec`` and
-   ``execute(array $arguments): string`` and carries
+   (``Classes/Service/Tool/``) declares four methods —
+   ``getSpec(): ToolSpec``, ``execute(array $arguments): string``,
+   ``isEnabledByDefault(): bool`` (curated low-risk tools return ``true``;
+   secret- or system-exposing tools return ``false`` so they are opt-in) and
+   ``requiresAdmin(): bool`` (admin-only gating for tools surfacing
+   system/host/cross-user data) — both central to the fail-open/fail-closed
+   security model below. It carries
    ``#[AutoconfigureTag('nr_llm.tool')]``. :php:`ToolRegistry` collects every
    tagged tool through an autowired iterator and indexes it by spec name (a
    duplicate name is a developer error → :php:`LogicException` at

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2154,6 +2154,190 @@
                 <source>Unknown tool</source>
                 <target>Unbekanntes Werkzeug</target>
             </trans-unit>
+            <trans-unit id="card.count.configurations">
+                <source>configuration(s) configured</source>
+                <target>Konfiguration(en) eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.models">
+                <source>model(s) configured</source>
+                <target>Modell(e) eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.none.configurations">
+                <source>No configurations configured</source>
+                <target>Keine Konfigurationen eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.none.models">
+                <source>No models configured</source>
+                <target>Keine Modelle eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.none.providers">
+                <source>No providers configured</source>
+                <target>Keine Provider eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.none.tasks">
+                <source>No tasks yet</source>
+                <target>Noch keine Aufgaben</target>
+            </trans-unit>
+            <trans-unit id="card.count.providers">
+                <source>provider(s) configured</source>
+                <target>Provider eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="card.count.tasks">
+                <source>task(s) configured</source>
+                <target>Aufgabe(n) eingerichtet</target>
+            </trans-unit>
+            <trans-unit id="configuration.card.button">
+                <source>Manage Configurations</source>
+                <target>Konfigurationen verwalten</target>
+            </trans-unit>
+            <trans-unit id="configuration.card.description">
+                <source>Create named configurations with prompts, parameters, and limits.</source>
+                <target>Erstellen Sie benannte Konfigurationen mit Prompts, Parametern und Limits.</target>
+            </trans-unit>
+            <trans-unit id="configuration.card.subtitle">
+                <source>Use-case specific presets</source>
+                <target>Anwendungsspezifische Voreinstellungen</target>
+            </trans-unit>
+            <trans-unit id="configuration.card.title">
+                <source>Configurations</source>
+                <target>Konfigurationen</target>
+            </trans-unit>
+            <trans-unit id="connectionSuccessful">
+                <source>Connection Successful</source>
+                <target>Verbindung erfolgreich</target>
+            </trans-unit>
+            <trans-unit id="discoveringModels">
+                <source>Discovering available models...</source>
+                <target>Verfügbare Modelle werden ermittelt …</target>
+            </trans-unit>
+            <trans-unit id="generatingConfigurations">
+                <source>Generating configurations...</source>
+                <target>Konfigurationen werden generiert …</target>
+            </trans-unit>
+            <trans-unit id="model.card.button">
+                <source>Manage Models</source>
+                <target>Modelle verwalten</target>
+            </trans-unit>
+            <trans-unit id="model.card.description">
+                <source>Configure model definitions, capabilities, and pricing per provider.</source>
+                <target>Konfigurieren Sie Modelldefinitionen, Fähigkeiten und Preise je Provider.</target>
+            </trans-unit>
+            <trans-unit id="model.card.subtitle">
+                <source>Define available models</source>
+                <target>Verfügbare Modelle definieren</target>
+            </trans-unit>
+            <trans-unit id="model.card.title">
+                <source>LLM Models</source>
+                <target>LLM-Modelle</target>
+            </trans-unit>
+            <trans-unit id="module.management">
+                <source>LLM Management</source>
+                <target>LLM-Verwaltung</target>
+            </trans-unit>
+            <trans-unit id="provider.card.button">
+                <source>Manage Providers</source>
+                <target>Provider verwalten</target>
+            </trans-unit>
+            <trans-unit id="provider.card.description">
+                <source>Configure endpoints, API keys, and timeouts for LLM services.</source>
+                <target>Konfigurieren Sie Endpunkte, API-Schlüssel und Timeouts für LLM-Dienste.</target>
+            </trans-unit>
+            <trans-unit id="provider.card.subtitle">
+                <source>Manage API connections</source>
+                <target>API-Verbindungen verwalten</target>
+            </trans-unit>
+            <trans-unit id="provider.card.title">
+                <source>API Providers</source>
+                <target>API-Provider</target>
+            </trans-unit>
+            <trans-unit id="reference.php.title">
+                <source>Usage in PHP</source>
+                <target>Verwendung in PHP</target>
+            </trans-unit>
+            <trans-unit id="reference.title">
+                <source>Quick Reference</source>
+                <target>Kurzreferenz</target>
+            </trans-unit>
+            <trans-unit id="saving">
+                <source>Saving...</source>
+                <target>Wird gespeichert …</target>
+            </trans-unit>
+            <trans-unit id="savingConfiguration">
+                <source>Saving configuration...</source>
+                <target>Konfiguration wird gespeichert …</target>
+            </trans-unit>
+            <trans-unit id="setupComplete">
+                <source>Setup Complete!</source>
+                <target>Einrichtung abgeschlossen!</target>
+            </trans-unit>
+            <trans-unit id="task.card.button">
+                <source>Manage Tasks</source>
+                <target>Aufgaben verwalten</target>
+            </trans-unit>
+            <trans-unit id="task.card.description">
+                <source>One-shot prompts for common operations. Not AI agents - limited capabilities.</source>
+                <target>Einmal-Prompts für gängige Vorgänge. Keine KI-Agenten – eingeschränkte Fähigkeiten.</target>
+            </trans-unit>
+            <trans-unit id="task.card.subtitle">
+                <source>Simple prompt templates</source>
+                <target>Einfache Prompt-Vorlagen</target>
+            </trans-unit>
+            <trans-unit id="task.card.title">
+                <source>Tasks (One-Shot)</source>
+                <target>Aufgaben (Einmal)</target>
+            </trans-unit>
+            <trans-unit id="wizard.callout.button">
+                <source>Start Setup Wizard</source>
+                <target>Einrichtungsassistenten starten</target>
+            </trans-unit>
+            <trans-unit id="wizard.callout.message">
+                <source>Use the Setup Wizard to auto-configure your provider, discover models, and generate configuration presets.</source>
+                <target>Nutzen Sie den Einrichtungsassistenten, um Ihren Provider automatisch zu konfigurieren, Modelle zu ermitteln und Konfigurationsvoreinstellungen zu generieren.</target>
+            </trans-unit>
+            <trans-unit id="wizard.callout.title">
+                <source>New to LLM Integration?</source>
+                <target>Neu bei der LLM-Integration?</target>
+            </trans-unit>
+            <trans-unit id="wizard.launch">
+                <source>Launch Setup Wizard</source>
+                <target>Einrichtungsassistenten öffnen</target>
+            </trans-unit>
+            <trans-unit id="wizard.selectModels.description">
+                <source>Select the models you want to add to your configuration. Recommended models are pre-selected.</source>
+                <target>Wählen Sie die Modelle aus, die Sie Ihrer Konfiguration hinzufügen möchten. Empfohlene Modelle sind vorausgewählt.</target>
+            </trans-unit>
+            <trans-unit id="wizard.step1.description">
+                <source>Enter your LLM provider's API endpoint and credentials. The wizard will auto-detect the provider type and configure everything for you.</source>
+                <target>Geben Sie den API-Endpunkt und die Zugangsdaten Ihres LLM-Providers ein. Der Assistent erkennt den Provider-Typ automatisch und konfiguriert alles für Sie.</target>
+            </trans-unit>
+            <trans-unit id="wizard.step1.title">
+                <source>Connect to LLM Provider</source>
+                <target>Mit LLM-Provider verbinden</target>
+            </trans-unit>
+            <trans-unit id="wizard.step2.title">
+                <source>Verify Connection</source>
+                <target>Verbindung überprüfen</target>
+            </trans-unit>
+            <trans-unit id="wizard.step3.title">
+                <source>Select Models</source>
+                <target>Modelle auswählen</target>
+            </trans-unit>
+            <trans-unit id="wizard.step4.description">
+                <source>The following configuration presets have been generated for common use cases. Select the ones you want to create.</source>
+                <target>Die folgenden Konfigurationsvoreinstellungen wurden für gängige Anwendungsfälle generiert. Wählen Sie die aus, die Sie erstellen möchten.</target>
+            </trans-unit>
+            <trans-unit id="wizard.step4.loading">
+                <source>Using AI to generate optimal configuration presets...</source>
+                <target>KI generiert optimale Konfigurationsvoreinstellungen …</target>
+            </trans-unit>
+            <trans-unit id="wizard.step4.title">
+                <source>Configuration Presets</source>
+                <target>Konfigurationsvoreinstellungen</target>
+            </trans-unit>
+            <trans-unit id="wizard.step5.title">
+                <source>Review &amp; Save</source>
+                <target>Prüfen &amp; Speichern</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1629,6 +1629,144 @@
             <trans-unit id="error.tool.unknownTool">
                 <source>Unknown tool</source>
             </trans-unit>
+            <trans-unit id="card.count.configurations">
+                <source>configuration(s) configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.models">
+                <source>model(s) configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.none.configurations">
+                <source>No configurations configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.none.models">
+                <source>No models configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.none.providers">
+                <source>No providers configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.none.tasks">
+                <source>No tasks yet</source>
+            </trans-unit>
+            <trans-unit id="card.count.providers">
+                <source>provider(s) configured</source>
+            </trans-unit>
+            <trans-unit id="card.count.tasks">
+                <source>task(s) configured</source>
+            </trans-unit>
+            <trans-unit id="configuration.card.button">
+                <source>Manage Configurations</source>
+            </trans-unit>
+            <trans-unit id="configuration.card.description">
+                <source>Create named configurations with prompts, parameters, and limits.</source>
+            </trans-unit>
+            <trans-unit id="configuration.card.subtitle">
+                <source>Use-case specific presets</source>
+            </trans-unit>
+            <trans-unit id="configuration.card.title">
+                <source>Configurations</source>
+            </trans-unit>
+            <trans-unit id="connectionSuccessful">
+                <source>Connection Successful</source>
+            </trans-unit>
+            <trans-unit id="discoveringModels">
+                <source>Discovering available models...</source>
+            </trans-unit>
+            <trans-unit id="generatingConfigurations">
+                <source>Generating configurations...</source>
+            </trans-unit>
+            <trans-unit id="model.card.button">
+                <source>Manage Models</source>
+            </trans-unit>
+            <trans-unit id="model.card.description">
+                <source>Configure model definitions, capabilities, and pricing per provider.</source>
+            </trans-unit>
+            <trans-unit id="model.card.subtitle">
+                <source>Define available models</source>
+            </trans-unit>
+            <trans-unit id="model.card.title">
+                <source>LLM Models</source>
+            </trans-unit>
+            <trans-unit id="module.management">
+                <source>LLM Management</source>
+            </trans-unit>
+            <trans-unit id="provider.card.button">
+                <source>Manage Providers</source>
+            </trans-unit>
+            <trans-unit id="provider.card.description">
+                <source>Configure endpoints, API keys, and timeouts for LLM services.</source>
+            </trans-unit>
+            <trans-unit id="provider.card.subtitle">
+                <source>Manage API connections</source>
+            </trans-unit>
+            <trans-unit id="provider.card.title">
+                <source>API Providers</source>
+            </trans-unit>
+            <trans-unit id="reference.php.title">
+                <source>Usage in PHP</source>
+            </trans-unit>
+            <trans-unit id="reference.title">
+                <source>Quick Reference</source>
+            </trans-unit>
+            <trans-unit id="saving">
+                <source>Saving...</source>
+            </trans-unit>
+            <trans-unit id="savingConfiguration">
+                <source>Saving configuration...</source>
+            </trans-unit>
+            <trans-unit id="setupComplete">
+                <source>Setup Complete!</source>
+            </trans-unit>
+            <trans-unit id="task.card.button">
+                <source>Manage Tasks</source>
+            </trans-unit>
+            <trans-unit id="task.card.description">
+                <source>One-shot prompts for common operations. Not AI agents - limited capabilities.</source>
+            </trans-unit>
+            <trans-unit id="task.card.subtitle">
+                <source>Simple prompt templates</source>
+            </trans-unit>
+            <trans-unit id="task.card.title">
+                <source>Tasks (One-Shot)</source>
+            </trans-unit>
+            <trans-unit id="wizard.callout.button">
+                <source>Start Setup Wizard</source>
+            </trans-unit>
+            <trans-unit id="wizard.callout.message">
+                <source>Use the Setup Wizard to auto-configure your provider, discover models, and generate configuration presets.</source>
+            </trans-unit>
+            <trans-unit id="wizard.callout.title">
+                <source>New to LLM Integration?</source>
+            </trans-unit>
+            <trans-unit id="wizard.launch">
+                <source>Launch Setup Wizard</source>
+            </trans-unit>
+            <trans-unit id="wizard.selectModels.description">
+                <source>Select the models you want to add to your configuration. Recommended models are pre-selected.</source>
+            </trans-unit>
+            <trans-unit id="wizard.step1.description">
+                <source>Enter your LLM provider's API endpoint and credentials. The wizard will auto-detect the provider type and configure everything for you.</source>
+            </trans-unit>
+            <trans-unit id="wizard.step1.title">
+                <source>Connect to LLM Provider</source>
+            </trans-unit>
+            <trans-unit id="wizard.step2.title">
+                <source>Verify Connection</source>
+            </trans-unit>
+            <trans-unit id="wizard.step3.title">
+                <source>Select Models</source>
+            </trans-unit>
+            <trans-unit id="wizard.step4.description">
+                <source>The following configuration presets have been generated for common use cases. Select the ones you want to create.</source>
+            </trans-unit>
+            <trans-unit id="wizard.step4.loading">
+                <source>Using AI to generate optimal configuration presets...</source>
+            </trans-unit>
+            <trans-unit id="wizard.step4.title">
+                <source>Configuration Presets</source>
+            </trans-unit>
+            <trans-unit id="wizard.step5.title">
+                <source>Review &amp; Save</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/Backend/Glossary.html
+++ b/Resources/Private/Partials/Backend/Glossary.html
@@ -1,3 +1,7 @@
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 <f:comment>
     Shared "Terms &amp; Parameters" glossary card. Collapsed by default so it
     does not clutter list views. Included via <f:render partial="Backend/Glossary" />.

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Configuration/WizardForm.html
+++ b/Resources/Private/Templates/Backend/Configuration/WizardForm.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Configuration/WizardPreview.html
+++ b/Resources/Private/Templates/Backend/Configuration/WizardPreview.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/PromptSnippet/List.html
+++ b/Resources/Private/Templates/Backend/PromptSnippet/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Provider/List.html
+++ b/Resources/Private/Templates/Backend/Provider/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/SetupWizard/Index.html
+++ b/Resources/Private/Templates/Backend/SetupWizard/Index.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Task/Execute.html
+++ b/Resources/Private/Templates/Backend/Task/Execute.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Task/WizardChainPreview.html
+++ b/Resources/Private/Templates/Backend/Task/WizardChainPreview.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Task/WizardForm.html
+++ b/Resources/Private/Templates/Backend/Task/WizardForm.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Task/WizardPreview.html
+++ b/Resources/Private/Templates/Backend/Task/WizardPreview.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -1,6 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Private/Templates/Backend/ToolPlayground/List.html
+++ b/Resources/Private/Templates/Backend/ToolPlayground/List.html
@@ -2,6 +2,10 @@
       xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
       xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
 
 <f:layout name="Module" />
 

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -284,9 +284,9 @@ class TaskExecute {
                 this.renderOutput();
                 this.updateFormatToggle();
 
-                this.outputModel.textContent = response.model || '-';
-                this.outputTokens.textContent = response.usage?.totalTokens || '-';
-                this.outputResult.classList.remove('d-none');
+                if (this.outputModel) this.outputModel.textContent = response.model || '-';
+                if (this.outputTokens) this.outputTokens.textContent = response.usage?.totalTokens || '-';
+                this.outputResult?.classList.remove('d-none');
 
                 Notification.success('Task completed', 'The task has been executed successfully.');
             } else {
@@ -390,7 +390,7 @@ class TaskExecute {
         // With fully sandboxed iframe, contentDocument is inaccessible.
         // Use a generous default height; content scrolls within.
         iframe.style.height = '400px';
-        this.outputContent.appendChild(iframe);
+        this.outputContent?.appendChild(iframe);
     }
 
     /**

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -285,7 +285,8 @@ class TaskExecute {
                 this.updateFormatToggle();
 
                 if (this.outputModel) this.outputModel.textContent = response.model || '-';
-                if (this.outputTokens) this.outputTokens.textContent = response.usage?.totalTokens || '-';
+                // Nullish-coalesce so a valid 0-token total is shown, not '-'.
+                if (this.outputTokens) this.outputTokens.textContent = response.usage?.totalTokens ?? '-';
                 this.outputResult?.classList.remove('d-none');
 
                 Notification.success('Task completed', 'The task has been executed successfully.');
@@ -346,6 +347,12 @@ class TaskExecute {
      *   script execution and blocks access to the parent page's DOM.
      */
     renderOutput() {
+        // All render helpers write into this.outputContent; guard once here so
+        // each of them can assume it is present.
+        if (!this.outputContent) {
+            return;
+        }
+
         const content = this._rawContent;
         const escaped = escapeHtml(content);
 
@@ -390,7 +397,7 @@ class TaskExecute {
         // With fully sandboxed iframe, contentDocument is inaccessible.
         // Use a generous default height; content scrolls within.
         iframe.style.height = '400px';
-        this.outputContent?.appendChild(iframe);
+        this.outputContent.appendChild(iframe);
     }
 
     /**

--- a/Tests/Functional/Repository/ModelRepositoryTest.php
+++ b/Tests/Functional/Repository/ModelRepositoryTest.php
@@ -152,6 +152,30 @@ final class ModelRepositoryTest extends AbstractFunctionalTestCase
         }
     }
 
+    #[Test]
+    public function countByProviderCountsHiddenActiveModels(): void
+    {
+        // findActive() ignores enable-fields (initializeObject →
+        // setIgnoreEnableFields), so a hidden but active model must still be
+        // counted — the grouped query must not apply the HiddenRestriction.
+        $before = $this->repository->countByProvider()[1] ?? 0;
+
+        $this->getConnection()->insert('tx_nrllm_model', [
+            'pid'          => 0,
+            'identifier'   => 'hidden-active',
+            'name'         => 'Hidden Active',
+            'provider_uid' => 1,
+            'model_id'     => 'hidden-active',
+            'is_active'    => 1,
+            'hidden'       => 1,
+            'deleted'      => 0,
+        ]);
+
+        $after = $this->repository->countByProvider()[1] ?? 0;
+
+        self::assertSame($before + 1, $after);
+    }
+
     // =========================================================================
     // Pathway 3.3: Toggle Model Status
     // =========================================================================

--- a/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
+++ b/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
@@ -275,7 +275,10 @@ class InputSanitizationFuzzyTest extends AbstractFuzzyTestCase
                 $config->setMaxTokens($value);
 
                 $result = $config->getMaxTokens();
-                $this->assertGreaterThanOrEqual(1, $result);
+                // setMaxTokens() clamps to a lower bound of 1 (no upper cap).
+                // Assert the exact contract for every boundary rather than a
+                // tautological >= 1 (which max(1, …) can never fail).
+                self::assertSame(max(1, $value), $result);
             });
     }
 

--- a/Tests/Unit/Controller/Backend/DTO/ExecuteTaskRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/ExecuteTaskRequestTest.php
@@ -101,7 +101,9 @@ class ExecuteTaskRequestTest extends AbstractUnitTestCase
             'non-numeric string' => ['abc', 0],
             'array' => [['test'], 0],
             'float string' => ['12.5', 12],
-            'negative' => [-5, -5],
+            // A negative uid is invalid (never a real record id) and is rejected
+            // to the default, matching the other invalid inputs above.
+            'negative' => [-5, 0],
         ];
     }
 

--- a/Tests/Unit/Controller/Backend/DTO/FetchRecordsRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/FetchRecordsRequestTest.php
@@ -201,8 +201,10 @@ class FetchRecordsRequestTest extends AbstractUnitTestCase
         return [
             'non-numeric string' => ['abc', 50],
             'array' => [['test'], 50],
-            'zero' => [0, 0],
-            'negative' => [-10, -10],
+            // Zero and negative limits are clamped up to the minimum of 1 so an
+            // invalid bound can never reach the query.
+            'zero' => [0, 1],
+            'negative' => [-10, 1],
         ];
     }
 

--- a/Tests/Unit/Controller/Backend/DTO/RefreshInputRequestTest.php
+++ b/Tests/Unit/Controller/Backend/DTO/RefreshInputRequestTest.php
@@ -89,8 +89,10 @@ class RefreshInputRequestTest extends AbstractUnitTestCase
             'array' => [['test'], 0],
             'float' => [12.5, 12],
             'float string' => ['12.5', 12],
-            'negative' => [-5, -5],
-            'negative string' => ['-10', -10],
+            // Negative uids are invalid (never a real record id) and reject to
+            // the default, matching the other invalid inputs.
+            'negative' => [-5, 0],
+            'negative string' => ['-10', 0],
             'empty string' => ['', 0],
             'boolean true' => [true, 0],
             'boolean false' => [false, 0],


### PR DESCRIPTION
Follow-up to the round-6 24-lens audit (#289 fixed the one genuine high). This addresses the **medium/low findings**, each verified against the code first (the audit over-rates severity, so a few turned out to be false positives — noted below).

## Fixed (12 atomic commits)

**Security / data-leakage**
- **Exception-message hygiene** — `ErrorResponse` sanitises at the AJAX boundary (covers every controller at once); Whisper/TTS throw a static message and log the Throwable; `SkillSyncService` sanitises before persisting to the user-visible `sync_error`.
- **ToolLoopService** — cap tool results at 50 KB (`mb_strcut`, multibyte-safe) so a tool can't flood the message list / bypass the token budget; log tool failures generically (no raw DBAL message).

**Correctness / validation**
- **Request DTOs** — reject non-positive uid; clamp record limit to ≥ 1 (tests updated to the validated behaviour).
- **PromptTemplateService** — whitelist versionable fields (no mass-assignment via the dynamic setter dispatch).
- **SetupWizardController** — keep only string model capabilities; clearer null-safe fallback.
- **WizardGeneratorService** — log the cause before falling back instead of swallowing it.

**Performance**
- **ModelRepository::countByProvider** — single `GROUP BY` query instead of N+1 lazy `getProvider()`.

**Conformance / quality**
- FlashMessage instantiated directly (not `makeInstance`); braced `{#…}` TCA `foreign_table_where`; explicit `public: false` on the 4 private aliases; SPDX headers on 18 templates; exact `maxTokens` clamp assertion (was tautological); optional-chaining guards in `TaskExecute.js`.

**i18n / docs**
- 46 backend translation keys added to `locallang.xlf` + German targets in `de.locallang.xlf` (were template `default=` only).
- ADR-038 now lists all four `ToolInterface` methods.

## Verified false positives (no change — a "fix" would be wrong)
- **Analytics `f:format.raw` JSON** — already safe via `JSON_HEX_TAG|AMP|APOS|QUOT`; the suggested `f:format.json()` doesn't exist in TYPO3 Fluid.
- **`TaskExecute.js` srcdoc / innerHTML** — the iframe is `sandbox=''` and the innerHTML is pre-escaped via `escapeHtml()` (both documented in-code).
- **`getAvailableProviders(): array`** — already has the `@return array<string, ProviderInterface>` docblock; PHPStan L10 narrows from it.

## Consciously left (with rationale, not silently dropped)
- **N+1 in `unsetAllDefaults` (×2) and `ModelSelectionService`** — rare / low-cardinality admin paths; the "fix" means raw SQL bypassing the Extbase identity map (real risk) for negligible gain, and Extbase already memoises the relation per entity. `countByProvider` (a read-display method) was worth it and is fixed.

## Verification (PHP 8.4)
PHPStan L10 ✓ · CGL ✓ · unit 3809 tests ✓ · functional 940 tests ✓