### PR TITLE
fix(playground): stop non-UTF-8 tool output from crashing a run

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -279,7 +279,13 @@ abstract class AbstractProvider implements ProviderInterface
         $request = $this->addProviderSpecificHeaders($request);
 
         if ($method === 'POST' && $payload !== []) {
-            $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+            // JSON_INVALID_UTF8_SUBSTITUTE: a request payload carrying an invalid
+            // byte (e.g. a tool result echoing non-UTF-8 log/env output back into
+            // the conversation) must degrade to a replacement character, never
+            // throw and abort the whole call.
+            $body = $this->streamFactory->createStream(
+                json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE),
+            );
             $request = $request->withBody($body);
         }
 

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -505,7 +505,7 @@ final class ClaudeProvider extends AbstractProvider implements
             ->withHeader('anthropic-version', self::API_VERSION)
             ->withHeader('Accept', 'text/event-stream');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -500,7 +500,7 @@ final class GeminiProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -285,7 +285,7 @@ final class GroqProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -314,7 +314,7 @@ final class MistralProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -455,7 +455,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -361,7 +361,7 @@ final class OpenAiProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -651,7 +651,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $request = $request->withHeader('X-Title', $this->appName);
         }
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
 
         return $request->withBody($body);
     }
@@ -890,7 +890,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $request = $request->withHeader('X-Title', $this->appName);
         }
 
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $response = $this->getHttpClient()->sendRequest($request);

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -416,7 +416,10 @@ final readonly class ToolLoopService
             return $result;
         }
 
-        return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
+        // Cast defends the string return type: mb_convert_encoding is typed
+        // string|false, and false (unreachable for the literal 'UTF-8' names)
+        // would otherwise be a TypeError.
+        return (string)mb_convert_encoding($result, 'UTF-8', 'UTF-8');
     }
 
     /**

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -384,6 +384,14 @@ final readonly class ToolLoopService
      */
     private function capResult(string $result): string
     {
+        // Tool output is untrusted bytes (logs, phpinfo, env, DB rows) and may
+        // not be valid UTF-8. It is appended to the message list and re-encoded
+        // as JSON on the next provider request — and serialised into the
+        // inspector trace — where a single invalid byte makes json_encode()
+        // throw a JsonException ("Malformed UTF-8"). Coerce to valid UTF-8 first
+        // so neither path can crash on a misbehaving tool.
+        $result = $this->toValidUtf8($result);
+
         if (strlen($result) <= self::MAX_TOOL_RESULT_BYTES) {
             return $result;
         }
@@ -395,6 +403,20 @@ final readonly class ToolLoopService
         $budget = self::MAX_TOOL_RESULT_BYTES - strlen($marker);
 
         return mb_strcut($result, 0, max(0, $budget), 'UTF-8') . $marker;
+    }
+
+    /**
+     * Coerce a byte string to valid UTF-8, replacing invalid sequences (the
+     * substitution is visible in the inspector rather than silently dropped).
+     * A no-op for already-valid input.
+     */
+    private function toValidUtf8(string $result): string
+    {
+        if (mb_check_encoding($result, 'UTF-8')) {
+            return $result;
+        }
+
+        return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
     }
 
     /**

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -89,7 +89,18 @@ class ToolPlayground {
         new AjaxRequest(url)
             .post(formData)
             .then(response => response.resolve())
-            .then(data => this.renderResult(data))
+            .then(data => {
+                // Keep a rendering exception out of the AJAX catch below, whose
+                // readAjaxError() only understands transport errors and would
+                // otherwise mask a client-side bug as a bare "Unknown error".
+                try {
+                    this.renderResult(data);
+                } catch (e) {
+                    const message = `Could not render the run result: ${e && e.message ? e.message : e}`;
+                    this.renderError(message);
+                    Notification.error('Error', message);
+                }
+            })
             .catch(async err => {
                 const message = await readAjaxError(err);
                 this.renderError(message);

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -96,7 +96,7 @@ class ToolPlayground {
                 try {
                     this.renderResult(data);
                 } catch (e) {
-                    const message = `Could not render the run result: ${e && e.message ? e.message : e}`;
+                    const message = `Could not render the run result: ${e?.message || String(e)}`;
                     this.renderError(message);
                     Notification.error('Error', message);
                 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
@@ -118,6 +119,62 @@ final class ToolLoopServiceAugmentationTest extends TestCase
         self::assertSame(RunStep::KIND_LLM, $steps[0]->kind);
         self::assertSame('done', $steps[0]->content);
         self::assertSame(10, $steps[0]->promptTokens);
+    }
+
+    #[Test]
+    public function toolResultWithInvalidUtf8IsCoercedSoTheReRequestCannotThrow(): void
+    {
+        // Round 1 asks for the tool; round 2 (after the tool result is appended)
+        // answers. Before the fix the round-2 request json_encode() threw a
+        // JsonException on the tool's non-UTF-8 bytes.
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnOnConsecutiveCalls(
+            new CompletionResponse(
+                content: '',
+                model: 'm',
+                usage: UsageStatistics::fromTokens(5, 2),
+                toolCalls: [new ToolCall('call_1', 'bad', [])],
+            ),
+            new CompletionResponse(content: 'final', model: 'm', usage: UsageStatistics::fromTokens(3, 1)),
+        );
+
+        // A tool echoing raw bytes (log/env/phpinfo output) that are not valid UTF-8.
+        $registry = new ToolRegistry([new FakeTool('bad', "before \xFF\xFE after")]);
+        $service  = new ToolLoopService(
+            $mgr,
+            $registry,
+            new FakeToolAvailability($registry->names()),
+            null,
+            5,
+            new SkillInjectionService(new SkillComposer(), new NullLogger()),
+            new PromptSnippetComposer(),
+        );
+
+        $trace  = new RunTrace();
+        $result = $service->runLoop(
+            [['role' => 'user', 'content' => 'go']],
+            new LlmConfiguration(),
+            ['bad'],
+            null,
+            null,
+            $trace,
+            new RunAugmentation(),
+        );
+
+        self::assertSame('final', $result->finalContent);
+
+        $toolStep = array_values(array_filter(
+            $trace->getSteps(),
+            static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL,
+        ))[0] ?? null;
+        self::assertNotNull($toolStep);
+        self::assertNotNull($toolStep->toolResult);
+        self::assertTrue(mb_check_encoding($toolStep->toolResult, 'UTF-8'), 'tool result must be valid UTF-8');
+        // The whole trace must be JSON-encodable (this is what the controller does).
+        self::assertIsString(json_encode(
+            array_map(static fn(RunStep $s): array => $s->toArray(), $trace->getSteps()),
+            JSON_THROW_ON_ERROR,
+        ));
     }
 
     private function service(LlmServiceManagerInterface $mgr): ToolLoopService


### PR DESCRIPTION
Fixes a crash in the Playground (regression surfaced by the new inspector, PR #314): clicking **Run** could fail with `JsonException: Malformed UTF-8 characters` when a tool returned non-UTF-8 bytes.

## Root cause

A tool result echoing raw bytes (logs, `phpinfo`, env vars, DB rows) that are not valid UTF-8 is appended to the conversation as a `tool` message. On the **next** round the provider re-encodes the whole message array with `json_encode(..., JSON_THROW_ON_ERROR)` in `AbstractProvider::sendRequest()` — a single invalid byte makes it throw and abort the run. Confirmed from the logged stack trace (`AbstractProvider.php:282`).

This is a latent bug in the tool loop; the richer inspector just made admins exercise byte-heavy tools.

## Fix

- **Coerce tool results to valid UTF-8** at the tool-loop boundary (`ToolLoopService::capResult`) — invalid sequences become U+FFFD, kept visible in the inspector rather than silently dropped. This makes both the re-sent request and the inspector trace safe.
- **Systemic guard:** add `JSON_INVALID_UTF8_SUBSTITUTE` to the provider request encoder so no request can 500 on an invalid byte from any source (only affects already-invalid payloads).
- **Better error surface:** a client-side render exception now shows its real message instead of a bare "Unknown error".

## Verification

- Unit: new regression test — a tool returning `"before \xFF\xFE after"` runs a full loop without throwing, the trace tool result is valid UTF-8, and the whole trace JSON-encodes.
- Live (ddev): `fetch_logs`, `get_php_info`, `get_env` each now complete a full 2-round tool loop (the previously-crashing re-encode path); dry-run works.
- cgl, phpstan (level 10), unit all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
