### PR TITLE
chore(release): prepare v0.14.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 
 | File | Purpose |
 |------|---------|
-| `ext_emconf.php` | Extension metadata, version 0.14.0 |
+| `ext_emconf.php` | Extension metadata, version 0.14.1 |
 | `ext_localconf.php` | Extension bootstrap |
 | `composer.json` | Dependencies (composer.lock NOT committed) |
 | `Build/phpunit.xml` | PHPUnit configuration |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-05
+
+### Fixed
+
+- Tool calling with parameterless tools now works. A tool that takes no arguments declared its JSON-Schema `properties` as an empty PHP array, which serialises to `[]` — but JSON Schema requires an object, and strict providers (Ollama) reject the whole request with HTTP 400 (`Value looks like object, but can't find closing '}' symbol`). The same applied to a parameterless tool call's empty `{}` arguments when the agent loop replayed them (`json_decode('{}', true) === []`). Both are now emitted as `{}`, so the bounded agent loop and the Tool Playground work when a parameterless tool — environment, logs, page tree, TCA or backend user/group introspection — is offered (#308).
+
+### Documentation
+
+- Refreshed the Skills, Tools and Playground admin guide: corrected the LLM module section count, replaced the outdated built-in tool list with the full catalogue, documented the two-tier (admin / non-admin) tool authorization, clarified that skill injection is eager and complete, and updated the screenshots (#307).
+
 ## [0.14.0] - 2026-07-04
 
 ### Added
@@ -930,6 +940,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial public release. See git history for prior commits.
 
 [Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...HEAD
+[0.14.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.11.1...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Tool calling with parameterless tools now works. A tool that takes no arguments declared its JSON-Schema `properties` as an empty PHP array, which serialises to `[]` — but JSON Schema requires an object, and strict providers (Ollama) reject the whole request with HTTP 400 (`Value looks like object, but can't find closing '}' symbol`). The same applied to a parameterless tool call's empty `{}` arguments when the agent loop replayed them (`json_decode('{}', true) === []`). Both are now emitted as `{}`, so the bounded agent loop and the Tool Playground work when a parameterless tool — environment, logs, page tree, TCA or backend user/group introspection — is offered (#308).
+- Tool calling with parameterless tools now works. A tool that takes no arguments declared its JSON-Schema `properties` as an empty PHP array, which serialises to `[]` — but JSON Schema requires an object, and strict providers (Ollama) reject the whole request with HTTP 400 (`Value looks like object, but can't find closing '}' symbol`). The same applied to a parameterless tool call's empty `{}` arguments when the agent loop replayed them (`json_decode('{}', true) === []`). Both are now emitted as `{}`, so the bounded agent loop and the Tool Playground work when a parameterless tool — environment, PHP info or backend user/group introspection — is offered (#308).
 
 ### Documentation
 
@@ -939,7 +939,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.1...HEAD
 [0.14.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.12.0...v0.13.0

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,26 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-14-1:
+
+Version 0.14.1 (2026-07-05)
+===========================
+
+A patch release fixing tool calling with parameterless tools. A tool that
+takes no arguments emitted its (empty) JSON-Schema ``properties`` — and its
+empty replayed call ``arguments`` — as a JSON array ``[]`` instead of an
+object ``{}``, which strict providers such as Ollama reject with an HTTP 400.
+The bounded agent loop and the Tool Playground now work when a parameterless
+tool (environment, logs, page tree, TCA, or backend user/group introspection)
+is offered.
+
+The Skills, Tools and Playground admin documentation was also refreshed to
+match the shipped backend (module section count, the full built-in tool
+catalogue, two-tier tool authorization, and updated screenshots).
+
+For the complete, itemised list see the canonical
+`CHANGELOG.md <https://github.com/netresearch/t3x-nr-llm/blob/main/CHANGELOG.md>`__.
+
 .. _version-0-14-0:
 
 Version 0.14.0 (2026-07-04)

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -21,8 +21,7 @@ takes no arguments emitted its (empty) JSON-Schema ``properties`` — and its
 empty replayed call ``arguments`` — as a JSON array ``[]`` instead of an
 object ``{}``, which strict providers such as Ollama reject with an HTTP 400.
 The bounded agent loop and the Tool Playground now work when a parameterless
-tool (environment, logs, page tree, TCA, or backend user/group introspection)
-is offered.
+tool (environment, PHP info, or backend user/group introspection) is offered.
 
 The Skills, Tools and Playground admin documentation was also refreshed to
 match the shipped backend (module section count, the full built-in tool

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.14.0"
-        release="0.14.0"
+        version="0.14.1"
+        release="0.14.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.14.0',
+    'version' => '0.14.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release-prep PR for **v0.14.1** (patch). Merge this, then a signed `v0.14.1` tag on the merge commit triggers `release.yml` (TER + Packagist + docs.typo3.org + GitHub release with SBOM/cosign).

## What ships (`git log v0.14.0..main`)

- **Fix — tool calling with parameterless tools** ([#308](https://github.com/netresearch/t3x-nr-llm/pull/308)): empty tool JSON-Schema `properties` and empty replayed tool-call `arguments` were serialised as `[]` instead of `{}`, which strict providers (Ollama) reject with HTTP 400. The bounded agent loop + Tool Playground now work when a parameterless tool is offered.
- **Docs** ([#307](https://github.com/netresearch/t3x-nr-llm/pull/307)): Skills/Tools/Playground admin guide refreshed to match the shipped backend.
- (Dev-only, not in the user-facing changelog: [#309](https://github.com/netresearch/t3x-nr-llm/pull/309) ddev seed default → qwen3:4b.)

No new features, no breaking changes → patch.

## Version surfaces bumped to 0.14.1

`ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml` (`version`/`release`), `AGENTS.md` file-map. `CHANGELOG.md` stamped `[0.14.1] - 2026-07-05` + compare link; `Documentation/Changelog.rst` version section added.

## Verification

- `VersionConsistencyTest` passes (all three authoritative surfaces match).
- `cgl` clean; docs render clean (no new warnings on the changelog pages).