### PR TITLE
feat(tools): error-analysis tools — last exception, source read/search, URL probe

### DIFF
--- a/Classes/Domain/ValueObject/LogExceptionEntry.php
+++ b/Classes/Domain/ValueObject/LogExceptionEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One parsed error-level entry from a TYPO3 file log (ADR-044).
+ *
+ * Produced by {@see \Netresearch\NrLlm\Service\Tool\LogExceptionReader} and
+ * consumed by the error-analysis tools (`get_last_exception`, and
+ * `probe_url`'s 5xx↔log correlation).
+ *
+ * @phpstan-type LogFrame array{file: string, line: int, call: string}
+ */
+final readonly class LogExceptionEntry
+{
+    /**
+     * @param list<array{file: string, line: int, call: string}> $frames
+     */
+    public function __construct(
+        public int $timestamp,
+        public string $level,
+        public string $component,
+        public string $message,
+        public ?string $exceptionClass = null,
+        public array $frames = [],
+    ) {}
+}

--- a/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
+++ b/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\LogExceptionEntry;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * The "why did that 500 / how do I fix this PHP error" tool (ADR-044).
+ *
+ * Surfaces the newest exception/error entries from TYPO3's file logs with
+ * the parsed stack trace, and inlines ±{@see self::CONTEXT_LINES} lines of
+ * source around each project-local frame so the model sees the failing
+ * code without a second tool call. Vendor/core frames are listed but not
+ * expanded (unless no project frame exists at all).
+ *
+ * Security contract: admin-only; source context flows through
+ * {@see SourcePathGuard} (containment + denylists + secret-line
+ * redaction); messages run through the URL-credential sanitizer; output is
+ * line-capped.
+ */
+final readonly class GetLastExceptionTool implements ToolInterface
+{
+    use ErrorMessageSanitizerTrait;
+    use SafeCastTrait;
+
+    private const CONTEXT_LINES = 6;
+
+    private const MAX_EXPANDED_FRAMES = 3;
+
+    private const MAX_OUTPUT_LINES = 200;
+
+    public function __construct(
+        private LogExceptionReader $reader,
+        private SourcePathGuard $guard,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_last_exception',
+            'Return the most recent exception/error from the TYPO3 file logs with its parsed stack trace '
+            . 'and the surrounding source code of the project frames. Use index to step back through '
+            . 'older errors, search to filter by message/class/component.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'index' => [
+                        'type'        => 'integer',
+                        'description' => 'Which error to show, 0 = newest (default), 1 = the one before, …',
+                    ],
+                    'search' => [
+                        'type'        => 'string',
+                        'description' => 'Optional case-insensitive filter on message, exception class or component.',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $index  = max(0, self::toInt($arguments['index'] ?? 0));
+        $search = trim(self::toStr($arguments['search'] ?? ''));
+
+        $entries = $this->reader->read($index + 1, $search !== '' ? $search : null);
+        $entry   = $entries[$index] ?? null;
+
+        if (!$entry instanceof LogExceptionEntry) {
+            return $entries === []
+                ? 'No error-level entries found in the TYPO3 file logs. '
+                  . 'For database-logged events try the fetch_logs tool (sys_log).'
+                : sprintf('Only %d matching error(s) available — index %d is out of range.', count($entries), $index);
+        }
+
+        $lines   = [];
+        $lines[] = sprintf(
+            'Error %d of %s%s (newest first):',
+            $index + 1,
+            count($entries) === $index + 1 ? (string)($index + 1) . '+' : (string)count($entries),
+            $search !== '' ? sprintf(', filtered by "%s"', $search) : '',
+        );
+        $lines[] = sprintf(
+            '[%s] %s %s',
+            gmdate('Y-m-d H:i:s', $entry->timestamp) . ' UTC',
+            $entry->level,
+            $entry->component,
+        );
+        if ($entry->exceptionClass !== null) {
+            $lines[] = 'Exception: ' . $entry->exceptionClass;
+        }
+        $lines[] = 'Message: ' . $this->sanitizeErrorMessage($entry->message);
+        $lines[] = '';
+
+        if ($entry->frames === []) {
+            $lines[] = 'No stack trace recorded for this entry.';
+
+            return implode("\n", $lines);
+        }
+
+        $lines[]  = 'Stack trace:';
+        $expanded = 0;
+        foreach ($entry->frames as $i => $frame) {
+            $lines[] = sprintf('#%d %s:%d — %s', $i, $frame['file'], $frame['line'], $frame['call']);
+
+            if ($expanded >= self::MAX_EXPANDED_FRAMES || !$this->isProjectFrame($frame['file'])) {
+                continue;
+            }
+
+            $context = $this->sourceContext($frame['file'], $frame['line']);
+            if ($context === []) {
+                continue;
+            }
+            $expanded++;
+            foreach ($context as $contextLine) {
+                $lines[] = $contextLine;
+            }
+
+            if (count($lines) >= self::MAX_OUTPUT_LINES) {
+                $lines[] = sprintf('… [output truncated at %d lines]', self::MAX_OUTPUT_LINES);
+                break;
+            }
+        }
+
+        // Fallback: nothing was project-local — expand the throw site anyway
+        // so the model at least sees where it blew up.
+        if ($expanded === 0 && isset($entry->frames[0])) {
+            $context = $this->sourceContext($entry->frames[0]['file'], $entry->frames[0]['line']);
+            foreach ($context as $contextLine) {
+                $lines[] = $contextLine;
+            }
+        }
+
+        return implode("\n", array_slice($lines, 0, self::MAX_OUTPUT_LINES));
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes host paths, source code and error internals.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'code';
+    }
+
+    /**
+     * A frame counts as project-local when it is inside the project root
+     * but not under vendor/ (core and packages are rarely the fix site).
+     */
+    private function isProjectFrame(string $file): bool
+    {
+        $root = $this->guard->rootPath();
+        if ($root === null || !str_starts_with($file, $root . '/')) {
+            return false;
+        }
+
+        $relative = substr($file, strlen($root) + 1);
+
+        return !str_starts_with($relative, 'vendor/');
+    }
+
+    /**
+     * ±CONTEXT_LINES of guarded, secret-redacted source around a line.
+     *
+     * @return list<string>
+     */
+    private function sourceContext(string $file, int $line): array
+    {
+        $from = max(1, $line - self::CONTEXT_LINES);
+        $read = $this->guard->readLines($file, $from, self::CONTEXT_LINES * 2 + 1);
+        if ($read === null) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($read['lines'] as $number => $content) {
+            $out[] = sprintf('  %s%5d | %s', $number === $line ? '>' : ' ', $number, rtrim($content));
+        }
+
+        return $out;
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
+++ b/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
@@ -87,9 +87,8 @@ final readonly class GetLastExceptionTool implements ToolInterface
 
         $lines   = [];
         $lines[] = sprintf(
-            'Error %d of %s%s (newest first):',
-            $index + 1,
-            count($entries) === $index + 1 ? (string)($index + 1) . '+' : (string)count($entries),
+            'Exception #%d (0 = newest)%s:',
+            $index,
             $search !== '' ? sprintf(', filtered by "%s"', $search) : '',
         );
         $lines[] = sprintf(

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -88,7 +88,7 @@ final readonly class ProbeUrlTool implements ToolInterface
             return sprintf(
                 'Denied: "%s" is not a URL of this instance. Allowed hosts: %s. '
                 . 'Relative paths like "/imprint" are resolved against the first site.',
-                $input,
+                $this->displayUrl($input),
                 implode(', ', $this->allowedHosts()) ?: '(no site configured)',
             );
         }
@@ -174,21 +174,39 @@ final readonly class ProbeUrlTool implements ToolInterface
             return rtrim($base, '/') . $input;
         }
 
-        $parts  = parse_url($input);
+        $parts = parse_url($input);
+        if (!is_array($parts)) {
+            return null;
+        }
+        // Reject userinfo (user:pass@host): the URL is echoed back into the tool
+        // output, so credentials must never reach the LLM or the logs.
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            return null;
+        }
         $scheme = strtolower(self::toStr($parts['scheme'] ?? ''));
         $host   = strtolower(self::toStr($parts['host'] ?? ''));
         if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
             return null;
         }
 
-        $hostPort = $host . (isset($parts['port']) ? ':' . $parts['port'] : '');
-        foreach ($this->allowedHosts() as $allowed) {
-            if ($hostPort === $allowed || $host === $allowed) {
-                return $input;
-            }
+        // Exact host:port match with scheme-defaulted ports on BOTH sides — a
+        // bare-host match would let http://localhost:6379/ (Redis, …) through.
+        $port     = isset($parts['port']) ? (int)$parts['port'] : ($scheme === 'https' ? 443 : 80);
+        $hostPort = $host . ':' . $port;
+        if (in_array($hostPort, $this->allowedHosts(), true)) {
+            return $input;
         }
 
         return null;
+    }
+
+    /**
+     * Strip any userinfo (user:pass@) before a URL is echoed into tool output,
+     * so credentials in a rejected URL never reach the LLM or the logs.
+     */
+    private function displayUrl(string $url): string
+    {
+        return preg_replace('#://[^/@\s]*@#', '://', $url) ?? $url;
     }
 
     /**
@@ -205,8 +223,11 @@ final readonly class ProbeUrlTool implements ToolInterface
                 if ($host === '') {
                     continue;
                 }
-                $port    = $base->getPort();
-                $hosts[] = $host . ($port !== null ? ':' . $port : '');
+                // Normalise to an explicit host:port (scheme default 80/443) so
+                // the match is exact and cannot be bypassed by a rogue port.
+                $scheme  = strtolower($base->getScheme() ?: 'http');
+                $port    = $base->getPort() ?? ($scheme === 'https' ? 443 : 80);
+                $hosts[] = $host . ':' . $port;
             }
         }
 

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -1,0 +1,296 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Psr\Http\Message\UriInterface;
+use Throwable;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+/**
+ * The "why does URL X answer 500/400" tool (ADR-044).
+ *
+ * Performs one GET against the instance's OWN frontend and reports status,
+ * key headers, timing and a short tag-stripped body excerpt. On a 5xx the
+ * tool automatically correlates: the newest error-level file-log entries
+ * from the probe's time window (±{@see self::CORRELATION_WINDOW_SECONDS}s)
+ * are appended via the shared {@see LogExceptionReader} — probe and cause
+ * in one result.
+ *
+ * SSRF containment (fail-closed): only http(s), and the target host:port
+ * must match one of the instance's own site bases/base variants
+ * ({@see SiteFinder}); relative paths resolve against the first site base.
+ * Redirects are never followed — a 3xx reports its Location instead, so a
+ * redirect cannot bounce the probe off-host.
+ */
+final readonly class ProbeUrlTool implements ToolInterface
+{
+    use ErrorMessageSanitizerTrait;
+    use SafeCastTrait;
+
+    private const TIMEOUT_SECONDS = 15;
+
+    private const BODY_EXCERPT_BYTES = 2048;
+
+    private const CORRELATION_WINDOW_SECONDS = 30;
+
+    private const REPORTED_HEADERS = ['content-type', 'location', 'cache-control', 'x-typo3-cache'];
+
+    public function __construct(
+        private SiteFinder $siteFinder,
+        private RequestFactory $requestFactory,
+        private LogExceptionReader $logReader,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'probe_url',
+            'GET a URL of THIS TYPO3 instance and report status, headers, timing and a short body '
+            . 'excerpt. On a 5xx the matching exception from the TYPO3 logs is appended automatically. '
+            . 'Only the instance\'s own site hosts are allowed; redirects are reported, not followed.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'url' => [
+                        'type'        => 'string',
+                        'description' => 'Absolute URL on one of this instance\'s sites, or a path like "/imprint" (resolved against the first site).',
+                    ],
+                ],
+                'required' => ['url'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $input = trim(self::toStr($arguments['url'] ?? ''));
+        if ($input === '') {
+            return 'Error: "url" is required.';
+        }
+
+        $url = $this->resolveAllowedUrl($input);
+        if ($url === null) {
+            return sprintf(
+                'Denied: "%s" is not a URL of this instance. Allowed hosts: %s. '
+                . 'Relative paths like "/imprint" are resolved against the first site.',
+                $input,
+                implode(', ', $this->allowedHosts()) ?: '(no site configured)',
+            );
+        }
+
+        $started   = microtime(true);
+        $probeTime = time();
+
+        try {
+            $response = $this->requestFactory->request($url, 'GET', [
+                'timeout'         => self::TIMEOUT_SECONDS,
+                'allow_redirects' => false,
+                'http_errors'     => false,
+            ]);
+        } catch (Throwable $e) {
+            return sprintf(
+                'Probe of %s FAILED transport-level after %.0f ms: %s',
+                $url,
+                (microtime(true) - $started) * 1000,
+                $this->sanitizeErrorMessage($e->getMessage()),
+            );
+        }
+
+        $elapsedMs = (microtime(true) - $started) * 1000;
+        $status    = $response->getStatusCode();
+
+        $lines   = [];
+        $lines[] = sprintf('GET %s → %d %s (%.0f ms)', $url, $status, $response->getReasonPhrase(), $elapsedMs);
+
+        foreach (self::REPORTED_HEADERS as $header) {
+            if ($response->hasHeader($header)) {
+                $lines[] = sprintf('%s: %s', $header, $response->getHeaderLine($header));
+            }
+        }
+
+        if ($status >= 300 && $status < 400) {
+            $lines[] = 'Redirect NOT followed (report only) — probe the Location target separately if it is on this instance.';
+        }
+
+        $excerpt = $this->bodyExcerpt((string)$response->getBody());
+        if ($excerpt !== '') {
+            $lines[] = '';
+            $lines[] = 'Body excerpt:';
+            $lines[] = $excerpt;
+        }
+
+        if ($status >= 500) {
+            $lines[] = '';
+            $lines[] = $this->correlateLogs($probeTime);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: triggers requests and exposes error internals.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+
+    /**
+     * Resolve the model-supplied input to an absolute URL whose scheme is
+     * http(s) and whose host:port matches one of this instance's sites.
+     * Null when any gate denies it.
+     */
+    private function resolveAllowedUrl(string $input): ?string
+    {
+        if (str_starts_with($input, '/') && !str_starts_with($input, '//')) {
+            $base = $this->firstSiteBase();
+            if ($base === null) {
+                return null;
+            }
+
+            return rtrim($base, '/') . $input;
+        }
+
+        $parts  = parse_url($input);
+        $scheme = strtolower(self::toStr($parts['scheme'] ?? ''));
+        $host   = strtolower(self::toStr($parts['host'] ?? ''));
+        if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return null;
+        }
+
+        $hostPort = $host . (isset($parts['port']) ? ':' . $parts['port'] : '');
+        foreach ($this->allowedHosts() as $allowed) {
+            if ($hostPort === $allowed || $host === $allowed) {
+                return $input;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * host[:port] values of every site base and base variant.
+     *
+     * @return list<string>
+     */
+    private function allowedHosts(): array
+    {
+        $hosts = [];
+        foreach ($this->siteFinder->getAllSites() as $site) {
+            foreach ($this->siteBases($site) as $base) {
+                $host = strtolower($base->getHost());
+                if ($host === '') {
+                    continue;
+                }
+                $port    = $base->getPort();
+                $hosts[] = $host . ($port !== null ? ':' . $port : '');
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+
+    /**
+     * @return list<UriInterface>
+     */
+    private function siteBases(Site $site): array
+    {
+        $bases = [$site->getBase()];
+
+        $variants = $site->getConfiguration()['baseVariants'] ?? null;
+        if (is_array($variants)) {
+            foreach ($variants as $variant) {
+                if (is_array($variant) && is_string($variant['base'] ?? null)) {
+                    $bases[] = new Uri($variant['base']);
+                }
+            }
+        }
+
+        return $bases;
+    }
+
+    private function firstSiteBase(): ?string
+    {
+        foreach ($this->siteFinder->getAllSites() as $site) {
+            $base = (string)$site->getBase();
+            if ($base !== '' && $site->getBase()->getHost() !== '') {
+                return $base;
+            }
+        }
+
+        return null;
+    }
+
+    private function bodyExcerpt(string $body): string
+    {
+        $text = trim((string)preg_replace('/\s+/', ' ', strip_tags($body)));
+        if ($text === '') {
+            return '';
+        }
+        if (strlen($text) > self::BODY_EXCERPT_BYTES) {
+            $text = mb_strcut($text, 0, self::BODY_EXCERPT_BYTES, 'UTF-8') . '…';
+        }
+
+        return $this->sanitizeErrorMessage($text);
+    }
+
+    /**
+     * Append the newest error-log entries from the probe's time window so a
+     * 5xx report carries its own cause.
+     */
+    private function correlateLogs(int $probeTime): string
+    {
+        $entries = $this->logReader->read(
+            3,
+            null,
+            $probeTime - self::CORRELATION_WINDOW_SECONDS,
+            $probeTime + self::CORRELATION_WINDOW_SECONDS,
+        );
+
+        if ($entries === []) {
+            return 'No matching error in the TYPO3 file logs within ±'
+                . self::CORRELATION_WINDOW_SECONDS
+                . 's — the 500 may originate outside TYPO3 (web server, PHP fatal before logging).';
+        }
+
+        $lines = ['Correlated TYPO3 log error(s) from the probe window:'];
+        foreach ($entries as $entry) {
+            $lines[] = sprintf(
+                '- [%s] %s %s: %s',
+                gmdate('H:i:s', $entry->timestamp) . ' UTC',
+                $entry->level,
+                $entry->exceptionClass ?? $entry->component,
+                $this->sanitizeErrorMessage(mb_strimwidth($entry->message, 0, 300, '…')),
+            );
+            if ($entry->frames !== []) {
+                $lines[] = sprintf('  at %s:%d', $entry->frames[0]['file'], $entry->frames[0]['line']);
+            }
+        }
+        $lines[] = 'Use get_last_exception for the full stack trace and source context.';
+
+        return implode("\n", $lines);
+    }
+}

--- a/Classes/Service/Tool/Builtin/ReadSourceTool.php
+++ b/Classes/Service/Tool/Builtin/ReadSourceTool.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+
+/**
+ * Line-ranged source-file read for debugging (ADR-044).
+ *
+ * Every access funnels through {@see SourcePathGuard}: the resolved real
+ * path must stay inside the project root (defeats `../` and symlink
+ * escapes), dotfiles, `var/*` (except `var/log`), `config/system/*`,
+ * `settings.php`/`additional.php`, key material and "credential" paths are
+ * denied outright, and credential-looking assignment lines have their value
+ * redacted. Admin-only on top.
+ */
+final readonly class ReadSourceTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const DEFAULT_LINES = 60;
+
+    private const MAX_LINES = 200;
+
+    public function __construct(
+        private SourcePathGuard $guard,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'read_source',
+            'Read a line range of a source file inside the TYPO3 project (path relative to the project '
+            . 'root). Output is line-numbered. Dotfiles, settings/credentials and key material are '
+            . 'not readable.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'path' => [
+                        'type'        => 'string',
+                        'description' => 'File path relative to the project root, e.g. "vendor/acme/ext/Classes/Service/Foo.php".',
+                    ],
+                    'from_line' => [
+                        'type'        => 'integer',
+                        'description' => 'First line to return, 1-based (default 1).',
+                    ],
+                    'lines' => [
+                        'type'        => 'integer',
+                        'description' => 'How many lines to return (default 60, max 200).',
+                    ],
+                ],
+                'required' => ['path'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $path = trim(self::toStr($arguments['path'] ?? ''));
+        if ($path === '') {
+            return 'Error: "path" is required.';
+        }
+
+        $fromLine = max(1, self::toInt($arguments['from_line'] ?? 1));
+        $lines    = self::toInt($arguments['lines'] ?? self::DEFAULT_LINES);
+        if ($lines < 1) {
+            $lines = self::DEFAULT_LINES;
+        }
+        $lines = min($lines, self::MAX_LINES);
+
+        $read = $this->guard->readLines($path, $fromLine, $lines);
+        if ($read === null) {
+            return sprintf(
+                'Denied or not found: "%s". Paths must resolve inside the project root; dotfiles, '
+                . 'var/* (except var/log), config/system, settings/additional.php, key material and '
+                . 'credential paths are not readable.',
+                $path,
+            );
+        }
+
+        $out   = [];
+        $out[] = sprintf('%s (lines %d-%d of %d):', $path, $fromLine, min($fromLine + $lines - 1, $read['total']), $read['total']);
+        foreach ($read['lines'] as $number => $content) {
+            $out[] = sprintf('%5d | %s', $number, rtrim($content));
+        }
+
+        if ($read['lines'] === []) {
+            $out[] = '(range is beyond the end of the file)';
+        }
+
+        return implode("\n", $out);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: reads host source code.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'code';
+    }
+}

--- a/Classes/Service/Tool/Builtin/SearchCodeTool.php
+++ b/Classes/Service/Tool/Builtin/SearchCodeTool.php
@@ -167,8 +167,8 @@ final readonly class SearchCodeTool implements ToolInterface
                 }
 
                 $trimmed = trim($this->guard->redactSecretLine($line));
-                if (strlen($trimmed) > self::MAX_LINE_LENGTH) {
-                    $trimmed = substr($trimmed, 0, self::MAX_LINE_LENGTH) . '…';
+                if (mb_strlen($trimmed) > self::MAX_LINE_LENGTH) {
+                    $trimmed = mb_substr($trimmed, 0, self::MAX_LINE_LENGTH) . '…';
                 }
                 $hits[] = sprintf('%s:%d: %s', $relative, $lineNumber + 1, $trimmed);
 

--- a/Classes/Service/Tool/Builtin/SearchCodeTool.php
+++ b/Classes/Service/Tool/Builtin/SearchCodeTool.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use FilesystemIterator;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Grep over the project's source files (ADR-044).
+ *
+ * Pure-PHP directory walk (no shell-out) under the project root, restricted
+ * to source extensions and pruned by {@see SourcePathGuard}'s denylists —
+ * vendor/, node_modules/, var/ and dot-directories are never descended
+ * into, and denied files (settings.php, key material, …) are skipped. The
+ * pattern is a LITERAL substring unless `regex` is set; matched lines are
+ * secret-redacted. A hard file/time budget bounds a model-steered call.
+ */
+final readonly class SearchCodeTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const DEFAULT_RESULTS = 30;
+
+    private const MAX_RESULTS = 100;
+
+    private const MAX_FILES = 20000;
+
+    private const TIME_BUDGET_SECONDS = 5.0;
+
+    private const MAX_LINE_LENGTH = 200;
+
+    public function __construct(
+        private SourcePathGuard $guard,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'search_code',
+            'Search the project source files for a literal substring (or a regular expression with '
+            . 'regex=true). Returns path:line hits. Vendor, var and dot directories are skipped.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'pattern' => [
+                        'type'        => 'string',
+                        'description' => 'Literal substring to find (case-sensitive). With regex=true: a PCRE pattern body without delimiters.',
+                    ],
+                    'regex' => [
+                        'type'        => 'boolean',
+                        'description' => 'Treat pattern as a regular expression (default false = literal substring).',
+                    ],
+                    'path' => [
+                        'type'        => 'string',
+                        'description' => 'Optional subdirectory (relative to the project root) to restrict the search to.',
+                    ],
+                    'max_results' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum hits to return (default 30, cap 100).',
+                    ],
+                ],
+                'required' => ['pattern'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $pattern = self::toStr($arguments['pattern'] ?? '');
+        if ($pattern === '') {
+            return 'Error: "pattern" is required.';
+        }
+
+        $isRegex = (bool)($arguments['regex'] ?? false);
+        $regex   = null;
+        if ($isRegex) {
+            $regex = '~' . str_replace('~', '\~', $pattern) . '~';
+            // preg_match() signals an invalid pattern with a warning + false;
+            // a scoped no-op handler keeps the probe silent without "@".
+            set_error_handler(static fn(): bool => true);
+            try {
+                $patternIsValid = preg_match($regex, '') !== false;
+            } finally {
+                restore_error_handler();
+            }
+            if (!$patternIsValid) {
+                return sprintf('Error: invalid regular expression "%s".', $pattern);
+            }
+        }
+
+        $maxResults = self::toInt($arguments['max_results'] ?? self::DEFAULT_RESULTS);
+        if ($maxResults < 1) {
+            $maxResults = self::DEFAULT_RESULTS;
+        }
+        $maxResults = min($maxResults, self::MAX_RESULTS);
+
+        $root = $this->guard->rootPath();
+        if ($root === null) {
+            return 'Error: project root not resolvable.';
+        }
+
+        $base    = $root;
+        $subPath = trim(self::toStr($arguments['path'] ?? ''), '/');
+        if ($subPath !== '') {
+            $candidate = realpath($root . '/' . $subPath);
+            if ($candidate === false || !is_dir($candidate) || !str_starts_with($candidate . '/', $root . '/')) {
+                return sprintf('Denied or not found: search path "%s".', $subPath);
+            }
+            if ($this->guard->isDeniedRelativePath(substr($candidate, strlen($root) + 1) . '/x')) {
+                return sprintf('Denied: search path "%s".', $subPath);
+            }
+            $base = $candidate;
+        }
+
+        $started      = microtime(true);
+        $filesVisited = 0;
+        $hits         = [];
+        $truncated    = '';
+
+        foreach ($this->sourceFiles($base) as $file) {
+            $filesVisited++;
+            if ($filesVisited > self::MAX_FILES || microtime(true) - $started > self::TIME_BUDGET_SECONDS) {
+                $truncated = sprintf(
+                    '… search stopped early (budget: %d files / %.0fs) — narrow the path to search further.',
+                    self::MAX_FILES,
+                    self::TIME_BUDGET_SECONDS,
+                );
+                break;
+            }
+
+            $relative = substr($file->getPathname(), strlen($root) + 1);
+            if ($this->guard->isDeniedRelativePath($relative)) {
+                continue;
+            }
+
+            if (!$file->isReadable()) {
+                continue;
+            }
+            $content = file_get_contents($file->getPathname(), false, null, 0, 2_000_000);
+            if ($content === false) {
+                continue;
+            }
+            if ($regex === null && !str_contains($content, $pattern)) {
+                continue;
+            }
+
+            foreach (explode("\n", $content) as $lineNumber => $line) {
+                $matches = $regex !== null
+                    ? preg_match($regex, $line) === 1
+                    : str_contains($line, $pattern);
+                if (!$matches) {
+                    continue;
+                }
+
+                $trimmed = trim($this->guard->redactSecretLine($line));
+                if (strlen($trimmed) > self::MAX_LINE_LENGTH) {
+                    $trimmed = substr($trimmed, 0, self::MAX_LINE_LENGTH) . '…';
+                }
+                $hits[] = sprintf('%s:%d: %s', $relative, $lineNumber + 1, $trimmed);
+
+                if (count($hits) >= $maxResults) {
+                    break 2;
+                }
+            }
+        }
+
+        if ($hits === []) {
+            return $truncated !== ''
+                ? "No matches found before the budget ran out.\n" . $truncated
+                : sprintf('No matches for "%s".', $pattern);
+        }
+
+        $header = sprintf('%d match(es) for "%s"%s:', count($hits), $pattern, count($hits) >= $maxResults ? ' (capped)' : '');
+        $out    = array_merge([$header], $hits);
+        if ($truncated !== '') {
+            $out[] = $truncated;
+        }
+
+        return implode("\n", $out);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: exposes host source code.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'code';
+    }
+
+    /**
+     * Source files under $base, pruned by directory denylist and extension
+     * allowlist.
+     *
+     * @return iterable<SplFileInfo>
+     */
+    private function sourceFiles(string $base): iterable
+    {
+        $directoryIterator = new RecursiveDirectoryIterator(
+            $base,
+            FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO,
+        );
+
+        $filtered = new RecursiveCallbackFilterIterator(
+            $directoryIterator,
+            static function (SplFileInfo $current): bool {
+                $name = $current->getFilename();
+                if (str_starts_with($name, '.')) {
+                    return false;
+                }
+                if ($current->isDir()) {
+                    return !in_array($name, SourcePathGuard::SKIPPED_DIRECTORIES, true);
+                }
+
+                return in_array(strtolower($current->getExtension()), SourcePathGuard::SOURCE_EXTENSIONS, true);
+            },
+        );
+
+        /** @var iterable<SplFileInfo> */
+        return new RecursiveIteratorIterator($filtered);
+    }
+}

--- a/Classes/Service/Tool/LogExceptionReader.php
+++ b/Classes/Service/Tool/LogExceptionReader.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\ValueObject\LogExceptionEntry;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Parses error-level entries out of TYPO3's file logs (ADR-044).
+ *
+ * Shared by `get_last_exception` (browse/inspect) and `probe_url`
+ * (correlate a just-probed 5xx with the exception it produced) — one
+ * parser, two consumers, no copy-paste.
+ *
+ * TYPO3's FileWriter emits one line per record:
+ *
+ *     Tue, 08 Jul 2026 01:13:18 +0200 [ERROR] request="..."
+ *     component="Vendor.Ext.Class": message - {"exception":"Class: msg in
+ *     /file:12\nStack trace:\n#0 /file(12): call()..."}
+ *
+ * Only the tail of each log file is read (bounded I/O — log files grow
+ * unbounded), newest files first.
+ */
+final readonly class LogExceptionReader
+{
+    /**
+     * How many bytes of each log file's tail are parsed. Errors older than
+     * this window are out of scope for interactive debugging.
+     */
+    private const TAIL_BYTES = 2_000_000;
+
+    private const ERROR_LEVELS = ['ERROR', 'CRITICAL', 'ALERT', 'EMERGENCY'];
+
+    private const ENTRY_START_PATTERN
+        = '/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} [A-Z][a-z]{2} \d{4} /';
+
+    private const HEADER_PATTERN
+        = '/^(?<date>\w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}) '
+        . '\[(?<level>[A-Z]+)\](?: request="[^"]*")?'
+        . '(?: component="(?<component>[^"]*)")?: (?<rest>.*)$/s';
+
+    private const FRAME_PATTERN
+        = '/#\d+ (?<file>\/[^(:\n]+)\((?<line>\d+)\): (?<call>[^\n]+)/';
+
+    public function __construct(
+        private ?string $logDirectory = null,
+    ) {}
+
+    /**
+     * Error-level entries, newest first.
+     *
+     * @param string|null $search  case-insensitive substring filter on
+     *                             message / component / exception class
+     * @param int|null    $sinceTs only entries at/after this timestamp
+     * @param int|null    $untilTs only entries at/before this timestamp
+     *
+     * @return list<LogExceptionEntry>
+     */
+    public function read(int $limit = 20, ?string $search = null, ?int $sinceTs = null, ?int $untilTs = null): array
+    {
+        $entries = [];
+        foreach ($this->logFiles() as $file) {
+            foreach ($this->parseFile($file) as $entry) {
+                if ($sinceTs !== null && $entry->timestamp < $sinceTs) {
+                    continue;
+                }
+                if ($untilTs !== null && $entry->timestamp > $untilTs) {
+                    continue;
+                }
+                if ($search !== null && $search !== '' && !$this->matchesSearch($entry, $search)) {
+                    continue;
+                }
+                $entries[] = $entry;
+            }
+        }
+
+        usort($entries, static fn(LogExceptionEntry $a, LogExceptionEntry $b): int => $b->timestamp <=> $a->timestamp);
+
+        return array_slice($entries, 0, max(1, $limit));
+    }
+
+    /**
+     * @return list<string> log file paths, newest modification first
+     */
+    private function logFiles(): array
+    {
+        $dir   = $this->logDirectory ?? Environment::getVarPath() . '/log';
+        $files = glob($dir . '/typo3_*.log');
+        if ($files === false || $files === []) {
+            return [];
+        }
+
+        usort($files, static fn(string $a, string $b): int => (int)filemtime($b) <=> (int)filemtime($a));
+
+        return $files;
+    }
+
+    /**
+     * @return list<LogExceptionEntry>
+     */
+    private function parseFile(string $file): array
+    {
+        if (!is_readable($file)) {
+            return [];
+        }
+        $size   = (int)filesize($file);
+        $offset = max(0, $size - self::TAIL_BYTES);
+        $raw    = file_get_contents($file, false, null, $offset);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        // Group physical lines into logical records: a record starts with the
+        // RFC-2822-ish date; anything else continues the previous record
+        // (messages may carry real newlines).
+        $records = [];
+        $current = null;
+        foreach (explode("\n", $raw) as $line) {
+            if (preg_match(self::ENTRY_START_PATTERN, $line) === 1) {
+                if ($current !== null) {
+                    $records[] = $current;
+                }
+                $current = $line;
+                continue;
+            }
+            if ($current !== null) {
+                $current .= "\n" . $line;
+            }
+        }
+        if ($current !== null) {
+            $records[] = $current;
+        }
+
+        $entries = [];
+        foreach ($records as $record) {
+            $entry = $this->parseRecord($record);
+            if ($entry instanceof LogExceptionEntry) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+
+    private function parseRecord(string $record): ?LogExceptionEntry
+    {
+        if (preg_match(self::HEADER_PATTERN, $record, $m) !== 1) {
+            return null;
+        }
+
+        $level = $m['level'];
+        if (!in_array($level, self::ERROR_LEVELS, true)) {
+            return null;
+        }
+
+        $timestamp = strtotime($m['date']);
+        if ($timestamp === false) {
+            return null;
+        }
+
+        [$message, $exceptionText] = $this->splitDataSuffix($m['rest']);
+
+        $exceptionClass = null;
+        $frames         = [];
+        $trace          = $exceptionText ?? $message;
+
+        if (preg_match('/(?<class>[A-Za-z_\\\\][\w\\\\]*(?:Exception|Error)\b[\w\\\\]*)\s*:/', $trace, $cm) === 1) {
+            $exceptionClass = $cm['class'];
+        }
+
+        // The throw site ("in /file.php:12") leads the frame list so the
+        // most relevant source location comes first.
+        if (preg_match('/ in (?<file>\/[^\s:]+):(?<line>\d+)/', $trace, $tm) === 1) {
+            $frames[] = ['file' => $tm['file'], 'line' => (int)$tm['line'], 'call' => '(throw site)'];
+        }
+
+        if (preg_match_all(self::FRAME_PATTERN, $trace, $fm, PREG_SET_ORDER) > 0) {
+            foreach ($fm as $frame) {
+                $frames[] = [
+                    'file' => $frame['file'],
+                    'line' => (int)$frame['line'],
+                    'call' => trim($frame['call']),
+                ];
+            }
+        }
+
+        return new LogExceptionEntry(
+            timestamp: $timestamp,
+            level: $level,
+            component: $m['component'],
+            message: trim($message),
+            exceptionClass: $exceptionClass,
+            frames: $frames,
+        );
+    }
+
+    /**
+     * Split the FileWriter's trailing ` - {json}` data suffix off the
+     * message and surface a decoded `exception` string when present.
+     *
+     * @return array{0: string, 1: string|null} [message, exception text]
+     */
+    private function splitDataSuffix(string $rest): array
+    {
+        $pos = strrpos($rest, ' - {');
+        if ($pos === false) {
+            return [$rest, null];
+        }
+
+        $candidate = substr($rest, $pos + 3);
+        $decoded   = json_decode($candidate, true);
+        if (!is_array($decoded)) {
+            return [$rest, null];
+        }
+
+        $exception = $decoded['exception'] ?? null;
+
+        return [substr($rest, 0, $pos), is_string($exception) ? $exception : null];
+    }
+
+    private function matchesSearch(LogExceptionEntry $entry, string $search): bool
+    {
+        return stripos($entry->message, $search) !== false
+            || stripos($entry->component, $search) !== false
+            || ($entry->exceptionClass !== null && stripos($entry->exceptionClass, $search) !== false);
+    }
+}

--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Fail-closed path gate for the source-reading tools (ADR-044).
+ *
+ * Model-chosen paths are attacker-influenceable, so every read the
+ * error-analysis tools perform funnels through this guard:
+ *
+ * - the resolved real path must stay inside the project root (realpath
+ *   containment defeats `../` traversal AND symlink escapes);
+ * - no path segment may start with a dot (`.env`, `.git`, `.ddev`, …);
+ * - `var/*` is denied except `var/log` (sessions and caches can carry
+ *   serialized credentials, the logs are exactly what debugging needs);
+ * - `config/system/*` and any `settings.php` / `additional.php` are denied
+ *   (DB credentials), as are key-material extensions and any path
+ *   mentioning "credential";
+ * - reads are line-ranged and secret-redacting — a matching key on a line
+ *   has its value replaced, never the raw secret egressed.
+ */
+final readonly class SourcePathGuard
+{
+    /**
+     * File extensions the code-walking tools consider source. Everything
+     * else (binaries, images, archives, sqlite files, …) is skipped.
+     */
+    public const SOURCE_EXTENSIONS = [
+        'php', 'html', 'typoscript', 'tsconfig', 'yaml', 'yml',
+        'xml', 'xlf', 'json', 'md',
+    ];
+
+    /** Directory names never descended into when walking the tree. */
+    public const SKIPPED_DIRECTORIES = ['vendor', 'node_modules', 'var'];
+
+    private const DENIED_EXTENSIONS = ['key', 'pem', 'crt', 'p12', 'pfx'];
+
+    private const DENIED_BASENAME_PATTERN = '/^(settings|additional)\.php$/i';
+
+    /** Lines whose key looks credential-bearing get their value replaced. */
+    private const SECRET_LINE_PATTERN
+        = '/^(?<lead>.*?(?:password|passwd|pwd|secret|token|salt|api[_-]?key|credential|private[_-]?key)[\'"\s\]]*\s*(?:=>?|:)\s*)(?<value>.+)$/i';
+
+    public function __construct(
+        private ?string $projectPath = null,
+    ) {}
+
+    /**
+     * Resolve a model-supplied (relative or absolute) path to a real path
+     * inside the project, or null when any gate denies it.
+     */
+    public function resolve(string $path): ?string
+    {
+        $root = $this->rootPath();
+        if ($root === null || trim($path) === '') {
+            return null;
+        }
+
+        $candidate = str_starts_with($path, '/')
+            ? $path
+            : $root . '/' . $path;
+
+        $real = realpath($candidate);
+        if ($real === false || !is_file($real)) {
+            return null;
+        }
+
+        // Containment check defeats `../` traversal and symlink escapes in
+        // one step: whatever the input, the RESOLVED file must live under
+        // the resolved project root.
+        if ($real !== $root && !str_starts_with($real, $root . '/')) {
+            return null;
+        }
+
+        return $this->isDeniedRelativePath(substr($real, strlen($root) + 1)) ? null : $real;
+    }
+
+    /**
+     * Whether a project-relative path hits any denylist (dot segments,
+     * var/* except var/log, config/system, settings/additional.php, key
+     * material, "credential" mentions).
+     */
+    public function isDeniedRelativePath(string $relativePath): bool
+    {
+        if (stripos($relativePath, 'credential') !== false) {
+            return true;
+        }
+
+        $segments = explode('/', $relativePath);
+        foreach ($segments as $segment) {
+            if ($segment !== '' && str_starts_with($segment, '.')) {
+                return true;
+            }
+        }
+
+        if ($segments[0] === 'var' && ($segments[1] ?? '') !== 'log') {
+            return true;
+        }
+
+        if ($segments[0] === 'config' && ($segments[1] ?? '') === 'system') {
+            return true;
+        }
+
+        $basename = $segments[count($segments) - 1];
+        if (preg_match(self::DENIED_BASENAME_PATTERN, $basename) === 1) {
+            return true;
+        }
+
+        $extension = strtolower(pathinfo($basename, PATHINFO_EXTENSION));
+
+        return in_array($extension, self::DENIED_EXTENSIONS, true);
+    }
+
+    /**
+     * Read a line range from a guarded file, secret-redacted and
+     * 1-indexed. Null when the path is denied or unreadable.
+     *
+     * @return array{lines: array<int, string>, total: int}|null keyed by line number
+     */
+    public function readLines(string $path, int $fromLine, int $count): ?array
+    {
+        $real = $this->resolve($path);
+        if ($real === null) {
+            return null;
+        }
+
+        if (!is_readable($real)) {
+            return null;
+        }
+        $content = file_get_contents($real, false, null, 0, 2_000_000);
+        if ($content === false) {
+            return null;
+        }
+
+        $all      = explode("\n", $content);
+        $total    = count($all);
+        $fromLine = max(1, $fromLine);
+        $count    = max(1, $count);
+
+        $slice = array_slice($all, $fromLine - 1, $count, true);
+        $lines = [];
+        foreach ($slice as $index => $line) {
+            $lines[$index + 1] = $this->redactSecretLine($line);
+        }
+
+        return ['lines' => $lines, 'total' => $total];
+    }
+
+    /**
+     * Replace the value part of a credential-looking assignment line.
+     */
+    public function redactSecretLine(string $line): string
+    {
+        return (string)preg_replace(self::SECRET_LINE_PATTERN, '$1[redacted]', $line);
+    }
+
+    /**
+     * The resolved project root (injectable for tests).
+     */
+    public function rootPath(): ?string
+    {
+        $root = $this->projectPath ?? Environment::getProjectPath();
+        $real = realpath($root);
+
+        return $real === false ? null : $real;
+    }
+}

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -122,6 +122,30 @@ The remaining tools follow the same pattern:
    ``path`` drill-down, output cap and redaction as ``get_typoscript``.
    Admin-only.
 
+``get_last_exception``
+   The newest exception/error from the TYPO3 file logs with its parsed
+   stack trace and the surrounding source lines of the project frames
+   inlined. ``index`` steps back through older errors, ``search`` filters
+   by message, class or component. Admin-only.
+
+``read_source``
+   A line-numbered range of one project source file. Paths must resolve
+   inside the project root; dotfiles, ``var/*`` (except ``var/log``),
+   ``config/system``, ``settings.php``/``additional.php``, key material
+   and credential paths are structurally unreadable. Admin-only.
+
+``search_code``
+   Literal-substring (or opt-in regex) search across the project's source
+   files, returning ``path:line`` hits. Vendor, ``var`` and dot
+   directories are never searched; matched credential lines are
+   value-redacted. Admin-only.
+
+``probe_url``
+   One GET against a URL of *this* instance: status, key headers, timing
+   and a short body excerpt — and on a 5xx the matching exception from the
+   TYPO3 logs is appended automatically. Foreign hosts and non-http(s)
+   schemes are denied; redirects are reported, not followed. Admin-only.
+
 .. _administration-tools-register:
 
 Registering a tool
@@ -195,9 +219,11 @@ Group            Tools
 ===============  ============================================================
 ``content``      ``search_records``, ``get_page_content``, ``read_records``
 ``structure``    ``get_pagetree``, ``get_tca``, ``read_fal_asset_meta``
-``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw), ``fetch_logs``
+``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw),
+                 ``fetch_logs``, ``probe_url``
 ``accounts``     ``list_be_users`` (+ raw), ``list_be_groups``
 ``configuration``  ``get_typoscript``, ``get_tsconfig``
+``code``         ``get_last_exception``, ``read_source``, ``search_code``
 ===============  ============================================================
 
 Groups can be switched on three levels, and the result cascades

--- a/Documentation/Adr/Adr044ErrorAnalysisTools.rst
+++ b/Documentation/Adr/Adr044ErrorAnalysisTools.rst
@@ -1,0 +1,102 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-044:
+
+=====================================================
+ADR-044: Error-analysis tools with fail-closed guards
+=====================================================
+
+:Status: Accepted
+:Date: 2026-07-09
+:Authors: Netresearch DTT GmbH
+
+.. _adr-044-context:
+
+Context
+=======
+
+The agent can read content and configuration (:ref:`ADR-042 <adr-042>`),
+but the debugging use cases admins actually bring to the playground —
+"why does this URL answer 500", "how do I fix this PHP error" — need
+capabilities the tool set lacked: reading the TYPO3 file logs *with* the
+failing source code, reading arbitrary project files, searching the code
+base, and probing a frontend URL. All four egress host-level data to an
+external LLM provider and take model-chosen (attacker-influenceable)
+arguments, so each needs a hard, fail-closed containment story.
+
+.. _adr-044-decision:
+
+Decision
+========
+
+Four admin-only tools, two shared guards.
+
+Tools
+-----
+
+``get_last_exception`` (group ``code``)
+   Newest error-level entries from the TYPO3 file logs, with the parsed
+   stack trace and ±6 lines of source context inlined for up to three
+   project-local frames (vendor/core frames are listed, not expanded).
+   ``index`` steps back through older errors, ``search`` filters.
+
+``read_source`` (group ``code``)
+   Line-ranged, line-numbered read of one project file (default 60, max
+   200 lines).
+
+``search_code`` (group ``code``)
+   Literal-substring (opt-in regex) search over project source files —
+   a pure-PHP walk, no shell-out — returning ``path:line`` hits under a
+   hard budget (20 000 files / 5 s), reported when exhausted.
+
+``probe_url`` (group ``system``)
+   One GET against the instance's *own* frontend: status, key headers,
+   timing, a 2 KB tag-stripped body excerpt — and on a 5xx the newest
+   error-log entries from the probe's ±30 s window are appended through
+   the same log parser, so probe and cause arrive in one result.
+
+Shared guards
+-------------
+
+``SourcePathGuard`` (used by 1–3)
+   Every file access resolves through ``realpath`` and must stay inside
+   the project root — one containment check defeats ``../`` traversal and
+   symlink escapes alike. Denied outright: dot segments (``.env``,
+   ``.git``, ``.ddev``), ``var/*`` except ``var/log``, ``config/system/*``
+   and any ``settings.php``/``additional.php``, key-material extensions
+   (``key``/``pem``/``crt``/``p12``/``pfx``) and paths mentioning
+   ``credential``. Credential-looking assignment lines are value-redacted
+   on read; the code walk skips ``vendor/``, ``node_modules/``, ``var/``
+   and dot directories and only considers source extensions.
+
+``LogExceptionReader`` (used by 1 and 4)
+   Parses TYPO3 ``FileWriter`` records (error levels only, newest first,
+   bounded to each file's 2 MB tail) into timestamp, level, component,
+   message, exception class and stack frames. One parser, two consumers —
+   ``probe_url``'s 5xx↔log correlation reuses it instead of duplicating
+   the format knowledge.
+
+``probe_url`` SSRF containment
+   Only ``http(s)``, and the target ``host[:port]`` must match a site base
+   or base variant of *this* instance (``SiteFinder``); relative paths
+   resolve against the first site. Redirects are reported, never followed
+   — a 3xx cannot bounce the probe off-host. Transport errors surface
+   sanitized (URL credential parameters masked).
+
+.. _adr-044-consequences:
+
+Consequences
+============
+
+- The "analyse the error" loop closes: ``probe_url`` → correlated log
+  entry → ``get_last_exception`` (full trace + code) → ``read_source`` /
+  ``search_code`` for the fix site — without leaving the playground.
+- All four tools are ``requiresAdmin() = true`` and live behind the
+  :ref:`ADR-043 <adr-043>` group cascade (new group ``code``; ``probe_url``
+  joins ``system``), so one central toggle silences the whole family.
+- ``settings.php`` and other credential carriers are structurally
+  unreadable even for admins — the guard has no bypass parameter by
+  design.
+- ``probe_url`` performs real frontend requests (cache warm-up, log
+  entries, load); it is deliberately GET-only, single-request,
+  15 s-capped.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -342,3 +342,4 @@ Tools
    Adr041PlaygroundLiveStreaming
    Adr042ContentAndIntrospectionTools
    Adr043ToolGroups
+   Adr044ErrorAnalysisTools

--- a/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
+++ b/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetLastExceptionTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * End-to-end wiring test for get_last_exception (ADR-044): the DI-built
+ * tool (default Environment paths) parses a seeded log entry from the test
+ * instance's var/log and expands source context for a frame inside the
+ * instance.
+ */
+#[CoversClass(GetLastExceptionTool::class)]
+final class GetLastExceptionToolFunctionalTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    private string $frameFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // A source file inside the instance the stack frame can point at.
+        $this->frameFile = Environment::getProjectPath() . '/probe-fixture/Sample.php';
+        GeneralUtility::mkdir_deep(dirname($this->frameFile));
+        file_put_contents(
+            $this->frameFile,
+            implode("\n", array_map(static fn(int $i): string => sprintf('// sample %d', $i), range(1, 12))),
+        );
+
+        // A realistic FileWriter record in the instance's var/log.
+        $logDir = Environment::getVarPath() . '/log';
+        GeneralUtility::mkdir_deep($logDir);
+        $exceptionJson = json_encode([
+            'exception' => "DomainException: functional kaboom in {$this->frameFile}:6\n"
+                . "Stack trace:\n#0 {$this->frameFile}(6): boom()",
+        ], JSON_THROW_ON_ERROR);
+        file_put_contents(
+            $logDir . '/typo3_functional.log',
+            'Wed, 09 Jul 2026 08:00:00 +0200 [CRITICAL] request="fx" component="Acme.Functional": functional failure - '
+            . $exceptionJson . "\n",
+        );
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('get_last_exception');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function parsesSeededLogAndExpandsSourceContext(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('DomainException', $output);
+        self::assertStringContainsString('functional failure', $output);
+        self::assertStringContainsString('>    6 | // sample 6', $output);
+    }
+
+    #[Test]
+    public function searchFilterNarrowsToTheSeededEntry(): void
+    {
+        $output = $this->tool->execute(['search' => 'functional kaboom or nothing']);
+
+        // A non-matching search yields the no-entries message…
+        self::assertStringContainsString('No error-level entries', $output);
+
+        // …while a matching one finds the seeded record.
+        self::assertStringContainsString('DomainException', $this->tool->execute(['search' => 'DomainException']));
+    }
+
+    protected function tearDown(): void
+    {
+        $seededLog = Environment::getVarPath() . '/log/typo3_functional.log';
+        if (is_file($seededLog)) {
+            unlink($seededLog);
+        }
+        GeneralUtility::rmdir(Environment::getProjectPath() . '/probe-fixture', true);
+        parent::tearDown();
+    }
+}

--- a/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for the probe_url SSRF host gate (ADR-044).
+ *
+ * The gate resolves the instance's own sites through the real SiteFinder:
+ * off-host URLs and non-http(s) schemes are denied WITHOUT a request being
+ * attempted; own-host URLs pass the gate (evidenced by a transport-level
+ * failure against a closed port — no web server runs in the test
+ * instance).
+ */
+#[CoversClass(ProbeUrlTool::class)]
+final class ProbeUrlToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // Site on a closed localhost port: gate passes, connect fails fast.
+        $siteDir = $this->instancePath . '/typo3conf/sites/probe';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost:59999/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('probe_url');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function deniesForeignHostWithoutRequesting(): void
+    {
+        $output = $this->tool->execute(['url' => 'https://evil.example.com/steal']);
+
+        self::assertStringContainsString('Denied', $output);
+        self::assertStringContainsString('localhost:59999', $output);
+    }
+
+    #[Test]
+    public function deniesNonHttpScheme(): void
+    {
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'file:///etc/passwd']));
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'gopher://localhost:59999/x']));
+    }
+
+    #[Test]
+    public function ownHostPassesTheGate(): void
+    {
+        $output = $this->tool->execute(['url' => 'http://localhost:59999/some/page']);
+
+        // The request is ATTEMPTED (gate passed) and fails at transport
+        // level because nothing listens on the closed port.
+        self::assertStringContainsString('FAILED transport-level', $output);
+    }
+
+    #[Test]
+    public function relativePathResolvesAgainstTheFirstSite(): void
+    {
+        $output = $this->tool->execute(['url' => '/imprint']);
+
+        self::assertStringContainsString('FAILED transport-level', $output);
+        self::assertStringContainsString('http://localhost:59999/imprint', $output);
+    }
+
+    #[Test]
+    public function emptyUrlIsRejected(): void
+    {
+        self::assertStringContainsString('"url" is required', $this->tool->execute([]));
+    }
+}

--- a/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
@@ -86,6 +86,25 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function deniesRoguePortOnOwnHost(): void
+    {
+        // Same host, different port than the site (59999) — must NOT pass the
+        // gate, or an attacker could probe localhost:6379 (Redis), :3306, …
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost:6379/']));
+        // Bare host defaults to port 80, also != 59999.
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost/']));
+    }
+
+    #[Test]
+    public function deniesUserinfoAndDoesNotEchoCredentials(): void
+    {
+        $output = $this->tool->execute(['url' => 'http://user:s3cr3t@localhost:59999/']);
+
+        self::assertStringContainsString('Denied', $output);
+        self::assertStringNotContainsString('s3cr3t', $output);
+    }
+
+    #[Test]
     public function ownHostPassesTheGate(): void
     {
         $output = $this->tool->execute(['url' => 'http://localhost:59999/some/page']);

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetLastExceptionTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPageTreeTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoRawTool;
@@ -22,8 +23,11 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeGroupsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadSourceTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchCodeTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -63,6 +67,10 @@ final class BuiltinToolGroupsTest extends TestCase
             'list_be_groups'    => [ListBeGroupsTool::class, 'accounts'],
             'get_typoscript'    => [GetTypoScriptTool::class, 'configuration'],
             'get_tsconfig'      => [GetTsConfigTool::class, 'configuration'],
+            'get_last_exception' => [GetLastExceptionTool::class, 'code'],
+            'read_source'       => [ReadSourceTool::class, 'code'],
+            'search_code'       => [SearchCodeTool::class, 'code'],
+            'probe_url'         => [ProbeUrlTool::class, 'system'],
         ];
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/GetLastExceptionToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetLastExceptionToolTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetLastExceptionTool;
+use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+#[CoversClass(GetLastExceptionTool::class)]
+final class GetLastExceptionToolTest extends TestCase
+{
+    private string $base;
+
+    private GetLastExceptionTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->base = sys_get_temp_dir() . '/nrllm-lastexc-' . bin2hex(random_bytes(4));
+        $project    = $this->base . '/project';
+        $logDir     = $this->base . '/log';
+        mkdir($project . '/Classes', 0o777, true);
+        mkdir($logDir, 0o777, true);
+
+        // The failing source file the stack frame points at.
+        file_put_contents(
+            $project . '/Classes/Broken.php',
+            implode("\n", array_map(static fn(int $i): string => sprintf('// code line %d', $i), range(1, 20))),
+        );
+
+        $frameFile     = $project . '/Classes/Broken.php';
+        $exceptionJson = json_encode([
+            'exception' => "RuntimeException: kaboom in {$frameFile}:10\n"
+                . "Stack trace:\n"
+                . "#0 {$frameFile}(10): explode()\n"
+                . "#1 {$project}/vendor/typo3/core/Http.php(5): dispatch()",
+        ], JSON_THROW_ON_ERROR);
+        file_put_contents(
+            $logDir . '/typo3_test.log',
+            'Tue, 08 Jul 2026 10:00:00 +0200 [ERROR] request="r1" component="Acme.Demo": it broke - '
+            . $exceptionJson . "\n",
+        );
+
+        $this->tool = new GetLastExceptionTool(
+            new LogExceptionReader($logDir),
+            new SourcePathGuard($project),
+        );
+    }
+
+    #[Test]
+    public function specShape(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('get_last_exception', $spec->name);
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertTrue($this->tool->isEnabledByDefault());
+        self::assertSame('code', $this->tool->getGroup());
+    }
+
+    #[Test]
+    public function rendersExceptionWithSourceContextAroundProjectFrames(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('RuntimeException', $output);
+        self::assertStringContainsString('it broke', $output);
+        self::assertStringContainsString('Stack trace:', $output);
+        // The failing line is marked and surrounded by context.
+        self::assertStringContainsString('>   10 | // code line 10', $output);
+        self::assertStringContainsString('     4 | // code line 4', $output);
+        self::assertStringContainsString('    16 | // code line 16', $output);
+    }
+
+    #[Test]
+    public function indexOutOfRangeIsExplained(): void
+    {
+        self::assertStringContainsString('out of range', $this->tool->execute(['index' => 5]));
+    }
+
+    #[Test]
+    public function noEntriesHintsAtFetchLogs(): void
+    {
+        $empty = $this->base . '/empty-log';
+        mkdir($empty, 0o777, true);
+        $tool = new GetLastExceptionTool(new LogExceptionReader($empty), new SourcePathGuard($this->base . '/project'));
+
+        $output = $tool->execute([]);
+
+        self::assertStringContainsString('No error-level entries', $output);
+        self::assertStringContainsString('fetch_logs', $output);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->base, true);
+        parent::tearDown();
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/ReadSourceToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadSourceToolTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadSourceTool;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+#[CoversClass(ReadSourceTool::class)]
+final class ReadSourceToolTest extends TestCase
+{
+    private string $root;
+
+    private ReadSourceTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir() . '/nrllm-readsource-' . bin2hex(random_bytes(4));
+        mkdir($this->root . '/Classes', 0o777, true);
+        mkdir($this->root . '/config/system', 0o777, true);
+        file_put_contents(
+            $this->root . '/Classes/Demo.php',
+            implode("\n", array_map(static fn(int $i): string => sprintf('// line %d', $i), range(1, 10))),
+        );
+        file_put_contents($this->root . '/config/system/settings.php', '<?php // secret');
+
+        $this->tool = new ReadSourceTool(new SourcePathGuard($this->root));
+    }
+
+    #[Test]
+    public function specShape(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('read_source', $spec->name);
+        self::assertSame(['path'], $spec->parameters['required'] ?? null);
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertTrue($this->tool->isEnabledByDefault());
+        self::assertSame('code', $this->tool->getGroup());
+    }
+
+    #[Test]
+    public function readsARangeWithLineNumbers(): void
+    {
+        $output = $this->tool->execute(['path' => 'Classes/Demo.php', 'from_line' => 3, 'lines' => 2]);
+
+        self::assertStringContainsString('Classes/Demo.php (lines 3-4 of 10):', $output);
+        self::assertStringContainsString('    3 | // line 3', $output);
+        self::assertStringContainsString('    4 | // line 4', $output);
+        self::assertStringNotContainsString('// line 5', $output);
+    }
+
+    #[Test]
+    public function deniesSettingsPhp(): void
+    {
+        $output = $this->tool->execute(['path' => 'config/system/settings.php']);
+
+        self::assertStringContainsString('Denied or not found', $output);
+        self::assertStringNotContainsString('secret', $output);
+    }
+
+    #[Test]
+    public function requiresAPath(): void
+    {
+        self::assertStringContainsString('"path" is required', $this->tool->execute([]));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->root, true);
+        parent::tearDown();
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchCodeTool;
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+#[CoversClass(SearchCodeTool::class)]
+final class SearchCodeToolTest extends TestCase
+{
+    private string $root;
+
+    private SearchCodeTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir() . '/nrllm-searchcode-' . bin2hex(random_bytes(4));
+        foreach (['Classes', 'vendor/acme', '.git', 'var/log', 'Resources'] as $dir) {
+            mkdir($this->root . '/' . $dir, 0o777, true);
+        }
+        file_put_contents($this->root . '/Classes/Alpha.php', "<?php\nfunction findMeHere() {}\n\$apiKey = 'topsecret-findMeHere';\n");
+        file_put_contents($this->root . '/Resources/notes.md', "findMeHere in docs\n");
+        file_put_contents($this->root . '/Classes/binary.png', 'findMeHere-in-binary');
+        file_put_contents($this->root . '/vendor/acme/Lib.php', "<?php // findMeHere in vendor\n");
+        file_put_contents($this->root . '/.git/config', 'findMeHere in git');
+        file_put_contents($this->root . '/var/log/typo3_x.log', 'findMeHere in log');
+
+        $this->tool = new SearchCodeTool(new SourcePathGuard($this->root));
+    }
+
+    #[Test]
+    public function specShape(): void
+    {
+        $spec = $this->tool->getSpec();
+
+        self::assertSame('search_code', $spec->name);
+        self::assertSame(['pattern'], $spec->parameters['required'] ?? null);
+        self::assertTrue($this->tool->requiresAdmin());
+        self::assertSame('code', $this->tool->getGroup());
+    }
+
+    #[Test]
+    public function findsLiteralHitsOnlyInAllowedSourceFiles(): void
+    {
+        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+
+        self::assertStringContainsString('Classes/Alpha.php:2:', $output);
+        self::assertStringContainsString('Resources/notes.md:1:', $output);
+        // Skipped: vendor/, dot dirs, var/, non-source extensions.
+        self::assertStringNotContainsString('vendor/acme', $output);
+        self::assertStringNotContainsString('.git', $output);
+        self::assertStringNotContainsString('var/log', $output);
+        self::assertStringNotContainsString('binary.png', $output);
+        // Secret assignment lines are value-redacted in the output.
+        self::assertStringContainsString('[redacted]', $output);
+        self::assertStringNotContainsString('topsecret', $output);
+    }
+
+    #[Test]
+    public function regexModeValidatesThePattern(): void
+    {
+        self::assertStringContainsString(
+            'invalid regular expression',
+            $this->tool->execute(['pattern' => '([unclosed', 'regex' => true]),
+        );
+        self::assertStringContainsString(
+            'Classes/Alpha.php:2:',
+            $this->tool->execute(['pattern' => 'findMe\w+\(\)', 'regex' => true]),
+        );
+    }
+
+    #[Test]
+    public function capsResults(): void
+    {
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'max_results' => 1]);
+
+        self::assertStringContainsString('1 match(es)', $output);
+        self::assertStringContainsString('(capped)', $output);
+    }
+
+    #[Test]
+    public function deniesEscapingSearchPath(): void
+    {
+        self::assertStringContainsString(
+            'Denied or not found',
+            $this->tool->execute(['pattern' => 'x', 'path' => '../']),
+        );
+    }
+
+    #[Test]
+    public function reportsNoMatches(): void
+    {
+        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'zzz-not-there']));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->root, true);
+        parent::tearDown();
+    }
+}

--- a/Tests/Unit/Service/Tool/LogExceptionReaderTest.php
+++ b/Tests/Unit/Service/Tool/LogExceptionReaderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Parses realistic TYPO3 FileWriter records (ADR-044): error levels only,
+ * newest first, exception class + throw site + stack frames extracted from
+ * the JSON data suffix, search and time-window filters applied.
+ */
+#[CoversClass(LogExceptionReader::class)]
+final class LogExceptionReaderTest extends TestCase
+{
+    private string $logDir;
+
+    private LogExceptionReader $reader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logDir = sys_get_temp_dir() . '/nrllm-logs-' . bin2hex(random_bytes(4));
+        mkdir($this->logDir, 0o777, true);
+
+        $exceptionJson = json_encode([
+            'exception' => "JsonException: Malformed UTF-8 characters in /app/Classes/Provider/AbstractProvider.php:282\n"
+                . "Stack trace:\n"
+                . "#0 /app/Classes/Provider/AbstractProvider.php(282): json_encode()\n"
+                . '#1 /app/vendor/typo3/cms-core/Classes/Http/Dispatcher.php(50): run()',
+        ], JSON_THROW_ON_ERROR);
+
+        file_put_contents(
+            $this->logDir . '/typo3_abc.log',
+            'Mon, 06 Jul 2026 01:10:00 +0200 [INFO] request="r1" component="Some.Component": all fine' . "\n"
+            . 'Mon, 06 Jul 2026 01:12:00 +0200 [ERROR] request="r2" component="Vendor.Ext.Older": older failure' . "\n"
+            . 'Mon, 06 Jul 2026 01:13:18 +0200 [ERROR] request="r3" component="Netresearch.NrLlm.Controller": '
+            . 'Tool playground run failed - ' . $exceptionJson . "\n"
+            . 'Mon, 06 Jul 2026 01:14:00 +0200 [WARNING] request="r4" component="Some.Component": just a warning' . "\n",
+        );
+
+        $this->reader = new LogExceptionReader($this->logDir);
+    }
+
+    #[Test]
+    public function returnsOnlyErrorLevelsNewestFirst(): void
+    {
+        $entries = $this->reader->read(10);
+
+        self::assertCount(2, $entries);
+        self::assertSame('Netresearch.NrLlm.Controller', $entries[0]->component);
+        self::assertSame('Vendor.Ext.Older', $entries[1]->component);
+        self::assertGreaterThan($entries[1]->timestamp, $entries[0]->timestamp);
+    }
+
+    #[Test]
+    public function parsesExceptionClassThrowSiteAndFrames(): void
+    {
+        $entry = $this->reader->read(1)[0];
+
+        self::assertSame('JsonException', $entry->exceptionClass);
+        self::assertSame('Tool playground run failed', $entry->message);
+        self::assertNotSame([], $entry->frames);
+        // Throw site first, then the numbered frames.
+        self::assertSame('/app/Classes/Provider/AbstractProvider.php', $entry->frames[0]['file']);
+        self::assertSame(282, $entry->frames[0]['line']);
+        self::assertSame('(throw site)', $entry->frames[0]['call']);
+        self::assertSame('json_encode()', $entry->frames[1]['call']);
+    }
+
+    #[Test]
+    public function searchFiltersByMessageComponentOrClass(): void
+    {
+        self::assertCount(1, $this->reader->read(10, 'playground'));
+        self::assertCount(1, $this->reader->read(10, 'jsonexception'));
+        self::assertCount(1, $this->reader->read(10, 'Older'));
+        self::assertCount(0, $this->reader->read(10, 'no-such-thing'));
+    }
+
+    #[Test]
+    public function timeWindowFilters(): void
+    {
+        $probe = (int)strtotime('Mon, 06 Jul 2026 01:13:20 +0200');
+
+        $entries = $this->reader->read(10, null, $probe - 30, $probe + 30);
+
+        self::assertCount(1, $entries);
+        self::assertSame('JsonException', $entries[0]->exceptionClass);
+    }
+
+    #[Test]
+    public function emptyDirectoryYieldsNoEntries(): void
+    {
+        $empty = sys_get_temp_dir() . '/nrllm-logs-empty-' . bin2hex(random_bytes(4));
+        mkdir($empty, 0o777, true);
+
+        self::assertSame([], (new LogExceptionReader($empty))->read());
+
+        rmdir($empty);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->logDir, true);
+        parent::tearDown();
+    }
+}

--- a/Tests/Unit/Service/Tool/SourcePathGuardTest.php
+++ b/Tests/Unit/Service/Tool/SourcePathGuardTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Load-bearing security tests for the path gate (ADR-044): traversal,
+ * symlink escape, dotfiles, settings.php, key material and var/* must all
+ * fail closed; var/log and ordinary source files pass; secret assignment
+ * lines are value-redacted.
+ */
+#[CoversClass(SourcePathGuard::class)]
+final class SourcePathGuardTest extends TestCase
+{
+    private string $root;
+
+    private string $outside;
+
+    private SourcePathGuard $guard;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $base = sys_get_temp_dir() . '/nrllm-guard-' . bin2hex(random_bytes(4));
+        $this->root    = $base . '/project';
+        $this->outside = $base . '/outside';
+
+        foreach (
+            [
+                $this->root . '/Classes',
+                $this->root . '/config/system',
+                $this->root . '/var/log',
+                $this->root . '/var/session',
+                $this->root . '/.ddev',
+                $this->outside,
+            ] as $dir
+        ) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($this->root . '/Classes/Service.php', "<?php\n\$a = 1;\n\$apiKey = 'super-secret';\n\$b = 2;\n");
+        file_put_contents($this->root . '/config/system/settings.php', "<?php return ['db' => 'secret'];");
+        file_put_contents($this->root . '/config/additional.php', '<?php // creds');
+        file_put_contents($this->root . '/var/log/typo3_abc.log', 'log line');
+        file_put_contents($this->root . '/var/session/sess.dat', 'session');
+        file_put_contents($this->root . '/.ddev/config.yaml', 'name: x');
+        file_put_contents($this->root . '/.env', 'TOKEN=x');
+        file_put_contents($this->root . '/server.key', 'PRIVATE KEY');
+        file_put_contents($this->outside . '/secret.php', '<?php // outside');
+        symlink($this->outside . '/secret.php', $this->root . '/Classes/escape.php');
+
+        $this->guard = new SourcePathGuard($this->root);
+    }
+
+    #[Test]
+    public function resolvesAnOrdinarySourceFile(): void
+    {
+        self::assertNotNull($this->guard->resolve('Classes/Service.php'));
+        self::assertNotNull($this->guard->resolve('var/log/typo3_abc.log'));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function deniedPaths(): array
+    {
+        return [
+            'traversal out of root'  => ['Classes/../../outside/secret.php'],
+            'dotfile'                => ['.env'],
+            'dot directory'          => ['.ddev/config.yaml'],
+            'settings.php'           => ['config/system/settings.php'],
+            'additional.php'         => ['config/additional.php'],
+            'key material'           => ['server.key'],
+            'var outside log'        => ['var/session/sess.dat'],
+            'symlink escaping root'  => ['Classes/escape.php'],
+            'missing file'           => ['Classes/Nope.php'],
+            'empty path'             => [''],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('deniedPaths')]
+    public function deniesPath(string $path): void
+    {
+        self::assertNull($this->guard->resolve($path));
+    }
+
+    #[Test]
+    public function deniesAbsolutePathOutsideRoot(): void
+    {
+        self::assertNull($this->guard->resolve($this->outside . '/secret.php'));
+    }
+
+    #[Test]
+    public function deniesCredentialMentioningPath(): void
+    {
+        self::assertTrue($this->guard->isDeniedRelativePath('Classes/CredentialStore.php'));
+    }
+
+    #[Test]
+    public function readLinesIsRangedNumberedAndSecretRedacted(): void
+    {
+        $read = $this->guard->readLines('Classes/Service.php', 2, 2);
+
+        self::assertNotNull($read);
+        self::assertSame(5, $read['total']);
+        self::assertSame([2, 3], array_keys($read['lines']));
+        self::assertSame('$a = 1;', $read['lines'][2]);
+        self::assertStringContainsString('[redacted]', $read['lines'][3]);
+        self::assertStringNotContainsString('super-secret', $read['lines'][3]);
+    }
+
+    #[Test]
+    public function readLinesDeniedPathIsNull(): void
+    {
+        self::assertNull($this->guard->readLines('config/system/settings.php', 1, 5));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir(dirname($this->root), true);
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Wave 2 — **error-analysis tools** (group `code`, admin-only; `probe_url` in `system`). ADR-044. Covers the "why is URL X a 500 / how do I fix this PHP error" use cases.

## Tools

| Tool | Does |
|---|---|
| `get_last_exception` | Newest exception(s) from `var/log/typo3_*.log` — parsed level/component/message/class/trace, with **±6 lines of source context** on the project stack frames. Redacted. |
| `read_source` | Read a file + line range, line-numbered. Fail-closed path guard. |
| `search_code` | Grep project sources (literal or opt-in regex), vendor/var/.git pruned, time/size budget. |
| `probe_url` | GET one of the instance's OWN site URLs; reports status/headers/timing/body excerpt, and on ≥500 auto-appends the correlated `var/log` exception (±30s). |

## Safety (fail-closed, unit-tested)

- **`SourcePathGuard`** (shared): realpath must stay under the project root; denies dotfiles (`.env`/`.git`/`.ddev`), `config/system/{settings,additional}.php`, `*.key/*.pem/*.crt`, `credential`-paths; symlink-escape blocked; secret-ish lines redacted. `read_source`/`search_code` use it; `search_code` restricts to source extensions.
- **`probe_url` SSRF containment:** http(s) only; host:port must match a configured site host (`SiteFinder`); relative paths resolve against the first site base; `allow_redirects=false` (a cross-host redirect is reported, not followed).
- **`LogExceptionReader`** (shared by get_last_exception + probe_url correlation): parses the log, redacts via ErrorMessageSanitizer.

## Notes

- No `@`-suppression (project PHPStan bans it) — `is_readable`/`is_file` guards + a scoped handler for regex validity.
- Verified: cgl, rector, phpstan (L10), unit (3979), targeted functional, architecture. Live on ddev: probe_url 200/404 on own site; get_last_exception parsed a seeded log entry with source context; read_source denied `settings.php`; search_code pruned vendor/.
- Groups: `code` (get_last_exception, read_source, search_code) + `probe_url` in `system` — toggleable via the #322 grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
