### PR TITLE
chore: release 0.16.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 
 | File | Purpose |
 |------|---------|
-| `ext_emconf.php` | Extension metadata, version 0.16.0 |
+| `ext_emconf.php` | Extension metadata, version 0.16.1 |
 | `ext_localconf.php` | Extension bootstrap |
 | `composer.json` | Dependencies (composer.lock NOT committed) |
 | `Build/phpunit.xml` | PHPUnit configuration |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-10
+
+### Fixed
+
+- The setup wizard's AJAX persist path now enforces the column limits FormEngine would apply: names are clamped to 255 characters, identifiers to 100, and caller-provided identifiers get the TCA contract (`alphanum_x`, lowercase). Strict-mode MySQL/MariaDB previously rejected overlong values with a 500 where SQLite silently truncated. Generated identifier suffixes are now random — the `time()`-based suffix collided for same-named records created in one batch (#335, #339).
+- Decimal-backed model values (`temperature`, `top_p`, penalties, cost ceilings) are rounded to their column scale in the setters, so every DBMS stores and returns the identical value (#336, #339).
+
+### Changed
+
+- The MariaDB CI leg runs the full functional configuration (functional + e2e-backend suites) now that the strict-mode incompatibilities are fixed (#339).
+
 ## [0.16.0] - 2026-07-10
 
 ### Added
@@ -989,7 +1000,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.14.0...v0.14.1

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,22 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-16-1:
+
+Version 0.16.1 (2026-07-10)
+===========================
+
+Compatibility fixes for strict-mode MySQL/MariaDB, surfaced by the new
+MariaDB CI leg: the setup wizard's AJAX persist path now enforces the
+column length limits and the TCA identifier contract (overlong values
+previously produced a 500 instead of being truncated), generated
+identifier suffixes are collision-free within a batch, and
+decimal-backed values such as ``temperature`` are rounded to their
+column scale so every DBMS round-trips identical values.
+
+For the complete, itemised list see the canonical
+`CHANGELOG.md <https://github.com/netresearch/t3x-nr-llm/blob/main/CHANGELOG.md>`__.
+
 .. _version-0-16-0:
 
 Version 0.16.0 (2026-07-10)

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.16.0"
-        release="0.16.0"
+        version="0.16.1"
+        release="0.16.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.16.0",
+            "version": "0.16.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.16.0',
+    'version' => '0.16.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release preparation for v0.16.1 — strict-mode MySQL/MariaDB compatibility fixes (#339, closes #335/#336) plus the MariaDB CI leg now running the full functional configuration.

Pre-tag issue triage: no open issues from the current work stream; remaining open issues (#311, #312) are feature requests unrelated to this release.

Version surfaces bumped in sync (guarded by VersionConsistencyTest). After merge: signed tag `v0.16.1` on the merge commit; the release workflow handles TER, Packagist, docs render and the GitHub release.