### PR TITLE
feat: NrLlmExceptionInterface marker for all public-surface exceptions (ADR-053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - `ToolCallingService` / `ToolCallingServiceInterface` — the feature-service pair for tool-calling chat (`chatWithTools()`, `chatWithToolsForConfiguration()`), completing the narrow-interface catalogue so consumers no longer need to depend on the 19-method `LlmServiceManagerInterface` for tool calling (ADR-051).
+- `NrLlmExceptionInterface` — a marker interface implemented by every exception thrown on the public API surface, so consumers can write a single `catch (NrLlmExceptionInterface $e)` instead of enumerating concrete classes. `ChatMessage`/`ToolSpec`/`ToolCall::fromArray()` normalisation errors now throw nr_llm's `Exception\InvalidArgumentException` (a subclass of PHP's, so existing catches keep matching) and are covered by the marker too (ADR-053).
 
 ### Changed
 

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
-use InvalidArgumentException;
 use JsonSerializable;
 use Netresearch\NrLlm\Domain\Enum\MessageRole;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Value Object representing a chat message.

--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
-use InvalidArgumentException;
 use JsonSerializable;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Value Object representing a single tool invocation the model emitted.

--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
-use InvalidArgumentException;
 use JsonSerializable;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use stdClass;
 
 /**

--- a/Classes/Exception/AccessDeniedException.php
+++ b/Classes/Exception/AccessDeniedException.php
@@ -14,4 +14,4 @@ use RuntimeException;
 /**
  * Exception thrown when access to an LLM configuration is denied.
  */
-class AccessDeniedException extends RuntimeException {}
+class AccessDeniedException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/BudgetExceededException.php
+++ b/Classes/Exception/BudgetExceededException.php
@@ -20,7 +20,7 @@ use Throwable;
  * flash messages) can surface which bucket tripped, the current usage,
  * and the limit without re-running the check.
  */
-final class BudgetExceededException extends RuntimeException
+final class BudgetExceededException extends RuntimeException implements NrLlmExceptionInterface
 {
     public function __construct(
         public readonly BudgetCheckResult $result,

--- a/Classes/Exception/ConfigurationNotFoundException.php
+++ b/Classes/Exception/ConfigurationNotFoundException.php
@@ -14,4 +14,4 @@ use RuntimeException;
 /**
  * Exception thrown when an LLM configuration cannot be found.
  */
-class ConfigurationNotFoundException extends RuntimeException {}
+class ConfigurationNotFoundException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/InvalidArgumentException.php
+++ b/Classes/Exception/InvalidArgumentException.php
@@ -12,4 +12,4 @@ namespace Netresearch\NrLlm\Exception;
 /**
  * Exception thrown when invalid arguments are provided to services.
  */
-class InvalidArgumentException extends \InvalidArgumentException {}
+class InvalidArgumentException extends \InvalidArgumentException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/NrLlmExceptionInterface.php
+++ b/Classes/Exception/NrLlmExceptionInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use Throwable;
+
+/**
+ * Marker interface implemented by every exception this extension throws
+ * on its public API surface.
+ *
+ * Lets a consumer wrap any nr_llm call in a single
+ * `catch (NrLlmExceptionInterface $e)` instead of enumerating the
+ * concrete classes (`ProviderException`, `BudgetExceededException`,
+ * `AccessDeniedException`, `ConfigurationNotFoundException`,
+ * `InvalidArgumentException`, ...) — an enumeration that silently goes
+ * stale whenever a new exception type is added (ADR-053).
+ */
+interface NrLlmExceptionInterface extends Throwable {}

--- a/Classes/Exception/PromptTemplateNotFoundException.php
+++ b/Classes/Exception/PromptTemplateNotFoundException.php
@@ -14,4 +14,4 @@ use RuntimeException;
 /**
  * Exception thrown when a requested prompt template is not found.
  */
-class PromptTemplateNotFoundException extends RuntimeException {}
+class PromptTemplateNotFoundException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Provider/Exception/ProviderException.php
+++ b/Classes/Provider/Exception/ProviderException.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
+use Netresearch\NrLlm\Exception\NrLlmExceptionInterface;
 use RuntimeException;
 
-class ProviderException extends RuntimeException {}
+class ProviderException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Documentation/Adr/Adr053ExceptionMarkerInterface.rst
+++ b/Documentation/Adr/Adr053ExceptionMarkerInterface.rst
@@ -1,0 +1,71 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-053:
+
+=========================================================
+ADR-053: One marker interface for all thrown exceptions
+=========================================================
+
+:Status: Accepted
+:Date: 2026-07-12
+:Authors: Netresearch DTT GmbH
+
+.. _adr-053-context:
+
+Context
+=======
+
+A consumer that wraps an nr_llm call and wants to convert failures into
+its own domain exception has to enumerate concrete classes today::
+
+    } catch (
+        InvalidArgumentException          // PHP's own, from ChatMessage/ToolSpec::fromArray()
+        | NrLlmInvalidArgumentException   // options validation
+        | ProviderException               // covers the 5 provider subtypes
+        | BudgetExceededException
+        | AccessDeniedException
+        | ConfigurationNotFoundException $e
+    ) {
+
+Two problems. The list goes stale silently: when a future version adds
+or rethrows a new exception type, existing catch lists let it escape as
+an uncaught 500 instead of the consumer's clean error path. And the
+chat/tool value objects' ``fromArray()`` normalisation threw **PHP's**
+global ``\InvalidArgumentException``, a different class from nr_llm's
+own ``Exception\InvalidArgumentException`` — the first entry in the
+list above exists only because of that mismatch (``nr_ai_search``'s
+``NrLlmChatClient`` documents exactly this trap).
+
+.. _adr-053-decision:
+
+Decision
+========
+
+- ``Netresearch\NrLlm\Exception\NrLlmExceptionInterface`` (extending
+  ``\Throwable``) marks every exception this extension throws on its
+  public API surface. The five core exceptions and ``ProviderException``
+  (which its five subtypes inherit from) implement it.
+- ``ChatMessage`` / ``ToolSpec`` / ``ToolCall`` normalisation errors now
+  throw ``Exception\InvalidArgumentException`` instead of PHP's global
+  class. Backwards compatible: the nr_llm class extends
+  ``\InvalidArgumentException``, so existing catches keep matching.
+- A reflection test sweeps both exception directories so a future
+  exception class cannot ship without the marker.
+
+Consumers can now write ``catch (NrLlmExceptionInterface $e)`` — one
+arm, future-proof.
+
+.. _adr-053-consequences:
+
+Consequences
+============
+
+- Remaining classes that import the global ``InvalidArgumentException``
+  for their own validation errors (response parsers, task readers,
+  backend response DTOs) are unchanged — they are not part of the
+  chat/embedding consumer surface. Migrating them onto
+  ``Exception\InvalidArgumentException`` is compatible follow-up work,
+  guarded by the same reflection test.
+- Catch-all remains opt-in: consumers that want to handle budget
+  exhaustion differently from provider outages keep catching the
+  concrete classes.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -351,3 +351,4 @@ Tools
    Adr050RetrievalAndEmbeddingScopeBoundary
    Adr051ToolCallingFeatureService
    Adr052UsageAttributionViaOptions
+   Adr053ExceptionMarkerInterface

--- a/Documentation/Api/Exceptions.rst
+++ b/Documentation/Api/Exceptions.rst
@@ -6,6 +6,22 @@
 Exceptions
 ==========
 
+.. php:namespace:: Netresearch\NrLlm\Exception
+
+.. php:interface:: NrLlmExceptionInterface
+
+   Marker interface implemented by every exception this extension
+   throws on its public API surface — including the ``fromArray()``
+   normalisation errors of ``ChatMessage`` / ``ToolSpec`` /
+   ``ToolCall``. Catch this when any nr_llm failure should take the
+   same error path (:ref:`ADR-053 <adr-053>`)::
+
+      try {
+          $response = $this->llmManager->chatWithTools($messages, $tools);
+      } catch (NrLlmExceptionInterface $e) {
+          throw new MyDomainException($e->getMessage(), 0, $e);
+      }
+
 .. php:namespace:: Netresearch\NrLlm\Provider\Exception
 
 .. php:class:: ProviderException

--- a/Tests/Unit/Exception/NrLlmExceptionInterfaceTest.php
+++ b/Tests/Unit/Exception/NrLlmExceptionInterfaceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Exception\NrLlmExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+use Throwable;
+
+/**
+ * Locks the ADR-053 contract: every exception class this extension
+ * throws is catchable via the single `NrLlmExceptionInterface` marker,
+ * including the `fromArray()` normalisation errors of the chat/tool
+ * value objects — so a consumer's `catch (NrLlmExceptionInterface $e)`
+ * cannot silently miss a class that a future change adds or rethrows.
+ */
+#[CoversNothing]
+final class NrLlmExceptionInterfaceTest extends TestCase
+{
+    private const EXCEPTION_DIRS = [
+        __DIR__ . '/../../../Classes/Exception',
+        __DIR__ . '/../../../Classes/Provider/Exception',
+    ];
+
+    #[Test]
+    public function everyExceptionClassImplementsTheMarkerInterface(): void
+    {
+        $checked = 0;
+
+        foreach (self::EXCEPTION_DIRS as $dir) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+
+            foreach ($iterator as $file) {
+                if (!$file instanceof SplFileInfo || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $class = $this->classNameFromFile($file);
+                $reflection = new ReflectionClass($class);
+
+                if ($reflection->isInterface()) {
+                    continue;
+                }
+
+                self::assertTrue(
+                    $reflection->implementsInterface(NrLlmExceptionInterface::class),
+                    sprintf('%s must implement %s (ADR-053).', $class, NrLlmExceptionInterface::class),
+                );
+                ++$checked;
+            }
+        }
+
+        self::assertGreaterThanOrEqual(6, $checked, 'The reflection sweep must actually find the exception classes.');
+    }
+
+    #[Test]
+    public function chatMessageNormalisationErrorIsCatchableViaTheMarker(): void
+    {
+        try {
+            ChatMessage::fromArray([]);
+            self::fail('fromArray([]) must throw');
+        } catch (Throwable $e) {
+            self::assertInstanceOf(NrLlmExceptionInterface::class, $e);
+        }
+    }
+
+    #[Test]
+    public function toolSpecNormalisationErrorIsCatchableViaTheMarker(): void
+    {
+        try {
+            ToolSpec::fromArray([]);
+            self::fail('fromArray([]) must throw');
+        } catch (Throwable $e) {
+            self::assertInstanceOf(NrLlmExceptionInterface::class, $e);
+        }
+    }
+
+    #[Test]
+    public function toolCallNormalisationErrorIsCatchableViaTheMarker(): void
+    {
+        try {
+            ToolCall::fromArray([]);
+            self::fail('fromArray([]) must throw');
+        } catch (Throwable $e) {
+            self::assertInstanceOf(NrLlmExceptionInterface::class, $e);
+        }
+    }
+
+    /**
+     * @return class-string
+     */
+    private function classNameFromFile(SplFileInfo $file): string
+    {
+        $contents = file_get_contents($file->getPathname());
+        self::assertNotFalse($contents);
+
+        $matched = preg_match('/^namespace\s+([^;]+);/m', $contents, $namespace);
+        self::assertSame(1, $matched, $file->getPathname() . ' must declare a namespace');
+
+        /** @var class-string $class */
+        $class = $namespace[1] . '\\' . $file->getBasename('.php');
+
+        return $class;
+    }
+}


### PR DESCRIPTION
## Problem

A consumer wrapping an nr_llm call has to enumerate concrete exception classes — nr_ai_search's `NrLlmChatClient` catches six:

```php
} catch (InvalidArgumentException|NrLlmInvalidArgumentException|ProviderException|BudgetExceededException|AccessDeniedException|ConfigurationNotFoundException $e) {
```

The list goes stale silently when a version adds or rethrows a new type — the new exception escapes as an uncaught 500 instead of the consumer's clean error path. And the first entry exists only because `ChatMessage`/`ToolSpec`/`ToolCall::fromArray()` threw **PHP's global** `\InvalidArgumentException`, a different class from nr_llm's own `Exception\InvalidArgumentException`.

## Change

- `Exception\NrLlmExceptionInterface` (extends `\Throwable`) — implemented by the five core exceptions and `ProviderException` (its five subtypes inherit it).
- `ChatMessage` / `ToolSpec` / `ToolCall` normalisation errors now throw nr_llm's `Exception\InvalidArgumentException`. Backwards compatible: it extends PHP's, so existing catches keep matching.
- Reflection sweep test over both exception directories locks the contract — a future exception class cannot ship without the marker; three cases pin the `fromArray()` paths.
- ADR-053, `Api/Exceptions.rst` section, CHANGELOG.

Consumers can then write a single `catch (NrLlmExceptionInterface $e)`.

## Scope

Classes importing the global `InvalidArgumentException` for internal validation (response parsers, task readers, backend response DTOs — 10 further files) are unchanged; they are not part of the chat/embedding consumer surface. Migrating them onto `Exception\InvalidArgumentException` is compatible follow-up, guarded by the same test.

## Verification

Full local gate via `runTests.sh`: cgl, lint, phpstan, rector pass; unit 4058 tests / 9638 assertions; functional 1104 tests / 12524 assertions. Docs rendered with render-guides — no new warnings.

Part of the consumer-integration review; see also #345, #346, #347, #348, #349.