### PR TITLE
fix(playground): render the system-prompt placeholder instead of raw Fluid

### DIFF
--- a/Resources/Private/Templates/Backend/Playground/List.html
+++ b/Resources/Private/Templates/Backend/Playground/List.html
@@ -120,7 +120,7 @@
                             <div class="nrllm-pg-ov-b">
                                 <div class="mb-2">
                                     <label class="form-label" for="nrllm-pg-system"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.systemOverride" default="System prompt override" /></label>
-                                    <textarea id="nrllm-pg-system" class="form-control" rows="2" placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.systemOverride.placeholder', default: 'Leave empty to use the configuration''s system prompt')}"></textarea>
+                                    <textarea id="nrllm-pg-system" class="form-control" rows="2" placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.systemOverride.placeholder', default: 'Leave empty to use the configuration\'s system prompt')}"></textarea>
                                 </div>
                                 <div class="mb-2">
                                     <label class="form-label" for="nrllm-pg-rounds"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.maxRounds" default="Max rounds" /></label>


### PR DESCRIPTION
The **System prompt override** field showed its placeholder as raw Fluid markup — `{f:translate(key: '…', default: 'Leave empty to use the configuration''s system prompt')}` — instead of the text.

**Cause:** the inline `default:` escaped the apostrophe as `configuration''s` (doubled single-quote). Fluid inline strings escape with a **backslash** (`\'`), not doubling, so Fluid couldn't parse the `f:translate` expression and emitted it verbatim (never reaching the XLF, which is correct). The maxTokens/temperature placeholders were unaffected — their defaults have no apostrophe.

**Fix:** `configuration''s` → `configuration\'s`.

Verified live on ddev — the field now renders "Leave empty to use the configuration's system prompt".

🤖 Generated with [Claude Code](https://claude.com/claude-code)