### PR TITLE
fix(backend): route the wizard 'Go to Configurations' link to the config module

### DIFF
--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -78,9 +78,17 @@ final class TaskWizardController extends ActionController
         $resolvedConfig   = $this->wizardGeneratorService->resolveConfiguration();
 
         $moduleTemplate->assignMultiple([
-            'wizardType'       => 'task',
-            'availableConfigs' => $availableConfigs,
-            'resolvedConfig'   => $resolvedConfig,
+            'wizardType'        => 'task',
+            'availableConfigs'  => $availableConfigs,
+            'resolvedConfig'    => $resolvedConfig,
+            // Cross-module link to the Configuration module (its own backend
+            // route); f:uri.action cannot reach another module's route. The
+            // controller/action are stated explicitly so the link does not
+            // depend on the module's default-action order.
+            'configurationsUrl' => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_configurations', [
+                'controller' => 'Backend\\Configuration',
+                'action'     => 'list',
+            ]),
         ]);
         return $moduleTemplate->renderResponse('Backend/Task/WizardForm');
     }

--- a/Resources/Private/Templates/Backend/Task/WizardForm.html
+++ b/Resources/Private/Templates/Backend/Task/WizardForm.html
@@ -82,7 +82,7 @@
                             <core:icon identifier="actions-exclamation-triangle" size="small" />
                             <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.shared.noConfig.title" default="No LLM configuration available." /></strong>
                             <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.shared.noConfig.hint" default="You need at least one active configuration with a model assigned before you can use the AI wizard." />
-                            <a href="{f:uri.action(action: 'list', controller: 'Configuration')}" class="alert-link"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.task.goToConfigurations" default="Go to Configurations" /></a>
+                            <a href="{configurationsUrl}" class="alert-link"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:wizard.task.goToConfigurations" default="Go to Configurations" /></a>
                         </div>
                     </f:else>
                 </f:if>


### PR DESCRIPTION
## Summary
The no-configuration hint in the Task AI wizard linked to the Configuration list via `f:uri.action(action: 'list', controller: 'Configuration')`. The Configuration list lives in a **separate** backend module (`nrllm_configurations`), and `f:uri.action` only builds URIs within the current module's route — so the link produced an empty/invalid URL and went nowhere.

## Change
- **Controller** (`TaskWizardController::wizardFormAction`): build the target as a cross-module URI via `BackendUriBuilder::buildUriFromRoute('nrllm_configurations')` and assign it as `configurationsUrl` — the same pattern already used for the `nrllm_tasks` links in this controller and `LlmModuleController`.
- **Template** (`Task/WizardForm.html`): reference `{configurationsUrl}` instead of the `f:uri.action` call.

## Testing
- cgl / PHPStan (level 10) / unit green locally on PHP 8.4.
- No unit test for the render action: `ModuleTemplate` is `final` and the project has no bypass-finals, so the render path is not mockable at unit level. The route `nrllm_configurations` is verified present in `Configuration/Backend/Modules.php`, and the fix mirrors the already-working cross-module link pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)