### PR TITLE
fix(ci): run functional suites without the PHP JIT

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -357,6 +357,13 @@ fi
 
 # PHP performance options
 PHP_OPCACHE_OPTS="-d opcache.enable_cli=1 -d opcache.jit=1255 -d opcache.jit_buffer_size=128M"
+# Functional/e2e-backend suites run WITHOUT the JIT: the tracing JIT in the
+# container PHP builds (reproduced on 8.3 and 8.5) segfaults silently during
+# suite bootstrap for certain — perfectly valid — source shapes (adding a
+# plain property+getter+setter to an entity flipped it). Identical runs with
+# opcache.jit=off pass; the functionalCoverage path below already ran without
+# the JIT. Functional tests are IO-bound, so the JIT buys nothing here anyway.
+PHP_FUNCTIONAL_OPTS="-d opcache.enable_cli=1"
 
 # Suite execution
 case ${TEST_SUITE} in
@@ -434,7 +441,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     functional)
-        COMMAND=(php ${PHP_OPCACHE_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml --exclude-group not-${DBMS} "$@")
+        COMMAND=(php ${PHP_FUNCTIONAL_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml --exclude-group not-${DBMS} "$@")
 
         case ${DBMS} in
             mariadb)
@@ -482,7 +489,7 @@ case ${TEST_SUITE} in
             PARALLEL_JOBS=$(( ($(nproc) + 1) / 2 ))
         fi
 
-        COMMAND="find Tests/Functional -name '*Test.php' | xargs -P${PARALLEL_JOBS} -I{} php ${PHP_OPCACHE_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml {}"
+        COMMAND="find Tests/Functional -name '*Test.php' | xargs -P${PARALLEL_JOBS} -I{} php ${PHP_FUNCTIONAL_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml {}"
         CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-parallel-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?


### PR DESCRIPTION
## Problem

The tracing JIT (`opcache.jit=1255`) in the container PHP builds segfaults **silently** during functional suite bootstrap for certain — perfectly valid — source shapes. Concretely: adding a plain string property with getter/setter to `LlmConfiguration` (17 innocuous lines, part of the upcoming #347 implementation) made every functional run die with exit 139 before the first test.

Diagnosis evidence:
- reproduced identically on the 8.3 and 8.5 container images (not version-specific),
- bisected to that one file's shape via stash bisection (revert file → suite passes; restore → segfault),
- the identical tree passes with `opcache.jit=off` in the same container, and on a host PHP 8.5.7 without JIT,
- no PHP error, no TYPO3 log entry — the process dies during PHPUnit suite construction.

## Change

New `PHP_FUNCTIONAL_OPTS` (opcache without JIT) used by the `functional` and `functionalParallel` suites. `functionalCoverage` already ran without the JIT. Unit/phpstan/cgl keep `PHP_OPCACHE_OPTS` — the JIT is beneficial and stable there.

Functional runs are IO-bound (sqlite, per-test container boot), so the JIT gains nothing in these suites.

## Note

`Build/Scripts/runTests.sh` is synced from the typo3-testing template — this change should be upstreamed there; flagging rather than silently diverging.

Unblocks the #347 implementation PR (its functional CI legs would die on this engine bug otherwise).