### PR TITLE
ci: use mariadb:10.11 for the functional leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # MariaDB functional leg (one cell): keeps the MySQL-only branches —
   # ke_search MATCH...AGAINST retrieval — permanently exercised in CI.
+  # mariadb:10.11 LTS: images >= 11 ship only mariadb-admin, which fails
+  # the reusable workflow's hardcoded mysqladmin health check.
   # The full matrix above stays on SQLite; this narrow second call trades
   # a small duplicate unit/PHPStan run for permanent engine coverage.
   # Scoped to the `functional` testsuite: the e2e-backend suite carries
@@ -43,5 +45,5 @@ jobs:
       typo3-versions: '["^14.3"]'
       run-functional-tests: true
       functional-test-db: mariadb
-      db-image: 'mariadb:11.4'
+      db-image: 'mariadb:10.11'
       functional-test-command: '.Build/bin/phpunit -c Build/FunctionalTests.xml --testsuite functional'


### PR DESCRIPTION
The mariadb:11.4 leg from #334 never started: mariadb images >= 11 ship only `mariadb-admin`, and the reusable workflow health-checks with a hardcoded `mysqladmin ping --silent`, so the service container fails to initialize ("Failed to initialize container mariadb:11.4"). mariadb:10.11 LTS still carries the mysql* symlinks.

Upstream follow-up filed on typo3-ci-workflows to make the health check cover both binaries.