### PR TITLE
fix(playground): don't 500 the inspector on non-UTF-8 trace data

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -33,7 +33,7 @@ use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -121,7 +121,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         $config = $this->configurationRepository->findByUid($configUid);
         if ($config === null || $prompt === '') {
-            return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.invalidInput', 'Invalid configuration or prompt')], 400);
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.invalidInput', 'Invalid configuration or prompt')], 400);
         }
 
         $captureRaw   = $this->boolFromBody($body, 'captureRaw');
@@ -170,7 +170,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         } catch (Throwable $e) {
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
 
-            return new JsonResponse(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
+            return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
         }
 
         $response = new PlaygroundRunResponse(
@@ -185,7 +185,33 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             estimatedCost: $result->usage->estimatedCost,
         );
 
-        return new JsonResponse($response->toArray());
+        return $this->respondJson($response->toArray());
+    }
+
+    /**
+     * Encode a payload as JSON, substituting invalid UTF-8 instead of throwing.
+     *
+     * The inspector trace echoes untrusted bytes back to the browser — tool
+     * output, injected skill/snippet text, and raw provider responses — any of
+     * which may not be valid UTF-8. TYPO3's {@see JsonResponse} encodes with
+     * JSON_THROW_ON_ERROR, so a single malformed byte would 500 an otherwise
+     * successful run and the UI could only show a bare "Unknown error". The
+     * substitute flag turns those bytes into U+FFFD so the inspector always
+     * renders.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function respondJson(array $data, int $status = 200): ResponseInterface
+    {
+        $response = new Response('php://temp', $status, ['Content-Type' => 'application/json; charset=utf-8']);
+        $response->getBody()->write(
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE),
+        );
+        // Rewind so a consumer reading via getContents() (emitters/middleware)
+        // sees the payload rather than an empty stream positioned at EOF.
+        $response->getBody()->rewind();
+
+        return $response;
     }
 
     /**

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -234,6 +234,67 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function runActionReturnsValidJsonWhenTheTraceCarriesInvalidUtf8(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-tools');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($configuration);
+
+        // The model answer carries raw non-UTF-8 bytes (as injected skill prose
+        // or a provider echo can). Before the fix the controller's JsonResponse
+        // threw and 500'd the whole run; now the bytes are substituted and the
+        // inspector still renders.
+        $adapter         = new ScriptedToolAdapter("Recent logs: \xFF\xFE done");
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = new LlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $controller      = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody(['configuration' => 1, 'prompt' => 'analyse the logs']);
+        $response = $controller->runAction($request);
+
+        // The run must not 500 on the malformed byte, and the body must be
+        // valid, decodable JSON with the bytes substituted (U+FFFD).
+        self::assertSame(200, $response->getStatusCode());
+        $raw = (string)$response->getBody();
+        self::assertTrue(mb_check_encoding($raw, 'UTF-8'), 'response body must be valid UTF-8');
+        $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertTrue($payload['success']);
+        self::assertIsString($payload['finalContent']);
+        self::assertStringContainsString('Recent logs:', $payload['finalContent']);
+    }
+
+    #[Test]
     public function runActionDryRunAssemblesWithoutCallingTheProvider(): void
     {
         $this->importFixture('LlmConfigurations.csv');

--- a/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
+++ b/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
@@ -33,6 +33,8 @@ final class ScriptedToolAdapter implements ProviderInterface, ToolCapableInterfa
 {
     private int $toolCallCount = 0;
 
+    public function __construct(private readonly string $finalContent = 'Here are your recent logs.') {}
+
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
         $this->toolCallCount++;
@@ -52,7 +54,7 @@ final class ScriptedToolAdapter implements ProviderInterface, ToolCapableInterfa
         }
 
         return new CompletionResponse(
-            content: 'Here are your recent logs.',
+            content: $this->finalContent,
             model: $model,
             usage: new UsageStatistics(5, 4, 9),
             finishReason: 'stop',


### PR DESCRIPTION
Fixes a second UTF-8 crash in the Playground inspector, reported after #315: a real run (e.g. prompt *"analysiere die logs"* with the `german-technical-writing` skill forced) failed with **"Unknown error"**.

## Root cause

Root-caused from the live log: `InvalidArgumentException #1504972434` in `JsonResponse.php:98` — *"Unable to encode data to JSON: Malformed UTF-8"*. The **controller's success response** (`new JsonResponse($response->toArray())`) encodes the full inspector trace, which echoes untrusted bytes back to the browser — tool output, **injected skill/snippet prose**, raw provider responses. #315 sanitised tool *results*, but a forced skill whose stored text carries a non-UTF-8 byte lands in the trace's `messagesSent`/`content`, which `JsonResponse` (JSON_THROW_ON_ERROR) can't encode. It threw an **uncaught** exception → an HTML 500 page → the JS couldn't parse it → bare "Unknown error".

## Fix

Encode the playground responses with `JSON_INVALID_UTF8_SUBSTITUTE` (via a small `respondJson()` helper, since TYPO3's `JsonResponse` takes no encode flags), so any malformed byte anywhere in the trace becomes `U+FFFD` and the inspector always renders — matching the "glass box shows whatever's there" intent.

## Verification

- **Functional regression test:** a scripted run whose model answer carries `"\xFF\xFE"` now returns **200** with valid, decodable JSON (previously threw). Targeted functional suite green (5 tests, 79 assertions).
- **Live (ddev):** the exact reported scenario — `analysiere die logs` + `german-technical-writing` forced — now returns 200 with a full `[llm, tool, llm]` trace (was a 500 HTML page).
- cgl, phpstan (level 10) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
