### PR TITLE
feat(tools): content search/read and TypoScript/TSconfig introspection tools

### DIFF
--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -15,7 +15,9 @@ use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
@@ -165,9 +167,12 @@ final readonly class GetPageContentTool implements ToolInterface
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
         if ($isAdmin) {
-            // Admins may inspect hidden pages; the [hidden] marker makes it
-            // explicit. Soft-deleted rows stay excluded.
-            $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+            // Admins may inspect hidden and timed-out pages; the [hidden]
+            // marker makes it explicit. Soft-deleted rows stay excluded.
+            $queryBuilder->getRestrictions()
+                ->removeByType(HiddenRestriction::class)
+                ->removeByType(StartTimeRestriction::class)
+                ->removeByType(EndTimeRestriction::class);
         }
 
         $row = $queryBuilder
@@ -192,7 +197,10 @@ final readonly class GetPageContentTool implements ToolInterface
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         if ($isAdmin) {
-            $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+            $queryBuilder->getRestrictions()
+                ->removeByType(HiddenRestriction::class)
+                ->removeByType(StartTimeRestriction::class)
+                ->removeByType(EndTimeRestriction::class);
         }
 
         $rows = $queryBuilder

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+
+/**
+ * Return one page's header data and its content elements in column/sorting
+ * order.
+ *
+ * Inspired by the GetPage tool of EXT:mcp_server (hauptsache.net,
+ * GPL-2.0-or-later); own implementation. Lists per content element the uid,
+ * column, CType, header, hidden flag (admins only — non-admins never see
+ * hidden elements) and a short tag-stripped bodytext excerpt.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): fail-closed
+ * without a backend user; non-admins must hold PAGE_SHOW permission on the
+ * page (checked via the acting user's page-perms clause) and get default
+ * query restrictions (no hidden/timed rows). A missing page and a denied
+ * page return the same neutral string, so the model cannot probe page
+ * existence.
+ */
+final readonly class GetPageContentTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Page not found or not permitted.';
+
+    private const EXCERPT_LENGTH = 200;
+
+    /** Upper bound on emitted content elements per call. */
+    private const ROW_CAP = 100;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_page_content',
+            'Return one page (title, doktype, slug) and its content elements ordered by column and '
+            . 'sorting: uid, colPos, CType, header and a short bodytext excerpt per element.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'The page uid to inspect.',
+                    ],
+                    'language' => [
+                        'type'        => 'integer',
+                        'description' => 'sys_language_uid of the content to list (default 0).',
+                    ],
+                ],
+                'required' => ['uid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return self::NOT_PERMITTED;
+        }
+
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid < 1) {
+            return self::NOT_PERMITTED;
+        }
+
+        $language = self::toInt($arguments['language'] ?? 0);
+        if ($language < 0) {
+            $language = 0;
+        }
+
+        $isAdmin = $user->isAdmin();
+
+        // Non-admins must hold PAGE_SHOW on the page itself; a missing page and
+        // a denied page are indistinguishable in the reply (fail-closed).
+        if (!$isAdmin) {
+            $permsClause = self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
+            if (!is_array(BackendUtility::readPageAccess($uid, $permsClause))) {
+                return self::NOT_PERMITTED;
+            }
+        }
+
+        $page = $this->fetchPage($uid, $isAdmin);
+        if ($page === null) {
+            return self::NOT_PERMITTED;
+        }
+
+        $lines   = [];
+        $lines[] = sprintf(
+            'Page [%d] %s (doktype %d, slug %s)%s',
+            self::toInt($page['uid'] ?? 0),
+            self::toStr($page['title'] ?? ''),
+            self::toInt($page['doktype'] ?? 0),
+            self::toStr($page['slug'] ?? '') !== '' ? self::toStr($page['slug'] ?? '') : '-',
+            self::toInt($page['hidden'] ?? 0) === 1 ? ' [hidden]' : '',
+        );
+
+        $rows = $this->fetchContent($uid, $language, $isAdmin);
+        if ($rows === []) {
+            $lines[] = sprintf('No content elements (language %d).', $language);
+
+            return implode("\n", $lines);
+        }
+
+        $lines[] = sprintf('Content elements (%d, language %d):', count($rows), $language);
+        foreach ($rows as $row) {
+            $header  = self::toStr($row['header'] ?? '');
+            $lines[] = sprintf(
+                '[%d] colPos=%d %s · %s%s',
+                self::toInt($row['uid'] ?? 0),
+                self::toInt($row['colPos'] ?? 0),
+                self::toStr($row['CType'] ?? ''),
+                $header !== '' ? $header : '(no header)',
+                self::toInt($row['hidden'] ?? 0) === 1 ? ' [hidden]' : '',
+            );
+
+            $excerpt = $this->excerpt(self::toStr($row['bodytext'] ?? ''));
+            if ($excerpt !== '') {
+                $lines[] = '  ' . $excerpt;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
+        return false;
+    }
+
+    /**
+     * The page row, or null when it does not exist (or, for non-admins, is
+     * hidden/timed out via the default restrictions).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchPage(int $uid, bool $isAdmin): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        if ($isAdmin) {
+            // Admins may inspect hidden pages; the [hidden] marker makes it
+            // explicit. Soft-deleted rows stay excluded.
+            $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+        }
+
+        $row = $queryBuilder
+            ->select('uid', 'title', 'doktype', 'slug', 'hidden')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return is_array($row) ? $row : null;
+    }
+
+    /**
+     * The page's content elements in column/sorting order. Admins also see
+     * hidden elements (marked); non-admins get the default restrictions.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fetchContent(int $pageUid, int $language, bool $isAdmin): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        if ($isAdmin) {
+            $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+        }
+
+        $rows = $queryBuilder
+            ->select('uid', 'colPos', 'CType', 'header', 'bodytext', 'hidden')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageUid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter($language, Connection::PARAM_INT),
+                ),
+            )
+            ->orderBy('colPos', 'ASC')
+            ->addOrderBy('sorting', 'ASC')
+            ->setMaxResults(self::ROW_CAP)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_values($rows);
+    }
+
+    /**
+     * A short single-line, tag-stripped bodytext excerpt.
+     */
+    private function excerpt(string $bodytext): string
+    {
+        $plain = trim((string)preg_replace('/\s+/', ' ', strip_tags($bodytext)));
+        if ($plain === '') {
+            return '';
+        }
+
+        if (mb_strlen($plain) > self::EXCERPT_LENGTH) {
+            return mb_substr($plain, 0, self::EXCERPT_LENGTH) . '…';
+        }
+
+        return $plain;
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetTsConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetTsConfigTool.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Return the rootline-merged Page TSconfig effective on a page.
+ *
+ * Inspired by the typo3-tsconfig tool of EXT:typo3_ai_mate (konradmichalik,
+ * GPL-2.0-or-later); own in-process implementation over
+ * {@see BackendUtility::getPagesTSconfig()}.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): ADMIN-only —
+ * TSconfig can expose backend structure and module configuration. Values
+ * under credential-ish keys are redacted for defence in depth, and the
+ * output is capped: without a `path` only the top-level keys are listed,
+ * with a `path` the subtree renders up to a hard line cap.
+ */
+final readonly class GetTsConfigTool implements ToolInterface
+{
+    use RendersTypoScriptTreeTrait;
+    use SafeCastTrait;
+
+    private const NOT_FOUND = 'Page not found.';
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_tsconfig',
+            'Return the rootline-merged Page TSconfig effective on a page. Without "path" only the '
+            . 'top-level keys are listed; with a dotted "path" (e.g. "TCEFORM.tt_content") that '
+            . 'subtree is rendered. Credential-like values are redacted.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'pageUid' => [
+                        'type'        => 'integer',
+                        'description' => 'The page uid to resolve the Page TSconfig for.',
+                    ],
+                    'path' => [
+                        'type'        => 'string',
+                        'description' => 'Optional dotted path to drill into (e.g. "mod.web_layout").',
+                    ],
+                ],
+                'required' => ['pageUid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $pageUid = self::toInt($arguments['pageUid'] ?? 0);
+        if ($pageUid < 1 || !$this->pageExists($pageUid)) {
+            return self::NOT_FOUND;
+        }
+
+        $path = trim(self::toStr($arguments['path'] ?? ''));
+
+        try {
+            $tsConfig = BackendUtility::getPagesTSconfig($pageUid);
+        } catch (Throwable) {
+            // Neutral by design — resolution internals must not egress.
+            return self::NOT_FOUND;
+        }
+
+        if ($tsConfig === []) {
+            return sprintf('No Page TSconfig for page %d.', $pageUid);
+        }
+
+        if ($path === '') {
+            $lines = $this->renderTopLevelKeys($tsConfig);
+            array_unshift($lines, sprintf(
+                'Page TSconfig for page %d — top-level keys (%d). Pass "path" to drill down:',
+                $pageUid,
+                count($tsConfig),
+            ));
+
+            return implode("\n", $lines);
+        }
+
+        [$value, $subtree] = $this->drillPath($tsConfig, $path);
+        if ($value === null && $subtree === null) {
+            return sprintf('No Page TSconfig at path "%s".', $path);
+        }
+
+        $lines = [sprintf('Page TSconfig for page %d at "%s":', $pageUid, $path)];
+        if ($value !== null) {
+            $lastSegment = substr((string)strrchr('.' . $path, '.'), 1);
+            $lines[]     = sprintf('%s = %s', $path, $this->redactSecretValue($lastSegment, $value));
+        }
+        if ($subtree !== null) {
+            $this->renderTree($subtree, $lines, 0);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: TSconfig exposes backend structure and configuration.
+        return true;
+    }
+
+    /**
+     * Whether a live (non-deleted) page row exists — a missing page returns
+     * the same neutral string as a resolution failure.
+     */
+    private function pageExists(int $pageUid): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+
+        $uid = $queryBuilder
+            ->select('uid')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($pageUid, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return $uid !== false;
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetTsConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetTsConfigTool.php
@@ -16,6 +16,7 @@ use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 
 /**
  * Return the rootline-merged Page TSconfig effective on a page.
@@ -131,6 +132,10 @@ final readonly class GetTsConfigTool implements ToolInterface
     private function pageExists(int $pageUid): bool
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        // Admin-only tool: hidden and timed-out pages are inspectable too;
+        // only soft-deleted rows stay excluded.
+        $queryBuilder->getRestrictions()->removeAll()
+            ->add(new DeletedRestriction());
 
         $uid = $queryBuilder
             ->select('uid')

--- a/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+/**
+ * Resolve the frontend TypoScript (setup or constants) effective on a page.
+ *
+ * Inspired by the typo3-typoscript tool of EXT:typo3_ai_mate
+ * (konradmichalik, GPL-2.0-or-later), but resolved in-process via the core
+ * v13/v14 TypoScript APIs (rootline → sys_template rows → FrontendTypoScript
+ * factory) instead of a CLI subprocess.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): ADMIN-only —
+ * TypoScript constants routinely carry API keys and DSNs. On top of that,
+ * values under credential-ish keys are redacted for defence in depth, and
+ * the output is capped: without a `path` only the top-level keys are listed,
+ * with a `path` the subtree renders up to a hard line cap. Resolution
+ * failures (no site, no template) return a neutral error string.
+ */
+final readonly class GetTypoScriptTool implements ToolInterface
+{
+    use RendersTypoScriptTreeTrait;
+    use SafeCastTrait;
+
+    private const TYPE_SETUP = 'setup';
+
+    private const TYPE_CONSTANTS = 'constants';
+
+    public function __construct(
+        protected FrontendTypoScriptFactory $typoScriptFactory,
+        protected SysTemplateRepository $sysTemplateRepository,
+        protected SiteFinder $siteFinder,
+        protected CacheManager $cacheManager,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_typoscript',
+            'Resolve the frontend TypoScript effective on a page. Without "path" only the top-level '
+            . 'keys are listed; with a dotted "path" (e.g. "plugin.tx_form") that subtree is rendered. '
+            . 'Credential-like values are redacted.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'pageUid' => [
+                        'type'        => 'integer',
+                        'description' => 'The page uid to resolve the TypoScript for.',
+                    ],
+                    'type' => [
+                        'type'        => 'string',
+                        'enum'        => [self::TYPE_SETUP, self::TYPE_CONSTANTS],
+                        'description' => 'Which document to resolve (default "setup").',
+                    ],
+                    'path' => [
+                        'type'        => 'string',
+                        'description' => 'Optional dotted path to drill into (e.g. "config" or "plugin.tx_form.settings").',
+                    ],
+                ],
+                'required' => ['pageUid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $pageUid = self::toInt($arguments['pageUid'] ?? 0);
+        if ($pageUid < 1) {
+            return 'Page not found or no TypoScript template.';
+        }
+
+        $type = self::toStr($arguments['type'] ?? self::TYPE_SETUP);
+        if (!in_array($type, [self::TYPE_SETUP, self::TYPE_CONSTANTS], true)) {
+            $type = self::TYPE_SETUP;
+        }
+
+        $path = trim(self::toStr($arguments['path'] ?? ''));
+
+        try {
+            if ($type === self::TYPE_CONSTANTS) {
+                return $this->renderConstants($this->resolveFlatConstants($pageUid), $pageUid, $path);
+            }
+
+            return $this->renderSetup($this->resolveSetup($pageUid), $pageUid, $path);
+        } catch (Throwable) {
+            // Deliberately neutral: rootline/site/template resolution failures
+            // must not leak exception internals into the provider egress.
+            return 'Page not found or no TypoScript template.';
+        }
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: TypoScript constants routinely carry credentials.
+        return true;
+    }
+
+    /**
+     * The fully resolved setup array (TypoScript AST notation: `key` values
+     * plus `key.` subtrees).
+     *
+     * @return array<array-key, mixed>
+     */
+    private function resolveSetup(int $pageUid): array
+    {
+        return $this->resolveFrontendTypoScript($pageUid)->getSetupArray();
+    }
+
+    /**
+     * The flattened constants (settings) map: `a.b.c` => value.
+     *
+     * @return array<array-key, mixed>
+     */
+    private function resolveFlatConstants(int $pageUid): array
+    {
+        return $this->resolveFrontendTypoScript($pageUid)->getFlatSettings();
+    }
+
+    private function resolveFrontendTypoScript(int $pageUid): FrontendTypoScript
+    {
+        $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid)->get();
+        $site     = $this->siteFinder->getSiteByPageId($pageUid);
+        $request  = (new ServerRequest())->withAttribute('site', $site);
+
+        $sysTemplateRows = $this->sysTemplateRepository->getSysTemplateRowsByRootline($rootline, $request);
+
+        $typoScriptCache = $this->cacheManager->getCache('typoscript');
+        if (!$typoScriptCache instanceof PhpFrontend) {
+            $typoScriptCache = null;
+        }
+
+        $frontendTypoScript = $this->typoScriptFactory->createSettingsAndSetupConditions(
+            $site,
+            $sysTemplateRows,
+            [],
+            $typoScriptCache,
+        );
+
+        return $this->typoScriptFactory->createSetupConfigOrFullSetup(
+            true,
+            $frontendTypoScript,
+            $site,
+            $sysTemplateRows,
+            [],
+            '0',
+            $typoScriptCache,
+            null,
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $setup
+     */
+    private function renderSetup(array $setup, int $pageUid, string $path): string
+    {
+        if ($setup === []) {
+            return 'Page not found or no TypoScript template.';
+        }
+
+        if ($path === '') {
+            $lines = $this->renderTopLevelKeys($setup);
+            array_unshift($lines, sprintf(
+                'TypoScript setup for page %d — top-level keys (%d). Pass "path" to drill down:',
+                $pageUid,
+                count($setup),
+            ));
+
+            return implode("\n", $lines);
+        }
+
+        [$value, $subtree] = $this->drillPath($setup, $path);
+        if ($value === null && $subtree === null) {
+            return sprintf('No TypoScript at path "%s".', $path);
+        }
+
+        $lines = [sprintf('TypoScript setup for page %d at "%s":', $pageUid, $path)];
+        if ($value !== null) {
+            $lastSegment = substr((string)strrchr('.' . $path, '.'), 1);
+            $lines[]     = sprintf('%s = %s', $path, $this->redactSecretValue($lastSegment, $value));
+        }
+        if ($subtree !== null) {
+            $this->renderTree($subtree, $lines, 0);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<array-key, mixed> $constants
+     */
+    private function renderConstants(array $constants, int $pageUid, string $path): string
+    {
+        if ($constants === []) {
+            return 'Page not found or no TypoScript template.';
+        }
+
+        $lines = [];
+        foreach ($constants as $key => $value) {
+            $key   = (string)$key;
+            $value = is_scalar($value) ? (string)$value : '';
+            if ($path !== '' && !str_starts_with($key, $path)) {
+                continue;
+            }
+            if (count($lines) >= self::MAX_LINES) {
+                $lines[] = sprintf('… [output truncated at %d lines]', self::MAX_LINES);
+                break;
+            }
+            $lastSegment = substr((string)strrchr('.' . $key, '.'), 1);
+            $lines[]     = sprintf('%s = %s', $key, $this->redactSecretValue($lastSegment, $value));
+        }
+
+        if ($lines === []) {
+            return sprintf('No TypoScript constants at path "%s".', $path);
+        }
+
+        array_unshift($lines, sprintf(
+            'TypoScript constants for page %d%s:',
+            $pageUid,
+            $path !== '' ? sprintf(' at "%s"', $path) : '',
+        ));
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
@@ -224,7 +224,7 @@ final readonly class GetTypoScriptTool implements ToolInterface
         foreach ($constants as $key => $value) {
             $key   = (string)$key;
             $value = is_scalar($value) ? (string)$value : '';
-            if ($path !== '' && !str_starts_with($key, $path)) {
+            if ($path !== '' && $key !== $path && !str_starts_with($key, $path . '.')) {
                 continue;
             }
             if (count($lines) >= self::MAX_LINES) {

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -1,0 +1,357 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+
+/**
+ * Generic filtered read of one TCA table — never raw SQL.
+ *
+ * Inspired by the ReadTable tool of EXT:mcp_server and the typo3-records
+ * tool of EXT:typo3_ai_mate (both GPL-2.0-or-later); own implementation.
+ * Filters are equality-only (`uid`, `pid`, `where_equals`) and bound as
+ * named parameters; the selectable fields are validated against the TCA
+ * column set.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): table access is
+ * gated through {@see TableReadAccessService} (sensitive-table denylist for
+ * everyone; `tables_select` + `adminOnly` for non-admins, fail-closed
+ * without a backend user); credential-ish columns are silently dropped from
+ * every field list and filter for every user; default query restrictions
+ * keep deleted/hidden/timed rows out; and for non-admins each row's page is
+ * checked against the acting user's PAGE_SHOW permission before it egresses.
+ */
+final readonly class ReadRecordsTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Table not found or not permitted.';
+
+    private const DEFAULT_LIMIT = 20;
+
+    private const MAX_LIMIT = 50;
+
+    private const MAX_OFFSET = 10000;
+
+    private const MAX_FILTERS = 5;
+
+    /** Per-field value cap so a single record cannot flood the egress. */
+    private const VALUE_CAP = 300;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+        protected TableReadAccessService $tableAccess,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'read_records',
+            'Read records of one TYPO3 table with equality filters (no SQL). Returns uid, pid and the '
+            . 'label field by default; pass "fields" for specific columns. Deleted and hidden records '
+            . 'are excluded; credential-like columns are never returned.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'The TCA table to read (e.g. "pages", "tt_content").',
+                    ],
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: a single record uid.',
+                    ],
+                    'pid' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: only records on this page uid.',
+                    ],
+                    'where_equals' => [
+                        'type'        => 'object',
+                        'description' => 'Optional: field => value equality filters (max 5, TCA columns only).',
+                        'additionalProperties' => true,
+                    ],
+                    'fields' => [
+                        'type'        => 'array',
+                        'items'       => ['type' => 'string'],
+                        'description' => 'Optional: columns to return (validated against the TCA).',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum rows (default 20, hard cap 50).',
+                    ],
+                    'offset' => [
+                        'type'        => 'integer',
+                        'description' => 'Rows to skip for pagination (default 0).',
+                    ],
+                ],
+                'required' => ['table'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return self::NOT_PERMITTED;
+        }
+
+        $table = trim(self::toStr($arguments['table'] ?? ''));
+        if (!$this->tableAccess->canReadTable($user, $table)) {
+            return self::NOT_PERMITTED;
+        }
+
+        $columns = $this->tcaColumns($table);
+
+        $fields = $this->resolveFields($table, $columns, $arguments['fields'] ?? null);
+        if ($fields === []) {
+            return 'No readable fields.';
+        }
+
+        $filters = $this->resolveFilters($columns, $arguments);
+        if ($filters === null) {
+            return 'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.';
+        }
+
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        if ($limit < 1) {
+            $limit = self::DEFAULT_LIMIT;
+        }
+        $limit = min($limit, self::MAX_LIMIT);
+
+        $offset = self::toInt($arguments['offset'] ?? 0);
+        $offset = max(0, min($offset, self::MAX_OFFSET));
+
+        $rows = $this->fetchRows($table, $fields, $filters, $limit, $offset);
+
+        // Non-admins only see rows on pages they may show (fail-closed).
+        if (!$user->isAdmin()) {
+            $permsClause = self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
+            $pidAccess   = [];
+            $rows        = array_values(array_filter(
+                $rows,
+                fn(array $row): bool => $this->pageIsReadable($table, $row, $permsClause, $pidAccess),
+            ));
+        }
+
+        if ($rows === []) {
+            return sprintf('No records in %s for the given filters.', $table);
+        }
+
+        $lines = [sprintf('Records in %s (%d, offset %d):', $table, count($rows), $offset)];
+        foreach ($rows as $row) {
+            $lines[] = sprintf('- %s:%d', $table, self::toInt($row['uid'] ?? 0));
+            foreach ($fields as $field) {
+                if ($field === 'uid') {
+                    continue;
+                }
+                $value   = $this->formatValue($row[$field] ?? null);
+                $lines[] = sprintf('  %s: %s', $field, $value);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
+        return false;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function tcaColumns(string $table): array
+    {
+        $tca        = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+        $definition = $tca[$table] ?? null;
+        $columns    = is_array($definition) ? ($definition['columns'] ?? null) : null;
+
+        return is_array($columns) ? $columns : [];
+    }
+
+    /**
+     * The validated select list: the caller's fields (existing, non-sensitive
+     * TCA columns plus uid/pid), or a compact default of uid, pid and the
+     * label field(s).
+     *
+     * @param array<array-key, mixed> $columns
+     *
+     * @return list<string>
+     */
+    private function resolveFields(string $table, array $columns, mixed $requested): array
+    {
+        $fields = [];
+        if (is_array($requested) && $requested !== []) {
+            foreach ($requested as $field) {
+                $field = trim(self::toStr($field));
+                if ($field === '' || $this->tableAccess->isSensitiveField($field)) {
+                    continue;
+                }
+                if ($field !== 'uid' && $field !== 'pid' && !isset($columns[$field])) {
+                    continue;
+                }
+                $fields[] = $field;
+            }
+        } else {
+            $tca        = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+            $definition = is_array($tca[$table] ?? null) ? $tca[$table] : [];
+            $ctrl       = is_array($definition['ctrl'] ?? null) ? $definition['ctrl'] : [];
+            $label = self::toStr($ctrl['label'] ?? '');
+            if ($label !== '' && isset($columns[$label]) && !$this->tableAccess->isSensitiveField($label)) {
+                $fields[] = $label;
+            }
+            foreach (explode(',', self::toStr($ctrl['label_alt'] ?? '')) as $alt) {
+                $alt = trim($alt);
+                if ($alt !== '' && isset($columns[$alt]) && !$this->tableAccess->isSensitiveField($alt)) {
+                    $fields[] = $alt;
+                }
+            }
+        }
+
+        if ($fields === []) {
+            return [];
+        }
+
+        return array_values(array_unique(array_merge(['uid', 'pid'], $fields)));
+    }
+
+    /**
+     * The validated equality filters (uid/pid arguments folded in), or null
+     * when any filter names a non-existent or credential-ish column or holds
+     * a non-scalar value.
+     *
+     * @param array<array-key, mixed> $columns
+     * @param array<string, mixed>    $arguments
+     *
+     * @return array<string, int|string>|null
+     */
+    private function resolveFilters(array $columns, array $arguments): ?array
+    {
+        $filters = [];
+
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid > 0) {
+            $filters['uid'] = $uid;
+        }
+
+        $pid = self::toInt($arguments['pid'] ?? -1);
+        if ($pid >= 0 && isset($arguments['pid'])) {
+            $filters['pid'] = $pid;
+        }
+
+        $whereEquals = $arguments['where_equals'] ?? null;
+        if (is_array($whereEquals)) {
+            $count = 0;
+            foreach ($whereEquals as $field => $value) {
+                if (++$count > self::MAX_FILTERS) {
+                    return null;
+                }
+                $field = trim(self::toStr($field));
+                if ($field === '' || $this->tableAccess->isSensitiveField($field)) {
+                    return null;
+                }
+                if ($field !== 'uid' && $field !== 'pid' && !isset($columns[$field])) {
+                    return null;
+                }
+                if (!is_scalar($value)) {
+                    return null;
+                }
+                $filters[$field] = is_int($value) ? $value : self::toStr($value);
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @param list<string>              $fields
+     * @param array<string, int|string> $filters
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fetchRows(string $table, array $fields, array $filters, int $limit, int $offset): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $queryBuilder
+            ->select(...$fields)
+            ->from($table)
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+
+        foreach ($filters as $field => $value) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq(
+                    $field,
+                    is_int($value)
+                        ? $queryBuilder->createNamedParameter($value, Connection::PARAM_INT)
+                        : $queryBuilder->createNamedParameter($value),
+                ),
+            );
+        }
+
+        return array_values($queryBuilder->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
+     * Whether the acting non-admin user may show the page a row lives on
+     * (the row itself for `pages`, the parent page otherwise), memoised per
+     * page uid. Root-level rows (pid 0) of non-pages tables fail closed for
+     * non-admins.
+     *
+     * @param array<string, mixed> $row
+     * @param array<int, bool>     $cache
+     */
+    private function pageIsReadable(string $table, array $row, string $permsClause, array &$cache): bool
+    {
+        $pageUid = $table === 'pages' ? self::toInt($row['uid'] ?? 0) : self::toInt($row['pid'] ?? 0);
+        if ($pageUid < 1) {
+            return false;
+        }
+
+        if (!isset($cache[$pageUid])) {
+            $cache[$pageUid] = is_array(BackendUtility::readPageAccess($pageUid, $permsClause));
+        }
+
+        return $cache[$pageUid];
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        $string = trim((string)preg_replace('/\s+/', ' ', self::toStr($value)));
+        if (mb_strlen($string) > self::VALUE_CAP) {
+            return mb_substr($string, 0, self::VALUE_CAP) . '…';
+        }
+
+        return $string;
+    }
+}

--- a/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
+++ b/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+/**
+ * Shared rendering for TypoScript-style nested arrays (`key` values plus
+ * `key.` subtrees, as produced by the TypoScript AST and by
+ * BackendUtility::getPagesTSconfig()).
+ *
+ * Three concerns, shared by {@see GetTypoScriptTool} and
+ * {@see GetTsConfigTool} (ADR-042):
+ *
+ * - **path drill-down**: a dotted path walks `key.` children so the model
+ *   can request one subtree instead of the whole document;
+ * - **output capping**: without a path only the top-level keys are listed,
+ *   and any rendered subtree stops at {@see line cap} lines with an explicit
+ *   truncation marker — a full setup dump would flood the provider egress;
+ * - **secret redaction**: values whose key looks credential-bearing render
+ *   as `[redacted]` for every user (TS constants routinely carry API keys).
+ */
+trait RendersTypoScriptTreeTrait
+{
+    /**
+     * Credential-ish key segments whose values are redacted. Matched on the
+     * last path segment, per camelCase/underscore word.
+     */
+    private const SECRET_KEY_PATTERN
+        = '/(password|passwd|pwd|secret|token|credential|apikey|api_key|privatekey|private_key|authorization)/i';
+
+    /** Maximum rendered lines per reply. */
+    private const MAX_LINES = 300;
+
+    /**
+     * Walk a dotted path through a TypoScript-style array. Returns
+     * [valueAtPath, subtreeAtPath] — either may be null when absent.
+     *
+     * @param array<array-key, mixed> $tree
+     *
+     * @return array{0: string|null, 1: array<array-key, mixed>|null}
+     */
+    private function drillPath(array $tree, string $path): array
+    {
+        $node     = $tree;
+        $segments = explode('.', trim($path, " \t."));
+
+        foreach ($segments as $index => $segment) {
+            $isLast  = $index === count($segments) - 1;
+            $value   = $node[$segment] ?? null;
+            $subtree = $node[$segment . '.'] ?? null;
+            $subtree = is_array($subtree) ? $subtree : null;
+
+            if ($isLast) {
+                return [
+                    is_scalar($value) ? (string)$value : null,
+                    $subtree,
+                ];
+            }
+
+            if ($subtree === null) {
+                return [null, null];
+            }
+            $node = $subtree;
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Render a TypoScript-style array as indented `key = value` lines,
+     * recursing into `key.` subtrees, capped at {@see self::MAX_LINES}.
+     *
+     * @param array<array-key, mixed> $tree
+     * @param list<string>            $lines
+     */
+    private function renderTree(array $tree, array &$lines, int $level = 0): void
+    {
+        foreach ($tree as $key => $value) {
+            if (count($lines) >= self::MAX_LINES) {
+                $lines[] = sprintf('… [output truncated at %d lines]', self::MAX_LINES);
+
+                return;
+            }
+
+            $key = (string)$key;
+            if (str_ends_with($key, '.')) {
+                if (!is_array($value)) {
+                    continue;
+                }
+                $lines[] = str_repeat('  ', $level) . rtrim($key, '.') . ' {';
+                $this->renderTree($value, $lines, $level + 1);
+                if (end($lines) !== sprintf('… [output truncated at %d lines]', self::MAX_LINES)) {
+                    $lines[] = str_repeat('  ', $level) . '}';
+                }
+
+                continue;
+            }
+
+            if (!is_scalar($value)) {
+                continue;
+            }
+
+            $lines[] = str_repeat('  ', $level) . sprintf(
+                '%s = %s',
+                $key,
+                $this->redactSecretValue($key, (string)$value),
+            );
+        }
+    }
+
+    /**
+     * List only the top-level keys of a tree (the no-path overview), marking
+     * branch keys with a child count.
+     *
+     * @param array<array-key, mixed> $tree
+     *
+     * @return list<string>
+     */
+    private function renderTopLevelKeys(array $tree): array
+    {
+        $lines = [];
+        foreach ($tree as $key => $value) {
+            if (count($lines) >= self::MAX_LINES) {
+                $lines[] = sprintf('… [output truncated at %d lines]', self::MAX_LINES);
+                break;
+            }
+
+            $key = (string)$key;
+            if (str_ends_with($key, '.') && is_array($value)) {
+                $lines[] = sprintf('%s (+%d children)', rtrim($key, '.'), count($value));
+            } elseif (is_scalar($value)) {
+                $lines[] = sprintf('%s = %s', $key, $this->redactSecretValue($key, (string)$value));
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The value, or `[redacted]` when its key looks credential-bearing.
+     */
+    private function redactSecretValue(string $key, string $value): string
+    {
+        if ($value !== '' && preg_match(self::SECRET_KEY_PATTERN, $key) === 1) {
+            return '[redacted]';
+        }
+
+        return $value;
+    }
+}

--- a/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
+++ b/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
@@ -20,7 +20,7 @@ namespace Netresearch\NrLlm\Service\Tool\Builtin;
  * - **path drill-down**: a dotted path walks `key.` children so the model
  *   can request one subtree instead of the whole document;
  * - **output capping**: without a path only the top-level keys are listed,
- *   and any rendered subtree stops at {@see line cap} lines with an explicit
+ *   and any rendered subtree stops at a fixed line cap with an explicit
  *   truncation marker — a full setup dump would flood the provider egress;
  * - **secret redaction**: values whose key looks credential-bearing render
  *   as `[redacted]` for every user (TS constants routinely carry API keys).

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -1,0 +1,312 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Schema\SearchableSchemaFieldsCollector;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+
+/**
+ * Full-text search across the tables that declare TCA `searchFields`.
+ *
+ * Inspired by the Search tool of EXT:mcp_server (hauptsache.net,
+ * GPL-2.0-or-later); own implementation. Per table a LIKE query runs across
+ * the declared search fields and returns compact `table:uid` hits with a
+ * short excerpt around the first matching field.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): the table set is
+ * gated through {@see TableReadAccessService} (sensitive-table denylist for
+ * everyone; `tables_select` + `adminOnly` for non-admins, fail-closed
+ * without a backend user), credential-ish columns are dropped from the
+ * search-field lists, default query restrictions keep deleted/hidden/timed
+ * rows out for every user, and for non-admins each hit's page is checked
+ * against the acting user's PAGE_SHOW permission (memoised per pid) before
+ * it egresses.
+ */
+final readonly class SearchRecordsTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const DEFAULT_LIMIT = 20;
+
+    private const MAX_LIMIT = 50;
+
+    private const MIN_QUERY_LENGTH = 2;
+
+    private const MAX_QUERY_LENGTH = 100;
+
+    private const EXCERPT_LENGTH = 120;
+
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+        protected TableReadAccessService $tableAccess,
+        protected SearchableSchemaFieldsCollector $searchableFields,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'search_records',
+            'Full-text search across the TYPO3 tables that define TCA searchFields (pages, content '
+            . 'elements, ...). Returns table:uid hits with a short excerpt around the match. '
+            . 'Deleted and hidden records are excluded.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'query' => [
+                        'type'        => 'string',
+                        'description' => 'The text to search for (2-100 characters).',
+                    ],
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'Optional: restrict the search to one table (e.g. "tt_content").',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum total hits (default 20, hard cap 50).',
+                    ],
+                ],
+                'required' => ['query'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return 'Not permitted.';
+        }
+
+        $query = trim(self::toStr($arguments['query'] ?? ''));
+        if (mb_strlen($query) < self::MIN_QUERY_LENGTH) {
+            return 'Query too short (minimum 2 characters).';
+        }
+        $query = mb_substr($query, 0, self::MAX_QUERY_LENGTH);
+
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        if ($limit < 1) {
+            $limit = self::DEFAULT_LIMIT;
+        }
+        $limit = min($limit, self::MAX_LIMIT);
+
+        $restrictTable = trim(self::toStr($arguments['table'] ?? ''));
+        $tables        = $this->searchableTables($restrictTable);
+        if ($tables === []) {
+            return $restrictTable !== ''
+                ? 'Table not found or not permitted.'
+                : 'No searchable tables available.';
+        }
+
+        $isAdmin     = $user->isAdmin();
+        $permsClause = $isAdmin ? '' : self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
+        $pidAccess   = [];
+
+        $lines     = [];
+        $remaining = $limit;
+        foreach ($tables as $table => $searchFields) {
+            if ($remaining < 1) {
+                break;
+            }
+
+            foreach ($this->searchTable($table, $searchFields, $query, $remaining) as $row) {
+                // Non-admins only see hits on pages they may show (fail-closed).
+                if (!$isAdmin && !$this->pageIsReadable($table, $row, $permsClause, $pidAccess)) {
+                    continue;
+                }
+
+                $lines[] = $this->formatHit($table, $row, $searchFields, $query);
+                --$remaining;
+                if ($remaining < 1) {
+                    break;
+                }
+            }
+        }
+
+        if ($lines === []) {
+            return 'No matches.';
+        }
+
+        array_unshift($lines, sprintf('Matches for "%s" (%d):', $query, count($lines)));
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
+        return false;
+    }
+
+    /**
+     * The tables this call may search, mapped to their searchable fields as
+     * resolved by the core's {@see SearchableSchemaFieldsCollector} (the
+     * cross-version source: `ctrl.searchFields` on v13, the per-column
+     * `searchable` flag on v14), minus credential-ish columns.
+     *
+     * @return array<string, list<string>>
+     */
+    private function searchableTables(string $restrictTable): array
+    {
+        $user   = $this->actingBackendUser();
+        $tca    = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+        $result = [];
+
+        foreach (array_keys($tca) as $table) {
+            $table = (string)$table;
+            if ($restrictTable !== '' && $table !== $restrictTable) {
+                continue;
+            }
+            if (!$this->tableAccess->canReadTable($user, $table)) {
+                continue;
+            }
+
+            $fields = array_values(array_filter(
+                $this->searchableFields->getFieldNames($table),
+                fn(string $field): bool => !$this->tableAccess->isSensitiveField($field),
+            ));
+
+            if ($fields !== []) {
+                $result[$table] = $fields;
+            }
+        }
+
+        ksort($result);
+
+        return $result;
+    }
+
+    /**
+     * LIKE across the table's search fields with default restrictions
+     * (deleted/hidden/timed rows excluded for every user).
+     *
+     * @param list<string> $searchFields
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function searchTable(string $table, array $searchFields, string $query, int $limit): array
+    {
+        $labelField   = $this->labelField($table);
+        $selectFields = array_values(array_unique(array_merge(
+            ['uid', 'pid'],
+            $labelField !== '' ? [$labelField] : [],
+            $searchFields,
+        )));
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $like         = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
+
+        $orConditions = [];
+        foreach ($searchFields as $field) {
+            $orConditions[] = $queryBuilder->expr()->like(
+                $field,
+                $queryBuilder->createNamedParameter($like),
+            );
+        }
+
+        $rows = $queryBuilder
+            ->select(...$selectFields)
+            ->from($table)
+            ->where($queryBuilder->expr()->or(...$orConditions))
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_values($rows);
+    }
+
+    /**
+     * Whether the acting non-admin user may show the page a hit lives on
+     * (the row itself for `pages` hits, the parent page otherwise), memoised
+     * per page uid. Unresolvable pages fail closed.
+     *
+     * @param array<string, mixed> $row
+     * @param array<int, bool>     $cache
+     */
+    private function pageIsReadable(string $table, array $row, string $permsClause, array &$cache): bool
+    {
+        $pageUid = $table === 'pages' ? self::toInt($row['uid'] ?? 0) : self::toInt($row['pid'] ?? 0);
+        if ($pageUid < 1) {
+            return false;
+        }
+
+        if (!isset($cache[$pageUid])) {
+            $cache[$pageUid] = is_array(BackendUtility::readPageAccess($pageUid, $permsClause));
+        }
+
+        return $cache[$pageUid];
+    }
+
+    /**
+     * One compact hit line plus a match excerpt: `table:uid · label · pid N`.
+     *
+     * @param array<string, mixed> $row
+     * @param list<string>         $searchFields
+     */
+    private function formatHit(string $table, array $row, array $searchFields, string $query): string
+    {
+        $labelField = $this->labelField($table);
+        $label      = $labelField !== '' ? self::toStr($row[$labelField] ?? '') : '';
+
+        $line = sprintf(
+            '%s:%d · %s · pid %d',
+            $table,
+            self::toInt($row['uid'] ?? 0),
+            $label !== '' ? $label : '(no label)',
+            self::toInt($row['pid'] ?? 0),
+        );
+
+        foreach ($searchFields as $field) {
+            $value = self::toStr($row[$field] ?? '');
+            if ($value === '') {
+                continue;
+            }
+            $plain    = trim((string)preg_replace('/\s+/', ' ', strip_tags($value)));
+            $position = mb_stripos($plain, $query);
+            if ($position === false) {
+                continue;
+            }
+
+            $start   = max(0, $position - (int)(self::EXCERPT_LENGTH / 2));
+            $excerpt = mb_substr($plain, $start, self::EXCERPT_LENGTH);
+
+            return $line . "\n" . sprintf(
+                '  match(%s): %s%s%s',
+                $field,
+                $start > 0 ? '…' : '',
+                $excerpt,
+                mb_strlen($plain) > $start + self::EXCERPT_LENGTH ? '…' : '',
+            );
+        }
+
+        return $line;
+    }
+
+    private function labelField(string $table): string
+    {
+        $tca = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+        $definition = $tca[$table] ?? null;
+        $ctrl = is_array($definition) ? ($definition['ctrl'] ?? null) : null;
+
+        return is_array($ctrl) ? self::toStr($ctrl['label'] ?? '') : '';
+    }
+}

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -305,8 +305,11 @@ final readonly class SearchRecordsTool implements ToolInterface
     {
         $tca = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
         $definition = $tca[$table] ?? null;
-        $ctrl = is_array($definition) ? ($definition['ctrl'] ?? null) : null;
+        $ctrl  = is_array($definition) ? ($definition['ctrl'] ?? null) : null;
+        $label = is_array($ctrl) ? self::toStr($ctrl['label'] ?? '') : '';
 
-        return is_array($ctrl) ? self::toStr($ctrl['label'] ?? '') : '';
+        // A customised ctrl.label could point at a credential-ish column —
+        // the field denylist applies to the label too (drop, don't leak).
+        return $this->tableAccess->isSensitiveField($label) ? '' : $label;
     }
 }

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Shared read-access policy for the record-reading tools (ADR-042).
+ *
+ * Centralises three fail-closed gates so {@see Builtin\SearchRecordsTool},
+ * {@see Builtin\GetPageContentTool} and {@see Builtin\ReadRecordsTool} apply
+ * one consistent model instead of three copies:
+ *
+ * - a **sensitive-table denylist** that holds for EVERY user including
+ *   admins — credentials/audit tables (`be_users`, `sys_log`, ...) have
+ *   dedicated redacting tools, and the nr_llm configuration tables carry
+ *   vault key references that must never egress to a provider;
+ * - the acting user's **`tables_select` right** plus the TCA `adminOnly`
+ *   flag for non-admins (admins pass, mirroring the backend);
+ * - a **sensitive-field denylist** (credential-ish column names) that is
+ *   dropped from every selected/filtered/searched field list — again for
+ *   every user, because tool output egresses to the external provider.
+ */
+final readonly class TableReadAccessService
+{
+    /**
+     * Tables no tool may read regardless of user rights: credential and
+     * audit tables (dedicated tools expose redacted views where needed).
+     */
+    private const SENSITIVE_TABLES = [
+        'be_users',
+        'be_groups',
+        'fe_users',
+        'fe_groups',
+        'sys_log',
+        'sys_history',
+        'sys_refindex',
+        'sys_http_report',
+        'sys_lockedrecords',
+    ];
+
+    /**
+     * Table-name prefixes treated like {@see self::SENSITIVE_TABLES} — the
+     * nr_llm tables store provider endpoints and vault key references.
+     */
+    private const SENSITIVE_TABLE_PREFIXES = ['tx_nrllm'];
+
+    /**
+     * Credential-ish field-name segments whose values must never egress.
+     * Matched per underscore-separated segment so `api_key` and
+     * `identifier_hash` hit while `author` does not.
+     */
+    private const SENSITIVE_FIELD_PATTERN
+        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa)($|_)/i';
+
+    /**
+     * Whether the acting user may read rows of the given table. Fail-closed:
+     * no user, unknown table, denylisted table, or (for non-admins) a table
+     * outside the user's `tables_select` rights or flagged `adminOnly` all
+     * yield false.
+     */
+    public function canReadTable(?BackendUserAuthentication $user, string $table): bool
+    {
+        if ($user === null || $table === '') {
+            return false;
+        }
+
+        if ($this->isSensitiveTable($table)) {
+            return false;
+        }
+
+        $allTca = $GLOBALS['TCA'] ?? null;
+        if (!is_array($allTca)) {
+            return false;
+        }
+        $tca = $allTca[$table] ?? null;
+        if (!is_array($tca)) {
+            return false;
+        }
+
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        $ctrl = is_array($tca['ctrl'] ?? null) ? $tca['ctrl'] : [];
+        if (($ctrl['adminOnly'] ?? false) === true) {
+            return false;
+        }
+
+        return $user->check('tables_select', $table);
+    }
+
+    /**
+     * Whether the table is denylisted for every user (see class docblock).
+     */
+    public function isSensitiveTable(string $table): bool
+    {
+        if (in_array($table, self::SENSITIVE_TABLES, true)) {
+            return true;
+        }
+
+        foreach (self::SENSITIVE_TABLE_PREFIXES as $prefix) {
+            if (str_starts_with($table, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a column name looks credential-bearing. Such fields are dropped
+     * from selects, filters and search-field lists for every user.
+     */
+    public function isSensitiveField(string $field): bool
+    {
+        return preg_match(self::SENSITIVE_FIELD_PATTERN, $field) === 1;
+    }
+
+    /**
+     * Drop sensitive names from a field list (see {@see isSensitiveField()}).
+     *
+     * @param list<string> $fields
+     *
+     * @return list<string>
+     */
+    public function filterSensitiveFields(array $fields): array
+    {
+        return array_values(array_filter(
+            $fields,
+            fn(string $field): bool => !$this->isSensitiveField($field),
+        ));
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -196,6 +196,11 @@ services:
   Netresearch\NrLlm\Service\Skill\GitHubClientInterface:
     alias: Netresearch\NrLlm\Service\Skill\GitHubClient
 
+  # Public so functional tests can fetch registered tools by spec name
+  # (the tools themselves stay private; ADR-042).
+  Netresearch\NrLlm\Service\Tool\ToolRegistry:
+    public: true
+
   Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface:
     alias: Netresearch\NrLlm\Service\Tool\ToolAvailabilityService
 

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -36,14 +36,18 @@ non-admin users.
 The built-in tools
 ==================
 
-nr-llm ships eleven read-only introspection tools. Each is a reference
+nr-llm ships sixteen read-only tools. Each is a reference
 implementation of the security contract: model-chosen arguments are
 validated and scoped, volumes are capped, and secret-bearing output is either
-redacted or gated behind a separate ``_raw`` variant. Eight ship **enabled**;
-the three unredacted ``_raw`` variants (``get_env_raw``, ``get_php_info_raw``
-and ``list_be_users_raw``) ship **disabled** and must be enabled deliberately.
-Most require admin; only ``get_pagetree``, ``get_tca`` and
-``read_fal_asset_meta`` are offered to non-admin backend users.
+redacted or gated behind a separate ``_raw`` variant. Thirteen ship
+**enabled**; the three unredacted ``_raw`` variants (``get_env_raw``,
+``get_php_info_raw`` and ``list_be_users_raw``) ship **disabled** and must be
+enabled deliberately. Most require admin; only ``get_pagetree``, ``get_tca``,
+``search_records``, ``get_page_content`` and ``read_records`` are offered to
+non-admin backend users — those self-enforce the acting user's TYPO3
+permissions (page-show rights, ``tables_select``) inside the tool, so a
+non-admin only ever sees what the backend already grants them (see
+:ref:`ADR-042 <adr-042>`).
 
 The two tools below are the fullest illustrations of the contract:
 
@@ -88,6 +92,35 @@ The remaining tools follow the same pattern:
    Backend users. ``list_be_users`` omits credentials (password hashes and MFA
    secrets are never included); ``list_be_users_raw`` returns the full
    non-credential profile columns and ships disabled.
+
+``search_records``
+   Full-text search across the tables that define TCA ``searchFields``.
+   Returns compact ``table:uid`` hits with a short excerpt around the match.
+   Credential and nr-llm configuration tables are never searched; non-admins
+   are limited to their ``tables_select`` tables and to hits on pages they
+   may show.
+
+``get_page_content``
+   One page's header data plus its content elements in column/sorting order
+   (uid, colPos, CType, header, a short bodytext excerpt). Non-admins need
+   page-show permission; only admins see hidden elements (marked
+   ``[hidden]``).
+
+``read_records``
+   Generic equality-filtered read of one TCA table — never raw SQL. Fields
+   are validated against the TCA and credential-like columns are silently
+   dropped; the same table gates as ``search_records`` apply.
+
+``get_typoscript``
+   The resolved frontend TypoScript (setup or constants) effective on a page,
+   with a dotted ``path`` drill-down and capped output. Admin-only —
+   constants routinely carry API keys — and credential-like values render as
+   ``[redacted]`` on top of that.
+
+``get_tsconfig``
+   The rootline-merged Page TSconfig effective on a page, with the same
+   ``path`` drill-down, output cap and redaction as ``get_typoscript``.
+   Admin-only.
 
 .. _administration-tools-register:
 

--- a/Documentation/Adr/Adr028PublicServicesPolicy.rst
+++ b/Documentation/Adr/Adr028PublicServicesPolicy.rst
@@ -120,11 +120,11 @@ The unit test
 ``Configuration/Services.yaml`` and asserts:
 
 * The total count of ``public: true`` keys matches the expected
-  total (currently **42**).
+  total (currently **43**).
 * The ADR file exists and references both ``REC #9c`` and the
   ``public: true`` policy text.
 
-Breakdown of the 42:
+Breakdown of the 43:
 
 * **22** Category 1 — Public LLM API surface
   (13 concrete services + 9 interface aliases).

--- a/Documentation/Adr/Adr042ContentAndIntrospectionTools.rst
+++ b/Documentation/Adr/Adr042ContentAndIntrospectionTools.rst
@@ -1,0 +1,135 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-042:
+
+===============================================================
+ADR-042: Content and configuration read tools for the agent
+===============================================================
+
+:Status: Accepted
+:Date: 2026-07-08
+:Authors: Netresearch DTT GmbH
+
+.. _adr-042-context:
+
+Context
+=======
+
+The first eleven built-in tools (:ref:`ADR-038 <adr-038>`) are system
+introspection: page-tree structure, TCA schema, logs, environment, backend
+accounts. The agent could not read the one thing most tasks are about —
+**content**: no full-text search, no "what is on this page", no generic
+record read, and no view of the TypoScript/TSconfig that shapes rendering.
+
+Two third-party extensions cover adjacent ground and informed this
+decision (both GPL-2.0-or-later, licence-compatible with nr-llm):
+
+- **EXT:typo3_ai_mate** (konradmichalik) — a dev-only, read-only debugging
+  toolset (records, page composition, resolved TypoScript/TSconfig, Fluid
+  resolution, logs, profiler). Its tool classes run *outside* TYPO3 in a
+  ``symfony/ai-mate`` MCP process and shell into TYPO3 console commands, so
+  they cannot be reused in-process — but its catalogue shows which
+  introspection reads matter.
+- **EXT:mcp_server** (hauptsache.net) — an in-TYPO3 MCP server for content
+  editing as an authenticated backend user (Search, GetPage, ReadTable,
+  WriteTable). Architecturally the closest cousin (tagged-iterator tool
+  registry, JSON-Schema specs); its layered permission model
+  (``tables_select`` → DataHandler → workspace-staged writes) is the
+  reference for any future write path.
+
+.. _adr-042-decision:
+
+Decision
+========
+
+Build five **native, read-only** tools — own implementations inspired by
+those catalogues, with no dependency on either extension:
+
+``search_records``
+    Full-text search across tables declaring TCA ``searchFields``
+    (mcp_server's Search as the model).
+
+``get_page_content``
+    One page plus its content elements in column/sorting order (mcp_server's
+    GetPage as the model).
+
+``read_records``
+    Generic equality-filtered read of one TCA table (mcp_server's ReadTable
+    and ai_mate's typo3-records as the models). Never raw SQL — equality
+    filters bound as named parameters only.
+
+``get_typoscript``
+    The resolved frontend TypoScript (setup/constants) for a page via the
+    core v13/v14 APIs (rootline → ``SysTemplateRepository`` →
+    ``FrontendTypoScriptFactory``), resolved in-process (ai_mate resolves
+    the same data via a CLI subprocess).
+
+``get_tsconfig``
+    The rootline-merged Page TSconfig via
+    ``BackendUtility::getPagesTSconfig()``.
+
+A shared :php:`TableReadAccessService` centralises the read policy for the
+three record tools instead of three copies.
+
+.. _adr-042-permission-model:
+
+Read-permission model
+=====================
+
+All five tools follow the fail-closed contract of :ref:`ADR-038 <adr-038>`
+(no backend user → no data) and add:
+
+#.  **Sensitive-table denylist — absolute.** ``be_users``, ``be_groups``,
+    ``fe_users``, ``fe_groups``, ``sys_log``, ``sys_history``,
+    ``sys_refindex`` and every ``tx_nrllm*`` table are unreadable for
+    *every* user including admins: credentials and audit data have
+    dedicated redacting tools, and the nr-llm tables carry provider
+    endpoints and vault key references that must never egress to a
+    provider.
+
+#.  **Sensitive-field denylist — absolute.** Columns whose name contains a
+    credential-ish segment (``password``, ``secret``, ``token``, ``salt``,
+    ``hash``, ``key``, ``mfa``, …) are dropped from every select, filter
+    and search-field list, for every user.
+
+#.  **Non-admin narrowing.** Non-admins are additionally limited to tables
+    granted by ``tables_select`` (TCA ``adminOnly`` tables excluded), get
+    the default query restrictions (no hidden/timed rows), and every
+    emitted row's page is checked against the acting user's ``PAGE_SHOW``
+    permission — memoised per page uid, applied *after* the query, so a
+    result page may return fewer than ``limit`` rows rather than weakening
+    the check. Root-level rows (``pid 0``) of non-``pages`` tables fail
+    closed for non-admins.
+
+#.  **Admin-only TypoScript/TSconfig.** ``get_typoscript`` and
+    ``get_tsconfig`` are admin-only — TypoScript constants routinely carry
+    API keys and DSNs — and still redact values under credential-ish keys
+    as defence in depth, and cap output (top-level keys without a ``path``,
+    hard line cap with one).
+
+.. _adr-042-writes-deferred:
+
+Write tools deferred
+====================
+
+State-changing tools (create/update/delete records) are **explicitly out of
+scope**. If nr-llm ever adds them, EXT:mcp_server's write design is the
+reference: all writes through :php:`DataHandler` as the acting backend user
+(page permissions and hooks apply), gated by a ``TableAccessService``, and
+staged in a non-live **workspace** so every agent change requires a human
+publish. Until that model is implemented here, the agent stays read-only.
+
+.. _adr-042-consequences:
+
+Consequences
+============
+
+- The agent can search and read content, records and the effective
+  TypoScript/TSconfig on every installation, with no third-party
+  dependency.
+- Non-admins can safely use the three content tools: the tools enforce the
+  same visibility the backend already grants them.
+- The denylists are intentionally not configurable — configurability would
+  invite weakening the egress guarantees.
+- The tool count grows to sixteen; the Tools module and the playground pick
+  the new tools up automatically via the registry (no UI change).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -340,3 +340,4 @@ Tools
    Adr039GlobalToolAvailabilityState
    Adr040PlaygroundRunTrace
    Adr041PlaygroundLiveStreaming
+   Adr042ContentAndIntrospectionTools

--- a/Tests/Functional/Service/Tool/GetPageContentToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageContentToolTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for GetPageContentTool (ADR-042).
+ *
+ * Load-bearing: content elements come back in column/sorting order, hidden
+ * elements are admin-only (marked), and a non-admin without page-show
+ * permission is denied with the same neutral string as a missing page
+ * (fail-closed).
+ */
+#[CoversClass(GetPageContentTool::class)]
+final class GetPageContentToolTest extends AbstractFunctionalTestCase
+{
+    private GetPageContentTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new GetPageContentTool($connectionPool);
+
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        // Owned by admin (uid 1); no group/everybody perms — the editor
+        // (uid 2, non-admin) must not pass the PAGE_SHOW check.
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1, 'slug' => '/',
+            'sorting' => 1, 'perms_userid' => 1, 'perms_user' => 31,
+            'perms_groupid' => 0, 'perms_group' => 0, 'perms_everybody' => 0,
+        ]);
+
+        $content = $connectionPool->getConnectionForTable('tt_content');
+        $content->insert('tt_content', [
+            'uid' => 20, 'pid' => 1, 'colPos' => 1, 'sorting' => 1, 'CType' => 'text',
+            'header' => 'Sidebar', 'bodytext' => '<p>Side <b>note</b>.</p>',
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 21, 'pid' => 1, 'colPos' => 0, 'sorting' => 1, 'CType' => 'textmedia',
+            'header' => 'Intro', 'bodytext' => '<p>Welcome to the intro paragraph.</p>',
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 22, 'pid' => 1, 'colPos' => 0, 'sorting' => 2, 'CType' => 'text',
+            'header' => 'Secret draft', 'bodytext' => 'Draft body', 'hidden' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function adminSeesElementsInColumnAndSortingOrderIncludingMarkedHidden(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['uid' => 1]);
+
+        self::assertStringContainsString('Page [1] Home (doktype 1, slug /)', $output);
+        // colPos 0 before colPos 1; hidden element present and marked.
+        $intro   = mb_strpos($output, '[21] colPos=0 textmedia · Intro');
+        $draft   = mb_strpos($output, '[22] colPos=0 text · Secret draft [hidden]');
+        $sidebar = mb_strpos($output, '[20] colPos=1 text · Sidebar');
+        self::assertNotFalse($intro);
+        self::assertNotFalse($draft);
+        self::assertNotFalse($sidebar);
+        self::assertLessThan($draft, $intro);
+        self::assertLessThan($sidebar, $draft);
+        // Tag-stripped excerpt.
+        self::assertStringContainsString('Welcome to the intro paragraph.', $output);
+        self::assertStringNotContainsString('<p>', $output);
+    }
+
+    #[Test]
+    public function nonAdminWithoutPagePermissionIsDenied(): void
+    {
+        $this->setUpBackendUser(2); // editor, no rights on page 1
+
+        $output = $this->tool->execute(['uid' => 1]);
+
+        self::assertSame('Page not found or not permitted.', $output);
+    }
+
+    #[Test]
+    public function missingPageReturnsTheSameNeutralString(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['uid' => 999]);
+
+        self::assertSame('Page not found or not permitted.', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/GetTsConfigToolTest.php
+++ b/Tests/Functional/Service/Tool/GetTsConfigToolTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTsConfigTool;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for GetTsConfigTool (ADR-042).
+ *
+ * Load-bearing: the rootline-merged Page TSconfig from the seeded page's
+ * ``TSconfig`` column resolves, the dotted path drills into the right
+ * subtree, credential-ish values are redacted, and a missing page returns
+ * the neutral string.
+ */
+#[CoversClass(GetTsConfigTool::class)]
+final class GetTsConfigToolTest extends AbstractFunctionalTestCase
+{
+    private GetTsConfigTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new GetTsConfigTool($connectionPool);
+
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1, 'sorting' => 1,
+            'TSconfig' => "demo.flag = 1\ndemo.nested.label = Editorial\nvault.apiKey = top-secret-value",
+        ]);
+    }
+
+    #[Test]
+    public function topLevelKeysListWithoutPath(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1]);
+
+        self::assertStringContainsString('Page TSconfig for page 1', $output);
+        self::assertStringContainsString('demo (+', $output);
+    }
+
+    #[Test]
+    public function dottedPathDrillsIntoTheSubtree(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo']);
+
+        self::assertStringContainsString('flag = 1', $output);
+        self::assertStringContainsString('nested {', $output);
+        self::assertStringContainsString('label = Editorial', $output);
+    }
+
+    #[Test]
+    public function credentialValuesAreRedacted(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'vault']);
+
+        self::assertStringContainsString('apiKey = [redacted]', $output);
+        self::assertStringNotContainsString('top-secret-value', $output);
+    }
+
+    #[Test]
+    public function missingPageReturnsNeutralString(): void
+    {
+        self::assertSame('Page not found.', $this->tool->execute(['pageUid' => 999]));
+    }
+}

--- a/Tests/Functional/Service/Tool/GetTypoScriptToolTest.php
+++ b/Tests/Functional/Service/Tool/GetTypoScriptToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for GetTypoScriptTool (ADR-042).
+ *
+ * Resolves real TypoScript through the core APIs against a seeded site
+ * configuration and sys_template row. Load-bearing: the dotted path drills
+ * into the setup subtree, constants resolve flat, credential-ish values are
+ * redacted, and a page without a site/template yields the neutral string.
+ */
+#[CoversClass(GetTypoScriptTool::class)]
+final class GetTypoScriptToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // A minimal site configuration so SiteFinder can map page 1.
+        $siteDir = $this->instancePath . '/typo3conf/sites/testing';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+
+        $templates = $connectionPool->getConnectionForTable('sys_template');
+        $templates->insert('sys_template', [
+            'uid' => 1, 'pid' => 1, 'title' => 'Root template', 'root' => 1, 'clear' => 3,
+            'config'    => "page = PAGE\ndemo.endpoint = https://api.example.org\ndemo.apiKey = setup-secret",
+            'constants' => "myConst.plain = visible-value\nmyConst.apiKey = constant-secret",
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('get_typoscript');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function setupTopLevelKeysListWithoutPath(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1]);
+
+        self::assertStringContainsString('TypoScript setup for page 1', $output);
+        self::assertStringContainsString('page = PAGE', $output);
+        self::assertStringContainsString('demo (+', $output);
+    }
+
+    #[Test]
+    public function pathDrillsIntoSetupSubtreeAndRedactsSecrets(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo']);
+
+        self::assertStringContainsString('endpoint = https://api.example.org', $output);
+        self::assertStringContainsString('apiKey = [redacted]', $output);
+        self::assertStringNotContainsString('setup-secret', $output);
+    }
+
+    #[Test]
+    public function constantsResolveFlatAndRedactSecrets(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1, 'type' => 'constants']);
+
+        self::assertStringContainsString('myConst.plain = visible-value', $output);
+        self::assertStringContainsString('myConst.apiKey = [redacted]', $output);
+        self::assertStringNotContainsString('constant-secret', $output);
+    }
+
+    #[Test]
+    public function pageWithoutSiteReturnsNeutralString(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 999]);
+
+        self::assertSame('Page not found or no TypoScript template.', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ReadRecordsTool (ADR-042).
+ *
+ * Load-bearing: equality filters bind as named parameters and select the
+ * right rows, requested fields are TCA-validated, and a non-admin without
+ * table rights (or page-show permission) gets nothing.
+ */
+#[CoversClass(ReadRecordsTool::class)]
+final class ReadRecordsToolTest extends AbstractFunctionalTestCase
+{
+    private ReadRecordsTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->tool = new ReadRecordsTool($connectionPool, new TableReadAccessService());
+
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1, 'sorting' => 1,
+            'perms_userid' => 1, 'perms_user' => 31, 'perms_everybody' => 0,
+        ]);
+
+        $content = $connectionPool->getConnectionForTable('tt_content');
+        $content->insert('tt_content', [
+            'uid' => 30, 'pid' => 1, 'colPos' => 0, 'sorting' => 1,
+            'CType' => 'text', 'header' => 'Alpha',
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 31, 'pid' => 1, 'colPos' => 0, 'sorting' => 2,
+            'CType' => 'textmedia', 'header' => 'Beta',
+        ]);
+    }
+
+    #[Test]
+    public function equalityFilterSelectsMatchingRowsOnly(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute([
+            'table'        => 'tt_content',
+            'where_equals' => ['CType' => 'textmedia'],
+            'fields'       => ['header', 'CType'],
+        ]);
+
+        self::assertStringContainsString('tt_content:31', $output);
+        self::assertStringContainsString('header: Beta', $output);
+        self::assertStringNotContainsString('tt_content:30', $output);
+    }
+
+    #[Test]
+    public function uidFilterReadsASingleRecordWithDefaultLabelFields(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 30]);
+
+        self::assertStringContainsString('tt_content:30', $output);
+        self::assertStringContainsString('header: Alpha', $output);
+    }
+
+    #[Test]
+    public function limitCapsTheRowCount(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'limit' => 1]);
+
+        self::assertStringContainsString('tt_content:30', $output);
+        self::assertStringNotContainsString('tt_content:31', $output);
+    }
+
+    #[Test]
+    public function nonAdminWithoutTableRightsIsDenied(): void
+    {
+        $this->setUpBackendUser(2); // editor without any group rights
+
+        $output = $this->tool->execute(['table' => 'tt_content']);
+
+        self::assertSame('Table not found or not permitted.', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Schema\SearchableSchemaFieldsCollector;
+
+/**
+ * Functional tests for SearchRecordsTool (ADR-042).
+ *
+ * Load-bearing: the search finds seeded content through the TCA
+ * searchFields, hidden rows never reach the output, and the sensitive-table
+ * denylist holds even for an admin.
+ */
+#[CoversClass(SearchRecordsTool::class)]
+final class SearchRecordsToolTest extends AbstractFunctionalTestCase
+{
+    private SearchRecordsTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // admin
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $collector = $this->get(SearchableSchemaFieldsCollector::class);
+        self::assertInstanceOf(SearchableSchemaFieldsCollector::class, $collector);
+        $this->tool = new SearchRecordsTool($connectionPool, new TableReadAccessService(), $collector);
+
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1, 'sorting' => 1,
+        ]);
+
+        $content = $connectionPool->getConnectionForTable('tt_content');
+        $content->insert('tt_content', [
+            'uid' => 10, 'pid' => 1, 'colPos' => 0, 'sorting' => 1, 'CType' => 'text',
+            'header' => 'About Netresearch', 'bodytext' => 'Netresearch builds durable web platforms.',
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 11, 'pid' => 1, 'colPos' => 0, 'sorting' => 2, 'CType' => 'text',
+            'header' => 'Hidden teaser', 'bodytext' => 'Netresearch hidden gem.', 'hidden' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function findsSeededContentThroughSearchFieldsWithExcerpt(): void
+    {
+        $output = $this->tool->execute(['query' => 'Netresearch']);
+
+        self::assertStringContainsString('tt_content:10', $output);
+        self::assertStringContainsString('About Netresearch', $output);
+        self::assertStringContainsString('match(', $output);
+    }
+
+    #[Test]
+    public function hiddenRowsNeverReachTheOutput(): void
+    {
+        $output = $this->tool->execute(['query' => 'hidden gem']);
+
+        self::assertSame('No matches.', $output);
+    }
+
+    #[Test]
+    public function tableRestrictionLimitsTheSearch(): void
+    {
+        $output = $this->tool->execute(['query' => 'Netresearch', 'table' => 'pages']);
+
+        self::assertStringNotContainsString('tt_content:', $output);
+    }
+
+    #[Test]
+    public function sensitiveTableIsDeniedEvenForAdmin(): void
+    {
+        $output = $this->tool->execute(['query' => 'admin', 'table' => 'be_users']);
+
+        self::assertSame('Table not found or not permitted.', $output);
+    }
+}

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -62,7 +62,7 @@ final class PublicServicesPolicyTest extends TestCase
      * `Documentation/Adr/Adr028PublicServicesPolicy.rst` in the
      * same PR — the diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 42;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 43;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTsConfigTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Schema\SearchableSchemaFieldsCollector;
+
+/**
+ * Unit tests for the five content/introspection tools (ADR-042): spec
+ * shape, admin tiering, and the fail-closed / input-validation paths that
+ * return before any database access (the injected ConnectionPool would
+ * throw on use — the mocks are intentionally unprimed).
+ */
+#[CoversClass(SearchRecordsTool::class)]
+#[CoversClass(GetPageContentTool::class)]
+#[CoversClass(ReadRecordsTool::class)]
+#[CoversClass(GetTypoScriptTool::class)]
+#[CoversClass(GetTsConfigTool::class)]
+final class ContentToolsSpecTest extends TestCase
+{
+    private mixed $tcaBackup = null;
+
+    private mixed $beUserBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tcaBackup    = $GLOBALS['TCA'] ?? null;
+        $this->beUserBackup = $GLOBALS['BE_USER'] ?? null;
+        unset($GLOBALS['BE_USER']);
+
+        $GLOBALS['TCA'] = [
+            'tt_content' => [
+                'ctrl'    => ['label' => 'header', 'searchFields' => 'header,bodytext'],
+                'columns' => ['header' => [], 'bodytext' => [], 'CType' => []],
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TCA'] = $this->tcaBackup;
+        if ($this->beUserBackup !== null) {
+            $GLOBALS['BE_USER'] = $this->beUserBackup;
+        } else {
+            unset($GLOBALS['BE_USER']);
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function specsDeclareTheExpectedNamesAndRequirements(): void
+    {
+        $expected = [
+            'search_records'   => [$this->searchTool(), false, ['query']],
+            'get_page_content' => [$this->pageContentTool(), false, ['uid']],
+            'read_records'     => [$this->readRecordsTool(), false, ['table']],
+            'get_typoscript'   => [$this->typoScriptTool(), true, ['pageUid']],
+            'get_tsconfig'     => [$this->tsConfigTool(), true, ['pageUid']],
+        ];
+
+        foreach ($expected as $name => [$tool, $adminOnly, $required]) {
+            $spec = $tool->getSpec();
+            self::assertSame($name, $spec->name);
+            self::assertSame($adminOnly, $tool->requiresAdmin(), $name);
+            self::assertTrue($tool->isEnabledByDefault(), $name);
+            self::assertSame($required, $spec->parameters['required'] ?? [], $name);
+        }
+    }
+
+    #[Test]
+    public function searchFailsClosedWithoutBackendUser(): void
+    {
+        self::assertSame('Not permitted.', $this->searchTool()->execute(['query' => 'foo']));
+    }
+
+    #[Test]
+    public function searchRejectsTooShortQuery(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+
+        self::assertSame(
+            'Query too short (minimum 2 characters).',
+            $this->searchTool()->execute(['query' => 'x']),
+        );
+    }
+
+    #[Test]
+    public function pageContentFailsClosedWithoutBackendUser(): void
+    {
+        self::assertSame(
+            'Page not found or not permitted.',
+            $this->pageContentTool()->execute(['uid' => 1]),
+        );
+    }
+
+    #[Test]
+    public function pageContentRejectsInvalidUid(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+
+        self::assertSame(
+            'Page not found or not permitted.',
+            $this->pageContentTool()->execute(['uid' => 0]),
+        );
+    }
+
+    #[Test]
+    public function readRecordsFailsClosedWithoutBackendUser(): void
+    {
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->readRecordsTool()->execute(['table' => 'tt_content']),
+        );
+    }
+
+    #[Test]
+    public function readRecordsDeniesSensitiveTableEvenForAdmins(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $GLOBALS['TCA']['be_users'] = ['ctrl' => ['label' => 'username'], 'columns' => ['username' => []]];
+
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->readRecordsTool()->execute(['table' => 'be_users']),
+        );
+    }
+
+    #[Test]
+    public function readRecordsRejectsUnknownFilterColumn(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+
+        self::assertSame(
+            'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.',
+            $this->readRecordsTool()->execute([
+                'table'        => 'tt_content',
+                'where_equals' => ['no_such_column' => 'x'],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function readRecordsRejectsCredentialFilterColumn(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $GLOBALS['TCA']['tt_content']['columns']['api_key'] = [];
+
+        self::assertSame(
+            'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.',
+            $this->readRecordsTool()->execute([
+                'table'        => 'tt_content',
+                'where_equals' => ['api_key' => 'x'],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function typoScriptRejectsInvalidPageUid(): void
+    {
+        self::assertSame(
+            'Page not found or no TypoScript template.',
+            $this->typoScriptTool()->execute(['pageUid' => 0]),
+        );
+    }
+
+    #[Test]
+    public function tsConfigRejectsInvalidPageUid(): void
+    {
+        self::assertSame('Page not found.', $this->tsConfigTool()->execute(['pageUid' => 0]));
+    }
+
+    private function adminUser(): BackendUserAuthentication
+    {
+        $user = $this->createMock(BackendUserAuthentication::class);
+        $user->method('isAdmin')->willReturn(true);
+
+        return $user;
+    }
+
+    private function searchTool(): SearchRecordsTool
+    {
+        return new SearchRecordsTool(
+            $this->createMock(ConnectionPool::class),
+            new TableReadAccessService(),
+            $this->createMock(SearchableSchemaFieldsCollector::class),
+        );
+    }
+
+    private function pageContentTool(): GetPageContentTool
+    {
+        return new GetPageContentTool($this->createMock(ConnectionPool::class));
+    }
+
+    private function readRecordsTool(): ReadRecordsTool
+    {
+        return new ReadRecordsTool($this->createMock(ConnectionPool::class), new TableReadAccessService());
+    }
+
+    private function typoScriptTool(): GetTypoScriptTool
+    {
+        // FrontendTypoScriptFactory and SysTemplateRepository are final — not
+        // mockable. The paths under test (spec, invalid pageUid) never touch
+        // the constructor-injected services, so instantiate without them.
+        $reflection = new ReflectionClass(GetTypoScriptTool::class);
+
+        return $reflection->newInstanceWithoutConstructor();
+    }
+
+    private function tsConfigTool(): GetTsConfigTool
+    {
+        return new GetTsConfigTool($this->createMock(ConnectionPool::class));
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/Fixtures/TypoScriptTreeRendererFixture.php
+++ b/Tests/Unit/Service/Tool/Builtin/Fixtures/TypoScriptTreeRendererFixture.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin\Fixtures;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\RendersTypoScriptTreeTrait;
+
+/**
+ * Exposes the trait's private helpers for direct unit testing.
+ */
+final class TypoScriptTreeRendererFixture
+{
+    use RendersTypoScriptTreeTrait;
+
+    /**
+     * @param array<array-key, mixed> $tree
+     *
+     * @return array{0: string|null, 1: array<array-key, mixed>|null}
+     */
+    public function drill(array $tree, string $path): array
+    {
+        return $this->drillPath($tree, $path);
+    }
+
+    /**
+     * @param array<array-key, mixed> $tree
+     *
+     * @return list<string>
+     */
+    public function render(array $tree): array
+    {
+        $lines = [];
+        $this->renderTree($tree, $lines);
+
+        return $lines;
+    }
+
+    /**
+     * @param array<array-key, mixed> $tree
+     *
+     * @return list<string>
+     */
+    public function topLevel(array $tree): array
+    {
+        return $this->renderTopLevelKeys($tree);
+    }
+
+    public function redact(string $key, string $value): string
+    {
+        return $this->redactSecretValue($key, $value);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/RendersTypoScriptTreeTraitTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/RendersTypoScriptTreeTraitTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\RendersTypoScriptTreeTrait;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin\Fixtures\TypoScriptTreeRendererFixture;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the shared TypoScript-tree rendering (ADR-042): dotted-path
+ * drill-down through `key.` subtrees, secret redaction by key, and the hard
+ * output cap.
+ */
+#[CoversTrait(RendersTypoScriptTreeTrait::class)]
+final class RendersTypoScriptTreeTraitTest extends TestCase
+{
+    private TypoScriptTreeRendererFixture $renderer;
+
+    /** @var array<string, mixed> */
+    private array $tree;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->renderer = new TypoScriptTreeRendererFixture();
+        $this->tree     = [
+            'config.' => [
+                'no_cache'  => '0',
+                'language.' => ['default' => 'en'],
+            ],
+            'plugin.' => [
+                'tx_demo.' => [
+                    'settings.' => [
+                        'apiKey'   => 'super-secret-value',
+                        'endpoint' => 'https://api.example.org',
+                    ],
+                ],
+            ],
+            'page' => 'PAGE',
+        ];
+    }
+
+    #[Test]
+    public function drillPathResolvesValueAndSubtree(): void
+    {
+        [$value, $subtree] = $this->renderer->drill($this->tree, 'config.no_cache');
+        self::assertSame('0', $value);
+        self::assertNull($subtree);
+
+        [$value, $subtree] = $this->renderer->drill($this->tree, 'config.language');
+        self::assertNull($value);
+        self::assertSame(['default' => 'en'], $subtree);
+
+        [$value, $subtree] = $this->renderer->drill($this->tree, 'nope.nothing');
+        self::assertNull($value);
+        self::assertNull($subtree);
+    }
+
+    #[Test]
+    public function renderTreeIndentsAndRedactsSecrets(): void
+    {
+        $lines = $this->renderer->render($this->tree);
+        $text  = implode("\n", $lines);
+
+        self::assertStringContainsString('page = PAGE', $text);
+        self::assertStringContainsString('endpoint = https://api.example.org', $text);
+        // The apiKey VALUE never appears; the redaction marker does.
+        self::assertStringNotContainsString('super-secret-value', $text);
+        self::assertStringContainsString('apiKey = [redacted]', $text);
+    }
+
+    #[Test]
+    public function topLevelListingMarksBranchesWithChildCounts(): void
+    {
+        $lines = $this->renderer->topLevel($this->tree);
+
+        self::assertContains('config (+2 children)', $lines);
+        self::assertContains('plugin (+1 children)', $lines);
+        self::assertContains('page = PAGE', $lines);
+    }
+
+    #[Test]
+    public function outputIsCappedWithExplicitMarker(): void
+    {
+        $huge = [];
+        for ($i = 0; $i < 400; ++$i) {
+            $huge['key' . $i] = 'value' . $i;
+        }
+
+        $lines = $this->renderer->render($huge);
+
+        self::assertLessThanOrEqual(301, count($lines));
+        self::assertStringContainsString('[output truncated at 300 lines]', (string)end($lines));
+    }
+
+    #[Test]
+    public function redactionMatchesCredentialKeysOnly(): void
+    {
+        self::assertSame('[redacted]', $this->renderer->redact('apiKey', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('password', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('authorization', 'x'));
+        self::assertSame('kept', $this->renderer->redact('title', 'kept'));
+        self::assertSame('kept', $this->renderer->redact('monkeys', 'kept'));
+    }
+}

--- a/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
+++ b/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Unit tests for the shared read-access policy (ADR-042).
+ *
+ * Load-bearing: the sensitive-table denylist holds even for admins, the
+ * sensitive-field pattern catches credential-ish segments without false
+ * positives on editorial columns, and every gate fails closed without a
+ * backend user.
+ */
+#[CoversClass(TableReadAccessService::class)]
+final class TableReadAccessServiceTest extends TestCase
+{
+    private TableReadAccessService $service;
+
+    private mixed $tcaBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service   = new TableReadAccessService();
+        $this->tcaBackup = $GLOBALS['TCA'] ?? null;
+
+        $GLOBALS['TCA'] = [
+            'pages'      => ['ctrl' => ['label' => 'title'], 'columns' => ['title' => []]],
+            'tt_content' => ['ctrl' => ['label' => 'header'], 'columns' => ['header' => []]],
+            'be_users'   => ['ctrl' => ['label' => 'username'], 'columns' => ['username' => []]],
+            'tx_nrllm_provider' => ['ctrl' => ['label' => 'name'], 'columns' => ['name' => []]],
+            'tx_secret_admin'   => ['ctrl' => ['label' => 'name', 'adminOnly' => true], 'columns' => ['name' => []]],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TCA'] = $this->tcaBackup;
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertFalse($this->service->canReadTable(null, 'pages'));
+    }
+
+    #[Test]
+    public function sensitiveTablesAreDeniedEvenForAdmins(): void
+    {
+        $admin = $this->createMock(BackendUserAuthentication::class);
+        $admin->method('isAdmin')->willReturn(true);
+
+        self::assertFalse($this->service->canReadTable($admin, 'be_users'));
+        self::assertFalse($this->service->canReadTable($admin, 'tx_nrllm_provider'));
+        self::assertTrue($this->service->canReadTable($admin, 'pages'));
+    }
+
+    #[Test]
+    public function unknownTableIsDenied(): void
+    {
+        $admin = $this->createMock(BackendUserAuthentication::class);
+        $admin->method('isAdmin')->willReturn(true);
+
+        self::assertFalse($this->service->canReadTable($admin, 'tx_does_not_exist'));
+    }
+
+    #[Test]
+    public function nonAdminNeedsTablesSelectRight(): void
+    {
+        $editor = $this->createMock(BackendUserAuthentication::class);
+        $editor->method('isAdmin')->willReturn(false);
+        $editor->method('check')->willReturnCallback(
+            static fn(string $type, string $value): bool => $value === 'tt_content',
+        );
+
+        self::assertTrue($this->service->canReadTable($editor, 'tt_content'));
+        self::assertFalse($this->service->canReadTable($editor, 'pages'));
+    }
+
+    #[Test]
+    public function nonAdminNeverReadsAdminOnlyTables(): void
+    {
+        $editor = $this->createMock(BackendUserAuthentication::class);
+        $editor->method('isAdmin')->willReturn(false);
+        $editor->method('check')->willReturn(true);
+
+        self::assertFalse($this->service->canReadTable($editor, 'tx_secret_admin'));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function fieldProvider(): array
+    {
+        return [
+            'password'          => ['password', true],
+            'api_key'           => ['api_key', true],
+            'identifier_hash'   => ['identifier_hash', true],
+            'ses_token'         => ['ses_token', true],
+            'mfa'               => ['mfa', true],
+            'salt'              => ['salt', true],
+            // No false positives on editorial columns:
+            'author'            => ['author', false],
+            'author_email'      => ['author_email', false],
+            'title'             => ['title', false],
+            'keywords'          => ['keywords', false],
+            'monkey'            => ['monkey', false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('fieldProvider')]
+    public function sensitiveFieldPatternMatchesCredentialSegments(string $field, bool $expected): void
+    {
+        self::assertSame($expected, $this->service->isSensitiveField($field));
+    }
+
+    #[Test]
+    public function filterSensitiveFieldsDropsCredentialColumns(): void
+    {
+        $fields = $this->service->filterSensitiveFields(['uid', 'title', 'password', 'api_key', 'author']);
+
+        self::assertSame(['uid', 'title', 'author'], $fields);
+    }
+}


### PR DESCRIPTION
Five new native read-only tools for the function-calling runtime — closing the biggest capability gaps (content search/read, resolved TypoScript/TSconfig). Designed after studying `konradmichalik/typo3-ai-mate` and `hn/typo3-mcp-server` (both GPL-2.0-or-later); own implementations, no dependency on either. **ADR-042.**

## Tools

| Tool | Does | Access |
|---|---|---|
| `search_records` | Full-text search across tables with searchable fields (core `SearchableSchemaFieldsCollector`), with matched-field excerpts | default on |
| `get_page_content` | One page's header + content elements (colPos/sorting order, tag-stripped excerpts, language-aware) | default on |
| `read_records` | Generic filtered record read (equality filters via QueryBuilder named params — never raw SQL; pagination) | default on |
| `get_typoscript` | Resolved frontend TypoScript per page, setup/constants, dotted-path drill-down | **admin-only** |
| `get_tsconfig` | Rootline-merged page TSconfig, dotted-path drill-down | **admin-only** |

## Permission model (shared `TableReadAccessService`, fail-closed)

- **Absolute denylists** (apply to admins too): sensitive tables (`be_users`, `be_groups`, `fe_*`, `sys_log`, `sys_history`, `sys_refindex`, `tx_nrllm*`) and credential-ish fields (segment-matched `password|secret|token|salt|hash|key|mfa|…`).
- **Non-admins additionally:** `tables_select` group rights, TCA `adminOnly` skip, default query restrictions (hidden/time), and per-row `PAGE_SHOW` checks (memoised `readPageAccess`; result pages may under-fill `limit` rather than weaken the check; pid-0 rows of non-pages tables fail closed).
- TS/TSconfig values matching secret-ish keys render as `[redacted]`; output capped (top-level key list when no path given).

## Notes

- `ctrl.searchFields` TCA parsing is wrong on v14 (migration strips it) — using core's `SearchableSchemaFieldsCollector` instead (public in 13.4 + 14.3); caught by a functional test.
- `ToolRegistry` becomes `public: true` for test resolution — ADR-028's public-services count + list updated per that ADR's process.
- Docs: tool table extended; corrected a pre-existing claim (`read_fal_asset_meta` is admin-only, not editor-accessible).
- Verified: cgl, rector, phpstan (L10), unit (3921), targeted functional (19 tests/92 assertions), architecture; live on ddev — each tool exercised through a real agent loop (search/page/records) resp. forced runs (TS/TSconfig), all 16 tools auto-listed in the playground.
- Write tools stay deferred; mcp-server's DataHandler+workspace staging is named in ADR-042 as the reference design. Tool **grouping** (central/config-level toggles) follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
