### PR TITLE
fix(provider): normalize the endpoint on the manual create/edit path (#300)

### DIFF
--- a/Classes/Hook/ProviderEndpointNormalizationHook.php
+++ b/Classes/Hook/ProviderEndpointNormalizationHook.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Hook;
+
+use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+/**
+ * Normalizes ``tx_nrllm_provider.endpoint_url`` to the adapter's canonical base
+ * URL when a provider is created or edited through the TCA record editor.
+ *
+ * The Setup Wizard already does this on save (see
+ * {@see \Netresearch\NrLlm\Controller\Backend\SetupWizardController} and
+ * ADR referencing #98), but a provider created/edited manually in the backend
+ * bypasses that path. Without normalization an admin who types
+ * ``https://api.openai.com`` would store a bare host, and every provider request
+ * would hit ``/models`` instead of ``/v1/models`` — the provider adapters build
+ * request URLs as ``baseUrl + '/' + path`` and do not add the version segment
+ * themselves. This DataHandler hook makes the manual write path store the same
+ * canonical base URL as the wizard (#300).
+ */
+final class ProviderEndpointNormalizationHook
+{
+    /**
+     * @param array<string, mixed> $fieldArray incoming field values (mutated in place)
+     * @param int|string           $id         record uid, or a "NEW..." placeholder for new records
+     */
+    public function processDatamap_preProcessFieldArray(
+        array &$fieldArray,
+        string $table,
+        int|string $id,
+        DataHandler $dataHandler,
+    ): void {
+        if ($table !== 'tx_nrllm_provider' || !array_key_exists('endpoint_url', $fieldArray)) {
+            return;
+        }
+
+        $endpoint = is_string($fieldArray['endpoint_url']) ? $fieldArray['endpoint_url'] : '';
+        if (trim($endpoint) === '') {
+            return;
+        }
+
+        $adapterType = $this->resolveAdapterType($fieldArray, $id);
+        if ($adapterType === '') {
+            return;
+        }
+
+        $fieldArray['endpoint_url'] = GeneralUtility::makeInstance(ProviderDetector::class)
+            ->normalizeEndpointForAdapter($endpoint, $adapterType);
+    }
+
+    /**
+     * Determine the adapter type for the record being saved: from the incoming
+     * change set when present, otherwise from the stored record (an edit that
+     * changes only the endpoint carries no ``adapter_type`` in ``$fieldArray``).
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    private function resolveAdapterType(array $fieldArray, int|string $id): string
+    {
+        if (isset($fieldArray['adapter_type']) && is_string($fieldArray['adapter_type']) && $fieldArray['adapter_type'] !== '') {
+            return $fieldArray['adapter_type'];
+        }
+
+        if (MathUtility::canBeInterpretedAsInteger($id)) {
+            $record = BackendUtility::getRecord('tx_nrllm_provider', (int)$id, 'adapter_type');
+            $stored = is_array($record) ? ($record['adapter_type'] ?? null) : null;
+            if (is_string($stored)) {
+                return $stored;
+            }
+        }
+
+        return '';
+    }
+}

--- a/Tests/Functional/Hook/ProviderEndpointNormalizationHookTest.php
+++ b/Tests/Functional/Hook/ProviderEndpointNormalizationHookTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Hook;
+
+use Netresearch\NrLlm\Hook\ProviderEndpointNormalizationHook;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+#[CoversClass(ProviderEndpointNormalizationHook::class)]
+final class ProviderEndpointNormalizationHookTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_provider';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+    }
+
+    #[Test]
+    public function createNormalizesBareOpenAiEndpointToV1(): void
+    {
+        // #300: a provider created through the TCA record editor (not the wizard)
+        // must still get the canonical /v1 base URL OpenAiProvider requires.
+        $uid = $this->createProvider('openai', 'https://api.openai.com');
+
+        self::assertSame('https://api.openai.com/v1', $this->endpointOf($uid));
+    }
+
+    #[Test]
+    public function createKeepsOllamaEndpointBare(): void
+    {
+        // Ollama's adapter adds "api/" per request, so its base URL must stay bare.
+        $uid = $this->createProvider('ollama', 'http://localhost:11434');
+
+        self::assertSame('http://localhost:11434', $this->endpointOf($uid));
+    }
+
+    #[Test]
+    public function createIsIdempotentForAnAlreadyVersionedEndpoint(): void
+    {
+        $uid = $this->createProvider('openai', 'https://api.openai.com/v1');
+
+        self::assertSame('https://api.openai.com/v1', $this->endpointOf($uid));
+    }
+
+    #[Test]
+    public function editingOnlyTheEndpointNormalizesUsingTheStoredAdapterType(): void
+    {
+        // Start from a correct record, then edit ONLY the endpoint to a bare host
+        // without sending adapter_type — the hook must read it from the stored row.
+        $uid = $this->createProvider('openai', 'https://api.openai.com/v1');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start(
+            [self::TABLE => [$uid => ['endpoint_url' => 'https://api.openai.com']]],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        self::assertSame('https://api.openai.com/v1', $this->endpointOf($uid));
+    }
+
+    private function createProvider(string $adapterType, string $endpoint): int
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start(
+            [
+                self::TABLE => [
+                    'NEW1' => [
+                        'pid'          => 0,
+                        'identifier'   => 'provider-' . $adapterType,
+                        'name'         => 'Provider ' . $adapterType,
+                        'adapter_type' => $adapterType,
+                        'endpoint_url' => $endpoint,
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        $uid = $dataHandler->substNEWwithIDs['NEW1'] ?? null;
+        self::assertNotNull($uid, 'DataHandler must have created the provider record');
+
+        return (int)$uid;
+    }
+
+    private function endpointOf(int $uid): string
+    {
+        $record = BackendUtility::getRecord(self::TABLE, $uid, 'endpoint_url');
+        self::assertIsArray($record);
+
+        return is_string($record['endpoint_url'] ?? null) ? $record['endpoint_url'] : '';
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Form\Element\ModelIdElement;
 use Netresearch\NrLlm\Form\FieldWizard\ModelConstraintsWizard;
+use Netresearch\NrLlm\Hook\ProviderEndpointNormalizationHook;
 use Netresearch\NrLlm\Service\CapabilityPermissionService;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 
@@ -74,4 +75,11 @@ defined('TYPO3') or die();
         'header' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_be.xlf:permissions.header',
         'items' => $capabilityItems,
     ];
+
+    // Normalize tx_nrllm_provider.endpoint_url to the adapter's canonical base URL
+    // when a provider is created/edited through the TCA record editor, so the
+    // manual write path stores a working base URL just like the Setup Wizard (#300).
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
+        = ProviderEndpointNormalizationHook::class;
 })();


### PR DESCRIPTION
Closes gap 1 of #300 (surfaced by the #98/#299 review).

## Problem

The Setup Wizard normalizes a provider's endpoint on save (#299), but a provider **created or edited through the TCA record editor** bypassed that path. An admin who types `https://api.openai.com` stored a bare host, and every provider request then hit `/models` instead of `/v1/models` — the exact #98 symptom, via a first-class backend UI.

## Fix

A DataHandler `processDatamap_preProcessFieldArray` hook for `tx_nrllm_provider` runs the same `ProviderDetector::normalizeEndpointForAdapter()` before the row is written, so the manual write path stores the adapter's canonical base URL just like the wizard. The adapter type comes from the incoming change set, or from the stored record for an edit that changes only the endpoint. The hook is dependency-free (resolves the normalizer via `makeInstance`).

## Tests

Functional (`ProviderEndpointNormalizationHookTest`, drives a real `DataHandler`): create OpenAI `→ /v1`, Ollama stays bare, already-`/v1` is idempotent, and an endpoint-only edit normalizes using the stored adapter type. Green locally: cgl, phpstan L10, functional, architecture.

## Remaining

Gap 2 of #300 (`together`/`fireworks`/`perplexity` are advertised but not `AdapterType` enum cases) is left for a separate change — it needs real enum cases with per-provider version paths (`together` `/v1`, `fireworks` `/inference/v1`, `perplexity` none), which is a distinct decision.