### PR TITLE
fix(provider): force fresh connection per request to defeat keep-alive reuse race

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -274,7 +274,16 @@ abstract class AbstractProvider implements ProviderInterface
         $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
 
         $request = $this->requestFactory->createRequest($method, $url)
-            ->withHeader('Content-Type', 'application/json');
+            ->withHeader('Content-Type', 'application/json')
+            // Force a fresh connection per request. The tool agent loop fires
+            // several POSTs to the same host in rapid succession; a pooled
+            // keep-alive connection the upstream (e.g. Ollama) has since
+            // half-closed can drop the tail of a larger request body mid-send,
+            // and the provider then rejects the truncated JSON with a 4xx that
+            // is (correctly) not retried. Disabling keep-alive trades a
+            // negligible TCP handshake — dwarfed by generation latency — for a
+            // reliable body delivery. See ADR-026 / the middleware pipeline.
+            ->withHeader('Connection', 'close');
 
         $request = $this->addProviderSpecificHeaders($request);
 

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -697,6 +697,49 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         self::assertEmpty($capturedBody);
     }
 
+    /**
+     * Every outgoing provider request must carry `Connection: close`. The tool
+     * agent loop fires several POSTs to the same host in rapid succession; a
+     * pooled keep-alive connection the upstream has half-closed can drop the
+     * tail of a larger request body, and the provider then rejects the
+     * truncated JSON with an un-retried 4xx. Disabling keep-alive per request
+     * defeats that reuse race — this test pins the header so it cannot be
+     * dropped silently.
+     */
+    #[Test]
+    public function sendRequestDisablesConnectionKeepAlive(): void
+    {
+        $capturedConnection = null;
+        $httpFactory        = new HttpFactory();
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedConnection) {
+                $capturedConnection = $request->getHeaderLine('Connection');
+
+                return $this->createJsonResponseMock(['ok' => true]);
+            });
+
+        $provider = new GeminiProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+        ]);
+        $provider->setHttpClient($httpClient);
+
+        $reflection = new ReflectionClass($provider);
+        $method     = $reflection->getMethod('sendRequest');
+        $method->invoke($provider, '/test', ['data' => 'value']);
+
+        self::assertSame('close', $capturedConnection);
+    }
+
     #[Test]
     public function sendRequestSetsBodyForPostWithPayload(): void
     {


### PR DESCRIPTION
## Problem

The bounded tool agent loop ([`ToolLoopService`](https://github.com/netresearch/t3x-nr-llm/blob/main/Classes/Service/Tool/ToolLoopService.php)) fires several POSTs to the same provider host in rapid succession — one per iteration. A pooled keep-alive connection the upstream has half-closed since the previous iteration can drop the tail of a *larger* request body mid-send (the second iteration replays the assistant tool-call turn plus the tool result, so its body is bigger than the first).

The provider then receives truncated JSON and rejects it with a 4xx. With Ollama the exact error is:

```
HTTP 400 — Value looks like object, but can't find closing '}' symbol
```

That 4xx is (correctly) **not** retried by [`AbstractProvider::sendRequest()`](https://github.com/netresearch/t3x-nr-llm/blob/main/Classes/Provider/AbstractProvider.php), so the whole tool run fails. It is **intermittent** — it only happens when a reused connection has gone stale — which is why the Tool Playground failed sporadically on repeated runs.

## Fix

Send `Connection: close` on every `AbstractProvider` request, so each call uses a fresh connection instead of a possibly-dead pooled one. This is the HTTP-standard way to opt out of keep-alive reuse and is portable across the vault-backed client and the plain Guzzle client (Ollama path). The extra TCP handshake per request is negligible next to LLM generation latency.

## Verification

- New regression test `sendRequestDisablesConnectionKeepAlive` pins the header (captures the outgoing PSR-7 request and asserts `Connection: close`).
- Reproduced live on ddev: before the fix the Playground tool loop 400'd intermittently on iteration 2; after it, every `/api/chat` request returned 200 across repeated runs.
- `cgl`, `phpstan` (level 10) and the full `unit` suite green on PHP 8.4 and 8.5.