### PR TITLE
fix: MySQL/MariaDB compatibility — wizard column limits, decimal scale (closes #335, #336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
   # the reusable workflow's hardcoded mysqladmin health check.
   # The full matrix above stays on SQLite; this narrow second call trades
   # a small duplicate unit/PHPStan run for permanent engine coverage.
-  # Scoped to the `functional` testsuite: the e2e-backend suite carries
-  # two pre-existing MySQL incompatibilities tracked separately.
   ci-functional-mariadb:
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main # NOSONAR — own-org reusable workflow deliberately tracks main, like the sibling job above
     permissions:
@@ -46,4 +44,3 @@ jobs:
       run-functional-tests: true
       functional-test-db: mariadb
       db-image: 'mariadb:10.11'
-      functional-test-command: '.Build/bin/phpunit -c Build/FunctionalTests.xml --testsuite functional'

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -492,7 +492,7 @@ final class SetupWizardController extends ActionController
 
             $config = new LlmConfiguration();
             // Identifier columns are varchar(100), name columns varchar(255).
-            $config->setIdentifier(mb_substr($configIdentifier !== '' ? trim($configIdentifier) : $this->generateIdentifier($configName), 0, 100));
+            $config->setIdentifier($configIdentifier !== '' ? $this->normalizeIdentifier($configIdentifier) : $this->generateIdentifier($configName));
             $config->setName($this->truncateLabel($configName));
             $config->setDescription($configDescription);
             $config->setSystemPrompt($systemPrompt);
@@ -647,8 +647,21 @@ final class SetupWizardController extends ActionController
         // identifier columns.
         $identifier = trim(mb_substr($identifier, 0, 93), '-');
 
-        // Add timestamp suffix for uniqueness
-        return $identifier . '-' . substr(md5((string)time()), 0, 6);
+        // Random suffix for uniqueness — a time()-based suffix is
+        // identical for every record created in the same request batch.
+        return $identifier . '-' . bin2hex(random_bytes(3));
+    }
+
+    /**
+     * Applies the TCA identifier contract (eval alphanum_x,lower, max 100)
+     * to a caller-provided identifier — the AJAX path bypasses FormEngine.
+     */
+    private function normalizeIdentifier(string $identifier): string
+    {
+        $identifier = strtolower(trim($identifier));
+        $identifier = (string)preg_replace('/[^a-z0-9_-]+/', '-', $identifier);
+
+        return mb_substr(trim($identifier, '-'), 0, 100);
     }
 
     /**

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -348,7 +348,7 @@ final class SetupWizardController extends ActionController
 
         $provider = new Provider();
         $provider->setIdentifier($this->generateIdentifier($providerName));
-        $provider->setName($providerName !== '' ? $providerName : 'New Provider');
+        $provider->setName($this->truncateLabel($providerName !== '' ? $providerName : 'New Provider'));
         $provider->setAdapterType($providerAdapter);
         $provider->setEndpointUrl($providerEndpoint);
         $provider->setApiKey($vaultIdentifier);
@@ -416,7 +416,7 @@ final class SetupWizardController extends ActionController
 
             $model = new Model();
             $model->setIdentifier($this->generateIdentifier($modelName));
-            $model->setName($modelName);
+            $model->setName($this->truncateLabel($modelName));
             $model->setDescription($modelDescription);
             $model->setModelId($modelId);
             $model->setProvider($provider);
@@ -491,8 +491,9 @@ final class SetupWizardController extends ActionController
             $maxTokens = max(1, min(128000, is_numeric($configData['maxTokens'] ?? null) ? (int)$configData['maxTokens'] : 4096));
 
             $config = new LlmConfiguration();
-            $config->setIdentifier($configIdentifier !== '' ? $configIdentifier : $this->generateIdentifier($configName));
-            $config->setName($configName);
+            // Identifier columns are varchar(100), name columns varchar(255).
+            $config->setIdentifier(mb_substr($configIdentifier !== '' ? trim($configIdentifier) : $this->generateIdentifier($configName), 0, 100));
+            $config->setName($this->truncateLabel($configName));
             $config->setDescription($configDescription);
             $config->setSystemPrompt($systemPrompt);
             $config->setLlmModel($model);
@@ -642,9 +643,22 @@ final class SetupWizardController extends ActionController
     {
         $identifier = strtolower(trim($name));
         $identifier = (string)preg_replace('/[^a-z0-9]+/', '-', $identifier);
-        $identifier = trim($identifier, '-');
+        // Keep slug + '-' + 6-char suffix within the varchar(100)
+        // identifier columns.
+        $identifier = trim(mb_substr($identifier, 0, 93), '-');
 
         // Add timestamp suffix for uniqueness
         return $identifier . '-' . substr(md5((string)time()), 0, 6);
+    }
+
+    /**
+     * The wizard's AJAX payload bypasses FormEngine, so the TCA input
+     * limit (max=255, matching the varchar(255) columns) is enforced
+     * here — a strict-mode DBMS rejects overlong values instead of
+     * truncating them like SQLite.
+     */
+    private function truncateLabel(string $value): string
+    {
+        return mb_substr(trim($value), 0, 255);
     }
 }

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -504,7 +504,9 @@ class LlmConfiguration extends AbstractEntity
 
     public function setTemperature(float $temperature): void
     {
-        $this->temperature = max(0.0, min(2.0, $temperature));
+        // Rounded to the decimal(3,2) column scale so every DBMS stores
+        // and returns the identical value (#336).
+        $this->temperature = round(max(0.0, min(2.0, $temperature)), 2);
     }
 
     public function setMaxTokens(int $maxTokens): void
@@ -514,17 +516,17 @@ class LlmConfiguration extends AbstractEntity
 
     public function setTopP(float $topP): void
     {
-        $this->topP = max(0.0, min(1.0, $topP));
+        $this->topP = round(max(0.0, min(1.0, $topP)), 2);
     }
 
     public function setFrequencyPenalty(float $frequencyPenalty): void
     {
-        $this->frequencyPenalty = max(-2.0, min(2.0, $frequencyPenalty));
+        $this->frequencyPenalty = round(max(-2.0, min(2.0, $frequencyPenalty)), 2);
     }
 
     public function setPresencePenalty(float $presencePenalty): void
     {
-        $this->presencePenalty = max(-2.0, min(2.0, $presencePenalty));
+        $this->presencePenalty = round(max(-2.0, min(2.0, $presencePenalty)), 2);
     }
 
     public function setTimeout(int $timeout): void
@@ -567,7 +569,7 @@ class LlmConfiguration extends AbstractEntity
 
     public function setMaxCostPerDay(float $maxCostPerDay): void
     {
-        $this->maxCostPerDay = max(0.0, $maxCostPerDay);
+        $this->maxCostPerDay = round(max(0.0, $maxCostPerDay), 2);
     }
 
     public function setIsActive(bool $isActive): void

--- a/Classes/Domain/Model/UserBudget.php
+++ b/Classes/Domain/Model/UserBudget.php
@@ -75,7 +75,7 @@ class UserBudget extends AbstractEntity
 
     public function setMaxCostPerDay(float $value): void
     {
-        $this->maxCostPerDay = max(0.0, $value);
+        $this->maxCostPerDay = round(max(0.0, $value), 4);
     }
 
     public function getMaxRequestsPerMonth(): int
@@ -105,7 +105,7 @@ class UserBudget extends AbstractEntity
 
     public function setMaxCostPerMonth(float $value): void
     {
-        $this->maxCostPerMonth = max(0.0, $value);
+        $this->maxCostPerMonth = round(max(0.0, $value), 4);
     }
 
     public function isActive(): bool

--- a/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
+++ b/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Psr7\Utils;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
@@ -161,6 +162,15 @@ abstract class AbstractBackendE2ETestCase extends AbstractFunctionalTestCase
     {
         $reflection = new ReflectionClass($controllerClass);
         $controller = $reflection->newInstanceWithoutConstructor();
+
+        // Skipping the constructor leaves every non-injected readonly
+        // property uninitialized. All backend controllers take a PSR
+        // logger that only error paths touch — on SQLite those paths
+        // rarely run, on strict-mode DBMS they do (#335). Default it so
+        // error handling behaves like production.
+        if (!array_key_exists('logger', $dependencies) && $reflection->hasProperty('logger')) {
+            $dependencies['logger'] = new NullLogger();
+        }
 
         foreach ($dependencies as $property => $value) {
             $this->setPrivateProperty($controller, $property, $value);

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -1584,8 +1584,9 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
 
         $retrieved = $this->configurationRepository->findOneByIdentifier($config->getIdentifier());
         self::assertNotNull($retrieved);
-        // Temperature should be close to original (may have float precision issues)
-        self::assertEqualsWithDelta(0.123456789, $retrieved->getTemperature(), 0.0001);
+        // The setter rounds to the decimal(3,2) column scale, so every
+        // DBMS round-trips the identical value (#336).
+        self::assertEqualsWithDelta(0.12, $retrieved->getTemperature(), 0.001);
     }
 
     #[Test]

--- a/Tests/E2E/Backend/SetupWizardE2ETest.php
+++ b/Tests/E2E/Backend/SetupWizardE2ETest.php
@@ -2139,8 +2139,10 @@ final class SetupWizardE2ETest extends AbstractBackendE2ETestCase
         ]);
         $response = $this->controller->saveAction($saveRequest);
 
-        // Should handle long name - possibly truncate
-        self::assertContains($response->getStatusCode(), [200, 400]);
+        // Overlong names are truncated to the varchar(255)/varchar(100)
+        // columns before persisting (#335), so the save succeeds on every
+        // DBMS.
+        self::assertSame(200, $response->getStatusCode());
         $body = json_decode((string)$response->getBody(), true);
         self::assertIsArray($body);
     }


### PR DESCRIPTION
## Summary

Fixes the two issues the MariaDB CI leg surfaced (#334), so the leg now runs the **full** functional config (functional + e2e-backend).

### #335 — wizard persist path vs. strict-mode DBMS
- The setup wizard's AJAX payload bypasses FormEngine, so nothing enforced the TCA length limits: names >255 and generated identifiers >100 chars made strict-mode MySQL/MariaDB reject the insert (500) where SQLite silently truncates. Names and identifiers are now clamped to their column widths before persisting.
- The "uninitialized `$logger`" from the issue turned out to be **test wiring, not production**: the E2E base class builds controllers via `newInstanceWithoutConstructor()` and never injected the logger, so every error path crashed instead of responding. It now defaults a `NullLogger` whenever the controller declares a logger property — covering all eight backend controller factories.

### #336 — platform-divergent decimal round-tripping
`temperature`/`top_p`/penalties are `decimal(3,2)`, the cost ceilings `decimal(10,2)`/`(10,4)`: SQLite stored the full float, MySQL truncated to column scale, so the same entity read back differently per DBMS. The setters now round to the schema scale.

### CI
The MariaDB leg's `--testsuite functional` scoping is removed.

## Verification

Full `FunctionalTests.xml` (functional + e2e-backend, 1104 tests) locally on **sqlite and mariadb: 0 errors, 0 failures** (remaining warnings/risky identical to unchanged main). cgl, PHPStan level 10 and the unit suite pass.

Note for reviewers: local full-config runs with today's *freshly resolved* vendor set segfault on WSL2 before the first test (guzzle 7.14.0/psr7 2.12.4 era resolution); verification above used the resolution CI ran green with this morning. CI on GitHub runners is authoritative and resolves fresh.