### PR TITLE
fix: multi-lens audit fixes — security, provider correctness, schema, usage, docs

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -158,8 +158,16 @@ abstract class AbstractProvider implements ProviderInterface
             return $this->configuredHttpClient;
         }
 
-        // For providers without API key, use httpClientFactory directly
+        // For providers without API key, use httpClientFactory directly.
+        // The authenticated path is gated by VaultHttpClient::sendRequest(),
+        // which rejects disallowed hosts via isHostAllowed(); the raw factory
+        // client has no such per-request gate, and the SSRF DNS-pin middleware
+        // deliberately skips IP-literal targets (trusting an isHostAllowed()
+        // call that never runs on this path). Gate the configured endpoint
+        // host here so an api-key-less provider (e.g. Ollama) pointed at a
+        // private/metadata IP literal cannot bypass the private-range filter.
         if ($this->apiKeyIdentifier === '') {
+            $this->assertEndpointHostAllowed();
             return $this->httpClientFactory->create();
         }
 
@@ -168,6 +176,32 @@ abstract class AbstractProvider implements ProviderInterface
             $this->getSecretPlacement(),
             $this->getSecretPlacementOptions(),
         );
+    }
+
+    /**
+     * Reject an api-key-less provider whose configured endpoint host is not
+     * permitted by nr-vault's SSRF host filter (private / link-local /
+     * loopback / carrier-grade-NAT / cloud-metadata ranges, unless the
+     * operator has opted the host into `allowed_hosts`). This mirrors the gate
+     * {@see VaultHttpClientInterface::sendRequest()} applies to every
+     * authenticated request, closing the IP-literal bypass on the raw
+     * factory-client path.
+     *
+     * @throws ProviderConfigurationException
+     */
+    private function assertEndpointHostAllowed(): void
+    {
+        $host = parse_url($this->baseUrl, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return;
+        }
+
+        if (!$this->httpClientFactory->isHostAllowed($host)) {
+            throw new ProviderConfigurationException(
+                sprintf('Provider endpoint host "%s" is not allowed by the SSRF host filter.', $host),
+                1751452800,
+            );
+        }
     }
 
     /**

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -191,9 +191,28 @@ abstract class AbstractProvider implements ProviderInterface
      */
     private function assertEndpointHostAllowed(): void
     {
-        $host = parse_url($this->baseUrl, PHP_URL_HOST);
-        if (!is_string($host) || $host === '') {
+        $baseUrl = trim($this->baseUrl);
+        if ($baseUrl === '') {
+            // Nothing configured; no absolute request URL can be formed.
             return;
+        }
+
+        // parse_url only populates the host when a scheme is present, so a
+        // schemeless endpoint like "169.254.169.254:11434" would yield a null
+        // host and slip past the gate. Prepend a scheme for parsing when none
+        // is present.
+        $forParsing = preg_match('#^[a-z][a-z0-9+.\-]*://#i', $baseUrl) === 1
+            ? $baseUrl
+            : 'http://' . $baseUrl;
+        $host = parse_url($forParsing, PHP_URL_HOST);
+
+        if (!is_string($host) || $host === '') {
+            // A non-empty but unparseable endpoint is malformed; fail closed
+            // rather than dispatch an unchecked request.
+            throw new ProviderConfigurationException(
+                sprintf('Could not determine the host of provider endpoint "%s".', $this->baseUrl),
+                1751452801,
+            );
         }
 
         if (!$this->httpClientFactory->isHostAllowed($host)) {

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -108,9 +108,22 @@ abstract class AbstractProvider implements ProviderInterface
 
     public function complete(string $prompt, array $options = []): CompletionResponse
     {
-        return $this->chatCompletion([
-            ['role' => 'user', 'content' => $prompt],
-        ], $options);
+        $messages = [];
+
+        // The configuration's system prompt reaches this method via
+        // `options['system_prompt']` (see LlmConfiguration::toOptionsArray()).
+        // chatCompletion() reads the system instruction from the message list,
+        // not from the options, so surface it as a leading system message here
+        // — otherwise a configuration's system prompt is silently dropped on
+        // every single-prompt completion (incl. task execution).
+        $systemPrompt = $options['system_prompt'] ?? null;
+        if (is_string($systemPrompt) && $systemPrompt !== '') {
+            $messages[] = ['role' => 'system', 'content' => $systemPrompt];
+        }
+
+        $messages[] = ['role' => 'user', 'content' => $prompt];
+
+        return $this->chatCompletion($messages, $options);
     }
 
     public function getDefaultModel(): string

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -197,13 +197,14 @@ abstract class AbstractProvider implements ProviderInterface
             return;
         }
 
-        // parse_url only populates the host when a scheme is present, so a
+        // parse_url only populates the host when an authority is present, so a
         // schemeless endpoint like "169.254.169.254:11434" would yield a null
-        // host and slip past the gate. Prepend a scheme for parsing when none
-        // is present.
+        // host and slip past the gate. Prepend a protocol-relative "//" for
+        // parsing when no scheme is present — this exposes the authority to
+        // parse_url without asserting any concrete protocol.
         $forParsing = preg_match('#^[a-z][a-z0-9+.\-]*://#i', $baseUrl) === 1
             ? $baseUrl
-            : 'http://' . $baseUrl;
+            : '//' . $baseUrl;
         $host = parse_url($forParsing, PHP_URL_HOST);
 
         if (!is_string($host) || $host === '') {

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -129,6 +129,38 @@ final class ClaudeProvider extends AbstractProvider implements
     }
 
     /**
+     * Build the Anthropic sampling parameters shared by the chat, tool and
+     * streaming payloads.
+     *
+     * Anthropic accepts `temperature` in [0.0, 1.0] and rejects anything above
+     * 1.0 with an HTTP 400. The configuration layer clamps temperature to the
+     * OpenAI-style [0.0, 2.0] range, so a configured value in (1.0, 2.0] must be
+     * clamped down here before it reaches the API. Anthropic also disallows
+     * sending `temperature` and `top_p` together, so prefer the (more commonly
+     * configured) temperature when both are present.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function buildSamplingParams(array $options): array
+    {
+        $params = [];
+
+        if (isset($options['temperature'])) {
+            $params['temperature'] = max(0.0, min(1.0, $this->getFloat($options, 'temperature')));
+        } elseif (isset($options['top_p'])) {
+            $params['top_p'] = max(0.0, min(1.0, $this->getFloat($options, 'top_p')));
+        }
+
+        if (isset($options['stop_sequences'])) {
+            $params['stop_sequences'] = $options['stop_sequences'];
+        }
+
+        return $params;
+    }
+
+    /**
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $options
      */
@@ -153,17 +185,7 @@ final class ClaudeProvider extends AbstractProvider implements
             $payload['system'] = $converted['systemMessage'];
         }
 
-        // Anthropic does not allow both temperature and top_p simultaneously.
-        // If both are set, prefer temperature (the more commonly configured one).
-        if (isset($options['temperature'])) {
-            $payload['temperature'] = $this->getFloat($options, 'temperature');
-        } elseif (isset($options['top_p'])) {
-            $payload['top_p'] = $this->getFloat($options, 'top_p');
-        }
-
-        if (isset($options['stop_sequences'])) {
-            $payload['stop_sequences'] = $options['stop_sequences'];
-        }
+        $payload = array_merge($payload, $this->buildSamplingParams($options));
 
         $response = $this->sendRequest('messages', $payload);
 
@@ -232,6 +254,8 @@ final class ClaudeProvider extends AbstractProvider implements
         if ($converted['systemMessage'] !== null) {
             $payload['system'] = $converted['systemMessage'];
         }
+
+        $payload = array_merge($payload, $this->buildSamplingParams($options));
 
         if (isset($options['tool_choice'])) {
             $payload['tool_choice'] = $this->mapToolChoice($options['tool_choice']);
@@ -470,6 +494,8 @@ final class ClaudeProvider extends AbstractProvider implements
         if ($converted['systemMessage'] !== null) {
             $payload['system'] = $converted['systemMessage'];
         }
+
+        $payload = array_merge($payload, $this->buildSamplingParams($options));
 
         $url = rtrim($this->baseUrl, '/') . '/messages';
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -45,7 +45,10 @@ final class GeminiProvider extends AbstractProvider implements
     ];
 
     private const DEFAULT_MODEL = 'gemini-3-flash-preview';
-    private const EMBEDDING_MODEL = 'text-embedding-004';
+    // text-embedding-004 was shut down 2026-01-14 and gemini-embedding-001
+    // retires 2026-07-14; gemini-embedding-2 is the current GA default and
+    // remains compatible with the text-only embedContent request below.
+    private const EMBEDDING_MODEL = 'gemini-embedding-2';
 
     public function getName(): string
     {

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -86,14 +86,21 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         LlmConfiguration $configuration,
         mixed $result,
     ): void {
-        [$usage, $provider] = $this->extractUsage($result);
+        [$usage, $provider, $responseModel] = $this->extractUsage($result);
         if ($usage === null) {
             return;
         }
 
         $model    = $configuration->getLlmModel();
         $modelUid = $model?->getUid() ?? 0;
+        // Ad-hoc/transient configurations (e.g. the embeddings path) carry no
+        // model, so getModelId() is ''. Fall back to the model the provider
+        // actually reported on the response so per-model analytics attribute
+        // the usage instead of dropping it into an empty-model bucket.
         $modelId  = $configuration->getModelId();
+        if ($modelId === '' && $responseModel !== '') {
+            $modelId = $responseModel;
+        }
 
         // Cost: prefer a cost the provider already computed; otherwise derive
         // it from the model's pricing and the prompt/completion token split.
@@ -137,10 +144,10 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
      * payloads (CacheMiddleware codec shape) carry the same information
      * under `usage` / `provider` keys — the middleware reconstructs a
      * `UsageStatistics` from those so recording happens identically on
-     * both paths. Unrecognised shapes return `[null, '']` so the
+     * both paths. Unrecognised shapes return `[null, '', '']` so the
      * middleware silently skips.
      *
-     * @return array{0: ?UsageStatistics, 1: string}
+     * @return array{0: ?UsageStatistics, 1: string, 2: string}
      */
     private function extractUsage(mixed $result): array
     {
@@ -149,7 +156,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             || $result instanceof EmbeddingResponse
             || $result instanceof VisionResponse
         ) {
-            return [$result->usage, $result->provider];
+            return [$result->usage, $result->provider, $result->model];
         }
 
         if (
@@ -160,10 +167,11 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         ) {
             /** @var array<string, mixed> $usageData */
             $usageData = $result['usage'];
+            $model     = isset($result['model']) && \is_string($result['model']) ? $result['model'] : '';
 
-            return [UsageStatistics::fromArray($usageData), $result['provider']];
+            return [UsageStatistics::fromArray($usageData), $result['provider'], $model];
         }
 
-        return [null, ''];
+        return [null, '', ''];
     }
 }

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -30,8 +30,12 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *  - `array{usage: array, provider: string, ...}` (array payload emitted by
  *    feature services that opt in to CacheMiddleware — CacheMiddleware
  *    stores `array<string, mixed>`, so the terminal is wrapped with a
- *    `$response->toArray()` codec. UsageMiddleware sees the array on both
- *    cache-hit and cache-miss paths and records consistently either way.)
+ *    `$response->toArray()` codec, and UsageMiddleware records from the array
+ *    shape on the cache-MISS path just as it does from a typed response.)
+ *
+ * A cache HIT is NOT recorded here: CacheMiddleware is the outermost layer
+ * (priority 100) and short-circuits with the cached value before Budget/Usage
+ * run, so a served-from-cache response is deliberately not re-billed.
  *
  * Streaming Generator, translation result, raw string, plain array without
  * `usage` / `provider` — silently skipped. Nothing reliable to record for

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -107,9 +107,10 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
     }
 
     /**
-     * Reduce an arbitrary value to the character set TYPO3 accepts for cache
-     * tags (`[a-zA-Z0-9_%\-&]`). Model identifiers legitimately contain `/`
-     * and `:` (e.g. the OpenRouter `anthropic/claude-3.5` or Ollama
+     * Reduce an arbitrary value to the strict `[A-Za-z0-9_]` subset of TYPO3's
+     * allowed cache-tag charset (`[a-zA-Z0-9_%\-&]`) — a deliberately narrower
+     * set that avoids any escaping ambiguity. Model identifiers legitimately
+     * contain `/` and `:` (e.g. the OpenRouter `anthropic/claude-3.5` or Ollama
      * `llama3:8b` form); left unescaped, the TYPO3 cache frontend rejects the
      * whole `set()` call with an InvalidArgumentException, which would abort
      * caching for every affected provider. Any non-conforming byte collapses
@@ -154,7 +155,9 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
         ];
 
         if (isset($options['model']) && is_string($options['model'])) {
-            $tags[] = 'nrllm_model_' . $this->sanitizeTagValue($options['model']);
+            // Cap at TYPO3's 250-char tag limit (prefix included) so an
+            // unusually long model id cannot make the cache frontend reject set().
+            $tags[] = substr('nrllm_model_' . $this->sanitizeTagValue($options['model']), 0, 250);
         }
 
         $this->set($cacheKey, $response, $lifetime, $tags);

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -107,6 +107,21 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
     }
 
     /**
+     * Reduce an arbitrary value to the character set TYPO3 accepts for cache
+     * tags (`[a-zA-Z0-9_%\-&]`). Model identifiers legitimately contain `/`
+     * and `:` (e.g. the OpenRouter `anthropic/claude-3.5` or Ollama
+     * `llama3:8b` form); left unescaped, the TYPO3 cache frontend rejects the
+     * whole `set()` call with an InvalidArgumentException, which would abort
+     * caching for every affected provider. Any non-conforming byte collapses
+     * to `_`; collisions only ever widen a tag's invalidation group, never
+     * corrupt cached data.
+     */
+    private function sanitizeTagValue(string $value): string
+    {
+        return preg_replace('/[^a-zA-Z0-9_]/', '_', $value) ?? '';
+    }
+
+    /**
      * Flush cache entries by provider.
      */
     public function flushByProvider(string $provider): void
@@ -139,7 +154,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
         ];
 
         if (isset($options['model']) && is_string($options['model'])) {
-            $tags[] = 'nrllm_model_' . str_replace(['.', '-'], '_', $options['model']);
+            $tags[] = 'nrllm_model_' . $this->sanitizeTagValue($options['model']);
         }
 
         $this->set($cacheKey, $response, $lifetime, $tags);

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -118,7 +118,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
      */
     private function sanitizeTagValue(string $value): string
     {
-        return preg_replace('/[^a-zA-Z0-9_]/', '_', $value) ?? '';
+        return preg_replace('/\W/', '_', $value) ?? '';
     }
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -445,7 +445,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        return $provider->streamChatCompletion($this->normaliseMessages($messages), $optionsArray);
+        return $provider->streamChatCompletion($this->applySystemPrompt($this->normaliseMessages($messages), $optionsArray), $optionsArray);
     }
 
     /**
@@ -880,7 +880,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        return $adapter->streamChatCompletion($this->normaliseMessages($messages), $options);
+        return $adapter->streamChatCompletion(
+            $this->applySystemPrompt($this->normaliseMessages($messages), $options),
+            $options,
+        );
     }
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -268,7 +268,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
-            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($normalisedMessages, $optionsArray),
+            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->applySystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
@@ -484,7 +484,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->chatCompletionWithTools($normalisedMessages, $normalisedTools, $optionsArray);
+                return $provider->chatCompletionWithTools($this->applySystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
             },
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
@@ -538,7 +538,11 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 $callOptions = array_merge($config->toOptionsArray(), $optionOverrides);
                 unset($callOptions['provider']);
 
-                return $adapter->chatCompletionWithTools($normalisedMessages, $normalisedTools, $callOptions);
+                return $adapter->chatCompletionWithTools(
+                    $this->applySystemPrompt($normalisedMessages, $callOptions),
+                    $normalisedTools,
+                    $callOptions,
+                );
             },
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
@@ -638,7 +642,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 $adapter = $this->getAdapterFromConfiguration($config);
                 $options = array_merge($config->toOptionsArray(), $optionOverrides);
                 unset($options['provider']);
-                return $adapter->chatCompletion($normalisedMessages, $options);
+                return $adapter->chatCompletion($this->applySystemPrompt($normalisedMessages, $options), $options);
             },
             $metadata,
         );
@@ -734,6 +738,43 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         }
 
         return $metadata;
+    }
+
+    /**
+     * Prepend the effective system prompt (from the merged call options) as a
+     * system message when the caller has not already supplied one.
+     *
+     * The provider adapters read the system instruction from the message list,
+     * NOT from `options['system_prompt']`. A configuration's stored system
+     * prompt is surfaced via {@see LlmConfiguration::toOptionsArray()} under
+     * that option key, so without this step it would be silently dropped on
+     * every chat and tool-loop call. An explicit system message already present
+     * in $messages always wins (per-call precedence over the configuration).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function applySystemPrompt(array $messages, array $options): array
+    {
+        $systemPrompt = $options['system_prompt'] ?? null;
+        if (!is_string($systemPrompt) || $systemPrompt === '') {
+            return $messages;
+        }
+
+        foreach ($messages as $message) {
+            $isSystem = $message instanceof ChatMessage
+                ? $message->isSystem()
+                : (is_array($message) && ($message['role'] ?? null) === 'system');
+            if ($isSystem) {
+                return $messages;
+            }
+        }
+
+        array_unshift($messages, ChatMessage::system($systemPrompt));
+
+        return $messages;
     }
 
     /**

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -398,7 +398,14 @@ final class SkillSyncService
             $skill->setAllowedTools('');
         } else {
             $tools = $frontmatter['allowed-tools'] ?? $frontmatter['allowed_tools'] ?? [];
-            $skill->setAllowedTools((string)json_encode(is_array($tools) ? $tools : []));
+            // A string form ("GetTca, GetEnv" / "GetTca GetEnv" / a single name)
+            // is a real declaration, not "no tools": split it into a list rather
+            // than collapsing to the declared-empty (fail-closed, all-tools-off)
+            // list. Only a genuinely empty/whitespace value stays empty.
+            if (is_string($tools)) {
+                $tools = preg_split('/[\s,]+/', trim($tools), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+            }
+            $skill->setAllowedTools((string)json_encode(is_array($tools) ? array_values($tools) : []));
         }
     }
 

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -33,8 +33,8 @@ final readonly class GetEnvTool implements ToolInterface
 
     /**
      * Matches the `user:password@` userinfo of a URL/URI value so credentials
-     * embedded in a non-secret-named connection string (e.g.
-     * REDIS_URL=redis://user:s3cret@host) are redacted while the host/path
+     * embedded in a non-secret-named connection-string variable (a scheme URL
+     * carrying a password before the `@`) are redacted while the host/path
      * stays visible for context.
      */
     private const INLINE_CREDENTIAL_PATTERN = '#([a-z][a-z0-9+.\-]*://)[^:@/\s]+:[^@/\s]+@#i';
@@ -68,8 +68,10 @@ final readonly class GetEnvTool implements ToolInterface
                 $masked = self::REDACTED;
             } else {
                 // Even a non-secret-named variable may carry credentials inside
-                // a connection-string value; strip any inline userinfo.
-                $masked = preg_replace(self::INLINE_CREDENTIAL_PATTERN, '$1' . self::REDACTED . '@', $value) ?? $value;
+                // a connection-string value; strip any inline userinfo. Fail
+                // closed: a PCRE error (null) redacts the whole value rather
+                // than egressing a possibly-credential-bearing string.
+                $masked = preg_replace(self::INLINE_CREDENTIAL_PATTERN, '$1' . self::REDACTED . '@', $value) ?? self::REDACTED;
             }
             $lines[] = $name . '=' . $masked;
         }

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -37,7 +37,7 @@ final readonly class GetEnvTool implements ToolInterface
      * carrying a password before the `@`) are redacted while the host/path
      * stays visible for context.
      */
-    private const INLINE_CREDENTIAL_PATTERN = '#([a-z][a-z0-9+.\-]*://)[^:@/\s]+:[^@/\s]+@#i';
+    private const INLINE_CREDENTIAL_PATTERN = '#([a-z][a-z0-9+.\-]*://)[^:@/\s]*:[^@/\s]+@#i';
 
     private const REDACTED = '***redacted***';
 

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -29,7 +29,15 @@ final readonly class GetEnvTool implements ToolInterface
     use CollectsEnvironmentTrait;
     use SafeCastTrait;
 
-    private const SECRET_PATTERN = '/PASS|PASSWORD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i';
+    private const SECRET_PATTERN = '/PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i';
+
+    /**
+     * Matches the `user:password@` userinfo of a URL/URI value so credentials
+     * embedded in a non-secret-named connection string (e.g.
+     * REDIS_URL=redis://user:s3cret@host) are redacted while the host/path
+     * stays visible for context.
+     */
+    private const INLINE_CREDENTIAL_PATTERN = '#([a-z][a-z0-9+.\-]*://)[^:@/\s]+:[^@/\s]+@#i';
 
     private const REDACTED = '***redacted***';
 
@@ -56,7 +64,13 @@ final readonly class GetEnvTool implements ToolInterface
         ksort($env);
         $lines = [];
         foreach ($env as $name => $value) {
-            $masked  = preg_match(self::SECRET_PATTERN, $name) === 1 ? self::REDACTED : $value;
+            if (preg_match(self::SECRET_PATTERN, $name) === 1) {
+                $masked = self::REDACTED;
+            } else {
+                // Even a non-secret-named variable may carry credentials inside
+                // a connection-string value; strip any inline userinfo.
+                $masked = preg_replace(self::INLINE_CREDENTIAL_PATTERN, '$1' . self::REDACTED . '@', $value) ?? $value;
+            }
             $lines[] = $name . '=' . $masked;
         }
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -187,9 +187,17 @@ final readonly class ToolLoopService
                 true,
                 UsageStatistics::fromTokens($promptTokens, $completionTokens),
             );
-        } catch (BudgetExceededException) {
+        } catch (BudgetExceededException $e) {
             // Budget fires pre-flight and tools are read-only, so the partial
-            // trace is consistent. Surface what ran rather than aborting.
+            // trace is consistent. Surface what ran rather than aborting — but
+            // log the denial (with the tripped bucket) so operators can tell a
+            // budget stop from an iteration cap, since both surface as
+            // truncated=true with an empty final answer.
+            $this->logger?->warning(
+                'Tool loop stopped: budget pre-flight denied the call.',
+                ['exception' => $e],
+            );
+
             return new ToolLoopResult(
                 '',
                 $trace,

--- a/Classes/Service/UsageTrackerService.php
+++ b/Classes/Service/UsageTrackerService.php
@@ -71,6 +71,10 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
         // the aggregation key: specialized calls carry model_uid=0 with only the
         // model_id string, so without it different models (gpt-image-2 vs dall-e-3)
         // would collide into one daily row and break the per-model breakdowns.
+        // configuration_uid is part of the key too — it is stored on the row,
+        // indexed (config_lookup) and grouped on by the analytics module, so two
+        // configurations on the same model must not merge into one row (which
+        // would keep only the first configuration_uid and misattribute usage).
         $existingUid = $queryBuilder
             ->select('uid')
             ->from(self::TABLE)
@@ -78,6 +82,7 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
                 $queryBuilder->expr()->eq('service_type', $queryBuilder->createNamedParameter($serviceType)),
                 $queryBuilder->expr()->eq('service_provider', $queryBuilder->createNamedParameter($provider)),
                 $queryBuilder->expr()->eq('be_user', $beUser),
+                $queryBuilder->expr()->eq('configuration_uid', $configurationUid ?? 0),
                 $queryBuilder->expr()->eq('model_uid', $modelUid),
                 $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($modelId)),
                 $queryBuilder->expr()->eq('task_uid', $taskUid),

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -30,7 +30,7 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;identity,
                     --palette--;;provider,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.parameters,
@@ -44,7 +44,7 @@ return [
                     fallback_chain,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.access,
                     allowed_groups,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     --palette--;;status
             ',

--- a/Configuration/TCA/tx_nrllm_model.php
+++ b/Configuration/TCA/tx_nrllm_model.php
@@ -30,7 +30,7 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;identity,
                     provider_uid,
                     model_id,
@@ -39,7 +39,7 @@ return [
                     --palette--;;limits,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.pricing,
                     --palette--;;pricing,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     --palette--;;status
             ',

--- a/Configuration/TCA/tx_nrllm_promptsnippet.php
+++ b/Configuration/TCA/tx_nrllm_promptsnippet.php
@@ -30,12 +30,12 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;identity,
                     tags,
                     snippet,
                     metadata,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     --palette--;;status,
             ',
         ],

--- a/Configuration/TCA/tx_nrllm_provider.php
+++ b/Configuration/TCA/tx_nrllm_provider.php
@@ -32,14 +32,14 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;identity,
                     adapter_type,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.connection,
                     --palette--;;connection,
                     --palette--;;request,
                     options,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     is_active,
                     priority

--- a/Configuration/TCA/tx_nrllm_skill.php
+++ b/Configuration/TCA/tx_nrllm_skill.php
@@ -34,7 +34,7 @@ return [
                     identifier,
                     description,
                     body,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:metadata,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.metadata,
                     support_status,
                     unsupported_notes,
                     allowed_tools,

--- a/Configuration/TCA/tx_nrllm_skill.php
+++ b/Configuration/TCA/tx_nrllm_skill.php
@@ -29,19 +29,19 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     name,
                     identifier,
                     description,
                     body,
-                --div--;core.form.tabs:metadata,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:metadata,
                     support_status,
                     unsupported_notes,
                     allowed_tools,
                     source_sha,
                     body_checksum,
                     raw_frontmatter,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     enabled,
                     orphaned,
                     hidden,

--- a/Configuration/TCA/tx_nrllm_skill_source.php
+++ b/Configuration/TCA/tx_nrllm_skill_source.php
@@ -34,7 +34,7 @@ return [
                     type,
                     url,
                     ref,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:metadata,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.metadata,
                     pinned_sha,
                     sync_status,
                     sync_error,

--- a/Configuration/TCA/tx_nrllm_skill_source.php
+++ b/Configuration/TCA/tx_nrllm_skill_source.php
@@ -29,17 +29,17 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     title,
                     type,
                     url,
                     ref,
-                --div--;core.form.tabs:metadata,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:metadata,
                     pinned_sha,
                     sync_status,
                     sync_error,
                     last_synced,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     enabled,
                     hidden,
             ',

--- a/Configuration/TCA/tx_nrllm_task.php
+++ b/Configuration/TCA/tx_nrllm_task.php
@@ -30,7 +30,7 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;identity,
                     --palette--;;settings,
                     prompt_template,
@@ -38,7 +38,7 @@ return [
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_task.tab.input_output,
                     --palette--;;input,
                     --palette--;;output,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     --palette--;;status,
             ',
         ],
@@ -81,7 +81,7 @@ return [
                 'size' => 30,
                 'max' => 100,
                 'trim' => true,
-                'eval' => 'alphanum_x,lower',
+                'eval' => 'alphanum_x,lower,unique',
                 'required' => true,
                 'placeholder' => 'analyze-syslog',
             ],
@@ -128,7 +128,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'tx_nrllm_configuration',
-                'foreign_table_where' => 'AND {#tx_nrllm_configuration}.{#deleted} = 0 ORDER BY tx_nrllm_configuration.name',
+                'foreign_table_where' => 'AND {#tx_nrllm_configuration}.{#hidden} = 0 AND {#tx_nrllm_configuration}.{#deleted} = 0 ORDER BY tx_nrllm_configuration.name',
                 'items' => [
                     ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_task.configuration_uid.default', 'value' => 0],
                 ],

--- a/Configuration/TCA/tx_nrllm_user_budget.php
+++ b/Configuration/TCA/tx_nrllm_user_budget.php
@@ -28,14 +28,14 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;core.form.tabs:general,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     be_user,
                     is_active,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.daily_limits,
                     --palette--;;daily_limits,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.monthly_limits,
                     --palette--;;monthly_limits,
-                --div--;core.form.tabs:access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden
             ',
         ],

--- a/Documentation/Architecture/Index.rst
+++ b/Documentation/Architecture/Index.rst
@@ -116,7 +116,7 @@ Database table: :sql:`tx_nrllm_provider`
    "name", "string", "Display name (e.g., ``OpenAI Production``)"
    "adapter_type", "string", "Protocol: ``openai``, ``anthropic``, ``gemini``, ``ollama``, etc."
    "endpoint_url", "string", "Custom endpoint (empty = default)"
-   "api_key", "string", "Encrypted API key (using sodium_crypto_secretbox)"
+   "api_key", "string", "nr-vault identifier (UUID) for the encrypted key"
    "organization_id", "string", "Optional organization ID (OpenAI)"
    "timeout", "int", "Request timeout in seconds"
    "max_retries", "int", "Retry count on failure"
@@ -127,7 +127,8 @@ Database table: :sql:`tx_nrllm_provider`
 - One provider = one API key = one billing relationship.
 - Same adapter type can have multiple providers (prod/dev accounts).
 - Adapter type determines the protocol/client class used.
-- API keys are encrypted at rest using sodium.
+- API keys are stored as nr-vault identifiers (UUIDs); the raw key never
+  touches nr-llm's tables.
 
 .. _architecture-model-layer:
 
@@ -265,16 +266,17 @@ Security
 API key encryption
 ------------------
 
-API keys are encrypted at rest in the database
-using :php:`sodium_crypto_secretbox`
-(XSalsa20-Poly1305).
+API keys are never stored as plaintext in nr-llm's own tables. Each provider
+record holds a vault identifier (UUID) issued by the `nr-vault
+<https://github.com/netresearch/t3x-nr-vault>`__ extension, which performs
+envelope encryption with audited access.
 
-- Keys are derived from TYPO3's :php:`encryptionKey` with domain separation.
-- Nonce is randomly generated per encryption (24 bytes).
-- Encrypted values are prefixed with ``enc:`` for detection.
-- Legacy plaintext values are automatically encrypted on first access.
+- The database stores only the vault UUID, never a raw key.
+- Retrieval and injection into outbound requests go through nr-vault's
+  secure, SSRF-guarded HTTP client.
+- Key rotation is handled by nr-vault.
 
-For details, see :ref:`adr-012`.
+For the historical sodium-based design that this replaced, see :ref:`adr-012`.
 
 .. _architecture-adapter-types:
 

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,37 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-13-0:
+
+Version 0.13.0 (2026-06-26)
+===========================
+
+Provider selection is now database-driven end to end. **Breaking:** the
+extension-configuration ``defaultProvider`` fallback is removed — select a
+provider per call (the options object's ``provider`` field) or mark a
+Configuration active and default in the backend module; otherwise
+``getProvider(null)`` throws (ADR-034). The dead ``plugin.tx_nrllm`` TypoScript
+constants/setup were removed and the "no provider specified" error now carries
+actionable backend-module guidance (#254, #255).
+
+For the complete, itemised list see the canonical
+`CHANGELOG.md <https://github.com/netresearch/t3x-nr-llm/blob/main/CHANGELOG.md>`__.
+
+.. _version-0-12-0:
+
+Version 0.12.0 (2026-06-11)
+===========================
+
+Specialized services (image, text-to-speech, transcription) gain full usage and
+cost tracking, join the model registry with ``image``/``text_to_speech``/
+``transcription`` capabilities, and resolve their model and system prompt from
+Configuration records (ADR-032, ADR-033). Adds a prompt-snippet library
+(``tx_nrllm_promptsnippet``, ADR-031), per-request timeouts on the secure HTTP
+client, and arbitrary gpt-image sizes. **Requires nr-vault ^0.10.0.**
+
+For the complete, itemised list see the canonical
+`CHANGELOG.md <https://github.com/netresearch/t3x-nr-llm/blob/main/CHANGELOG.md>`__.
+
 .. _version-0-11-1:
 
 Version 0.11.1 (2026-06-10)

--- a/Documentation/Configuration/Settings.rst
+++ b/Documentation/Configuration/Settings.rst
@@ -43,9 +43,6 @@ Environment variables
    # TYPO3 encryption key (used for API key encryption)
    TYPO3_CONF_VARS__SYS__encryptionKey=your-key
 
-   # Optional: Override default timeout
-   TYPO3_NR_LLM_DEFAULT_TIMEOUT=60
-
 .. _configuration-security:
 
 Security
@@ -79,11 +76,10 @@ Sanitize user input before sending to providers:
 .. code-block:: php
    :caption: Example: Sanitizing user input
 
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
-
-   $sanitizedInput = GeneralUtility::removeXSS(
-       $userInput
-   );
+   // Strip markup and control characters from free-text input before it is
+   // sent to a provider. (GeneralUtility::removeXSS() was removed from the
+   // TYPO3 core and must not be used.)
+   $sanitizedInput = trim(strip_tags($userInput));
 
    $response = $adapter->chatCompletion([
        ['role' => 'user', 'content' => $sanitizedInput],

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -42,7 +42,7 @@ Ensure your system meets these requirements:
 - PHP 8.2 or higher.
 - TYPO3 v13.4 LTS or v14.3 LTS.
 - Composer 2.x.
-- :composer:`netresearch/nr-vault` ^0.6.0 (required for
+- :composer:`netresearch/nr-vault` ^0.10.0 (required for
   API key encryption; installed automatically via
   Composer).
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -39,8 +39,8 @@ The extension enables developers to:
   AI tasks (translation, vision, embeddings).
 - **Cache responses** to reduce API costs and improve performance.
 - **Stream responses** for real-time user experiences.
-- **Store API keys securely** with sodium
-  encryption or nr-vault envelope encryption.
+- **Store API keys securely** as nr-vault
+  identifiers (envelope encryption).
 
 .. _introduction-supported-providers:
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ The **Admin Tools > LLM** backend module gives you full control:
 
 ### Security by default
 
-- **Encrypted API keys** — All keys stored with sodium_crypto_secretbox (XSalsa20-Poly1305),
-  optionally via [nr-vault](https://github.com/netresearch/t3x-nr-vault) envelope encryption
+- **Encrypted API keys** — All keys stored as vault identifiers (UUIDs) via
+  [nr-vault](https://github.com/netresearch/t3x-nr-vault) envelope encryption; nr-llm never stores raw keys
 - **Admin-only access** — Backend module restricted to administrators
 - **No plaintext secrets** — Keys never stored or logged in plain text
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ That's it. Provider selection, API keys, caching, error handling — all managed
 | Capability | Without nr-llm | With nr-llm |
 |---|---|---|
 | Provider switching | Rewrite HTTP calls | Change one admin setting |
-| API key storage | `$GLOBALS` or plaintext | Encrypted (sodium / nr-vault) |
+| API key storage | `$GLOBALS` or plaintext | nr-vault UUIDs (envelope encryption) |
 | Response caching | Build your own | Built-in, TYPO3 caching framework |
 | Streaming (SSE) | Implement per provider | `foreach ($llm->streamChat($msg) as $chunk)` |
 | Error handling | Parse each provider's errors | Typed exceptions with provider context |

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -73,6 +73,10 @@
                 <source>Access Control</source>
                 <target>Zugriffskontrolle</target>
             </trans-unit>
+            <trans-unit id="tab.metadata">
+                <source>Metadata</source>
+                <target>Metadaten</target>
+            </trans-unit>
             <trans-unit id="tab.fallback">
                 <source>Fallback Chain</source>
                 <target>Fallback-Kette</target>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -57,6 +57,9 @@
             <trans-unit id="tab.access">
                 <source>Access Control</source>
             </trans-unit>
+            <trans-unit id="tab.metadata">
+                <source>Metadata</source>
+            </trans-unit>
             <trans-unit id="tab.fallback">
                 <source>Fallback Chain</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/Backend/HtmlEscape.js
+++ b/Resources/Public/JavaScript/Backend/HtmlEscape.js
@@ -19,13 +19,20 @@ const escapeElement = document.createElement('div');
  * Escape HTML entities to prevent XSS attacks.
  * LLM responses are untrusted external content.
  *
+ * The textContent -> innerHTML round-trip escapes `&`, `<` and `>` but NOT
+ * quotes, so the result is unsafe when interpolated into a quoted HTML
+ * attribute value. Escape `"` and `'` as well so the output is safe in both
+ * text and attribute contexts.
+ *
  * @param {string} text - The text to escape
- * @returns {string} - HTML-escaped text
+ * @returns {string} - HTML-escaped text, safe for text and attribute contexts
  */
 export function escapeHtml(text) {
     if (typeof text !== 'string') {
         return '';
     }
     escapeElement.textContent = text;
-    return escapeElement.innerHTML;
+    return escapeElement.innerHTML
+        .replaceAll('"', '&quot;')
+        .replaceAll('\'', '&#39;');
 }

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -42,16 +42,22 @@ class SetupWizard {
     /**
      * Escape HTML entities to prevent XSS attacks.
      * External API data (model names, descriptions, etc.) is untrusted content.
+     * The escaped value is also interpolated into quoted HTML attributes (e.g.
+     * aria-label), so `"` and `'` must be escaped too — the textContent ->
+     * innerHTML round-trip alone leaves quotes intact and would allow attribute
+     * breakout.
      *
      * @param {string} text - The text to escape
-     * @returns {string} - HTML-escaped text
+     * @returns {string} - HTML-escaped text, safe for text and attribute contexts
      */
     escapeHtml(text) {
         if (typeof text !== 'string') {
             return '';
         }
         this._escapeEl.textContent = text;
-        return this._escapeEl.innerHTML;
+        return this._escapeEl.innerHTML
+            .replaceAll('"', '&quot;')
+            .replaceAll('\'', '&#39;');
     }
 
     init() {

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -261,6 +261,22 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function syncSplitsStringFormAllowedToolsIntoList(): void
+    {
+        // A string-form declaration ("A, B") is a real list, not the
+        // declared-empty (all-tools-off) list — it must be split into a list,
+        // not silently collapsed to '[]'.
+        $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH], [
+            self::SKILL_A_PATH => $this->mdWithTools('A', '"GetTca, GetEnv"', 'body a'),
+        ]);
+        $this->service($gitHub)->sync($this->repoSource());
+
+        $skill = $this->get(SkillRepository::class)->findBySourceAndIdentifier(10, self::SKILL_A_ID);
+        self::assertNotNull($skill);
+        self::assertSame('["GetTca","GetEnv"]', $skill->getAllowedTools(), 'string-form allowed-tools splits into a list');
+    }
+
+    #[Test]
     public function resyncAutoDisablesEnabledSkillWhenBodyChanged(): void
     {
         $source = $this->repoSource();

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -267,7 +267,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         // declared-empty (all-tools-off) list — it must be split into a list,
         // not silently collapsed to '[]'.
         $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH], [
-            self::SKILL_A_PATH => $this->mdWithTools('A', '"GetTca, GetEnv"', 'body a'),
+            self::SKILL_A_PATH => $this->mdWithTools('A', '"GetTca, GetEnv"', 'string-tools body content'),
         ]);
         $this->service($gitHub)->sync($this->repoSource());
 

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -131,6 +131,32 @@ final class UsageTrackerServiceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function trackUsageKeepsSeparateRecordsForDifferentConfigurations(): void
+    {
+        // Two configurations on the same model (same everything else) must yield
+        // two rows so per-configuration analytics are not misattributed.
+        $this->service->trackUsage('completion', 'openai', ['tokens' => 10, 'cost' => 0.01], configurationUid: 1, modelId: 'gpt-4o');
+        $this->service->trackUsage('completion', 'openai', ['tokens' => 20, 'cost' => 0.02], configurationUid: 2, modelId: 'gpt-4o');
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $count = $connection->count('*', self::TABLE, ['service_type' => 'completion', 'model_id' => 'gpt-4o']);
+        self::assertSame(2, $count);
+
+        // A repeat call on configuration 1 aggregates into ITS row only.
+        $this->service->trackUsage('completion', 'openai', ['tokens' => 5, 'cost' => 0.01], configurationUid: 1, modelId: 'gpt-4o');
+        $count = $connection->count('*', self::TABLE, ['service_type' => 'completion', 'model_id' => 'gpt-4o']);
+        self::assertSame(2, $count);
+
+        $row = $connection->select(
+            ['request_count'],
+            self::TABLE,
+            ['service_type' => 'completion', 'model_id' => 'gpt-4o', 'configuration_uid' => 1],
+        )->fetchAssociative();
+        self::assertIsArray($row);
+        self::assertSame(2, (int)$row['request_count']);
+    }
+
+    #[Test]
     public function trackUsageKeepsSeparateRecordsForDifferentProviders(): void
     {
         $this->service->trackUsage('translation', 'deepl', ['characters' => 100]);

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -29,6 +29,8 @@ use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 /**
@@ -178,6 +180,58 @@ class AbstractProviderTest extends AbstractUnitTestCase
         $result = $provider->complete('Hello world');
 
         self::assertEquals('Test reply', $result->content);
+    }
+
+    /**
+     * complete() must surface options['system_prompt'] (how a configuration's
+     * system prompt reaches this method) as a leading system message, since the
+     * adapters read the system instruction from the message list.
+     */
+    #[Test]
+    public function completePrependsConfiguredSystemPromptAsSystemMessage(): void
+    {
+        $capturedBody = null;
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $apiResponse = [
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'mistral-large-latest',
+            'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 3, 'total_tokens' => 8],
+        ];
+        $httpClientMock = $this->createHttpClientMock();
+        $httpClientMock->method('sendRequest')->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($httpClientMock);
+
+        $provider->complete('Hello world', ['system_prompt' => 'You are helpful']);
+
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload['messages'] ?? null);
+        self::assertSame(['role' => 'system', 'content' => 'You are helpful'], $payload['messages'][0]);
+        self::assertSame('user', $payload['messages'][1]['role']);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(ClaudeProvider::class)]
@@ -760,6 +761,125 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         $result = $this->subject->chatCompletion($messages, $options);
 
         self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    /**
+     * Anthropic rejects temperature > 1.0 with an HTTP 400, but the
+     * configuration layer clamps to the OpenAI-style [0.0, 2.0] range. A
+     * configured value in (1.0, 2.0] must therefore be clamped down to 1.0
+     * before it reaches the API.
+     */
+    #[Test]
+    public function chatCompletionClampsTemperatureToAnthropicMaximum(): void
+    {
+        $payload = $this->captureChatPayload(['temperature' => 1.8]);
+
+        $this->assertPayloadTemperature($payload, 1.0);
+    }
+
+    #[Test]
+    public function chatCompletionKeepsInRangeTemperatureUnchanged(): void
+    {
+        $payload = $this->captureChatPayload(['temperature' => 0.3]);
+
+        $this->assertPayloadTemperature($payload, 0.3);
+    }
+
+    /**
+     * The tool-calling path must honour the configured sampling parameters,
+     * just like the plain chat path (a Claude tool run previously ignored the
+     * configuration's temperature entirely).
+     */
+    #[Test]
+    public function chatCompletionWithToolsAppliesClampedTemperature(): void
+    {
+        $payload = $this->captureChatPayload(
+            ['temperature' => 1.8],
+            [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])],
+        );
+
+        $this->assertPayloadTemperature($payload, 1.0);
+    }
+
+    /**
+     * Assert the (JSON-decoded) payload carries the expected temperature.
+     * json_encode() serialises a whole float such as 1.0 as `1`, so the
+     * decoded value may be an int — compare numerically after narrowing.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function assertPayloadTemperature(array $payload, float $expected): void
+    {
+        self::assertArrayHasKey('temperature', $payload);
+        $temperature = $payload['temperature'];
+        self::assertIsNumeric($temperature);
+        self::assertEqualsWithDelta($expected, (float)$temperature, 1e-9);
+    }
+
+    /**
+     * Run a Claude completion with a stream factory that captures the encoded
+     * request payload and return it decoded. When $tools is non-empty the
+     * tool-calling path is exercised instead of plain chat.
+     *
+     * @param array<string, mixed> $options
+     * @param list<ToolSpec>       $tools
+     *
+     * @return array<string, mixed>
+     */
+    private function captureChatPayload(array $options, array $tools = []): array
+    {
+        $capturedBody = null;
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $subject = new ClaudeProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'claude-sonnet-4-20250514',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        $subject->setHttpClient($this->httpClientStub);
+
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [['type' => 'text', 'text' => 'Response']],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ];
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $messages = [['role' => 'user', 'content' => 'test']];
+        if ($tools === []) {
+            $subject->chatCompletion($messages, $options);
+        } else {
+            $subject->chatCompletionWithTools($messages, $tools, $options);
+        }
+
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
     }
 
     #[Test]

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -49,7 +49,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 150, 'promptTokens' => 100, 'completionTokens' => 50, 'cost' => 0.0012],
                 7,
                 0,
-                '',
+                'gpt-4o-mini',
                 0,
             );
 
@@ -81,7 +81,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 42, 'promptTokens' => 42, 'completionTokens' => 0],
                 null,
                 0,
-                '',
+                'claude-embed',
                 0,
             );
 
@@ -110,7 +110,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 300, 'promptTokens' => 200, 'completionTokens' => 100, 'cost' => 0.003],
                 12,
                 0,
-                '',
+                'gemini-vision',
                 0,
             );
 
@@ -139,7 +139,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 10, 'promptTokens' => 5, 'completionTokens' => 5],
                 null,
                 0,
-                '',
+                'm',
                 0,
             );
 
@@ -238,7 +238,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 42, 'promptTokens' => 42, 'completionTokens' => 0, 'cost' => 0.0015],
                 null,
                 0,
-                '',
+                'text-embedding-3-small',
                 0,
             );
 
@@ -406,7 +406,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
                 ['tokens' => 10, 'promptTokens' => 5, 'completionTokens' => 5],
                 null,
                 0,
-                '',
+                'm',
                 42,
             );
 

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OllamaProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -90,6 +91,37 @@ class OllamaProviderTest extends AbstractUnitTestCase
     public function getNameReturnsOllama(): void
     {
         self::assertEquals('Ollama', $this->subject->getName());
+    }
+
+    /**
+     * An api-key-less provider (Ollama) pointed at a cloud-metadata / private
+     * IP literal must be rejected by the SSRF host gate before any request is
+     * dispatched — the raw factory-client path used for keyless providers has
+     * no per-request isHostAllowed() gate, and the DNS-pin middleware skips IP
+     * literals. Without the endpoint-host gate this SSRF target would slip
+     * through. No HTTP client is injected here so the real keyless code path
+     * (getHttpClient → assertEndpointHostAllowed) runs.
+     */
+    #[Test]
+    public function keylessProviderRejectsMetadataIpEndpoint(): void
+    {
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'llama3.2',
+            'baseUrl' => 'http://169.254.169.254:11434',
+            'timeout' => 30,
+        ]);
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        $subject->complete('hello');
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -124,6 +124,33 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $subject->complete('hello');
     }
 
+    /**
+     * A schemeless endpoint (no http:// prefix) must not slip past the SSRF
+     * gate: parse_url yields no host without a scheme, so the gate normalises
+     * one before parsing and still rejects the metadata IP.
+     */
+    #[Test]
+    public function keylessProviderRejectsSchemelessMetadataIpEndpoint(): void
+    {
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'llama3.2',
+            'baseUrl' => '169.254.169.254:11434',
+            'timeout' => 30,
+        ]);
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        $subject->complete('hello');
+    }
+
     #[Test]
     public function getIdentifierReturnsOllama(): void
     {

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -346,6 +346,45 @@ class CacheManagerTest extends AbstractUnitTestCase
         $subject->cacheCompletion('openai', $messages, $options, $response);
     }
 
+    /**
+     * Model identifiers with `/` (OpenRouter) or `:` (Ollama) must be reduced
+     * to the TYPO3 cache-tag charset; an unescaped `/` or `:` makes the cache
+     * frontend reject the whole set() call with an InvalidArgumentException.
+     */
+    #[Test]
+    public function cacheCompletionSanitizesModelTagWithSlashAndColon(): void
+    {
+        /** @var array{subject: CacheManager, cacheFrontend: FrontendInterface&MockObject} $setup */
+        $setup = $this->createSubjectWithMockFrontend();
+        $subject = $setup['subject'];
+        $cacheFrontendMock = $setup['cacheFrontend'];
+
+        $messages = [['role' => 'user', 'content' => 'Hello']];
+        $options = ['model' => 'anthropic/claude-3.5:beta'];
+        $response = ['content' => 'Hi'];
+
+        $cacheFrontendMock
+            ->expects(self::once())
+            ->method('set')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(
+                    static function (array $tags): bool {
+                        foreach ($tags as $tag) {
+                            self::assertIsString($tag);
+                            self::assertMatchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/', $tag);
+                        }
+
+                        return in_array('nrllm_model_anthropic_claude_3_5_beta', $tags, true);
+                    },
+                ),
+                self::anything(),
+            );
+
+        $subject->cacheCompletion('openrouter', $messages, $options, $response);
+    }
+
     #[Test]
     public function getCachedCompletionReturnsNullWhenNotCached(): void
     {

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -618,6 +618,95 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertSame($expectedResponse, $result);
     }
 
+    /**
+     * A configuration's stored system prompt must reach the adapter as a
+     * leading system message — the adapters read the system instruction from
+     * the message list, not from options['system_prompt'].
+     */
+    #[Test]
+    public function chatWithConfigurationInjectsConfiguredSystemPrompt(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['temperature' => 0.7, 'system_prompt' => 'You are helpful']);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [
+                    ChatMessage::system('You are helpful'),
+                    ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello']),
+                ],
+                ['temperature' => 0.7, 'system_prompt' => 'You are helpful'],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config);
+    }
+
+    /**
+     * An explicit system message supplied by the caller wins over the
+     * configuration's stored system prompt (per-call precedence).
+     */
+    #[Test]
+    public function chatWithConfigurationKeepsExplicitSystemMessageOverConfigPrompt(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['system_prompt' => 'Config prompt']);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [
+                    ChatMessage::fromArray(['role' => 'system', 'content' => 'Caller prompt']),
+                    ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello']),
+                ],
+                ['system_prompt' => 'Config prompt'],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration(
+            [
+                ['role' => 'system', 'content' => 'Caller prompt'],
+                ['role' => 'user', 'content' => 'Hello'],
+            ],
+            $config,
+        );
+    }
+
     #[Test]
     public function completeWithConfigurationUsesAdapter(): void
     {

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -1032,6 +1032,36 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertEquals(['Streaming', ' response'], $chunks);
     }
 
+    /**
+     * The streaming path must apply the configuration's system prompt too —
+     * the adapters read the system instruction from the message list.
+     */
+    #[Test]
+    public function streamChatWithConfigurationInjectsConfiguredSystemPrompt(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['system_prompt' => 'You are helpful']);
+
+        $adapter = new StubStreamingProvider();
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($adapter);
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        iterator_to_array($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config));
+
+        self::assertEquals(
+            [
+                ChatMessage::system('You are helpful'),
+                ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello']),
+            ],
+            $adapter->capturedMessages,
+        );
+    }
+
     #[Test]
     public function streamChatRoutesThroughDefaultConfigurationWithOptionOverrides(): void
     {
@@ -1647,6 +1677,9 @@ class StubStreamingProvider extends TestableProvider implements StreamingCapable
     /** @var array<string, mixed> */
     public array $capturedOptions = [];
 
+    /** @var list<ChatMessage|array<string, mixed>> */
+    public array $capturedMessages = [];
+
     public function __construct()
     {
         parent::__construct('mock', 'Mock', true);
@@ -1654,6 +1687,7 @@ class StubStreamingProvider extends TestableProvider implements StreamingCapable
 
     public function streamChatCompletion(array $messages, array $options = []): Generator
     {
+        $this->capturedMessages = $messages;
         $this->capturedOptions = $options;
         yield 'Streaming';
         yield ' response';

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -28,22 +28,42 @@ final class GetEnvToolTest extends TestCase
     private const PLAIN_VALUE = 'web-01.example.test';
     private const SECRET_KEY = 'NRLLM_TEST_DB_PASSWORD';
     private const SECRET_VALUE = 'sup3r-s3cr3t-value';
+    // Name uses PWD (not PASS), matched by the secret-name pattern.
+    private const PWD_KEY = 'NRLLM_TEST_MYSQL_PWD';
+    private const PWD_VALUE = 'dbpass123';
+    // Non-secret NAME whose VALUE embeds credentials in a connection URL.
+    private const URL_KEY = 'NRLLM_TEST_REDIS_URL';
+    private const URL_VALUE = 'redis://cacheuser:s3cr3turl@cache-01:6379/0';
 
     protected function setUp(): void
     {
         parent::setUp();
-        putenv(self::PLAIN_KEY . '=' . self::PLAIN_VALUE);
-        putenv(self::SECRET_KEY . '=' . self::SECRET_VALUE);
-        $_ENV[self::PLAIN_KEY]  = self::PLAIN_VALUE;
-        $_ENV[self::SECRET_KEY] = self::SECRET_VALUE;
+        foreach ($this->fixtureEnv() as $name => $value) {
+            putenv($name . '=' . $value);
+            $_ENV[$name] = $value;
+        }
     }
 
     protected function tearDown(): void
     {
-        putenv(self::PLAIN_KEY);
-        putenv(self::SECRET_KEY);
-        unset($_ENV[self::PLAIN_KEY], $_ENV[self::SECRET_KEY]);
+        foreach (array_keys($this->fixtureEnv()) as $name) {
+            putenv($name);
+            unset($_ENV[$name]);
+        }
         parent::tearDown();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fixtureEnv(): array
+    {
+        return [
+            self::PLAIN_KEY  => self::PLAIN_VALUE,
+            self::SECRET_KEY => self::SECRET_VALUE,
+            self::PWD_KEY    => self::PWD_VALUE,
+            self::URL_KEY    => self::URL_VALUE,
+        ];
     }
 
     #[Test]
@@ -64,5 +84,35 @@ final class GetEnvToolTest extends TestCase
         // The secret variable appears, but its value is masked.
         self::assertStringContainsString(self::SECRET_KEY . '=***redacted***', $output);
         self::assertStringNotContainsString(self::SECRET_VALUE, $output);
+    }
+
+    #[Test]
+    public function pwdStyleSecretNameIsRedacted(): void
+    {
+        $output = (new GetEnvTool())->execute([]);
+
+        // MYSQL_PWD uses PWD, not PASS — it must still be caught.
+        self::assertStringContainsString(self::PWD_KEY . '=***redacted***', $output);
+        self::assertStringNotContainsString(self::PWD_VALUE, $output);
+    }
+
+    #[Test]
+    public function inlineUrlCredentialsAreRedactedWhileHostRemains(): void
+    {
+        $output = (new GetEnvTool())->execute([]);
+
+        // The variable NAME is not secret-looking, but its VALUE embeds
+        // credentials: the userinfo is stripped, the host/port kept for context.
+        self::assertStringNotContainsString('s3cr3turl', $output);
+        self::assertStringNotContainsString('cacheuser', $output);
+        self::assertStringContainsString(self::URL_KEY . '=redis://***redacted***@cache-01:6379/0', $output);
+    }
+
+    #[Test]
+    public function requiresAdminIsTrue(): void
+    {
+        // Security invariant: get_env egresses host/cross-user data and must
+        // stay admin-gated. Pin it so a refactor cannot silently flip it.
+        self::assertTrue((new GetEnvTool())->requiresAdmin());
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -34,6 +34,9 @@ final class GetEnvToolTest extends TestCase
     // Non-secret NAME whose VALUE embeds credentials in a connection URL.
     private const URL_KEY = 'NRLLM_TEST_REDIS_URL';
     private const URL_VALUE = 'redis://cacheuser:s3cr3turl@cache-01:6379/0';
+    // Same, but with an EMPTY username (redis://:password@host).
+    private const NOUSER_URL_KEY = 'NRLLM_TEST_NOUSER_URL';
+    private const NOUSER_URL_VALUE = 'redis://:s3cr3tnouser@cache-02:6379/0';
 
     protected function setUp(): void
     {
@@ -59,10 +62,11 @@ final class GetEnvToolTest extends TestCase
     private function fixtureEnv(): array
     {
         return [
-            self::PLAIN_KEY  => self::PLAIN_VALUE,
-            self::SECRET_KEY => self::SECRET_VALUE,
-            self::PWD_KEY    => self::PWD_VALUE,
-            self::URL_KEY    => self::URL_VALUE,
+            self::PLAIN_KEY       => self::PLAIN_VALUE,
+            self::SECRET_KEY      => self::SECRET_VALUE,
+            self::PWD_KEY         => self::PWD_VALUE,
+            self::URL_KEY         => self::URL_VALUE,
+            self::NOUSER_URL_KEY  => self::NOUSER_URL_VALUE,
         ];
     }
 
@@ -106,6 +110,17 @@ final class GetEnvToolTest extends TestCase
         self::assertStringNotContainsString('s3cr3turl', $output);
         self::assertStringNotContainsString('cacheuser', $output);
         self::assertStringContainsString(self::URL_KEY . '=redis://***redacted***@cache-01:6379/0', $output);
+    }
+
+    #[Test]
+    public function inlineUrlCredentialsWithEmptyUsernameAreRedacted(): void
+    {
+        $output = (new GetEnvTool())->execute([]);
+
+        // redis://:password@host has no username — the password must still be
+        // stripped rather than leaking to the provider.
+        self::assertStringNotContainsString('s3cr3tnouser', $output);
+        self::assertStringContainsString(self::NOUSER_URL_KEY . '=redis://***redacted***@cache-02:6379/0', $output);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -320,6 +320,33 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function budgetExceededIsLoggedServerSide(): void
+    {
+        // A budget stop and an iteration-cap stop both surface as
+        // truncated=true with an empty answer; the denial must be logged so
+        // operators can tell them apart (and see which bucket tripped).
+        $budgetException = new BudgetExceededException(
+            BudgetCheckResult::denied(BudgetCheckResult::LIMIT_MONTHLY_COST, 10.0, 5.0),
+        );
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willThrowException($budgetException);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('budget'),
+                self::callback(static fn(array $ctx): bool => ($ctx['exception'] ?? null) instanceof BudgetExceededException),
+            );
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]), $logger);
+        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), null);
+
+        self::assertTrue($result->truncated);
+    }
+
+    #[Test]
     public function usageTokensSummedAcrossIterations(): void
     {
         $mgr   = self::createStub(LlmServiceManagerInterface::class);

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -347,6 +347,29 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function oversizedToolResultIsCappedToMaxBytes(): void
+    {
+        // A tool returning more than the byte cap must be truncated before it is
+        // fed back to the model, with a visible marker.
+        $big = str_repeat('x', 60000);
+
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'big_tool', [])]),
+            $this->response('done'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('big_tool', $big)]));
+        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+
+        self::assertCount(1, $result->trace);
+        $toolResult = $result->trace[0]->result;
+        self::assertLessThanOrEqual(50000, strlen($toolResult));
+        self::assertStringContainsString('tool result truncated', $toolResult);
+    }
+
+    #[Test]
     public function usageTokensSummedAcrossIterations(): void
     {
         $mgr   = self::createStub(LlmServiceManagerInterface::class);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -188,7 +188,10 @@ CREATE TABLE tx_nrllm_user_budget (
 
     PRIMARY KEY (uid),
     KEY parent (pid),
-    UNIQUE KEY be_user (be_user)
+    -- No DB UNIQUE on be_user: a soft-deleted row keeps its be_user value in
+    -- the index and would block re-creating a budget for that user. One budget
+    -- per user is enforced in application logic (repository getFirst()).
+    KEY be_user (be_user)
 );
 
 #
@@ -251,7 +254,10 @@ CREATE TABLE tx_nrllm_task (
     PRIMARY KEY (uid),
     KEY parent (pid),
     KEY configuration_uid (configuration_uid),
-    UNIQUE KEY identifier (identifier),
+    -- No DB UNIQUE on identifier: a soft-deleted row keeps its identifier in
+    -- the index and would block recreating/re-seeding a task with the same
+    -- identifier. Uniqueness is enforced (delete-aware) via TCA eval=unique.
+    KEY identifier (identifier),
     KEY category (category)
 );
 
@@ -388,8 +394,10 @@ CREATE TABLE tx_nrllm_service_usage (
     audio_seconds_used int(11) unsigned DEFAULT '0' NOT NULL,
     images_generated int(11) unsigned DEFAULT '0' NOT NULL,
 
-    -- Cost tracking
-    estimated_cost decimal(10,6) DEFAULT '0.000000' NOT NULL,
+    -- Cost tracking. Width aligned with the budget-ceiling columns
+    -- (max_cost_per_day/month) so an aggregated daily cost cannot overflow the
+    -- column before it can be compared against a configured budget ceiling.
+    estimated_cost decimal(14,6) DEFAULT '0.000000' NOT NULL,
 
     -- Time tracking
     request_date int(11) unsigned DEFAULT '0' NOT NULL,
@@ -404,7 +412,11 @@ CREATE TABLE tx_nrllm_service_usage (
     KEY user_lookup (be_user, service_type, request_date),
     KEY config_lookup (configuration_uid, request_date),
     KEY model_lookup (model_uid, request_date),
-    KEY task_lookup (task_uid, request_date)
+    KEY task_lookup (task_uid, request_date),
+    -- Leading request_date index for the analytics/dashboard read paths that
+    -- filter by a date-range window only (no leading dimension) — the other
+    -- composite indexes cannot serve those range scans.
+    KEY request_date (request_date)
 );
 
 #


### PR DESCRIPTION
## Multi-lens audit fixes (2026-07-02)

Three independent multi-agent review passes (41 lenses in rounds 1–2, then a 14-lens regression/residual pass in round 3) produced ~95 raw findings. Each fix was verified end-to-end before implementing; low-confidence and false-positive findings were dropped. **Round 3 confirmed 0 regressions** from these commits and drove residual findings down to a small, mostly-deferred set.

All 19 commits pass locally on PHP 8.4 (`cgl`, `phpstan` level 10, `unit`, `functional`), and the PR's CI matrix (PHP 8.2–8.5 × TYPO3 13.4/14.3) is green.

### Security
- **SSRF gate on the api-key-less provider path** — an Ollama endpoint set to a private/metadata IP literal (`http://169.254.169.254/`) bypassed the private-range filter (the raw factory client has no per-request `isHostAllowed()` gate and the DNS-pin middleware skips IP literals). Now gated in `getHttpClient()`, covering non-streaming and streaming.
- **Attribute-context XSS** — `escapeHtml()` (shared + SetupWizard copy) didn't escape quotes, allowing breakout from `aria-label="…"` built from untrusted model/config names. Now escapes `"`/`'`.
- **`get_env` redaction** — `MYSQL_PWD` (matches `PWD`, not `PASS`) and inline `user:pass@` credentials in `*_URL`/`*_URI` values now redacted; redaction fails closed on a PCRE error. `requiresAdmin` invariant pinned by test.

### Correctness (providers / middleware / runtime)
- **Configuration system prompt was silently dropped** on the chat, tool-loop, completion AND streaming paths (it reached adapters via `options['system_prompt']`, which no adapter reads). Now injected as a leading system message on every path; an explicit caller message keeps precedence.
- **Claude temperature > 1.0 → HTTP 400** — clamped to Anthropic's `[0,1]`; the tool path now honours the configured sampling params.
- **Gemini default embedding model** `text-embedding-004` (shut down 2026-01-14) → `gemini-embedding-2` (GA).
- **Cache tag charset** — model ids with `/` (OpenRouter) or `:` (Ollama) produced invalid TYPO3 tags, aborting caching; now sanitized.
- **Skill `allowed-tools` string form** (`"A, B"`) was stored as declared-empty → all tools disabled; now split into a list.
- **Budget-denied tool loops** were swallowed silently; now logged with the tripped bucket.

### Usage / analytics
- Daily aggregation now keys on `configuration_uid` (two configs on one model no longer merge/misattribute).
- `UsageMiddleware` falls back to the response model when the (ad-hoc/embeddings) configuration carries none; docstring corrected re: cache-hit recording.

### Schema / TCA
- Dropped soft-delete-incompatible `UNIQUE` keys on `tx_nrllm_task.identifier` and `tx_nrllm_user_budget.be_user`; widened `estimated_cost` to `decimal(14,6)`; added a leading `request_date` index for the analytics read paths.
- TCA tab labels use the dual-version `LLL:EXT:core/…/locallang_tabs.xlf:` form (the `core.form.tabs:` shorthand is v14-only); the `metadata` tab (absent from v13.4 core) now uses an extension-owned label; task→configuration relation excludes hidden configs; `task.identifier` gains `eval=unique`.

### Docs
- nr-vault `^0.6.0` → `^0.10.0`; removed the never-read `TYPO3_NR_LLM_DEFAULT_TIMEOUT` and the removed `GeneralUtility::removeXSS()` example; corrected all current-state API-key-encryption claims (README, Architecture, Introduction) to nr-vault UUIDs; added the missing 0.12.0/0.13.0 changelog entries.

### Deferred (follow-up — flagged, not changed here)
- **Reusable-workflow `@main` pins** (release/auto-merge): a repo-wide convention on first-party netresearch workflows; pinning to a tag/SHA is an org-level decision and must be verified per workflow file to avoid breaking the release pipeline.
- **N+1 in `UsageAnalyticsService::getPerUserUsage`**: `budgetConsumption()` runs one window-aggregate query per budgeted user (bounded, admin-only view) — worth batching into one grouped query in a follow-up.
- **`PromptTemplate`**: SQL table with no TCA/Extbase mapping and no production caller — needs a keep-vs-remove decision.
- Per-row API-key decryption on the provider list; embeddings cache key omitting the effective model; backend-JS strings bypassing translation; `@api` annotations; the broken "Go to Configurations" wizard link (short controller alias); assorted LOW/INFO observations.
- **SonarCloud (advisory, non-blocking)**: 5 remaining new-issue flags are intentional test constructs — credential-looking fixtures in the `get_env` redaction test and a metadata-IP-over-http fixture in the SSRF test — plus one phpstan-narrowing temp var. Recommend marking them "review as safe" in the SonarCloud UI rather than contorting the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
