### PR TITLE
fix(tools): serialise empty tool parameters and arguments as JSON objects, not arrays

### DIFF
--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 
 use InvalidArgumentException;
 use JsonSerializable;
+use stdClass;
 
 /**
  * Value Object describing a tool the model is allowed to call.
@@ -43,6 +44,13 @@ final readonly class ToolSpec implements JsonSerializable
     public const TYPE_FUNCTION = 'function';
 
     /**
+     * @var array<string, mixed> JSON-Schema-shaped parameter description;
+     *                           passed verbatim to the provider (with the
+     *                           empty-`properties` normalisation below applied).
+     */
+    public array $parameters;
+
+    /**
      * @param array<string, mixed> $parameters JSON-Schema-shaped parameter
      *                                         description; passed verbatim
      *                                         to the provider.
@@ -50,7 +58,7 @@ final readonly class ToolSpec implements JsonSerializable
     public function __construct(
         public string $name,
         public string $description,
-        public array $parameters,
+        array $parameters,
         public string $type = self::TYPE_FUNCTION,
     ) {
         if ($this->name === '') {
@@ -65,6 +73,30 @@ final readonly class ToolSpec implements JsonSerializable
                 1745410002,
             );
         }
+
+        $this->parameters = self::normaliseParameters($parameters);
+    }
+
+    /**
+     * JSON Schema requires `properties` to be an object. A parameterless tool
+     * declares it as an empty PHP array, which `json_encode` renders as `[]` —
+     * and strict providers (Ollama) then reject the whole request with
+     * "Value looks like object, but can't find closing '}' symbol". Force the
+     * empty case to a `stdClass` so it serialises as `{}`. Applied at
+     * construction so the stored value is already correct and
+     * `fromArray(toArray())` stays idempotent.
+     *
+     * @param array<string, mixed> $parameters
+     *
+     * @return array<string, mixed>
+     */
+    private static function normaliseParameters(array $parameters): array
+    {
+        if (($parameters['properties'] ?? null) === []) {
+            $parameters['properties'] = new stdClass();
+        }
+
+        return $parameters;
     }
 
     /**

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -364,8 +364,13 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             return $call;
         }
 
-        $decoded = json_decode($arguments, true);
-        if (is_array($decoded)) {
+        // Decode WITHOUT associative arrays. json_decode('{}', true) === [],
+        // which would re-encode a parameterless tool call's empty arguments as
+        // the array [] and make Ollama reject the replayed turn with
+        // "Value looks like object, but can't find closing '}' symbol".
+        // Decoding to a stdClass preserves the empty object as {}.
+        $decoded = json_decode($arguments);
+        if (is_object($decoded) || is_array($decoded)) {
             $function['arguments'] = $decoded;
             $call['function']      = $function;
         }

--- a/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
@@ -64,7 +64,14 @@ final class ListBeUsersToolTest extends AbstractFunctionalTestCase
         $spec = $this->tool->getSpec();
 
         self::assertSame('list_be_users', $spec->name);
-        self::assertSame([], $spec->parameters['properties'] ?? null);
+        // A parameterless tool must expose its (empty) `properties` as a JSON
+        // object `{}`, not an array `[]` — strict providers (Ollama) reject
+        // `[]`. ToolSpec normalises the empty case to a stdClass at construction.
+        self::assertEquals(new \stdClass(), $spec->parameters['properties'] ?? null);
+        self::assertStringContainsString(
+            '"properties":{}',
+            json_encode($spec->toArray(), JSON_THROW_ON_ERROR),
+        );
     }
 
     #[Test]

--- a/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use stdClass;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -67,7 +68,7 @@ final class ListBeUsersToolTest extends AbstractFunctionalTestCase
         // A parameterless tool must expose its (empty) `properties` as a JSON
         // object `{}`, not an array `[]` — strict providers (Ollama) reject
         // `[]`. ToolSpec normalises the empty case to a stdClass at construction.
-        self::assertEquals(new \stdClass(), $spec->parameters['properties'] ?? null);
+        self::assertEquals(new stdClass(), $spec->parameters['properties'] ?? null);
         self::assertStringContainsString(
             '"properties":{}',
             json_encode($spec->toArray(), JSON_THROW_ON_ERROR),

--- a/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolSpecTest.php
@@ -172,4 +172,44 @@ final class ToolSpecTest extends TestCase
 
         self::assertSame($spec->toArray(), $spec->jsonSerialize());
     }
+
+    /**
+     * A parameterless tool declares `properties => []`. JSON Schema requires
+     * `properties` to be an object, and `json_encode([])` produces `[]`, which
+     * strict providers (Ollama) reject with "Value looks like object, but can't
+     * find closing '}' symbol". The empty case must serialise as `{}`.
+     */
+    #[Test]
+    public function emptyPropertiesSerialiseAsJsonObjectNotArray(): void
+    {
+        $spec = ToolSpec::function('get_env', 'no params', [
+            'type'       => 'object',
+            'properties' => [],
+        ]);
+
+        $json = json_encode($spec->toArray(), JSON_THROW_ON_ERROR);
+
+        self::assertStringContainsString('"properties":{}', $json);
+        self::assertStringNotContainsString('"properties":[]', $json);
+    }
+
+    /**
+     * The empty-properties normalisation must not disturb the idempotency
+     * contract: a spec built from an empty-properties schema round-trips
+     * unchanged through `fromArray(toArray())`.
+     */
+    #[Test]
+    public function emptyPropertiesRoundTripIsIdempotent(): void
+    {
+        $spec = ToolSpec::function('get_env', 'no params', [
+            'type'       => 'object',
+            'properties' => [],
+        ]);
+
+        self::assertEquals($spec, ToolSpec::fromArray($spec->toArray()));
+        self::assertSame(
+            json_encode($spec->toArray(), JSON_THROW_ON_ERROR),
+            json_encode(ToolSpec::fromArray($spec->toArray())->toArray(), JSON_THROW_ON_ERROR),
+        );
+    }
 }

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -184,6 +184,42 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
         self::assertSame('LOGS', $toolTurn['content'] ?? null);
     }
 
+    /**
+     * A parameterless tool call is replayed with empty `{}` arguments. On the
+     * wire this must stay a JSON object `{}`, not become the array `[]`:
+     * `json_decode('{}', true) === []`, and Ollama rejects a tool call whose
+     * arguments serialise as `[]` ("Value looks like object, but can't find
+     * closing '}' symbol"). Asserted against the raw body because the decoded
+     * form cannot distinguish `{}` from `[]`.
+     */
+    #[Test]
+    public function replayedEmptyToolCallArgumentsSerialiseAsObject(): void
+    {
+        $subject = $this->buildSubject($this->plainAssistantResponse('ok'));
+
+        $messages = [
+            ['role' => 'user', 'content' => 'list users'],
+            [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    [
+                        'id'       => 'call_0',
+                        'type'     => 'function',
+                        'function' => ['name' => 'list_be_users', 'arguments' => '{}'],
+                    ],
+                ],
+            ],
+            ['role' => 'tool', 'tool_call_id' => 'call_0', 'content' => 'USERS'],
+        ];
+
+        $subject->chatCompletionWithTools($messages, []);
+
+        self::assertIsString($this->capturedBody);
+        self::assertStringContainsString('"arguments":{}', $this->capturedBody);
+        self::assertStringNotContainsString('"arguments":[]', $this->capturedBody);
+    }
+
     #[Test]
     public function nonToolResponseReturnsPlainContent(): void
     {


### PR DESCRIPTION
## Root cause

A parameterless built-in tool declares its JSON-Schema parameters as:

```php
['type' => 'object', 'properties' => []]
```

PHP's `json_encode` renders the empty `properties` **array** as `[]`, but JSON Schema requires `properties` to be an **object** `{}`. Ollama's strict parser hits `[` where it expects `{` and rejects the *entire* request:

```
HTTP 400 — Value looks like object, but can't find closing '}' symbol
```

So any [Tool Playground](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Administration/Tools.rst) / tool-loop run that offers a **parameterless** tool — `get_env`, `get_php_info`, `get_pagetree`, `get_tca`, `list_be_groups`, `list_be_users` — fails. Runs limited to tools that *have* parameters (`fetch_logs`, `read_fal_asset_meta`) worked, which made this look intermittent.

Confirmed directly against Ollama: `"properties":[]` → 400, `"properties":{}` → 200.

## Fix

Normalise an empty `properties` to a `stdClass` in the [`ToolSpec`](https://github.com/netresearch/t3x-nr-llm/blob/main/Classes/Domain/ValueObject/ToolSpec.php) constructor so it serialises as `{}`. Doing it at construction (not in `toArray()`) keeps the documented `fromArray(toArray()) == $spec` idempotency and fixes **every** provider, not just Ollama.

## Verification

- New tests: `emptyPropertiesSerialiseAsJsonObjectNotArray` (asserts `"properties":{}`, not `[]`) and `emptyPropertiesRoundTripIsIdempotent`.
- Live on ddev with Ollama `qwen3:14b`: before, the Playground 400'd whenever a parameterless tool was selected; after, a full two-iteration `fetch_logs` loop completes (`Iterations: 2 · Truncated: no`, redacted result, final answer) with all parameterless tools selected.
- `cgl`, `phpstan` (level 10), unit suite green on PHP 8.4 and 8.5.

## Supersedes #306

[#306](https://github.com/netresearch/t3x-nr-llm/pull/306) attributed the same 400 to a keep-alive connection-reuse race and added a `Connection: close` header. That diagnosis was wrong — the failure is this deterministic `[]`-vs-`{}` schema bug — so #306 is being closed in favour of this PR.