### PR TITLE
feat(tools): system diagnostics — extensions, sites, scheduler, status, deprecations, middlewares

### DIFF
--- a/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+/**
+ * Site configuration inspection (ADR-048).
+ *
+ * Without an identifier: one line per configured site (identifier, base,
+ * root page). With one: the site's configuration flattened to dotted
+ * `key: value` lines — the answer to "why does language 1 behave oddly" or
+ * "which error handler is configured".
+ *
+ * Security contract (see {@see ToolInterface}): admin-only. Values whose key
+ * segment matches the credential pattern of {@see TableReadAccessService}
+ * (site settings routinely carry API keys) render as `[redacted]`; values
+ * and the line count are capped, so a huge settings tree cannot flood the
+ * egress.
+ */
+final readonly class GetSiteConfigTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const MAX_LINES = 200;
+
+    private const VALUE_WIDTH = 120;
+
+    private const REDACTED = '[redacted]';
+
+    public function __construct(
+        private SiteFinder $siteFinder,
+        private TableReadAccessService $tableAccess,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_site_config',
+            'Show the site configuration: without arguments list all sites (identifier, base, root page); '
+            . 'with "identifier" return that site\'s configuration as flat key: value lines '
+            . '(credential-like values are redacted).',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'identifier' => [
+                        'type'        => 'string',
+                        'description' => 'Optional site identifier (from the identifier-less listing).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $identifier = trim(self::toStr($arguments['identifier'] ?? ''));
+
+        if ($identifier === '') {
+            $lines = [];
+            foreach ($this->siteFinder->getAllSites() as $site) {
+                $lines[] = sprintf(
+                    '- %s (base %s, root page %d)',
+                    $site->getIdentifier(),
+                    (string)$site->getBase(),
+                    $site->getRootPageId(),
+                );
+            }
+            if ($lines === []) {
+                return 'No sites configured.';
+            }
+            sort($lines);
+
+            return sprintf(
+                "Configured sites (%d) — pass \"identifier\" for a site's configuration:\n",
+                count($lines),
+            ) . implode("\n", $lines);
+        }
+
+        $sites = $this->siteFinder->getAllSites();
+        $site  = $sites[$identifier] ?? null;
+        if ($site === null) {
+            return sprintf('No site "%s". Call without arguments to list the identifiers.', $identifier);
+        }
+
+        $lines = [];
+        $this->flatten($site->getConfiguration(), '', $lines);
+
+        $total = count($lines);
+        if ($total > self::MAX_LINES) {
+            $lines   = array_slice($lines, 0, self::MAX_LINES);
+            $lines[] = sprintf('… %d more lines not shown', $total - self::MAX_LINES);
+        }
+
+        return sprintf("Site \"%s\" configuration (%d entries):\n", $identifier, $total)
+            . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: site configuration is instance configuration.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'configuration';
+    }
+
+    /**
+     * Flatten the configuration array to dotted `key: value` lines; any key
+     * SEGMENT matching the credential pattern redacts the whole subtree value.
+     *
+     * @param array<array-key, mixed> $config
+     * @param list<string>            $lines
+     */
+    private function flatten(array $config, string $prefix, array &$lines): void
+    {
+        foreach ($config as $key => $value) {
+            $keyName = (string)$key;
+            $path    = $prefix === '' ? $keyName : $prefix . '.' . $keyName;
+
+            // Normalize camelCase (apiKey → api_Key) first — the credential
+            // pattern is snake_case-segment based, site settings are often
+            // camelCase.
+            $normalizedKey = (string)preg_replace('/(?<=[a-z0-9])(?=[A-Z])/', '_', $keyName);
+            if ($this->tableAccess->isSensitiveField($normalizedKey)) {
+                $lines[] = sprintf('%s: %s', $path, self::REDACTED);
+                continue;
+            }
+
+            if (is_array($value)) {
+                if ($value === []) {
+                    $lines[] = sprintf('%s: []', $path);
+                    continue;
+                }
+                $this->flatten($value, $path, $lines);
+                continue;
+            }
+
+            $lines[] = sprintf('%s: %s', $path, $this->renderValue($value));
+        }
+    }
+
+    private function renderValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if ($value === null) {
+            return 'null';
+        }
+
+        $text = trim((string)preg_replace('/\s+/', ' ', self::toStr($value)));
+
+        return mb_strimwidth($text, 0, self::VALUE_WIDTH, '…');
+    }
+}

--- a/Classes/Service/Tool/Builtin/GetSystemStatusTool.php
+++ b/Classes/Service/Tool/Builtin/GetSystemStatusTool.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Throwable;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * One compact system status block (ADR-048).
+ *
+ * TYPO3 / PHP / database versions, application context, composer mode, OS
+ * family and timezone — the first thing to establish in any "why does X
+ * behave differently here" conversation.
+ *
+ * Security contract (see {@see ToolInterface}): admin-only; no paths and no
+ * hostnames egress — versions and flags only.
+ */
+final readonly class GetSystemStatusTool implements ToolInterface
+{
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'get_system_status',
+            'One compact status block: TYPO3, PHP and database versions, application context, '
+            . 'composer mode, OS family and timezone.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $typo3 = new Typo3Version();
+
+        $lines   = [];
+        $lines[] = sprintf('TYPO3: %s', $typo3->getVersion());
+        $lines[] = sprintf('PHP: %s', PHP_VERSION);
+        $lines[] = sprintf('Database: %s', $this->databaseVersion());
+        $lines[] = sprintf('Application context: %s', (string)Environment::getContext());
+        $lines[] = sprintf('Composer mode: %s', Environment::isComposerMode() ? 'yes' : 'no (classic)');
+        $lines[] = sprintf('OS family: %s', PHP_OS_FAMILY);
+        $lines[] = sprintf('Timezone: %s', date_default_timezone_get());
+
+        return implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: version fingerprinting is reconnaissance data.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+
+    private function databaseVersion(): string
+    {
+        try {
+            $connection = $this->connectionPool->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+
+            return $connection->getServerVersion();
+        } catch (Throwable) {
+            return '(unavailable)';
+        }
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
+++ b/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Tail the TYPO3 deprecation log (ADR-048).
+ *
+ * The newest distinct deprecation messages from the file-based deprecation
+ * channel (`var/log/typo3_deprecations_*.log`) — the work list for an
+ * upgrade. Identical messages are deduplicated with a ×count suffix.
+ *
+ * Security contract (see {@see ToolInterface}): admin-only; absolute project
+ * paths inside messages are rewritten to project-relative form before the
+ * egress, output is bounded (never the raw file), and a disabled channel /
+ * absent file degrades to a plain message.
+ */
+final readonly class ListDeprecationsTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const NO_LOG = 'No deprecation log found (the deprecation channel may be disabled).';
+
+    private const DEFAULT_LIMIT = 15;
+
+    private const MAX_LIMIT = 40;
+
+    /** Read at most this many bytes from the file tail. */
+    private const TAIL_BYTES = 262144;
+
+    private const MESSAGE_WIDTH = 300;
+
+    public function __construct(
+        private ?string $logDirectory = null,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_deprecations',
+            'List the newest distinct messages from the TYPO3 deprecation log — the upgrade work list. '
+            . 'Duplicates are collapsed with a ×count suffix.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum distinct messages (default 15, capped at 40).',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $file = $this->newestLogFile();
+        if ($file === null) {
+            return self::NO_LOG;
+        }
+
+        $tail = $this->tail($file);
+        if ($tail === '') {
+            return self::NO_LOG;
+        }
+
+        // Newest last in the file → iterate reversed so "newest first" wins.
+        $counts = [];
+        foreach (array_reverse(explode("\n", $tail)) as $line) {
+            $message = $this->normalizeLine($line);
+            if ($message === '') {
+                continue;
+            }
+            $counts[$message] = ($counts[$message] ?? 0) + 1;
+        }
+        if ($counts === []) {
+            return self::NO_LOG;
+        }
+
+        $total  = count($counts);
+        $counts = array_slice($counts, 0, $limit, true);
+
+        $lines = [];
+        foreach ($counts as $message => $count) {
+            $lines[] = sprintf('- %s%s', $message, $count > 1 ? sprintf(' (×%d)', $count) : '');
+        }
+
+        return sprintf(
+            "Deprecations (%d distinct%s, newest first):\n",
+            $total,
+            $total > $limit ? sprintf(', showing %d', $limit) : '',
+        ) . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: log content reveals code paths and versions.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+
+    private function newestLogFile(): ?string
+    {
+        $dir   = $this->logDirectory ?? Environment::getVarPath() . '/log';
+        $files = glob($dir . '/typo3_deprecations_*.log');
+        if (!is_array($files) || $files === []) {
+            return null;
+        }
+
+        usort($files, static fn(string $a, string $b): int => (int)filemtime($b) <=> (int)filemtime($a));
+
+        return $files[0];
+    }
+
+    private function tail(string $file): string
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return '';
+        }
+        $size = (int)filesize($file);
+        if ($size < 1) {
+            return '';
+        }
+        $handle = fopen($file, 'r');
+        if ($handle === false) {
+            return '';
+        }
+        try {
+            if ($size > self::TAIL_BYTES) {
+                fseek($handle, -self::TAIL_BYTES, SEEK_END);
+                // Drop the (likely partial) first line of the window.
+                fgets($handle);
+            }
+            $content = stream_get_contents($handle);
+        } finally {
+            fclose($handle);
+        }
+
+        return is_string($content) ? $content : '';
+    }
+
+    /**
+     * Strip the timestamp/level prefix, relativize project paths and cap the
+     * width, so identical deprecations from different requests deduplicate.
+     */
+    private function normalizeLine(string $line): string
+    {
+        $line = trim($line);
+        if ($line === '') {
+            return '';
+        }
+
+        // Typical FileWriter line: "Tue, 08 Jul 2026 12:34:56 +0000 [NOTICE] request="…" component="…": message"
+        $position = strpos($line, ': ');
+        if ($position !== false && preg_match('/^\S{3}, \d{2} /', $line) === 1) {
+            $line = substr($line, $position + 2);
+        }
+
+        $line = str_replace(Environment::getProjectPath() . '/', '', $line);
+        $line = trim((string)preg_replace('/\s+/', ' ', $line));
+
+        return mb_strimwidth($line, 0, self::MESSAGE_WIDTH, '…');
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListExtensionsTool.php
+++ b/Classes/Service/Tool/Builtin/ListExtensionsTool.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Package\PackageManager;
+
+/**
+ * List the installed TYPO3 extensions (ADR-048).
+ *
+ * One line per active package: extension key, version, composer name and
+ * title — the inventory a model needs to reason about "which extension could
+ * cause X" or "is Y installed at all".
+ *
+ * Security contract (see {@see ToolInterface}): admin-only — the extension
+ * inventory enumerates the instance's attack surface. Package PATHS never
+ * egress; the listing is naturally bounded by the package count.
+ */
+final readonly class ListExtensionsTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    public function __construct(
+        private PackageManager $packageManager,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_extensions',
+            'List the installed (active) TYPO3 extensions: extension key, version, composer name and title.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $lines = [];
+        foreach ($this->packageManager->getActivePackages() as $package) {
+            $meta     = $package->getPackageMetaData();
+            $composer = self::toStr($package->getValueFromComposerManifest('name'));
+            $title    = self::toStr($meta->getTitle() ?? '');
+
+            $lines[$package->getPackageKey()] = sprintf(
+                '- %s %s%s%s',
+                $package->getPackageKey(),
+                self::toStr($meta->getVersion()) ?: '(no version)',
+                $composer !== '' ? sprintf(' (%s)', $composer) : '',
+                $title !== '' ? sprintf(' — %s', $title) : '',
+            );
+        }
+
+        if ($lines === []) {
+            return 'No active packages.';
+        }
+
+        ksort($lines);
+
+        return sprintf("Active extensions (%d):\n", count($lines)) . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: the extension inventory enumerates the attack surface.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
+++ b/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Core\Http\MiddlewareStackResolver;
+
+/**
+ * List a PSR-15 middleware stack in execution order (ADR-048).
+ *
+ * Middleware identifier plus implementing class per entry — the map for
+ * "which middleware could intercept/redirect this request".
+ *
+ * Security contract (see {@see ToolInterface}): admin-only. The resolver is
+ * `@internal` core API (stable across 13.4/14 except its return type,
+ * array vs ArrayObject — both iterable, handled transparently); any
+ * resolution failure collapses into one neutral message. Output is capped.
+ */
+final readonly class ListMiddlewaresTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const STACKS = ['frontend', 'backend'];
+
+    private const MAX_ENTRIES = 100;
+
+    public function __construct(
+        private MiddlewareStackResolver $stackResolver,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_middlewares',
+            'List a PSR-15 middleware stack ("frontend" or "backend") in execution order: '
+            . 'middleware identifier and implementing class.',
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'stack' => [
+                        'type'        => 'string',
+                        'enum'        => self::STACKS,
+                        'description' => 'The middleware stack to list (default "frontend").',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        $stack = trim(self::toStr($arguments['stack'] ?? 'frontend'));
+        if (!in_array($stack, self::STACKS, true)) {
+            return sprintf('Unknown stack — use one of: %s.', implode(', ', self::STACKS));
+        }
+
+        try {
+            // array on 13.4, ArrayObject on v14 — both iterate identically.
+            $middlewares = $this->stackResolver->resolve($stack);
+        } catch (Throwable) {
+            return 'Could not resolve the middleware stack.';
+        }
+
+        $lines = [];
+        foreach ($middlewares as $identifier => $className) {
+            if (count($lines) >= self::MAX_ENTRIES) {
+                $lines[] = '… more entries not shown';
+                break;
+            }
+            $lines[] = sprintf('%2d. %s (%s)', count($lines) + 1, (string)$identifier, self::toStr($className));
+        }
+
+        if ($lines === []) {
+            return sprintf('The %s middleware stack is empty.', $stack);
+        }
+
+        return sprintf("PSR-15 %s middleware stack (%d, execution order):\n", $stack, count($lines))
+            . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: the middleware map is request-processing internals.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+}

--- a/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
+++ b/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
@@ -64,27 +64,29 @@ final readonly class ListMiddlewaresTool implements ToolInterface
             return sprintf('Unknown stack — use one of: %s.', implode(', ', self::STACKS));
         }
 
+        $lines = [];
+        $shown = 0;
         try {
-            // array on 13.4, ArrayObject on v14 — both iterate identically.
-            $middlewares = $this->stackResolver->resolve($stack);
+            // array on 13.4, ArrayObject on v14 — iterated inside the try so
+            // a future return-type change of the @internal resolver collapses
+            // into the neutral message instead of an uncaught TypeError.
+            foreach ($this->stackResolver->resolve($stack) as $identifier => $className) {
+                if ($shown >= self::MAX_ENTRIES) {
+                    $lines[] = '… more entries not shown';
+                    break;
+                }
+                ++$shown;
+                $lines[] = sprintf('%2d. %s (%s)', $shown, (string)$identifier, self::toStr($className));
+            }
         } catch (Throwable) {
             return 'Could not resolve the middleware stack.';
         }
 
-        $lines = [];
-        foreach ($middlewares as $identifier => $className) {
-            if (count($lines) >= self::MAX_ENTRIES) {
-                $lines[] = '… more entries not shown';
-                break;
-            }
-            $lines[] = sprintf('%2d. %s (%s)', count($lines) + 1, (string)$identifier, self::toStr($className));
-        }
-
-        if ($lines === []) {
+        if ($shown === 0) {
             return sprintf('The %s middleware stack is empty.', $stack);
         }
 
-        return sprintf("PSR-15 %s middleware stack (%d, execution order):\n", $stack, count($lines))
+        return sprintf("PSR-15 %s middleware stack (%d, execution order):\n", $stack, $shown)
             . implode("\n", $lines);
     }
 

--- a/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
+++ b/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
@@ -102,10 +102,17 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
             }
             $label = mb_strimwidth(trim((string)preg_replace('/\s+/', ' ', $label)), 0, 100, '…');
 
-            $next    = self::toInt($row['nextexecution'] ?? 0);
-            $failed  = self::toStr($row['lastexecution_failure'] ?? '') !== '';
+            $next = self::toInt($row['nextexecution'] ?? 0);
+            // The failure column carries an error string; '' / '0' / NULL all
+            // mean "no failure" (the DB default is numeric on some versions).
+            $failure = trim(self::toStr($row['lastexecution_failure'] ?? ''));
+            $failed  = $failure !== '' && $failure !== '0';
             $flags   = [];
             $flags[] = $next > 0 ? 'next ' . gmdate('Y-m-d H:i', $next) . ' UTC' : 'no next execution';
+            $lastRun = self::toInt($row['lastexecution_time'] ?? 0);
+            if ($lastRun > 0) {
+                $flags[] = 'last run ' . gmdate('Y-m-d H:i', $lastRun) . ' UTC';
+            }
             if (self::toInt($row['disable'] ?? 0) === 1) {
                 $flags[] = 'DISABLED';
             }

--- a/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
+++ b/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Throwable;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * List the scheduler task records (ADR-048).
+ *
+ * uid, description/type, next execution (UTC), disabled flag and a
+ * last-run-failed indicator per task — enough to answer "why did the nightly
+ * import not run".
+ *
+ * Security contract (see {@see ToolInterface}): admin-only. EXT:scheduler is
+ * optional: an absent `tx_scheduler_task` table degrades to a plain message.
+ * The `serialized_task_object` blob is NEVER unserialized (unserializing a
+ * DB-supplied object graph is an object-injection primitive) — only the plain
+ * columns are read, and only the columns that exist in the installed
+ * scheduler version (the column set changed between 13.4 and 14).
+ */
+final readonly class ListSchedulerTasksTool implements ToolInterface
+{
+    use SafeCastTrait;
+
+    private const NOT_INSTALLED = 'Scheduler is not installed.';
+
+    private const TABLE = 'tx_scheduler_task';
+
+    /** Columns rendered when the installed scheduler version provides them. */
+    private const OPTIONAL_COLUMNS = ['tasktype', 'description', 'nextexecution', 'lastexecution_time', 'lastexecution_failure', 'disable'];
+
+    private const MAX_TASKS = 50;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            'list_scheduler_tasks',
+            'List the scheduler tasks: uid, description/type, next execution time, disabled flag and '
+            . 'whether the last run failed. Degrades gracefully when EXT:scheduler is not installed.',
+            [
+                'type'       => 'object',
+                'properties' => [],
+            ],
+        );
+    }
+
+    public function execute(array $arguments): string
+    {
+        try {
+            $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+            $available  = array_keys($connection->createSchemaManager()->listTableColumns(self::TABLE));
+        } catch (Throwable) {
+            return self::NOT_INSTALLED;
+        }
+        if ($available === []) {
+            return self::NOT_INSTALLED;
+        }
+
+        $select = array_values(array_intersect(
+            array_merge(['uid'], self::OPTIONAL_COLUMNS),
+            array_map(static fn(string|int $c): string => strtolower((string)$c), $available),
+        ));
+
+        try {
+            $queryBuilder = $connection->createQueryBuilder();
+            $queryBuilder->getRestrictions()->removeAll();
+            $rows = $queryBuilder
+                ->select(...$select)
+                ->from(self::TABLE)
+                ->orderBy('uid')
+                ->setMaxResults(self::MAX_TASKS)
+                ->executeQuery()
+                ->fetchAllAssociative();
+        } catch (Throwable) {
+            return self::NOT_INSTALLED;
+        }
+
+        if ($rows === []) {
+            return 'No scheduler tasks configured.';
+        }
+
+        $lines = [];
+        foreach ($rows as $row) {
+            $label = self::toStr($row['description'] ?? '');
+            if ($label === '') {
+                $label = self::toStr($row['tasktype'] ?? '') ?: '(no description)';
+            }
+            $label = mb_strimwidth(trim((string)preg_replace('/\s+/', ' ', $label)), 0, 100, '…');
+
+            $next    = self::toInt($row['nextexecution'] ?? 0);
+            $failed  = self::toStr($row['lastexecution_failure'] ?? '') !== '';
+            $flags   = [];
+            $flags[] = $next > 0 ? 'next ' . gmdate('Y-m-d H:i', $next) . ' UTC' : 'no next execution';
+            if (self::toInt($row['disable'] ?? 0) === 1) {
+                $flags[] = 'DISABLED';
+            }
+            if ($failed) {
+                $flags[] = 'LAST RUN FAILED';
+            }
+
+            $lines[] = sprintf('- [%d] %s (%s)', self::toInt($row['uid'] ?? 0), $label, implode(', ', $flags));
+        }
+
+        return sprintf("Scheduler tasks (%d, capped at %d):\n", count($lines), self::MAX_TASKS)
+            . implode("\n", $lines);
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        // Admin-only: task inventory reveals automation internals.
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'system';
+    }
+}

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -36,10 +36,10 @@ non-admin users.
 The built-in tools
 ==================
 
-nr-llm ships thirty-three read-only tools. Each is a reference
+nr-llm ships thirty-nine read-only tools. Each is a reference
 implementation of the security contract: model-chosen arguments are
 validated and scoped, volumes are capped, and secret-bearing output is either
-redacted or gated behind a separate ``_raw`` variant. Thirty ship
+redacted or gated behind a separate ``_raw`` variant. Thirty-six ship
 **enabled**; the three unredacted ``_raw`` variants (``get_env_raw``,
 ``get_php_info_raw`` and ``list_be_users_raw``) ship **disabled** and must be
 enabled deliberately. Many require admin; the read-only structure, content
@@ -231,6 +231,35 @@ The remaining tools follow the same pattern:
    Reports source and line number only, never the offending line's content
    (a constants line may carry an API key). Admin-only.
 
+``list_extensions``
+   The installed (active) extensions: key, version, composer name and
+   title — no package paths. Admin-only.
+
+``get_site_config``
+   Without arguments the configured sites (identifier, base, root page);
+   with ``identifier`` that site's configuration flattened to dotted
+   ``key: value`` lines. Credential-like keys (camelCase included, e.g.
+   ``apiKey``) render as ``[redacted]``. Admin-only.
+
+``list_scheduler_tasks``
+   The scheduler tasks with next execution, disabled flag and a
+   last-run-failed marker. The serialized task object is **never
+   unserialized**; degrades gracefully when EXT:scheduler is absent.
+   Admin-only.
+
+``get_system_status``
+   One compact block: TYPO3/PHP/database versions, application context,
+   composer mode, OS family, timezone — no paths, no hostnames. Admin-only.
+
+``list_deprecations``
+   The newest distinct messages from the deprecation log, deduplicated with
+   a ×count suffix and project paths relativized — the upgrade work list.
+   Admin-only.
+
+``list_middlewares``
+   A PSR-15 middleware stack (frontend or backend) in execution order with
+   identifiers and classes. Admin-only.
+
 .. _administration-tools-register:
 
 Registering a tool
@@ -308,10 +337,12 @@ Group            Tools
                  ``get_full_tca``, ``get_table_schema``, ``get_flexform_schema``,
                  ``resolve_url``, ``validate_tca``
 ``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw),
-                 ``fetch_logs``, ``probe_url``
+                 ``fetch_logs``, ``probe_url``, ``list_extensions``,
+                 ``list_scheduler_tasks``, ``get_system_status``,
+                 ``list_deprecations``, ``list_middlewares``
 ``accounts``     ``list_be_users`` (+ raw), ``list_be_groups``
 ``configuration``  ``get_typoscript``, ``get_tsconfig``, ``fluid_resolve``,
-                 ``check_typoscript``
+                 ``check_typoscript``, ``get_site_config``
 ``code``         ``get_last_exception``, ``read_source``, ``search_code``
 ``files``        ``list_fal_storages``, ``browse_fal_folder``,
                  ``search_fal_files``, ``get_fal_references``,

--- a/Documentation/Adr/Adr048DiagnosticsTools.rst
+++ b/Documentation/Adr/Adr048DiagnosticsTools.rst
@@ -1,0 +1,90 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-048:
+
+==========================
+ADR-048: Diagnostics tools
+==========================
+
+:Status: Accepted
+:Date: 2026-07-09
+:Deciders: nr_llm maintainers
+
+Context
+=======
+
+The tool family answers content, schema, configuration, code and file
+questions — but "establish the system context first" still needed a human:
+which extensions and versions run here, which sites exist, did the nightly
+task fire, is this a composer-mode v14 on PostgreSQL, what does the
+deprecation log say, which middleware could intercept this request. Every
+diagnosis conversation starts with a subset of these.
+
+Decision
+========
+
+Six read-only, **admin-only** built-in tools — they enumerate the
+instance's configuration and attack surface, so none is offered to
+non-admins:
+
+``list_extensions`` (group ``system``)
+   Active packages with key, version, composer name and title via
+   :php:`PackageManager`. Package paths never egress.
+
+``get_site_config`` (group ``configuration``)
+   Site listing, or one site's configuration flattened to dotted
+   ``key: value`` lines. Keys matching the credential pattern of
+   :php:`TableReadAccessService` redact their value — with camelCase
+   normalization (``apiKey`` → ``api_Key``) because site settings are
+   commonly camelCase while the pattern is snake_case-segment based.
+   Output is line- and value-capped, never raw YAML.
+
+``list_scheduler_tasks`` (group ``system``)
+   Plain columns of ``tx_scheduler_task`` only. The
+   ``serialized_task_object`` blob is **never unserialized** — feeding a
+   DB-supplied object graph to :php:`unserialize()` is an object-injection
+   primitive, and the plain columns answer the diagnostic question. The
+   column set differs between 13.4 (SQL-defined) and 14 (TCA-defined,
+   adds ``tasktype``), so available columns are introspected per instance.
+   An absent table degrades to "Scheduler is not installed."
+
+``get_system_status`` (group ``system``)
+   TYPO3/PHP/database versions, application context, composer mode, OS
+   family, timezone — versions and flags only, no paths, no hostnames.
+   The database version comes from Doctrine's
+   :php:`Connection::getServerVersion()` (dbal ~4.4 on both 13.4 and 14).
+
+``list_deprecations`` (group ``system``)
+   Tail of the newest ``var/log/typo3_deprecations_*.log``: distinct
+   messages deduplicated with a ×count suffix, absolute project paths
+   rewritten to relative, width- and count-capped. A missing file or
+   disabled channel degrades to a plain message.
+
+``list_middlewares`` (group ``system``)
+   One PSR-15 stack in execution order via
+   :php:`MiddlewareStackResolver` — ``@internal`` core API (same caveat as
+   the include-tree classes used by ``check_typoscript``, ADR-046); its
+   return type differs across versions (``array`` on 13.4,
+   ``ArrayObject`` on 14) and is consumed as an iterable. Resolution
+   failures collapse into one neutral message.
+
+Considered and rejected
+=======================
+
+``list_event_listeners`` was part of the original idea list: the core
+:php:`ListenerProvider` exposes no stable public enumeration API across
+13.4 and 14, so a listener inventory would depend on container internals
+that change per version. Dropped until the core offers a supported way.
+
+Consequences
+============
+
+- A model can establish the full system context (versions, extensions,
+  sites, automation, upgrade debt, request pipeline) without a human
+  relaying installer or reports-module screenshots.
+- All six are admin-only; the ``system``/``configuration`` group toggles
+  (ADR-043) disable them centrally, per configuration and per run.
+- Two ``@internal`` core APIs are consumed (``MiddlewareStackResolver``
+  here, the include-tree scanner in ADR-046) — accepted as the only
+  practical access path, guarded by neutral failure modes and the CI
+  matrix across both supported majors.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -346,3 +346,4 @@ Tools
    Adr045SchemaAndResolutionTools
    Adr046HistoryUrlAndValidationTools
    Adr047FalTools
+   Adr048DiagnosticsTools

--- a/Tests/Functional/Service/Tool/DiagnosticsToolsFunctionalTest.php
+++ b/Tests/Functional/Service/Tool/DiagnosticsToolsFunctionalTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSystemStatusTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListDeprecationsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListMiddlewaresTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListSchedulerTasksTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for the status, scheduler, deprecation and middleware
+ * diagnostics tools (ADR-048).
+ */
+#[CoversClass(GetSystemStatusTool::class)]
+#[CoversClass(ListDeprecationsTool::class)]
+#[CoversClass(ListMiddlewaresTool::class)]
+#[CoversClass(ListSchedulerTasksTool::class)]
+final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    private function tool(string $name): ToolInterface
+    {
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get($name);
+        self::assertInstanceOf(ToolInterface::class, $tool);
+
+        return $tool;
+    }
+
+    #[Test]
+    public function systemStatusReportsVersionsWithoutPaths(): void
+    {
+        $output = $this->tool('get_system_status')->execute([]);
+
+        self::assertStringContainsString('TYPO3: ' . (new Typo3Version())->getVersion(), $output);
+        self::assertStringContainsString('PHP: ' . PHP_VERSION, $output);
+        self::assertStringContainsString('Database: ', $output);
+        self::assertStringContainsString('Composer mode: ', $output);
+        // No filesystem detail egresses.
+        self::assertStringNotContainsString($this->instancePath, $output);
+        self::assertStringNotContainsString('/var/', $output);
+    }
+
+    #[Test]
+    public function schedulerAbsenceDegradesGracefully(): void
+    {
+        // EXT:scheduler is not part of the test instance.
+        self::assertSame('Scheduler is not installed.', $this->tool('list_scheduler_tasks')->execute([]));
+    }
+
+    #[Test]
+    public function deprecationsAreDedupedAndPathsRelativized(): void
+    {
+        $logDir = $this->instancePath . '/typo3temp/var/tests/deprecations';
+        GeneralUtility::mkdir_deep($logDir);
+        $projectFile = Environment::getProjectPath() . '/vendor/acme/thing/Classes/Old.php';
+        file_put_contents($logDir . '/typo3_deprecations_test.log', implode("\n", [
+            'Tue, 08 Jul 2026 12:00:00 +0000 [NOTICE] request="a1" component="TYPO3.CMS.deprecations": Method foo() is deprecated',
+            'Tue, 08 Jul 2026 12:00:01 +0000 [NOTICE] request="a2" component="TYPO3.CMS.deprecations": Method foo() is deprecated',
+            'Tue, 08 Jul 2026 12:00:02 +0000 [NOTICE] request="a3" component="TYPO3.CMS.deprecations": Class deprecated in ' . $projectFile,
+        ]) . "\n");
+
+        $output = (new ListDeprecationsTool($logDir))->execute([]);
+
+        self::assertStringContainsString('Method foo() is deprecated (×2)', $output);
+        self::assertStringContainsString('vendor/acme/thing/Classes/Old.php', $output);
+        self::assertStringNotContainsString(Environment::getProjectPath() . '/vendor', $output);
+    }
+
+    #[Test]
+    public function missingDeprecationLogDegradesGracefully(): void
+    {
+        $emptyDir = $this->instancePath . '/typo3temp/var/tests/no-deprecations';
+        GeneralUtility::mkdir_deep($emptyDir);
+
+        self::assertSame(
+            'No deprecation log found (the deprecation channel may be disabled).',
+            (new ListDeprecationsTool($emptyDir))->execute([]),
+        );
+    }
+
+    #[Test]
+    public function middlewareStackListsBackendMiddlewares(): void
+    {
+        $output = $this->tool('list_middlewares')->execute(['stack' => 'backend']);
+
+        self::assertStringContainsString('PSR-15 backend middleware stack (', $output);
+        self::assertStringContainsString('typo3/cms-core/normalized-params-attribute', $output);
+        self::assertMatchesRegularExpression('/\(TYPO3\\\\CMS\\\\[A-Za-z\\\\]+\)/', $output);
+    }
+
+    #[Test]
+    public function unknownMiddlewareStackIsRejected(): void
+    {
+        self::assertStringContainsString(
+            'Unknown stack',
+            $this->tool('list_middlewares')->execute(['stack' => 'cli']),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
+++ b/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSiteConfigTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for GetSiteConfigTool (ADR-048): the site listing, the
+ * flattened per-site configuration and the credential redaction (site
+ * settings routinely carry API keys, camelCase included).
+ */
+#[CoversClass(GetSiteConfigTool::class)]
+final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $siteDir = $this->instancePath . '/typo3conf/sites/diag';
+        GeneralUtility::mkdir_deep($siteDir);
+        file_put_contents($siteDir . '/config.yaml', <<<YAML
+            rootPageId: 1
+            base: 'http://localhost:59999/'
+            settings:
+              maps:
+                apiKey: 'super-secret-value-123'
+                zoom: 12
+            languages:
+              - languageId: 0
+                title: English
+                locale: en_US.UTF-8
+                base: /
+            YAML);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('get_site_config');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsAllSitesWithoutIdentifier(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Configured sites (', $output);
+        self::assertStringContainsString('- diag (base http://localhost:59999/, root page 1)', $output);
+    }
+
+    #[Test]
+    public function flattensConfigurationAndRedactsCredentialKeys(): void
+    {
+        $output = $this->tool->execute(['identifier' => 'diag']);
+
+        self::assertStringContainsString('rootPageId: 1', $output);
+        self::assertStringContainsString('languages.0.locale: en_US.UTF-8', $output);
+        // The credential KEY is visible, its camelCase VALUE is not.
+        self::assertStringContainsString('settings.maps.apiKey: [redacted]', $output);
+        self::assertStringNotContainsString('super-secret-value-123', $output);
+        self::assertStringContainsString('settings.maps.zoom: 12', $output);
+    }
+
+    #[Test]
+    public function unknownIdentifierIsReported(): void
+    {
+        self::assertStringContainsString(
+            'No site "nope"',
+            $this->tool->execute(['identifier' => 'nope']),
+        );
+    }
+}

--- a/Tests/Functional/Service/Tool/ListExtensionsToolTest.php
+++ b/Tests/Functional/Service/Tool/ListExtensionsToolTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\ListExtensionsTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Functional tests for ListExtensionsTool (ADR-048): the active packages
+ * list with versions, without package paths.
+ */
+#[CoversClass(ListExtensionsTool::class)]
+final class ListExtensionsToolTest extends AbstractFunctionalTestCase
+{
+    private ToolInterface $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get('list_extensions');
+        self::assertInstanceOf(ToolInterface::class, $tool);
+        $this->tool = $tool;
+    }
+
+    #[Test]
+    public function listsActivePackagesWithVersions(): void
+    {
+        $output = $this->tool->execute([]);
+
+        self::assertStringContainsString('Active extensions (', $output);
+        self::assertStringContainsString('- nr_llm ', $output);
+        self::assertStringContainsString('- core ', $output);
+        // A semver-looking version somewhere in the list.
+        self::assertMatchesRegularExpression('/ \d+\.\d+/', $output);
+        // Never a filesystem path.
+        self::assertStringNotContainsString('/vendor/', $output);
+        self::assertStringNotContainsString($this->instancePath, $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/BuiltinToolGroupsTest.php
@@ -25,6 +25,8 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetPageTreeTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetPhpInfoTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetRecordHistoryTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSiteConfigTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSystemStatusTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTableSchemaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTcaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetTsConfigTool;
@@ -32,7 +34,11 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetTypoScriptTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeGroupsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersRawTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListBeUsersTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListDeprecationsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListExtensionsTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ListFalStoragesTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListMiddlewaresTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListSchedulerTasksTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadFalAssetMetaTool;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
@@ -84,6 +90,12 @@ final class BuiltinToolGroupsTest extends TestCase
             'list_be_groups'    => [ListBeGroupsTool::class, 'accounts'],
             'get_typoscript'    => [GetTypoScriptTool::class, 'configuration'],
             'get_tsconfig'      => [GetTsConfigTool::class, 'configuration'],
+            'list_extensions'   => [ListExtensionsTool::class, 'system'],
+            'get_site_config'   => [GetSiteConfigTool::class, 'configuration'],
+            'list_scheduler_tasks'   => [ListSchedulerTasksTool::class, 'system'],
+            'get_system_status' => [GetSystemStatusTool::class, 'system'],
+            'list_deprecations' => [ListDeprecationsTool::class, 'system'],
+            'list_middlewares'  => [ListMiddlewaresTool::class, 'system'],
             'get_record_history' => [GetRecordHistoryTool::class, 'content'],
             'resolve_url'       => [ResolveUrlTool::class, 'structure'],
             'validate_tca'      => [ValidateTcaTool::class, 'structure'],

--- a/Tests/Unit/Service/Tool/Builtin/DiagnosticsToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/DiagnosticsToolsSpecTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSiteConfigTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\GetSystemStatusTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListDeprecationsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListExtensionsTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListMiddlewaresTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ListSchedulerTasksTool;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Spec shape + admin/default flags of the diagnostics tools (ADR-048). The
+ * runtime paths are covered functionally. getSpec()/requiresAdmin()/
+ * isEnabledByDefault() touch no collaborator, so
+ * newInstanceWithoutConstructor is safe.
+ */
+#[CoversClass(GetSiteConfigTool::class)]
+#[CoversClass(GetSystemStatusTool::class)]
+#[CoversClass(ListDeprecationsTool::class)]
+#[CoversClass(ListExtensionsTool::class)]
+#[CoversClass(ListMiddlewaresTool::class)]
+#[CoversClass(ListSchedulerTasksTool::class)]
+final class DiagnosticsToolsSpecTest extends TestCase
+{
+    /**
+     * @return list<class-string<ToolInterface>>
+     */
+    private static function toolClasses(): array
+    {
+        return [
+            ListExtensionsTool::class,
+            GetSiteConfigTool::class,
+            ListSchedulerTasksTool::class,
+            GetSystemStatusTool::class,
+            ListDeprecationsTool::class,
+            ListMiddlewaresTool::class,
+        ];
+    }
+
+    /**
+     * @param class-string<ToolInterface> $class
+     */
+    private static function bare(string $class): ToolInterface
+    {
+        $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        self::assertInstanceOf(ToolInterface::class, $tool);
+
+        return $tool;
+    }
+
+    #[Test]
+    public function specsExposeNamesAndNoRequiredParameters(): void
+    {
+        $expected = [
+            ListExtensionsTool::class     => 'list_extensions',
+            GetSiteConfigTool::class      => 'get_site_config',
+            ListSchedulerTasksTool::class => 'list_scheduler_tasks',
+            GetSystemStatusTool::class    => 'get_system_status',
+            ListDeprecationsTool::class   => 'list_deprecations',
+            ListMiddlewaresTool::class    => 'list_middlewares',
+        ];
+
+        foreach ($expected as $class => $name) {
+            $spec = self::bare($class)->getSpec();
+            self::assertSame($name, $spec->name);
+            // All arguments are optional across the whole wave.
+            self::assertArrayNotHasKey('required', $spec->parameters);
+        }
+    }
+
+    #[Test]
+    public function allAreAdminOnlyAndEnabledByDefault(): void
+    {
+        foreach (self::toolClasses() as $class) {
+            $tool = self::bare($class);
+            self::assertTrue($tool->requiresAdmin(), $class);
+            self::assertTrue($tool->isEnabledByDefault(), $class);
+        }
+    }
+
+    #[Test]
+    public function groupsFollowTheTaxonomy(): void
+    {
+        foreach (self::toolClasses() as $class) {
+            $tool     = self::bare($class);
+            $expected = $class === GetSiteConfigTool::class ? 'configuration' : 'system';
+            self::assertSame($expected, $tool->getGroup(), $class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Final tool wave (ADR-048): six admin-only diagnostics tools.

| Tool | Group | Purpose |
|---|---|---|
| `list_extensions` | system | active packages: key, version, title, composer name — no paths |
| `get_site_config` | configuration | site listing / one site's config as flat `key: value`; credential-like keys redacted (camelCase-aware — `apiKey` matches the snake_case segment pattern) |
| `list_scheduler_tasks` | system | plain columns only; `serialized_task_object` is **never unserialized**; graceful "Scheduler is not installed." |
| `get_system_status` | system | TYPO3/PHP/DB versions, context, composer mode, OS, timezone — no paths, no hostnames |
| `list_deprecations` | system | tail of the newest deprecation log: deduped ×count, paths relativized; graceful when the channel is off |
| `list_middlewares` | system | frontend/backend PSR-15 stack in execution order (capped 100) |

`list_event_listeners` from the original idea list was considered and rejected — no stable public enumeration API across 13.4/14 (documented in the ADR).

## Cross-version

Verified before coding: `MiddlewareStackResolver::resolve()` returns `array` (13.4) vs `ArrayObject` (14) → consumed as iterable; `tx_scheduler_task` columns differ (14 adds `tasktype`) → runtime column introspection; `PackageManager::getActivePackages()` argless valid on both.

## Tests

Spec unit test + 6 taxonomy entries (39 tools pinned) + functional tests: redaction of an `apiKey` settings value (key visible, value `[redacted]`), scheduler-absent message, no-path assertion on system status, deprecation dedupe ×count + path relativization from a fixture log, backend middleware stack listing.

## Docs

ADR-048 + Tools.rst (tool count now thirty-nine, thirty-six enabled).