### PR TITLE
chore: release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-13
+
 ### Added
 
 - **Configuration presets**: consuming extensions declare the `LlmConfiguration` records they need via the `nr_llm.configuration_preset` DI tag (`ConfigurationPresetProviderInterface` + `ConfigurationPreset` value objects). Presets express requirements as `ModelSelectionCriteria` — never providers, models, or API keys — and a backend admin imports a pending preset with one confirmation through the new admin-gated AJAX endpoints `nrllm_preset_list` (pending presets incl. a per-preset preflight against the configured models) and `nrllm_preset_import`. Imported records are active criteria-mode configurations resolved at runtime by `ModelSelectionService`; the new `preset_checksum` column makes a changed declaration detectable (ADR-056) (#347).

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.16.1"
-        release="0.16.1"
+        version="0.17.0"
+        release="0.17.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.16.1",
+            "version": "0.17.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.16.1',
+    'version' => '0.17.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release preparation for v0.17.0 — the consumer-integration release.

## Contents (see CHANGELOG)

### Added
- `ToolCallingService` / `ToolCallingServiceInterface` (ADR-051, #348)
- `NrLlmExceptionInterface` marker for all public-surface exceptions (ADR-053, #350)
- Typed tool-turn messages on `ChatMessage` (ADR-054, #352, closes #345)
- Embedding configuration path + model `dimensions` metadata (ADR-055, #353, closes #346)
- Configuration presets declared by consuming extensions (ADR-056, #354, closes #347)

### Changed
- Usage attribution honours caller-supplied `beUserUid` (ADR-052, #349)
- Functional suites run without the PHP JIT — engine segfault workaround (#351)

## Version bumps
`composer.json` (extra), `ext_emconf.php`, `Documentation/guides.xml` (version + release), CHANGELOG section `0.17.0 - 2026-07-13`.

Interface additions in this release (implementers must extend): `LlmServiceManagerInterface::embedForConfiguration()`, `EmbeddingServiceInterface::embedForConfiguration()/embedBatchForConfiguration()`, `UsageTrackerServiceInterface::trackUsage(..., ?int $beUserUid)`.

Pre-tag issue triage: #345/#346/#347 closed by their PRs; only the Renovate dependency dashboard (#80) remains open.

After merge: signed tag `v0.17.0` on the merge commit triggers the release workflow (SBOM, cosign, SLSA).