### PR TITLE
feat(tools)!: group tools with fail-closed central/config/run toggles

### DIFF
--- a/Classes/Controller/Backend/ToolController.php
+++ b/Classes/Controller/Backend/ToolController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Psr\Http\Message\ResponseInterface;
@@ -41,6 +42,7 @@ final class ToolController extends ActionController
         private readonly ToolRegistry $toolRegistry,
         private readonly ToolAvailabilityServiceInterface $toolAvailability,
         private readonly ToolStateRepository $toolStateRepository,
+        private readonly ToolGroupStateRepository $toolGroupStateRepository,
         private readonly PageRenderer $pageRenderer,
     ) {}
 
@@ -50,7 +52,8 @@ final class ToolController extends ActionController
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $moduleTemplate->assignMultiple([
-            'toolStates' => $this->toolAvailability->states(),
+            'toolStates'  => $this->toolAvailability->states(),
+            'groupStates' => $this->groupStatesByName(),
         ]);
         return $moduleTemplate->renderResponse('Backend/Tool/List');
     }
@@ -80,6 +83,50 @@ final class ToolController extends ActionController
         $this->toolStateRepository->setEnabled($toolName, $enabled);
 
         return new JsonResponse(['success' => true, 'enabled' => $enabled]);
+    }
+
+    /**
+     * Toggle the global enable state of a whole tool GROUP (AJAX, admin-gated).
+     *
+     * Mirrors {@see toggleToolAction()}: admin gate first (ADR-037), then the
+     * override is persisted to `tx_nrllm_tool_group_state`. Only a group of a
+     * currently registered tool is accepted so the table cannot accumulate
+     * orphan rows; the stored NAME still covers same-group tools installed
+     * later. The cascade in ToolAvailabilityService keeps a disabled group
+     * authoritative over any per-tool override (fail-closed).
+     */
+    public function toggleToolGroupAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body      = $request->getParsedBody();
+        $groupName = $this->stringFromBody($body, 'group');
+        $known     = array_column($this->toolAvailability->groupStates(), 'name');
+        if ($groupName === '' || !in_array($groupName, $known, true)) {
+            return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.unknownGroup', 'Unknown tool group')], 404);
+        }
+
+        $enabled = $this->boolFromBody($body, 'enabled');
+        $this->toolGroupStateRepository->setEnabled($groupName, $enabled);
+
+        return new JsonResponse(['success' => true, 'enabled' => $enabled]);
+    }
+
+    /**
+     * Group states keyed by group name for direct template lookup.
+     *
+     * @return array<string, array{name: string, enabled: bool, overridden: bool}>
+     */
+    private function groupStatesByName(): array
+    {
+        $byName = [];
+        foreach ($this->toolAvailability->groupStates() as $state) {
+            $byName[$state['name']] = $state;
+        }
+
+        return $byName;
     }
 
     private function stringFromBody(mixed $body, string $key): string

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -60,6 +60,12 @@ class LlmConfiguration extends AbstractEntity
     protected float $presencePenalty = 0.0;
     protected int $timeout = 0;
     protected string $options = '';
+
+    /**
+     * Comma list of permitted tool groups; empty = all groups allowed.
+     * See {@see getAllowedToolGroupsList()} and AllowedToolsResolver.
+     */
+    protected string $allowedToolGroups = '';
     protected int $maxRequestsPerDay = 0;
     protected int $maxTokensPerDay = 0;
     protected float $maxCostPerDay = 0.0;
@@ -724,5 +730,38 @@ class LlmConfiguration extends AbstractEntity
     public function getProvider(): ?Provider
     {
         return $this->llmModel?->getProvider();
+    }
+
+    public function getAllowedToolGroups(): string
+    {
+        return $this->allowedToolGroups;
+    }
+
+    public function setAllowedToolGroups(string $allowedToolGroups): void
+    {
+        $this->allowedToolGroups = $allowedToolGroups;
+    }
+
+    /**
+     * The permitted tool groups as a trimmed list; empty list = no
+     * group-based restriction (all groups allowed).
+     *
+     * @return list<string>
+     */
+    public function getAllowedToolGroupsList(): array
+    {
+        if (trim($this->allowedToolGroups) === '') {
+            return [];
+        }
+
+        $list = [];
+        foreach (explode(',', $this->allowedToolGroups) as $group) {
+            $group = trim($group);
+            if ($group !== '') {
+                $list[] = $group;
+            }
+        }
+
+        return $list;
     }
 }

--- a/Classes/Form/Tca/ToolGroupItems.php
+++ b/Classes/Form/Tca/ToolGroupItems.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Form\Tca;
+
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TCA itemsProcFunc listing the tool groups of the currently registered
+ * tools for the `allowed_tool_groups` select on tx_nrllm_configuration.
+ *
+ * The group list is derived from the registry (not hardcoded) so third-party
+ * tools' groups appear automatically. Values already stored on the record but
+ * no longer known (an uninstalled extension's group) are appended so the
+ * stored selection stays visible and editable rather than silently dropped.
+ */
+final class ToolGroupItems
+{
+    /**
+     * @param array{items: array<int, array{label: string, value: string}>, row?: array<string, mixed>} $params
+     */
+    public function addItems(array &$params): void
+    {
+        $registry = GeneralUtility::makeInstance(ToolRegistry::class);
+
+        $groups = [];
+        foreach ($registry->names() as $name) {
+            $tool = $registry->get($name);
+            if ($tool instanceof ToolInterface) {
+                $groups[$tool->getGroup()] = true;
+            }
+        }
+        ksort($groups);
+
+        // Keep already-stored but currently unknown groups selectable.
+        $row    = is_array($params['row'] ?? null) ? $params['row'] : [];
+        $stored = $row['allowed_tool_groups'] ?? '';
+        if (is_array($stored)) {
+            $stored = implode(',', array_map(
+                static fn(mixed $value): string => is_scalar($value) ? (string)$value : '',
+                $stored,
+            ));
+        } elseif (!is_scalar($stored)) {
+            $stored = '';
+        } else {
+            $stored = (string)$stored;
+        }
+        foreach (GeneralUtility::trimExplode(',', $stored, true) as $known) {
+            $groups[$known] ??= true;
+        }
+
+        foreach (array_keys($groups) as $group) {
+            $params['items'][] = ['label' => $group, 'value' => $group];
+        }
+    }
+}

--- a/Classes/Service/Tool/AllowedToolsResolver.php
+++ b/Classes/Service/Tool/AllowedToolsResolver.php
@@ -30,6 +30,7 @@ final readonly class AllowedToolsResolver
 {
     public function __construct(
         private SkillComposer $composer,
+        private ToolRegistry $registry,
     ) {}
 
     /**
@@ -53,7 +54,46 @@ final readonly class AllowedToolsResolver
             }
         }
 
-        return $any ? array_keys($declared) : null;
+        $names = $any ? array_keys($declared) : null;
+
+        return $this->applyGroupGate($names, $config->getAllowedToolGroupsList());
+    }
+
+    /**
+     * Intersect the skill-derived allow-list with the configuration's
+     * `allowed_tool_groups` gate.
+     *
+     * An empty group set means "no group restriction" and passes `$names`
+     * through unchanged. A non-empty set restricts to registered tools whose
+     * {@see ToolInterface::getGroup()} is in the set — combined with the skill
+     * list when one exists, otherwise as the allow-list itself. The global
+     * group/tool enable cascade (ToolAvailabilityService) applies on top in
+     * the runtime gate regardless.
+     *
+     * @param list<string>|null $names
+     * @param list<string>      $groupSet
+     *
+     * @return list<string>|null
+     */
+    private function applyGroupGate(?array $names, array $groupSet): ?array
+    {
+        if ($groupSet === []) {
+            return $names;
+        }
+
+        $inGroups = [];
+        foreach ($this->registry->names() as $name) {
+            $tool = $this->registry->get($name);
+            if ($tool !== null && in_array($tool->getGroup(), $groupSet, true)) {
+                $inGroups[] = $name;
+            }
+        }
+
+        if ($names === null) {
+            return $inGroups;
+        }
+
+        return array_values(array_intersect($names, $inGroups));
     }
 
     /**

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -126,4 +126,9 @@ final readonly class FetchLogsTool implements ToolInterface
         // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetEnvRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvRawTool.php
@@ -70,4 +70,8 @@ final readonly class GetEnvRawTool implements ToolInterface
         return true;
     }
 
+    public function getGroup(): string
+    {
+        return 'system';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -90,4 +90,8 @@ final readonly class GetEnvTool implements ToolInterface
         return true;
     }
 
+    public function getGroup(): string
+    {
+        return 'system';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -238,4 +238,9 @@ final readonly class GetPageContentTool implements ToolInterface
 
         return $plain;
     }
+
+    public function getGroup(): string
+    {
+        return 'content';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -172,4 +172,9 @@ final readonly class GetPageTreeTool implements ToolInterface
             $this->appendChildren($uid, $level + 1, $maxDepth, $lines, $count);
         }
     }
+
+    public function getGroup(): string
+    {
+        return 'structure';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
@@ -74,4 +74,9 @@ final readonly class GetPhpInfoRawTool implements ToolInterface
         // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
@@ -77,4 +77,9 @@ final readonly class GetPhpInfoTool implements ToolInterface
         // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTcaTool.php
@@ -137,4 +137,9 @@ final readonly class GetTcaTool implements ToolInterface
 
         return implode("\n", $lines);
     }
+
+    public function getGroup(): string
+    {
+        return 'structure';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetTsConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetTsConfigTool.php
@@ -148,4 +148,9 @@ final readonly class GetTsConfigTool implements ToolInterface
 
         return $uid !== false;
     }
+
+    public function getGroup(): string
+    {
+        return 'configuration';
+    }
 }

--- a/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
@@ -247,4 +247,9 @@ final readonly class GetTypoScriptTool implements ToolInterface
 
         return implode("\n", $lines);
     }
+
+    public function getGroup(): string
+    {
+        return 'configuration';
+    }
 }

--- a/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
@@ -88,4 +88,9 @@ final readonly class ListBeGroupsTool implements ToolInterface
         // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'accounts';
+    }
 }

--- a/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
@@ -120,4 +120,9 @@ final readonly class ListBeUsersRawTool implements ToolInterface
 
         return mb_substr($value, 0, self::MAX_VALUE_LENGTH) . '…';
     }
+
+    public function getGroup(): string
+    {
+        return 'accounts';
+    }
 }

--- a/Classes/Service/Tool/Builtin/ListBeUsersTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersTool.php
@@ -98,4 +98,9 @@ final readonly class ListBeUsersTool implements ToolInterface
         // Admin-only: exposes system / host / cross-user data a non-admin must never reach.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'accounts';
+    }
 }

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -145,4 +145,9 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
         // non-admin), with the storage allow-list as a further bound.
         return true;
     }
+
+    public function getGroup(): string
+    {
+        return 'structure';
+    }
 }

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -354,4 +354,9 @@ final readonly class ReadRecordsTool implements ToolInterface
 
         return $string;
     }
+
+    public function getGroup(): string
+    {
+        return 'content';
+    }
 }

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -312,4 +312,9 @@ final readonly class SearchRecordsTool implements ToolInterface
         // the field denylist applies to the label too (drop, don't leak).
         return $this->tableAccess->isSensitiveField($label) ? '' : $label;
     }
+
+    public function getGroup(): string
+    {
+        return 'content';
+    }
 }

--- a/Classes/Service/Tool/ToolAvailabilityService.php
+++ b/Classes/Service/Tool/ToolAvailabilityService.php
@@ -25,6 +25,7 @@ final readonly class ToolAvailabilityService implements ToolAvailabilityServiceI
     public function __construct(
         private ToolRegistry $registry,
         private ToolStateRepository $stateRepository,
+        private ToolGroupStateRepository $groupStateRepository,
     ) {}
 
     public function enabledNames(): array
@@ -41,7 +42,8 @@ final readonly class ToolAvailabilityService implements ToolAvailabilityServiceI
 
     public function states(): array
     {
-        $overrides = $this->stateRepository->overrides();
+        $overrides      = $this->stateRepository->overrides();
+        $groupOverrides = $this->groupStateRepository->overrides();
 
         $states = [];
         foreach ($this->registry->names() as $name) {
@@ -52,16 +54,52 @@ final readonly class ToolAvailabilityService implements ToolAvailabilityServiceI
 
             $default    = $tool->isEnabledByDefault();
             $overridden = array_key_exists($name, $overrides);
+            $group      = $tool->getGroup();
+            // Unknown / never-toggled group => enabled (only an explicit
+            // admin override disables a group).
+            $groupEnabled = $groupOverrides[$group] ?? true;
+            $toolEnabled  = $overridden ? $overrides[$name] : $default;
 
             $states[] = [
                 'name'           => $name,
                 'description'    => $tool->getSpec()->description,
-                'enabled'        => $overridden ? $overrides[$name] : $default,
+                'group'          => $group,
+                // Fail-closed cascade: a per-tool override can never
+                // re-enable a tool inside a disabled group.
+                'enabled'        => $groupEnabled && $toolEnabled,
+                'toolEnabled'    => $toolEnabled,
+                'groupEnabled'   => $groupEnabled,
                 'defaultEnabled' => $default,
                 'overridden'     => $overridden,
             ];
         }
 
         return $states;
+    }
+
+    public function groupStates(): array
+    {
+        $groupOverrides = $this->groupStateRepository->overrides();
+
+        $groups = [];
+        foreach ($this->registry->names() as $name) {
+            $tool = $this->registry->get($name);
+            if ($tool === null) {
+                continue;
+            }
+            $group = $tool->getGroup();
+            if (isset($groups[$group])) {
+                continue;
+            }
+            $groups[$group] = [
+                'name'       => $group,
+                'enabled'    => $groupOverrides[$group] ?? true,
+                'overridden' => array_key_exists($group, $groupOverrides),
+            ];
+        }
+
+        ksort($groups);
+
+        return array_values($groups);
     }
 }

--- a/Classes/Service/Tool/ToolAvailabilityServiceInterface.php
+++ b/Classes/Service/Tool/ToolAvailabilityServiceInterface.php
@@ -28,17 +28,31 @@ interface ToolAvailabilityServiceInterface
     public function enabledNames(): array;
 
     /**
-     * Per-tool state rows for the management UI: name, description, the
-     * effective enabled flag, the tool default and whether an explicit admin
-     * override is in effect.
+     * Per-tool state rows for the management UI: name, description, group,
+     * the effective enabled flag (group AND tool cascade), the tool-level
+     * flag, the group-level flag, the tool default and whether an explicit
+     * admin override is in effect.
      *
      * @return list<array{
      *     name: string,
      *     description: string,
+     *     group: string,
      *     enabled: bool,
+     *     toolEnabled: bool,
+     *     groupEnabled: bool,
      *     defaultEnabled: bool,
      *     overridden: bool,
      * }>
      */
     public function states(): array;
+
+    /**
+     * Per-group state rows for the management UI, one per group of the
+     * currently registered tools: name, the effective enabled flag (an
+     * unknown / never-toggled group is enabled) and whether an explicit
+     * admin override row exists.
+     *
+     * @return list<array{name: string, enabled: bool, overridden: bool}>
+     */
+    public function groupStates(): array;
 }

--- a/Classes/Service/Tool/ToolGroupStateRepository.php
+++ b/Classes/Service/Tool/ToolGroupStateRepository.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * ConnectionPool-backed store for the global per-GROUP enable/disable
+ * overrides (`tx_nrllm_tool_group_state`), mirroring {@see ToolStateRepository}.
+ *
+ * A row exists only for a group an admin has toggled; the absence of a row
+ * means "group enabled". Because the state is keyed by group NAME (not by the
+ * currently registered tools), a disabled group also covers tools of that
+ * group that are installed later — the cascade in
+ * {@see ToolAvailabilityService} stays fail-closed.
+ */
+final readonly class ToolGroupStateRepository
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_tool_group_state';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * Return the explicit overrides keyed by group name: `group => enabled`.
+     *
+     * @return array<string, bool>
+     */
+    public function overrides(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('group_name', 'enabled')
+            ->from(self::TABLE)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $overrides = [];
+        foreach ($rows as $row) {
+            $name = self::toStr($row['group_name'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+            $overrides[$name] = self::toInt($row['enabled'] ?? 0) === 1;
+        }
+
+        return $overrides;
+    }
+
+    /**
+     * Upsert the override for a single group (select-then-write, mirroring
+     * {@see ToolStateRepository::setEnabled()}).
+     */
+    public function setEnabled(string $groupName, bool $enabled): void
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $existingUid = $queryBuilder
+            ->select('uid')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('group_name', $queryBuilder->createNamedParameter($groupName)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $value      = $enabled ? 1 : 0;
+        if ($existingUid !== false) {
+            $connection->update(self::TABLE, ['enabled' => $value], ['uid' => self::toInt($existingUid)]);
+
+            return;
+        }
+
+        $connection->insert(self::TABLE, [
+            'pid'        => 0,
+            'group_name' => $groupName,
+            'enabled'    => $value,
+        ]);
+    }
+}

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -84,4 +84,20 @@ interface ToolInterface
      * (TYPO3 admins see everything).
      */
     public function requiresAdmin(): bool;
+
+    /**
+     * The tool's group — a short, stable identifier used to enable or disable
+     * whole families of tools at once (Tools module group toggles, the
+     * per-configuration `allowed_tool_groups` gate and the playground's
+     * grouped checkboxes).
+     *
+     * Builtins use the curated taxonomy `content`, `structure`, `system`,
+     * `accounts`, `configuration`. Third-party tools declare their own group;
+     * the recommended value is the providing extension's key. Enablement
+     * cascades fail-closed: a tool is only offered when its group is enabled
+     * AND the tool itself is enabled AND the run's configuration permits the
+     * group — a per-tool override never re-enables a tool inside a disabled
+     * group.
+     */
+    public function getGroup(): string;
 }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -149,6 +149,11 @@ return [
         'path' => '/nrllm/tool/toggle',
         'target' => ToolController::class . '::toggleToolAction',
     ],
+    // Tool group management route (enable/disable a whole group)
+    'nrllm_toolgroup_toggle' => [
+        'path' => '/nrllm/toolgroup/toggle',
+        'target' => ToolController::class . '::toggleToolGroupAction',
+    ],
 
     // Setup Wizard routes
     'nrllm_wizard_detect' => [

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration',
@@ -389,7 +391,7 @@ return [
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectCheckBox',
-                'itemsProcFunc' => \Netresearch\NrLlm\Form\Tca\ToolGroupItems::class . '->addItems',
+                'itemsProcFunc' => ToolGroupItems::class . '->addItems',
                 'default' => '',
             ],
         ],

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -44,6 +44,7 @@ return [
                     fallback_chain,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.access,
                     allowed_groups,
+                    allowed_tool_groups,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     --palette--;;status
@@ -380,6 +381,16 @@ return [
                 'size' => 5,
                 'minitems' => 0,
                 'maxitems' => 100,
+            ],
+        ],
+        'allowed_tool_groups' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.allowed_tool_groups',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.allowed_tool_groups.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'itemsProcFunc' => \Netresearch\NrLlm\Form\Tca\ToolGroupItems::class . '->addItems',
+                'default' => '',
             ],
         ],
         'skills' => [

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -139,6 +139,13 @@ A tool is a PHP class that implements
    Runs the tool with the model-provided arguments and returns a plain
    string that is fed back into the conversation as a tool turn.
 
+``getGroup(): string``
+   The tool's *group* — a short, stable identifier used to enable or disable
+   whole families of tools at once. Built-ins use ``content``, ``structure``,
+   ``system``, ``accounts`` and ``configuration``; third-party tools declare
+   their own group (recommended: the providing extension's key). See
+   :ref:`administration-tools-groups`.
+
 The interface carries ``#[AutoconfigureTag('nr_llm.tool')]``, so a class is
 **auto-registered simply by implementing it** — no central registration file
 to edit. :php:`ToolRegistry` collects every tagged tool through a DI iterator
@@ -174,6 +181,45 @@ them only deliberately.
    toggle. The ``_raw`` variants show as :guilabel:`Disabled`, the redacted
    tools as :guilabel:`Enabled`; the :guilabel:`Default` badge marks a tool
    sitting at its shipped state.
+
+.. _administration-tools-groups:
+
+Tool groups
+===========
+
+Every tool belongs to a **group** (its ``getGroup()`` value). The built-in
+taxonomy:
+
+===============  ============================================================
+Group            Tools
+===============  ============================================================
+``content``      ``search_records``, ``get_page_content``, ``read_records``
+``structure``    ``get_pagetree``, ``get_tca``, ``read_fal_asset_meta``
+``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw), ``fetch_logs``
+``accounts``     ``list_be_users`` (+ raw), ``list_be_groups``
+``configuration``  ``get_typoscript``, ``get_tsconfig``
+===============  ============================================================
+
+Groups can be switched on three levels, and the result cascades
+**fail-closed** — a tool is offered only when *every* level permits it:
+
+#. **Centrally** in the Tools module: each group header carries an
+   Enable/Disable group toggle. A disabled group refuses all of its tools —
+   including same-group tools installed later — and a per-tool override can
+   **not** re-enable a tool inside a disabled group (predictable,
+   fail-closed). Per-tool toggles keep working but take effect only once the
+   group is enabled again.
+#. **Per configuration**: the :guilabel:`Allowed tool groups` field on an
+   LLM configuration restricts agent runs with that configuration to tools of
+   the selected groups (empty = all groups). This intersects with a skill's
+   ``allowed-tools`` declaration.
+#. **Per run** in the playground: the tool checkboxes are grouped, and each
+   group checkbox (de)selects its children.
+
+Third-party extensions declare their own group per tool; the recommended
+value is the extension key, so an admin can disable an extension's whole
+tool family with one toggle. The design is recorded in
+:ref:`ADR-043 <adr-043>`.
 
 .. _administration-tools-playground:
 

--- a/Documentation/Adr/Adr043ToolGroups.rst
+++ b/Documentation/Adr/Adr043ToolGroups.rst
@@ -1,0 +1,80 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-043:
+
+=========================================================
+ADR-043: Tool groups with a fail-closed enable cascade
+=========================================================
+
+:Status: Accepted
+:Date: 2026-07-08
+:Authors: Netresearch DTT GmbH
+
+.. _adr-043-context:
+
+Context
+=======
+
+With sixteen built-in tools (:ref:`ADR-038 <adr-038>`,
+:ref:`ADR-042 <adr-042>`) and third-party tools registering through the same
+``nr_llm.tool`` tag, per-tool administration stops scaling: an admin who
+wants "no system introspection for this instance" or "only content tools for
+this configuration" has to know and toggle every individual tool — and a
+tool added later by an extension update silently escapes a decision that was
+meant to cover its whole family.
+
+.. _adr-043-decision:
+
+Decision
+========
+
+Every tool declares a **group**, and enablement cascades across three
+levels, fail-closed:
+
+``ToolInterface::getGroup(): string`` (**breaking**, third parties must
+implement it — the same expansion pattern as ``requiresAdmin()`` in
+:ref:`ADR-038 <adr-038>`). Built-ins use the curated taxonomy ``content``,
+``structure``, ``system``, ``accounts``, ``configuration``. Third-party
+tools declare their own group; the recommended value is the providing
+extension's key.
+
+**Level 1 — central group state.** ``tx_nrllm_tool_group_state`` stores
+per-group admin overrides (mirroring ``tx_nrllm_tool_state``; a missing row
+means *enabled*). Because the state is keyed by group **name**, a disabled
+group also covers same-group tools installed later.
+``ToolAvailabilityService`` computes the effective state as
+``group_enabled && tool_enabled``: a per-tool override can **not**
+re-enable a tool inside a disabled group. The alternative — letting an
+explicit tool override outrank its group — was rejected because it turns
+"disable the group" into a soft hint whose real effect depends on
+invisible per-tool rows; the chosen rule keeps one glance at the group
+toggle authoritative.
+
+**Level 2 — per configuration.** ``tx_nrllm_configuration`` gains
+``allowed_tool_groups`` (comma list via ``selectCheckBox``; items derived
+from the registry by an ``itemsProcFunc``, so third-party groups appear
+automatically). Empty means "no group restriction".
+``AllowedToolsResolver`` intersects the skill-declared ``allowed-tools``
+union with the group gate; when only the group gate is set, it becomes the
+allow-list itself.
+
+**Level 3 — per run.** The playground groups its tool checkboxes and adds a
+group checkbox with an indeterminate mixed state; the per-run selection is
+still intersected with levels 1–2 by the runtime gate.
+
+.. _adr-043-consequences:
+
+Consequences
+============
+
+- **Breaking**: every ``ToolInterface`` implementation must add
+  ``getGroup()``. Costs one method per tool; buys family-wise control that
+  survives extension updates.
+- An unknown or never-toggled group is **enabled** — grouping restricts, it
+  does not quarantine new tools (``isEnabledByDefault()`` and
+  ``requiresAdmin()`` keep covering per-tool risk).
+- The group table stays name-keyed and FormEngine-free, like the tool-state
+  table; orphaned group rows (extension removed) are harmless and inert.
+- The configuration gate composes with — never replaces — the global
+  cascade: a globally disabled tool stays off even when its group is listed
+  in ``allowed_tool_groups``.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -341,3 +341,4 @@ Tools
    Adr040PlaygroundRunTrace
    Adr041PlaygroundLiveStreaming
    Adr042ContentAndIntrospectionTools
+   Adr043ToolGroups

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2154,6 +2154,10 @@
                 <source>Unknown tool</source>
                 <target>Unbekanntes Werkzeug</target>
             </trans-unit>
+            <trans-unit id="error.tool.unknownGroup">
+                <source>Unknown tool group</source>
+                <target>Unbekannte Werkzeuggruppe</target>
+            </trans-unit>
             <trans-unit id="card.count.configurations">
                 <source>configuration(s) configured</source>
                 <target>Konfiguration(en) eingerichtet</target>

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -90,6 +90,18 @@
                 <source>Disable</source>
                 <target>Deaktivieren</target>
             </trans-unit>
+            <trans-unit id="group.disable">
+                <source>Disable group</source>
+                <target>Gruppe deaktivieren</target>
+            </trans-unit>
+            <trans-unit id="group.enable">
+                <source>Enable group</source>
+                <target>Gruppe aktivieren</target>
+            </trans-unit>
+            <trans-unit id="group.disabledHint">
+                <source>All tools of this group are refused; per-tool toggles have no effect while the group is disabled.</source>
+                <target>Alle Werkzeuge dieser Gruppe werden abgelehnt; Einzelschalter haben keine Wirkung, solange die Gruppe deaktiviert ist.</target>
+            </trans-unit>
             <trans-unit id="playground.help.title">
                 <source>How to add a tool</source>
                 <target>Ein Tool hinzufügen</target>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -285,6 +285,14 @@
                 <source>If empty, configuration is accessible to all users with LLM permissions</source>
                 <target>Wenn leer, ist die Konfiguration für alle Benutzer mit LLM-Berechtigungen zugänglich</target>
             </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_tool_groups">
+                <source>Allowed tool groups</source>
+                <target>Erlaubte Werkzeuggruppen</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_tool_groups.description">
+                <source>Restrict agent runs with this configuration to tools of the selected groups. Empty = all groups allowed. Globally disabled tools or groups stay disabled regardless.</source>
+                <target>Beschränkt Agent-Läufe mit dieser Konfiguration auf Werkzeuge der gewählten Gruppen. Leer = alle Gruppen erlaubt. Global deaktivierte Werkzeuge oder Gruppen bleiben unabhängig davon deaktiviert.</target>
+            </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1629,6 +1629,9 @@
             <trans-unit id="error.tool.unknownTool">
                 <source>Unknown tool</source>
             </trans-unit>
+            <trans-unit id="error.tool.unknownGroup">
+                <source>Unknown tool group</source>
+            </trans-unit>
             <trans-unit id="card.count.configurations">
                 <source>configuration(s) configured</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -68,6 +68,15 @@
             <trans-unit id="playground.tool.disable">
                 <source>Disable</source>
             </trans-unit>
+            <trans-unit id="group.disable">
+                <source>Disable group</source>
+            </trans-unit>
+            <trans-unit id="group.enable">
+                <source>Enable group</source>
+            </trans-unit>
+            <trans-unit id="group.disabledHint">
+                <source>All tools of this group are refused; per-tool toggles have no effect while the group is disabled.</source>
+            </trans-unit>
             <trans-unit id="playground.help.title">
                 <source>How to add a tool</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -222,6 +222,12 @@
             <trans-unit id="tx_nrllm_configuration.allowed_groups.description">
                 <source>If empty, configuration is accessible to all users with LLM permissions</source>
             </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_tool_groups">
+                <source>Allowed tool groups</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_tool_groups.description">
+                <source>Restrict agent runs with this configuration to tools of the selected groups. Empty = all groups allowed. Globally disabled tools or groups stay disabled regardless.</source>
+            </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>

--- a/Resources/Private/Templates/Backend/Playground/List.html
+++ b/Resources/Private/Templates/Backend/Playground/List.html
@@ -65,19 +65,29 @@
                                 <details class="nrllm-pg-ov mb-2" open="open">
                                     <summary><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.run.tools" default="Tools available to this run" /></summary>
                                     <div class="nrllm-pg-ov-b">
-                                        <f:for each="{toolStates}" as="tool">
-                                            <div class="form-check">
-                                                <f:if condition="{tool.enabled}">
-                                                    <f:then>
-                                                        <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" checked="checked" />
-                                                    </f:then>
-                                                    <f:else>
-                                                        <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" />
-                                                    </f:else>
-                                                </f:if>
-                                                <label class="form-check-label" for="nrllm-tool-select-{tool.name}"><code>{tool.name}</code></label>
+                                        <f:groupedFor each="{toolStates}" as="groupTools" groupBy="group" groupKey="groupName">
+                                            <div class="nrllm-pg-toolgroup mb-2">
+                                                <div class="form-check">
+                                                    <input class="form-check-input js-toolgroup-select" type="checkbox" id="nrllm-toolgroup-select-{groupName}" data-group="{groupName}" />
+                                                    <label class="form-check-label fw-bold" for="nrllm-toolgroup-select-{groupName}"><code>{groupName}</code></label>
+                                                </div>
+                                                <div class="ms-4">
+                                                    <f:for each="{groupTools}" as="tool">
+                                                        <div class="form-check">
+                                                            <f:if condition="{tool.enabled}">
+                                                                <f:then>
+                                                                    <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" data-group="{groupName}" checked="checked" />
+                                                                </f:then>
+                                                                <f:else>
+                                                                    <input class="form-check-input js-tool-select" type="checkbox" id="nrllm-tool-select-{tool.name}" value="{tool.name}" data-group="{groupName}" />
+                                                                </f:else>
+                                                            </f:if>
+                                                            <label class="form-check-label" for="nrllm-tool-select-{tool.name}"><code>{tool.name}</code></label>
+                                                        </div>
+                                                    </f:for>
+                                                </div>
                                             </div>
-                                        </f:for>
+                                        </f:groupedFor>
                                     </div>
                                 </details>
                             </f:then>

--- a/Resources/Private/Templates/Backend/Tool/List.html
+++ b/Resources/Private/Templates/Backend/Tool/List.html
@@ -35,9 +35,33 @@
                 <h2><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tools" default="Available tools" /></h2>
                 <f:if condition="{f:count(subject: toolStates)}">
                     <f:then>
+                        <f:groupedFor each="{toolStates}" as="groupTools" groupBy="group" groupKey="groupName">
                         <div class="card mb-4">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong><core:icon identifier="actions-folder" size="small" /> <code>{groupName}</code></strong>
+                                    <f:if condition="{groupStates.{groupName}.enabled}">
+                                        <f:then>
+                                            <span class="badge bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.enabled" default="Enabled" /></span>
+                                        </f:then>
+                                        <f:else>
+                                            <span class="badge bg-secondary">✕ <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.disabled" default="Disabled" /></span>
+                                            <small class="text-body-secondary ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:group.disabledHint" default="All tools of this group are refused; per-tool toggles have no effect while the group is disabled." /></small>
+                                        </f:else>
+                                    </f:if>
+                                </div>
+                                <button type="button"
+                                        class="btn btn-sm js-toolgroup-toggle {f:if(condition: groupStates.{groupName}.enabled, then: 'btn-outline-secondary', else: 'btn-outline-success')}"
+                                        data-group="{groupName}"
+                                        data-enabled="{f:if(condition: groupStates.{groupName}.enabled, then: '1', else: '0')}">
+                                    <f:if condition="{groupStates.{groupName}.enabled}">
+                                        <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:group.disable" default="Disable group" /></f:then>
+                                        <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:group.enable" default="Enable group" /></f:else>
+                                    </f:if>
+                                </button>
+                            </div>
                             <ul class="list-group list-group-flush">
-                                <f:for each="{toolStates}" as="tool">
+                                <f:for each="{groupTools}" as="tool">
                                     <li class="list-group-item d-flex justify-content-between align-items-start">
                                         <div class="me-3">
                                             <strong><code>{tool.name}</code></strong>
@@ -62,10 +86,10 @@
                                             </f:if>
                                         </div>
                                         <button type="button"
-                                                class="btn btn-sm js-tool-toggle {f:if(condition: tool.enabled, then: 'btn-outline-secondary', else: 'btn-outline-success')}"
+                                                class="btn btn-sm js-tool-toggle {f:if(condition: tool.toolEnabled, then: 'btn-outline-secondary', else: 'btn-outline-success')}"
                                                 data-tool="{tool.name}"
-                                                data-enabled="{f:if(condition: tool.enabled, then: '1', else: '0')}">
-                                            <f:if condition="{tool.enabled}">
+                                                data-enabled="{f:if(condition: tool.toolEnabled, then: '1', else: '0')}">
+                                            <f:if condition="{tool.toolEnabled}">
                                                 <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.disable" default="Disable" /></f:then>
                                                 <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.tool.enable" default="Enable" /></f:else>
                                             </f:if>
@@ -74,6 +98,7 @@
                                 </f:for>
                             </ul>
                         </div>
+                        </f:groupedFor>
                     </f:then>
                     <f:else>
                         <f:be.infobox state="-1">

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -57,6 +57,24 @@ class ToolPlayground {
         this.formBody = document.getElementById('nrllm-pg-form-body');
         this.formSummary = document.getElementById('nrllm-pg-form-summary');
 
+        // Tool-group tri-state checkboxes: a group box (de)selects its
+        // children; a child updates its group box (checked / indeterminate).
+        this.root.addEventListener('change', (e) => {
+            const groupBox = e.target.closest('.js-toolgroup-select');
+            if (groupBox) {
+                this.root.querySelectorAll(`.js-tool-select[data-group="${CSS.escape(groupBox.dataset.group)}"]`)
+                    .forEach((box) => { box.checked = groupBox.checked; });
+                groupBox.indeterminate = false;
+                return;
+            }
+            const toolBox = e.target.closest('.js-tool-select');
+            if (toolBox && toolBox.dataset.group) {
+                this.syncGroupCheckbox(toolBox.dataset.group);
+            }
+        });
+        this.root.querySelectorAll('.js-toolgroup-select')
+            .forEach((box) => this.syncGroupCheckbox(box.dataset.group));
+
         this.runButton?.addEventListener('click', () => this.run(false));
         this.dryRunButton?.addEventListener('click', () => this.run(true));
         this.formToggle?.addEventListener('click', () => this.setFormCollapsed(this.formToggle.getAttribute('aria-expanded') === 'true'));
@@ -253,6 +271,21 @@ class ToolPlayground {
             this.renderError(message);
             Notification.error('Error', message);
         }
+    }
+
+    /**
+     * Reflect the children's state onto a group checkbox: all checked ->
+     * checked, none -> unchecked, mixed -> indeterminate.
+     */
+    syncGroupCheckbox(group) {
+        const groupBox = this.root.querySelector(`.js-toolgroup-select[data-group="${CSS.escape(group)}"]`);
+        if (!groupBox) {
+            return;
+        }
+        const children = [...this.root.querySelectorAll(`.js-tool-select[data-group="${CSS.escape(group)}"]`)];
+        const checked = children.filter((box) => box.checked).length;
+        groupBox.checked = checked > 0 && checked === children.length;
+        groupBox.indeterminate = checked > 0 && checked < children.length;
     }
 
     appendChecked(formData, selector, field) {

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -26,6 +26,13 @@ class ToolState {
 
     init() {
         document.body.addEventListener('click', (e) => {
+            const groupBtn = e.target.closest('.js-toolgroup-toggle');
+            if (groupBtn) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.handleGroupToggle(groupBtn);
+                return;
+            }
             const toggleBtn = e.target.closest('.js-tool-toggle');
             if (toggleBtn) {
                 e.preventDefault();
@@ -35,6 +42,37 @@ class ToolState {
         });
 
         console.debug('[ToolState] Initialized with event delegation');
+    }
+
+    handleGroupToggle(btn) {
+        const group = btn.dataset.group;
+        const enabled = btn.dataset.enabled === '1' ? 0 : 1;
+        const url = TYPO3.settings.ajaxUrls['nrllm_toolgroup_toggle'];
+        if (!url) {
+            Notification.error('Error', 'AJAX URL not configured');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('group', group);
+        formData.append('enabled', String(enabled));
+
+        btn.disabled = true;
+        new AjaxRequest(url)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                    btn.disabled = false;
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+                btn.disabled = false;
+            });
     }
 
     handleToggle(btn) {

--- a/Tests/Functional/Controller/Backend/ToolControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolControllerTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Netresearch\NrLlm\Controller\Backend\ToolController;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
@@ -130,6 +131,74 @@ final class ToolControllerTest extends AbstractFunctionalTestCase
         self::assertNotContains('fetch_logs', $this->availabilityFor($toolRegistry)->enabledNames());
     }
 
+    #[Test]
+    public function listActionRendersGroupHeadersAndGroupToggle(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $backendUser     = $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $toolRegistry = new ToolRegistry([
+            new FakeTool('alpha_tool', group: 'alpha'),
+            new FakeTool('beta_tool', group: 'beta'),
+        ]);
+        $controller = $this->makeController($toolRegistry);
+        $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
+
+        $body = (string)$controller->listAction()->getBody();
+
+        self::assertStringContainsString('js-toolgroup-toggle', $body);
+        self::assertStringContainsString('data-group="alpha"', $body);
+        self::assertStringContainsString('data-group="beta"', $body);
+    }
+
+    #[Test]
+    public function toggleToolGroupActionDeniesNonAdmin(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(2); // non-admin editor
+
+        $controller = $this->makeController(new ToolRegistry([new FakeTool('t', group: 'alpha')]));
+        $request    = (new GuzzleServerRequest('POST', '/ajax/nrllm/toolgroup/toggle'))
+            ->withParsedBody(['group' => 'alpha', 'enabled' => 'false']);
+
+        self::assertSame(403, $controller->toggleToolGroupAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function toggleToolGroupActionRejectsUnknownGroup(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $controller = $this->makeController(new ToolRegistry([new FakeTool('t', group: 'alpha')]));
+        $request    = (new GuzzleServerRequest('POST', '/ajax/nrllm/toolgroup/toggle'))
+            ->withParsedBody(['group' => 'nope', 'enabled' => 'false']);
+
+        self::assertSame(404, $controller->toggleToolGroupAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function toggleToolGroupActionPersistsAndCascades(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $toolRegistry = new ToolRegistry([
+            new FakeTool('alpha_tool', group: 'alpha'),
+            new FakeTool('beta_tool', group: 'beta'),
+        ]);
+        $controller = $this->makeController($toolRegistry);
+        $request    = (new GuzzleServerRequest('POST', '/ajax/nrllm/toolgroup/toggle'))
+            ->withParsedBody(['group' => 'alpha', 'enabled' => 'false']);
+
+        $response = $controller->toggleToolGroupAction($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        // The cascade drops the whole group from the enabled set.
+        self::assertSame(['beta_tool'], $this->availabilityFor($toolRegistry)->enabledNames());
+    }
+
     private function makeController(ToolRegistry $toolRegistry): ToolController
     {
         $moduleTemplateFactory = $this->get(ModuleTemplateFactory::class);
@@ -142,13 +211,14 @@ final class ToolControllerTest extends AbstractFunctionalTestCase
             $toolRegistry,
             $this->availabilityFor($toolRegistry),
             new ToolStateRepository($this->toolConnectionPool()),
+            new ToolGroupStateRepository($this->toolConnectionPool()),
             $pageRenderer,
         );
     }
 
     private function availabilityFor(ToolRegistry $toolRegistry): ToolAvailabilityService
     {
-        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()));
+        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()), new ToolGroupStateRepository($this->toolConnectionPool()));
     }
 
     private function toolConnectionPool(): ConnectionPool

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
@@ -119,6 +120,9 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         // separate Tools module, {@see ToolControllerTest}).
         self::assertStringContainsString('fetch_logs', $body);
         self::assertStringContainsString('js-tool-select', $body);
+        // Grouped: the group checkbox and the child's group attribution render.
+        self::assertStringContainsString('js-toolgroup-select', $body);
+        self::assertStringContainsString('data-group="test"', $body);
     }
 
     #[Test]
@@ -550,7 +554,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
      */
     private function availabilityFor(ToolRegistry $toolRegistry): ToolAvailabilityService
     {
-        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()));
+        return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()), new ToolGroupStateRepository($this->toolConnectionPool()));
     }
 
     private function toolConnectionPool(): ConnectionPool

--- a/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
+++ b/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
@@ -27,6 +28,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
 {
     private ToolStateRepository $stateRepository;
+    private ToolGroupStateRepository $groupStateRepository;
 
     protected function setUp(): void
     {
@@ -34,7 +36,8 @@ final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
 
         $connectionPool = $this->get(ConnectionPool::class);
         self::assertInstanceOf(ConnectionPool::class, $connectionPool);
-        $this->stateRepository = new ToolStateRepository($connectionPool);
+        $this->stateRepository      = new ToolStateRepository($connectionPool);
+        $this->groupStateRepository = new ToolGroupStateRepository($connectionPool);
     }
 
     #[Test]
@@ -44,7 +47,7 @@ final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
             new FakeTool('safe_tool', 'ok', true),
             new FakeTool('raw_tool', 'ok', false),
         ]);
-        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
 
         self::assertSame(['safe_tool'], $service->enabledNames());
     }
@@ -56,7 +59,7 @@ final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
             new FakeTool('safe_tool', 'ok', true),
             new FakeTool('raw_tool', 'ok', false),
         ]);
-        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
 
         $this->stateRepository->setEnabled('raw_tool', true);
         $this->stateRepository->setEnabled('safe_tool', false);
@@ -71,7 +74,7 @@ final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
             new FakeTool('safe_tool', 'ok', true),
             new FakeTool('raw_tool', 'ok', false),
         ]);
-        $service = new ToolAvailabilityService($registry, $this->stateRepository);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
 
         $this->stateRepository->setEnabled('raw_tool', true);
 
@@ -88,5 +91,59 @@ final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
         self::assertTrue($states['raw_tool']['enabled']);
         self::assertFalse($states['raw_tool']['defaultEnabled']);
         self::assertSame('desc of raw_tool', $states['raw_tool']['description']);
+    }
+
+    #[Test]
+    public function disabledGroupBeatsAnEnablingToolOverride(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('safe_tool', group: 'alpha'),
+            new FakeTool('other_tool', group: 'beta'),
+        ]);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
+
+        // Explicitly enable the tool, then disable its group: the group wins.
+        $this->stateRepository->setEnabled('safe_tool', true);
+        $this->groupStateRepository->setEnabled('alpha', false);
+
+        self::assertSame(['other_tool'], $service->enabledNames());
+
+        $states = $service->states();
+        self::assertFalse($states[0]['enabled']);
+        self::assertTrue($states[0]['toolEnabled']);
+        self::assertFalse($states[0]['groupEnabled']);
+    }
+
+    #[Test]
+    public function unknownGroupDefaultsToEnabledAndReenablingRestoresTools(): void
+    {
+        $registry = new ToolRegistry([new FakeTool('safe_tool', group: 'alpha')]);
+        $service  = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
+
+        // Never-toggled group: enabled.
+        self::assertSame(['safe_tool'], $service->enabledNames());
+
+        $this->groupStateRepository->setEnabled('alpha', false);
+        self::assertSame([], $service->enabledNames());
+
+        $this->groupStateRepository->setEnabled('alpha', true);
+        self::assertSame(['safe_tool'], $service->enabledNames());
+    }
+
+    #[Test]
+    public function groupStatesListsEachGroupOnceWithOverrideFlag(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('a', group: 'alpha'),
+            new FakeTool('b', group: 'alpha'),
+            new FakeTool('c', group: 'beta'),
+        ]);
+        $service = new ToolAvailabilityService($registry, $this->stateRepository, $this->groupStateRepository);
+        $this->groupStateRepository->setEnabled('beta', false);
+
+        self::assertSame([
+            ['name' => 'alpha', 'enabled' => true, 'overridden' => false],
+            ['name' => 'beta', 'enabled' => false, 'overridden' => true],
+        ], $service->groupStates());
     }
 }

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
@@ -144,7 +145,7 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
     private function buildService(LlmServiceManagerInterface $mgr): ToolLoopService
     {
         $registry     = new ToolRegistry([new FetchLogsTool($this->connectionPool)]);
-        $availability = new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool));
+        $availability = new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool), new ToolGroupStateRepository($this->connectionPool));
 
         return new ToolLoopService($mgr, $registry, $availability);
     }

--- a/Tests/Unit/Service/Tool/AllowedToolsResolverTest.php
+++ b/Tests/Unit/Service/Tool/AllowedToolsResolverTest.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -21,11 +23,20 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AllowedToolsResolver::class)]
 final class AllowedToolsResolverTest extends TestCase
 {
-    private function resolver(): AllowedToolsResolver
+    private function resolver(?ToolRegistry $registry = null): AllowedToolsResolver
     {
         // A real (pure) SkillComposer: effectiveSkills() has no side effects, so the
         // resolver is exercised against the genuine enabled/non-orphaned/dedup selection.
-        return new AllowedToolsResolver(new SkillComposer());
+        return new AllowedToolsResolver(new SkillComposer(), $registry ?? new ToolRegistry([]));
+    }
+
+    private function groupedRegistry(): ToolRegistry
+    {
+        return new ToolRegistry([
+            new FakeTool('content_a', group: 'content'),
+            new FakeTool('content_b', group: 'content'),
+            new FakeTool('system_a', group: 'system'),
+        ]);
     }
 
     private function skill(
@@ -99,5 +110,50 @@ final class AllowedToolsResolverTest extends TestCase
         self::assertNotNull($result);
         sort($result);
         self::assertSame(['a', 'b'], $result);
+    }
+
+    #[Test]
+    public function emptyGroupSetLeavesSkillResultUntouched(): void
+    {
+        $config = new LlmConfiguration();
+        $config->addSkill($this->skill('a', ''));
+
+        self::assertNull($this->resolver($this->groupedRegistry())->resolve($config));
+    }
+
+    #[Test]
+    public function groupSetAloneBecomesTheAllowList(): void
+    {
+        $config = new LlmConfiguration();
+        $config->setAllowedToolGroups('content');
+        $config->addSkill($this->skill('a', ''));
+
+        self::assertSame(
+            ['content_a', 'content_b'],
+            $this->resolver($this->groupedRegistry())->resolve($config),
+        );
+    }
+
+    #[Test]
+    public function groupSetIntersectsTheSkillDeclaredUnion(): void
+    {
+        $config = new LlmConfiguration();
+        $config->setAllowedToolGroups('content');
+        $config->addSkill($this->skill('a', '["content_a", "system_a"]'));
+
+        self::assertSame(
+            ['content_a'],
+            $this->resolver($this->groupedRegistry())->resolve($config),
+        );
+    }
+
+    #[Test]
+    public function unknownGroupInSetYieldsNoToolsFailClosed(): void
+    {
+        $config = new LlmConfiguration();
+        $config->setAllowedToolGroups('nonexistent');
+        $config->addSkill($this->skill('a', ''));
+
+        self::assertSame([], $this->resolver($this->groupedRegistry())->resolve($config));
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvRawTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageTreeTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoRawTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTcaTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTsConfigTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeGroupsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersRawTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Pins the curated group taxonomy of every built-in tool (ADR-043).
+ *
+ * getGroup() is a constant return on every builtin, so instantiating via
+ * newInstanceWithoutConstructor is safe — no collaborator is touched.
+ */
+#[CoversNothing]
+final class BuiltinToolGroupsTest extends TestCase
+{
+    /**
+     * @return array<string, array{class-string<ToolInterface>, string}>
+     */
+    public static function taxonomy(): array
+    {
+        return [
+            'search_records'    => [SearchRecordsTool::class, 'content'],
+            'get_page_content'  => [GetPageContentTool::class, 'content'],
+            'read_records'      => [ReadRecordsTool::class, 'content'],
+            'get_pagetree'      => [GetPageTreeTool::class, 'structure'],
+            'get_tca'           => [GetTcaTool::class, 'structure'],
+            'read_fal_asset'    => [ReadFalAssetMetaTool::class, 'structure'],
+            'get_env'           => [GetEnvTool::class, 'system'],
+            'get_env_raw'       => [GetEnvRawTool::class, 'system'],
+            'get_php_info'      => [GetPhpInfoTool::class, 'system'],
+            'get_php_info_raw'  => [GetPhpInfoRawTool::class, 'system'],
+            'fetch_logs'        => [FetchLogsTool::class, 'system'],
+            'list_be_users'     => [ListBeUsersTool::class, 'accounts'],
+            'list_be_users_raw' => [ListBeUsersRawTool::class, 'accounts'],
+            'list_be_groups'    => [ListBeGroupsTool::class, 'accounts'],
+            'get_typoscript'    => [GetTypoScriptTool::class, 'configuration'],
+            'get_tsconfig'      => [GetTsConfigTool::class, 'configuration'],
+        ];
+    }
+
+    /**
+     * @param class-string<ToolInterface> $class
+     */
+    #[Test]
+    #[DataProvider('taxonomy')]
+    public function builtinDeclaresItsCuratedGroup(string $class, string $expectedGroup): void
+    {
+        $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+
+        self::assertSame($expectedGroup, $tool->getGroup());
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -52,7 +52,7 @@ final class BuiltinToolGroupsTest extends TestCase
             'read_records'      => [ReadRecordsTool::class, 'content'],
             'get_pagetree'      => [GetPageTreeTool::class, 'structure'],
             'get_tca'           => [GetTcaTool::class, 'structure'],
-            'read_fal_asset'    => [ReadFalAssetMetaTool::class, 'structure'],
+            'read_fal_asset_meta'    => [ReadFalAssetMetaTool::class, 'structure'],
             'get_env'           => [GetEnvTool::class, 'system'],
             'get_env_raw'       => [GetEnvRawTool::class, 'system'],
             'get_php_info'      => [GetPhpInfoTool::class, 'system'],

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -55,6 +55,7 @@ final readonly class FakeTool implements ToolInterface
     {
         return $this->requiresAdmin;
     }
+
     public function getGroup(): string
     {
         return $this->group;

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -26,6 +26,7 @@ final readonly class FakeTool implements ToolInterface
         private string $result = 'ok',
         private bool $enabledByDefault = true,
         private bool $requiresAdmin = false,
+        private string $group = 'test',
     ) {}
 
     public function getSpec(): ToolSpec
@@ -53,5 +54,9 @@ final readonly class FakeTool implements ToolInterface
     public function requiresAdmin(): bool
     {
         return $this->requiresAdmin;
+    }
+    public function getGroup(): string
+    {
+        return $this->group;
     }
 }

--- a/Tests/Unit/Service/Tool/Fixtures/FakeToolAvailability.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeToolAvailability.php
@@ -36,4 +36,9 @@ final readonly class FakeToolAvailability implements ToolAvailabilityServiceInte
     {
         return [];
     }
+
+    public function groupStates(): array
+    {
+        return [];
+    }
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -128,6 +128,11 @@ final class ToolLoopServiceTest extends TestCase
             {
                 return false;
             }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
         };
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -176,6 +181,11 @@ final class ToolLoopServiceTest extends TestCase
             public function requiresAdmin(): bool
             {
                 return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
             }
         };
 
@@ -437,6 +447,11 @@ final class ToolLoopServiceTest extends TestCase
             public function requiresAdmin(): bool
             {
                 return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
             }
         };
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -139,6 +139,9 @@ CREATE TABLE tx_nrllm_configuration (
     -- Access control (MM relation to be_groups)
     allowed_groups int(11) DEFAULT '0' NOT NULL,
 
+    -- Comma list of permitted tool groups (empty = all groups allowed)
+    allowed_tool_groups varchar(255) DEFAULT '' NOT NULL,
+
     -- Attached skills (MM relation to tx_nrllm_skill)
     skills int(11) DEFAULT '0' NOT NULL,
 
@@ -544,4 +547,22 @@ CREATE TABLE tx_nrllm_tool_state (
 
     PRIMARY KEY (uid),
     UNIQUE KEY tool_name (tool_name)
+);
+
+#
+# Table structure for table 'tx_nrllm_tool_group_state'
+# Global per-GROUP enable/disable overrides for the agent tool runtime.
+# Managed via the Tools module group toggles (no FormEngine UI / no TCA);
+# a missing row means "group enabled". A disabled group also covers tools
+# of that group installed later — the runtime gate is fail-closed.
+#
+CREATE TABLE tx_nrllm_tool_group_state (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    group_name varchar(190) DEFAULT '' NOT NULL,
+    enabled smallint(5) unsigned DEFAULT '1' NOT NULL,
+
+    PRIMARY KEY (uid),
+    UNIQUE KEY group_name (group_name)
 );


### PR DESCRIPTION
Tool **groups**: whole capability groups can now be switched on/off centrally, per configuration, and per playground run — instead of 16 individual toggles. **ADR-043.**

## Model

- **`ToolInterface::getGroup(): string`** — every tool declares its group. Builtins: `content` (search_records, get_page_content, read_records) · `structure` (get_pagetree, get_tca, read_fal_asset_meta) · `system` (get_env(+raw), get_php_info(+raw), fetch_logs) · `accounts` (list_be_users(+raw), list_be_groups) · `configuration` (get_typoscript, get_tsconfig). Third-party tools declare their own (recommended: extension key). **BREAKING** — same pattern as `requiresAdmin()` (#262/ADR-038).
- **Fail-closed cascade:** effective = group ∧ tool ∧ configuration. A per-tool override cannot re-enable a tool inside a disabled group; a disabled group also covers tools installed later. Unknown groups default to enabled.

## Three toggle levels

1. **Tools module:** group headers with group toggles (new admin-gated AJAX route `nrllm_toolgroup_toggle`, persisted in `tx_nrllm_tool_group_state`); per-tool toggles inside a disabled group render inert with a hint.
2. **Per configuration:** new `allowed_tool_groups` multi-select on LLM configurations (empty = all; items from the registry via itemsProcFunc, stored-but-unknown groups stay selectable). `AllowedToolsResolver` intersects on top of the skill allow-list.
3. **Playground:** per-run checkboxes grouped with tri-state group checkboxes.

## Verification

- Cascade truth table + per-builtin group unit tests; functional: group-toggle persistence, grouped Tools module render, resolver with `allowed_tool_groups` fixture, grouped playground render (24 tests / 248 assertions targeted).
- Live on ddev: disabling `system` removed its 5 tools from runs — a **forced** `tools[]=get_env` run yielded `toolSpecs: []` (runtime gate, not just UI); config restricted to `structure` offered exactly its 3 tools; tri-state verified.
- cgl, rector, phpstan (L10), unit (3941), architecture green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
