### PR TITLE
fix(wizard): store the canonical provider base URL (add /v1 for OpenAI) — closes #98

### DIFF
--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -320,6 +320,11 @@ final class SetupWizardController extends ActionController
         $providerName = is_string($providerData['suggestedName'] ?? null) ? $providerData['suggestedName'] : 'provider';
         $providerAdapter = is_string($providerData['adapterType'] ?? null) ? $providerData['adapterType'] : 'openai';
         $providerEndpoint = is_string($providerData['endpoint'] ?? null) ? $providerData['endpoint'] : '';
+        // Store the canonical base URL for the adapter (e.g. append "/v1" for OpenAI) so
+        // the saved provider works even if the client sent the raw, un-versioned host.
+        if ($providerEndpoint !== '') {
+            $providerEndpoint = $this->providerDetector->normalizeEndpointForAdapter($providerEndpoint, $providerAdapter);
+        }
         $providerApiKey = is_string($providerData['apiKey'] ?? null) ? $providerData['apiKey'] : '';
 
         // Store the API key in the vault and use the vault identifier

--- a/Classes/Domain/Model/AdapterType.php
+++ b/Classes/Domain/Model/AdapterType.php
@@ -57,7 +57,9 @@ enum AdapterType: string
             self::OpenRouter => 'https://openrouter.ai/api/v1',
             self::Mistral => 'https://api.mistral.ai/v1',
             self::Groq => 'https://api.groq.com/openai/v1',
-            self::Ollama => 'http://localhost:11434/api',
+            // Bare host: OllamaProvider adds the "api/" segment to each request path
+            // itself, so its base URL must NOT include it (otherwise "/api/api/tags").
+            self::Ollama => 'http://localhost:11434',
             self::AzureOpenAI, self::Custom => '',
         };
     }

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -80,7 +80,10 @@ final class ModelDiscovery implements ModelDiscoveryInterface
         try {
             $base = rtrim($provider->endpoint, '/');
             $endpoint = match ($provider->adapterType) {
-                'ollama' => $base . '/tags',
+                // Ollama's base URL is a bare host (OllamaProvider adds "api/" per
+                // request); model discovery must do the same to hit /api/tags. A legacy
+                // or user-entered trailing "/api" is stripped first to avoid /api/api.
+                'ollama' => $this->ollamaBaseUrl($base) . '/api/tags',
                 default => $base . self::MODELS_PATH,
             };
 
@@ -951,6 +954,16 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     }
 
     /**
+     * Ollama's base URL is a bare host (OllamaProvider prefixes every request path with
+     * "api/"); strip a trailing "/api" (a legacy default or user-entered value) so
+     * appended discovery paths do not become "/api/api/...".
+     */
+    private function ollamaBaseUrl(string $endpoint): string
+    {
+        return (string)preg_replace('#/api/*$#', '', rtrim($endpoint, '/'));
+    }
+
+    /**
      * Discover Ollama models via API.
      *
      * @return array<DiscoveredModel>
@@ -958,7 +971,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private function discoverOllama(string $endpoint): array
     {
         try {
-            $request = $this->requestFactory->createRequest('GET', $endpoint . '/tags');
+            $endpoint = $this->ollamaBaseUrl($endpoint);
+            $request = $this->requestFactory->createRequest('GET', $endpoint . '/api/tags');
             $response = $this->dispatch($request, self::VAULT_DISPATCH_REASON);
 
             if ($response->getStatusCode() !== 200) {
@@ -1026,7 +1040,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             $body = json_encode(['name' => $modelId], JSON_THROW_ON_ERROR);
             $stream = $this->streamFactory->createStream($body);
 
-            $request = $this->requestFactory->createRequest('POST', $endpoint . '/show')
+            $request = $this->requestFactory->createRequest('POST', $this->ollamaBaseUrl($endpoint) . '/api/show')
                 ->withHeader('Content-Type', 'application/json')
                 ->withBody($stream);
 

--- a/Classes/Service/SetupWizard/ProviderDetector.php
+++ b/Classes/Service/SetupWizard/ProviderDetector.php
@@ -107,6 +107,61 @@ final class ProviderDetector
     }
 
     /**
+     * Normalize a user-entered endpoint into the canonical base URL for the given
+     * adapter, so a stored provider's base URL matches what the provider adapter
+     * expects at runtime.
+     *
+     * The provider adapters build request URLs as `baseUrl + '/' + path` and do NOT
+     * add the API version segment themselves — e.g. OpenAiProvider posts to
+     * `chat/completions`, so its base URL must already end in `/v1`. A user who
+     * enters just `https://api.openai.com` in the wizard would otherwise have that
+     * bare host stored and every request would hit `/models` instead of `/v1/models`.
+     *
+     * A bare host (no path) gains the adapter's canonical version-path suffix (taken
+     * from {@see AdapterType::defaultEndpoint()}); an endpoint that already carries a
+     * path is the user's explicit choice and is left untouched, which also makes this
+     * idempotent (`https://api.openai.com/v1` stays as-is). Adapters whose base URL is
+     * a bare host (e.g. Ollama, which adds `api/` in the request path) get no suffix.
+     */
+    public function normalizeEndpointForAdapter(string $endpoint, string $adapterType): string
+    {
+        if (trim($endpoint) === '') {
+            return '';
+        }
+
+        $normalized = $this->normalizeEndpoint($endpoint);
+
+        // Ollama's base URL is a bare host (OllamaProvider adds "api/" to every request
+        // path itself); strip a user-entered or legacy trailing "/api" so it is not later
+        // doubled into "/api/api/...".
+        if ($adapterType === 'ollama') {
+            $normalized = (string)preg_replace('#/api/*$#', '', $normalized);
+        }
+
+        // Only a truly bare host (no path, query or fragment) gains the adapter's version
+        // path. Anything more specific is the user's explicit choice and is returned
+        // untouched — idempotent for already-versioned endpoints, and it never appends the
+        // suffix into a query string (which naive concatenation would mangle).
+        $parts = parse_url($normalized);
+        if (!is_array($parts)
+            || isset($parts['query'])
+            || isset($parts['fragment'])
+            || trim($parts['path'] ?? '', '/') !== ''
+        ) {
+            return $normalized;
+        }
+
+        $default = AdapterType::tryFrom($adapterType)?->defaultEndpoint() ?? '';
+        $suffix = $default !== '' ? parse_url($default, PHP_URL_PATH) : null;
+        if (!is_string($suffix) || trim($suffix, '/') === '') {
+            // Adapter has no canonical version path (e.g. Ollama, Custom): keep the host.
+            return $normalized;
+        }
+
+        return $normalized . '/' . trim($suffix, '/');
+    }
+
+    /**
      * Detect provider from known host patterns, falling back to OpenAI-compatible
      * and finally to an unknown/custom provider.
      */

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -501,6 +501,56 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function saveActionNormalizesBareOpenAiEndpointToIncludeV1(): void
+    {
+        // #98: a bare OpenAI host entered in the wizard must be stored WITH the /v1
+        // version path — OpenAiProvider expects it in the base URL and does not add
+        // it — otherwise every request hits /models instead of /v1/models.
+        $request = new ServerRequest('POST', self::AJAX_NRLLM_WIZARD_SAVE);
+        $request = $request->withHeader('Content-Type', self::APPLICATION_JSON);
+        $request = $request->withBody(Utils::streamFor(json_encode([
+            'provider' => [
+                'suggestedName' => 'Bare OpenAI',
+                'adapterType' => 'openai',
+                'endpoint' => 'https://api.openai.com',
+                'apiKey' => 'sk-test-key-12345',
+            ],
+            'models' => [
+                [
+                    'modelId' => 'gpt-5',
+                    'name' => 'GPT-5',
+                    'capabilities' => ['chat'],
+                    'contextLength' => 128000,
+                    'selected' => true,
+                ],
+            ],
+            'configurations' => [],
+            'pid' => 0,
+        ])));
+
+        $response = $this->controller->saveAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('provider', $body);
+        $provider = $body['provider'];
+        self::assertIsArray($provider);
+        self::assertArrayHasKey('uid', $provider);
+        $uid = (int)$provider['uid'];
+
+        $providerRepository = $this->get(ProviderRepository::class);
+        self::assertInstanceOf(ProviderRepository::class, $providerRepository);
+        $saved = $providerRepository->findByUid($uid);
+        self::assertNotNull($saved);
+        self::assertSame(
+            'https://api.openai.com/v1',
+            $saved->getEndpointUrl(),
+            'the wizard must persist the canonical /v1 base URL for OpenAI',
+        );
+    }
+
+    #[Test]
     public function saveActionCreatesProviderWithConfigurations(): void
     {
         // The admin backend user (required by both the admin guard and the

--- a/Tests/Unit/Domain/Model/AdapterTypeTest.php
+++ b/Tests/Unit/Domain/Model/AdapterTypeTest.php
@@ -88,7 +88,7 @@ class AdapterTypeTest extends AbstractUnitTestCase
             'OpenRouter' => [AdapterType::OpenRouter, 'https://openrouter.ai/api/v1'],
             'Mistral' => [AdapterType::Mistral, 'https://api.mistral.ai/v1'],
             'Groq' => [AdapterType::Groq, 'https://api.groq.com/openai/v1'],
-            'Ollama' => [AdapterType::Ollama, 'http://localhost:11434/api'],
+            'Ollama' => [AdapterType::Ollama, 'http://localhost:11434'],
             'AzureOpenAI' => [AdapterType::AzureOpenAI, ''],
             'Custom' => [AdapterType::Custom, ''],
         ];

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -629,7 +629,7 @@ final class ProviderTest extends AbstractUnitTestCase
             'openrouter' => ['openrouter', 'https://openrouter.ai/api/v1'],
             'mistral' => ['mistral', 'https://api.mistral.ai/v1'],
             'groq' => ['groq', 'https://api.groq.com/openai/v1'],
-            'ollama' => ['ollama', 'http://localhost:11434/api'],
+            'ollama' => ['ollama', 'http://localhost:11434'],
         ];
     }
 

--- a/Tests/Unit/Service/SetupWizard/ProviderDetectorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ProviderDetectorTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard;
 use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(ProviderDetector::class)]
@@ -373,5 +374,47 @@ class ProviderDetectorTest extends AbstractUnitTestCase
         self::assertEquals('OpenAI', $types['openai']);
         self::assertEquals('Anthropic', $types['anthropic']);
         self::assertEquals('Ollama (Local)', $types['ollama']);
+    }
+
+    // ==================== normalizeEndpointForAdapter ====================
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function normalizeEndpointForAdapterProvider(): array
+    {
+        return [
+            // A bare host gains the adapter's canonical version path (the bug in #98).
+            'openai bare host gains /v1'        => ['https://api.openai.com', 'openai', 'https://api.openai.com/v1'],
+            'openai scheme-less gains https+/v1' => ['api.openai.com', 'openai', 'https://api.openai.com/v1'],
+            'openai trailing slash gains /v1'   => ['https://api.openai.com/', 'openai', 'https://api.openai.com/v1'],
+            'anthropic bare gains /v1'          => ['https://api.anthropic.com', 'anthropic', 'https://api.anthropic.com/v1'],
+            'gemini bare gains /v1beta'         => ['https://generativelanguage.googleapis.com', 'gemini', 'https://generativelanguage.googleapis.com/v1beta'],
+            'groq bare gains /openai/v1'        => ['https://api.groq.com', 'groq', 'https://api.groq.com/openai/v1'],
+            'mistral bare gains /v1'            => ['https://api.mistral.ai', 'mistral', 'https://api.mistral.ai/v1'],
+            'openrouter bare gains /api/v1'     => ['https://openrouter.ai', 'openrouter', 'https://openrouter.ai/api/v1'],
+            // Ollama's adapter adds "api/" itself, so its base URL must stay a bare host.
+            'ollama bare stays bare'            => ['http://localhost:11434', 'ollama', 'http://localhost:11434'],
+            'ollama scheme-less stays bare'     => ['localhost:11434', 'ollama', 'http://localhost:11434'],
+            // A legacy/user-entered trailing "/api" for Ollama is stripped (else /api/api/...).
+            'ollama trailing /api stripped'     => ['http://localhost:11434/api', 'ollama', 'http://localhost:11434'],
+            'ollama trailing /api/ stripped'    => ['http://localhost:11434/api/', 'ollama', 'http://localhost:11434'],
+            // An explicit path is the user's choice: idempotent and non-destructive.
+            'openai already versioned is idempotent' => ['https://api.openai.com/v1', 'openai', 'https://api.openai.com/v1'],
+            'custom host with explicit path kept'    => ['https://llm.example.com/v1', 'openai', 'https://llm.example.com/v1'],
+            // A query string is never mangled by suffix concatenation: left untouched.
+            'endpoint with query string untouched'   => ['https://api.openai.com?x=1', 'openai', 'https://api.openai.com?x=1'],
+            // Adapters without a canonical version path keep the host untouched.
+            'custom adapter keeps bare host'    => ['https://llm.example.com', 'custom', 'https://llm.example.com'],
+            'unknown adapter keeps bare host'   => ['https://llm.example.com', 'not-an-adapter', 'https://llm.example.com'],
+            'empty endpoint stays empty'        => ['', 'openai', ''],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('normalizeEndpointForAdapterProvider')]
+    public function normalizeEndpointForAdapterYieldsCanonicalBaseUrl(string $endpoint, string $adapterType, string $expected): void
+    {
+        self::assertSame($expected, $this->subject->normalizeEndpointForAdapter($endpoint, $adapterType));
     }
 }


### PR DESCRIPTION
## Problem (#98)

The Setup Wizard stored the raw endpoint a user entered (e.g. `https://api.openai.com`) without the `/v1` version path. The provider adapters build request URLs as `baseUrl + '/' + path` and do **not** add the version segment themselves (`OpenAiProvider` posts to `chat/completions`), so a saved OpenAI provider failed every call with *"Invalid URL (GET /models)"* — hitting `/models` instead of `/v1/models`.

## Fix

- **Normalize on save (backend-authoritative)** — `ProviderDetector::normalizeEndpointForAdapter()` appends the adapter's canonical version-path suffix to a bare host and is **idempotent** for endpoints that already carry a path (`.../v1` stays). `SetupWizardController::persistWizardResult()` applies it before persisting, so the stored provider is correct regardless of what the client sent.
- **Align `AdapterType::Ollama->defaultEndpoint()`** with `OllamaProvider` — it is a bare host (`http://localhost:11434`), not `.../api` (the adapter adds `api/` per request). The old value would have produced `/api/api/tags` for an endpoint-less Ollama provider.
- **Make `ModelDiscovery`'s Ollama paths consistent** with that bare base URL (`/api/tags`, `/api/show`), fixing Ollama model discovery for the bare endpoint the wizard stores.

## Tests

- Unit: `ProviderDetectorTest::normalizeEndpointForAdapter…` — 14 cases (every adapter, idempotency, scheme-less, custom/unknown, empty).
- Functional: `SetupWizardControllerTest::saveActionNormalizesBareOpenAiEndpointToIncludeV1` — asserts a bare OpenAI host is persisted as `https://api.openai.com/v1`.
- Updated `AdapterTypeTest` / `ProviderTest` for the corrected Ollama default.
- Green locally: cgl, phpstan L10, unit (ProviderDetector, ModelDiscovery, AdapterType, Provider), functional (SetupWizardController).

## Verification

Fix was adversarially reviewed by a 4-lens workflow (cross-provider correctness, Ollama blast-radius, completeness, test-adequacy). It confirmed the cross-provider mapping is correct and closed out two hypothesised non-issues (no `/v1/v1/models` double-path in ModelDiscovery; no JS change needed). It also surfaced two **confirmed, pre-existing** gaps left as follow-ups (see below).

## Follow-ups (confirmed by review, out of this PR's wizard scope)

1. **Manual provider-create path** (`ProviderController` → FormEngine → TCA `endpoint_url`) applies no normalization, so an admin manually typing `https://api.openai.com` hits the same #98 symptom. A path-independent seam (a `processDatamap` DataHandler hook on `tx_nrllm_provider`, or normalizing in `Provider::getEffectiveEndpointUrl()` — note the latter changes a tested getter contract) would cover wizard + manual + import in one place.
2. **`together` / `fireworks` adapter strings** are advertised in `getSupportedAdapterTypes()` / `DETECTION_PATTERNS` but are **not** `AdapterType` enum cases, so they get no version-path suffix and fall back to `OpenAiProvider` un-versioned. Either add real enum cases (+ `defaultEndpoint`) or stop advertising them.