### PR TITLE
fix: surface Ollama's native message.thinking in completion responses

### DIFF
--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -213,6 +213,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                 completionTokens: $this->getInt($response, 'eval_count'),
             ),
             finishReason: $this->getString($response, 'done_reason', 'stop'),
+            thinking: $this->messageThinking($message),
         );
     }
 
@@ -303,7 +304,22 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             provider: $this->getIdentifier(),
             toolCalls: $toolCalls,
             metadata: $this->rawResponseMetadata($options, $response),
+            thinking: $this->messageThinking($message),
         );
+    }
+
+    /**
+     * With native reasoning (`think: true`, #341) Ollama returns the
+     * reasoning in a separate `message.thinking` field instead of inline
+     * `<think>` tags — surface it so run traces can show it.
+     *
+     * @param array<string, mixed> $message
+     */
+    private function messageThinking(array $message): ?string
+    {
+        $thinking = trim($this->getString($message, 'thinking'));
+
+        return $thinking !== '' ? $thinking : null;
     }
 
     public function supportsTools(): bool

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -273,6 +273,18 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
         // No thinking field -> null, never an empty string.
         $result = $this->buildSubject($this->plainAssistantResponse('blue'))->chatCompletionWithTools($messages, []);
         self::assertNull($result->thinking);
+
+        // Whitespace-only thinking normalises to null.
+        $response = $this->plainAssistantResponse('blue');
+        $response['message']['thinking'] = '   ';
+        $result = $this->buildSubject($response)->chatCompletionWithTools($messages, []);
+        self::assertNull($result->thinking);
+
+        // The plain chat path surfaces the field as well.
+        $response = $this->plainAssistantResponse('blue');
+        $response['message']['thinking'] = 'Scattering, obviously.';
+        $result = $this->buildSubject($response)->chatCompletion($messages, ['think' => true]);
+        self::assertSame('Scattering, obviously.', $result->thinking);
     }
 
     /**

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -258,6 +258,23 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
         self::assertArrayNotHasKey('think', $this->capturedRequest());
     }
 
+    #[Test]
+    public function surfacesNativeThinkingFieldFromTheResponse(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'why is the sky blue?']];
+
+        // Native reasoning: `message.thinking` arrives as a separate field.
+        $response = $this->plainAssistantResponse('blue');
+        $response['message']['thinking'] = 'Rayleigh scattering favours short wavelengths.';
+        $result = $this->buildSubject($response)->chatCompletionWithTools($messages, [], ['think' => true]);
+        self::assertSame('Rayleigh scattering favours short wavelengths.', $result->thinking);
+        self::assertSame('blue', $result->content);
+
+        // No thinking field -> null, never an empty string.
+        $result = $this->buildSubject($this->plainAssistantResponse('blue'))->chatCompletionWithTools($messages, []);
+        self::assertNull($result->thinking);
+    }
+
     /**
      * Build an Ollama provider whose stream factory records the outgoing JSON
      * request body and whose HTTP client returns the given canned response.


### PR DESCRIPTION
Follow-up to #341, found during live verification: with `think: true`, Ollama returns the reasoning in a separate `message.thinking` field (content stays clean) — the provider never read it, so the playground inspector's Thinking tab showed "No reasoning returned" although the model demonstrably thought (verified with a direct `/api/chat` probe: `thinking` populated, `content` = "blue").

Both non-streaming chat paths (`chatCompletion`, `chatCompletionWithTools`) now surface the field into `CompletionResponse::$thinking`; inline `<think>`-tag handling is untouched. Unit test covers populated field and absent-field → null.