### PR TITLE
chore: release 0.16.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 
 | File | Purpose |
 |------|---------|
-| `ext_emconf.php` | Extension metadata, version 0.15.0 |
+| `ext_emconf.php` | Extension metadata, version 0.16.0 |
 | `ext_localconf.php` | Extension bootstrap |
 | `composer.json` | Dependencies (composer.lock NOT committed) |
 | `Build/phpunit.xml` | PHPUnit configuration |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-10
+
 ### Added
 
-- **RAG site-search tools** (41 tools / 8 groups): new `rag` tool group with `site_rag_query` — cited evidence about the website's own public content (source id, title, URL, match excerpt), retrieved through a priority cascade over whichever search index is installed (EXT:solr via its HTTP select API, ke_search, indexed_search) with an always-available pages/tt_content database fallback — and `site_fetch_source` to read a source's full indexed text. Index-level filtering is strictly public-only (what the anonymous visitor could read); the answering backend is named in every evidence package (ADR-049).
+- **RAG site-search tools** (41 tools / 8 groups): new `rag` tool group with `site_rag_query` — cited evidence about the website's own public content (source id, title, URL, match excerpt), retrieved through a priority cascade over whichever search index is installed (EXT:solr via its HTTP select API, ke_search, indexed_search) with an always-available pages/tt_content database fallback — and `site_fetch_source` to read a source's full indexed text. Index-level filtering is strictly public-only (what the anonymous visitor could read); the answering backend is named in every evidence package (ADR-049). The database fallback matches natural-language questions word-wise and ranks pages by how many query words they cover (#332, #333).
+
+### Changed
+
+- Functional tests additionally run against MariaDB in CI (one matrix cell), keeping the MySQL-only retrieval branches exercised; two pre-existing MySQL incompatibilities in the e2e-backend suite surfaced by this are tracked in #335/#336 (#334, #337).
 
 ## [0.15.0] - 2026-07-09
 
@@ -983,7 +989,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.13.0...v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **RAG site-search tools** (41 tools / 8 groups): new `rag` tool group with `site_rag_query` — cited evidence about the website's own public content (source id, title, URL, match excerpt), retrieved through a priority cascade over whichever search index is installed (EXT:solr via its HTTP select API, ke_search, indexed_search) with an always-available pages/tt_content database fallback — and `site_fetch_source` to read a source's full indexed text. Index-level filtering is strictly public-only (what the anonymous visitor could read); the answering backend is named in every evidence package (ADR-049). The database fallback matches natural-language questions word-wise and ranks pages by how many query words they cover (#332, #333).
+- **RAG site-search tools** (41 tools / 8 groups): new `rag` tool group with `site_rag_query` — cited evidence about the website's own public content (`source_id`, title, URL, match excerpt), retrieved through a priority cascade over whichever search index is installed (EXT:solr via its HTTP select API, ke_search, indexed_search) with an always-available pages/tt_content database fallback — and `site_fetch_source` to read a source's full indexed text. Index-level filtering is strictly public-only (what the anonymous visitor could read); the answering backend is named in every evidence package (ADR-049). The database fallback matches natural-language questions word-wise and ranks pages by how many query words they cover (#332, #333).
 
 ### Changed
 

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -19,7 +19,7 @@ Version 0.16.0 (2026-07-10)
 This release adds **RAG site-search tools**: the new ``rag`` tool group
 lets agent runs answer questions about the website's own public
 content with cited evidence. ``site_rag_query`` returns curated sources
-(source id, title, URL, match excerpt) from a priority cascade over
+(``source_id``, title, URL, match excerpt) from a priority cascade over
 whichever search index is installed — EXT:solr (via its HTTP select
 API), ke_search, indexed_search — with an always-available
 pages/tt_content database fallback that matches natural-language

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,26 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-16-0:
+
+Version 0.16.0 (2026-07-10)
+===========================
+
+This release adds **RAG site-search tools**: the new ``rag`` tool group
+lets agent runs answer questions about the website's own public
+content with cited evidence. ``site_rag_query`` returns curated sources
+(source id, title, URL, match excerpt) from a priority cascade over
+whichever search index is installed — EXT:solr (via its HTTP select
+API), ke_search, indexed_search — with an always-available
+pages/tt_content database fallback that matches natural-language
+questions word-wise; ``site_fetch_source`` reads a source's full
+indexed text. Index-level filtering is strictly public-only (what the
+anonymous visitor could read), and every evidence package names the
+answering backend. See :ref:`ADR-049 <adr-049>`.
+
+For the complete, itemised list see the canonical
+`CHANGELOG.md <https://github.com/netresearch/t3x-nr-llm/blob/main/CHANGELOG.md>`__.
+
 .. _version-0-15-0:
 
 Version 0.15.0 (2026-07-09)

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.15.0"
-        release="0.15.0"
+        version="0.16.0"
+        release="0.16.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.15.0',
+    'version' => '0.16.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release preparation for v0.16.0 — RAG site-search tools (#332, #333) plus the MariaDB functional CI leg (#334, #337).

Version surfaces bumped in sync (guarded by VersionConsistencyTest): `ext_emconf.php`, `composer.json` `extra.typo3/cms.version`, `Documentation/guides.xml`, `Documentation/Changelog.rst`, `CHANGELOG.md` (stamp + compare links), `AGENTS.md`.

After merge: signed tag `v0.16.0` on the merge commit; the release workflow handles TER, Packagist, docs render and the GitHub release.