### PR TITLE
fix(backend): avoid Fluid 5 compound-condition mis-evaluation in status warnings

### DIFF
--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -49,8 +49,16 @@
         </div>
 
         <f:comment>Setup readiness checklist (Provider → Model → Configuration)</f:comment>
-        <f:comment>Attribute-form f:if so the &amp;&amp; entities decode — inline {f:if(...)} does not decode them.</f:comment>
-        <f:variable name="setupReady"><f:if condition="{dbProviderCount} > 0 &amp;&amp; {dbModelCount} > 0 &amp;&amp; {dbConfigurationCount} > 0"><f:then>1</f:then><f:else>0</f:else></f:if></f:variable>
+        <f:comment>Nested f:if (not a single compound condition): Fluid 5 mis-evaluates a mixed
+        count-and-negation compound in one condition, so each check is its own block.</f:comment>
+        <f:variable name="setupReady">0</f:variable>
+        <f:if condition="{dbProviderCount} &gt; 0">
+            <f:if condition="{dbModelCount} &gt; 0">
+                <f:if condition="{dbConfigurationCount} &gt; 0">
+                    <f:variable name="setupReady">1</f:variable>
+                </f:if>
+            </f:if>
+        </f:if>
         <div class="card mb-4">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:readiness.title" default="Setup readiness" /></h2>

--- a/Resources/Private/Templates/Backend/Model/List.html
+++ b/Resources/Private/Templates/Backend/Model/List.html
@@ -27,11 +27,13 @@
 
         <f:render partial="Backend/Glossary" />
 
-        <f:if condition="{models -> f:count()} &gt; 0 &amp;&amp; !{hasDefaultModel}">
-            <div class="alert alert-warning">
-                <core:icon identifier="actions-exclamation-triangle" size="small" />
-                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.noDefault.warning" default="No default model is set. Tasks and features that do not specify a model will fail until you mark one model as default." />
-            </div>
+        <f:if condition="{models -> f:count()} &gt; 0">
+            <f:if condition="!{hasDefaultModel}">
+                <div class="alert alert-warning">
+                    <core:icon identifier="actions-exclamation-triangle" size="small" />
+                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:model.noDefault.warning" default="No default model is set. Tasks and features that do not specify a model will fail until you mark one model as default." />
+                </div>
+            </f:if>
         </f:if>
 
         <f:if condition="{models -> f:count()}">

--- a/Resources/Private/Templates/Backend/Task/List.html
+++ b/Resources/Private/Templates/Backend/Task/List.html
@@ -34,11 +34,13 @@
 
         <f:render partial="Backend/Glossary" />
 
-        <f:if condition="{totalCount} &gt; 0 &amp;&amp; {activeCount} == 0">
-            <div class="alert alert-warning">
-                <core:icon identifier="actions-exclamation-triangle" size="small" />
-                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.noActive.warning" default="No active tasks. Only active tasks are exposed to consuming extensions and the API. Activate a task to make it available." />
-            </div>
+        <f:if condition="{totalCount} &gt; 0">
+            <f:if condition="{activeCount} == 0">
+                <div class="alert alert-warning">
+                    <core:icon identifier="actions-exclamation-triangle" size="small" />
+                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.noActive.warning" default="No active tasks. Only active tasks are exposed to consuming extensions and the API. Activate a task to make it available." />
+                </div>
+            </f:if>
         </f:if>
 
         <f:if condition="{totalCount} == 0">


### PR DESCRIPTION
## Summary
On TYPO3 v14 (Fluid 5), a compound `f:if` condition like `{a -> f:count()} > 0 && !{hasDefaultModel}` **mis-evaluates to TRUE** even when the right operand is false. Proven live with a debug marker in the rendered module:
- `data-has="1"` — `hasDefaultModel` is true
- `!{hasDefaultModel}` **alone** → renders FALSE (correct)
- `{...count} > 0 && !{hasDefaultModel}` → renders **TRUE** (wrong)

This made three backend status checks fire against correct data:
- **Model list**: "No default model is set" shown even though a default model exists (`findDefault()` returns it).
- **Task list**: "No active tasks" shown even though all tasks are active (`countActive()` = 5).
- **Dashboard**: `setupReady` computed from a triple-`&&` condition.

## Fix
Split each compound condition into **nested** `f:if` blocks — no `&&`/comparison mix in a single condition. Nested conditions evaluate correctly in Fluid 5.

## Testing
Verified on a running **v14.3.4** instance (authenticated backend fetch): both warnings disappear with the seeded data while the model and task lists still render. (Fluid templates are not covered by cgl/phpstan/unit; live render is the verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)