### PR TITLE
feat(playground): stream the run live + expose token/temperature controls

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Closure;
 use Netresearch\NrLlm\Controller\Backend\Response\PlaygroundRunResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
@@ -142,7 +143,13 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         // a crafted request cannot drive an unbounded, cost-accruing loop.
         $maxRounds    = min($this->intFromBody($body, 'maxRounds'), self::MAX_ROUNDS);
         $maxTokens    = $this->intFromBody($body, 'maxTokens');
+        // Clamp to ChatOptions' valid range: an out-of-range value would throw
+        // an InvalidArgumentException from the ToolOptions constructor below —
+        // which is outside the run try/catch — and 500 the request.
         $temperature  = $this->floatFromBody($body, 'temperature');
+        if ($temperature !== null) {
+            $temperature = max(0.0, min(2.0, $temperature));
+        }
         $options      = new ToolOptions(
             temperature: $temperature,
             maxTokens: $maxTokens > 0 ? $maxTokens : null,
@@ -239,16 +246,53 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             header('X-Accel-Buffering: no');
         }
 
+        $this->streamRun(
+            function (array $event): void {
+                $this->streamLine($event);
+            },
+            $messages,
+            $config,
+            $allowed,
+            $options,
+            $maxIterations,
+            $augmentation,
+            $captureRaw,
+        );
+
+        return new NullResponse();
+    }
+
+    /**
+     * Run the loop and emit the streamed protocol through {@see $emit}: one
+     * ``step`` event per recorded step (live, via the {@see RunTrace} callback),
+     * then a terminal ``done`` — or ``error`` on failure. Transport-agnostic (no
+     * output buffering, headers or flushing), so the event sequence can be
+     * asserted in isolation from the echo/flush plumbing in {@see runStreamed()}.
+     *
+     * @param Closure(array<string, mixed>): void    $emit
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<string>|null                      $allowed
+     */
+    private function streamRun(
+        Closure $emit,
+        array $messages,
+        LlmConfiguration $config,
+        ?array $allowed,
+        ToolOptions $options,
+        ?int $maxIterations,
+        RunAugmentation $augmentation,
+        bool $captureRaw,
+    ): void {
         $trace = new RunTrace(
             captureRaw: $captureRaw,
-            onRecord: function (RunStep $step): void {
-                $this->streamLine(['event' => 'step', 'step' => $step->toArray()]);
+            onRecord: static function (RunStep $step) use ($emit): void {
+                $emit(['event' => 'step', 'step' => $step->toArray()]);
             },
         );
 
         try {
             $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
-            $this->streamLine([
+            $emit([
                 'event'        => 'done',
                 'success'      => true,
                 'finalContent' => $result->finalContent,
@@ -264,10 +308,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             ]);
         } catch (Throwable $e) {
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
-            $this->streamLine(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($e)]);
+            $emit(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($e)]);
         }
-
-        return new NullResponse();
     }
 
     /**

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -10,12 +10,14 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\Response\PlaygroundRunResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
@@ -33,6 +35,7 @@ use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\NullResponse;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -65,6 +68,14 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * cost-accruing agent loop.
      */
     private const MAX_ROUNDS = 20;
+
+    /**
+     * Minimum byte length of each streamed NDJSON line. A TYPO3 backend AJAX
+     * response is buffered by the reverse proxy until a chunk clears its flush
+     * threshold; padding every event past ~4 KB makes it flush immediately, so
+     * steps reach the browser as they happen instead of all at once at the end.
+     */
+    private const STREAM_MIN_LINE_BYTES = 4096;
 
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
@@ -130,7 +141,11 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         // Cap the per-run round count server-side (matching the UI ceiling) so
         // a crafted request cannot drive an unbounded, cost-accruing loop.
         $maxRounds    = min($this->intFromBody($body, 'maxRounds'), self::MAX_ROUNDS);
+        $maxTokens    = $this->intFromBody($body, 'maxTokens');
+        $temperature  = $this->floatFromBody($body, 'temperature');
         $options      = new ToolOptions(
+            temperature: $temperature,
+            maxTokens: $maxTokens > 0 ? $maxTokens : null,
             systemPrompt: $systemPrompt !== '' ? $systemPrompt : null,
             beUserUid: $this->currentBackendUserUid(),
             captureRaw: $captureRaw,
@@ -155,18 +170,20 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             forcedSnippets: $this->promptSnippetRepository->findByUids($this->uidListFromBody($body, 'forcedSnippets')),
             dryRun: $dryRun,
         );
+        $messages      = [ChatMessage::user($prompt)];
+        $maxIterations = $maxRounds > 0 ? $maxRounds : null;
+
+        // Live path: stream each recorded step to the browser as it happens.
+        if ($this->boolFromBody($body, 'stream')) {
+            return $this->runStreamed($messages, $config, $allowed, $options, $maxIterations, $augmentation, $captureRaw);
+        }
+
+        // Batch path: run the whole loop, then return the full trace as one JSON
+        // document (the no-JS fallback and the shape the functional tests assert).
         $trace = new RunTrace(captureRaw: $captureRaw);
 
         try {
-            $result = $this->toolLoopService->runLoop(
-                [ChatMessage::user($prompt)],
-                $config,
-                $allowed,
-                $options,
-                $maxRounds > 0 ? $maxRounds : null,
-                $trace,
-                $augmentation,
-            );
+            $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
         } catch (Throwable $e) {
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
 
@@ -186,6 +203,88 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         );
 
         return $this->respondJson($response->toArray());
+    }
+
+    /**
+     * Run the loop while streaming one NDJSON line per recorded step to the
+     * browser as it happens, then a final ``done`` (or ``error``) line.
+     *
+     * Output buffering and compression are disabled and each line is padded
+     * (see {@see self::STREAM_MIN_LINE_BYTES}) so the reverse proxy flushes it
+     * immediately; a {@see NullResponse} is returned so TYPO3 emits nothing
+     * further (it has already been sent). The step callback runs inside
+     * {@see RunTrace}, fired the moment each step is recorded.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<string>|null                      $allowed
+     */
+    private function runStreamed(
+        array $messages,
+        LlmConfiguration $config,
+        ?array $allowed,
+        ToolOptions $options,
+        ?int $maxIterations,
+        RunAugmentation $augmentation,
+        bool $captureRaw,
+    ): ResponseInterface {
+        ini_set('zlib.output_compression', '0');
+        ini_set('output_buffering', '0');
+        ini_set('implicit_flush', '1');
+        while (ob_get_level() > 0) {
+            ob_end_flush();
+        }
+        if (!headers_sent()) {
+            header('Content-Type: application/x-ndjson; charset=utf-8');
+            header('Cache-Control: no-cache, no-transform');
+            header('X-Accel-Buffering: no');
+        }
+
+        $trace = new RunTrace(
+            captureRaw: $captureRaw,
+            onRecord: function (RunStep $step): void {
+                $this->streamLine(['event' => 'step', 'step' => $step->toArray()]);
+            },
+        );
+
+        try {
+            $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
+            $this->streamLine([
+                'event'        => 'done',
+                'success'      => true,
+                'finalContent' => $result->finalContent,
+                'iterations'   => $result->iterations,
+                'truncated'    => $result->truncated,
+                'dryRun'       => $augmentation->dryRun,
+                'usage'        => [
+                    'promptTokens'     => $result->usage->promptTokens,
+                    'completionTokens' => $result->usage->completionTokens,
+                    'totalTokens'      => $result->usage->totalTokens,
+                    'estimatedCost'    => $result->usage->estimatedCost,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            $this->logger?->error('Tool playground run failed', ['exception' => $e]);
+            $this->streamLine(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($e)]);
+        }
+
+        return new NullResponse();
+    }
+
+    /**
+     * Echo one NDJSON event and flush it. Encoded with the same UTF-8-substitute
+     * guard as {@see self::respondJson()} (a malformed byte must not break the
+     * stream) and padded past the proxy flush threshold.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function streamLine(array $data): void
+    {
+        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+        // Trailing whitespace is ignored by JSON.parse on the client, so pad the
+        // line to the flush threshold with spaces before the newline.
+        $padding = self::STREAM_MIN_LINE_BYTES - strlen($json);
+        echo $json . ($padding > 0 ? str_repeat(' ', $padding) : '') . "\n";
+        flush();
     }
 
     /**
@@ -237,6 +336,19 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
         $value = $body[$key] ?? 0;
         return is_numeric($value) ? (int)$value : 0;
+    }
+
+    /**
+     * Read an optional float (e.g. temperature, where 0.0 is a valid value so a
+     * numeric zero must not be treated as "unset"). Null when absent/non-numeric.
+     */
+    private function floatFromBody(mixed $body, string $key): ?float
+    {
+        if (!is_array($body) || !isset($body[$key]) || !is_numeric($body[$key])) {
+            return null;
+        }
+
+        return (float)$body[$key];
     }
 
     private function stringFromBody(mixed $body, string $key): string

--- a/Classes/Service/Tool/RunTrace.php
+++ b/Classes/Service/Tool/RunTrace.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Closure;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
@@ -35,11 +36,17 @@ final class RunTrace
     private array $steps = [];
 
     /**
-     * @param bool $captureRaw When true the loop asks the provider to retain
-     *                         the decoded raw response so it can be inspected.
-     *                         Off by default so production runs never keep it.
+     * @param bool                          $captureRaw When true the loop asks the provider to retain
+     *                                                  the decoded raw response so it can be inspected.
+     *                                                  Off by default so production runs never keep it.
+     * @param (Closure(RunStep): void)|null $onRecord   Fired the moment each step is recorded, so a
+     *                                                  caller can stream steps live as the loop runs.
+     *                                                  Null (every production/test caller) ⇒ collect only.
      */
-    public function __construct(private readonly bool $captureRaw = false) {}
+    public function __construct(
+        private readonly bool $captureRaw = false,
+        private readonly ?Closure $onRecord = null,
+    ) {}
 
     public function capturesRaw(): bool
     {
@@ -80,7 +87,7 @@ final class RunTrace
             );
         }
 
-        $this->steps[] = new RunStep(
+        $this->add(new RunStep(
             kind: RunStep::KIND_LLM,
             round: $round,
             durationMs: $durationMs,
@@ -95,7 +102,7 @@ final class RunTrace
             estimatedCost: $response->usage->estimatedCost,
             requestedToolCalls: $requestedToolCalls,
             raw: $raw,
-        );
+        ));
     }
 
     /**
@@ -111,7 +118,7 @@ final class RunTrace
         string $result,
         bool $isError,
     ): void {
-        $this->steps[] = new RunStep(
+        $this->add(new RunStep(
             kind: RunStep::KIND_TOOL,
             round: $round,
             durationMs: $durationMs,
@@ -119,7 +126,7 @@ final class RunTrace
             toolArguments: $arguments,
             toolResult: $result,
             toolIsError: $isError,
-        );
+        ));
     }
 
     /**
@@ -129,12 +136,12 @@ final class RunTrace
      */
     public function recordAssembledMessages(array $messages): void
     {
-        $this->steps[] = new RunStep(
+        $this->add(new RunStep(
             kind: RunStep::KIND_ASSEMBLED,
             round: 0,
             durationMs: 0.0,
             messagesSent: self::snapshotMessages($messages),
-        );
+        ));
     }
 
     /**
@@ -143,6 +150,18 @@ final class RunTrace
     public function getSteps(): array
     {
         return $this->steps;
+    }
+
+    /**
+     * Append a step and, if a live listener was provided, hand it the step at
+     * once so the caller can stream it before the run finishes.
+     */
+    private function add(RunStep $step): void
+    {
+        $this->steps[] = $step;
+        if ($this->onRecord !== null) {
+            ($this->onRecord)($step);
+        }
     }
 
     /**

--- a/Documentation/Adr/Adr041PlaygroundLiveStreaming.rst
+++ b/Documentation/Adr/Adr041PlaygroundLiveStreaming.rst
@@ -1,0 +1,77 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-041:
+
+==================================================================
+ADR-041: Playground live run streaming
+==================================================================
+
+:Status: Accepted
+:Date: 2026-07-06
+:Authors: Netresearch DTT GmbH
+
+.. _adr-041-context:
+
+Context
+=======
+
+The playground inspector (:ref:`ADR-040 <adr-040>`) ran the whole bounded
+agent loop server-side and returned the complete trace as one JSON document.
+The browser therefore showed nothing until the entire run — every model
+round-trip and tool execution — had finished, then rendered all at once. For a
+multi-round run against a slow local model that is several seconds of a blank
+pane, and it hides *when* each step happened.
+
+The goal is a live inspector: each step appears the moment it is recorded.
+
+.. _adr-041-decision:
+
+Decision
+========
+
+Stream the run as newline-delimited JSON (NDJSON), one event per line, over the
+existing admin AJAX route:
+
+- **Opt-in.** The client sends ``stream=1``; the controller then streams.
+  Without it the controller keeps the batch path — one
+  :php:`respondJson()` document — which remains the no-JavaScript fallback and
+  the shape the functional tests assert.
+- **Per-step callback.** :php:`RunTrace` takes an optional ``onRecord`` closure
+  fired the instant each :php:`RunStep` is recorded. The streaming controller
+  passes a closure that echoes one ``{"event":"step","step":…}`` line and
+  flushes; a final ``{"event":"done",…}`` (or ``{"event":"error",…}``) line
+  carries the summary. When no closure is passed (every production and test
+  caller) the loop is byte-for-byte unchanged.
+- **Beat the proxy buffer.** A TYPO3 backend response is buffered by the reverse
+  proxy until a chunk clears its flush threshold, so small lines all arrive at
+  the end. The stream disables output buffering and zlib compression at runtime
+  and pads every line past ~4 KB with trailing whitespace (ignored by
+  ``JSON.parse``), which makes each event flush immediately.
+- **NullResponse.** Having written output directly, the controller returns
+  :php:`\TYPO3\CMS\Core\Http\NullResponse`, which
+  :php:`AbstractApplication::sendResponse()` skips — TYPO3 emits nothing
+  further, avoiding a double body or a headers-already-sent warning.
+- **Same UTF-8 guard.** Each line is encoded with
+  ``JSON_INVALID_UTF8_SUBSTITUTE`` (as :ref:`ADR-040 <adr-040>` established for
+  the batch response), so a malformed byte substitutes rather than aborting the
+  stream.
+
+The client reads the response body stream, splits on newlines, parses each
+line, appends the step to a live trace and re-renders. If the browser cannot
+read a streaming body it falls back to the batch request.
+
+.. _adr-041-consequences:
+
+Consequences
+============
+
+- Steps render as they happen; the summary strip fills in live from the
+  per-round token counts and finalises on ``done``.
+- The 4 KB padding is transfer overhead (a few KB per event) that never reaches
+  the user — an accepted cost for reliable incremental flushing across proxies.
+- Direct ``echo``/``flush`` plus ``NullResponse`` is deliberately outside the
+  PSR-7 body abstraction; it is confined to the one streaming method and the
+  batch path stays a normal response.
+- A run whose final model round stops on ``finishReason: length`` is now
+  flagged with a truncation banner, and **Max tokens**/**Temperature** are
+  exposed as per-run controls so the operator can lift the cap.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -339,3 +339,4 @@ Tools
    Adr038ToolRuntime
    Adr039GlobalToolAvailabilityState
    Adr040PlaygroundRunTrace
+   Adr041PlaygroundLiveStreaming

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -150,6 +150,22 @@
                 <source>Max rounds</source>
                 <target>Maximale Runden</target>
             </trans-unit>
+            <trans-unit id="playground.maxTokens">
+                <source>Max tokens</source>
+                <target>Maximale Tokens</target>
+            </trans-unit>
+            <trans-unit id="playground.maxTokens.placeholder">
+                <source>Model default — raise if the answer is cut off</source>
+                <target>Modell-Standard — erhöhen, wenn die Antwort abgeschnitten wird</target>
+            </trans-unit>
+            <trans-unit id="playground.temperature">
+                <source>Temperature</source>
+                <target>Temperatur</target>
+            </trans-unit>
+            <trans-unit id="playground.temperature.placeholder">
+                <source>Configuration default</source>
+                <target>Standard der Konfiguration</target>
+            </trans-unit>
             <trans-unit id="playground.captureRaw">
                 <source>Capture raw provider response</source>
                 <target>Rohe Provider-Antwort erfassen</target>
@@ -157,6 +173,14 @@
             <trans-unit id="playground.dryRun">
                 <source>Dry run — assemble only</source>
                 <target>Trockenlauf — nur zusammenstellen</target>
+            </trans-unit>
+            <trans-unit id="playground.running">
+                <source>Running…</source>
+                <target>Läuft…</target>
+            </trans-unit>
+            <trans-unit id="playground.truncatedBanner">
+                <source>Response truncated — the model hit the max-tokens limit. Raise Max tokens in Advanced and run again.</source>
+                <target>Antwort abgeschnitten — das Modell hat das Token-Limit erreicht. Maximale Tokens unter „Erweitert“ erhöhen und erneut ausführen.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -113,11 +113,29 @@
             <trans-unit id="playground.maxRounds">
                 <source>Max rounds</source>
             </trans-unit>
+            <trans-unit id="playground.maxTokens">
+                <source>Max tokens</source>
+            </trans-unit>
+            <trans-unit id="playground.maxTokens.placeholder">
+                <source>Model default — raise if the answer is cut off</source>
+            </trans-unit>
+            <trans-unit id="playground.temperature">
+                <source>Temperature</source>
+            </trans-unit>
+            <trans-unit id="playground.temperature.placeholder">
+                <source>Configuration default</source>
+            </trans-unit>
             <trans-unit id="playground.captureRaw">
                 <source>Capture raw provider response</source>
             </trans-unit>
             <trans-unit id="playground.dryRun">
                 <source>Dry run — assemble only</source>
+            </trans-unit>
+            <trans-unit id="playground.running">
+                <source>Running…</source>
+            </trans-unit>
+            <trans-unit id="playground.truncatedBanner">
+                <source>Response truncated — the model hit the max-tokens limit. Raise Max tokens in Advanced and run again.</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Templates/Backend/Playground/List.html
+++ b/Resources/Private/Templates/Backend/Playground/List.html
@@ -10,7 +10,7 @@
 <f:layout name="Module" />
 
 <f:section name="Content">
-    <div id="nrllm-tool-playground" class="nrllm-pg" data-ajax-route="{ajaxRoute}">
+    <div id="nrllm-tool-playground" class="nrllm-pg" data-ajax-route="{ajaxRoute}" data-msg-truncated="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.truncatedBanner', default: 'Response truncated — the model hit the max-tokens limit. Raise Max tokens in Advanced and run again.')}" data-msg-running="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.running', default: 'Running…')}">
         <h1>
             <core:icon identifier="module-nrllm-tool" size="medium" />
             <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.title" default="Tool Playground" />
@@ -125,6 +125,14 @@
                                 <div class="mb-2">
                                     <label class="form-label" for="nrllm-pg-rounds"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.maxRounds" default="Max rounds" /></label>
                                     <input type="number" min="1" max="20" id="nrllm-pg-rounds" class="form-control" placeholder="5" />
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label" for="nrllm-pg-maxtokens"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.maxTokens" default="Max tokens" /></label>
+                                    <input type="number" min="1" step="1" id="nrllm-pg-maxtokens" class="form-control" placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.maxTokens.placeholder', default: 'Model default — raise if the answer is cut off')}" />
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label" for="nrllm-pg-temperature"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.temperature" default="Temperature" /></label>
+                                    <input type="number" min="0" max="2" step="0.1" id="nrllm-pg-temperature" class="form-control" placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.temperature.placeholder', default: 'Configuration default')}" />
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="nrllm-pg-raw" />

--- a/Resources/Public/Css/Backend/Playground.css
+++ b/Resources/Public/Css/Backend/Playground.css
@@ -141,6 +141,36 @@
     background: color-mix(in srgb, var(--pg-primary) 16%, transparent);
 }
 
+.nrllm-pg-status.is-run {
+    color: var(--pg-primary);
+    background: color-mix(in srgb, var(--pg-primary) 16%, transparent);
+}
+
+/* ---- truncation banner (semantic colour + glyph + text, never colour alone) ---- */
+.nrllm-pg-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin: 10px 0;
+    padding: 10px 14px;
+    border-radius: var(--pg-radius);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.nrllm-pg-banner.is-warn {
+    color: var(--pg-warn);
+    background: color-mix(in srgb, var(--pg-warn) 12%, var(--pg-surface));
+    border: 1px solid color-mix(in srgb, var(--pg-warn) 45%, transparent);
+    border-left-width: 3px;
+}
+
+.nrllm-pg-banner-ico {
+    flex: 0 0 auto;
+    font-weight: 700;
+}
+
 /* ---- split: step list + detail ---- */
 .nrllm-pg-split {
     display: grid;

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -39,6 +39,8 @@ class ToolPlayground {
         }
 
         this.route = this.root.dataset.ajaxRoute || '';
+        this.msgTruncated = this.root.dataset.msgTruncated || 'Response truncated — the model hit the max-tokens limit. Raise Max tokens in Advanced and run again.';
+        this.msgRunning = this.root.dataset.msgRunning || 'Running…';
         this.configSelect = document.getElementById('nrllm-tool-config');
         this.promptInput = document.getElementById('nrllm-tool-prompt');
         this.runButton = document.getElementById('nrllm-tool-run');
@@ -62,6 +64,29 @@ class ToolPlayground {
             return;
         }
 
+        const formData = this.buildFormData(dryRun, prompt);
+
+        this.setBusy(true);
+        this.renderStatus(dryRun ? 'Assembling…' : this.msgRunning);
+
+        // Live path: stream each step as it happens. Falls back to the batch
+        // request when the browser can't read a streaming body.
+        if (typeof fetch === 'function' && typeof ReadableStream === 'function') {
+            formData.append('stream', '1');
+            this.runStreaming(url, formData)
+                .catch(async err => {
+                    const message = err?.message || String(err) || 'Run failed';
+                    this.renderError(message);
+                    Notification.error('Error', message);
+                })
+                .finally(() => this.setBusy(false));
+            return;
+        }
+
+        this.runBatch(url, formData);
+    }
+
+    buildFormData(dryRun, prompt) {
         const formData = new FormData();
         formData.append('configuration', this.configSelect?.value || '');
         formData.append('prompt', prompt);
@@ -75,38 +100,119 @@ class ToolPlayground {
         if (system.trim() !== '') {
             formData.append('systemPrompt', system);
         }
-        const rounds = document.getElementById('nrllm-pg-rounds')?.value || '';
-        if (rounds !== '') {
-            formData.append('maxRounds', rounds);
-        }
+        this.appendIfSet(formData, 'nrllm-pg-rounds', 'maxRounds');
+        this.appendIfSet(formData, 'nrllm-pg-maxtokens', 'maxTokens');
+        this.appendIfSet(formData, 'nrllm-pg-temperature', 'temperature');
         this.appendChecked(formData, '.js-tool-select', 'tools[]');
         this.appendChecked(formData, '.js-skill-select', 'forcedSkills[]');
         this.appendChecked(formData, '.js-snippet-select', 'forcedSnippets[]');
+        return formData;
+    }
 
-        this.setBusy(true);
-        this.renderStatus(dryRun ? 'Assembling…' : 'Running…');
+    appendIfSet(formData, elementId, field) {
+        const value = document.getElementById(elementId)?.value ?? '';
+        if (String(value).trim() !== '') {
+            formData.append(field, value);
+        }
+    }
 
+    /**
+     * Read the NDJSON event stream and render each step as it arrives. A
+     * `step` event appends to the live trace and re-renders; `done` finalises
+     * the summary; `error` surfaces the real message.
+     */
+    async runStreaming(url, formData) {
+        const response = await fetch(url, { method: 'POST', body: formData, headers: { Accept: 'application/x-ndjson' } });
+        if (!response.ok || !response.body) {
+            // Fallback: consume the whole body and treat it as a batch payload.
+            const text = await response.text();
+            let data = null;
+            try { data = JSON.parse(text); } catch { /* not JSON */ }
+            if (data) {
+                this.safeRender(data);
+            } else {
+                this.renderError(`The server returned an error (HTTP ${response.status}).`);
+            }
+            return;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        const live = { success: true, running: true, steps: [], usage: {}, finalContent: '', truncated: false, dryRun: false };
+        let buffer = '';
+        let sawTerminal = false;
+
+        for (;;) {
+            const { value, done } = await reader.read();
+            if (done) {
+                break;
+            }
+            buffer += decoder.decode(value, { stream: true });
+            let newline;
+            while ((newline = buffer.indexOf('\n')) >= 0) {
+                const line = buffer.slice(0, newline).trim();
+                buffer = buffer.slice(newline + 1);
+                if (line === '') {
+                    continue;
+                }
+                let event;
+                try { event = JSON.parse(line); } catch { continue; }
+
+                if (event.event === 'step' && event.step) {
+                    live.steps.push(event.step);
+                    this.safeRender(live);
+                } else if (event.event === 'done') {
+                    live.running = false;
+                    live.finalContent = event.finalContent || '';
+                    live.iterations = event.iterations;
+                    live.truncated = !!event.truncated;
+                    live.dryRun = !!event.dryRun;
+                    live.usage = event.usage || {};
+                    sawTerminal = true;
+                    this.safeRender(live);
+                } else if (event.event === 'error') {
+                    sawTerminal = true;
+                    const message = event.error || 'Run failed';
+                    this.renderError(message);
+                    Notification.error('Error', message);
+                    return;
+                }
+            }
+        }
+
+        if (!sawTerminal) {
+            // Stream ended without a done/error line — show whatever arrived.
+            live.running = false;
+            this.safeRender(live);
+        }
+    }
+
+    runBatch(url, formData) {
         new AjaxRequest(url)
             .post(formData)
             .then(response => response.resolve())
-            .then(data => {
-                // Keep a rendering exception out of the AJAX catch below, whose
-                // readAjaxError() only understands transport errors and would
-                // otherwise mask a client-side bug as a bare "Unknown error".
-                try {
-                    this.renderResult(data);
-                } catch (e) {
-                    const message = `Could not render the run result: ${e?.message || String(e)}`;
-                    this.renderError(message);
-                    Notification.error('Error', message);
-                }
-            })
+            .then(data => this.safeRender(data))
             .catch(async err => {
                 const message = await readAjaxError(err);
                 this.renderError(message);
                 Notification.error('Error', message);
             })
             .finally(() => this.setBusy(false));
+    }
+
+    /**
+     * Render, keeping a rendering exception out of any AJAX catch (whose
+     * readAjaxError only understands transport errors and would mask a
+     * client-side bug as a bare "Unknown error").
+     */
+    safeRender(data) {
+        try {
+            this.renderResult(data);
+        } catch (e) {
+            const message = `Could not render the run result: ${e?.message || String(e)}`;
+            this.renderError(message);
+            Notification.error('Error', message);
+        }
     }
 
     appendChecked(formData, selector, field) {
@@ -141,6 +247,12 @@ class ToolPlayground {
         const steps = Array.isArray(data.steps) ? data.steps : [];
 
         this.output.appendChild(this.buildSummary(data, steps));
+
+        // A model round that stopped on the token limit was cut off mid-answer;
+        // say so plainly rather than showing a silent half-sentence.
+        if (steps.some(s => s.kind === 'llm' && s.finishReason === 'length')) {
+            this.output.appendChild(this.buildTruncationBanner());
+        }
 
         const split = document.createElement('div');
         split.className = 'nrllm-pg-split';
@@ -182,11 +294,17 @@ class ToolPlayground {
         const wall = steps.reduce((sum, s) => sum + (Number(s.durationMs) || 0), 0);
         const usage = data.usage || {};
         const cost = usage.estimatedCost;
+        // While streaming, the summed usage arrives only with the final `done`
+        // event, so fall back to summing the per-round token counts so far.
+        const sumTokens = key => llm.reduce((s, x) => s + (Number(x[key]) || 0), 0);
+        const total = usage.totalTokens != null ? usage.totalTokens : sumTokens('totalTokens');
+        const promptT = usage.promptTokens != null ? usage.promptTokens : sumTokens('promptTokens');
+        const completionT = usage.completionTokens != null ? usage.completionTokens : sumTokens('completionTokens');
 
         const cells = [
             ['Rounds', String(llm.length)],
             ['Tool calls', String(tools)],
-            ['Tokens', `${this.num(usage.totalTokens)} (${this.num(usage.promptTokens)}p / ${this.num(usage.completionTokens)}c)`],
+            ['Tokens', `${this.num(total)} (${this.num(promptT)}p / ${this.num(completionT)}c)`],
             ['Est. cost', cost != null ? `$${Number(cost).toFixed(4)}` : '—'],
             ['Wall time', `${(wall / 1000).toFixed(2)}s`],
         ];
@@ -194,7 +312,10 @@ class ToolPlayground {
 
         const status = document.createElement('span');
         status.className = 'nrllm-pg-status';
-        if (data.dryRun) {
+        if (data.running) {
+            status.classList.add('is-run');
+            status.textContent = `● ${this.msgRunning}`;
+        } else if (data.dryRun) {
             status.classList.add('is-dry');
             status.textContent = '⧉ Dry run — assembled, not sent';
         } else if (data.truncated) {
@@ -474,6 +595,21 @@ class ToolPlayground {
             return;
         }
         this.output.appendChild(this.note(message));
+    }
+
+    buildTruncationBanner() {
+        const banner = document.createElement('div');
+        banner.className = 'nrllm-pg-banner is-warn';
+        banner.setAttribute('role', 'status');
+        const icon = document.createElement('span');
+        icon.className = 'nrllm-pg-banner-ico';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.textContent = '⚠';
+        const text = document.createElement('span');
+        text.textContent = this.msgTruncated;
+        banner.appendChild(icon);
+        banner.appendChild(text);
+        return banner;
     }
 
     renderError(message) {

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -329,6 +329,62 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertSame('assembled', $firstStep['kind']);
     }
 
+    #[Test]
+    public function runActionForwardsMaxTokensAndTemperatureToTheProvider(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-tools');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($configuration);
+
+        $adapter         = new ScriptedToolAdapter();
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = new LlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $controller      = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody([
+                'configuration' => 1,
+                'prompt'        => 'analyse the logs',
+                'maxTokens'     => '4096',
+                'temperature'   => '0.1',
+            ]);
+        $response = $controller->runAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        // The per-run overrides reached the adapter as real provider options.
+        self::assertSame(4096, $adapter->lastOptions['max_tokens'] ?? null);
+        self::assertSame(0.1, $adapter->lastOptions['temperature'] ?? null);
+    }
+
     /**
      * Build the controller with the two AJAX-only collaborators supplied by the
      * caller; the ModuleTemplate stack and PageRenderer come from the container.

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -17,12 +17,15 @@ use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -34,6 +37,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
 use ReflectionClass;
+use ReflectionMethod;
 use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -389,6 +393,111 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
      * Build the controller with the two AJAX-only collaborators supplied by the
      * caller; the ModuleTemplate stack and PageRenderer come from the container.
      */
+    #[Test]
+    public function runActionClampsOutOfRangeTemperatureInsteadOf500(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller] = $this->scriptedController();
+
+        // temperature 5.0 is outside ToolOptions' 0.0–2.0 range; unclamped it
+        // would throw an uncaught InvalidArgumentException (a 500), not a run.
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody(['configuration' => 1, 'prompt' => 'go', 'temperature' => '5']);
+        $response = $controller->runAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertTrue($payload['success']);
+    }
+
+    #[Test]
+    public function streamRunEmitsAStepPerRecordedStepThenDone(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, $config] = $this->scriptedController();
+
+        $events = [];
+        $emit   = static function (array $event) use (&$events): void {
+            $events[] = $event;
+        };
+
+        // Exercise the transport-free protocol directly (runStreamed's echo/flush
+        // tears down output buffering, which can't run inside PHPUnit).
+        $method = new ReflectionMethod($controller, 'streamRun');
+        $method->invoke(
+            $controller,
+            $emit,
+            [ChatMessage::user('analyse the logs')],
+            $config,
+            ['fetch_logs'],
+            new ToolOptions(),
+            null,
+            new RunAugmentation(),
+            false,
+        );
+
+        $kinds = array_map(static fn(array $e): mixed => $e['event'] ?? null, $events);
+        // One 'step' per recorded step (2 LLM rounds + 1 tool), then a terminal 'done'.
+        self::assertContains('step', $kinds);
+        self::assertGreaterThanOrEqual(3, count(array_filter($kinds, static fn(mixed $k): bool => $k === 'step')));
+        self::assertNotEmpty($events);
+        $last = end($events);
+        self::assertIsArray($last);
+        self::assertSame('done', $last['event']);
+        self::assertTrue($last['success']);
+        self::assertSame('Here are your recent logs.', $last['finalContent']);
+        self::assertIsArray($last['usage']);
+    }
+
+    /**
+     * Build a controller wired to the scripted tool adapter (one tool call, then
+     * a plain answer) over an in-memory configuration.
+     *
+     * @return array{0: ToolPlaygroundController, 1: LlmConfiguration}
+     */
+    private function scriptedController(string $finalContent = 'Here are your recent logs.'): array
+    {
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg-tools');
+        $config->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn(new ScriptedToolAdapter($finalContent));
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = new LlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+
+        return [$this->makeController($configurationRepository, $toolRegistry, $toolLoopService), $config];
+    }
+
     private function makeController(
         LlmConfigurationRepository $configurationRepository,
         ToolRegistry $toolRegistry,

--- a/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
+++ b/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
@@ -33,11 +33,15 @@ final class ScriptedToolAdapter implements ProviderInterface, ToolCapableInterfa
 {
     private int $toolCallCount = 0;
 
+    /** @var array<string, mixed> Options seen on the last call, for assertions. */
+    public array $lastOptions = [];
+
     public function __construct(private readonly string $finalContent = 'Here are your recent logs.') {}
 
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
     {
         $this->toolCallCount++;
+        $this->lastOptions = $options;
         $model = is_string($options['model'] ?? null) ? $options['model'] : 'unknown';
 
         // First round: request a single tool call. Later rounds: stop with a

--- a/Tests/Unit/Service/Tool/RunTraceTest.php
+++ b/Tests/Unit/Service/Tool/RunTraceTest.php
@@ -90,6 +90,39 @@ final class RunTraceTest extends TestCase
         self::assertSame('system', $assembled->messagesSent[0]['role']);
     }
 
+    #[Test]
+    public function firesOnRecordOncePerStepInOrderWithTheRecordedStep(): void
+    {
+        /** @var list<RunStep> $streamed */
+        $streamed = [];
+        $trace    = new RunTrace(onRecord: static function (RunStep $step) use (&$streamed): void {
+            $streamed[] = $step;
+        });
+
+        $trace->recordLlmCall(1, 1.0, [], [], $this->response(null));
+        $trace->recordToolExecution(1, 2.0, 'fetch', [], 'ok', false);
+        $trace->recordAssembledMessages([ChatMessage::user('go')]);
+
+        // The listener saw each step live, in order, and they are the very same
+        // objects the trace collected (so a streaming caller and a batch caller
+        // observe identical data).
+        self::assertCount(3, $streamed);
+        self::assertSame($trace->getSteps(), $streamed);
+        self::assertSame(RunStep::KIND_LLM, $streamed[0]->kind);
+        self::assertSame(RunStep::KIND_TOOL, $streamed[1]->kind);
+        self::assertSame(RunStep::KIND_ASSEMBLED, $streamed[2]->kind);
+    }
+
+    #[Test]
+    public function withoutOnRecordCallbackNothingIsStreamedButStepsCollect(): void
+    {
+        $trace = new RunTrace();
+        $trace->recordToolExecution(1, 1.0, 'fetch', [], 'ok', false);
+
+        // No listener ⇒ no side effect, steps still collected (batch path).
+        self::assertCount(1, $trace->getSteps());
+    }
+
     /**
      * @param array<string, mixed>|null $metadata
      */


### PR DESCRIPTION
Two Playground improvements requested after the inspector shipped: make the run **live** (steps appeared all at once), and stop answers **cutting off mid-sentence**.

## Live streaming

The inspector now fills in **per step as the run happens** instead of after the whole loop.

- `RunTrace` gained an optional `onRecord` closure, fired the moment each step is recorded (null for every other caller → unchanged).
- A new streaming path in `runAction` (opt-in via `stream=1`) disables output buffering/compression and, through that closure, `echo`+`flush`es one NDJSON line per step, then a final `done`/`error` line, returning `NullResponse`. Each line is padded past a ~4 KB threshold — a TYPO3 backend AJAX response is buffered by the reverse proxy until a chunk clears that threshold, so padding makes each step flush immediately (verified: steps arrived ~9 s apart, not bundled at the end). Lines use the same `JSON_INVALID_UTF8_SUBSTITUTE` guard as the batch path.
- The **batch path is unchanged** (no-JS fallback + what the functional tests assert). JS reads `response.body.getReader()`, parses NDJSON, and appends steps live, falling back to batch when `ReadableStream` is unavailable.

## Truncation fix

Answers were cut off because the model hit its 2048-token cap (`finishReason: length`).

- **Max tokens** and **Temperature** are now per-run controls in Advanced → `ToolOptions` (both real `ChatOptions` fields; verified `maxTokens=8000` completes with `finishReason: stop`).
- A run that still hits the cap shows a WCAG-safe banner ("⚠ Response truncated — the model hit the max-tokens limit. Raise Max tokens in Advanced.") — semantic colour + glyph + text, so it never looks like a silent mid-sentence stop.

## Notes

- Design recorded in **ADR-041**.
- Verified: cgl, phpstan (level 10), rector, unit, targeted functional (6 tests / 89 assertions) green; live on ddev — streaming arrives incrementally, raised max-tokens completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
