### PR TITLE
fix(tools): validate_tca ctrl-field false positives, check_typoscript site sets

### DIFF
--- a/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
@@ -97,7 +97,10 @@ final readonly class CheckTypoScriptTool implements ToolInterface
             $request  = (new ServerRequest())->withAttribute('site', $site);
 
             $sysTemplateRows = $this->sysTemplateRepository->getSysTemplateRowsByRootline($rootline, $request);
-            if ($sysTemplateRows === []) {
+            // No sys_template rows is fine when the site brings TypoScript
+            // itself (site sets / site-defined TS, v13+) — the tree builder
+            // includes those; only bail out when NEITHER source exists.
+            if ($sysTemplateRows === [] && !$site->isTypoScriptRoot()) {
                 return self::NEUTRAL_ERROR;
             }
 
@@ -123,11 +126,22 @@ final readonly class CheckTypoScriptTool implements ToolInterface
 
         $errors = array_values(array_unique($errors));
         if ($errors === []) {
+            $sources = [];
+            if ($sysTemplateRows !== []) {
+                $sources[] = sprintf(
+                    '%d sys_template row%s',
+                    count($sysTemplateRows),
+                    count($sysTemplateRows) === 1 ? '' : 's',
+                );
+            }
+            if ($site->isTypoScriptRoot()) {
+                $sources[] = 'site-set TypoScript';
+            }
+
             return sprintf(
-                'No TypoScript syntax errors on page %d (constants and setup of %d sys_template row%s checked).',
+                'No TypoScript syntax errors on page %d (constants and setup of %s checked).',
                 $pageUid,
-                count($sysTemplateRows),
-                count($sysTemplateRows) === 1 ? '' : 's',
+                implode(' + ', $sources),
             );
         }
 

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -138,6 +138,11 @@ final readonly class ValidateTcaTool implements ToolInterface
         $columns  = is_array($tca['columns'] ?? null) ? $tca['columns'] : [];
         $palettes = is_array($tca['palettes'] ?? null) ? $tca['palettes'] : [];
 
+        // Fields declared via ctrl are core-managed (and since v13 mostly
+        // auto-created): enablecolumns, language fields, editlock, … — a
+        // showitem reference to them is valid without a columns definition.
+        $ctrlFields = $this->ctrlDeclaredFields($ctrl);
+
         $findings = [];
 
         // 1. ctrl.label must name a defined column.
@@ -189,7 +194,7 @@ final readonly class ValidateTcaTool implements ToolInterface
         $types = is_array($tca['types'] ?? null) ? $tca['types'] : [];
         foreach ($types as $typeName => $typeConf) {
             $showitem = is_array($typeConf) ? self::toStr($typeConf['showitem'] ?? '') : '';
-            foreach ($this->showitemFindings($showitem, $columns, $palettes) as $message) {
+            foreach ($this->showitemFindings($showitem, $columns, $ctrlFields, $palettes) as $message) {
                 $findings[] = sprintf('%s: types[%s] %s', $table, (string)$typeName, $message);
             }
         }
@@ -197,7 +202,7 @@ final readonly class ValidateTcaTool implements ToolInterface
         // 5. palettes[*].showitem references (no palette nesting allowed).
         foreach ($palettes as $paletteName => $paletteConf) {
             $showitem = is_array($paletteConf) ? self::toStr($paletteConf['showitem'] ?? '') : '';
-            foreach ($this->showitemFindings($showitem, $columns, null) as $message) {
+            foreach ($this->showitemFindings($showitem, $columns, $ctrlFields, null) as $message) {
                 $findings[] = sprintf('%s: palettes[%s] %s', $table, (string)$paletteName, $message);
             }
         }
@@ -210,11 +215,12 @@ final readonly class ValidateTcaTool implements ToolInterface
      * references themselves are flagged (palettes cannot nest).
      *
      * @param array<array-key, mixed>      $columns
+     * @param list<string>                 $ctrlFields
      * @param array<array-key, mixed>|null $palettes
      *
      * @return list<string>
      */
-    private function showitemFindings(string $showitem, array $columns, ?array $palettes): array
+    private function showitemFindings(string $showitem, array $columns, array $ctrlFields, ?array $palettes): array
     {
         $findings = [];
         foreach (explode(',', $showitem) as $item) {
@@ -235,7 +241,7 @@ final readonly class ValidateTcaTool implements ToolInterface
                 continue;
             }
 
-            if (!$this->isKnownField($fieldName, $columns)) {
+            if (!$this->isKnownField($fieldName, $columns) && !in_array($fieldName, $ctrlFields, true)) {
                 $findings[] = sprintf('showitem references undefined column "%s"', $fieldName);
             }
         }
@@ -249,6 +255,46 @@ final readonly class ValidateTcaTool implements ToolInterface
     private function isKnownField(string $field, array $columns): bool
     {
         return isset($columns[$field]) || in_array($field, self::IMPLICIT_FIELDS, true);
+    }
+
+    /**
+     * Column names declared through ctrl: enablecolumns values plus the
+     * single-field ctrl keys the core manages (auto-created since v13).
+     *
+     * @param array<string, mixed> $ctrl
+     *
+     * @return list<string>
+     */
+    private function ctrlDeclaredFields(array $ctrl): array
+    {
+        $fields = [];
+
+        $enablecolumns = is_array($ctrl['enablecolumns'] ?? null) ? $ctrl['enablecolumns'] : [];
+        foreach ($enablecolumns as $field) {
+            if (is_string($field) && $field !== '') {
+                $fields[] = $field;
+            }
+        }
+
+        foreach ([
+            'languageField',
+            'transOrigPointerField',
+            'translationSource',
+            'transOrigDiffSourceField',
+            'editlock',
+            'descriptionColumn',
+            'sortby',
+            'tstamp',
+            'crdate',
+            'delete',
+        ] as $key) {
+            $field = self::toStr($ctrl[$key] ?? '');
+            if ($field !== '') {
+                $fields[] = $field;
+            }
+        }
+
+        return array_values(array_unique($fields));
     }
 
     /**

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -281,6 +281,7 @@ final readonly class ValidateTcaTool implements ToolInterface
             'transOrigPointerField',
             'translationSource',
             'transOrigDiffSourceField',
+            'origUid',
             'editlock',
             'descriptionColumn',
             'sortby',

--- a/Tests/Functional/Service/Tool/CheckTypoScriptToolSiteSetTest.php
+++ b/Tests/Functional/Service/Tool/CheckTypoScriptToolSiteSetTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\CheckTypoScriptTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * CheckTypoScriptTool on a site WITHOUT any sys_template row whose
+ * TypoScript comes from the site itself (`setup.typoscript` beside the
+ * config — the v13+ site-set mechanism). The scan must include that source
+ * instead of reporting "no TypoScript template" (ADR-046).
+ */
+#[CoversClass(CheckTypoScriptTool::class)]
+final class CheckTypoScriptToolSiteSetTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $siteDir = $this->instancePath . '/typo3conf/sites/sitets';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost:59999/'
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+        // Site-local setup with an unbalanced brace — and NO sys_template row.
+        file_put_contents($siteDir . '/setup.typoscript', "page = PAGE\npage {\n  10 = TEXT\n");
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        $pages->insert('pages', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Home', 'doktype' => 1,
+            'sorting' => 1, 'is_siteroot' => 1, 'slug' => '/',
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('check_typoscript');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function scansSiteProvidedTypoScriptWithoutSysTemplateRow(): void
+    {
+        $output = $this->tool->execute(['pageUid' => 1]);
+
+        self::assertStringContainsString('TypoScript syntax errors on page 1', $output);
+        self::assertStringContainsString('missing closing "}"', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
+++ b/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
@@ -62,6 +62,29 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
             ],
         ];
 
+        // showitem references ctrl-declared fields (enablecolumns, language
+        // fields) that have NO columns definition — auto-created by the core
+        // since v13, so they must NOT be flagged.
+        $GLOBALS['TCA']['tx_demo_ctrlfields'] = [
+            'ctrl' => [
+                'title'                    => 'Ctrl Fields Demo',
+                'label'                    => 'name',
+                'languageField'            => 'sys_language_uid',
+                'transOrigPointerField'    => 'l18n_parent',
+                'transOrigDiffSourceField' => 'l18n_diffsource',
+                'enablecolumns'            => [
+                    'disabled'  => 'disable',
+                    'starttime' => 'starttime',
+                ],
+            ],
+            'columns' => [
+                'name' => ['config' => ['type' => 'input']],
+            ],
+            'types' => [
+                '0' => ['showitem' => 'name, disable, starttime, sys_language_uid, l18n_parent'],
+            ],
+        ];
+
         $registry = $this->get(ToolRegistry::class);
         self::assertInstanceOf(ToolRegistry::class, $registry);
         $tool = $registry->get('validate_tca');
@@ -91,6 +114,17 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
         self::assertSame(
             'No TCA issues found in table "tx_demo_clean".',
             $this->tool->execute(['table' => 'tx_demo_clean']),
+        );
+    }
+
+    #[Test]
+    public function ctrlDeclaredFieldsInShowitemAreNotFlagged(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'No TCA issues found in table "tx_demo_ctrlfields".',
+            $this->tool->execute(['table' => 'tx_demo_ctrlfields']),
         );
     }
 


### PR DESCRIPTION
## Summary

Two quality gaps in the #325 tools, both surfaced by live verification against the v14 ddev instance (site-set based, styleguide installed):

1. **`validate_tca` false positives**: showitem references to ctrl-declared columns (`enablecolumns` values, `languageField`, `transOrigPointerField`, …) were flagged as "undefined column" — the core auto-creates those since v13 (live: 40+ FPs like `disable`, `l18n_parent` across styleguide tables). They are now treated as known fields.
2. **`check_typoscript` blind to site sets**: instances whose TypoScript comes from site sets / site-local `setup.typoscript` (v13+) instead of `sys_template` rows got "no TypoScript template". The include tree already carries that source when `Site::isTypoScriptRoot()` — the tool now only bails out when neither source exists, and names the checked sources in the zero-errors message.

## Tests

- `ctrlDeclaredFieldsInShowitemAreNotFlagged` — synthetic table whose showitem references only ctrl-declared fields → no findings
- `CheckTypoScriptToolSiteSetTest` — site-local `setup.typoscript` with an unbalanced brace, **no** sys_template row → error with line reported (previously "no template")

`Site::isTypoScriptRoot()` and the site-TS loading verified present in both 13.4 and 14.