### PR TITLE
feat: split Tool Playground into separate Playground and Tools modules

### DIFF
--- a/Classes/Controller/Backend/ToolController.php
+++ b/Classes/Controller/Backend/ToolController.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+/**
+ * Admin-only tool management backend module.
+ *
+ * Lists every registered tool with its global enable state and lets an admin
+ * toggle it. Split from {@see ToolPlaygroundController} so the management view
+ * (list + enable/disable) and the interactive playground (pick a config, run
+ * the agent loop) are separate modules. {@see listAction()} renders the tool
+ * table; the AJAX {@see toggleToolAction()} persists the global override that
+ * the fail-closed runtime gate then enforces on every later run (ADR-038).
+ */
+#[AsController]
+final class ToolController extends ActionController
+{
+    use RequiresBackendAdminTrait;
+    use DefensiveLocalizationTrait;
+
+    public function __construct(
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly ToolRegistry $toolRegistry,
+        private readonly ToolAvailabilityServiceInterface $toolAvailability,
+        private readonly ToolStateRepository $toolStateRepository,
+        private readonly PageRenderer $pageRenderer,
+    ) {}
+
+    public function listAction(): ResponseInterface
+    {
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolState.js');
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->makeDocHeaderModuleMenu();
+        $moduleTemplate->assignMultiple([
+            'toolStates' => $this->toolAvailability->states(),
+        ]);
+        return $moduleTemplate->renderResponse('Backend/Tool/List');
+    }
+
+    /**
+     * Toggle the global enable state of a single tool (AJAX, admin-gated).
+     *
+     * Admin-gated via {@see denyNonAdmin()} FIRST (ADR-037). The override is
+     * persisted to `tx_nrllm_tool_state` via {@see ToolStateRepository}; the
+     * fail-closed runtime gate then refuses a disabled tool on every later run.
+     * Only a registered tool name is accepted so the table cannot accumulate
+     * orphan rows.
+     */
+    public function toggleToolAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body     = $request->getParsedBody();
+        $toolName = $this->stringFromBody($body, 'tool');
+        if ($toolName === '' || $this->toolRegistry->get($toolName) === null) {
+            return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.unknownTool', 'Unknown tool')], 404);
+        }
+
+        $enabled = $this->boolFromBody($body, 'enabled');
+        $this->toolStateRepository->setEnabled($toolName, $enabled);
+
+        return new JsonResponse(['success' => true, 'enabled' => $enabled]);
+    }
+
+    private function stringFromBody(mixed $body, string $key): string
+    {
+        if (!is_array($body)) {
+            return '';
+        }
+        $value = $body[$key] ?? '';
+        return is_scalar($value) ? (string)$value : '';
+    }
+
+    private function boolFromBody(mixed $body, string $key): bool
+    {
+        if (!is_array($body)) {
+            return false;
+        }
+        // filter_var (not a plain cast) so the string "false"/"0" from form bodies is correctly false.
+        return filter_var($body[$key] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -17,8 +17,6 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
-use Netresearch\NrLlm\Service\Tool\ToolRegistry;
-use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -58,19 +56,16 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
-        private readonly ToolRegistry $toolRegistry,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly PageRenderer $pageRenderer,
         private readonly ToolLoopService $toolLoopService,
         private readonly ToolAvailabilityServiceInterface $toolAvailability,
-        private readonly ToolStateRepository $toolStateRepository,
         private readonly AllowedToolsResolver $allowedToolsResolver,
     ) {}
 
     public function listAction(): ResponseInterface
     {
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolPlayground.js');
-        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolState.js');
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $moduleTemplate->assignMultiple([
@@ -78,7 +73,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             'toolStates' => $this->toolAvailability->states(),
             'ajaxRoute' => 'nrllm_tool_run',
         ]);
-        return $moduleTemplate->renderResponse('Backend/ToolPlayground/List');
+        return $moduleTemplate->renderResponse('Backend/Playground/List');
     }
 
     /**
@@ -157,33 +152,6 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     }
 
     /**
-     * Toggle the global enable state of a single tool (AJAX, admin-gated).
-     *
-     * Admin-gated via {@see denyNonAdmin()} FIRST (ADR-037). The override is
-     * persisted to `tx_nrllm_tool_state` via {@see ToolStateRepository}; the
-     * fail-closed runtime gate then refuses a disabled tool on every later run.
-     * Only a registered tool name is accepted so the table cannot accumulate
-     * orphan rows.
-     */
-    public function toggleToolAction(ServerRequestInterface $request): ResponseInterface
-    {
-        if (($deny = $this->denyNonAdmin()) !== null) {
-            return $deny;
-        }
-
-        $body     = $request->getParsedBody();
-        $toolName = $this->stringFromBody($body, 'tool');
-        if ($toolName === '' || $this->toolRegistry->get($toolName) === null) {
-            return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.unknownTool', 'Unknown tool')], 404);
-        }
-
-        $enabled = $this->boolFromBody($body, 'enabled');
-        $this->toolStateRepository->setEnabled($toolName, $enabled);
-
-        return new JsonResponse(['success' => true, 'enabled' => $enabled]);
-    }
-
-    /**
      * Resolve the current backend user's uid for the budget pre-flight (0 when
      * no real BE user is present — the budget check then treats it as anonymous).
      */
@@ -215,15 +183,6 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
-    }
-
-    private function boolFromBody(mixed $body, string $key): bool
-    {
-        if (!is_array($body)) {
-            return false;
-        }
-        // filter_var (not a plain cast) so the string "false"/"0" from form bodies is correctly false.
-        return filter_var($body[$key] ?? false, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Controller\Backend\SetupWizardController;
 use Netresearch\NrLlm\Controller\Backend\SkillSourceController;
 use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
 use Netresearch\NrLlm\Controller\Backend\TaskRecordsController;
+use Netresearch\NrLlm\Controller\Backend\ToolController;
 use Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController;
 
 /**
@@ -131,14 +132,15 @@ return [
         'target' => SkillSourceController::class . '::setTokenAction',
     ],
 
-    // Tool playground route
+    // Tool playground route (interactive agent loop)
     'nrllm_tool_run' => [
         'path' => '/nrllm/tool/run',
         'target' => ToolPlaygroundController::class . '::runAction',
     ],
+    // Tool management route (global enable/disable)
     'nrllm_tool_toggle' => [
         'path' => '/nrllm/tool/toggle',
-        'target' => ToolPlaygroundController::class . '::toggleToolAction',
+        'target' => ToolController::class . '::toggleToolAction',
     ],
 
     // Setup Wizard routes

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Controller\Backend\SkillSourceController;
 use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
 use Netresearch\NrLlm\Controller\Backend\TaskListController;
 use Netresearch\NrLlm\Controller\Backend\TaskWizardController;
+use Netresearch\NrLlm\Controller\Backend\ToolController;
 use Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController;
 
 /**
@@ -200,16 +201,35 @@ return [
             ],
         ],
     ],
-    // Tool playground - child of main module
-    // Admin-only interactive playground for the tool runtime (PR-A).
-    // Note: the AJAX runAction is registered via AjaxRoutes.php (nrllm_tool_run)
-    // and additionally guards itself with RequiresBackendAdminTrait (ADR-037).
+    // Tool management - child of main module
+    // Admin-only: list every registered tool and toggle its global enable state.
+    // Note: the AJAX toggleToolAction is registered via AjaxRoutes.php
+    // (nrllm_tool_toggle) and additionally guards itself with
+    // RequiresBackendAdminTrait (ADR-037).
     'nrllm_tools' => [
         'parent' => 'nrllm',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-tool',
         'path' => '/module/nrllm/tools',
         'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf',
+        'extensionName' => 'NrLlm',
+        'controllerActions' => [
+            ToolController::class => [
+                'list',
+            ],
+        ],
+    ],
+    // Tool playground - child of main module
+    // Admin-only interactive playground for the tool runtime (ADR-037/038):
+    // pick a configuration, enter a prompt and run the bounded agent loop.
+    // Note: the AJAX runAction is registered via AjaxRoutes.php (nrllm_tool_run)
+    // and additionally guards itself with RequiresBackendAdminTrait.
+    'nrllm_playground' => [
+        'parent' => 'nrllm',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-tool',
+        'path' => '/module/nrllm/playground',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_playground.xlf',
         'extensionName' => 'NrLlm',
         'controllerActions' => [
             ToolPlaygroundController::class => [

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -41,7 +41,8 @@ left-hand navigation:
 - **Tasks** — one-shot prompt templates
 - **Snippets** — tagged reusable prompt fragments
 - **Skills** — GitHub-hosted ``SKILL.md`` sources (admin-only)
-- **Tool Playground** — run the agent tool loop (admin-only)
+- **Tools** — enable or disable the agent tools (admin-only)
+- **Playground** — run the agent tool loop interactively (admin-only)
 
 .. toctree::
    :maxdepth: 2

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -77,13 +77,29 @@ attacker-influenced (the model is steerable by injected skill prose),
 **validate and scope** every input (cap volumes, scope identifier lookups),
 and never return secrets — the result leaves the instance.
 
+.. _administration-tools-manage:
+
+Managing tools
+==============
+
+The :guilabel:`Admin Tools > LLM > Tools` module lists every registered tool
+with its global enable state and lets an admin toggle it. A **disabled** tool
+is refused on every run, everywhere — the runtime gate is fail-closed, so a
+disabled tool can never be offered to the model regardless of a skill's
+``allowed-tools`` or the per-run selection in the playground. Some built-in
+tools (for example ``get_env_raw`` and ``get_php_info_raw``) ship **disabled
+by default** because they return unredacted, secret-bearing output; enable
+them only deliberately.
+
 .. _administration-tools-playground:
 
 Using the Tool Playground
 =========================
 
-The playground lives in :guilabel:`Admin Tools > LLM > Tool Playground` and
-is admin-only.
+The playground lives in :guilabel:`Admin Tools > LLM > Playground` and is
+admin-only. It is a sibling of the :ref:`Tools
+<administration-tools-manage>` management module: the playground *runs* the
+loop, while the Tools module governs *which* tools exist and are enabled.
 
 .. figure:: /Images/ToolPlaygroundShell.png
    :alt: The Tool Playground module with the LLM configuration picker, an
@@ -113,10 +129,13 @@ is admin-only.
    ``fetch_logs`` (arguments ``{"limit": 20}``); the redacted ``sys_log``
    result is fed back and the model's final answer closes the trace.
 
-The :guilabel:`Available tools` panel lists every registered tool. Every
-displayed string — tool arguments, tool results (which may include
-``sys_log`` content), and the final answer — is rendered escaped; HTML is
-only ever shown inside a sandboxed preview, never injected into the page.
+The :guilabel:`Tools available to this run` list lets you narrow a single run
+to a subset of the globally-enabled tools (the full list and the global
+enable/disable controls live in the :ref:`Tools
+<administration-tools-manage>` module). Every displayed string — tool
+arguments, tool results (which may include ``sys_log`` content), and the
+final answer — is rendered escaped; HTML is only ever shown inside a
+sandboxed preview, never injected into the page.
 
 Each run is bounded by the iteration cap (default 5) and, when the
 configuration's backend user has a budget, by the per-iteration budget

--- a/Resources/Private/Language/de.locallang_mod_playground.xlf
+++ b/Resources/Private/Language/de.locallang_mod_playground.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Tool Playground</source>
+                <target>LLM-Tool-Playground</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Playground</source>
+                <target>Playground</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Interactively run the agent tool loop: pick an LLM configuration, enter a prompt, and watch each tool call, its result and the final answer</source>
+                <target>Die Agenten-Tool-Schleife interaktiv ausführen: eine LLM-Konfiguration wählen, einen Prompt eingeben und jeden Tool-Aufruf, dessen Ergebnis und die finale Antwort verfolgen</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -3,16 +3,32 @@
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">
-                <source>LLM Tool Playground</source>
-                <target>LLM-Tool-Playground</target>
+                <source>LLM Tools</source>
+                <target>LLM-Tools</target>
             </trans-unit>
             <trans-unit id="mlang_tabs_tab">
-                <source>Tool Playground</source>
-                <target>Tool-Playground</target>
+                <source>Tools</source>
+                <target>Tools</target>
             </trans-unit>
             <trans-unit id="mlang_labels_tabdescr">
-                <source>Interactively run the agent tool loop: pick an LLM configuration, enter a prompt, and watch each tool call, its result and the final answer</source>
-                <target>Die Agenten-Tool-Schleife interaktiv ausführen: eine LLM-Konfiguration wählen, einen Prompt eingeben und jeden Tool-Aufruf, dessen Ergebnis und die finale Antwort verfolgen</target>
+                <source>Manage the tools available to the agent tool loop: enable or disable each tool. A disabled tool is refused on every run, everywhere</source>
+                <target>Die für die Agenten-Tool-Schleife verfügbaren Tools verwalten: jedes Tool aktivieren oder deaktivieren. Ein deaktiviertes Tool wird bei jedem Lauf überall abgelehnt</target>
+            </trans-unit>
+            <trans-unit id="manage.title">
+                <source>Tools</source>
+                <target>Tools</target>
+            </trans-unit>
+            <trans-unit id="manage.intro">
+                <source>Enable or disable the tools available to the agent tool loop. A disabled tool is refused on every run, everywhere — the runtime gate is fail-closed. This module is admin-only.</source>
+                <target>Die für die Agenten-Tool-Schleife verfügbaren Tools aktivieren oder deaktivieren. Ein deaktiviertes Tool wird bei jedem Lauf überall abgelehnt — die Laufzeit-Sperre ist fail-closed. Dieses Modul ist nur für Administratoren.</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.manageTools">
+                <source>Manage tools</source>
+                <target>Tools verwalten</target>
+            </trans-unit>
+            <trans-unit id="seeAlso.playground">
+                <source>Tool Playground</source>
+                <target>Tool-Playground</target>
             </trans-unit>
             <trans-unit id="playground.title">
                 <source>Tool Playground</source>

--- a/Resources/Private/Language/locallang_mod_playground.xlf
+++ b/Resources/Private/Language/locallang_mod_playground.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Tool Playground</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Playground</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Interactively run the agent tool loop: pick an LLM configuration, enter a prompt, and watch each tool call, its result and the final answer</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -3,13 +3,25 @@
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">
-                <source>LLM Tool Playground</source>
+                <source>LLM Tools</source>
             </trans-unit>
             <trans-unit id="mlang_tabs_tab">
-                <source>Tool Playground</source>
+                <source>Tools</source>
             </trans-unit>
             <trans-unit id="mlang_labels_tabdescr">
-                <source>Interactively run the agent tool loop: pick an LLM configuration, enter a prompt, and watch each tool call, its result and the final answer</source>
+                <source>Manage the tools available to the agent tool loop: enable or disable each tool. A disabled tool is refused on every run, everywhere</source>
+            </trans-unit>
+            <trans-unit id="manage.title">
+                <source>Tools</source>
+            </trans-unit>
+            <trans-unit id="manage.intro">
+                <source>Enable or disable the tools available to the agent tool loop. A disabled tool is refused on every run, everywhere — the runtime gate is fail-closed. This module is admin-only.</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.manageTools">
+                <source>Manage tools</source>
+            </trans-unit>
+            <trans-unit id="seeAlso.playground">
+                <source>Tool Playground</source>
             </trans-unit>
             <trans-unit id="playground.title">
                 <source>Tool Playground</source>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -321,6 +321,9 @@
                 </div>
                 <div class="card-footer">
                     <a href="{be:moduleLink(route: 'nrllm_tools')}" class="btn btn-secondary">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.title" default="Tools" />
+                    </a>
+                    <a href="{be:moduleLink(route: 'nrllm_playground')}" class="btn btn-secondary">
                         <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tool.card.button" default="Open Tool Playground" />
                     </a>
                 </div>

--- a/Resources/Private/Templates/Backend/Playground/List.html
+++ b/Resources/Private/Templates/Backend/Playground/List.html
@@ -1,0 +1,100 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <div id="nrllm-tool-playground" data-ajax-route="{ajaxRoute}">
+        <h1>
+            <core:icon identifier="module-nrllm-tool" size="medium" />
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" />
+        </h1>
+
+        <f:be.infobox state="-2">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.intro" default="Pick an LLM configuration, enter a prompt and run the agent loop. Each tool call, its result and the final answer are shown below. Tools run with full backend privileges and their results egress to the configured provider — this module is admin-only." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_tools')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:seeAlso.manageTools" default="Manage tools" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.list.title" default="Configurations" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_skills')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.list.title" default="Skills" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
+            <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
+        </div>
+
+        <f:render partial="Backend/Glossary" />
+
+        <div class="row">
+            <div class="col-md-8">
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label" for="nrllm-tool-config">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.config" default="LLM configuration" />
+                            </label>
+                            <select id="nrllm-tool-config" class="form-select">
+                                <f:for each="{configurations}" as="configuration">
+                                    <option value="{configuration.uid}">{configuration.name}</option>
+                                </f:for>
+                            </select>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label" for="nrllm-tool-prompt">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.prompt" default="Prompt" />
+                            </label>
+                            <textarea id="nrllm-tool-prompt" class="form-control" rows="4"></textarea>
+                        </div>
+
+                        <f:if condition="{f:count(subject: toolStates)}">
+                            <f:then>
+                                <div class="mb-3">
+                                    <label class="form-label">
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run.tools" default="Tools available to this run" />
+                                    </label>
+                                    <f:for each="{toolStates}" as="tool">
+                                        <div class="form-check">
+                                            <f:if condition="{tool.enabled}">
+                                                <f:then>
+                                                    <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" checked="checked" />
+                                                </f:then>
+                                                <f:else>
+                                                    <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" />
+                                                </f:else>
+                                            </f:if>
+                                            <label class="form-check-label" for="nrllm-tool-select-{tool.name}">
+                                                <code>{tool.name}</code>
+                                            </label>
+                                        </div>
+                                    </f:for>
+                                </div>
+                            </f:then>
+                            <f:else>
+                                <f:be.infobox state="-1">
+                                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.empty" default="No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool." /></p>
+                                </f:be.infobox>
+                            </f:else>
+                        </f:if>
+
+                        <button type="button" id="nrllm-tool-run" class="btn btn-primary">
+                            <core:icon identifier="actions-play" size="small" />
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run" default="Run" />
+                        </button>
+                    </div>
+                </div>
+
+                <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.output" default="Output" /></h2>
+                <div id="nrllm-tool-output" class="card mb-4"></div>
+            </div>
+        </div>
+    </div>
+</f:section>
+
+</html>

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -22,7 +22,8 @@
 
         <div class="mb-3">
             <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
-            <a href="{be:moduleLink(route: 'nrllm_tools')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_playground')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_tools')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.title" default="Tools" /></a>
             <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
             <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
         </div>

--- a/Resources/Private/Templates/Backend/Tool/List.html
+++ b/Resources/Private/Templates/Backend/Tool/List.html
@@ -10,20 +10,20 @@
 <f:layout name="Module" />
 
 <f:section name="Content">
-    <div id="nrllm-tool-playground" data-ajax-route="{ajaxRoute}">
+    <div id="nrllm-tool-management">
         <h1>
             <core:icon identifier="module-nrllm-tool" size="medium" />
-            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" />
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.title" default="Tools" />
         </h1>
 
         <f:be.infobox state="-2">
-            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.intro" default="Pick an LLM configuration, enter a prompt and run the agent loop. Each tool call, its result and the final answer are shown below. Tools run with full backend privileges and their results egress to the configured provider — this module is admin-only." /></p>
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.intro" default="Enable or disable the tools available to the agent tool loop. A disabled tool is refused on every run, everywhere — the runtime gate is fail-closed. This module is admin-only." /></p>
         </f:be.infobox>
 
         <div class="mb-3">
             <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_playground')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:seeAlso.playground" default="Tool Playground" /></a>
             <a href="{be:moduleLink(route: 'nrllm_configurations')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.list.title" default="Configurations" /></a>
-            <a href="{be:moduleLink(route: 'nrllm_skills')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.list.title" default="Skills" /></a>
             <a href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.help" default="Open Help" /></a>
             <a href="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/" target="_blank" rel="noopener" class="badge text-bg-info text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.docs" default="Read the documentation" /></a>
         </div>
@@ -32,63 +32,8 @@
 
         <div class="row">
             <div class="col-md-7">
-                <div class="card mb-4">
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <label class="form-label" for="nrllm-tool-config">
-                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.config" default="LLM configuration" />
-                            </label>
-                            <select id="nrllm-tool-config" class="form-select">
-                                <f:for each="{configurations}" as="configuration">
-                                    <option value="{configuration.uid}">{configuration.name}</option>
-                                </f:for>
-                            </select>
-                        </div>
-
-                        <div class="mb-3">
-                            <label class="form-label" for="nrllm-tool-prompt">
-                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.prompt" default="Prompt" />
-                            </label>
-                            <textarea id="nrllm-tool-prompt" class="form-control" rows="4"></textarea>
-                        </div>
-
-                        <f:if condition="{toolStates -> f:count()}">
-                            <div class="mb-3">
-                                <label class="form-label">
-                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run.tools" default="Tools available to this run" />
-                                </label>
-                                <f:for each="{toolStates}" as="tool">
-                                    <div class="form-check">
-                                        <f:if condition="{tool.enabled}">
-                                            <f:then>
-                                                <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" checked="checked" />
-                                            </f:then>
-                                            <f:else>
-                                                <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" />
-                                            </f:else>
-                                        </f:if>
-                                        <label class="form-check-label" for="nrllm-tool-select-{tool.name}">
-                                            <code>{tool.name}</code>
-                                        </label>
-                                    </div>
-                                </f:for>
-                            </div>
-                        </f:if>
-
-                        <button type="button" id="nrllm-tool-run" class="btn btn-primary">
-                            <core:icon identifier="actions-play" size="small" />
-                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run" default="Run" />
-                        </button>
-                    </div>
-                </div>
-
-                <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.output" default="Output" /></h2>
-                <div id="nrllm-tool-output" class="card mb-4"></div>
-            </div>
-
-            <div class="col-md-5">
                 <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tools" default="Available tools" /></h2>
-                <f:if condition="{toolStates -> f:count()}">
+                <f:if condition="{f:count(subject: toolStates)}">
                     <f:then>
                         <div class="card mb-4">
                             <ul class="list-group list-group-flush">
@@ -133,12 +78,13 @@
                     <f:else>
                         <f:be.infobox state="-1">
                             <p class="mb-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.empty" default="No tools are registered. Add a tool by tagging a ToolInterface implementation with nr_llm.tool." /></p>
-                            <p class="mb-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:playground.empty.admin" default="Administrators: enable a tool below, pick a configuration and run a prompt to try the agent loop." /></p>
                             <p class="mb-0 text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:playground.empty.developer" default="Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool." /></p>
                         </f:be.infobox>
                     </f:else>
                 </f:if>
+            </div>
 
+            <div class="col-md-5">
                 <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.help.title" default="How to add a tool" /></h2>
                 <div class="card mb-4">
                     <div class="card-body">

--- a/Tests/Functional/Controller/Backend/ToolControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolControllerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
+use Netresearch\NrLlm\Controller\Backend\ToolController;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+
+/**
+ * Functional tests for the admin-only Tools management backend module.
+ *
+ * Renders listAction() through the real ModuleTemplate stack and asserts each
+ * registered tool surfaces with its description and an enable/disable control.
+ * The AJAX toggleToolAction is covered by the admin-guard, happy-path and
+ * unknown-tool tests below.
+ */
+#[CoversClass(ToolController::class)]
+final class ToolControllerTest extends AbstractFunctionalTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function listActionRendersToolManagementList(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $backendUser = $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $toolRegistry = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $controller   = $this->makeController($toolRegistry);
+        $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
+
+        $response = $controller->listAction();
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+
+        // The management list shows the tool name, its description and the toggle button.
+        self::assertStringContainsString('fetch_logs', $body);
+        self::assertStringContainsString('desc of fetch_logs', $body);
+        self::assertStringContainsString('js-tool-toggle', $body);
+        // The playground run form (config picker) does NOT live here anymore.
+        self::assertStringNotContainsString('id="nrllm-tool-config"', $body);
+    }
+
+    #[Test]
+    public function toggleToolActionDeniesNonAdmin(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(2); // uid 2 is a non-admin editor (admin=0)
+
+        $controller = $this->makeController(new ToolRegistry([new FakeTool('fetch_logs')]));
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/toggle'))
+            ->withParsedBody(['tool' => 'fetch_logs', 'enabled' => '0']);
+        $response = $controller->toggleToolAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+    }
+
+    #[Test]
+    public function toggleToolActionRejectsUnknownTool(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // admin
+
+        $controller = $this->makeController(new ToolRegistry([new FakeTool('fetch_logs')]));
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/toggle'))
+            ->withParsedBody(['tool' => 'no_such_tool', 'enabled' => '0']);
+        $response = $controller->toggleToolAction($request);
+
+        self::assertSame(404, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+    }
+
+    #[Test]
+    public function toggleToolActionPersistsDisabledState(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // admin
+
+        $toolRegistry = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $controller   = $this->makeController($toolRegistry);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/toggle'))
+            ->withParsedBody(['tool' => 'fetch_logs', 'enabled' => '0']);
+        $response = $controller->toggleToolAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertTrue($payload['success']);
+        self::assertFalse($payload['enabled']);
+
+        // The fail-closed gate now reports the tool as disabled on every read.
+        self::assertNotContains('fetch_logs', $this->availabilityFor($toolRegistry)->enabledNames());
+    }
+
+    private function makeController(ToolRegistry $toolRegistry): ToolController
+    {
+        $moduleTemplateFactory = $this->get(ModuleTemplateFactory::class);
+        self::assertInstanceOf(ModuleTemplateFactory::class, $moduleTemplateFactory);
+        $pageRenderer = $this->get(PageRenderer::class);
+        self::assertInstanceOf(PageRenderer::class, $pageRenderer);
+
+        return new ToolController(
+            $moduleTemplateFactory,
+            $toolRegistry,
+            $this->availabilityFor($toolRegistry),
+            new ToolStateRepository($this->toolConnectionPool()),
+            $pageRenderer,
+        );
+    }
+
+    private function availabilityFor(ToolRegistry $toolRegistry): ToolAvailabilityService
+    {
+        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()));
+    }
+
+    private function toolConnectionPool(): ConnectionPool
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        return $connectionPool;
+    }
+
+    /**
+     * Build an Extbase backend request carrying the route package name so the
+     * BackendViewFactory resolves the extension's template root path.
+     */
+    private function createBackendRequest(): ExtbaseRequest
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\Tool');
+        $extbaseParameters->setControllerActionName('list');
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/nrllm/tools', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('extbase', $extbaseParameters);
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        return new ExtbaseRequest($serverRequest);
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+}

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -81,12 +81,10 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $controller = new ToolPlaygroundController(
             $moduleTemplateFactory,
-            $toolRegistry,
             $configurationRepository,
             $pageRenderer,
             new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), $availability),
             $availability,
-            new ToolStateRepository($this->toolConnectionPool()),
             $this->get(AllowedToolsResolver::class),
         );
         $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
@@ -103,9 +101,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('id="nrllm-tool-prompt"', $body);
         self::assertStringContainsString('id="nrllm-tool-run"', $body);
         self::assertStringContainsString('id="nrllm-tool-output"', $body);
-        // Tools panel lists the registered tool (name + description).
+        // The per-run tool selection lists the registered tool by name (the
+        // enable/disable management list — with descriptions — now lives in the
+        // separate Tools module, {@see ToolControllerTest}).
         self::assertStringContainsString('fetch_logs', $body);
-        self::assertStringContainsString('desc of fetch_logs', $body);
+        self::assertStringContainsString('js-tool-select', $body);
     }
 
     #[Test]
@@ -229,12 +229,10 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         return new ToolPlaygroundController(
             $moduleTemplateFactory,
-            $toolRegistry,
             $configurationRepository,
             $pageRenderer,
             $toolLoopService,
             $this->availabilityFor($toolRegistry),
-            new ToolStateRepository($this->toolConnectionPool()),
             $this->get(AllowedToolsResolver::class),
         );
     }
@@ -269,7 +267,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
             ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
-            ->withAttribute('route', new Route('/module/nrllm/tools', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('route', new Route('/module/nrllm/playground', ['packageName' => 'netresearch/nr-llm']))
             ->withAttribute('extbase', $extbaseParameters);
         $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
         $GLOBALS['TYPO3_REQUEST'] = $serverRequest;


### PR DESCRIPTION
The single **Tool Playground** module (`nrllm_tools`, `ToolPlaygroundController`) rendered *both* the interactive agent-loop playground **and** the global tool enable/disable list in one view. This splits them into two focused, admin-only modules.

## Modules

| Module | Path | Controller | Purpose |
|--------|------|-----------|---------|
| **Playground** | `/module/nrllm/playground` | `ToolPlaygroundController` | Pick a configuration, enter a prompt, select the tools for the run, run the bounded agent loop |
| **Tools** | `/module/nrllm/tools` | new `ToolController` | List every registered tool with its global enable state and toggle it |

## Changes

- `ToolPlaygroundController` drops the toggle action and its `ToolRegistry` / `ToolStateRepository` dependencies; renders `Backend/Playground/List`.
- New `ToolController` (list + `toggleToolAction`) renders `Backend/Tool/List`; the `nrllm_tool_toggle` AJAX route now targets it.
- New `locallang_mod_playground.xlf` (EN + DE) for the Playground menu labels; `locallang_mod_tool.xlf` becomes the Tools menu.
- Cross-links: dashboard card gets **Tools** + **Open Tool Playground** buttons; the Skills "See also" links both.
- Admin docs (`Administration/Tools.rst`, `Index.rst`) describe both modules.
- Tests: new `ToolControllerTest` (list + toggle guard + toggle persistence); `ToolPlaygroundControllerTest` adjusted for the slimmed constructor.

## Verification

On TYPO3 v14.3.4: both modules render correctly, the **Disable** button persists `enabled=0` to `tx_nrllm_tool_state`, and the playground renders the config picker + per-run tool selection + Run/Output. `cgl`, `phpstan` (level 10) and the functional suite (7 tests, 74 assertions) are green.

> Note: the two playground screenshots in `Administration/Tools.rst` still show the pre-split combined UI; a screenshot refresh is a follow-up.