### PR TITLE
fix(skills): recover interrupted sync locks + restore skill-list status badges

### DIFF
--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -68,6 +68,9 @@ final class SkillSourceController extends ActionController
         /** @var array<int, string> $sourceEditUrls */
         $sourceEditUrls = [];
         foreach ($sources as $source) {
+            // Surface an interrupted sync (a stale SYNCING lock) as a retryable ERROR here, so the
+            // list never shows a source wedged on "Syncing" after a crash; a live sync is untouched.
+            $this->syncService->reclaimStaleLock($source);
             $uid = $source->getUid();
             if ($uid === null) {
                 continue;

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -31,8 +31,13 @@ final class SkillSyncService
 {
     use ErrorMessageSanitizerTrait;
 
-    /** A SYNCING lock older than this many seconds is considered stale and may be reclaimed. */
-    private const STALE_LOCK_SECONDS = 600;
+    /**
+     * A SYNCING lock whose heartbeat (lastSynced) is older than this many seconds is considered
+     * stale and may be reclaimed. A live sync renews its heartbeat every {@see $heartbeatSeconds}
+     * while collecting, so this window only has to outlast one heartbeat gap plus a single slow
+     * HTTP fetch — not the whole sync — which is why it can be well below the per-sync time bound.
+     */
+    private const STALE_LOCK_SECONDS = 180;
 
     /** Claude Code convention path of a marketplace index inside a repository. */
     private const MARKETPLACE_INDEX_PATH = '.claude-plugin/marketplace.json';
@@ -40,11 +45,15 @@ final class SkillSyncService
     private int $syncDeadline = 0;
     private int $filesProcessed = 0;
     private bool $boundsExceeded = false;
+    private int $lastHeartbeat = 0;
 
     /**
-     * @param int $maxFiles   Hard ceiling on files fetched per sync; prevents a huge repo/marketplace
-     *                        from running unbounded (constructor-injectable so tests can lower it).
-     * @param int $maxSeconds Hard ceiling on wall-clock seconds spent collecting per sync.
+     * @param int $maxFiles         Hard ceiling on files fetched per sync; prevents a huge repo/marketplace
+     *                              from running unbounded (constructor-injectable so tests can lower it).
+     * @param int $maxSeconds       Hard ceiling on wall-clock seconds spent collecting per sync.
+     * @param int $heartbeatSeconds Minimum seconds between lock heartbeats written while collecting;
+     *                              renewing the lock this often keeps a long but healthy sync from being
+     *                              mistaken for a stale one (constructor-injectable so tests can force it).
      */
     public function __construct(
         private readonly GitHubClientInterface $gitHub,
@@ -57,6 +66,7 @@ final class SkillSyncService
         private readonly LoggerInterface $logger,
         private readonly int $maxFiles = 500,
         private readonly int $maxSeconds = 120,
+        private readonly int $heartbeatSeconds = 30,
     ) {}
 
     public function sync(SkillSource $source): SyncResult
@@ -71,6 +81,7 @@ final class SkillSyncService
         $source->setLastSynced($now);
         $this->persistSource($source);
 
+        $this->lastHeartbeat = $now;
         $this->syncDeadline = $now + $this->maxSeconds;
         $this->filesProcessed = 0;
         $this->boundsExceeded = false;
@@ -160,6 +171,26 @@ final class SkillSyncService
     }
 
     /**
+     * Reclaim a source whose SYNCING lock is stale: the previous sync was interrupted (the process
+     * was killed / timed out before {@see sync()} could release the lock), so the source would
+     * otherwise display a perpetual "Syncing" badge and reject a retry until the window elapses on
+     * the next manual attempt. Flip it to ERROR — but only when the lock is provably NOT active, so
+     * a genuinely running sync (fresh heartbeat) and an already-terminal source are left untouched.
+     * Intended to be called when listing sources, turning an invisible auto-reclaim into a visible,
+     * retryable state. Returns true if it reclaimed the lock.
+     */
+    public function reclaimStaleLock(SkillSource $source): bool
+    {
+        if ($source->getSyncStatusEnum() !== SyncStatus::SYNCING || $this->isLockActive($source, time())) {
+            return false;
+        }
+        $source->setSyncStatus(SyncStatus::ERROR->value);
+        $source->setSyncError('The previous sync was interrupted before it finished. Trigger a new sync to retry.');
+        $this->persistSource($source);
+        return true;
+    }
+
+    /**
      * @param list<string> $errors
      *
      * @return array{
@@ -237,7 +268,7 @@ final class SkillSyncService
         // Discovered = every path the tree listing surfaced, even if its body fetch/parse fails below.
         $parsed = [];
         foreach ($paths as $path) {
-            if ($this->limitReached($errors)) {
+            if ($this->limitReached($source, $errors)) {
                 break;
             }
             $this->filesProcessed++;
@@ -289,7 +320,7 @@ final class SkillSyncService
             $listedPrefixSet[$prefix]  = true;
 
             // A bound hit leaves the remaining plugins listed (protected) but unvisited this run.
-            if ($this->limitReached($errors)) {
+            if ($this->limitReached($source, $errors)) {
                 continue;
             }
             try {
@@ -328,12 +359,14 @@ final class SkillSyncService
     }
 
     /**
-     * Stop collecting once the per-sync file or wall-time bound is exceeded.
+     * Stop collecting once the per-sync file or wall-time bound is exceeded. Called once per unit of
+     * work (per file / per plugin), so it is also where the lock heartbeat is renewed.
      *
      * @param list<string> $errors
      */
-    private function limitReached(array &$errors): bool
+    private function limitReached(SkillSource $source, array &$errors): bool
     {
+        $this->heartbeat($source);
         if ($this->boundsExceeded) {
             return true;
         }
@@ -347,6 +380,24 @@ final class SkillSyncService
             return true;
         }
         return false;
+    }
+
+    /**
+     * Renew the SYNCING lock by re-stamping the heartbeat (lastSynced), throttled to at most once
+     * per {@see $heartbeatSeconds}. This keeps a long but healthy sync from ageing past
+     * STALE_LOCK_SECONDS and being reclaimed as stale, while a crashed sync stops renewing and
+     * becomes reclaimable within one window. Only the source row is flushed here (skills are
+     * upserted after collection), so the mid-collect persist cannot leak partial skill state.
+     */
+    private function heartbeat(SkillSource $source): void
+    {
+        $now = time();
+        if ($now - $this->lastHeartbeat < $this->heartbeatSeconds) {
+            return;
+        }
+        $this->lastHeartbeat = $now;
+        $source->setLastSynced($now);
+        $this->persistSource($source);
     }
 
     /**

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -54,15 +54,15 @@
                                 <f:for each="{sources}" as="source">
                                     <tr data-source-uid="{source.uid}">
                                         <td><strong>{source.title}</strong></td>
-                                        <td><span class="badge text-bg-info">{source.type.value}</span></td>
+                                        <td><span class="badge text-bg-info">{source.type}</span></td>
                                         <td>
-                                            <f:switch expression="{source.syncStatus.value}">
+                                            <f:switch expression="{source.syncStatus}">
                                                 <f:case value="ok"><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.ok" default="Synced" /></span></f:case>
                                                 <f:case value="never_synced"><span class="badge text-bg-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.never" default="Never synced" /></span></f:case>
                                                 <f:case value="syncing"><span class="badge text-bg-info"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.syncing" default="Syncing" /></span></f:case>
                                                 <f:case value="partial"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.partial" default="Partial" /></span></f:case>
                                                 <f:case value="error"><span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.error" default="Failed" /></span></f:case>
-                                                <f:defaultCase><code>{source.syncStatus.value}</code></f:defaultCase>
+                                                <f:defaultCase><code>{source.syncStatus}</code></f:defaultCase>
                                             </f:switch>
                                         </td>
                                         <td>
@@ -126,7 +126,7 @@
                                             </f:if>
                                         </td>
                                         <td>
-                                            <f:if condition="{skill.supportStatus.value} == 'full'">
+                                            <f:if condition="{skill.supportStatus} == 'full'">
                                                 <f:then><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.support.full" default="Full" /></span></f:then>
                                                 <f:else><span class="badge text-bg-warning" title="{skill.unsupportedNotes}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.support.partial" default="Partial" /></span></f:else>
                                             </f:if>

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -41,7 +41,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     private const MARKET_A_ID = '30:' . self::PLUGIN_A . '/' . self::SKILL_A_PATH;
     private const MARKET_B_ID = '30:' . self::PLUGIN_B . '/' . self::SKILL_A_PATH;
 
-    private function service(FakeGitHubClient $gitHub, int $maxFiles = 500, int $maxSeconds = 120): SkillSyncService
+    private function service(FakeGitHubClient $gitHub, int $maxFiles = 500, int $maxSeconds = 120, int $heartbeatSeconds = 30): SkillSyncService
     {
         return new SkillSyncService(
             $gitHub,
@@ -54,6 +54,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
             new NullLogger(),
             $maxFiles,
             $maxSeconds,
+            $heartbeatSeconds,
         );
     }
 
@@ -358,6 +359,70 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         $result = $this->service($gitHub)->sync($source);
         self::assertSame(SyncStatus::OK, $result->status);
         self::assertSame(1, $result->created);
+    }
+
+    #[Test]
+    public function reclaimStaleLockFlipsInterruptedSyncToRetryableError(): void
+    {
+        // A SYNCING lock whose heartbeat is older than the stale window is an interrupted (crashed)
+        // sync: reclaim flips it to ERROR so the list stops showing a wedged "Syncing" and a retry
+        // is unblocked.
+        $source = $this->repoSource();
+        $source->setSyncStatus(SyncStatus::SYNCING->value);
+        $source->setLastSynced(time() - 3600);
+
+        $reclaimed = $this->service(new FakeGitHubClient())->reclaimStaleLock($source);
+
+        self::assertTrue($reclaimed);
+        self::assertSame(SyncStatus::ERROR, $source->getSyncStatusEnum());
+        self::assertStringContainsString('interrupted', $source->getSyncError());
+    }
+
+    #[Test]
+    public function reclaimStaleLockLeavesAGenuinelyRunningSyncUntouched(): void
+    {
+        // A fresh heartbeat means a sync is actually in progress; reclaim must not steal its lock.
+        $source = $this->repoSource();
+        $source->setSyncStatus(SyncStatus::SYNCING->value);
+        $source->setLastSynced(time());
+
+        $reclaimed = $this->service(new FakeGitHubClient())->reclaimStaleLock($source);
+
+        self::assertFalse($reclaimed);
+        self::assertSame(SyncStatus::SYNCING, $source->getSyncStatusEnum());
+    }
+
+    #[Test]
+    public function reclaimStaleLockIgnoresACompletedSource(): void
+    {
+        // An OK source with an old lastSynced is a finished sync, not a stale lock: it must not be
+        // flipped to ERROR just because its last-synced timestamp is old.
+        $source = $this->repoSource();
+        $source->setSyncStatus(SyncStatus::OK->value);
+        $source->setLastSynced(time() - 3600);
+
+        $reclaimed = $this->service(new FakeGitHubClient())->reclaimStaleLock($source);
+
+        self::assertFalse($reclaimed);
+        self::assertSame(SyncStatus::OK, $source->getSyncStatusEnum());
+    }
+
+    #[Test]
+    public function heartbeatDuringCollectDoesNotDisturbTheSyncFlow(): void
+    {
+        // With a zero heartbeat interval the lock is re-persisted on every file mid-collect; the
+        // create/persist flow must still complete correctly (the mid-collect flush of the source row
+        // must not leak partial state or disturb the later skill upserts).
+        $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH, self::SKILL_B_PATH], [
+            self::SKILL_A_PATH => $this->md('A', 'body a'),
+            self::SKILL_B_PATH => $this->md('B', 'body b'),
+        ]);
+
+        $result = $this->service($gitHub, heartbeatSeconds: 0)->sync($this->repoSource());
+
+        self::assertSame(SyncStatus::OK, $result->status);
+        self::assertSame(2, $result->created);
+        self::assertCount(2, $this->get(SkillRepository::class)->findBySource(10));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Skill/SkillSyncServiceOrphanEligibilityTest.php
+++ b/Tests/Unit/Service/Skill/SkillSyncServiceOrphanEligibilityTest.php
@@ -97,9 +97,9 @@ final class SkillSyncServiceOrphanEligibilityTest extends AbstractUnitTestCase
     #[Test]
     public function recentSyncingHeartbeatIsAnActiveLock(): void
     {
-        // SYNCING with a heartbeat inside the stale window => a concurrent sync is running.
+        // SYNCING with a heartbeat inside the stale window (180s) => a concurrent sync is running.
         self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_000));
-        self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_500));
+        self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_150));
         // Small clock skew / backwards NTP nudge (heartbeat slightly in the
         // future) is still an active lock, not a permanent wedge.
         self::assertTrue($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 995));
@@ -108,8 +108,8 @@ final class SkillSyncServiceOrphanEligibilityTest extends AbstractUnitTestCase
     #[Test]
     public function staleOrNeverSetSyncingHeartbeatIsReclaimable(): void
     {
-        // Heartbeat older than STALE_LOCK_SECONDS (600) => a crashed sync, reclaimable.
-        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_601));
+        // Heartbeat older than STALE_LOCK_SECONDS (180) => a crashed sync, reclaimable.
+        self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 1_000), 1_181));
         // Never-set heartbeat (0) => reclaimable regardless of "now".
         self::assertFalse($this->isLockActive($this->sourceWith(SyncStatus::SYNCING, 0), 1_000));
         // Heartbeat FAR in the future (large clock correction / corruption) is


### PR DESCRIPTION
Two related fixes to the Skills backend module.

## 1. Interrupted sync wedged a source (the reported "stuck syncing")

An interrupted skill sync (process killed / PHP timeout before `sync()` released the lock) left the source stuck on `SYNCING`. The existing stale-lock recovery only kicked in on the *next* manual sync after a 600s window, and nothing reset the *displayed* status — so the list showed a perpetual "Syncing" that also rejected retries (had to be cleared by a manual `UPDATE`).

- **Heartbeat** — a live sync now renews its `SYNCING` lock (throttled, every 30s) while collecting, so a long-but-healthy sync is never mistaken for a crashed one.
- **Tighter window** — stale-lock window 600s → 180s (safe now that a live sync renews its heartbeat), so a crashed sync self-heals within minutes.
- **Reclaim on list** — opening the Skills module now flips a *stale* `SYNCING` lock to a retryable `ERROR` ("The previous sync was interrupted…"), so the list stops showing a wedged "Syncing" and the next sync isn't falsely blocked. A genuinely running sync (fresh heartbeat) and already-terminal sources are left untouched (`SkillSyncService::reclaimStaleLock`).

## 2. Skill-list status/type badges rendered empty (regression from `79d29a5`)

`79d29a5` ("string-backed enum properties with getXEnum()") changed `SkillSource::getType()/getSyncStatus()` and `Skill::getSupportStatus()` to return the backing *string*, but the list template still read `.value` on them as if they were enums. Since then the source type/sync-status badges rendered **empty** and every skill's support badge fell through the `== 'full'` check to "Partial". Fixed by reading the string getters directly. Without this, the reclaim above would flip the data but stay invisible in the UI.

## Tests

- Functional `SkillSyncServiceTest` (+4): reclaim flips a stale lock to ERROR; leaves a running sync untouched; ignores a completed source; heartbeat during collect doesn't disturb the sync flow. **25 tests green.**
- Unit `SkillSyncServiceOrphanEligibilityTest`: stale-window boundary updated to 180s. **14 tests green.**
- `cgl` + `phpstan` (level 10) green.

## Verified live on ddev v14 (real UI)

1. Forced a source into a stale `SYNCING` lock (age 3600s) → opened the Skills module → auto-reclaimed to a red **"Failed"** badge.
2. Type badge shows **marketplace**; a full-support skill shows **"Full"** (previously silently "Partial") — badges restored.
3. Clicked **Sync** on the reclaimed source → ran ~66s (heartbeat fired mid-sync, no breakage) → green **"Synced"**, 60 skills materialised.

## Risk analysis

- Reclaim writes during the list (GET) action, but only to genuinely-stale locks, guarded by `isLockActive`; idempotent; a running sync is never touched.
- The 180s window assumes a live sync heartbeats at least once per window; with a 30s throttle it tolerates a single slow fetch up to 150s. A pathologically hung fetch (no HTTP timeout configured on the transport) remains an edge case — the same class as before, just with a shorter window.