### PR TITLE
ci: add MariaDB functional leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,19 @@ jobs:
       run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # MariaDB functional leg (one cell): keeps the MySQL-only branches —
+  # ke_search MATCH...AGAINST retrieval — permanently exercised in CI.
+  # The full matrix above stays on SQLite; this narrow second call trades
+  # a small duplicate unit/PHPStan run for permanent engine coverage.
+  ci-functional-mariadb:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.4"]'
+      typo3-versions: '["^14.3"]'
+      run-functional-tests: true
+      functional-test-db: mariadb
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,14 @@ jobs:
       run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   # MariaDB functional leg (one cell): keeps the MySQL-only branches —
   # ke_search MATCH...AGAINST retrieval — permanently exercised in CI.
   # The full matrix above stays on SQLite; this narrow second call trades
   # a small duplicate unit/PHPStan run for permanent engine coverage.
+  # Scoped to the `functional` testsuite: the e2e-backend suite carries
+  # two pre-existing MySQL incompatibilities tracked separately.
   ci-functional-mariadb:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main # NOSONAR — own-org reusable workflow deliberately tracks main, like the sibling job above
     permissions:
       contents: read
     with:
@@ -42,5 +43,5 @@ jobs:
       typo3-versions: '["^14.3"]'
       run-functional-tests: true
       functional-test-db: mariadb
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      db-image: 'mariadb:11.4'
+      functional-test-command: '.Build/bin/phpunit -c Build/FunctionalTests.xml --testsuite functional'


### PR DESCRIPTION
## Summary

Adds one narrow extra call of the reusable CI workflow (PHP 8.4 × ^14.3) with `functional-test-db: mariadb`. The reusable workflow's two functional jobs are mutually exclusive per call (`== sqlite` vs `!= sqlite`), so a second call is the additive way to run both engines.

## Why

#332/#333 introduced retrieval code with MySQL-only branches (ke_search `MATCH…AGAINST`, boolean-mode scoring) that the SQLite-only functional CI never executes — until now they were verified only in local `runTests.sh -d mariadb` runs. This keeps that engine coverage permanent.

Cost: one duplicated unit/PHPStan cell (~2–3 min); the full matrix stays on SQLite.