### PR TITLE
feat: reasoning toggle for hybrid-thinking models (Ollama think)

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -150,12 +150,20 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         if ($temperature !== null) {
             $temperature = max(0.0, min(2.0, $temperature));
         }
+        // Tri-state reasoning toggle (#312): '1' forces thinking on, '0'
+        // off, anything else keeps the provider/model default.
+        $think = match ($this->stringFromBody($body, 'think')) {
+            '1' => true,
+            '0' => false,
+            default => null,
+        };
         $options      = new ToolOptions(
             temperature: $temperature,
             maxTokens: $maxTokens > 0 ? $maxTokens : null,
             systemPrompt: $systemPrompt !== '' ? $systemPrompt : null,
             beUserUid: $this->currentBackendUserUid(),
             captureRaw: $captureRaw,
+            think: $think,
         );
 
         // The checked tool boxes restrict this run; absent any selection, fall

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -190,6 +190,13 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             'stream' => false,
         ];
 
+        // Top-level request field (not an `options` entry): forces hybrid
+        // reasoning models to think (true) or answer directly (false);
+        // absent = model default (#312).
+        if (isset($options['think']) && is_bool($options['think'])) {
+            $payload['think'] = $options['think'];
+        }
+
         if ($payloadOptions !== []) {
             $payload['options'] = $payloadOptions;
         }
@@ -255,6 +262,10 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             'stream' => false,
             'tools' => array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $tools),
         ];
+
+        if (isset($options['think']) && is_bool($options['think'])) {
+            $payload['think'] = $options['think'];
+        }
 
         if ($payloadOptions !== []) {
             $payload['options'] = $payloadOptions;
@@ -445,6 +456,10 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             'messages' => $messages,
             'stream' => true,
         ];
+
+        if (isset($options['think']) && is_bool($options['think'])) {
+            $payload['think'] = $options['think'];
+        }
 
         if ($payloadOptions !== []) {
             $payload['options'] = $payloadOptions;

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -37,6 +37,7 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         private ?string $model = null,
         ?int $beUserUid = null,
         ?float $plannedCost = null,
+        private ?bool $think = null,
     ) {
         $this->setBudgetFields($beUserUid, $plannedCost);
         $this->validate();
@@ -210,6 +211,15 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         return $this->temperature;
     }
 
+    /**
+     * Reasoning toggle for hybrid-thinking models: true forces thinking
+     * on, false off, null leaves the provider/model default untouched.
+     */
+    public function getThink(): ?bool
+    {
+        return $this->think;
+    }
+
     public function getMaxTokens(): ?int
     {
         return $this->maxTokens;
@@ -267,7 +277,7 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 
     public function toArray(): array
     {
-        return $this->filterNull([
+        $options = $this->filterNull([
             'temperature' => $this->temperature,
             'max_tokens' => $this->maxTokens,
             'top_p' => $this->topP,
@@ -279,6 +289,14 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
             'provider' => $this->provider,
             'model' => $this->model,
         ]);
+
+        // Tri-state: `false` (thinking explicitly OFF) must survive, so this
+        // bypasses filterNull; unset = provider/model default.
+        if ($this->think !== null) {
+            $options['think'] = $this->think;
+        }
+
+        return $options;
     }
 
     /**

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -36,6 +36,7 @@ class ToolOptions extends ChatOptions
         ?string $model = null,
         ?int $beUserUid = null,
         ?float $plannedCost = null,
+        ?bool $think = null,
         private ?string $toolChoice = null,
         private ?bool $parallelToolCalls = null,
         private bool $captureRaw = false,
@@ -53,6 +54,7 @@ class ToolOptions extends ChatOptions
             $model,
             $beUserUid,
             $plannedCost,
+            $think,
         );
         $this->validateToolOptions();
     }

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -178,6 +178,22 @@
                 <source>Configuration default</source>
                 <target>Standard der Konfiguration</target>
             </trans-unit>
+            <trans-unit id="playground.think">
+                <source>Thinking (reasoning models)</source>
+                <target>Thinking (Reasoning-Modelle)</target>
+            </trans-unit>
+            <trans-unit id="playground.think.default">
+                <source>Model default</source>
+                <target>Modell-Standard</target>
+            </trans-unit>
+            <trans-unit id="playground.think.on">
+                <source>On — think before answering</source>
+                <target>An — erst denken, dann antworten</target>
+            </trans-unit>
+            <trans-unit id="playground.think.off">
+                <source>Off — answer directly</source>
+                <target>Aus — direkt antworten</target>
+            </trans-unit>
             <trans-unit id="playground.captureRaw">
                 <source>Capture raw provider response</source>
                 <target>Rohe Provider-Antwort erfassen</target>

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -134,6 +134,18 @@
             <trans-unit id="playground.temperature.placeholder">
                 <source>Configuration default</source>
             </trans-unit>
+            <trans-unit id="playground.think">
+                <source>Thinking (reasoning models)</source>
+            </trans-unit>
+            <trans-unit id="playground.think.default">
+                <source>Model default</source>
+            </trans-unit>
+            <trans-unit id="playground.think.on">
+                <source>On — think before answering</source>
+            </trans-unit>
+            <trans-unit id="playground.think.off">
+                <source>Off — answer directly</source>
+            </trans-unit>
             <trans-unit id="playground.captureRaw">
                 <source>Capture raw provider response</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/Playground/List.html
+++ b/Resources/Private/Templates/Backend/Playground/List.html
@@ -150,6 +150,14 @@
                                     <label class="form-label" for="nrllm-pg-temperature"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.temperature" default="Temperature" /></label>
                                     <input type="number" min="0" max="2" step="0.1" id="nrllm-pg-temperature" class="form-control" placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.temperature.placeholder', default: 'Configuration default')}" />
                                 </div>
+                                <div class="mb-2">
+                                    <label class="form-label" for="nrllm-pg-think"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.think" default="Thinking (reasoning models)" /></label>
+                                    <select id="nrllm-pg-think" class="form-select">
+                                        <option value=""><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.think.default" default="Model default" /></option>
+                                        <option value="1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.think.on" default="On — think before answering" /></option>
+                                        <option value="0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.think.off" default="Off — answer directly" /></option>
+                                    </select>
+                                </div>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="nrllm-pg-raw" />
                                     <label class="form-check-label" for="nrllm-pg-raw"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:playground.captureRaw" default="Capture raw provider response" /></label>

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -161,6 +161,7 @@ class ToolPlayground {
         this.appendIfSet(formData, 'nrllm-pg-rounds', 'maxRounds');
         this.appendIfSet(formData, 'nrllm-pg-maxtokens', 'maxTokens');
         this.appendIfSet(formData, 'nrllm-pg-temperature', 'temperature');
+        this.appendIfSet(formData, 'nrllm-pg-think', 'think');
         this.appendChecked(formData, '.js-tool-select', 'tools[]');
         this.appendChecked(formData, '.js-skill-select', 'forcedSkills[]');
         this.appendChecked(formData, '.js-snippet-select', 'forcedSnippets[]');

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -231,6 +231,33 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
         self::assertSame('plain answer', $result->content);
     }
 
+    #[Test]
+    public function threadsThinkToggleIntoThePayload(): void
+    {
+        $tool = ToolSpec::function('fetch_logs', 'Fetch recent log entries', [
+            'type'       => 'object',
+            'properties' => ['limit' => ['type' => 'integer']],
+        ]);
+        $messages = [['role' => 'user', 'content' => 'show logs']];
+
+        // Explicitly OFF: the top-level `think` field carries `false`.
+        $subject = $this->buildSubject($this->plainAssistantResponse('done'));
+        $subject->chatCompletionWithTools($messages, [$tool], ['think' => false]);
+        $payload = $this->capturedRequest();
+        self::assertArrayHasKey('think', $payload);
+        self::assertFalse($payload['think']);
+
+        // Explicitly ON.
+        $subject = $this->buildSubject($this->plainAssistantResponse('done'));
+        $subject->chatCompletionWithTools($messages, [$tool], ['think' => true]);
+        self::assertTrue($this->capturedRequest()['think']);
+
+        // Unset: the model default stays untouched — no `think` key at all.
+        $subject = $this->buildSubject($this->plainAssistantResponse('done'));
+        $subject->chatCompletionWithTools($messages, [$tool]);
+        self::assertArrayNotHasKey('think', $this->capturedRequest());
+    }
+
     /**
      * Build an Ollama provider whose stream factory records the outgoing JSON
      * request body and whose HTTP client returns the given canned response.

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -339,6 +339,25 @@ class ChatOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function thinkIsTriState(): void
+    {
+        // Unset: provider/model default — the key must be absent.
+        self::assertArrayNotHasKey('think', (new ChatOptions())->toArray());
+        self::assertNull((new ChatOptions())->getThink());
+
+        // Explicitly ON.
+        $on = new ChatOptions(think: true);
+        self::assertTrue($on->getThink());
+        self::assertTrue($on->toArray()['think']);
+
+        // Explicitly OFF — `false` must survive the null filtering.
+        $off = new ChatOptions(think: false);
+        self::assertFalse($off->getThink());
+        self::assertArrayHasKey('think', $off->toArray());
+        self::assertFalse($off->toArray()['think']);
+    }
+
+    #[Test]
     public function toArrayUsesSnakeCaseKeys(): void
     {
         $options = new ChatOptions(


### PR DESCRIPTION
## Summary

Implements #312: a tri-state reasoning toggle for hybrid-thinking models (qwen3 on Ollama thinks by default; until now the only lever was a prompt-level `/no_think`).

- **Options**: `ChatOptions`/`ToolOptions` gain `?bool $think` — `true` forces thinking on, `false` off, `null` (default) leaves the provider/model default untouched. `false` deliberately survives the null-filtering in `toArray()`.
- **Provider**: `OllamaProvider` maps it to the **top-level** `think` request field on all three chat paths (plain, tools, streaming). Other providers ignore the key.
- **Playground**: three-way select (`Model default / On / Off`) in the Advanced section, threaded through the controller into `ToolOptions` (XLF EN+DE).

Out of scope (as the issue marks it optional): a per-`LlmConfiguration` TCA pin — can follow if wanted.

Also in this stream: #311 was closed as already implemented by the playground rebuild (#314, v0.15.0).

## Tests

- `ChatOptionsTest::thinkIsTriState` — key absent when unset, `false` survives serialisation.
- `OllamaProviderToolsTest::threadsThinkToggleIntoThePayload` — payload carries `think: true/false`, no key when unset.