### PR TITLE
fix: usage attribution honours the caller-supplied beUserUid (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `ToolCallingService` / `ToolCallingServiceInterface` — the feature-service pair for tool-calling chat (`chatWithTools()`, `chatWithToolsForConfiguration()`), completing the narrow-interface catalogue so consumers no longer need to depend on the 19-method `LlmServiceManagerInterface` for tool calling (ADR-051).
 
+### Changed
+
+- Usage attribution honours the caller-supplied `beUserUid`: `UsageMiddleware` forwards the uid the options carry (`withBeUserUid()`, the same metadata the budget gate enforces against) to `UsageTrackerService`, instead of always reading the ambient `backend.user` aspect. Frontend/CLI callers that pass a uid no longer need to impersonate a technical backend user just to get correct `be_user` rows; without a caller uid the ambient fallback behaves as before. `UsageTrackerServiceInterface::trackUsage()` gains an optional trailing `?int $beUserUid = null` parameter — implementers outside this repo must add it (ADR-052).
+
 ## [0.16.1] - 2026-07-10
 
 ### Fixed

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -130,6 +130,15 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             ? $context->metadata[self::METADATA_TASK_UID]
             : 0;
 
+        // The caller-supplied attribution uid (options `withBeUserUid()`,
+        // forwarded by the manager as budget metadata). BudgetMiddleware reads
+        // the same key for enforcement; recording it here keeps enforcement and
+        // attribution consistent for callers that run outside a backend-user
+        // request context (frontend plugins, CLI workers).
+        $beUserUid = isset($context->metadata[BudgetMiddleware::METADATA_BE_USER_UID]) && is_int($context->metadata[BudgetMiddleware::METADATA_BE_USER_UID])
+            ? $context->metadata[BudgetMiddleware::METADATA_BE_USER_UID]
+            : null;
+
         $this->usageTracker->trackUsage(
             serviceType: $context->operation->value,
             provider: $provider !== '' ? $provider : 'unknown',
@@ -138,6 +147,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             modelUid: $modelUid,
             modelId: $modelId,
             taskUid: $taskUid,
+            beUserUid: $beUserUid,
         );
     }
 

--- a/Classes/Service/UsageTrackerService.php
+++ b/Classes/Service/UsageTrackerService.php
@@ -50,6 +50,9 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
      * @param int      $modelUid         Model UID (0 when unknown / no DB model)
      * @param string   $modelId          Model identifier label (e.g. "gpt-4o"); '' when unknown
      * @param int      $taskUid          Task UID (0 when the call is not a task execution)
+     * @param int|null $beUserUid        Backend user to attribute the usage to; null falls
+     *                                   back to the ambient `backend.user` context aspect
+     *                                   (0 when no backend user is authenticated)
      */
     public function trackUsage(
         string $serviceType,
@@ -59,8 +62,9 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
         int $modelUid = 0,
         string $modelId = '',
         int $taskUid = 0,
+        ?int $beUserUid = null,
     ): void {
-        $beUser = $this->getCurrentBackendUserId();
+        $beUser = $beUserUid ?? $this->getCurrentBackendUserId();
         $today = strtotime('today');
         $now = time();
 

--- a/Classes/Service/UsageTrackerServiceInterface.php
+++ b/Classes/Service/UsageTrackerServiceInterface.php
@@ -36,6 +36,9 @@ interface UsageTrackerServiceInterface
      * @param int      $modelUid         Model UID (0 when unknown / no DB model)
      * @param string   $modelId          Model identifier label (e.g. "gpt-4o"); '' when unknown
      * @param int      $taskUid          Task UID (0 when the call is not a task execution)
+     * @param int|null $beUserUid        Backend user to attribute the usage to; null falls
+     *                                   back to the ambient `backend.user` context aspect
+     *                                   (0 when no backend user is authenticated)
      */
     public function trackUsage(
         string $serviceType,
@@ -45,6 +48,7 @@ interface UsageTrackerServiceInterface
         int $modelUid = 0,
         string $modelId = '',
         int $taskUid = 0,
+        ?int $beUserUid = null,
     ): void;
 
     /**

--- a/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
+++ b/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
@@ -1,0 +1,68 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-052:
+
+================================================================
+ADR-052: Usage attribution honours the caller-supplied beUserUid
+================================================================
+
+:Status: Accepted
+:Date: 2026-07-12
+:Authors: Netresearch DTT GmbH
+
+.. _adr-052-context:
+
+Context
+=======
+
+Every option object carries ``withBeUserUid()``
+(``BudgetAwareOptionsInterface``), and the manager forwards that uid as
+pipeline metadata (``BudgetMiddleware::METADATA_BE_USER_UID``), where
+``BudgetMiddleware`` uses it for per-user budget **enforcement**. Usage
+**attribution**, however, ignored it: ``UsageTrackerService`` always
+read the ambient ``backend.user`` context aspect to fill the
+``be_user`` column.
+
+For backend-module calls the two sources agree. For every caller
+outside a backend-user request — frontend plugins, Messenger/CLI
+workers, scheduler tasks — they do not: the aspect resolves to ``0``,
+so usage lands in the anonymous bucket even when the caller passed an
+explicit uid. Downstream extensions worked around this by
+impersonating a technical backend user for the duration of a call —
+swapping the ``backend.user`` aspect (and restoring it in a
+``finally``) purely so the usage row gets the right ``be_user``.
+``nr_ai_search``'s ``BackendUserContext::runAs()`` is such a
+workaround, wrapped around every RAG chat call. Enforcement and
+attribution also disagreed with each other: the budget gate charged
+the option-supplied user while the usage row credited the ambient one.
+
+.. _adr-052-decision:
+
+Decision
+========
+
+The caller-supplied uid wins; the ambient aspect stays the fallback.
+
+- ``UsageTrackerServiceInterface::trackUsage()`` gains an optional
+  trailing ``?int $beUserUid = null`` parameter. ``null`` preserves the
+  previous behaviour (ambient ``backend.user`` aspect, ``0`` when
+  unauthenticated).
+- ``UsageMiddleware`` reads ``BudgetMiddleware::METADATA_BE_USER_UID``
+  from the pipeline context — the same key the budget gate reads — and
+  passes it through, so enforcement and attribution can no longer
+  disagree.
+
+.. _adr-052-consequences:
+
+Consequences
+============
+
+- A consumer that already sets ``withBeUserUid()`` gets correct
+  attribution in frontend/CLI contexts with no further wiring; the
+  aspect-swap workaround becomes unnecessary for usage tracking.
+- Backend-module calls are unaffected: they set no option uid, and the
+  ambient fallback resolves the same user as before.
+- ``UsageTrackerServiceInterface`` implementers must add the new
+  parameter (semver-minor breaking in the 0.x line, same policy as
+  ``ToolInterface::getGroup()`` in 0.15.0). In-repo,
+  ``UsageTrackerService`` is the only implementation.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -350,3 +350,4 @@ Tools
    Adr049RagSiteSearchTools
    Adr050RetrievalAndEmbeddingScopeBoundary
    Adr051ToolCallingFeatureService
+   Adr052UsageAttributionViaOptions

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -273,6 +273,67 @@ final class UsageTrackerServiceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function trackUsageAttributesToExplicitBeUserUid(): void
+    {
+        $this->service->trackUsage(
+            'chat',
+            'openai',
+            ['tokens' => 10],
+            beUserUid: 42,
+        );
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(
+            ['be_user'],
+            self::TABLE,
+            ['service_type' => 'chat'],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertArrayHasKey('be_user', $row);
+        self::assertIsNumeric($row['be_user']);
+        self::assertSame(42, (int)$row['be_user']);
+    }
+
+    #[Test]
+    public function trackUsageFallsBackToAmbientContextWhenBeUserUidIsNull(): void
+    {
+        // The functional container has no authenticated backend user, so the
+        // ambient backend.user aspect resolves to 0 — the pre-existing default.
+        $this->service->trackUsage(
+            'chat',
+            'openai',
+            ['tokens' => 10],
+        );
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(
+            ['be_user'],
+            self::TABLE,
+            ['service_type' => 'chat'],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertArrayHasKey('be_user', $row);
+        self::assertIsNumeric($row['be_user']);
+        self::assertSame(0, (int)$row['be_user']);
+    }
+
+    #[Test]
+    public function trackUsageKeepsSeparateRecordsForDifferentBeUsers(): void
+    {
+        // be_user is part of the daily aggregation key — two users on the same
+        // provider/model/day must not merge into one row.
+        $this->service->trackUsage('chat', 'openai', ['tokens' => 10], beUserUid: 42);
+        $this->service->trackUsage('chat', 'openai', ['tokens' => 10], beUserUid: 43);
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $count = $connection->count('*', self::TABLE, ['service_type' => 'chat']);
+
+        self::assertSame(2, $count);
+    }
+
+    #[Test]
     public function trackUsageHandlesEmptyMetrics(): void
     {
         $this->service->trackUsage('test', 'provider', []);

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -412,6 +413,65 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
 
         $this->pipeline()->run(
             context: ProviderCallContext::for(ProviderOperation::Chat, [UsageMiddleware::METADATA_TASK_UID => 42]),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+                content: 'x',
+                model: 'm',
+                usage: new UsageStatistics(5, 5, 10),
+                provider: 'openai',
+            ),
+        );
+    }
+
+    #[Test]
+    public function recordsBeUserUidFromContextMetadata(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Chat->value,
+                'openai',
+                ['tokens' => 10, 'promptTokens' => 5, 'completionTokens' => 5],
+                null,
+                0,
+                'm',
+                0,
+                99,
+            );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat, [BudgetMiddleware::METADATA_BE_USER_UID => 99]),
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+                content: 'x',
+                model: 'm',
+                usage: new UsageStatistics(5, 5, 10),
+                provider: 'openai',
+            ),
+        );
+    }
+
+    #[Test]
+    public function passesNullBeUserUidWhenMetadataAbsent(): void
+    {
+        // Null defers the attribution decision to the tracker's ambient
+        // backend.user fallback — the middleware must not coerce it to 0,
+        // which would silently re-attribute backend-module calls.
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                ProviderOperation::Chat->value,
+                'openai',
+                ['tokens' => 10, 'promptTokens' => 5, 'completionTokens' => 5],
+                null,
+                0,
+                'm',
+                0,
+                null,
+            );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
             configuration: $this->configuration(),
             terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
                 content: 'x',


### PR DESCRIPTION
## Problem

`withBeUserUid()` on the option objects feeds the budget gate (`BudgetMiddleware` reads it from pipeline metadata), but usage **attribution** ignored it: `UsageTrackerService::trackUsage()` always resolved the user from the ambient `backend.user` context aspect. Outside a backend-user request — frontend plugins, Messenger/CLI workers, scheduler — the aspect is `0`, so usage landed in the anonymous bucket even when the caller passed an explicit uid, and the budget gate charged a different user than the usage row credited.

Consumers work around this by impersonating a technical backend user around every call: nr_ai_search's `BackendUserContext::runAs()` swaps the `backend.user` aspect (restoring it in a `finally`) purely so the usage row gets the right `be_user`. With this change that wrapper becomes unnecessary for usage tracking.

## Change

- `UsageMiddleware` reads `BudgetMiddleware::METADATA_BE_USER_UID` — the same metadata key the budget gate enforces against — and passes it to `trackUsage()`, so enforcement and attribution cannot disagree.
- `UsageTrackerServiceInterface::trackUsage()` / `UsageTrackerService` gain an optional trailing `?int $beUserUid = null`; `null` preserves the ambient-aspect fallback byte-for-byte (backend-module calls are unaffected).
- ADR-052 documents the decision; CHANGELOG notes the interface addition (implementers outside this repo must add the parameter — same 0.x policy as `ToolInterface::getGroup()` in 0.15.0; in-repo `UsageTrackerService` is the only implementation).

## Scope

**Not covered (unchanged):** the Specialized services' direct `trackUsage()` calls (Whisper, TTS, DallE, FAL, DeepL/LLM translators) — their call sites have no options context to take a uid from; wiring one through is a separate refactor.

## Verification

Full local gate via `runTests.sh`: cgl, lint, phpstan, rector pass; unit 4056 tests / 9616 assertions (2 new middleware cases: metadata uid forwarded, absent metadata stays `null`); functional 1107 tests / 12539 assertions (3 new: explicit uid attribution, ambient fallback, per-user row separation). Docs rendered with render-guides — no new warnings.

Part of the consumer-integration review; see also #345, #346, #347, #348.