### PR TITLE
docs(tools): advise narrow tool groups for small local models

### DIFF
--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -393,13 +393,14 @@ loop, while the Tools module governs *which* tools exist and are enabled.
 
 .. tip::
 
-   **Small local models need a narrow tool set.** With every group enabled,
-   the model is offered 36 tool declarations at once — small models (such
-   as the seeded ``qwen3:4b``) then routinely fail to pick the right tool
-   or reason themselves past the token budget without calling any. Untick
-   the groups that are irrelevant to the question; with one or two groups,
-   the same model answers reliably. Larger hosted models cope with the
-   full set.
+   **Small local models work best with a narrow tool set.** With every
+   group enabled, the model is offered every enabled tool declaration at
+   once (several dozen). Small models such as the seeded ``qwen3:4b``
+   often fail to pick the right tool from a set that large, or reason
+   past the token budget without calling any. Untick the groups that are
+   irrelevant to the question — restricted to one or two groups, the same
+   model picks the right tool. Larger hosted models cope with the full
+   set.
 
 1. Pick an **LLM configuration** from the dropdown. Its vault-stored API key,
    model, temperature and system prompt are what the loop actually runs on —

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -393,11 +393,11 @@ loop, while the Tools module governs *which* tools exist and are enabled.
 
 .. tip::
 
-   **Small local models need a narrow tool set.** With every group enabled
+   **Small local models need a narrow tool set.** With every group enabled,
    the model is offered 36 tool declarations at once — small models (such
    as the seeded ``qwen3:4b``) then routinely fail to pick the right tool
    or reason themselves past the token budget without calling any. Untick
-   the groups that are irrelevant to the question; with one or two groups
+   the groups that are irrelevant to the question; with one or two groups,
    the same model answers reliably. Larger hosted models cope with the
    full set.
 

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -391,6 +391,16 @@ loop, while the Tools module governs *which* tools exist and are enabled.
    registered tool with the default-enabled ones pre-checked and the
    disabled ``_raw`` variants unchecked.
 
+.. tip::
+
+   **Small local models need a narrow tool set.** With every group enabled
+   the model is offered 36 tool declarations at once — small models (such
+   as the seeded ``qwen3:4b``) then routinely fail to pick the right tool
+   or reason themselves past the token budget without calling any. Untick
+   the groups that are irrelevant to the question; with one or two groups
+   the same model answers reliably. Larger hosted models cope with the
+   full set.
+
 1. Pick an **LLM configuration** from the dropdown. Its vault-stored API key,
    model, temperature and system prompt are what the loop actually runs on —
    the playground never falls back to a default model.


### PR DESCRIPTION
## Summary

Adds a tip to the playground guide, from live E2E verification with the seeded `qwen3:4b`:

- offered all **36** tool declarations, the model made **no tool call at all** — it either reasoned past the token budget (`finish: length`) or concluded the needed tool "does not exist" while `get_record_history` was in the list
- restricted to a single group it called `get_record_history` correctly on the first round and answered with the real history data

That is exactly the per-run group selection ADR-043 provides — the tip makes the failure mode and its remedy explicit for users of small local models.