### PR TITLE
docs(adr): audit ADRs against current code — fix drift, add ADR-039

### DIFF
--- a/Documentation/Adr/Adr001ProviderAbstractionLayer.rst
+++ b/Documentation/Adr/Adr001ProviderAbstractionLayer.rst
@@ -33,12 +33,13 @@ Decision
 Implement a **provider abstraction layer** with:
 
 1. :php:`ProviderInterface` as the core contract.
-2. Capability interfaces for optional features:
+2. Capability interfaces for optional features (embeddings are a core
+   :php:`ProviderInterface` method, not an opt-in capability):
 
-   - :php:`EmbeddingCapableInterface`.
    - :php:`VisionCapableInterface`.
    - :php:`StreamingCapableInterface`.
    - :php:`ToolCapableInterface`.
+   - :php:`DocumentCapableInterface`.
 
 3. :php:`AbstractProvider` base class with shared functionality.
 4. :php:`LlmServiceManager` as the unified entry point.

--- a/Documentation/Adr/Adr004Psr14EventSystem.rst
+++ b/Documentation/Adr/Adr004Psr14EventSystem.rst
@@ -10,7 +10,20 @@ ADR-004: PSR-14 Event System
 
 Status
 ======
-**Accepted** (2024-02)
+**Superseded by** :ref:`ADR-026 <adr-026>` (2024-02, superseded 2026)
+
+.. note::
+
+   The PSR-14 events described below (:php:`BeforeRequestEvent` /
+   :php:`AfterResponseEvent`) were **never implemented** and no longer reflect
+   the code — there is no ``Classes/Event/`` directory and
+   :php:`LlmServiceManager` dispatches no events. The extension points this ADR
+   set out to provide (request modification, response processing, cost tracking,
+   rate limiting) are delivered instead by the **provider middleware pipeline**
+   (:ref:`ADR-026 <adr-026>`): ``FallbackMiddleware``, ``BudgetMiddleware``,
+   ``UsageMiddleware`` and ``CacheMiddleware`` wrap every provider call. New
+   cross-cutting behaviour should be added as a middleware, not an event
+   listener. The original decision is kept below for historical context.
 
 .. _adr-004-context:
 

--- a/Documentation/Adr/Adr007MultiProviderStrategy.rst
+++ b/Documentation/Adr/Adr007MultiProviderStrategy.rst
@@ -43,12 +43,23 @@ Use **tagged service collection** with priority:
        - name: nr_llm.provider
          priority: 90
 
-Provider selection hierarchy:
+.. note::
 
-1. Explicit provider in options.
-2. Default provider from configuration.
-3. First configured provider by priority.
-4. Throw exception if none available.
+   The shipped providers no longer carry an explicit ``tags:`` entry — they
+   self-register via the :php:`#[AsLlmProvider]` attribute collected by
+   :php:`ProviderCompilerPass` (:ref:`ADR-022 <adr-022>`). The ``tags:`` form
+   above still works for third-party providers.
+
+Provider selection:
+
+1. Explicit provider in the per-call options.
+2. Otherwise the active DB-backed default configuration's provider.
+3. Otherwise :php:`getProvider(null)` **throws** a :php:`ProviderException`.
+
+There is deliberately **no** "first provider by priority" fallback: the
+implicit default-provider fallback was removed in :ref:`ADR-034 <adr-034>`, so
+provider selection is always explicit (per-call option or the active
+configuration).
 
 .. _adr-007-consequences:
 

--- a/Documentation/Adr/Adr008ErrorHandlingStrategy.rst
+++ b/Documentation/Adr/Adr008ErrorHandlingStrategy.rst
@@ -31,22 +31,29 @@ Decision
 Implement **hierarchical exception system**:
 
 .. code-block:: text
-   :caption: Exception hierarchy
+   :caption: Exception hierarchy (Classes/Provider/Exception/ + Classes/Exception/)
 
-   Exception
-   └── ProviderException (base for provider errors)
-       ├── AuthenticationException (invalid API key)
-       ├── RateLimitException (quota exceeded)
-       └── ContentFilteredException (blocked content)
-   └── InvalidArgumentException (bad inputs)
-   └── ConfigurationNotFoundException (missing config)
+   \RuntimeException
+   ├── Netresearch\NrLlm\Provider\Exception\ProviderException (base for provider errors)
+   │   ├── ProviderConnectionException (transport / network failure)
+   │   ├── ProviderResponseException (non-2xx / malformed API response)
+   │   ├── ProviderConfigurationException (missing/invalid provider setup)
+   │   ├── UnsupportedFeatureException (capability not implemented)
+   │   └── FallbackChainExhaustedException (all providers in the chain failed)
+   └── Netresearch\NrLlm\Exception\ConfigurationNotFoundException (missing configuration record)
+   \InvalidArgumentException
+   └── Netresearch\NrLlm\Exception\InvalidArgumentException (bad inputs)
 
 Key features:
 
-- All provider errors extend :php:`ProviderException`.
-- :php:`RateLimitException` includes :php:`getRetryAfter()`.
+- All provider errors extend :php:`ProviderException` (itself a
+  :php:`\RuntimeException`).
+- :php:`FallbackChainExhaustedException` is raised by
+  :php:`FallbackMiddleware` when every provider in the chain fails
+  (:ref:`ADR-021 <adr-021>`, :ref:`ADR-026 <adr-026>`).
+- :php:`ProviderResponseException` carries the offending HTTP status and a
+  sanitised message (secrets stripped by ``ErrorMessageSanitizerTrait``).
 - Exceptions include provider context.
-- HTTP status code mapping.
 
 .. _adr-008-consequences:
 

--- a/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
+++ b/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
@@ -50,9 +50,10 @@ Support **OpenAI-compatible tool format**:
 
 Tool calls returned in :php:`CompletionResponse::$toolCalls`:
 
-- Array of tool call objects.
-- Includes function name and arguments.
-- JSON-encoded arguments for parsing.
+- A typed ``list<ToolCall>`` (nullable) of :php:`ToolCall` value objects —
+  each with the tool ``id``, ``name`` and its arguments as an already
+  **JSON-decoded** associative array (not an encoded string). A full
+  tool-execution runtime was added later in :ref:`ADR-038 <adr-038>`.
 
 .. _adr-010-consequences:
 

--- a/Documentation/Adr/Adr015TypeSafeDomainModels.rst
+++ b/Documentation/Adr/Adr015TypeSafeDomainModels.rst
@@ -67,7 +67,7 @@ Enums implemented:
    :widths: 30, 40, 30
 
    "AdapterType", "LLM provider protocol type", "9 cases (OpenAI through Custom)"
-   "ModelCapability", "Model feature flags", "8 cases (chat, vision, tools...)"
+   "ModelCapability", "Model feature flags", "11 cases (chat, completion, embeddings, vision, streaming, tools, json_mode, audio, image, text_to_speech, transcription)"
    "TaskCategory", "Task organization", "5 cases (content, log_analysis...)"
    "TaskInputType", "Task input source", "5 cases (manual, syslog, file...)"
    "TaskOutputFormat", "Response rendering format", "4 cases (markdown, json...)"

--- a/Documentation/Adr/Adr017SafeCastTrait.rst
+++ b/Documentation/Adr/Adr017SafeCastTrait.rst
@@ -124,5 +124,6 @@ Files changed
 
 - :file:`Classes/Service/WizardGeneratorService.php` --
   Uses :php:`SafeCastTrait` for JSON normalization.
-- :file:`Classes/Controller/Backend/TaskController.php`
-  -- Uses :php:`SafeCastTrait` for form data casting.
+- :file:`Classes/Controller/Backend/TaskWizardController.php`
+  -- Uses :php:`SafeCastTrait` for form data casting (the monolithic
+  ``TaskController`` was split per :ref:`ADR-027 <adr-027>`).

--- a/Documentation/Adr/Adr019InternationalizationStrategy.rst
+++ b/Documentation/Adr/Adr019InternationalizationStrategy.rst
@@ -55,20 +55,21 @@ One XLIFF file per backend module, plus German translations:
 Locale-aware LLM features
 --------------------------
 
-The :php:`TestPromptTrait` resolves the backend user's
-language and substitutes a ``{lang}`` placeholder in
+The :php:`TestPromptResolverService` (a :php:`final readonly class` implementing
+:php:`TestPromptResolverInterface`, injected via DI — it replaced the former
+``TestPromptTrait`` when the logic was extracted out of the controller) resolves
+the backend user's language and substitutes a ``{lang}`` placeholder in
 configurable test prompts:
 
 .. code-block:: php
-   :caption: TestPromptTrait locale resolution
+   :caption: TestPromptResolverService locale resolution
 
-   private function resolveTestPrompt(): string
+   public function resolve(): string
    {
-       $default = 'Say hello and introduce yourself in one sentence. Respond in {lang}.';
-       // ... resolve from extension configuration ...
-
-       $lang = $uc['lang'] ?? 'default';
-       $languageName = $this->mapLanguageCodeToName($lang);
+       // Reads the configurable prompt (default: "Say hello and introduce
+       // yourself in one sentence. Respond in {lang}.") and the BE user's language.
+       $prompt       = $this->loadConfiguredPrompt();
+       $languageName = self::LANGUAGE_MAP[$this->resolveBackendUserLanguage()] ?? 'English';
 
        return str_replace('{lang}', $languageName, $prompt);
    }
@@ -121,4 +122,5 @@ Files changed
 - :file:`Resources/Private/Language/locallang_mod_task.xlf` and ``de.*``
 - :file:`Resources/Private/Language/locallang_mod_wizard.xlf` and ``de.*``
 - :file:`Resources/Private/Language/locallang_mod_overview.xlf` and ``de.*``
-- :file:`Classes/Controller/Backend/TestPromptTrait.php`
+- :file:`Classes/Service/TestPromptResolverService.php` and
+  :file:`Classes/Service/TestPromptResolverInterface.php`

--- a/Documentation/Adr/Adr020BackendOutputFormatRendering.rst
+++ b/Documentation/Adr/Adr020BackendOutputFormatRendering.rst
@@ -134,7 +134,8 @@ Files changed
 
 - :file:`Resources/Private/Templates/Backend/Task/Execute.html`
   -- Format toggle UI and output container.
-- :file:`Classes/Controller/Backend/TaskController.php`
-  -- Returns ``outputFormat`` in AJAX response.
+- :file:`Classes/Controller/Backend/TaskExecutionController.php`
+  -- Returns ``outputFormat`` in the AJAX response (the monolithic
+  ``TaskController`` was split per :ref:`ADR-027 <adr-027>`).
 - :file:`Classes/Domain/Enum/TaskOutputFormat.php`
   -- Defines valid output formats with content types.

--- a/Documentation/Adr/Adr021ProviderFallbackChain.rst
+++ b/Documentation/Adr/Adr021ProviderFallbackChain.rst
@@ -28,8 +28,9 @@ Decision
 A configuration's ``fallback_chain`` column stores an ordered JSON list of
 other :php:`LlmConfiguration` identifiers. On retryable failures during
 :php:`LlmServiceManager::chatWithConfiguration()` or
-:php:`completeWithConfiguration()`, a :php:`FallbackChainExecutor` walks the
-chain and returns the first successful response — or throws
+:php:`completeWithConfiguration()`, :php:`FallbackMiddleware` (a stage of the
+provider middleware pipeline, :ref:`ADR-026 <adr-026>`) walks the chain and
+returns the first successful response — or throws
 :php:`FallbackChainExhaustedException` carrying every attempt error.
 
 "Retryable" is narrowly defined: the request *might* succeed against a

--- a/Documentation/Adr/Adr022AttributeBasedProviderRegistration.rst
+++ b/Documentation/Adr/Adr022AttributeBasedProviderRegistration.rst
@@ -37,11 +37,14 @@ deliberate: overrides should be explicit, not silently merged.
 
 The shipped providers now declare their priority via the attribute, and the
 ``tags:`` entries have been removed from :file:`Configuration/Services.yaml`.
-Attribute-tagged providers are also made public automatically by
-:php:`ProviderCompilerPass` so that backend diagnostics can resolve them by
-class name. The legacy yaml-tagging path still works for third-party
-providers, but yaml-tagged services remain private unless the yaml entry
-sets ``public: true`` explicitly.
+:php:`ProviderCompilerPass` collects every ``nr_llm.provider``-tagged service
+(from the attribute or a legacy yaml tag), sorts them by priority, and wires
+each one into :php:`LlmServiceManager` with a ``registerProvider()`` method
+call. The providers stay **private** — they are never individually resolved
+from the container (which keeps the public-services set locked by
+:ref:`ADR-028 <adr-028>`); the backend instantiates the concrete adapter for a
+provider record directly through :php:`ProviderAdapterRegistry`. The legacy
+yaml-tagging path still works for third-party providers.
 
 .. _adr-022-tradeoffs:
 

--- a/Documentation/Adr/Adr023BackendCapabilityPermissions.rst
+++ b/Documentation/Adr/Adr023BackendCapabilityPermissions.rst
@@ -32,8 +32,9 @@ Decision
 Register every :php:`ModelCapability` enum value as a native TYPO3 BE group
 permission under
 :code:`$TYPO3_CONF_VARS['BE']['customPermOptions']['nrllm']`. The BE group
-edit view now shows a checkbox per capability (chat, completion,
-embeddings, vision, streaming, tools, json_mode, audio). A new service,
+edit view now shows a checkbox for every :php:`ModelCapability` case (11 today:
+chat, completion, embeddings, vision, streaming, tools, json_mode, audio, image,
+text_to_speech, transcription). A new service,
 :php:`CapabilityPermissionService`, resolves the check against the
 currently logged-in backend user.
 

--- a/Documentation/Adr/Adr024DashboardWidgets.rst
+++ b/Documentation/Adr/Adr024DashboardWidgets.rst
@@ -39,11 +39,13 @@ up with nr-llm-specific data providers:
   type (chat, vision, translation, speech, image) by ``service_provider``
   over the last seven days.
 
-Both are registered in a dedicated :file:`Configuration/Services.Dashboard.yaml`
-imported conditionally from :file:`Configuration/Services.php` when
-:php:`TYPO3\\CMS\\Dashboard\\Widgets\\WidgetInterface` exists. Without that
-guard, TYPO3 instances that do not have :code:`typo3/cms-dashboard` installed
-would fail at container compile time on the unresolved widget class.
+Both are registered in a dedicated :file:`Configuration/Services.Dashboard.php`
+imported conditionally from :file:`Configuration/Services.php` only when
+:php:`interface_exists(TYPO3\\CMS\\Dashboard\\Widgets\\WidgetInterface::class)`.
+A PHP config file (not YAML) is used so the import can be guarded by that
+runtime :php:`interface_exists()` check. Without the guard, TYPO3 instances that
+do not have :code:`typo3/cms-dashboard` installed would fail at container
+compile time on the unresolved widget class.
 
 Classes/Widgets/* is excluded from the global auto-registration in
 :file:`Services.yaml` for the same reason — the data provider classes

--- a/Documentation/Adr/Adr035SkillIngest.rst
+++ b/Documentation/Adr/Adr035SkillIngest.rst
@@ -59,8 +59,10 @@ Decision
    guard, :php:`GitHubClient` enforces an **app-level GitHub host
    allowlist**: ``scheme = https`` AND host ∈ ``{github.com,
    raw.githubusercontent.com, api.github.com, codeload.github.com}`` on
-   the initial URL and every redirect target. A rejected URL raises a
-   typed :php:`HostNotAllowedException` — never a silent skip.
+   the **initial request URL**. The transport does **not follow redirects**
+   (any 3xx is treated as an error), so there is no redirect target to
+   escape the allowlist. A rejected URL raises a typed
+   :php:`HostNotAllowedException` — never a silent skip.
 
 4. **Fetch by immutable commit SHA + checksum.** A source ``ref``
    (branch/tag) is resolved once to a commit SHA via

--- a/Documentation/Adr/Adr036SkillInjection.rst
+++ b/Documentation/Adr/Adr036SkillInjection.rst
@@ -61,9 +61,10 @@ Decision
    ``enabled`` and non-``orphaned`` skills. The configuration block renders
    first.
 
-5. **Conservative character budget, deterministic drop.** Because no
-   tokenizer exists, the budget is a conservative **character** cap
-   (default 24 000, constructor-injectable). When exceeded, skills are
+5. **Conservative byte budget, deterministic drop.** Because no
+   tokenizer exists, the budget is a conservative **byte** cap
+   (:php:`strlen`, default 24 000, constructor-injectable — a byte count is a
+   safe over-estimate of tokens for any encoding). When exceeded, skills are
    dropped **from the tail first** (task-additive before configuration
    baseline), each drop logged as a warning. This is intentionally an
    over-estimate set well below the smallest expected context window; with
@@ -98,7 +99,7 @@ Consequences
 - ● Fail-closed checksum verification means a tampered or stale skill row
   is dropped, not silently injected — the ingest-time pin (ADR-035) is
   enforced again at the moment of use.
-- ◐ The budget is a character heuristic, not a token guarantee; it is
+- ◐ The budget is a byte heuristic, not a token guarantee; it is
   deliberately conservative and logs every drop, but very large skills on
   tiny-context local models may still be trimmed.
 - ◐ Injection touches the live text-generation path; it is scoped to

--- a/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
+++ b/Documentation/Adr/Adr037BackendAjaxAdminGuard.rst
@@ -45,9 +45,10 @@ Decision
 1. **One shared guard trait.** :php:`RequiresBackendAdminTrait`
    (``Classes/Controller/Backend/``) exposes a single private
    ``denyNonAdmin(): ?ResponseInterface`` that returns ``null`` for an admin
-   and a ``403`` ``{"success": false, "error": "Forbidden"}`` JSON response
-   otherwise. :php:`SkillSourceController` now uses the trait; its identical
-   private copy was deleted.
+   and a ``403`` ``{"success": false, "error": "<message>"}`` JSON response
+   otherwise, where ``<message>`` is the localised
+   ``error.adminRequired`` label. :php:`SkillSourceController` now uses the
+   trait; its identical private copy was deleted.
 
 2. **Guard every AJAX-routed action, at the very top.** Each action listed in
    ``AjaxRoutes.php`` begins with
@@ -58,9 +59,10 @@ Decision
    :php:`LlmModuleController`, :php:`ProviderController`, :php:`ModelController`,
    :php:`ConfigurationController`, :php:`TaskRecordsController`,
    :php:`TaskExecutionController`, :php:`SetupWizardController`,
-   :php:`ToolPlaygroundController` and the already-guarded
-   :php:`SkillSourceController` — 29 actions in total, matching the route table
-   exactly.
+   :php:`ToolPlaygroundController`, :php:`ToolController` (the tool-management
+   module split out later — :ref:`ADR-039 <adr-039>`) and the already-guarded
+   :php:`SkillSourceController` — every AJAX-routed action, matching the route
+   table exactly.
 
 3. **Non-AJAX module actions are left untouched.** Extbase module actions
    (``listAction``, ``indexAction``, ``executeFormAction``,

--- a/Documentation/Adr/Adr038ToolRuntime.rst
+++ b/Documentation/Adr/Adr038ToolRuntime.rst
@@ -161,7 +161,7 @@ Consequences
   reach a tool the skills did not grant.
 - ◐ The shipped built-in tools (``fetch_logs``, ``read_fal_asset_meta``, and
   the later diagnostic/record tools — ``get_php_info``, ``get_env``,
-  ``get_page_tree``, ``get_tca``, ``list_be_users``, ``list_be_groups`` and
+  ``get_pagetree``, ``get_tca``, ``list_be_users``, ``list_be_groups`` and
   their secret-redacted/raw variants) are admin-curated, **read-only**,
   input-bounded and scoped (limit cap + PII redaction; storage-scoped lookup).
   They are reference implementations of the security contract, not a general

--- a/Documentation/Adr/Adr039GlobalToolAvailabilityState.rst
+++ b/Documentation/Adr/Adr039GlobalToolAvailabilityState.rst
@@ -1,0 +1,103 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-039:
+
+==================================================================
+ADR-039: Global per-tool availability state
+==================================================================
+
+:Status: Accepted
+:Date: 2026-06-30
+:Authors: Netresearch DTT GmbH
+
+.. _adr-039-context:
+
+Context
+=======
+
+The tool runtime (:ref:`ADR-038 <adr-038>`) gates *which* tools a single agent
+run may call through two mechanisms:
+
+- each :php:`ToolInterface` declares :php:`isEnabledByDefault()` — a compile-time
+  default (e.g. read-only tools ship on, mutating ones ship off);
+- every run carries a per-request **allow-list** (the skill's ``allowed-tools``
+  or the playground selection), so a run only ever sees the subset it asked for.
+
+What was missing is an **operator control**: an administrator could not globally
+turn a registered tool off for the whole instance. A tool shipping
+``isEnabledByDefault() === true`` was callable by every run that allow-listed it,
+with no site-wide kill switch; and a default-off tool could not be switched on
+without a code change. Neither the per-tool default nor the per-run allow-list is
+the right seam for "this instance does not permit ``get_env`` at all".
+
+.. _adr-039-decision:
+
+Decision
+========
+
+Introduce a **global, per-tool availability override** that sits above the
+per-tool default and below the per-run allow-list.
+
+- **Storage** — a dedicated table ``tx_nrllm_tool_state`` (``tool_name`` unique,
+  ``enabled`` boolean). It has **no TCA and no FormEngine UI**: it is operational
+  state toggled from the backend, not editorial content edited as a record. A
+  **missing row falls back to the tool's** :php:`isEnabledByDefault()`, so the
+  table only ever holds explicit admin overrides.
+- **Repository** — :php:`ToolStateRepository` exposes :php:`overrides()` (the
+  sparse override map) and :php:`setEnabled(name, bool)` (upsert one override).
+- **Effective-state service** — :php:`ToolAvailabilityService` computes the
+  authoritative *"what may run at all"* set: for every registered tool the
+  effective state is its admin override when one exists, otherwise its
+  :php:`isEnabledByDefault()`. :php:`enabledNames()` returns the enabled subset;
+  :php:`states()` returns the full name / description / enabled / defaultEnabled
+  rows the backend renders.
+- **Runtime enforcement** — :php:`ToolLoopService` **intersects every per-run
+  allow-list with** :php:`enabledNames()`, so a globally-disabled tool can never
+  be invoked regardless of what a skill or the playground requested. This is the
+  same defense-in-depth layering as the acting-user RBAC intersection in
+  :ref:`ADR-038 <adr-038>` — the allow-list narrows, it never widens.
+- **Backend surface** — the toggles are rendered and persisted by the dedicated
+  **Tools** backend module (:php:`ToolController`), split out from the interactive
+  **Playground** module so managing availability and running the agent loop are
+  separate admin concerns (see the two-module split). :php:`toggleToolAction()`
+  is admin-guarded (:ref:`ADR-037 <adr-037>`) and writes through
+  :php:`ToolStateRepository::setEnabled()`.
+
+.. _adr-039-consequences:
+
+Consequences
+============
+
+- Administrators get a **site-wide kill switch** per tool, independent of code
+  defaults and of any individual run's allow-list.
+- Availability resolves in two steps: the **effective global state** is the admin
+  override when one exists, **otherwise** the compile-time default (so an override
+  can enable a default-off tool or disable a default-on one — it *replaces* the
+  default, it does not merely narrow it). The **per-run allow-list is then
+  intersected** with that effective set, so a run can only ever *narrow* what is
+  globally enabled — a globally-disabled tool can never be called, but the
+  allow-list can never re-enable one.
+- The table is **deliberately TCA-less**: it is a small operational toggle set
+  keyed by ``tool_name``, not a versioned/localisable record, so a bespoke
+  toggle endpoint is a better fit than FormEngine (and avoids exposing an
+  editable "tool" record that implies more than a boolean).
+- Because a missing row falls back to the tool default, **shipping a new tool**
+  needs no data migration: its :php:`isEnabledByDefault()` applies until an admin
+  overrides it.
+- Reads go through :php:`ToolAvailabilityService` on every agent run; the override
+  map is a single small query, cheap relative to the LLM calls it gates.
+
+.. _adr-039-alternatives:
+
+Alternatives considered
+=======================
+
+- **Reuse the per-run allow-list only** — rejected: the allow-list is authored per
+  skill/run and cannot express an instance-wide policy; a globally-forbidden tool
+  would have to be scrubbed from every skill.
+- **Flip** :php:`isEnabledByDefault()` **in code** — rejected: the default is a
+  ship-time property of the tool, not per-instance operator policy, and changing
+  it requires a release.
+- **A TCA-backed ``tool`` record** — rejected: tools are code-registered, not
+  editable entities; a full record UI would imply create/delete/localise
+  semantics that do not apply to a boolean override keyed by a code identifier.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -287,6 +287,15 @@ Tools
       .. card-footer:: :ref:`Read <adr-038>`
          :button-style: btn btn-secondary stretched-link
 
+   .. card:: ADR-039: Global tool availability
+
+      Site-wide per-tool enable/disable override
+      (``tx_nrllm_tool_state``, no TCA) intersected with every
+      run's allow-list — a hard admin kill switch.
+
+      .. card-footer:: :ref:`Read <adr-039>`
+         :button-style: btn btn-secondary stretched-link
+
 .. toctree::
    :hidden:
 
@@ -328,3 +337,4 @@ Tools
    Adr036SkillInjection
    Adr037BackendAjaxAdminGuard
    Adr038ToolRuntime
+   Adr039GlobalToolAvailabilityState


### PR DESCRIPTION
A full audit of all 38 ADRs against the **current code** (each finding verified with file:line evidence, via a multi-lens review). It corrects stale/drifted records and adds the one architectural decision that lacked an ADR.

## Stale — substantive rewrites

| ADR | Was | Now |
|---|---|---|
| **004** PSR-14 events | `BeforeRequestEvent`/`AfterResponseEvent` dispatched by `LlmServiceManager` | **Superseded by ADR-026** — those events were never implemented; extension points are the provider **middleware pipeline** |
| **008** Error handling | `AuthenticationException` / `RateLimitException::getRetryAfter()` / `ContentFilteredException` | real `ProviderException` subclasses: `ProviderConnection/Response/Configuration`, `UnsupportedFeature`, `FallbackChainExhausted` |
| **019** i18n | `TestPromptTrait` (controller) | `TestPromptResolverService` (extracted DI service) |
| **021** Fallback chain | `FallbackChainExecutor` | `FallbackMiddleware` |
| **022** Provider registration | providers "made public automatically" | registered into `LlmServiceManager`, kept **private** (per ADR-028) |
| **024** Dashboard widgets | `Services.Dashboard.yaml` | `Services.Dashboard.php` (`interface_exists` guard) |

## Drift — factual corrections

ADR-001 (`Embedding`→`DocumentCapableInterface`), ADR-007 (no default/first-by-priority fallback — `getProvider(null)` throws; attribute registration), ADR-010 (typed `ToolCall` value objects, decoded args), ADR-015 & ADR-023 (`ModelCapability` 8 → **11** cases), ADR-017 & ADR-020 (`TaskController` split citations → `TaskWizard`/`TaskExecution`), ADR-035 (allowlist on the initial URL; redirects **refused**, not followed), ADR-036 (byte cap via `strlen`, not "character"), ADR-037 (localized 403 body + `ToolController` now guarded), ADR-038 (`get_pagetree` spec name).

## New

**ADR-039: Global per-tool availability state** — documents the `tx_nrllm_tool_state` / `ToolStateRepository` / `ToolAvailabilityService` layer (from #274): a TCA-less, site-wide per-tool enable/disable override that `ToolLoopService` **intersects** with every run's allow-list, giving admins a hard kill switch layered above the per-tool default and below the per-run allow-list. Added to the index (card + toctree).

Docs-only; rendering verified in CI.