### PR TITLE
fix: hydrate SkillSource githubToken so skill sync can authenticate

### DIFF
--- a/Configuration/TCA/tx_nrllm_skill_source.php
+++ b/Configuration/TCA/tx_nrllm_skill_source.php
@@ -106,6 +106,14 @@ return [
                 'readOnly' => true,
             ],
         ],
+        // Vault UUID of the GitHub token; written by SkillSourceController::setTokenAction (never edited in
+        // FormEngine). MUST be declared here so Extbase hydrates SkillSource::$githubToken — without a TCA
+        // column the DataMapper leaves it '', so every sync runs unauthenticated and hits the 60/hour limit.
+        'github_token' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
         'sync_status' => [
             'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_skill_source.sync_status',
             'config' => [


### PR DESCRIPTION
The \`github_token\` column (the nr-vault UUID of a source's GitHub token) is declared in \`ext_tables.sql\` and written by \`SkillSourceController::tokenAction\`, but it was **missing from the TCA \`columns\`** of \`tx_nrllm_skill_source\`.

Extbase builds its DataMapper column map from TCA, so with no column entry the \`githubToken\` property was never hydrated:

- \`SkillSource::getGithubToken()\` always returned \`''\`
- \`SkillSyncService::token()\` therefore always returned \`null\`
- every sync ran **unauthenticated** against the GitHub API, exhausting the 60 req/hour anonymous limit on any repository/marketplace sync

The result: skill sync **always failed** with a GitHub rate-limit error, and **no token an admin added could ever take effect** — the token was persisted to the DB but never read back.

## Fix

Add \`github_token\` as a \`passthrough\` TCA column — a real column Extbase maps, but FormEngine does not render (the UUID is managed by the vault token flow, never hand-edited). \`getGithubToken()\` now returns the stored UUID, the sync authenticates (5000 req/hour), and marketplace/repository syncs complete.

## Verification

On a TYPO3 v14.3.4 instance, with a token configured on the source:

| | before | after |
|---|---|---|
| \`SkillSource::getGithubToken()\` | \`''\` | \`ghtoken_…\` (the UUID) |
| GitHub API rate limit used | 60/hour (anonymous) | 5000/hour (authenticated) |
| Sync result | rate-limit error, **0 skills** | \`sync_status=ok\`, **60 skills** |

Verified end-to-end through the real Skills-module **Sync** button in the backend UI.

## Tests

\`cgl\`, \`phpstan\` (level 10) green. TCA-only change; existing skill functional tests unaffected.