### PR TITLE
fix: match database-fallback retrieval word-wise, rank by word coverage

### DIFF
--- a/Classes/Service/Retrieval/DatabaseSearchBackend.php
+++ b/Classes/Service/Retrieval/DatabaseSearchBackend.php
@@ -72,8 +72,10 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
 
         // routeUid (default-language page uid) => partial evidence data;
         // 'words' collects which query words the page covers (over the page
-        // row AND all its content elements) for the relevance ordering.
-        /** @var array<int, array{title: string, excerpt: string, words: list<string>}> $byPage */
+        // row AND all its content elements) for the relevance ordering,
+        // 'phrase' whether the excerpt is already centred on the literal
+        // phrase (a later row with a phrase hit upgrades a word excerpt).
+        /** @var array<int, array{title: string, excerpt: string, phrase: bool, words: list<string>}> $byPage */
         $byPage = [];
 
         foreach ($this->searchPages($words, $languageId) as $row) {
@@ -84,15 +86,8 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
                 continue;
             }
 
-            $byPage[$routeUid] ??= [
-                'title' => self::toStr($row['title'] ?? ''),
-                'excerpt' => $this->excerptFromRow($row, $this->pageFields(), $query->query, $words),
-                'words' => [],
-            ];
-            $byPage[$routeUid]['words'] = array_values(array_unique(array_merge(
-                $byPage[$routeUid]['words'],
-                $this->matchedWords($row, $this->pageFields(), $words),
-            )));
+            $byPage[$routeUid] ??= ['title' => self::toStr($row['title'] ?? ''), 'excerpt' => '', 'phrase' => false, 'words' => []];
+            $this->mergeRow($byPage[$routeUid], $row, $this->pageFields(), $query->query, $words);
         }
 
         foreach ($this->searchContent($words, $languageId) as $row) {
@@ -101,15 +96,8 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
                 continue;
             }
 
-            $byPage[$routeUid] ??= [
-                'title' => '',
-                'excerpt' => $this->excerptFromRow($row, $this->contentFields(), $query->query, $words),
-                'words' => [],
-            ];
-            $byPage[$routeUid]['words'] = array_values(array_unique(array_merge(
-                $byPage[$routeUid]['words'],
-                $this->matchedWords($row, $this->contentFields(), $words),
-            )));
+            $byPage[$routeUid] ??= ['title' => '', 'excerpt' => '', 'phrase' => false, 'words' => []];
+            $this->mergeRow($byPage[$routeUid], $row, $this->contentFields(), $query->query, $words);
         }
 
         if ($byPage === []) {
@@ -536,14 +524,46 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     }
 
     /**
-     * Excerpt centred on the full query phrase when it occurs literally,
-     * else on the first matching query word.
+     * Folds one matched row into the page's partial evidence: unions the
+     * covered query words and keeps the best excerpt seen so far — centred
+     * on the full query phrase when any row contains it literally, else on
+     * the first matching word of the first matching row.
+     *
+     * @param array{title: string, excerpt: string, phrase: bool, words: list<string>} $partial
+     * @param array<string, mixed>                                                     $row
+     * @param list<string>                                                             $fields
+     * @param list<string>                                                             $words
+     */
+    private function mergeRow(array &$partial, array $row, array $fields, string $query, array $words): void
+    {
+        $partial['words'] = array_values(array_unique(array_merge(
+            $partial['words'],
+            $this->matchedWords($row, $fields, $words),
+        )));
+
+        if ($partial['phrase']) {
+            return;
+        }
+
+        ['excerpt' => $excerpt, 'phrase' => $isPhrase] = $this->excerptFromRow($row, $fields, $query, $words);
+        if ($isPhrase || $partial['excerpt'] === '') {
+            $partial['excerpt'] = $excerpt;
+            $partial['phrase'] = $isPhrase;
+        }
+    }
+
+    /**
+     * Excerpt centred on the full query phrase when it occurs literally
+     * (`phrase` reports which case applied), else on the first matching
+     * query word.
      *
      * @param array<string, mixed> $row
      * @param list<string>         $fields
      * @param list<string>         $words
+     *
+     * @return array{excerpt: string, phrase: bool}
      */
-    private function excerptFromRow(array $row, array $fields, string $query, array $words): string
+    private function excerptFromRow(array $row, array $fields, string $query, array $words): array
     {
         $fallback = '';
         foreach ($fields as $field) {
@@ -556,16 +576,16 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
                 $fallback = mb_substr($plain, 0, ExcerptBuilder::DEFAULT_LENGTH);
             }
             if (mb_stripos($plain, $query) !== false) {
-                return ExcerptBuilder::around($plain, $query);
+                return ['excerpt' => ExcerptBuilder::around($plain, $query), 'phrase' => true];
             }
             foreach ($words as $word) {
                 if (mb_stripos($plain, $word) !== false) {
-                    return ExcerptBuilder::around($plain, $word);
+                    return ['excerpt' => ExcerptBuilder::around($plain, $word), 'phrase' => false];
                 }
             }
         }
 
-        return $fallback;
+        return ['excerpt' => $fallback, 'phrase' => false];
     }
 
     /**

--- a/Classes/Service/Retrieval/DatabaseSearchBackend.php
+++ b/Classes/Service/Retrieval/DatabaseSearchBackend.php
@@ -21,8 +21,11 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Always-available retrieval fallback (ADR-049): LIKE search across the
- * TCA search fields of `pages` and `tt_content`, grouped per page.
+ * Always-available retrieval fallback (ADR-049): word-wise LIKE search
+ * across the TCA search fields of `pages` and `tt_content`, grouped per
+ * page and ranked by how many distinct query words a page covers —
+ * models pass whole natural-language questions, which as a single
+ * phrase-needle matched next to nothing.
  *
  * Runs when no search extension index exists. Public-only by
  * construction: default restrictions plus a live-workspace restriction
@@ -65,35 +68,48 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     public function search(RetrievalQuery $query, AccessContext $context): EvidenceList
     {
         $languageId = $query->languageId;
+        $words = $this->queryWords($query->query);
 
-        // routeUid (default-language page uid) => partial evidence data.
-        /** @var array<int, array{title: string, excerpt: string}> $byPage */
+        // routeUid (default-language page uid) => partial evidence data;
+        // 'words' collects which query words the page covers (over the page
+        // row AND all its content elements) for the relevance ordering.
+        /** @var array<int, array{title: string, excerpt: string, words: list<string>}> $byPage */
         $byPage = [];
 
-        foreach ($this->searchPages($query->query, $languageId) as $row) {
+        foreach ($this->searchPages($words, $languageId) as $row) {
             $routeUid = $languageId === 0
                 ? self::toInt($row['uid'] ?? 0)
                 : self::toInt($row['l10n_parent'] ?? 0);
-            if ($routeUid < 1 || isset($byPage[$routeUid])) {
+            if ($routeUid < 1) {
                 continue;
             }
 
-            $byPage[$routeUid] = [
+            $byPage[$routeUid] ??= [
                 'title' => self::toStr($row['title'] ?? ''),
-                'excerpt' => $this->excerptFromRow($row, $this->pageFields(), $query->query),
+                'excerpt' => $this->excerptFromRow($row, $this->pageFields(), $query->query, $words),
+                'words' => [],
             ];
+            $byPage[$routeUid]['words'] = array_values(array_unique(array_merge(
+                $byPage[$routeUid]['words'],
+                $this->matchedWords($row, $this->pageFields(), $words),
+            )));
         }
 
-        foreach ($this->searchContent($query->query, $languageId) as $row) {
+        foreach ($this->searchContent($words, $languageId) as $row) {
             $routeUid = self::toInt($row['pid'] ?? 0);
-            if ($routeUid < 1 || isset($byPage[$routeUid])) {
+            if ($routeUid < 1) {
                 continue;
             }
 
-            $byPage[$routeUid] = [
+            $byPage[$routeUid] ??= [
                 'title' => '',
-                'excerpt' => $this->excerptFromRow($row, $this->contentFields(), $query->query),
+                'excerpt' => $this->excerptFromRow($row, $this->contentFields(), $query->query, $words),
+                'words' => [],
             ];
+            $byPage[$routeUid]['words'] = array_values(array_unique(array_merge(
+                $byPage[$routeUid]['words'],
+                $this->matchedWords($row, $this->contentFields(), $words),
+            )));
         }
 
         if ($byPage === []) {
@@ -102,8 +118,16 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
 
         $pageRows = $this->visiblePages(array_keys($byPage), $languageId);
 
+        // Pages covering more distinct query words rank first.
+        $rankedUids = array_keys($byPage);
+        usort(
+            $rankedUids,
+            static fn(int $a, int $b): int => (count($byPage[$b]['words']) <=> count($byPage[$a]['words'])) ?: ($a <=> $b),
+        );
+
         $sources = [];
-        foreach ($byPage as $routeUid => $partial) {
+        foreach ($rankedUids as $routeUid) {
+            $partial = $byPage[$routeUid];
             if (!isset($pageRows[$routeUid])) {
                 // Hidden, timed, access-protected or non-searchable page.
                 continue;
@@ -181,9 +205,11 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     }
 
     /**
+     * @param list<string> $words
+     *
      * @return list<array<string, mixed>>
      */
-    private function searchPages(string $query, int $languageId): array
+    private function searchPages(array $words, int $languageId): array
     {
         $fields = $this->pageFields();
         $queryBuilder = $this->liveQueryBuilder('pages');
@@ -193,7 +219,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             ->select(...$select)
             ->from('pages')
             ->where(
-                $this->likeAnyCondition($queryBuilder, $fields, $query),
+                $this->likeAnyCondition($queryBuilder, $fields, $words),
                 $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($languageId, Connection::PARAM_INT)),
                 $queryBuilder->expr()->eq('no_search', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                 $queryBuilder->expr()->lt('doktype', $queryBuilder->createNamedParameter(199, Connection::PARAM_INT)),
@@ -208,9 +234,11 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     }
 
     /**
+     * @param list<string> $words
+     *
      * @return list<array<string, mixed>>
      */
-    private function searchContent(string $query, int $languageId): array
+    private function searchContent(array $words, int $languageId): array
     {
         $fields = $this->contentFields();
         $queryBuilder = $this->liveQueryBuilder('tt_content');
@@ -220,7 +248,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             ->select(...$select)
             ->from('tt_content')
             ->where(
-                $this->likeAnyCondition($queryBuilder, $fields, $query),
+                $this->likeAnyCondition($queryBuilder, $fields, $words),
                 // -1 = "all languages": rendered in every language.
                 $queryBuilder->expr()->in('sys_language_uid', $queryBuilder->createNamedParameter([$languageId, -1], Connection::PARAM_INT_ARRAY)),
                 $this->publicGroupCondition($queryBuilder),
@@ -326,17 +354,75 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     }
 
     /**
+     * A row qualifies when ANY query word occurs in ANY search field —
+     * the per-page word-coverage ranking in search() sorts broad matches
+     * up, so a one-word hit can appear but ranks last.
+     *
      * @param list<string> $fields
+     * @param list<string> $words
      */
-    private function likeAnyCondition(QueryBuilder $queryBuilder, array $fields, string $query): string
+    private function likeAnyCondition(QueryBuilder $queryBuilder, array $fields, array $words): string
     {
-        $like = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
         $conditions = [];
-        foreach ($fields as $field) {
-            $conditions[] = $queryBuilder->expr()->like($field, $queryBuilder->createNamedParameter($like));
+        foreach ($words as $word) {
+            $like = '%' . $queryBuilder->escapeLikeWildcards($word) . '%';
+            $placeholder = $queryBuilder->createNamedParameter($like);
+            foreach ($fields as $field) {
+                $conditions[] = $queryBuilder->expr()->like($field, $placeholder);
+            }
         }
 
         return (string)$queryBuilder->expr()->or(...$conditions);
+    }
+
+    /**
+     * Words of the (model-chosen, natural-language) question worth
+     * matching: 4+ characters — models pass whole questions, and requiring
+     * fill words like "what"/"does" as a phrase found nothing. Falls back
+     * to 2+ characters, then to the raw query, so short queries stay
+     * searchable. Capped at 8 words.
+     *
+     * @return non-empty-list<string>
+     */
+    private function queryWords(string $query): array
+    {
+        $split = preg_split('/[^\p{L}\p{N}]+/u', mb_strtolower($query)) ?: [];
+        $split = array_values(array_filter($split, static fn(string $word): bool => $word !== ''));
+
+        foreach ([4, 2] as $minimumLength) {
+            $words = array_values(array_unique(array_filter(
+                $split,
+                static fn(string $word): bool => mb_strlen($word) >= $minimumLength,
+            )));
+            if ($words !== []) {
+                return array_slice($words, 0, 8);
+            }
+        }
+
+        return [mb_strtolower($query)];
+    }
+
+    /**
+     * The query words occurring in any of the row's search fields.
+     *
+     * @param array<string, mixed> $row
+     * @param list<string>         $fields
+     * @param list<string>         $words
+     *
+     * @return list<string>
+     */
+    private function matchedWords(array $row, array $fields, array $words): array
+    {
+        $haystack = '';
+        foreach ($fields as $field) {
+            $haystack .= ' ' . self::toStr($row[$field] ?? '');
+        }
+        $haystack = ExcerptBuilder::plain($haystack);
+
+        return array_values(array_filter(
+            $words,
+            static fn(string $word): bool => mb_stripos($haystack, $word) !== false,
+        ));
     }
 
     /**
@@ -450,10 +536,14 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
     }
 
     /**
+     * Excerpt centred on the full query phrase when it occurs literally,
+     * else on the first matching query word.
+     *
      * @param array<string, mixed> $row
      * @param list<string>         $fields
+     * @param list<string>         $words
      */
-    private function excerptFromRow(array $row, array $fields, string $query): string
+    private function excerptFromRow(array $row, array $fields, string $query, array $words): string
     {
         $fallback = '';
         foreach ($fields as $field) {
@@ -467,6 +557,11 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             }
             if (mb_stripos($plain, $query) !== false) {
                 return ExcerptBuilder::around($plain, $query);
+            }
+            foreach ($words as $word) {
+                if (mb_stripos($plain, $word) !== false) {
+                    return ExcerptBuilder::around($plain, $word);
+                }
             }
         }
 

--- a/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
+++ b/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
@@ -98,6 +98,11 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             'uid' => 30, 'pid' => 1, 'title' => 'Aikido overview', 'doktype' => 1,
             'sorting' => 8, 'slug' => '/overview',
         ]);
+        // Phrase sits in a LATER content element than the first word match.
+        $pages->insert('pages', [
+            'uid' => 31, 'pid' => 1, 'title' => 'Summer programme', 'doktype' => 1,
+            'sorting' => 9, 'slug' => '/summer',
+        ]);
         // Hidden section root with extendToSubpages, public child row.
         $pages->insert('pages', [
             'uid' => 8, 'pid' => 1, 'title' => 'Staging section', 'doktype' => 1,
@@ -130,6 +135,14 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             'uid' => 15, 'pid' => 2, 'colPos' => 0, 'sorting' => 1, 'CType' => 'text',
             'header' => 'Unser Aikido-Angebot', 'bodytext' => 'Aikido Migrationen richtig gemacht.',
             'sys_language_uid' => 1, 'l18n_parent' => 10,
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 16, 'pid' => 31, 'colPos' => 0, 'sorting' => 1, 'CType' => 'text',
+            'header' => 'Basics', 'bodytext' => 'Aikido basics for beginners.',
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 17, 'pid' => 31, 'colPos' => 0, 'sorting' => 2, 'CType' => 'text',
+            'header' => 'Summer special', 'bodytext' => 'We bundle aikido migration services every summer.',
         ]);
         // Unpublished workspace draft of element 10 (t3ver_wsid > 0).
         $content->insert('tt_content', [
@@ -302,6 +315,28 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
         $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
         self::assertSame('database:2:0', $ids[0] ?? null, 'page covering all three words must rank first');
         self::assertContains('database:30:0', $ids, 'single-word match missing entirely');
+    }
+
+    #[Test]
+    public function phraseHitInALaterContentElementUpgradesTheExcerpt(): void
+    {
+        $result = $this->backend->search(
+            RetrievalQuery::create('aikido migration services'),
+            AccessContext::publicOnly(),
+        );
+
+        foreach ($result->sources as $source) {
+            if ($source->sourceId === 'database:31:0') {
+                self::assertStringContainsString(
+                    'aikido migration services every summer',
+                    $source->excerpt,
+                    'excerpt stuck on the first (word-only) content element',
+                );
+
+                return;
+            }
+        }
+        self::fail('database:31:0 missing from the result');
     }
 
     #[Test]

--- a/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
+++ b/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
@@ -93,6 +93,11 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             'uid' => 20, 'pid' => 1, 'title' => 'Aikido Migrationsdienste', 'doktype' => 1,
             'sorting' => 2, 'slug' => '/migration', 'sys_language_uid' => 1, 'l10n_parent' => 2,
         ]);
+        // Narrow match: covers only ONE word of a multi-word query.
+        $pages->insert('pages', [
+            'uid' => 30, 'pid' => 1, 'title' => 'Aikido overview', 'doktype' => 1,
+            'sorting' => 8, 'slug' => '/overview',
+        ]);
         // Hidden section root with extendToSubpages, public child row.
         $pages->insert('pages', [
             'uid' => 8, 'pid' => 1, 'title' => 'Staging section', 'doktype' => 1,
@@ -270,6 +275,33 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
 
         self::assertTrue($result->isEmpty());
         self::assertSame('database', $result->backend);
+    }
+
+    #[Test]
+    public function naturalLanguageQuestionsMatchWordWise(): void
+    {
+        // Models pass whole questions — as a single phrase needle this
+        // found nothing; the fill words must not defeat the match either.
+        $result = $this->backend->search(
+            RetrievalQuery::create('What migration services does this aikido site offer?'),
+            AccessContext::publicOnly(),
+        );
+
+        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        self::assertContains('database:2:0', $ids);
+    }
+
+    #[Test]
+    public function pagesCoveringMoreQueryWordsRankFirst(): void
+    {
+        $result = $this->backend->search(
+            RetrievalQuery::create('aikido migration services'),
+            AccessContext::publicOnly(),
+        );
+
+        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        self::assertSame('database:2:0', $ids[0] ?? null, 'page covering all three words must rank first');
+        self::assertContains('database:30:0', $ids, 'single-word match missing entirely');
     }
 
     #[Test]

--- a/Tests/Functional/Service/Tool/SiteRagToolsTest.php
+++ b/Tests/Functional/Service/Tool/SiteRagToolsTest.php
@@ -151,8 +151,9 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
         // 350 chars in, truncated to 200 and answered cleanly — the echoed
         // question ends mid-word instead of raising a VO exception.
         $longQuestion = $this->queryTool->execute(['question' => str_repeat('aikido ', 50)]);
-        self::assertStringStartsWith('No evidence found for "aikido ', $longQuestion);
+        self::assertStringStartsWith('Evidence for "aikido ', $longQuestion);
         self::assertStringContainsString('aiki" (backend:', $longQuestion);
+        self::assertStringContainsString('database:2:0', $longQuestion);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Follow-up to #332, found during live verification on ddev: the playground agent (qwen3:4b) passes the **whole natural-language question** to `site_rag_query` — as a single LIKE phrase-needle the database fallback found next to nothing (`"What migration services does this website offer?"` missed the page titled "TYPO3 Migration Services").

## Change

`DatabaseSearchBackend` now:
- splits the question into words (4+ chars — fill words like "what"/"does" would otherwise be required; falls back to 2+ chars, then the raw query; capped at 8 words),
- qualifies a page when **any** word occurs in **any** search field,
- ranks pages by how many **distinct query words** they cover across the page row and its content elements (broad matches first, one-word matches last, capped by `max_sources`),
- centres excerpts on the literal phrase when present, else on the first matching word.

The index backends (Solr/ke_search/indexed_search) already match word-wise natively and are untouched.

## Tests

Functional: natural-language question finds the page; coverage ranking (3-word match before 1-word match); the long-question clamp test updated (a truncated `aikido …` question now legitimately finds evidence). Verified on sqlite and mariadb.