### PR TITLE
feat(tools): record history, URL resolution, TCA and TypoScript validation

### DIFF
--- a/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\IncludeNode\IncludeInterface;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateTreeBuilder;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\Traverser\IncludeTreeTraverser;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\Visitor\IncludeTreeSyntaxScannerVisitor;
+use TYPO3\CMS\Core\TypoScript\Tokenizer\Line\LineInterface;
+use TYPO3\CMS\Core\TypoScript\Tokenizer\LosslessTokenizer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+/**
+ * Scan the TypoScript effective on a page for syntax errors (ADR-046) — the
+ * "prüfe TypoScript auf Fehler" tool.
+ *
+ * Builds the constants and setup include trees for the page's sys_template
+ * chain (rootline → sys_template rows → include tree, same resolution as
+ * {@see GetTypoScriptTool}) and runs the core
+ * :php:`IncludeTreeSyntaxScannerVisitor` over both — the same scanner the
+ * backend's TypoScript module uses to mark broken syntax: invalid lines,
+ * excess/missing braces, `@import` statements matching no file.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): ADMIN-only, in
+ * line with get_typoscript — and errors are reported as source + line number
+ * + error kind only. The offending line's CONTENT is never echoed: a broken
+ * constants line may carry an API key.
+ */
+final readonly class CheckTypoScriptTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NEUTRAL_ERROR = 'Page not found or no TypoScript template.';
+
+    /** Upper bound on reported errors per run. */
+    private const MAX_ERRORS = 50;
+
+    private const ERROR_TEXT = [
+        'line.invalid'  => 'invalid line syntax',
+        'brace.excess'  => 'excess closing "}"',
+        'brace.missing' => 'missing closing "}"',
+        'import.empty'  => '@import matches no file',
+    ];
+
+    public function __construct(
+        private SysTemplateRepository $sysTemplateRepository,
+        private SysTemplateTreeBuilder $treeBuilder,
+        private SiteFinder $siteFinder,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'check_typoscript',
+            'Scan the TypoScript effective on a page (constants and setup) for syntax errors: invalid '
+            . 'lines, unbalanced braces, @import statements that match no file. Reports source and line '
+            . 'number per error.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'pageUid' => [
+                        'type'        => 'integer',
+                        'description' => 'The page uid whose TypoScript chain to check.',
+                    ],
+                ],
+                'required' => ['pageUid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $pageUid = self::toInt($arguments['pageUid'] ?? 0);
+        if ($pageUid < 1) {
+            return self::NEUTRAL_ERROR;
+        }
+
+        try {
+            $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid)->get();
+            $site     = $this->siteFinder->getSiteByPageId($pageUid);
+            $request  = (new ServerRequest())->withAttribute('site', $site);
+
+            $sysTemplateRows = $this->sysTemplateRepository->getSysTemplateRowsByRootline($rootline, $request);
+            if ($sysTemplateRows === []) {
+                return self::NEUTRAL_ERROR;
+            }
+
+            $errors = [];
+            foreach (['constants', 'setup'] as $type) {
+                $root = $this->treeBuilder->getTreeBySysTemplateRowsAndSite(
+                    $type,
+                    $sysTemplateRows,
+                    new LosslessTokenizer(),
+                    $site,
+                );
+                $scanner = new IncludeTreeSyntaxScannerVisitor();
+                (new IncludeTreeTraverser())->traverse($root, [$scanner]);
+                foreach ($scanner->getErrors() as $error) {
+                    $errors[] = $this->renderError($type, $error);
+                }
+            }
+        } catch (Throwable) {
+            // Deliberately neutral: rootline/site/template resolution failures
+            // must not leak exception internals into the provider egress.
+            return self::NEUTRAL_ERROR;
+        }
+
+        $errors = array_values(array_unique($errors));
+        if ($errors === []) {
+            return sprintf(
+                'No TypoScript syntax errors on page %d (constants and setup of %d sys_template row%s checked).',
+                $pageUid,
+                count($sysTemplateRows),
+                count($sysTemplateRows) === 1 ? '' : 's',
+            );
+        }
+
+        $total = count($errors);
+        if ($total > self::MAX_ERRORS) {
+            $errors   = array_slice($errors, 0, self::MAX_ERRORS);
+            $errors[] = sprintf('… %d more errors not shown', $total - self::MAX_ERRORS);
+        }
+
+        return sprintf("TypoScript syntax errors on page %d (%d):\n", $pageUid, $total)
+            . '- ' . implode("\n- ", $errors);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only, like get_typoscript: the scanned chain is configuration
+        // an editor has no business enumerating.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'configuration';
+    }
+
+    /**
+     * One error as "source, line N: kind" — the line CONTENT is never
+     * included (constants may carry credentials).
+     *
+     * @param array{type: string, include: IncludeInterface, line: LineInterface, lineNumber: int} $error
+     */
+    private function renderError(string $type, array $error): string
+    {
+        $name = $error['include']->getName();
+
+        return sprintf(
+            '[%s] %s, line %d: %s',
+            $type,
+            $name !== '' ? $name : '(unnamed include)',
+            $error['lineNumber'],
+            self::ERROR_TEXT[$error['type']] ?? $error['type'],
+        );
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
+++ b/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
@@ -1,0 +1,324 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\History\RecordHistoryStore;
+
+/**
+ * The "who changed this record" tool (ADR-046).
+ *
+ * Renders a record's change history from `sys_history` newest-first: when,
+ * who (resolved backend username), what action, and — for modifications —
+ * the changed fields as `old → new` value pairs.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): fail-closed
+ * without a backend user; the TARGET table passes
+ * {@see TableReadAccessService::canReadTable()} (sensitive-table denylist for
+ * everyone, `tables_select` for non-admins) with the same neutral denial as
+ * the schema tools. Values of credential-like fields are never rendered —
+ * only the fact that they changed. All values are length-capped.
+ */
+final readonly class GetRecordHistoryTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Table not found or not permitted.';
+
+    private const DEFAULT_LIMIT = 10;
+
+    private const MAX_LIMIT = 20;
+
+    /** Per-value render cap, keeps one entry roughly one line. */
+    private const VALUE_WIDTH = 120;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private TableReadAccessService $tableAccess,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_record_history',
+            'Show the change history of one record (from sys_history): when, which backend user, and '
+            . 'which fields changed with old → new values. Use to answer "who changed X and when".',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'The record\'s table (e.g. "tt_content", "pages").',
+                    ],
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'The record uid.',
+                    ],
+                    'field' => [
+                        'type'        => 'string',
+                        'description' => 'Optional column name — only show changes touching this field (e.g. "header").',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum history entries (default 10, capped at 20).',
+                    ],
+                ],
+                'required' => ['table', 'uid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $table = trim(self::toStr($arguments['table'] ?? ''));
+        $uid   = self::toInt($arguments['uid'] ?? 0);
+        if ($table === '' || $uid < 1) {
+            return self::NOT_PERMITTED;
+        }
+
+        $user = $this->actingBackendUser();
+        if (!$this->tableAccess->canReadTable($user, $table)) {
+            // Same neutral string whether unknown, denylisted or unpermitted.
+            return self::NOT_PERMITTED;
+        }
+
+        $fieldFilter = trim(self::toStr($arguments['field'] ?? ''));
+        $limit       = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        $limit       = max(1, min(self::MAX_LIMIT, $limit));
+
+        $rows = $this->fetchHistory($table, $uid, $limit);
+        if ($rows === []) {
+            return sprintf('No change history for %s:%d.', $table, $uid);
+        }
+
+        $usernames = $this->resolveUsernames($rows);
+
+        $entries = [];
+        $skipped = 0;
+        foreach ($rows as $row) {
+            $changes = $this->renderChanges($row, $fieldFilter);
+            if ($fieldFilter !== '' && $changes === null) {
+                ++$skipped;
+                continue;
+            }
+
+            $entries[] = sprintf(
+                '- %s UTC by %s (%s)%s%s',
+                gmdate('Y-m-d H:i', self::toInt($row['tstamp'] ?? 0)),
+                $usernames[self::toInt($row['userid'] ?? 0)] ?? '(unknown)',
+                $this->actionWord(self::toInt($row['actiontype'] ?? 0)),
+                $this->impersonationSuffix($row, $usernames),
+                $changes !== null && $changes !== '' ? ': ' . $changes : '',
+            );
+        }
+
+        if ($entries === []) {
+            return sprintf(
+                'No changes touching "%s" in the last %d history entries of %s:%d.',
+                $fieldFilter,
+                count($rows),
+                $table,
+                $uid,
+            );
+        }
+
+        $header = sprintf(
+            'Change history for %s:%d (%d %s, newest first%s):',
+            $table,
+            $uid,
+            count($entries),
+            count($entries) === 1 ? 'entry' : 'entries',
+            $fieldFilter !== '' ? sprintf(', filtered to "%s"', $fieldFilter) : '',
+        );
+        if ($skipped > 0) {
+            $entries[] = sprintf('(%d entries not touching "%s" skipped.)', $skipped, $fieldFilter);
+        }
+
+        return $header . "\n" . implode("\n", $entries);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces table read access.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'content';
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchHistory(string $table, int $uid, int $limit): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_history');
+
+        $rows = $queryBuilder
+            ->select('tstamp', 'actiontype', 'userid', 'originaluserid', 'history_data')
+            ->from('sys_history')
+            ->where(
+                $queryBuilder->expr()->eq('tablename', $queryBuilder->createNamedParameter($table)),
+                $queryBuilder->expr()->eq('recuid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+            )
+            ->orderBy('tstamp', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_values($rows);
+    }
+
+    /**
+     * One batched uid → username lookup for all user ids in the result set.
+     *
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<int, string>
+     */
+    private function resolveUsernames(array $rows): array
+    {
+        $uids = [];
+        foreach ($rows as $row) {
+            foreach (['userid', 'originaluserid'] as $key) {
+                $userUid = self::toInt($row[$key] ?? 0);
+                if ($userUid > 0) {
+                    $uids[$userUid] = true;
+                }
+            }
+        }
+        if ($uids === []) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
+        // History must name authors even when their account is meanwhile
+        // disabled or deleted — only the username egresses, nothing else.
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $userRows = $queryBuilder
+            ->select('uid', 'username')
+            ->from('be_users')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->createNamedParameter(array_keys($uids), Connection::PARAM_INT_ARRAY),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $map = [];
+        foreach ($userRows as $userRow) {
+            $map[self::toInt($userRow['uid'] ?? 0)] = self::toStr($userRow['username'] ?? '');
+        }
+
+        return $map;
+    }
+
+    /**
+     * The changed fields of one history row as `field: 'old' → 'new'` pairs.
+     * Null when a field filter is set and the row does not touch it.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function renderChanges(array $row, string $fieldFilter): ?string
+    {
+        $data = json_decode(self::toStr($row['history_data'] ?? ''), true);
+        if (!is_array($data)) {
+            return $fieldFilter === '' ? '' : null;
+        }
+
+        $old = is_array($data['oldRecord'] ?? null) ? $data['oldRecord'] : [];
+        $new = is_array($data['newRecord'] ?? null) ? $data['newRecord'] : [];
+        if ($old === [] && $new === []) {
+            return $fieldFilter === '' ? '' : null;
+        }
+
+        $fields = array_unique(array_merge(array_keys($old), array_keys($new)));
+        $parts  = [];
+        foreach ($fields as $field) {
+            $fieldName = (string)$field;
+            if ($fieldFilter !== '' && $fieldName !== $fieldFilter) {
+                continue;
+            }
+            // Credential-like fields: the change is visible, the values are not.
+            if ($this->tableAccess->isSensitiveField($fieldName)) {
+                $parts[] = sprintf('%s: [changed — detail withheld]', $fieldName);
+                continue;
+            }
+            $parts[] = sprintf(
+                "%s: '%s' → '%s'",
+                $fieldName,
+                $this->renderValue($old[$fieldName] ?? null),
+                $this->renderValue($new[$fieldName] ?? null),
+            );
+        }
+
+        if ($parts === []) {
+            return $fieldFilter === '' ? '' : null;
+        }
+
+        return implode('; ', $parts);
+    }
+
+    private function renderValue(mixed $value): string
+    {
+        if ($value === null) {
+            return '(unset)';
+        }
+        if (!is_scalar($value)) {
+            return '[complex value]';
+        }
+
+        $text = trim((string)preg_replace('/\s+/', ' ', (string)$value));
+
+        return mb_strimwidth($text, 0, self::VALUE_WIDTH, '…');
+    }
+
+    private function actionWord(int $actionType): string
+    {
+        return match ($actionType) {
+            RecordHistoryStore::ACTION_ADD      => 'add',
+            RecordHistoryStore::ACTION_MODIFY   => 'modify',
+            RecordHistoryStore::ACTION_MOVE     => 'move',
+            RecordHistoryStore::ACTION_DELETE   => 'delete',
+            RecordHistoryStore::ACTION_UNDELETE => 'undelete',
+            default                             => sprintf('action #%d', $actionType),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, string>   $usernames
+     */
+    private function impersonationSuffix(array $row, array $usernames): string
+    {
+        $original = self::toInt($row['originaluserid'] ?? 0);
+        if ($original < 1 || $original === self::toInt($row['userid'] ?? 0)) {
+            return '';
+        }
+
+        return sprintf(' via impersonation by %s', $usernames[$original] ?? '(unknown)');
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
+++ b/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
@@ -13,9 +13,12 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\History\RecordHistoryStore;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
  * The "who changed this record" tool (ADR-046).
@@ -28,8 +31,10 @@ use TYPO3\CMS\Core\DataHandling\History\RecordHistoryStore;
  * without a backend user; the TARGET table passes
  * {@see TableReadAccessService::canReadTable()} (sensitive-table denylist for
  * everyone, `tables_select` for non-admins) with the same neutral denial as
- * the schema tools. Values of credential-like fields are never rendered —
- * only the fact that they changed. All values are length-capped.
+ * the schema tools, and non-admins additionally need PAGE_SHOW on the
+ * record's page (same per-row gate as read_records). Values of
+ * credential-like fields are never rendered — only the fact that they
+ * changed. All values are length-capped.
  */
 final readonly class GetRecordHistoryTool implements ToolInterface
 {
@@ -92,6 +97,13 @@ final readonly class GetRecordHistoryTool implements ToolInterface
         $user = $this->actingBackendUser();
         if (!$this->tableAccess->canReadTable($user, $table)) {
             // Same neutral string whether unknown, denylisted or unpermitted.
+            return self::NOT_PERMITTED;
+        }
+
+        // Non-admins must hold PAGE_SHOW on the record's page (same gate as
+        // read_records) — history values must not leak from unreadable pages.
+        // Fail-closed: an unresolvable record (e.g. hard-deleted) denies too.
+        if ($user !== null && !$user->isAdmin() && !$this->recordPageIsReadable($user, $table, $uid)) {
             return self::NOT_PERMITTED;
         }
 
@@ -164,6 +176,29 @@ final readonly class GetRecordHistoryTool implements ToolInterface
     public function getGroup(): string
     {
         return 'content';
+    }
+
+    /**
+     * True when the record's page passes the acting non-admin's PAGE_SHOW
+     * permission ({@see ReadRecordsTool} applies the same per-row gate). The
+     * record row is loaded ignoring enable-fields but not soft-delete; a
+     * record that cannot be resolved denies (fail-closed).
+     */
+    private function recordPageIsReadable(BackendUserAuthentication $user, string $table, int $uid): bool
+    {
+        $row = BackendUtility::getRecord($table, $uid, 'uid,pid');
+        if (!is_array($row)) {
+            return false;
+        }
+
+        $pageUid = $table === 'pages' ? self::toInt($row['uid'] ?? 0) : self::toInt($row['pid'] ?? 0);
+        if ($pageUid < 1) {
+            return false;
+        }
+
+        $permsClause = self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
+
+        return is_array(BackendUtility::readPageAccess($pageUid, $permsClause));
     }
 
     /**

--- a/Classes/Service/Tool/Builtin/ResolveUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ResolveUrlTool.php
@@ -144,11 +144,19 @@ final readonly class ResolveUrlTool implements ToolInterface
     }
 
     /**
-     * Absolute http(s) URL for the input; a "/path" resolves against the
-     * first configured site. Null when nothing sensible can be built.
+     * Absolute http(s) URL for the input; a path (with or without leading
+     * slash) resolves against the first configured site. Null when nothing
+     * sensible can be built.
      */
     private function absoluteUrl(string $input): ?string
     {
+        // Schemeless input like "imprint" or "en/imprint" is a path too —
+        // "//host/…" (protocol-relative) is deliberately NOT, it falls
+        // through to the scheme check below and is rejected there.
+        if (!str_contains($input, '://') && !str_starts_with($input, '/')) {
+            $input = '/' . $input;
+        }
+
         if (str_starts_with($input, '/') && !str_starts_with($input, '//')) {
             $base = $this->firstSiteBase();
             if ($base === null) {
@@ -168,11 +176,23 @@ final readonly class ResolveUrlTool implements ToolInterface
 
     private function firstSiteBase(): ?string
     {
+        $relativeBase = null;
         foreach ($this->siteFinder->getAllSites() as $site) {
             $base = (string)$site->getBase();
-            if ($base !== '' && $site->getBase()->getHost() !== '') {
+            if ($base === '') {
+                continue;
+            }
+            if ($site->getBase()->getHost() !== '') {
                 return $base;
             }
+            $relativeBase ??= $base;
+        }
+
+        // Sites with a relative base (`base: /`) match ANY host in the
+        // SiteMatcher, so for this routing-only resolution a placeholder
+        // host suffices — no request is ever sent to it.
+        if ($relativeBase !== null) {
+            return 'http://localhost/' . ltrim($relativeBase, '/');
         }
 
         return null;

--- a/Classes/Service/Tool/Builtin/ResolveUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ResolveUrlTool.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Routing\RouteNotFoundException;
+use TYPO3\CMS\Core\Routing\SiteMatcher;
+use TYPO3\CMS\Core\Routing\SiteRouteResult;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+
+/**
+ * Map a URL of this instance to the page (and route arguments) that serves
+ * it — routing only, no HTTP request is made (ADR-046).
+ *
+ * The answer to "which page is behind /imprint?" and the first step of
+ * "why does URL X misbehave?": site + language + page uid/title/slug, ready
+ * for a follow-up with get_page_content or probe_url.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): no allowlist is
+ * needed — {@see SiteMatcher} only knows THIS instance's sites, so a foreign
+ * host cannot match by construction and is reported neutrally. Fail-closed
+ * without a backend user; non-admins must hold PAGE_SHOW on the resolved
+ * page (same neutral denial as get_page_content, so page existence cannot
+ * be probed).
+ */
+final readonly class ResolveUrlTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Page not found or not permitted.';
+
+    private const NO_SITE = 'Not a URL of this instance (no site matches).';
+
+    /** Render cap for the route/query argument dump. */
+    private const ARGS_WIDTH = 300;
+
+    public function __construct(
+        private SiteMatcher $siteMatcher,
+        private SiteFinder $siteFinder,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'resolve_url',
+            'Resolve a URL of THIS TYPO3 instance to the page that serves it: site, language, page '
+            . 'uid/title/slug and route arguments. Routing only — no request is sent. '
+            . 'Use probe_url to actually fetch the URL.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'url' => [
+                        'type'        => 'string',
+                        'description' => 'Absolute URL on one of this instance\'s sites, or a path like "/imprint" (resolved against the first site).',
+                    ],
+                ],
+                'required' => ['url'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $input = trim(self::toStr($arguments['url'] ?? ''));
+        if ($input === '') {
+            return 'Error: "url" is required.';
+        }
+
+        $user = $this->actingBackendUser();
+        if ($user === null) {
+            return self::NOT_PERMITTED;
+        }
+
+        $url = $this->absoluteUrl($input);
+        if ($url === null) {
+            return self::NO_SITE;
+        }
+
+        try {
+            $request     = new ServerRequest($url, 'GET');
+            $routeResult = $this->siteMatcher->matchRequest($request);
+        } catch (Throwable) {
+            return self::NO_SITE;
+        }
+
+        if (!$routeResult instanceof SiteRouteResult) {
+            return self::NO_SITE;
+        }
+        $site = $routeResult->getSite();
+        if (!$site instanceof Site) {
+            // NullSite: the host/path prefix belongs to no configured site.
+            return self::NO_SITE;
+        }
+
+        try {
+            $pageArguments = $site->getRouter()->matchRequest($request, $routeResult);
+        } catch (RouteNotFoundException) {
+            return sprintf(
+                'No page route matches "%s" on site "%s" — the slug may not exist, or the page is hidden/not translated.',
+                $this->pathOf($url),
+                $site->getIdentifier(),
+            );
+        } catch (Throwable) {
+            return self::NO_SITE;
+        }
+
+        if (!$pageArguments instanceof PageArguments) {
+            return self::NO_SITE;
+        }
+
+        return $this->renderResult($site, $routeResult, $pageArguments, $user->isAdmin());
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces PAGE_SHOW on the page.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'structure';
+    }
+
+    /**
+     * Absolute http(s) URL for the input; a "/path" resolves against the
+     * first configured site. Null when nothing sensible can be built.
+     */
+    private function absoluteUrl(string $input): ?string
+    {
+        if (str_starts_with($input, '/') && !str_starts_with($input, '//')) {
+            $base = $this->firstSiteBase();
+            if ($base === null) {
+                return null;
+            }
+
+            return rtrim($base, '/') . $input;
+        }
+
+        $scheme = strtolower(self::toStr(parse_url($input, PHP_URL_SCHEME) ?: ''));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            return null;
+        }
+
+        return $input;
+    }
+
+    private function firstSiteBase(): ?string
+    {
+        foreach ($this->siteFinder->getAllSites() as $site) {
+            $base = (string)$site->getBase();
+            if ($base !== '' && $site->getBase()->getHost() !== '') {
+                return $base;
+            }
+        }
+
+        return null;
+    }
+
+    private function pathOf(string $url): string
+    {
+        return self::toStr(parse_url($url, PHP_URL_PATH) ?: '/');
+    }
+
+    private function renderResult(
+        Site $site,
+        SiteRouteResult $routeResult,
+        PageArguments $pageArguments,
+        bool $isAdmin,
+    ): string {
+        $pageUid = $pageArguments->getPageId();
+
+        // Non-admins must hold PAGE_SHOW on the resolved page; a missing page
+        // and a denied page are indistinguishable in the reply (fail-closed).
+        if (!$isAdmin) {
+            $user        = $this->actingBackendUser();
+            $permsClause = $user !== null ? self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW)) : '1=0';
+            if ($user === null || !is_array(BackendUtility::readPageAccess($pageUid, $permsClause))) {
+                return self::NOT_PERMITTED;
+            }
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageUid, 'uid, title, slug, doktype, hidden');
+        if (!is_array($page)) {
+            return self::NOT_PERMITTED;
+        }
+
+        $language = $routeResult->getLanguage();
+
+        $lines   = [];
+        $lines[] = sprintf('Site: %s (base %s)', $site->getIdentifier(), (string)$site->getBase());
+        if ($language !== null) {
+            $lines[] = sprintf('Language: %d (%s)', $language->getLanguageId(), (string)$language->getLocale());
+        }
+        $lines[] = sprintf(
+            'Page: [%d] %s (doktype %d, slug %s)%s',
+            self::toInt($page['uid'] ?? 0),
+            self::toStr($page['title'] ?? ''),
+            self::toInt($page['doktype'] ?? 0),
+            self::toStr($page['slug'] ?? '') !== '' ? self::toStr($page['slug'] ?? '') : '-',
+            self::toInt($page['hidden'] ?? 0) === 1 ? ' [hidden]' : '',
+        );
+
+        $routeArguments = $pageArguments->getRouteArguments();
+        if ($routeArguments !== []) {
+            $lines[] = 'Route arguments: ' . $this->renderArguments($routeArguments);
+        }
+        $queryArguments = $pageArguments->getQueryArguments();
+        if ($queryArguments !== []) {
+            $lines[] = 'Query arguments: ' . $this->renderArguments($queryArguments);
+        }
+
+        $lines[] = 'Use get_page_content(uid) for the content.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<array-key, mixed> $arguments
+     */
+    private function renderArguments(array $arguments): string
+    {
+        $json = json_encode($arguments, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (!is_string($json)) {
+            return '[unrenderable]';
+        }
+
+        return mb_strimwidth($json, 0, self::ARGS_WIDTH, '…');
+    }
+}

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Deterministic structural TCA checks (ADR-046): the "prüfe TCA auf Fehler"
+ * answer an LLM cannot compute reliably by reading the schema alone.
+ *
+ * Checks per table: `ctrl.label`/`ctrl.type` name defined columns; every
+ * `foreign_table` is a TCA table; `types`/`palettes` showitem entries
+ * reference defined columns and palettes; `ds_pointerField` on flex fields
+ * is flagged on TYPO3 v14+ (removed there). Pure array walking over the
+ * live `$GLOBALS['TCA']` — the core :php:`TcaMigration` is NOT reusable
+ * here because it only reports while migrating the raw, pre-boot TCA.
+ *
+ * Security contract (see {@see ToolInterface} and ADR-042): only tables
+ * passing {@see TableReadAccessService::canReadTable()} are validated (the
+ * denylist holds for admins too); single-table mode answers with the same
+ * neutral denial as the schema tools. Findings name schema keys, never data.
+ */
+final readonly class ValidateTcaTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Table not found or not permitted.';
+
+    /** Global cap on emitted findings. */
+    private const MAX_FINDINGS = 50;
+
+    /** Row-level fields that are valid targets without being TCA columns. */
+    private const IMPLICIT_FIELDS = ['uid', 'pid'];
+
+    public function __construct(
+        private TableReadAccessService $tableAccess,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'validate_tca',
+            'Run structural checks over the TCA and report misconfigurations: label/type fields that do '
+            . 'not exist, foreign_table references to unknown tables, showitem entries referencing '
+            . 'undefined columns or palettes. Omit "table" to scan all accessible tables.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'Optional: validate only this table (e.g. "tx_myext_item").',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $allTca = $GLOBALS['TCA'] ?? null;
+        if (!is_array($allTca) || $allTca === []) {
+            return 'No TCA available.';
+        }
+
+        $user  = $this->actingBackendUser();
+        $table = trim(self::toStr($arguments['table'] ?? ''));
+
+        if ($table !== '') {
+            if (!$this->tableAccess->canReadTable($user, $table) || !is_array($allTca[$table] ?? null)) {
+                return self::NOT_PERMITTED;
+            }
+
+            $findings = $this->validateTable($table, $allTca[$table], $allTca);
+            if ($findings === []) {
+                return sprintf('No TCA issues found in table "%s".', $table);
+            }
+
+            return $this->render($findings, 1);
+        }
+
+        $findings = [];
+        $checked  = 0;
+        foreach ($allTca as $name => $definition) {
+            $tableName = (string)$name;
+            if (!is_array($definition) || !$this->tableAccess->canReadTable($user, $tableName)) {
+                continue;
+            }
+            ++$checked;
+            foreach ($this->validateTable($tableName, $definition, $allTca) as $finding) {
+                $findings[] = $finding;
+            }
+        }
+
+        if ($findings === []) {
+            return sprintf('No TCA issues found in %d checked tables.', $checked);
+        }
+
+        return $this->render($findings, $checked);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; execute() self-enforces table read access.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'structure';
+    }
+
+    /**
+     * @param array<mixed>            $tca
+     * @param array<array-key, mixed> $allTca
+     *
+     * @return list<string>
+     */
+    private function validateTable(string $table, array $tca, array $allTca): array
+    {
+        $ctrl     = is_array($tca['ctrl'] ?? null) ? $tca['ctrl'] : [];
+        $columns  = is_array($tca['columns'] ?? null) ? $tca['columns'] : [];
+        $palettes = is_array($tca['palettes'] ?? null) ? $tca['palettes'] : [];
+
+        $findings = [];
+
+        // 1. ctrl.label must name a defined column.
+        $label = self::toStr($ctrl['label'] ?? '');
+        if ($label === '') {
+            $findings[] = sprintf('%s: ctrl.label is not set', $table);
+        } elseif (!$this->isKnownField($label, $columns)) {
+            $findings[] = sprintf('%s: ctrl.label "%s" is not a defined column', $table, $label);
+        }
+
+        // 2. ctrl.type (record type field; "field:pointer" takes the first part).
+        $typeField = self::toStr($ctrl['type'] ?? '');
+        if ($typeField !== '') {
+            $first = trim(explode(':', $typeField)[0]);
+            if ($first !== '' && !$this->isKnownField($first, $columns)) {
+                $findings[] = sprintf('%s: ctrl.type "%s" is not a defined column', $table, $first);
+            }
+        }
+
+        // 3. Relational configs must point at existing TCA tables; 6. flex
+        //    ds_pointerField no longer exists on v14.
+        $v14Plus = (new Typo3Version())->getMajorVersion() >= 14;
+        foreach ($columns as $field => $column) {
+            $config = is_array($column) && is_array($column['config'] ?? null) ? $column['config'] : [];
+
+            $foreign = self::toStr($config['foreign_table'] ?? '');
+            if ($foreign !== '' && !is_array($allTca[$foreign] ?? null)) {
+                $findings[] = sprintf(
+                    '%s: column "%s" foreign_table "%s" is not a TCA table',
+                    $table,
+                    (string)$field,
+                    $foreign,
+                );
+            }
+
+            if ($v14Plus
+                && self::toStr($config['type'] ?? '') === 'flex'
+                && isset($config['ds_pointerField'])
+            ) {
+                $findings[] = sprintf(
+                    '%s: column "%s" uses ds_pointerField — removed in TYPO3 v14 (use record types)',
+                    $table,
+                    (string)$field,
+                );
+            }
+        }
+
+        // 4. types[*].showitem references.
+        $types = is_array($tca['types'] ?? null) ? $tca['types'] : [];
+        foreach ($types as $typeName => $typeConf) {
+            $showitem = is_array($typeConf) ? self::toStr($typeConf['showitem'] ?? '') : '';
+            foreach ($this->showitemFindings($showitem, $columns, $palettes) as $message) {
+                $findings[] = sprintf('%s: types[%s] %s', $table, (string)$typeName, $message);
+            }
+        }
+
+        // 5. palettes[*].showitem references (no palette nesting allowed).
+        foreach ($palettes as $paletteName => $paletteConf) {
+            $showitem = is_array($paletteConf) ? self::toStr($paletteConf['showitem'] ?? '') : '';
+            foreach ($this->showitemFindings($showitem, $columns, null) as $message) {
+                $findings[] = sprintf('%s: palettes[%s] %s', $table, (string)$paletteName, $message);
+            }
+        }
+
+        return array_values(array_unique($findings));
+    }
+
+    /**
+     * Findings for one showitem string. With $palettes === null, palette
+     * references themselves are flagged (palettes cannot nest).
+     *
+     * @param array<array-key, mixed>      $columns
+     * @param array<array-key, mixed>|null $palettes
+     *
+     * @return list<string>
+     */
+    private function showitemFindings(string $showitem, array $columns, ?array $palettes): array
+    {
+        $findings = [];
+        foreach (explode(',', $showitem) as $item) {
+            $parts     = explode(';', trim($item));
+            $fieldName = trim($parts[0]);
+
+            if ($fieldName === '' || $fieldName === '--div--' || $fieldName === '--linebreak--') {
+                continue;
+            }
+
+            if ($fieldName === '--palette--') {
+                $paletteName = trim($parts[2] ?? '');
+                if ($palettes === null) {
+                    $findings[] = 'nests a --palette-- reference (palettes cannot contain palettes)';
+                } elseif ($paletteName === '' || !is_array($palettes[$paletteName] ?? null)) {
+                    $findings[] = sprintf('references unknown palette "%s"', $paletteName);
+                }
+                continue;
+            }
+
+            if (!$this->isKnownField($fieldName, $columns)) {
+                $findings[] = sprintf('showitem references undefined column "%s"', $fieldName);
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<array-key, mixed> $columns
+     */
+    private function isKnownField(string $field, array $columns): bool
+    {
+        return isset($columns[$field]) || in_array($field, self::IMPLICIT_FIELDS, true);
+    }
+
+    /**
+     * @param list<string> $findings
+     */
+    private function render(array $findings, int $checked): string
+    {
+        $total = count($findings);
+        if ($total > self::MAX_FINDINGS) {
+            $findings   = array_slice($findings, 0, self::MAX_FINDINGS);
+            $findings[] = sprintf('… %d more findings not shown', $total - self::MAX_FINDINGS);
+        }
+
+        return sprintf("TCA findings (%d):\n", $total)
+            . '- ' . implode("\n- ", $findings)
+            . sprintf("\nChecked %d %s.", $checked, $checked === 1 ? 'table' : 'tables');
+    }
+}

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -36,16 +36,17 @@ non-admin users.
 The built-in tools
 ==================
 
-nr-llm ships twenty-four read-only tools. Each is a reference
+nr-llm ships twenty-eight read-only tools. Each is a reference
 implementation of the security contract: model-chosen arguments are
 validated and scoped, volumes are capped, and secret-bearing output is either
-redacted or gated behind a separate ``_raw`` variant. Twenty-one ship
+redacted or gated behind a separate ``_raw`` variant. Twenty-five ship
 **enabled**; the three unredacted ``_raw`` variants (``get_env_raw``,
 ``get_php_info_raw`` and ``list_be_users_raw``) ship **disabled** and must be
 enabled deliberately. Many require admin; the read-only structure and content
 tools (``get_pagetree``, ``get_tca``, ``get_full_tca``, ``get_table_schema``,
 ``get_flexform_schema``, ``fluid_resolve``, ``search_records``,
-``get_page_content``, ``read_records``) are offered to
+``get_page_content``, ``read_records``, ``get_record_history``,
+``resolve_url``, ``validate_tca``) are offered to
 non-admin backend users — those self-enforce the acting user's TYPO3
 permissions (page-show rights, ``tables_select``) inside the tool, so a
 non-admin only ever sees what the backend already grants them (see
@@ -113,6 +114,19 @@ The remaining tools follow the same pattern:
    are validated against the TCA and credential-like columns are silently
    dropped; the same table gates as ``search_records`` apply.
 
+``get_record_history``
+   One record's change history from ``sys_history``, newest first: when,
+   which backend user, which action, and per modification the changed
+   fields as old → new values. Values of credential-like fields are never
+   rendered — only the fact that they changed. Same table gates as
+   ``read_records``.
+
+``resolve_url``
+   Map a URL (or path) of this instance to the page that serves it: site,
+   language, page uid/title/slug and route arguments. Routing only — no
+   request is sent; foreign hosts cannot match by construction. Non-admins
+   need page-show permission on the resolved page.
+
 ``get_typoscript``
    The resolved frontend TypoScript (setup or constants) effective on a page,
    with a dotted ``path`` drill-down and capped output. Admin-only —
@@ -172,6 +186,19 @@ The remaining tools follow the same pattern:
    the winning path — to debug a wrong or missing template. Paths only.
    (Resolves an extension's own ``Resources/Private`` paths; TypoScript
    override root paths need a live rendering context and are not reflected.)
+
+``validate_tca``
+   Structural TCA checks: ``ctrl.label``/``ctrl.type`` naming undefined
+   columns, ``foreign_table`` references to unknown tables, ``showitem``
+   entries referencing undefined columns or palettes. One table or all
+   accessible tables; findings name schema keys, never record data.
+
+``check_typoscript``
+   Scans the TypoScript effective on a page (constants **and** setup) for
+   syntax errors — invalid lines, unbalanced braces, ``@import`` matching no
+   file — using the same core scanner as the backend's TypoScript module.
+   Reports source and line number only, never the offending line's content
+   (a constants line may carry an API key). Admin-only.
 
 .. _administration-tools-register:
 
@@ -244,13 +271,16 @@ taxonomy:
 ===============  ============================================================
 Group            Tools
 ===============  ============================================================
-``content``      ``search_records``, ``get_page_content``, ``read_records``
+``content``      ``search_records``, ``get_page_content``, ``read_records``,
+                 ``get_record_history``
 ``structure``    ``get_pagetree``, ``get_tca``, ``read_fal_asset_meta``,
-                 ``get_full_tca``, ``get_table_schema``, ``get_flexform_schema``
+                 ``get_full_tca``, ``get_table_schema``, ``get_flexform_schema``,
+                 ``resolve_url``, ``validate_tca``
 ``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw),
                  ``fetch_logs``, ``probe_url``
 ``accounts``     ``list_be_users`` (+ raw), ``list_be_groups``
-``configuration``  ``get_typoscript``, ``get_tsconfig``, ``fluid_resolve``
+``configuration``  ``get_typoscript``, ``get_tsconfig``, ``fluid_resolve``,
+                 ``check_typoscript``
 ``code``         ``get_last_exception``, ``read_source``, ``search_code``
 ===============  ============================================================
 

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -119,7 +119,8 @@ The remaining tools follow the same pattern:
    which backend user, which action, and per modification the changed
    fields as old → new values. Values of credential-like fields are never
    rendered — only the fact that they changed. Same table gates as
-   ``read_records``.
+   ``read_records``, and non-admins additionally need page-show access on
+   the record's page.
 
 ``resolve_url``
    Map a URL (or path) of this instance to the page that serves it: site,

--- a/Documentation/Adr/Adr046HistoryUrlAndValidationTools.rst
+++ b/Documentation/Adr/Adr046HistoryUrlAndValidationTools.rst
@@ -1,0 +1,89 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-046:
+
+==============================================
+ADR-046: History, URL and validation tools
+==============================================
+
+:Status: Accepted
+:Date: 2026-07-09
+:Deciders: nr_llm maintainers
+
+Context
+=======
+
+The schema tools (:ref:`ADR-045 <adr-045>`) let an agent *retrieve* structure
+and reason over it. Three recurring editor/integrator questions still had no
+tool: "who changed this record?", "which page serves this URL?", and "is this
+TCA/TypoScript actually broken?". The last two are *deterministic* questions —
+an LLM guessing at brace balance or showitem consistency over retrieved text
+is unreliable where an exact scanner exists.
+
+For TCA validation the core :php:`TcaMigration` was considered and rejected:
+it only emits messages while migrating the **raw, pre-boot** TCA; at runtime
+``$GLOBALS['TCA']`` is already migrated, so replaying it reports nothing.
+Structural checks over the live TCA are implemented directly instead.
+
+For TypoScript the core include-tree scanner
+(:php:`IncludeTreeSyntaxScannerVisitor`, with
+:php:`SysTemplateTreeBuilder`/:php:`IncludeTreeTraverser`) is reused — the
+same code path the backend's TypoScript module uses to mark broken syntax.
+These classes are ``@internal``; the risk is accepted because the surface
+used is tiny, covered by functional tests, and verified identical on 13.4
+and 14.
+
+Decision
+========
+
+Four read-only built-in tools:
+
+``get_record_history`` (group ``content``)
+   One record's ``sys_history`` newest-first: timestamp, resolved backend
+   username, action, and per modification the changed fields as
+   ``old → new`` pairs. Answers "wer hat die Überschrift geändert".
+
+``resolve_url`` (group ``structure``)
+   URL → page mapping via the real :php:`SiteMatcher`/`PageRouter` — site,
+   language, page uid/title/slug, route arguments. Routing only, no HTTP;
+   the complement of ``probe_url`` (which fetches but does not explain).
+
+``validate_tca`` (group ``structure``)
+   Structural checks over the live TCA: ``ctrl.label``/``ctrl.type`` must
+   name defined columns, ``foreign_table`` must reference TCA tables,
+   ``types``/``palettes`` showitem entries must reference defined columns
+   and palettes, flex ``ds_pointerField`` is flagged on v14+ (removed
+   there).
+
+``check_typoscript`` (group ``configuration``)
+   Constants and setup include trees of a page's sys_template chain run
+   through the core syntax scanner: invalid lines, unbalanced braces,
+   ``@import`` matching no file — each with source and line number.
+
+Access model
+============
+
+``get_record_history`` and ``validate_tca`` reuse
+:php:`TableReadAccessService` (ADR-042): the sensitive-table denylist holds
+for every user including admins; non-admins additionally pass
+``tables_select``. History values of credential-like fields are withheld
+(the *fact* of the change stays visible). ``resolve_url`` needs no host
+allowlist — :php:`SiteMatcher` only knows this instance's sites, so foreign
+hosts cannot match by construction; non-admins must hold page-show on the
+resolved page, with the same neutral denial as ``get_page_content``.
+``check_typoscript`` is **admin-only** like ``get_typoscript``, and reports
+source + line number + error kind only — the offending line's content is
+never echoed, because a broken constants line may carry an API key.
+
+Consequences
+============
+
+- The four remaining diagnostic use-cases named in the tool-expansion plan
+  (record attribution, URL mapping, TCA and TypoScript validation) are
+  covered by deterministic tools instead of model guesswork.
+- ``check_typoscript`` depends on ``@internal`` core classes; a core
+  refactoring may require adaptation. The functional tests pin the observable
+  behaviour, so a break surfaces in CI, not at runtime.
+- ``validate_tca`` intentionally implements a *small* rule set with exact
+  semantics rather than replicating the Extension Scanner; new rules can be
+  added as they prove useful.

--- a/Documentation/Adr/Adr046HistoryUrlAndValidationTools.rst
+++ b/Documentation/Adr/Adr046HistoryUrlAndValidationTools.rst
@@ -66,8 +66,10 @@ Access model
 ``get_record_history`` and ``validate_tca`` reuse
 :php:`TableReadAccessService` (ADR-042): the sensitive-table denylist holds
 for every user including admins; non-admins additionally pass
-``tables_select``. History values of credential-like fields are withheld
-(the *fact* of the change stays visible). ``resolve_url`` needs no host
+``tables_select``, and ``get_record_history`` also requires page-show on
+the record's page (the per-row gate of ``read_records``, fail-closed for
+unresolvable records). History values of credential-like fields are
+withheld (the *fact* of the change stays visible). ``resolve_url`` needs no host
 allowlist — :php:`SiteMatcher` only knows this instance's sites, so foreign
 hosts cannot match by construction; non-admins must hold page-show on the
 resolved page, with the same neutral denial as ``get_page_content``.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -344,3 +344,4 @@ Tools
    Adr043ToolGroups
    Adr044ErrorAnalysisTools
    Adr045SchemaAndResolutionTools
+   Adr046HistoryUrlAndValidationTools

--- a/Tests/Functional/Service/Tool/CheckTypoScriptToolTest.php
+++ b/Tests/Functional/Service/Tool/CheckTypoScriptToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\CheckTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for CheckTypoScriptTool (ADR-046): the core syntax
+ * scanner runs over the page's real sys_template chain — unbalanced braces
+ * are reported with a line number and never with the line's content; a
+ * clean template gets a clean bill.
+ */
+#[CoversClass(CheckTypoScriptTool::class)]
+final class CheckTypoScriptToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    private Connection $templates;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $siteDir = $this->instancePath . '/typo3conf/sites/tscheck';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost:59999/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+
+        $templates = $connectionPool->getConnectionForTable('sys_template');
+        self::assertInstanceOf(Connection::class, $templates);
+        $this->templates = $templates;
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('check_typoscript');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function reportsUnbalancedBraceWithLineNumberButWithoutContent(): void
+    {
+        $this->templates->insert('sys_template', [
+            'uid' => 10, 'pid' => 1, 'title' => 'Broken', 'root' => 1, 'clear' => 3,
+            'config' => "page = PAGE\npage {\n  10 = TEXT\n  10.value = secret-value-99\n",
+        ]);
+
+        $output = $this->tool->execute(['pageUid' => 1]);
+
+        self::assertStringContainsString('TypoScript syntax errors on page 1', $output);
+        self::assertStringContainsString('missing closing "}"', $output);
+        self::assertStringContainsString('[setup]', $output);
+        self::assertMatchesRegularExpression('/line \d+:/', $output);
+        // The offending line's content must never egress.
+        self::assertStringNotContainsString('secret-value-99', $output);
+    }
+
+    #[Test]
+    public function cleanTemplateReportsNoErrors(): void
+    {
+        $this->templates->insert('sys_template', [
+            'uid' => 11, 'pid' => 1, 'title' => 'Clean', 'root' => 1, 'clear' => 3,
+            'config' => "page = PAGE\npage.10 = TEXT\npage.10.value = Hello\n",
+        ]);
+
+        $output = $this->tool->execute(['pageUid' => 1]);
+
+        self::assertStringContainsString('No TypoScript syntax errors on page 1', $output);
+    }
+
+    #[Test]
+    public function missingTemplateYieldsNeutralAnswer(): void
+    {
+        self::assertSame(
+            'Page not found or no TypoScript template.',
+            $this->tool->execute(['pageUid' => 1]),
+        );
+        self::assertSame(
+            'Page not found or no TypoScript template.',
+            $this->tool->execute(['pageUid' => 12345]),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
+++ b/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
  * Functional tests for GetRecordHistoryTool (ADR-046): history renders
@@ -151,5 +152,78 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
             'Table not found or not permitted.',
             $this->tool->execute(['table' => 'tt_content', 'uid' => 5]),
         );
+    }
+
+    #[Test]
+    public function nonAdminWithoutPageAccessIsDenied(): void
+    {
+        // Editor MAY select tt_content but has no PAGE_SHOW on page 9 — the
+        // per-record page gate must deny (values must not leak from
+        // unreadable pages).
+        $this->grantEditorTableSelect();
+        $this->insertPageWithContentAndHistory(9, 0, 40);
+        $this->setUpBackendUser(2);
+
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 40]),
+        );
+    }
+
+    #[Test]
+    public function nonAdminWithPageAccessSeesHistory(): void
+    {
+        // Same editor, but page 9 grants PAGE_SHOW to everybody.
+        $this->grantEditorTableSelect();
+        $this->insertPageWithContentAndHistory(9, Permission::PAGE_SHOW, 40);
+        $this->setUpBackendUser(2);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 40]);
+
+        self::assertStringContainsString('Change history for tt_content:40', $output);
+        self::assertStringContainsString("header: 'A' → 'B'", $output);
+    }
+
+    private function grantEditorTableSelect(): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $groups = $connectionPool->getConnectionForTable('be_groups');
+        self::assertInstanceOf(Connection::class, $groups);
+        // db_mountpoints + options=3: readPageAccess also requires the page
+        // inside a webmount, and group mounts are only inherited with the
+        // options bits set.
+        $groups->insert('be_groups', [
+            'uid' => 7, 'pid' => 0, 'title' => 'Readers',
+            'tables_select' => 'tt_content,pages', 'db_mountpoints' => '9',
+        ]);
+        $groups->update('be_users', ['usergroup' => '7', 'options' => 3], ['uid' => 2]);
+    }
+
+    private function insertPageWithContentAndHistory(int $pageUid, int $permsEverybody, int $contentUid): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connection = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        $connection->insert('pages', [
+            'uid' => $pageUid, 'pid' => 0, 'title' => 'Gated', 'doktype' => 1, 'sorting' => 1,
+            'perms_userid' => 1, 'perms_user' => 31, 'perms_everybody' => $permsEverybody,
+        ]);
+        $connection->insert('tt_content', [
+            'uid' => $contentUid, 'pid' => $pageUid, 'colPos' => 0, 'sorting' => 1,
+            'CType' => 'text', 'header' => 'B',
+        ]);
+        $connection->insert('sys_history', [
+            'tstamp'       => 1700000000,
+            'actiontype'   => 2,
+            'usertype'     => 'BE',
+            'userid'       => 1,
+            'recuid'       => $contentUid,
+            'tablename'    => 'tt_content',
+            'history_data' => '{"oldRecord":{"header":"A"},"newRecord":{"header":"B"}}',
+            'workspace'    => 0,
+        ]);
     }
 }

--- a/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
+++ b/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetRecordHistoryTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for GetRecordHistoryTool (ADR-046): history renders
+ * newest-first with resolved usernames and old → new values; credential-like
+ * field values are withheld; sensitive tables stay denied.
+ */
+#[CoversClass(GetRecordHistoryTool::class)]
+final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connection = $connectionPool->getConnectionForTable('sys_history');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        // Two modifications by admin (uid 1), oldest first; a third row on a
+        // sensitive column proves value withholding.
+        $connection->insert('sys_history', [
+            'tstamp'       => 1700000000,
+            'actiontype'   => 2,
+            'usertype'     => 'BE',
+            'userid'       => 1,
+            'recuid'       => 5,
+            'tablename'    => 'tt_content',
+            'history_data' => '{"oldRecord":{"header":"Old headline"},"newRecord":{"header":"New headline"}}',
+            'workspace'    => 0,
+        ]);
+        $connection->insert('sys_history', [
+            'tstamp'       => 1700000600,
+            'actiontype'   => 2,
+            'usertype'     => 'BE',
+            'userid'       => 2,
+            'recuid'       => 5,
+            'tablename'    => 'tt_content',
+            'history_data' => '{"oldRecord":{"bodytext":"Lorem"},"newRecord":{"bodytext":"Ipsum"}}',
+            'workspace'    => 0,
+        ]);
+        $connection->insert('sys_history', [
+            'tstamp'       => 1700001200,
+            'actiontype'   => 2,
+            'usertype'     => 'BE',
+            'userid'       => 1,
+            'recuid'       => 5,
+            'tablename'    => 'tt_content',
+            'history_data' => '{"oldRecord":{"secret_token":"oldtoken123"},"newRecord":{"secret_token":"newtoken456"}}',
+            'workspace'    => 0,
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('get_record_history');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function rendersNewestFirstWithUsernamesAndValues(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5]);
+
+        self::assertStringContainsString('Change history for tt_content:5 (3 entries, newest first):', $output);
+        self::assertStringContainsString("header: 'Old headline' → 'New headline'", $output);
+        self::assertStringContainsString('by admin (modify)', $output);
+        self::assertStringContainsString('by editor (modify)', $output);
+        // Newest (secret_token change) before oldest (header change).
+        $posSecret = strpos($output, 'secret_token:');
+        $posHeader = strpos($output, "header: 'Old headline'");
+        self::assertIsInt($posSecret);
+        self::assertIsInt($posHeader);
+        self::assertLessThan($posHeader, $posSecret);
+    }
+
+    #[Test]
+    public function withholdsSensitiveFieldValues(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5]);
+
+        self::assertStringContainsString('secret_token: [changed — detail withheld]', $output);
+        self::assertStringNotContainsString('oldtoken123', $output);
+        self::assertStringNotContainsString('newtoken456', $output);
+    }
+
+    #[Test]
+    public function fieldFilterSkipsUnrelatedEntries(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5, 'field' => 'header']);
+
+        self::assertStringContainsString('filtered to "header"', $output);
+        self::assertStringContainsString("header: 'Old headline' → 'New headline'", $output);
+        self::assertStringNotContainsString('bodytext', $output);
+        self::assertStringContainsString('2 entries not touching "header" skipped', $output);
+    }
+
+    #[Test]
+    public function reportsWhenNoHistoryExists(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'No change history for tt_content:999.',
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 999]),
+        );
+    }
+
+    #[Test]
+    public function deniesSensitiveTableEvenForAdmin(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->tool->execute(['table' => 'be_users', 'uid' => 1]),
+        );
+    }
+
+    #[Test]
+    public function deniesWithoutBackendUser(): void
+    {
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 5]),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/ResolveUrlToolRelativeBaseTest.php
+++ b/Tests/Functional/Service/Tool/ResolveUrlToolRelativeBaseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolveUrlTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * ResolveUrlTool with a site whose base is RELATIVE (`base: /`) — common in
+ * local development. Path inputs must still resolve: the tool falls back to
+ * a placeholder host, which the SiteMatcher accepts because a relative base
+ * matches any host (ADR-046).
+ */
+#[CoversClass(ResolveUrlTool::class)]
+final class ResolveUrlToolRelativeBaseTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $siteDir = $this->instancePath . '/typo3conf/sites/relative';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: '/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+        $pages->insert('pages', [
+            'uid' => 2, 'pid' => 1, 'title' => 'Imprint', 'doktype' => 1,
+            'sorting' => 2, 'slug' => '/imprint',
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('resolve_url');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function resolvesPathAgainstRelativeSiteBase(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['url' => '/imprint']);
+
+        self::assertStringContainsString('Page: [2] Imprint', $output);
+        self::assertStringContainsString('slug /imprint', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolveUrlTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for ResolveUrlTool (ADR-046): own-site URLs resolve to
+ * their page via the real SiteMatcher/PageRouter, foreign hosts and unknown
+ * slugs are reported, and the tool fails closed without a backend user.
+ */
+#[CoversClass(ResolveUrlTool::class)]
+final class ResolveUrlToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $siteDir = $this->instancePath . '/typo3conf/sites/resolver';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost:59999/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+        $pages->insert('pages', [
+            'uid' => 2, 'pid' => 1, 'title' => 'Imprint', 'doktype' => 1,
+            'sorting' => 2, 'slug' => '/imprint',
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('resolve_url');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function resolvesRelativePathToPage(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['url' => '/imprint']);
+
+        self::assertStringContainsString('Site: resolver (base http://localhost:59999/)', $output);
+        self::assertStringContainsString('Page: [2] Imprint', $output);
+        self::assertStringContainsString('slug /imprint', $output);
+        self::assertStringContainsString('Use get_page_content(uid) for the content.', $output);
+    }
+
+    #[Test]
+    public function resolvesAbsoluteUrlToRootPage(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['url' => 'http://localhost:59999/']);
+
+        self::assertStringContainsString('Page: [1] Home', $output);
+        self::assertStringContainsString('Language: 0', $output);
+    }
+
+    #[Test]
+    public function reportsForeignHostNeutrally(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Not a URL of this instance (no site matches).',
+            $this->tool->execute(['url' => 'https://evil.example.com/x']),
+        );
+    }
+
+    #[Test]
+    public function reportsUnknownSlugAsNoRoute(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['url' => '/nope']);
+
+        self::assertStringContainsString('No page route matches "/nope" on site "resolver"', $output);
+    }
+
+    #[Test]
+    public function deniesWithoutBackendUser(): void
+    {
+        self::assertSame(
+            'Page not found or not permitted.',
+            $this->tool->execute(['url' => '/imprint']),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
@@ -91,6 +91,27 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function resolvesSchemelessPathWithoutLeadingSlash(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['url' => 'imprint']);
+
+        self::assertStringContainsString('Page: [2] Imprint', $output);
+    }
+
+    #[Test]
+    public function rejectsProtocolRelativeUrl(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Not a URL of this instance (no site matches).',
+            $this->tool->execute(['url' => '//evil.example.com/x']),
+        );
+    }
+
+    #[Test]
     public function reportsForeignHostNeutrally(): void
     {
         $this->setUpBackendUser(1);

--- a/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
+++ b/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ValidateTcaTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Functional tests for ValidateTcaTool (ADR-046): structural findings on a
+ * deliberately broken synthetic table, a clean bill for a correct one, and
+ * the usual neutral denial for sensitive tables.
+ */
+#[CoversClass(ValidateTcaTool::class)]
+final class ValidateTcaToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        self::assertIsArray($GLOBALS['TCA']);
+        $GLOBALS['TCA']['tx_demo_broken'] = [
+            'ctrl' => [
+                'title' => 'Broken Demo',
+                'label' => 'missing_label_column',
+            ],
+            'columns' => [
+                'name'   => ['config' => ['type' => 'input']],
+                'author' => ['config' => ['type' => 'select', 'foreign_table' => 'tx_does_not_exist']],
+            ],
+            'types' => [
+                '0' => ['showitem' => 'name, ghost_field, --palette--;;nope'],
+            ],
+        ];
+        $GLOBALS['TCA']['tx_demo_clean'] = [
+            'ctrl' => [
+                'title' => 'Clean Demo',
+                'label' => 'name',
+            ],
+            'columns' => [
+                'name'     => ['config' => ['type' => 'input']],
+                'category' => ['config' => ['type' => 'select', 'foreign_table' => 'sys_category']],
+            ],
+            'types' => [
+                '0' => ['showitem' => 'name, --palette--;;meta'],
+            ],
+            'palettes' => [
+                'meta' => ['showitem' => 'category'],
+            ],
+        ];
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('validate_tca');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function reportsLabelForeignTableAndShowitemFindings(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tx_demo_broken']);
+
+        self::assertStringContainsString('ctrl.label "missing_label_column" is not a defined column', $output);
+        self::assertStringContainsString('foreign_table "tx_does_not_exist" is not a TCA table', $output);
+        self::assertStringContainsString('showitem references undefined column "ghost_field"', $output);
+        self::assertStringContainsString('references unknown palette "nope"', $output);
+        self::assertStringContainsString('Checked 1 table.', $output);
+    }
+
+    #[Test]
+    public function cleanTableReportsNoIssues(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'No TCA issues found in table "tx_demo_clean".',
+            $this->tool->execute(['table' => 'tx_demo_clean']),
+        );
+    }
+
+    #[Test]
+    public function allTablesScanIncludesTheBrokenTable(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('tx_demo_broken: ctrl.label "missing_label_column"', $output);
+        self::assertStringContainsString('Checked', $output);
+    }
+
+    #[Test]
+    public function deniesSensitiveTableEvenForAdmin(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Table not found or not permitted.',
+            $this->tool->execute(['table' => 'be_users']),
+        );
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Service\Tool\Builtin\CheckTypoScriptTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\FluidResolveTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvRawTool;
@@ -20,6 +21,7 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPageTreeTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetRecordHistoryTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTableSchemaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTcaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTsConfigTool;
@@ -31,8 +33,10 @@ use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadSourceTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolveUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\SearchCodeTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ValidateTcaTool;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -75,6 +79,10 @@ final class BuiltinToolGroupsTest extends TestCase
             'list_be_groups'    => [ListBeGroupsTool::class, 'accounts'],
             'get_typoscript'    => [GetTypoScriptTool::class, 'configuration'],
             'get_tsconfig'      => [GetTsConfigTool::class, 'configuration'],
+            'get_record_history' => [GetRecordHistoryTool::class, 'content'],
+            'resolve_url'       => [ResolveUrlTool::class, 'structure'],
+            'validate_tca'      => [ValidateTcaTool::class, 'structure'],
+            'check_typoscript'  => [CheckTypoScriptTool::class, 'configuration'],
             'get_last_exception' => [GetLastExceptionTool::class, 'code'],
             'read_source'       => [ReadSourceTool::class, 'code'],
             'search_code'       => [SearchCodeTool::class, 'code'],

--- a/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\CheckTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetRecordHistoryTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolveUrlTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ValidateTcaTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Spec shape + admin/default flags of the history/URL/validation tools that
+ * don't need a TYPO3 bootstrap (ADR-046). The DB/routing/TS paths are
+ * covered functionally. getSpec()/requiresAdmin()/isEnabledByDefault() touch
+ * no collaborator, so newInstanceWithoutConstructor is safe.
+ */
+#[CoversClass(CheckTypoScriptTool::class)]
+#[CoversClass(GetRecordHistoryTool::class)]
+#[CoversClass(ResolveUrlTool::class)]
+#[CoversClass(ValidateTcaTool::class)]
+final class HistoryValidationToolsSpecTest extends TestCase
+{
+    /**
+     * @param class-string<ToolInterface> $class
+     */
+    private static function bare(string $class): ToolInterface
+    {
+        $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        self::assertInstanceOf(ToolInterface::class, $tool);
+
+        return $tool;
+    }
+
+    #[Test]
+    public function specsExposeNamesAndRequiredParameters(): void
+    {
+        $history = self::bare(GetRecordHistoryTool::class)->getSpec();
+        self::assertSame('get_record_history', $history->name);
+        self::assertSame(['table', 'uid'], $history->parameters['required'] ?? []);
+
+        $resolve = self::bare(ResolveUrlTool::class)->getSpec();
+        self::assertSame('resolve_url', $resolve->name);
+        self::assertSame(['url'], $resolve->parameters['required'] ?? []);
+
+        $validate = self::bare(ValidateTcaTool::class)->getSpec();
+        self::assertSame('validate_tca', $validate->name);
+        self::assertArrayNotHasKey('required', $validate->parameters);
+
+        $check = self::bare(CheckTypoScriptTool::class)->getSpec();
+        self::assertSame('check_typoscript', $check->name);
+        self::assertSame(['pageUid'], $check->parameters['required'] ?? []);
+    }
+
+    #[Test]
+    public function adminAndDefaultFlagsArePinned(): void
+    {
+        self::assertFalse(self::bare(GetRecordHistoryTool::class)->requiresAdmin());
+        self::assertFalse(self::bare(ResolveUrlTool::class)->requiresAdmin());
+        self::assertFalse(self::bare(ValidateTcaTool::class)->requiresAdmin());
+        // check_typoscript scans configuration — admin-only like get_typoscript.
+        self::assertTrue(self::bare(CheckTypoScriptTool::class)->requiresAdmin());
+
+        self::assertTrue(self::bare(GetRecordHistoryTool::class)->isEnabledByDefault());
+        self::assertTrue(self::bare(ResolveUrlTool::class)->isEnabledByDefault());
+        self::assertTrue(self::bare(ValidateTcaTool::class)->isEnabledByDefault());
+        self::assertTrue(self::bare(CheckTypoScriptTool::class)->isEnabledByDefault());
+    }
+
+    #[Test]
+    public function invalidInputIsRejectedWithoutTouchingCollaborators(): void
+    {
+        // No $GLOBALS['BE_USER'] in unit context → fail-closed paths.
+        self::assertSame(
+            'Table not found or not permitted.',
+            self::bare(GetRecordHistoryTool::class)->execute(['table' => '', 'uid' => 0]),
+        );
+        self::assertSame(
+            'Page not found or no TypoScript template.',
+            self::bare(CheckTypoScriptTool::class)->execute(['pageUid' => 0]),
+        );
+        self::assertSame(
+            'Error: "url" is required.',
+            self::bare(ResolveUrlTool::class)->execute([]),
+        );
+        self::assertSame(
+            'Page not found or not permitted.',
+            self::bare(ResolveUrlTool::class)->execute(['url' => '/x']),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tool wave 2b (ADR-046): four built-in tools closing the remaining diagnostic use-cases — "who changed this?", "which page serves this URL?", "check TCA for errors", "check TypoScript for errors".

| Tool | Group | Access | Purpose |
|---|---|---|---|
| `get_record_history` | content | non-admin¹ | `sys_history` newest-first: when, who, which fields `old → new`; credential-like field values withheld |
| `resolve_url` | structure | non-admin¹ | URL/path → site, language, page uid/title/slug, route args — routing only, no HTTP |
| `validate_tca` | structure | non-admin¹ | structural checks: label/type fields, dangling `foreign_table`, showitem/palette refs, `ds_pointerField` on v14+ |
| `check_typoscript` | configuration | **admin** | constants+setup include trees through the core syntax scanner: invalid lines, unbalanced braces, dead `@import` — source + line number, never line content |

¹ self-enforcing: `TableReadAccessService` table gates, and `get_record_history`/`resolve_url` additionally require PAGE_SHOW on the page (same per-row gate as `read_records`/`get_page_content`).

## Security notes

- `resolve_url` needs no host allowlist: `SiteMatcher` only knows this instance's sites, foreign hosts cannot match by construction.
- `check_typoscript` never echoes the offending line's content — a broken constants line may carry an API key.
- `get_record_history` withholds values of credential-like fields (the fact of the change stays visible) and fails closed for unresolvable records.

## Cross-version

`SysTemplateTreeBuilder`, `IncludeTreeSyntaxScannerVisitor` (incl. `lineNumber` in `getErrors()`), `SiteMatcher` verified identical on 13.4 and 14 — no version gates needed. `validate_tca`'s `ds_pointerField` warning is v14-gated via `Typo3Version`.

## Tests

- Taxonomy + spec unit tests for all four tools
- Functional: 23 new tests incl. sensitive-value withholding, field filter, neutral denials, non-admin page-gate denial **and** positive path (group with `tables_select` + `db_mountpoints`), foreign-host/unknown-slug handling, broken-TCA findings, unbalanced-brace detection with line number

## Docs

ADR-046 + `Tools.rst` (tool count now twenty-eight, twenty-five enabled).