### PR TITLE
feat: add ToolCallingService feature-service pair (ADR-051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `ToolCallingService` / `ToolCallingServiceInterface` — the feature-service pair for tool-calling chat (`chatWithTools()`, `chatWithToolsForConfiguration()`), completing the narrow-interface catalogue so consumers no longer need to depend on the 19-method `LlmServiceManagerInterface` for tool calling (ADR-051).
+
 ## [0.16.1] - 2026-07-10
 
 ### Fixed

--- a/Classes/Service/Feature/ToolCallingService.php
+++ b/Classes/Service/Feature/ToolCallingService.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+
+/**
+ * High-level service for tool-calling chat completion.
+ *
+ * Thin, typed facade over the manager's tool-calling entry points —
+ * option handling and dispatch semantics are identical to calling
+ * `LlmServiceManagerInterface` directly (the manager keeps owning
+ * normalisation, provider resolution and the middleware pipeline).
+ *
+ * Budget pre-flight (REC #4): when a caller does not set an explicit
+ * `beUserUid` on the options, the service consults
+ * `BackendUserContextResolverInterface` to find the active backend user
+ * and populates the option so the BudgetMiddleware in the pipeline can
+ * enforce per-user limits without every caller having to remember the
+ * wiring. The resolver injection is optional so unit tests that only
+ * care about the messaging path can omit it; in production DI the
+ * Symfony container always autowires it from
+ * `Configuration/Services.yaml`.
+ */
+final readonly class ToolCallingService implements ToolCallingServiceInterface
+{
+    use AutoPopulatesBeUserUidTrait;
+
+    public function __construct(
+        private LlmServiceManagerInterface $llmManager,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
+    ) {}
+
+    public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
+    {
+        $options ??= new ToolOptions();
+        $options = $this->autoPopulateBeUserUid($options);
+
+        return $this->llmManager->chatWithTools($messages, $tools, $options);
+    }
+
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse
+    {
+        $options ??= new ToolOptions();
+        $options = $this->autoPopulateBeUserUid($options);
+
+        return $this->llmManager->chatWithToolsForConfiguration($messages, $tools, $configuration, $options);
+    }
+}

--- a/Classes/Service/Feature/ToolCallingServiceInterface.php
+++ b/Classes/Service/Feature/ToolCallingServiceInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+
+/**
+ * Public surface of the high-level tool-calling chat service.
+ *
+ * Consumers (backend agents, RAG query flows, tests, downstream
+ * extensions) should depend on this interface rather than
+ * `LlmServiceManagerInterface`: it exposes exactly the tool-calling
+ * capability, so a consumer's test double covers two methods instead
+ * of the whole manager surface and does not break when the manager
+ * interface grows unrelated methods (ADR-051).
+ */
+interface ToolCallingServiceInterface
+{
+    /**
+     * Chat completion with tool calling.
+     *
+     * Legacy array-shaped message and tool fixtures are accepted for
+     * back-compat and normalised via `ChatMessage::fromArray()` /
+     * `ToolSpec::fromArray()` before dispatch.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
+     */
+    public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse;
+
+    /**
+     * Chat completion with tool calling against a specific LLM configuration.
+     *
+     * Unlike {@see self::chatWithTools()} — which resolves a provider from
+     * ExtensionConfiguration against a model-less transient configuration —
+     * this entry point resolves the adapter from the configuration's model
+     * (vault key + model + pricing) so the middleware pipeline records real
+     * cost and budget.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec|array<string, mixed>>    $tools
+     */
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -113,6 +113,13 @@ services:
     alias: Netresearch\NrLlm\Service\Feature\TranslationService
     public: true
 
+  Netresearch\NrLlm\Service\Feature\ToolCallingService:
+    public: true
+
+  Netresearch\NrLlm\Service\Feature\ToolCallingServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\ToolCallingService
+    public: true
+
   # ========================================
   # Supporting Services (PUBLIC)
   # ========================================

--- a/Documentation/Adr/Adr028PublicServicesPolicy.rst
+++ b/Documentation/Adr/Adr028PublicServicesPolicy.rst
@@ -50,6 +50,8 @@ surface; they MUST be public.
 * ``Service\Feature\EmbeddingService`` (+ Interface)
 * ``Service\Feature\TranslationService`` (+ Interface)
 * ``Service\Feature\VisionService`` (+ Interface)
+* ``Service\Feature\ToolCallingService`` (+ Interface, ADR-051)
+* ``Service\Prompt\PromptSnippetComposer`` (concrete-only, ADR-031)
 * ``Service\BudgetService`` (+ ``BudgetServiceInterface``)
 * ``Service\CacheManager`` (+ ``CacheManagerInterface``)
 * ``Service\UsageTrackerService`` (+ ``UsageTrackerServiceInterface``)
@@ -120,28 +122,18 @@ The unit test
 ``Configuration/Services.yaml`` and asserts:
 
 * The total count of ``public: true`` keys matches the expected
-  total (currently **43**).
+  total (currently **45**).
 * The ADR file exists and references both ``REC #9c`` and the
   ``public: true`` policy text.
 
-Breakdown of the 43:
+Breakdown of the 45:
 
-* **22** Category 1 — Public LLM API surface
-  (13 concrete services + 9 interface aliases).
-  Note the 13 / 9 asymmetry: ``CompletionService``,
-  ``EmbeddingService``, ``TranslationService``, ``VisionService``
-  contribute 4 concrete entries but their interface aliases are
-  registered separately (4 aliases). Of the remaining 9 concrete
-  services, three core services
-  (``LlmServiceManager``, ``ProviderAdapterRegistry``,
-  ``TranslatorRegistry``) keep the interface-alias entry while
-  ``BudgetService``, ``CacheManager``, ``UsageTrackerService``,
-  ``LlmConfigurationService``, ``PromptTemplateService`` each have
-  both a concrete + interface entry, and
-  ``Service\Prompt\PromptSnippetComposer`` (ADR-031) is
-  concrete-only — consuming extensions resolve it by class name,
-  it has no interface alias. The maths: 13 concrete + 9
-  aliases = 22.
+* **27** Category 1 — Public LLM API surface
+  (14 concrete services + 13 interface aliases). Every Category-1
+  service has a public interface alias except
+  ``Service\Prompt\PromptSnippetComposer`` (ADR-031), which is
+  concrete-only — consuming extensions resolve it by class name.
+  The maths: 14 concrete + 13 aliases = 27.
 * **4** Category 2 — Specialized services
   (Whisper, TextToSpeech, DallE, Fal).
 * **8** Category 3 — Repositories
@@ -154,14 +146,15 @@ Breakdown of the 43:
 * **4** Category 4 — SetupWizard
   (3 concrete: ProviderDetector, ModelDiscovery,
   ConfigurationGenerator + 1 alias: ModelDiscoveryInterface).
-* **4** Doctrine + provider-adapter wiring tail —
-  small set of services that the host instance / dashboard widgets
-  resolve by class-name through the public container. Includes
+* **2** Class-name-resolution tail —
   ``Service\UsageAnalyticsService``, the read-only Analytics-module
-  reporting service, which is public solely so its functional test
-  resolves it via ``FunctionalTestCase::get()`` (same rationale as
-  Category 3; production callers use constructor injection). Its
-  ``UsageAnalyticsServiceInterface`` alias stays private.
+  reporting service, public solely so its functional test resolves
+  it via ``FunctionalTestCase::get()`` (same rationale as
+  Category 3; production callers use constructor injection — its
+  ``UsageAnalyticsServiceInterface`` alias stays private), and
+  ``Service\Tool\ToolRegistry``, public so functional tests fetch
+  registered tools by spec name (the tools themselves stay
+  private, ADR-042).
 
 The current test enforces only the **count** and the **ADR's
 presence**. It does not statically validate that each individual

--- a/Documentation/Adr/Adr051ToolCallingFeatureService.rst
+++ b/Documentation/Adr/Adr051ToolCallingFeatureService.rst
@@ -1,0 +1,68 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-051:
+
+====================================================================
+ADR-051: Tool-calling feature service — narrow consumer interface
+====================================================================
+
+:Status: Accepted
+:Date: 2026-07-12
+:Authors: Netresearch DTT GmbH
+
+.. _adr-051-context:
+
+Context
+=======
+
+Every capability except tool calling has a narrow feature-service
+interface (``CompletionServiceInterface``, ``EmbeddingServiceInterface``,
+``VisionServiceInterface``, ``TranslationServiceInterface``) whose
+docblocks tell consumers to depend on the interface, not the concrete
+class. Tool calling is the exception: ``chatWithTools()`` and
+``chatWithToolsForConfiguration()`` exist only on
+``LlmServiceManagerInterface`` — a nineteen-method surface.
+
+A consumer that needs exactly tool calling therefore binds to the whole
+manager interface. That coupling is not theoretical: ``nr_ai_search``
+needs a single method, keeps a hand-written fake of the manager
+interface for its unit tests, and that fake fatals every time the
+manager interface grows a method — its 0.13 → 0.16 update was blocked in
+CI by the two methods 0.14 added, none of which it calls.
+
+.. _adr-051-decision:
+
+Decision
+========
+
+Add the missing feature-service pair, mirroring the existing pattern:
+
+- ``Netresearch\NrLlm\Service\Feature\ToolCallingServiceInterface``
+  with exactly the two tool-calling entry points,
+  ``chatWithTools()`` and ``chatWithToolsForConfiguration()``,
+  signature-identical to the manager's.
+- ``Netresearch\NrLlm\Service\Feature\ToolCallingService`` delegating to
+  ``LlmServiceManagerInterface``, adding only the feature-service
+  standard beUserUid auto-population
+  (``AutoPopulatesBeUserUidTrait``, REC #4) so per-user budget
+  enforcement works without caller wiring.
+- Registered in ``Configuration/Services.yaml`` like the other feature
+  services (public service + public interface alias).
+
+The manager keeps its methods unchanged — this is additive; the feature
+service is the documented consumer entry point going forward.
+
+.. _adr-051-consequences:
+
+Consequences
+============
+
+- A tool-calling consumer's test double is two methods, and additions to
+  ``LlmServiceManagerInterface`` no longer break consumers that do not
+  call them.
+- The feature-service catalogue now covers every capability, so the
+  integration guide's "depend on the feature interface" rule holds
+  without exception.
+- Consumers pinning a provider or configuration keep doing so through
+  ``ToolOptions`` / the ``LlmConfiguration`` parameter — the service adds
+  no second way to select one.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -349,3 +349,4 @@ Tools
    Adr048DiagnosticsTools
    Adr049RagSiteSearchTools
    Adr050RetrievalAndEmbeddingScopeBoundary
+   Adr051ToolCallingFeatureService

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -16,6 +16,7 @@ Complete API reference for the TYPO3 LLM extension.
    EmbeddingService
    VisionService
    TranslationService
+   ToolCallingService
    ResponseObjects
    OptionClasses
    ProviderInterface

--- a/Documentation/Api/ToolCallingService.rst
+++ b/Documentation/Api/ToolCallingService.rst
@@ -1,0 +1,84 @@
+.. include:: /Includes.rst.txt
+
+.. _api-tool-calling-service:
+
+==================
+ToolCallingService
+==================
+
+.. php:namespace:: Netresearch\NrLlm\Service\Feature
+
+.. php:class:: ToolCallingService
+
+   Tool-calling chat completion. Depend on
+   ``ToolCallingServiceInterface`` rather than this class (or the
+   service manager) — the interface exposes exactly the tool-calling
+   capability, so consumer test doubles stay two methods small
+   (:ref:`ADR-051 <adr-051>`).
+
+   When no ``beUserUid`` is set on the options, the active backend user
+   is resolved and populated automatically so per-user budget
+   enforcement applies.
+
+   .. php:method:: chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
+
+      Chat completion with tool calling. The provider is resolved from
+      the options (or the extension's default); the configuration is a
+      model-less transient one.
+
+      :param array $messages: list of ``ChatMessage`` (or legacy ``{role, content}`` arrays)
+      :param array $tools: list of ``ToolSpec`` (or legacy OpenAI-wire arrays)
+      :param ?ToolOptions $options: Tool choice, provider/model pin, budget fields
+      :returns: CompletionResponse (``toolCalls`` carries requested calls)
+
+   .. php:method:: chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse
+
+      Chat completion with tool calling against a specific LLM
+      configuration — the adapter is resolved from the configuration's
+      model (vault key, model, pricing), so budget and usage middleware
+      record real cost. Prefer this entry point when a database-backed
+      configuration exists.
+
+      :param array $messages: list of ``ChatMessage`` (or legacy ``{role, content}`` arrays)
+      :param array $tools: list of ``ToolSpec`` (or legacy OpenAI-wire arrays)
+      :param LlmConfiguration $configuration: The configuration to run on
+      :param ?ToolOptions $options: Tool choice and budget fields
+      :returns: CompletionResponse (``toolCalls`` carries requested calls)
+
+Usage
+=====
+
+.. code-block:: php
+
+   use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+   use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+   use Netresearch\NrLlm\Service\Feature\ToolCallingServiceInterface;
+   use Netresearch\NrLlm\Service\Option\ToolOptions;
+
+   final readonly class WeatherAgent
+   {
+       public function __construct(
+           private ToolCallingServiceInterface $toolCalling,
+       ) {}
+
+       public function ask(string $question): string
+       {
+           $response = $this->toolCalling->chatWithTools(
+               [ChatMessage::user($question)],
+               [ToolSpec::function(
+                   'get_weather',
+                   'Get the current weather for a location.',
+                   [
+                       'type' => 'object',
+                       'properties' => ['location' => ['type' => 'string']],
+                       'required' => ['location'],
+                   ],
+               )],
+               ToolOptions::auto(),
+           );
+
+           // Dispatch $response->toolCalls and continue the conversation —
+           // see :ref:`tool-calling` for the full loop.
+           return $response->content;
+       }
+   }

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -33,13 +33,15 @@ use PHPUnit\Framework\TestCase;
 final class PublicServicesPolicyTest extends TestCase
 {
     /**
-     * Audited count of `public: true` overrides as of slice 25
-     * (REC #9c, ADR-028). Categories per ADR-028:
+     * Audited count of `public: true` overrides (REC #9c, ADR-028).
+     * Categories per ADR-028:
      *
-     * - Category 1 (Public LLM API surface): 13 concrete services
-     *   + 9 interface aliases = 22. Includes the concrete-only
+     * - Category 1 (Public LLM API surface): 14 concrete services
+     *   + 13 interface aliases = 27. Every Category-1 service has a
+     *   public interface alias except the concrete-only
      *   PromptSnippetComposer (ADR-031), the snippet composition
-     *   surface for consuming extensions.
+     *   surface for consuming extensions. Includes the
+     *   ToolCallingService feature pair (ADR-051).
      * - Category 2 (Specialized services): 4
      * - Category 3 (Repositories — required public for
      *   FunctionalTestCase::get(); PromptSnippetRepository is also
@@ -49,20 +51,20 @@ final class PublicServicesPolicyTest extends TestCase
      *   functional tests resolve them via FunctionalTestCase::get().
      * - Category 4 (SetupWizard collaborators): 3 concrete +
      *   1 interface alias = 4
-     * - Doctrine + provider wiring tail (services exposed for
-     *   LlmServiceManager / dashboard widget / analytics-module
-     *   resolution by class-name): 4. Includes
-     *   UsageAnalyticsService, public solely so the Analytics
-     *   functional test resolves it via FunctionalTestCase::get().
+     * - Class-name-resolution tail: 2 — UsageAnalyticsService
+     *   (public solely so the Analytics functional test resolves it
+     *   via FunctionalTestCase::get()) and ToolRegistry (public so
+     *   functional tests fetch registered tools by spec name,
+     *   ADR-042).
      *
-     * Total: 22 + 4 + 8 + 4 + 4 = **42**.
+     * Total: 27 + 4 + 8 + 4 + 2 = **45**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
      * `Documentation/Adr/Adr028PublicServicesPolicy.rst` in the
      * same PR — the diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 43;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 45;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Service/Feature/ToolCallingServiceTest.php
+++ b/Tests/Unit/Service/Feature/ToolCallingServiceTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\Feature\ToolCallingService;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(ToolCallingService::class)]
+class ToolCallingServiceTest extends AbstractUnitTestCase
+{
+    /**
+     * Create a subject with a mock LLM manager for expectation testing.
+     *
+     * @return array{subject: ToolCallingService, llmManager: LlmServiceManagerInterface&MockObject}
+     */
+    private function createSubjectWithMockManager(): array
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+
+        return [
+            'subject' => new ToolCallingService($llmManagerMock),
+            'llmManager' => $llmManagerMock,
+        ];
+    }
+
+    /**
+     * @return list<ChatMessage>
+     */
+    private function messages(): array
+    {
+        return [ChatMessage::user('What is the weather in Leipzig?')];
+    }
+
+    /**
+     * @return list<ToolSpec>
+     */
+    private function tools(): array
+    {
+        return [
+            ToolSpec::function(
+                'get_weather',
+                'Get the current weather for a location.',
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'location' => ['type' => 'string'],
+                    ],
+                    'required' => ['location'],
+                ],
+            ),
+        ];
+    }
+
+    #[Test]
+    public function chatWithToolsDelegatesMessagesToolsAndOptionsToManager(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $messages = $this->messages();
+        $tools = $this->tools();
+        $options = ToolOptions::required();
+        $expected = $this->createMockResponse('ok');
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chatWithTools')
+            ->with($messages, $tools, $options)
+            ->willReturn($expected);
+
+        self::assertSame($expected, $subject->chatWithTools($messages, $tools, $options));
+    }
+
+    #[Test]
+    public function chatWithToolsDefaultsOptionsWhenNoneGiven(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chatWithTools')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::isInstanceOf(ToolOptions::class),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->chatWithTools($this->messages(), $this->tools());
+    }
+
+    #[Test]
+    public function chatWithToolsPopulatesBeUserUidFromResolverWhenUnset(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new ToolCallingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chatWithTools')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(static fn(ToolOptions $options): bool
+                    => $options->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->chatWithTools($this->messages(), $this->tools());
+    }
+
+    #[Test]
+    public function chatWithToolsRespectsExplicitBeUserUidOverResolver(): void
+    {
+        // Caller-supplied uid wins — the resolver is for the absent-default
+        // case only. We assert by giving the resolver an expectation that
+        // would fail the test if it were ever called.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::never())
+            ->method('resolveBeUserUid');
+
+        $subject = new ToolCallingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chatWithTools')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(static fn(ToolOptions $options): bool
+                    => $options->getBeUserUid() === 7),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->chatWithTools($this->messages(), $this->tools(), ToolOptions::auto()->withBeUserUid(7));
+    }
+
+    #[Test]
+    public function chatWithToolsForConfigurationDelegatesToManager(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $messages = $this->messages();
+        $tools = $this->tools();
+        $configuration = new LlmConfiguration();
+        $options = ToolOptions::auto();
+        $expected = $this->createMockResponse('ok');
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chatWithToolsForConfiguration')
+            ->with($messages, $tools, $configuration, $options)
+            ->willReturn($expected);
+
+        self::assertSame($expected, $subject->chatWithToolsForConfiguration($messages, $tools, $configuration, $options));
+    }
+
+    #[Test]
+    public function chatWithToolsForConfigurationPopulatesBeUserUidFromResolverWhenUnset(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())
+            ->method('resolveBeUserUid')
+            ->willReturn(42);
+
+        $subject = new ToolCallingService($llmManagerMock, $resolver);
+
+        $llmManagerMock->expects(self::once())
+            ->method('chatWithToolsForConfiguration')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::isInstanceOf(LlmConfiguration::class),
+                self::callback(static fn(ToolOptions $options): bool
+                    => $options->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->chatWithToolsForConfiguration($this->messages(), $this->tools(), new LlmConfiguration());
+    }
+
+    private function createMockResponse(
+        string $content,
+        string $finishReason = 'stop',
+    ): CompletionResponse {
+        return new CompletionResponse(
+            content: $content,
+            model: 'test-model',
+            usage: new UsageStatistics(
+                promptTokens: 10,
+                completionTokens: 20,
+                totalTokens: 30,
+            ),
+            finishReason: $finishReason,
+            provider: 'test',
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Tool calling is the only capability without a narrow feature interface. `chatWithTools()` / `chatWithToolsForConfiguration()` exist only on the 19-method `LlmServiceManagerInterface`, so a consumer that needs exactly tool calling depends on — and, for unit tests, fakes — the entire manager surface. That coupling breaks consumers on every manager-interface addition: nr_ai_search's hand-written fake fataled in CI when 0.14 added `resolveEffectiveConfiguration()` and `chatWithToolsForConfiguration()`, neither of which it calls.

## Change

- `Service\Feature\ToolCallingServiceInterface` — exactly the two tool-calling entry points, signature-identical to the manager's.
- `Service\Feature\ToolCallingService` — delegates to `LlmServiceManagerInterface` unchanged; adds only the feature-service standard beUserUid auto-population (`AutoPopulatesBeUserUidTrait`, REC #4). Option handling mirrors the manager (`$options ??= new ToolOptions()`), so behaviour is identical to calling the manager directly.
- `Configuration/Services.yaml`: public service + public interface alias, like the other feature services.
- Docs: ADR-051, `Api/ToolCallingService.rst`, index entries, CHANGELOG.

### Public-services policy (ADR-028)

The count moves 43 → 45 (+1 concrete, +1 alias). While updating the audit trail I reconciled the recorded breakdown with the actual `Services.yaml`, which had drifted: 9 interface aliases recorded vs. 12 present, `ToolRegistry` and `PromptSnippetRepository` unlisted, and the documented totals (42) not adding up to the enforced count (43). The breakdown now enumerates the real 45 keys (27 + 4 + 8 + 4 + 2).

## Verification

Full local gate via `runTests.sh`: cgl, lint, phpstan, rector all pass; unit 4060 tests / 9629 assertions; functional 1104 tests / 12524 assertions. Docs rendered with render-guides — no new warnings (pre-existing ones in `Administration/Tools.rst` / `Api/VisionService.rst` unchanged).

## Notes

- `Developer/ToolCalling.rst` still teaches raw-array tool turns and treats `$response->toolCalls` as arrays — pre-existing drift, tracked in #345 rather than mixed into this PR.
- Part of the consumer-integration review; see also #345, #346, #347.