### PR TITLE
feat(tools): FAL file tools — storages, browse, search, references, missing

### DIFF
--- a/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
+++ b/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
@@ -86,6 +86,13 @@ final readonly class BrowseFalFolderTool implements ToolInterface
             if ($storage === null || !$storage->isOnline()) {
                 return self::NOT_PERMITTED;
             }
+            // Folder-level enforcement on top of the storage gate: with
+            // evaluatePermissions the read calls below check the acting
+            // user's file-mount boundaries and throw outside them — which
+            // collapses into the neutral denial.
+            if ($user !== null && !$user->isAdmin()) {
+                $storage->setEvaluatePermissions(true);
+            }
             $folder = $storage->getFolder($folderId);
 
             $lines   = [];

--- a/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
+++ b/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+
+/**
+ * Directory listing of one FAL folder (ADR-047).
+ *
+ * Subfolders (with file count) first, then files with human-readable size and
+ * MIME type — enough for the model to navigate a storage without ever seeing
+ * a server path: all identifiers are storage-relative, resolution goes
+ * exclusively through the storage API ({@see \TYPO3\CMS\Core\Resource\ResourceStorage::getFolder()}),
+ * and any resolution failure collapses into one neutral denial, so folder
+ * names outside the gate cannot be probed.
+ */
+final readonly class BrowseFalFolderTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Folder not found or not permitted.';
+
+    /** Upper bound on listed entries (folders + files). */
+    private const MAX_ENTRIES = 100;
+
+    public function __construct(
+        private StorageRepository $storageRepository,
+        private FalStorageGate $storageGate,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'browse_fal_folder',
+            'List one folder of a FAL file storage: subfolders (with file count) and files with size and '
+            . 'MIME type. Identifiers are storage-relative. Use list_fal_storages to discover storages.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'folder' => [
+                        'type'        => 'string',
+                        'description' => 'Storage-relative folder identifier (default "/", the storage root).',
+                    ],
+                    'storage' => [
+                        'type'        => 'integer',
+                        'description' => 'sys_file_storage uid (default: the first accessible storage).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user      = $this->actingBackendUser();
+        $effective = $this->storageGate->effectiveStorages($user);
+        if ($effective === []) {
+            return self::NOT_PERMITTED;
+        }
+
+        $storageUid = self::toInt($arguments['storage'] ?? ($effective[0] ?? 0));
+        if (!in_array($storageUid, $effective, true)) {
+            return self::NOT_PERMITTED;
+        }
+
+        $folderId = trim(self::toStr($arguments['folder'] ?? '/'));
+        if ($folderId === '') {
+            $folderId = '/';
+        }
+
+        try {
+            $storage = $this->storageRepository->findByUid($storageUid);
+            if ($storage === null || !$storage->isOnline()) {
+                return self::NOT_PERMITTED;
+            }
+            $folder = $storage->getFolder($folderId);
+
+            $lines   = [];
+            $count   = 0;
+            $skipped = 0;
+
+            foreach ($storage->getFoldersInFolder($folder) as $subfolder) {
+                if ($count >= self::MAX_ENTRIES) {
+                    ++$skipped;
+                    continue;
+                }
+                $lines[] = sprintf(
+                    '- %s/ (%d files)',
+                    $subfolder->getName(),
+                    $storage->countFilesInFolder($subfolder),
+                );
+                ++$count;
+            }
+
+            foreach ($storage->getFilesInFolder($folder) as $file) {
+                if ($count >= self::MAX_ENTRIES) {
+                    ++$skipped;
+                    continue;
+                }
+                $lines[] = sprintf(
+                    '- %s (%s, %s)',
+                    $file->getName(),
+                    $file->getMimeType(),
+                    $this->humanSize($file->getSize()),
+                );
+                ++$count;
+            }
+        } catch (Throwable) {
+            // Neutral by design: a missing folder, a folder outside the
+            // storage and a driver error are indistinguishable to the model.
+            return self::NOT_PERMITTED;
+        }
+
+        if ($lines === []) {
+            return sprintf('Folder %s of storage %d is empty.', $folder->getIdentifier(), $storageUid);
+        }
+
+        $header = sprintf(
+            'Folder %s of storage %d (%d entries%s):',
+            $folder->getIdentifier(),
+            $storageUid,
+            $count,
+            $skipped > 0 ? sprintf(', %d more not shown', $skipped) : '',
+        );
+
+        return $header . "\n" . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; the storage gate intersects with file mounts.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'files';
+    }
+
+    private function humanSize(int $bytes): string
+    {
+        if ($bytes >= 1048576) {
+            return sprintf('%.1f MiB', $bytes / 1048576);
+        }
+        if ($bytes >= 1024) {
+            return sprintf('%.1f KiB', $bytes / 1024);
+        }
+
+        return $bytes . ' B';
+    }
+}

--- a/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
+++ b/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Index records whose physical file is gone (ADR-047): `sys_file` rows with
+ * `missing = 1` — the classic "broken image on the page" diagnosis.
+ *
+ * Bound to the effective storages of {@see FalStorageGate}; identifiers are
+ * storage-relative, output is capped, and the total count is always reported
+ * so a capped listing cannot read as a complete one.
+ */
+final readonly class FindMissingFilesTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const DEFAULT_LIMIT = 20;
+
+    private const MAX_LIMIT = 50;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private FalStorageGate $storageGate,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'find_missing_files',
+            'List managed files (FAL) whose physical file is missing on disk (sys_file.missing = 1) — '
+            . 'the cause of broken images/downloads. Returns uid, storage-relative identifier and last '
+            . 'known size; use get_fal_references(uid) to see where a missing file is still used.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'storage' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: restrict to one sys_file_storage uid.',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum results (default 20, capped at 50).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user      = $this->actingBackendUser();
+        $effective = $this->storageGate->effectiveStorages($user);
+        if ($effective === []) {
+            return 'No accessible file storages.';
+        }
+
+        $storageFilter = self::toInt($arguments['storage'] ?? 0);
+        if ($storageFilter > 0) {
+            $effective = in_array($storageFilter, $effective, true) ? [$storageFilter] : [];
+            if ($effective === []) {
+                return 'No accessible file storages.';
+            }
+        }
+
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $countQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
+        $countQuery->getRestrictions()->removeAll();
+        $total = self::toInt($countQuery
+            ->count('uid')
+            ->from('sys_file')
+            ->where(
+                $countQuery->expr()->eq('missing', $countQuery->createNamedParameter(1, Connection::PARAM_INT)),
+                $countQuery->expr()->in(
+                    'storage',
+                    $countQuery->createNamedParameter($effective, Connection::PARAM_INT_ARRAY),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne());
+
+        if ($total === 0) {
+            return 'No missing files in the accessible storages.';
+        }
+
+        $listQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
+        $listQuery->getRestrictions()->removeAll();
+        $rows = $listQuery
+            ->select('uid', 'storage', 'identifier', 'size')
+            ->from('sys_file')
+            ->where(
+                $listQuery->expr()->eq('missing', $listQuery->createNamedParameter(1, Connection::PARAM_INT)),
+                $listQuery->expr()->in(
+                    'storage',
+                    $listQuery->createNamedParameter($effective, Connection::PARAM_INT_ARRAY),
+                ),
+            )
+            ->orderBy('storage')
+            ->addOrderBy('identifier')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $lines = [sprintf('%d missing file%s (showing %d):', $total, $total === 1 ? '' : 's', count($rows))];
+        foreach ($rows as $row) {
+            $lines[] = sprintf(
+                '- [%d] %d:%s (last known size %d bytes)',
+                self::toInt($row['uid'] ?? 0),
+                self::toInt($row['storage'] ?? 0),
+                self::toStr($row['identifier'] ?? ''),
+                self::toInt($row['size'] ?? 0),
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; the storage gate intersects with file mounts.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'files';
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -108,6 +108,10 @@ final readonly class GetFalReferencesTool implements ToolInterface
         $skipped = 0;
         foreach ($rows as $row) {
             $table = self::toStr($row['tablenames'] ?? '');
+            // A reference without a table name is dangling — skip it.
+            if ($table === '') {
+                continue;
+            }
             // Non-admins only see references from tables they may read.
             if (!$isAdmin && !$this->tableAccess->canReadTable($user, $table)) {
                 continue;

--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Where is this file used? (ADR-047).
+ *
+ * Lists the `sys_file_reference` usages of one managed file as
+ * `table:uid (field)` pairs — the "can I delete this asset?" and "which
+ * content shows this image?" answer. Soft references (RTE links, plain-text
+ * URLs) are NOT tracked here, which the output states explicitly so the
+ * model never concludes "unused" too strongly.
+ *
+ * Gates: the file's storage must pass {@see FalStorageGate} (same neutral
+ * denial as read_fal_asset_meta), and non-admins only see references from
+ * tables they may read ({@see TableReadAccessService}).
+ */
+final readonly class GetFalReferencesTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const NOT_PERMITTED = 'Asset not found or not permitted.';
+
+    /** Upper bound on listed references. */
+    private const MAX_REFERENCES = 50;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private FalStorageGate $storageGate,
+        private TableReadAccessService $tableAccess,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_fal_references',
+            'List where a managed file (sys_file uid) is used: the referencing records as table:uid with '
+            . 'the field name. Soft references (RTE links, plain URLs) are not tracked — "no references" '
+            . 'does not guarantee the file is unused.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'The sys_file uid whose usages to list.',
+                    ],
+                ],
+                'required' => ['uid'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid < 1) {
+            return self::NOT_PERMITTED;
+        }
+
+        $user = $this->actingBackendUser();
+
+        $fileQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
+        $fileQuery->getRestrictions()->removeAll();
+        $file = $fileQuery
+            ->select('storage', 'name')
+            ->from('sys_file')
+            ->where($fileQuery->expr()->eq('uid', $fileQuery->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($file) || !$this->storageGate->isAllowed($user, self::toInt($file['storage'] ?? 0))) {
+            return self::NOT_PERMITTED;
+        }
+
+        $refQuery = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
+        $refQuery->getRestrictions()->removeAll();
+        $rows = $refQuery
+            ->select('tablenames', 'uid_foreign', 'fieldname', 'hidden')
+            ->from('sys_file_reference')
+            ->where(
+                $refQuery->expr()->eq('uid_local', $refQuery->createNamedParameter($uid, Connection::PARAM_INT)),
+                $refQuery->expr()->eq('deleted', $refQuery->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('tablenames')
+            ->addOrderBy('uid_foreign')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $isAdmin = $user !== null && $user->isAdmin();
+
+        $lines   = [];
+        $skipped = 0;
+        foreach ($rows as $row) {
+            $table = self::toStr($row['tablenames'] ?? '');
+            // Non-admins only see references from tables they may read.
+            if (!$isAdmin && !$this->tableAccess->canReadTable($user, $table)) {
+                continue;
+            }
+            if (count($lines) >= self::MAX_REFERENCES) {
+                ++$skipped;
+                continue;
+            }
+            $lines[] = sprintf(
+                '- %s:%d (field %s)%s',
+                $table,
+                self::toInt($row['uid_foreign'] ?? 0),
+                self::toStr($row['fieldname'] ?? ''),
+                self::toInt($row['hidden'] ?? 0) === 1 ? ' [hidden]' : '',
+            );
+        }
+
+        if ($lines === []) {
+            return sprintf(
+                'No references to %s — the file appears unused (soft references and inline RTE links are not tracked here).',
+                self::toStr($file['name'] ?? ''),
+            );
+        }
+
+        $header = sprintf(
+            'References to %s (%d%s):',
+            self::toStr($file['name'] ?? ''),
+            count($lines),
+            $skipped > 0 ? sprintf(', %d more not shown', $skipped) : '',
+        );
+
+        return $header . "\n" . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; storage gate + per-table read gate self-enforce.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'files';
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
+++ b/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Throwable;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+
+/**
+ * The entry point of the FAL tool family (ADR-047): which file storages may
+ * this run touch at all?
+ *
+ * Lists the effective storages ({@see FalStorageGate}: configured allow-list,
+ * intersected with the acting non-admin's file mounts) with uid, name, driver
+ * and capability flags. The server-side base path is deliberately NOT part of
+ * the output — tool results egress to the external provider, and filesystem
+ * layout is nobody's business there.
+ */
+final readonly class ListFalStoragesTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+
+    public function __construct(
+        private StorageRepository $storageRepository,
+        private FalStorageGate $storageGate,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_fal_storages',
+            'List the file storages (FAL) accessible to this run: uid, name, driver and status flags. '
+            . 'Use the uid with browse_fal_folder, search_fal_files or find_missing_files.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $user  = $this->actingBackendUser();
+        $lines = [];
+        foreach ($this->storageGate->effectiveStorages($user) as $uid) {
+            try {
+                $storage = $this->storageRepository->findByUid($uid);
+            } catch (Throwable) {
+                $storage = null;
+            }
+            if ($storage === null) {
+                continue;
+            }
+
+            $flags = [];
+            $flags[] = $storage->isOnline() ? 'online' : 'offline';
+            if ($storage->isBrowsable()) {
+                $flags[] = 'browsable';
+            }
+            if ($storage->isPublic()) {
+                $flags[] = 'public';
+            }
+
+            $lines[] = sprintf(
+                '- [%d] %s (driver %s; %s)',
+                $storage->getUid(),
+                $storage->getName(),
+                $storage->getDriverType(),
+                implode(', ', $flags),
+            );
+        }
+
+        if ($lines === []) {
+            return 'No accessible file storages.';
+        }
+
+        return sprintf("Accessible file storages (%d):\n", count($lines)) . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; the storage gate intersects with file mounts.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'files';
+    }
+}

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Substring search over managed files (ADR-047): file name plus the
+ * default-language title/alternative from `sys_file_metadata`.
+ *
+ * Bound to the effective storages of {@see FalStorageGate}; the model-chosen
+ * query is LIKE-escaped so `%`/`_` are matched literally, results are capped,
+ * and missing files are excluded (see find_missing_files for those).
+ * Identifiers are storage-relative (`storage:/path/name`), never server paths.
+ */
+final readonly class SearchFalFilesTool implements ToolInterface
+{
+    use ResolvesActingBackendUserTrait;
+    use SafeCastTrait;
+
+    private const DEFAULT_LIMIT = 20;
+
+    private const MAX_LIMIT = 50;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private FalStorageGate $storageGate,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'search_fal_files',
+            'Search managed files (FAL) by substring in file name, title or alternative text. Returns '
+            . 'uid, storage-relative identifier, MIME type and size; use read_fal_asset_meta(uid) for detail.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'query' => [
+                        'type'        => 'string',
+                        'description' => 'Substring to search for (matched literally, case-insensitive).',
+                    ],
+                    'storage' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: restrict to one sys_file_storage uid.',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum results (default 20, capped at 50).',
+                    ],
+                ],
+                'required' => ['query'],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $query = trim(self::toStr($arguments['query'] ?? ''));
+        if ($query === '') {
+            return 'Error: "query" is required.';
+        }
+
+        $user      = $this->actingBackendUser();
+        $effective = $this->storageGate->effectiveStorages($user);
+        if ($effective === []) {
+            return 'No accessible file storages.';
+        }
+
+        $storageFilter = self::toInt($arguments['storage'] ?? 0);
+        if ($storageFilter > 0) {
+            $effective = in_array($storageFilter, $effective, true) ? [$storageFilter] : [];
+            if ($effective === []) {
+                return 'No accessible file storages.';
+            }
+        }
+
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        // sys_file has no enable columns; metadata is language-pinned below
+        // and the storage gate is the access boundary (cf. read_fal_asset_meta).
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $like = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
+
+        $rows = $queryBuilder
+            ->select('f.uid', 'f.storage', 'f.identifier', 'f.mime_type', 'f.size')
+            ->from('sys_file', 'f')
+            ->leftJoin('f', 'sys_file_metadata', 'm', (string)$queryBuilder->expr()->and(
+                $queryBuilder->expr()->eq('m.file', $queryBuilder->quoteIdentifier('f.uid')),
+                $queryBuilder->expr()->eq('m.sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            ))
+            ->where(
+                $queryBuilder->expr()->in(
+                    'f.storage',
+                    $queryBuilder->createNamedParameter($effective, Connection::PARAM_INT_ARRAY),
+                ),
+                $queryBuilder->expr()->eq('f.missing', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->like('f.name', $queryBuilder->createNamedParameter($like)),
+                    $queryBuilder->expr()->like('m.title', $queryBuilder->createNamedParameter($like)),
+                    $queryBuilder->expr()->like('m.alternative', $queryBuilder->createNamedParameter($like)),
+                ),
+            )
+            ->orderBy('f.name')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        if ($rows === []) {
+            return sprintf('No files match "%s" in the accessible storages.', $query);
+        }
+
+        $lines = [sprintf('Files matching "%s" (%d, capped at %d):', $query, count($rows), $limit)];
+        foreach ($rows as $row) {
+            $lines[] = sprintf(
+                '- [%d] %d:%s (%s, %d bytes)',
+                self::toInt($row['uid'] ?? 0),
+                self::toInt($row['storage'] ?? 0),
+                self::toStr($row['identifier'] ?? ''),
+                self::toStr($row['mime_type'] ?? ''),
+                self::toInt($row['size'] ?? 0),
+            );
+        }
+        $lines[] = 'Use read_fal_asset_meta(uid) for title/alternative detail.';
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Usable by non-admins; the storage gate intersects with file mounts.
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'files';
+    }
+}

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -95,7 +95,9 @@ final readonly class SearchFalFilesTool implements ToolInterface
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file');
         $queryBuilder->getRestrictions()->removeAll();
 
-        $like = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
+        // LOWER() on both sides: plain LIKE is collation-dependent (e.g.
+        // case-sensitive on PostgreSQL), the spec promises case-insensitive.
+        $like = '%' . $queryBuilder->escapeLikeWildcards(mb_strtolower($query)) . '%';
 
         $rows = $queryBuilder
             ->select('f.uid', 'f.storage', 'f.identifier', 'f.mime_type', 'f.size')
@@ -111,9 +113,9 @@ final readonly class SearchFalFilesTool implements ToolInterface
                 ),
                 $queryBuilder->expr()->eq('f.missing', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                 $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->like('f.name', $queryBuilder->createNamedParameter($like)),
-                    $queryBuilder->expr()->like('m.title', $queryBuilder->createNamedParameter($like)),
-                    $queryBuilder->expr()->like('m.alternative', $queryBuilder->createNamedParameter($like)),
+                    $queryBuilder->expr()->comparison('LOWER(f.name)', 'LIKE', $queryBuilder->createNamedParameter($like)),
+                    $queryBuilder->expr()->comparison('LOWER(m.title)', 'LIKE', $queryBuilder->createNamedParameter($like)),
+                    $queryBuilder->expr()->comparison('LOWER(m.alternative)', 'LIKE', $queryBuilder->createNamedParameter($like)),
                 ),
             )
             ->orderBy('f.name')

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Shared storage gate of the FAL tools (ADR-047).
+ *
+ * The effective storage set is the intersection of the configured allow-list
+ * and — for non-admins — the storages the backend user can actually reach
+ * through their file mounts ({@see BackendUserAuthentication::getFileStorages()}).
+ * Fail-closed: no backend user means no storages, and an empty intersection
+ * means every FAL tool answers with its neutral denial.
+ */
+final readonly class FalStorageGate
+{
+    /**
+     * @param list<int> $allowedStorages sys_file_storage uids the FAL tools may touch
+     */
+    public function __construct(
+        private array $allowedStorages = [1],
+    ) {}
+
+    /**
+     * The storage uids the acting user may touch, in allow-list order.
+     *
+     * @return list<int>
+     */
+    public function effectiveStorages(?BackendUserAuthentication $user): array
+    {
+        if ($user === null) {
+            return [];
+        }
+
+        if ($user->isAdmin()) {
+            return $this->allowedStorages;
+        }
+
+        $reachable = [];
+        foreach ($user->getFileStorages() as $storage) {
+            $reachable[$storage->getUid()] = true;
+        }
+
+        return array_values(array_filter(
+            $this->allowedStorages,
+            static fn(int $uid): bool => isset($reachable[$uid]),
+        ));
+    }
+
+    public function isAllowed(?BackendUserAuthentication $user, int $storageUid): bool
+    {
+        return in_array($storageUid, $this->effectiveStorages($user), true);
+    }
+}

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -36,17 +36,19 @@ non-admin users.
 The built-in tools
 ==================
 
-nr-llm ships twenty-eight read-only tools. Each is a reference
+nr-llm ships thirty-three read-only tools. Each is a reference
 implementation of the security contract: model-chosen arguments are
 validated and scoped, volumes are capped, and secret-bearing output is either
-redacted or gated behind a separate ``_raw`` variant. Twenty-five ship
+redacted or gated behind a separate ``_raw`` variant. Thirty ship
 **enabled**; the three unredacted ``_raw`` variants (``get_env_raw``,
 ``get_php_info_raw`` and ``list_be_users_raw``) ship **disabled** and must be
-enabled deliberately. Many require admin; the read-only structure and content
-tools (``get_pagetree``, ``get_tca``, ``get_full_tca``, ``get_table_schema``,
-``get_flexform_schema``, ``fluid_resolve``, ``search_records``,
-``get_page_content``, ``read_records``, ``get_record_history``,
-``resolve_url``, ``validate_tca``) are offered to
+enabled deliberately. Many require admin; the read-only structure, content
+and file tools (``get_pagetree``, ``get_tca``, ``get_full_tca``,
+``get_table_schema``, ``get_flexform_schema``, ``fluid_resolve``,
+``search_records``, ``get_page_content``, ``read_records``,
+``get_record_history``, ``resolve_url``, ``validate_tca``,
+``list_fal_storages``, ``browse_fal_folder``, ``search_fal_files``,
+``get_fal_references``, ``find_missing_files``) are offered to
 non-admin backend users — those self-enforce the acting user's TYPO3
 permissions (page-show rights, ``tables_select``) inside the tool, so a
 non-admin only ever sees what the backend already grants them (see
@@ -70,6 +72,34 @@ The two tools below are the fullest illustrations of the contract:
    missing uid — the model cannot enumerate arbitrary files.
 
 The remaining tools follow the same pattern:
+
+``list_fal_storages``
+   The file storages this run may touch (uid, name, driver, status flags).
+   The effective set is the configured allow-list, intersected for
+   non-admins with their file mounts; the server-side base path is never
+   part of the output.
+
+``browse_fal_folder``
+   One FAL folder: subfolders (with file count), then files with size and
+   MIME type. Storage-relative identifiers only; anything unresolvable
+   collapses into one neutral denial. Capped at 100 entries.
+
+``search_fal_files``
+   Substring search over file name and metadata title/alternative within
+   the accessible storages. ``%``/``_`` in the query match literally;
+   missing files are excluded.
+
+``get_fal_references``
+   Where a file is used: ``sys_file_reference`` rows as ``table:uid
+   (field)``, hidden references marked. Soft references (RTE links, plain
+   URLs) are not tracked — stated in the output so "no references" is
+   never read as "safe to delete". Non-admins only see references from
+   tables they may read.
+
+``find_missing_files``
+   ``sys_file`` records whose physical file is gone (``missing = 1``) —
+   the "broken image" diagnosis. The total count is always reported next
+   to the capped listing.
 
 ``get_env`` / ``get_env_raw``
    Process environment variables. ``get_env`` redacts secret-looking values
@@ -283,6 +313,9 @@ Group            Tools
 ``configuration``  ``get_typoscript``, ``get_tsconfig``, ``fluid_resolve``,
                  ``check_typoscript``
 ``code``         ``get_last_exception``, ``read_source``, ``search_code``
+``files``        ``list_fal_storages``, ``browse_fal_folder``,
+                 ``search_fal_files``, ``get_fal_references``,
+                 ``find_missing_files``
 ===============  ============================================================
 
 Groups can be switched on three levels, and the result cascades

--- a/Documentation/Adr/Adr047FalTools.rst
+++ b/Documentation/Adr/Adr047FalTools.rst
@@ -66,6 +66,12 @@ the neutral denial. A file or folder outside the gate is indistinguishable
 from a missing one — the same neutrality contract as
 ``read_fal_asset_meta``. ``get_fal_references`` additionally drops rows
 whose referencing table fails :php:`TableReadAccessService` for non-admins.
+``browse_fal_folder`` enforces FOLDER-level file-mount boundaries on top:
+for non-admins it sets :php:`ResourceStorage::setEvaluatePermissions()`, so
+the core mount checks apply to every folder read. The mounts themselves are
+attached by the core ``StoragePermissionsAspect`` only inside a backend
+request — in any other context (CLI, scheduler) non-admin folder access
+therefore fails CLOSED (denied) rather than mount-blind.
 Server paths never egress: listings use storage-relative identifiers, and
 ``list_fal_storages`` omits the base path by design.
 

--- a/Documentation/Adr/Adr047FalTools.rst
+++ b/Documentation/Adr/Adr047FalTools.rst
@@ -1,0 +1,81 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-047:
+
+==================
+ADR-047: FAL tools
+==================
+
+:Status: Accepted
+:Date: 2026-07-09
+:Deciders: nr_llm maintainers
+
+Context
+=======
+
+The tool family covered records, schema, configuration and code — but not
+the File Abstraction Layer. The recurring questions "which storages exist?",
+"what is in this folder?", "find that PDF", "where is this image used?" and
+"why is this image broken?" had a single narrow answer
+(``read_fal_asset_meta``, one file by uid) and no navigation around it.
+
+FAL output egresses to the external LLM provider, so the family needs one
+shared containment: storage scoping. A single allow-list in one place beats
+five copies of the same intersection logic.
+
+Decision
+========
+
+Five read-only built-in tools in the NEW group ``files`` — the first group
+added since the initial taxonomy (ADR-043); third-party extensions remain
+advised to use their extension key as group:
+
+``list_fal_storages``
+   The effective storages with uid, name, driver and status flags. The
+   server-side base path is never part of the output.
+
+``browse_fal_folder``
+   One folder's subfolders (with file count) and files (size, MIME type),
+   resolved exclusively through the storage API. Identifiers are
+   storage-relative; entries are capped.
+
+``search_fal_files``
+   Substring search over file name and default-language metadata
+   title/alternative. The model-chosen query is LIKE-escaped (literal
+   ``%``/``_``), missing files are excluded, results are capped.
+
+``get_fal_references``
+   ``sys_file_reference`` usages of one file as ``table:uid (field)`` —
+   hidden references marked, deleted ones invisible. The output states
+   explicitly that soft references (RTE links, plain URLs) are not tracked,
+   so "no references" is never read as "safe to delete".
+
+``find_missing_files``
+   ``sys_file`` rows with ``missing = 1`` in the effective storages, with
+   the total count always reported alongside the capped listing.
+
+Access model
+============
+
+All five share :php:`FalStorageGate`: the configured storage allow-list
+(default ``[1]``), intersected for non-admins with the storages reachable
+through their file mounts
+(:php:`BackendUserAuthentication::getFileStorages()`, verified identical on
+13.4 and 14). Fail-closed: no backend user or an empty intersection yields
+the neutral denial. A file or folder outside the gate is indistinguishable
+from a missing one — the same neutrality contract as
+``read_fal_asset_meta``. ``get_fal_references`` additionally drops rows
+whose referencing table fails :php:`TableReadAccessService` for non-admins.
+Server paths never egress: listings use storage-relative identifiers, and
+``list_fal_storages`` omits the base path by design.
+
+Consequences
+============
+
+- The FAL gap in the tool taxonomy is closed with navigation
+  (storages → folders → files), search, usage and integrity tools.
+- The new ``files`` group can be disabled centrally, per configuration and
+  per run like every other group (ADR-043).
+- ``get_fal_references`` reads ``sys_file_reference`` only; soft-reference
+  tracking (``sys_refindex``) is a possible later extension if "is this
+  file really unused?" needs a stronger answer.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -345,3 +345,4 @@ Tools
    Adr044ErrorAnalysisTools
    Adr045SchemaAndResolutionTools
    Adr046HistoryUrlAndValidationTools
+   Adr047FalTools

--- a/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
+++ b/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
@@ -87,6 +87,13 @@ final class BrowseFalFolderToolFileMountTest extends AbstractFunctionalTestCase
         $this->tool = $tool;
     }
 
+    protected function tearDown(): void
+    {
+        // The faked backend request must not leak into later tests.
+        unset($GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
     #[Test]
     public function nonAdminIsConfinedToTheirFileMount(): void
     {

--- a/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
+++ b/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\BrowseFalFolderTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * File-mount confinement of browse_fal_folder for non-admins (ADR-047).
+ *
+ * The storage ROW is inserted directly (no object instantiation) so the
+ * ResourceStorage object is first created while the editor is logged in —
+ * only then does the core StoragePermissionsAspect attach the user's file
+ * mounts and permissions to the storage object, exactly as in a real
+ * backend request. Outside a backend request the aspect never runs and the
+ * tool's own setEvaluatePermissions(true) makes non-admin access fail
+ * CLOSED (everything denied) rather than mount-blind.
+ */
+#[CoversClass(BrowseFalFolderTool::class)]
+final class BrowseFalFolderToolFileMountTest extends AbstractFunctionalTestCase
+{
+    private const STORAGE_CONFIGURATION = '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3FlexForms>
+    <data>
+        <sheet index="sDEF">
+            <language index="lDEF">
+                <field index="basePath"><value index="vDEF">fileadmin/</value></field>
+                <field index="pathType"><value index="vDEF">relative</value></field>
+                <field index="caseSensitive"><value index="vDEF">1</value></field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>';
+
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/docs');
+        file_put_contents($this->instancePath . '/fileadmin/top-secret.txt', 'root file');
+        file_put_contents($this->instancePath . '/fileadmin/docs/manual.txt', 'The manual');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connection = $connectionPool->getConnectionForTable('sys_file_storage');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        // Row only — the ResourceStorage OBJECT must not exist before login.
+        $connection->insert('sys_file_storage', [
+            'uid' => 1, 'pid' => 0, 'name' => 'Main storage', 'driver' => 'Local',
+            'configuration' => self::STORAGE_CONFIGURATION,
+            'is_online' => 1, 'is_browsable' => 1, 'is_public' => 1, 'is_writable' => 1,
+        ]);
+        $connection->insert('sys_filemounts', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Docs mount', 'identifier' => '1:/docs/',
+        ]);
+        $connection->insert('be_groups', [
+            'uid' => 9, 'pid' => 0, 'title' => 'Doc readers', 'file_mountpoints' => '1',
+            'file_permissions' => 'readFolder,readFile',
+        ]);
+        // options=3: inherit db AND file mounts from groups.
+        $connection->update('be_users', ['usergroup' => '9', 'options' => 3], ['uid' => 2]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('browse_fal_folder');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function nonAdminIsConfinedToTheirFileMount(): void
+    {
+        $this->setUpBackendUser(2);
+        // The core StoragePermissionsAspect only attaches mounts/permissions
+        // when the storage object is created inside a BACKEND request — set
+        // the request context the real tool-loop (backend AJAX) runs in.
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest('https://typo3-testing.local/typo3/'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+
+        // The storage root lies outside the /docs/ mount — denied, and the
+        // root file's name never egresses.
+        $rootOutput = $this->tool->execute(['folder' => '/']);
+        self::assertSame('Folder not found or not permitted.', $rootOutput);
+
+        // The mounted folder lists.
+        $output = $this->tool->execute(['folder' => '/docs/']);
+        self::assertStringContainsString('- manual.txt (text/plain, 10 B)', $output);
+        self::assertStringNotContainsString('top-secret', $output);
+    }
+}

--- a/Tests/Functional/Service/Tool/BrowseFalFolderToolTest.php
+++ b/Tests/Functional/Service/Tool/BrowseFalFolderToolTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\BrowseFalFolderTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for BrowseFalFolderTool (ADR-047): a real Local storage
+ * folder lists subfolders and files, and everything unresolvable collapses
+ * into the neutral denial.
+ */
+#[CoversClass(BrowseFalFolderTool::class)]
+final class BrowseFalFolderToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/docs');
+        file_put_contents($this->instancePath . '/fileadmin/hello.txt', 'Hello FAL');
+        file_put_contents($this->instancePath . '/fileadmin/docs/manual.txt', 'The manual');
+
+        $storageRepository = $this->get(StorageRepository::class);
+        self::assertInstanceOf(StorageRepository::class, $storageRepository);
+        self::assertSame(1, $storageRepository->createLocalStorage('Main storage', 'fileadmin/', 'relative'));
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('browse_fal_folder');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsSubfoldersAndFilesOfTheRoot(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Folder / of storage 1', $output);
+        self::assertStringContainsString('- docs/ (1 files)', $output);
+        self::assertStringContainsString('- hello.txt (text/plain, 9 B)', $output);
+    }
+
+    #[Test]
+    public function listsASubfolderByIdentifier(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['folder' => '/docs/']);
+
+        self::assertStringContainsString('- manual.txt (text/plain, 10 B)', $output);
+        self::assertStringNotContainsString('hello.txt', $output);
+    }
+
+    #[Test]
+    public function unknownFolderIsDeniedNeutrally(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Folder not found or not permitted.',
+            $this->tool->execute(['folder' => '/does-not-exist/']),
+        );
+    }
+
+    #[Test]
+    public function unknownStorageIsDeniedNeutrally(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'Folder not found or not permitted.',
+            $this->tool->execute(['storage' => 99]),
+        );
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertSame('Folder not found or not permitted.', $this->tool->execute([]));
+    }
+}

--- a/Tests/Functional/Service/Tool/FindMissingFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/FindMissingFilesToolTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\FindMissingFilesTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for FindMissingFilesTool (ADR-047): only missing=1 rows
+ * of the effective storages surface, with the total count always reported.
+ */
+#[CoversClass(FindMissingFilesTool::class)]
+final class FindMissingFilesToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $files = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $files);
+
+        $files->insert('sys_file', [
+            'uid' => 30, 'storage' => 1, 'identifier' => '/lost.pdf',
+            'name' => 'lost.pdf', 'mime_type' => 'application/pdf', 'size' => 1234, 'missing' => 1,
+        ]);
+        $files->insert('sys_file', [
+            'uid' => 31, 'storage' => 1, 'identifier' => '/present.pdf',
+            'name' => 'present.pdf', 'mime_type' => 'application/pdf', 'size' => 10, 'missing' => 0,
+        ]);
+        // Missing, but in a storage outside the gate.
+        $files->insert('sys_file', [
+            'uid' => 32, 'storage' => 2, 'identifier' => '/foreign-lost.pdf',
+            'name' => 'foreign-lost.pdf', 'mime_type' => 'application/pdf', 'size' => 20, 'missing' => 1,
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('find_missing_files');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsOnlyMissingFilesOfTheEffectiveStorages(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('1 missing file (showing 1):', $output);
+        self::assertStringContainsString('- [30] 1:/lost.pdf (last known size 1234 bytes)', $output);
+        self::assertStringNotContainsString('present.pdf', $output);
+        self::assertStringNotContainsString('foreign-lost.pdf', $output);
+    }
+
+    #[Test]
+    public function storageArgumentOutsideTheGateIsDenied(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame('No accessible file storages.', $this->tool->execute(['storage' => 2]));
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertSame('No accessible file storages.', $this->tool->execute([]));
+    }
+}

--- a/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetFalReferencesTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for GetFalReferencesTool (ADR-047): usages render as
+ * table:uid (field), deleted references stay invisible, hidden ones are
+ * marked, and files outside the storage gate are denied neutrally.
+ */
+#[CoversClass(GetFalReferencesTool::class)]
+final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connection = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        $connection->insert('sys_file', [
+            'uid' => 20, 'storage' => 1, 'identifier' => '/logo.svg',
+            'name' => 'logo.svg', 'mime_type' => 'image/svg+xml', 'size' => 500, 'missing' => 0,
+        ]);
+        $connection->insert('sys_file', [
+            'uid' => 21, 'storage' => 2, 'identifier' => '/other.svg',
+            'name' => 'other.svg', 'mime_type' => 'image/svg+xml', 'size' => 600, 'missing' => 0,
+        ]);
+
+        $connection->insert('sys_file_reference', [
+            'uid' => 200, 'uid_local' => 20, 'uid_foreign' => 5, 'tablenames' => 'tt_content',
+            'fieldname' => 'image', 'deleted' => 0, 'hidden' => 0,
+        ]);
+        $connection->insert('sys_file_reference', [
+            'uid' => 201, 'uid_local' => 20, 'uid_foreign' => 1, 'tablenames' => 'pages',
+            'fieldname' => 'media', 'deleted' => 0, 'hidden' => 1,
+        ]);
+        $connection->insert('sys_file_reference', [
+            'uid' => 202, 'uid_local' => 20, 'uid_foreign' => 9, 'tablenames' => 'tt_content',
+            'fieldname' => 'assets', 'deleted' => 1, 'hidden' => 0,
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('get_fal_references');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsReferencesWithHiddenMarkAndWithoutDeletedOnes(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['uid' => 20]);
+
+        self::assertStringContainsString('References to logo.svg (2):', $output);
+        self::assertStringContainsString('- tt_content:5 (field image)', $output);
+        self::assertStringContainsString('- pages:1 (field media) [hidden]', $output);
+        self::assertStringNotContainsString('tt_content:9', $output);
+    }
+
+    #[Test]
+    public function unusedFileSaysSoWithTheSoftReferenceCaveat(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connection = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $connection);
+        $connection->insert('sys_file', [
+            'uid' => 22, 'storage' => 1, 'identifier' => '/unused.png',
+            'name' => 'unused.png', 'mime_type' => 'image/png', 'size' => 10, 'missing' => 0,
+        ]);
+
+        $output = $this->tool->execute(['uid' => 22]);
+
+        self::assertStringContainsString('No references to unused.png', $output);
+        self::assertStringContainsString('soft references', $output);
+    }
+
+    #[Test]
+    public function fileInForeignStorageIsDeniedNeutrally(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 21]));
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 20]));
+    }
+}

--- a/Tests/Functional/Service/Tool/ListFalStoragesToolTest.php
+++ b/Tests/Functional/Service/Tool/ListFalStoragesToolTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ListFalStoragesTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+
+/**
+ * Functional tests for ListFalStoragesTool (ADR-047): the effective storages
+ * render with name/driver/flags, the server-side base path never egresses,
+ * and the tool fails closed without a backend user.
+ */
+#[CoversClass(ListFalStoragesTool::class)]
+final class ListFalStoragesToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $storageRepository = $this->get(StorageRepository::class);
+        self::assertInstanceOf(StorageRepository::class, $storageRepository);
+        self::assertSame(1, $storageRepository->createLocalStorage('Main storage', 'fileadmin/', 'relative'));
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('list_fal_storages');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsTheAccessibleStorageWithoutServerPath(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Accessible file storages (1):', $output);
+        self::assertStringContainsString('[1] Main storage (driver Local', $output);
+        // The server-side base path must never egress.
+        self::assertStringNotContainsString('fileadmin', $output);
+        self::assertStringNotContainsString($this->instancePath, $output);
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertSame('No accessible file storages.', $this->tool->execute([]));
+    }
+}

--- a/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchFalFilesTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for SearchFalFilesTool (ADR-047): name and metadata-title
+ * matches, literal LIKE-wildcard handling, storage scoping, missing files
+ * excluded.
+ */
+#[CoversClass(SearchFalFilesTool::class)]
+final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $files = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $files);
+
+        // Storage 1 (allowed): a name match, a metadata match, a missing file.
+        $files->insert('sys_file', [
+            'uid' => 10, 'storage' => 1, 'identifier' => '/brochure-2026.pdf',
+            'name' => 'brochure-2026.pdf', 'mime_type' => 'application/pdf', 'size' => 1000, 'missing' => 0,
+        ]);
+        $files->insert('sys_file', [
+            'uid' => 11, 'storage' => 1, 'identifier' => '/img/DSC01.jpg',
+            'name' => 'DSC01.jpg', 'mime_type' => 'image/jpeg', 'size' => 2000, 'missing' => 0,
+        ]);
+        $files->insert('sys_file', [
+            'uid' => 12, 'storage' => 1, 'identifier' => '/gone-brochure.pdf',
+            'name' => 'gone-brochure.pdf', 'mime_type' => 'application/pdf', 'size' => 100, 'missing' => 1,
+        ]);
+        // Storage 2 (NOT allowed): must never surface.
+        $files->insert('sys_file', [
+            'uid' => 13, 'storage' => 2, 'identifier' => '/secret-brochure.pdf',
+            'name' => 'secret-brochure.pdf', 'mime_type' => 'application/pdf', 'size' => 3000, 'missing' => 0,
+        ]);
+
+        $files->insert('sys_file_metadata', [
+            'uid' => 100, 'file' => 11, 'sys_language_uid' => 0, 'title' => 'Team brochure photo',
+        ]);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('search_fal_files');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function matchesFileNameAndMetadataTitleWithinAllowedStorages(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['query' => 'brochure']);
+
+        // Name match (uid 10) and metadata-title match (uid 11).
+        self::assertStringContainsString('[10] 1:/brochure-2026.pdf', $output);
+        self::assertStringContainsString('[11] 1:/img/DSC01.jpg', $output);
+        // Missing files and foreign storages never surface.
+        self::assertStringNotContainsString('gone-brochure', $output);
+        self::assertStringNotContainsString('secret-brochure', $output);
+    }
+
+    #[Test]
+    public function likeWildcardsAreMatchedLiterally(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertStringContainsString(
+            'No files match "%"',
+            $this->tool->execute(['query' => '%']),
+        );
+    }
+
+    #[Test]
+    public function storageArgumentOutsideTheGateIsDenied(): void
+    {
+        $this->setUpBackendUser(1);
+
+        self::assertSame(
+            'No accessible file storages.',
+            $this->tool->execute(['query' => 'brochure', 'storage' => 2]),
+        );
+    }
+
+    #[Test]
+    public function failsClosedWithoutBackendUser(): void
+    {
+        self::assertSame(
+            'No accessible file storages.',
+            $this->tool->execute(['query' => 'brochure']),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
@@ -113,4 +113,18 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
             $this->tool->execute(['query' => 'brochure']),
         );
     }
+    #[Test]
+    public function searchIsCaseInsensitive(): void
+    {
+        $this->setUpBackendUser(1);
+
+        // Fixture name is lowercase 'brochure-2026.pdf'; DB collations with
+        // case-sensitive LIKE (e.g. PostgreSQL) must still match.
+        $output = $this->tool->execute(['query' => 'BROCHURE']);
+
+        self::assertStringContainsString('brochure-2026.pdf', $output);
+        // Uppercase name matched by lowercase query, too.
+        $output = $this->tool->execute(['query' => 'dsc01']);
+        self::assertStringContainsString('DSC01.jpg', $output);
+    }
 }

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Service\Tool\Builtin\BrowseFalFolderTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\CheckTypoScriptTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\FindMissingFilesTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\FluidResolveTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetFalReferencesTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetFlexFormSchemaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetFullTcaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetLastExceptionTool;
@@ -29,12 +32,14 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeGroupsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListFalStoragesTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadSourceTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ResolveUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\SearchCodeTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchFalFilesTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ValidateTcaTool;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -87,6 +92,11 @@ final class BuiltinToolGroupsTest extends TestCase
             'read_source'       => [ReadSourceTool::class, 'code'],
             'search_code'       => [SearchCodeTool::class, 'code'],
             'probe_url'         => [ProbeUrlTool::class, 'system'],
+            'list_fal_storages' => [ListFalStoragesTool::class, 'files'],
+            'browse_fal_folder' => [BrowseFalFolderTool::class, 'files'],
+            'search_fal_files'  => [SearchFalFilesTool::class, 'files'],
+            'get_fal_references' => [GetFalReferencesTool::class, 'files'],
+            'find_missing_files' => [FindMissingFilesTool::class, 'files'],
         ];
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\BrowseFalFolderTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\FindMissingFilesTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetFalReferencesTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListFalStoragesTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchFalFilesTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Spec shape + admin/default flags of the FAL tools (ADR-047). The storage
+ * and DB paths are covered functionally. getSpec()/requiresAdmin()/
+ * isEnabledByDefault() touch no collaborator, so
+ * newInstanceWithoutConstructor is safe.
+ */
+#[CoversClass(BrowseFalFolderTool::class)]
+#[CoversClass(FindMissingFilesTool::class)]
+#[CoversClass(GetFalReferencesTool::class)]
+#[CoversClass(ListFalStoragesTool::class)]
+#[CoversClass(SearchFalFilesTool::class)]
+final class FalToolsSpecTest extends TestCase
+{
+    /**
+     * @return list<class-string<ToolInterface>>
+     */
+    private static function toolClasses(): array
+    {
+        return [
+            ListFalStoragesTool::class,
+            BrowseFalFolderTool::class,
+            SearchFalFilesTool::class,
+            GetFalReferencesTool::class,
+            FindMissingFilesTool::class,
+        ];
+    }
+
+    /**
+     * @param class-string<ToolInterface> $class
+     */
+    private static function bare(string $class): ToolInterface
+    {
+        $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        self::assertInstanceOf(ToolInterface::class, $tool);
+
+        return $tool;
+    }
+
+    #[Test]
+    public function specsExposeNamesAndRequiredParameters(): void
+    {
+        $storages = self::bare(ListFalStoragesTool::class)->getSpec();
+        self::assertSame('list_fal_storages', $storages->name);
+        self::assertArrayNotHasKey('required', $storages->parameters);
+
+        $browse = self::bare(BrowseFalFolderTool::class)->getSpec();
+        self::assertSame('browse_fal_folder', $browse->name);
+        self::assertArrayNotHasKey('required', $browse->parameters);
+
+        $search = self::bare(SearchFalFilesTool::class)->getSpec();
+        self::assertSame('search_fal_files', $search->name);
+        self::assertSame(['query'], $search->parameters['required'] ?? []);
+
+        $references = self::bare(GetFalReferencesTool::class)->getSpec();
+        self::assertSame('get_fal_references', $references->name);
+        self::assertSame(['uid'], $references->parameters['required'] ?? []);
+
+        $missing = self::bare(FindMissingFilesTool::class)->getSpec();
+        self::assertSame('find_missing_files', $missing->name);
+        self::assertArrayNotHasKey('required', $missing->parameters);
+    }
+
+    #[Test]
+    public function allToolsAreNonAdminEnabledByDefaultAndInTheFilesGroup(): void
+    {
+        foreach (self::toolClasses() as $class) {
+            $tool = self::bare($class);
+            self::assertFalse($tool->requiresAdmin(), $class);
+            self::assertTrue($tool->isEnabledByDefault(), $class);
+            self::assertSame('files', $tool->getGroup(), $class);
+        }
+    }
+
+    #[Test]
+    public function failClosedWithoutBackendUser(): void
+    {
+        // No $GLOBALS['BE_USER'] in unit context → the storage gate yields
+        // no storages and every tool answers with its neutral denial.
+        self::assertSame(
+            'Asset not found or not permitted.',
+            self::bare(GetFalReferencesTool::class)->execute(['uid' => 0]),
+        );
+        self::assertSame(
+            'Error: "query" is required.',
+            self::bare(SearchFalFilesTool::class)->execute([]),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

FAL tool wave (ADR-047): five built-in tools in the new **`files`** group, closing the FAL gap in the tool set.

| Tool | Purpose |
|---|---|
| `list_fal_storages` | accessible storages: name, driver, online/browsable/public — never the base path |
| `browse_fal_folder` | one folder: subfolders (file count) + files (size, MIME), storage-relative identifiers only |
| `search_fal_files` | substring search over file names + metadata title/alt (LIKE-escaped), missing files excluded |
| `get_fal_references` | where a file is used: `table:uid` + field from `sys_file_reference` (deleted invisible, hidden marked; soft-reference caveat stated) |
| `find_missing_files` | `sys_file.missing = 1` — the "broken image" diagnosis, total count always reported |

## Access model

- Shared `FalStorageGate`: configured storage allow-list (default `[1]`) ∩ — for non-admins — the storages reachable through their file mounts (`getFileStorages()`, byte-identical 13.4/14). Fail-closed, neutral denials.
- `browse_fal_folder` additionally enforces **folder-level** mount boundaries: non-admins get `setEvaluatePermissions(true)`, so core mount checks apply per folder read. Outside a backend request (no `StoragePermissionsAspect`) non-admin access fails closed rather than mount-blind.
- `get_fal_references` drops rows whose referencing table fails `TableReadAccessService` for non-admins.
- Server paths never egress.

## Tests

Spec unit test + 5 taxonomy entries + 6 functional classes (19 tests / ~115 assertions), incl. a mount-confinement test proving the storage root is denied (root file name never egresses) while the mounted subfolder lists — with the real core aspect attaching the mounts under a faked backend request context.

## Docs

ADR-047 + Tools.rst (new `files` group row; tool count now thirty-three, thirty enabled).