### PR TITLE
feat: pending-preset panel and drift hint in the configurations module (ADR-056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Configuration presets module UI** (the ADR-056 follow-up): the Configurations backend module surfaces pending presets — one row per preset with name, identifier, description, and the preflight result (the model the criteria currently match, or the missing requirement) — and imports one via the existing `nrllm_preset_import` endpoint with a single click; the panel renders only while presets are pending. Imported records whose declaration changed since import are flagged with a non-blocking "Preset changed" hint (checksum comparison via the new `ConfigurationPresetRegistry::drifted()`), and `nrllm_preset_list` returns these as a new `drifted` list. The checksum-driven update flow remains future work (ADR-056).
+
 ### Changed
 
 - The specialized translators forward the caller-supplied `beUserUid` to usage tracking: `TranslationService` re-attaches the resolved uid to the options array handed to `TranslatorInterface` implementations (`beUserUid` key — budget fields are deliberately excluded from `TranslationOptions::toArray()`), and `DeepLTranslator` / `LlmTranslator` pass it on to `trackUsage()`, so translator usage rows are attributed like the middleware-pipeline paths. The speech/image services (Whisper, TTS, DALL-E, FAL) keep ambient attribution — their option shapes carry no budget fields (ADR-052).

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -25,6 +25,8 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\UsageAnalyticsService;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
@@ -79,6 +81,8 @@ final class ConfigurationController extends ActionController
         private readonly TestPromptResolverInterface $testPromptResolver,
         private readonly UsageAnalyticsServiceInterface $analytics,
         private readonly LoggerInterface $logger,
+        private readonly ConfigurationPresetRegistry $presetRegistry,
+        private readonly ConfigurationPresetImportService $presetImportService,
     ) {}
 
     protected function initializeAction(): void
@@ -94,6 +98,7 @@ final class ConfigurationController extends ActionController
             'nrllm_config_toggle_active' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_config_toggle_active'),
             'nrllm_config_set_default' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_config_set_default'),
             'nrllm_config_test' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_config_test'),
+            'nrllm_preset_import' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_preset_import'),
         ]);
 
         // Load JavaScript for configuration list actions (ES6 module)
@@ -133,6 +138,8 @@ final class ConfigurationController extends ActionController
             'costByConfig' => $usage['cost'],
             'reqByConfig' => $usage['requests'],
             'tokByConfig' => $usage['tokens'],
+            'pendingPresets' => $this->buildPendingPresetRows(),
+            'driftedUids' => $this->buildDriftedUidMap(),
         ]);
 
         if (method_exists($this->moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
@@ -548,6 +555,50 @@ final class ConfigurationController extends ActionController
     private function getOllamaConstraints(): array
     {
         return $this->getDefaultConstraints();
+    }
+
+    /**
+     * Pending configuration presets (ADR-056) as template rows, each with
+     * its preflight result so the list can show upfront whether an import
+     * can succeed.
+     *
+     * @return list<array{identifier: string, name: string, description: string, satisfiable: bool, matchedModelLabel: string|null, missingRequirement: string|null}>
+     */
+    private function buildPendingPresetRows(): array
+    {
+        $rows = [];
+        foreach ($this->presetRegistry->pending() as $preset) {
+            $preflight = $this->presetImportService->preflight($preset);
+            $rows[] = [
+                'identifier' => $preset->identifier,
+                'name' => $preset->name,
+                'description' => $preset->description,
+                'satisfiable' => $preflight->satisfiable,
+                'matchedModelLabel' => $preflight->matchedModelLabel,
+                'missingRequirement' => $preflight->missingRequirement,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Configuration UIDs whose imported preset declaration drifted
+     * (checksum mismatch, ADR-056) — keyed by UID for O(1) template lookup.
+     *
+     * @return array<int, bool>
+     */
+    private function buildDriftedUidMap(): array
+    {
+        $driftedUids = [];
+        foreach ($this->presetRegistry->drifted() as $drift) {
+            $uid = $drift['configuration']->getUid();
+            if ($uid !== null) {
+                $driftedUids[$uid] = true;
+            }
+        }
+
+        return $driftedUids;
     }
 
     /**

--- a/Classes/Controller/Backend/PresetController.php
+++ b/Classes/Controller/Backend/PresetController.php
@@ -24,7 +24,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * `listPresetsAction` returns the pending presets (declared by consuming
  * extensions via the `nr_llm.configuration_preset` DI tag but not yet
  * imported), each with its preflight result so the admin sees upfront
- * whether an import can succeed. `importAction` imports one preset by
+ * whether an import can succeed, plus the drifted imported presets whose
+ * declaration changed since import. `importAction` imports one preset by
  * identifier as a criteria-mode configuration record.
  *
  * Both actions are admin-gated via {@see RequiresBackendAdminTrait} FIRST
@@ -42,7 +43,15 @@ final class PresetController extends ActionController
     ) {}
 
     /**
-     * List pending presets including a preflight result per preset (AJAX, admin-gated).
+     * List pending presets (with preflight) and drifted imported presets (AJAX, admin-gated).
+     *
+     * JSON shape:
+     * `presets` — one entry per pending preset: `identifier`, `name`,
+     * `description`, `criteria` (array), `satisfiable` (bool),
+     * `missingRequirement` (string|null), `matchedModelLabel` (string|null).
+     * `drifted` — one entry per imported preset whose declaration changed
+     * since import (checksum mismatch, ADR-056): `identifier`, `name`,
+     * `configurationUid` (int|null). Detection only — no update flow.
      */
     public function listPresetsAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -62,7 +71,15 @@ final class PresetController extends ActionController
                 'matchedModelLabel' => $preflight->matchedModelLabel,
             ];
         }
-        return new JsonResponse(['success' => true, 'presets' => $presets]);
+        $drifted = [];
+        foreach ($this->presetRegistry->drifted() as $drift) {
+            $drifted[] = [
+                'identifier' => $drift['preset']->identifier,
+                'name' => $drift['preset']->name,
+                'configurationUid' => $drift['configuration']->getUid(),
+            ];
+        }
+        return new JsonResponse(['success' => true, 'presets' => $presets, 'drifted' => $drifted]);
     }
 
     /**

--- a/Classes/Service/Preset/ConfigurationPresetRegistry.php
+++ b/Classes/Service/Preset/ConfigurationPresetRegistry.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Preset;
 
 use LogicException;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
@@ -24,7 +25,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  *
  * `pending()` narrows the declared set to presets whose identifier has no
  * `tx_nrllm_configuration` record yet — the list a backend admin sees and
- * imports from.
+ * imports from. `drifted()` is the counterpart for already-imported
+ * presets: the pairs whose current declaration checksum no longer matches
+ * the checksum stored at import time.
  */
 final class ConfigurationPresetRegistry
 {
@@ -80,5 +83,34 @@ final class ConfigurationPresetRegistry
         }
 
         return $pending;
+    }
+
+    /**
+     * Imported presets whose current declaration differs from the imported one.
+     *
+     * Compares each declared preset's checksum against the `preset_checksum`
+     * stored on its configuration record at import time (ADR-056). Only
+     * records created by a preset import are considered — a hand-created
+     * record that happens to share a declared identifier carries no stored
+     * checksum and is never reported as drifted. Detection only; there is
+     * no update flow (deliberately deferred in ADR-056).
+     *
+     * @return list<array{preset: ConfigurationPreset, configuration: LlmConfiguration}>
+     */
+    public function drifted(): array
+    {
+        $drifted = [];
+        foreach ($this->byIdentifier as $identifier => $preset) {
+            $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
+            if ($configuration === null) {
+                continue;
+            }
+            $storedChecksum = $configuration->getPresetChecksum();
+            if ($storedChecksum !== '' && $storedChecksum !== $preset->checksum()) {
+                $drifted[] = ['preset' => $preset, 'configuration' => $configuration];
+            }
+        }
+
+        return $drifted;
     }
 }

--- a/Documentation/Administration/Configurations.rst
+++ b/Documentation/Administration/Configurations.rst
@@ -57,6 +57,44 @@ Adding a configuration manually
    fields from a plain-language description of your
    use case.
 
+.. _administration-configurations-presets:
+
+Importing configuration presets
+===============================
+
+Extensions consuming nr_llm can declare the
+configurations they need as *presets*
+(:ref:`ADR-056 <adr-056>`). When at least one
+declared preset has not been imported yet, the
+configuration list shows a :guilabel:`Pending
+presets` panel above the records.
+
+Each pending preset row shows the preset's name,
+identifier, description, and a requirement check:
+
+*  *Satisfiable* — an active model currently
+   matches the preset's requirements; the model
+   that would be used right now is named. Click
+   :guilabel:`Import` to create the configuration
+   record with one confirmation.
+*  *Not satisfiable* — no active model matches;
+   the first missing requirement is named. The
+   :guilabel:`Import` button stays disabled until
+   you configure a matching provider and model.
+
+Imported records are normal criteria-mode
+configurations: the model is resolved at runtime
+from the providers and models you configured, and
+you can edit or delete the record like any other.
+The panel disappears once no presets are pending.
+
+If a consuming extension later changes its preset
+declaration, the imported configuration is flagged
+with a :guilabel:`Preset changed` badge in the
+list. This is a hint only — the record is never
+updated automatically; review and adjust it
+manually if needed.
+
 .. _administration-configurations-test:
 
 Testing a configuration

--- a/Documentation/Adr/Adr056ConfigurationPresets.rst
+++ b/Documentation/Adr/Adr056ConfigurationPresets.rst
@@ -10,6 +10,17 @@ ADR-056: Configuration presets — consumer-declared, admin-imported records
 :Date: 2026-07-13
 :Authors: Netresearch DTT GmbH
 
+.. note::
+
+   The backend-module UI named below as a follow-up has been implemented
+   since: the Configurations backend module lists pending presets with
+   their preflight result and imports one via the existing
+   ``nrllm_preset_import`` endpoint, and imported records whose
+   declaration checksum drifted are flagged with a non-blocking hint
+   (see :ref:`administration-configurations-presets`). The
+   checksum-driven *update flow* (diff + re-confirm) remains future
+   work.
+
 .. _adr-056-context:
 
 Context
@@ -108,9 +119,11 @@ Negative
 
 * One more DI-tag discovery surface to maintain.
 * v1 has no backend-module UI; admins need the AJAX endpoints (or the
-  follow-up module) to see and import pending presets.
+  follow-up module) to see and import pending presets. *(Implemented
+  since — see the note above.)*
 * The stored checksum only *detects* declaration drift; an update flow
-  (diff + re-confirm) is deliberately deferred.
+  (diff + re-confirm) is deliberately deferred. *(Still the case: the
+  module UI shows a drift hint, nothing more.)*
 
 .. _adr-056-alternatives:
 

--- a/Documentation/Developer/ConfigurationPresets.rst
+++ b/Documentation/Developer/ConfigurationPresets.rst
@@ -108,5 +108,24 @@ Import flow
    detectable.
 
 Both endpoints are restricted to backend administrators
-(:ref:`ADR-037 <adr-037>`). A backend-module UI on top of these
-endpoints is a planned follow-up.
+(:ref:`ADR-037 <adr-037>`). Admins normally go through the
+Configurations backend module, which renders the pending presets —
+including each preflight result — above the configuration records and
+imports one through ``nrllm_preset_import`` with a single click; see
+:ref:`administration-configurations-presets`.
+
+.. _developer-configuration-presets-drift:
+
+Change detection
+================
+
+``nrllm_preset_list`` additionally returns a ``drifted`` list: imported
+presets whose current declaration checksum no longer matches the
+``preset_checksum`` stored at import time. Each entry carries
+``identifier``, ``name``, and ``configurationUid``. The Configurations
+module flags such records with a non-blocking "Preset changed" hint.
+
+Detection only: nr_llm never updates an imported record automatically.
+If your extension changes a preset declaration, document what admins
+should adjust — the checksum-driven update flow (diff + re-confirm) is
+deliberately deferred (:ref:`ADR-056 <adr-056>`).

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -968,6 +968,52 @@
                 <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
                 <target>Konfigurationen sind die dritte Stufe der Einrichtung und erfordern zuerst ein Modell (Anbieter → Modell → Konfiguration).</target>
             </trans-unit>
+
+            <!-- Configuration presets (ADR-056) -->
+            <trans-unit id="configuration.presets.title">
+                <source>Pending presets</source>
+                <target>Ausstehende Presets</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.intro">
+                <source>Installed extensions declare the following LLM configurations they need. Importing creates a criteria-mode configuration record; the model is resolved at runtime from the providers and models you configured.</source>
+                <target>Installierte Erweiterungen deklarieren die folgenden benötigten LLM-Konfigurationen. Der Import legt einen kriterienbasierten Konfigurationsdatensatz an; das Modell wird zur Laufzeit aus den von Ihnen konfigurierten Anbietern und Modellen aufgelöst.</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.col.preflight">
+                <source>Requirement check</source>
+                <target>Anforderungsprüfung</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.satisfiable">
+                <source>Satisfiable</source>
+                <target>Erfüllbar</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.notSatisfiable">
+                <source>Not satisfiable</source>
+                <target>Nicht erfüllbar</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.matchedModel">
+                <source>Would currently use</source>
+                <target>Würde aktuell verwenden</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.missing">
+                <source>Missing</source>
+                <target>Fehlt</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.import">
+                <source>Import</source>
+                <target>Importieren</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.importDisabled.title">
+                <source>Cannot import: no active model satisfies the requirements</source>
+                <target>Import nicht möglich: Kein aktives Modell erfüllt die Anforderungen</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.drift.badge">
+                <source>Preset changed</source>
+                <target>Preset geändert</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.drift.title">
+                <source>The preset declaration changed since this configuration was imported. Review the record; it is not updated automatically.</source>
+                <target>Die Preset-Deklaration hat sich seit dem Import dieser Konfiguration geändert. Prüfen Sie den Datensatz; er wird nicht automatisch aktualisiert.</target>
+            </trans-unit>
             <trans-unit id="task.empty.title">
                 <source>No Tasks Configured</source>
                 <target>Keine Aufgaben konfiguriert</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -735,6 +735,41 @@
             <trans-unit id="configuration.empty.hint">
                 <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
             </trans-unit>
+
+            <!-- Configuration presets (ADR-056) -->
+            <trans-unit id="configuration.presets.title">
+                <source>Pending presets</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.intro">
+                <source>Installed extensions declare the following LLM configurations they need. Importing creates a criteria-mode configuration record; the model is resolved at runtime from the providers and models you configured.</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.col.preflight">
+                <source>Requirement check</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.satisfiable">
+                <source>Satisfiable</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.notSatisfiable">
+                <source>Not satisfiable</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.matchedModel">
+                <source>Would currently use</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.missing">
+                <source>Missing</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.import">
+                <source>Import</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.importDisabled.title">
+                <source>Cannot import: no active model satisfies the requirements</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.drift.badge">
+                <source>Preset changed</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.drift.title">
+                <source>The preset declaration changed since this configuration was imported. Review the record; it is not updated automatically.</source>
+            </trans-unit>
             <trans-unit id="task.empty.title">
                 <source>No Tasks Configured</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -33,6 +33,76 @@
 
         <f:render partial="Backend/Glossary" />
 
+        <f:comment>Pending configuration presets (ADR-056): rendered only when at least one preset is pending — no empty-state noise.</f:comment>
+        <f:if condition="{pendingPresets -> f:count()}">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h2 class="card-title mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.title" default="Pending presets" /></h2>
+                </div>
+                <div class="card-body">
+                    <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.intro" default="Installed extensions declare the following LLM configurations they need. Importing creates a criteria-mode configuration record; the model is resolved at runtime from the providers and models you configured." /></p>
+                    <div class="table-fit mb-0">
+                        <table class="table table-striped table-hover">
+                            <thead>
+                                <tr>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.name" default="Name" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.field.identifier" default="Identifier" /></th>
+                                    <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.col.preflight" default="Requirement check" /></th>
+                                    <th scope="col" class="col-control"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:actions" default="Actions" /></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <f:for each="{pendingPresets}" as="preset">
+                                    <tr data-preset-identifier="{preset.identifier}">
+                                        <td>
+                                            <strong>{preset.name}</strong>
+                                            <f:if condition="{preset.description}">
+                                                <br /><span class="text-body-secondary">{preset.description}</span>
+                                            </f:if>
+                                        </td>
+                                        <td><code>{preset.identifier}</code></td>
+                                        <td>
+                                            <f:if condition="{preset.satisfiable}">
+                                                <f:then>
+                                                    <span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.satisfiable" default="Satisfiable" /></span>
+                                                    <br /><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.matchedModel" default="Would currently use" />: {preset.matchedModelLabel}</span>
+                                                </f:then>
+                                                <f:else>
+                                                    <span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.notSatisfiable" default="Not satisfiable" /></span>
+                                                    <br /><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.missing" default="Missing" />: <code>{preset.missingRequirement}</code></span>
+                                                </f:else>
+                                            </f:if>
+                                        </td>
+                                        <td class="col-control">
+                                            <f:if condition="{preset.satisfiable}">
+                                                <f:then>
+                                                    <button type="button" class="btn btn-primary btn-sm js-import-preset"
+                                                            data-identifier="{preset.identifier}"
+                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.import')}"
+                                                            aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.import')}">
+                                                        <core:icon identifier="actions-download" size="small" />
+                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.import" default="Import" />
+                                                    </button>
+                                                </f:then>
+                                                <f:else>
+                                                    <button type="button" class="btn btn-primary btn-sm" disabled
+                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.importDisabled.title')}"
+                                                            aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.importDisabled.title')}">
+                                                        <core:icon identifier="actions-download" size="small" />
+                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.import" default="Import" />
+                                                    </button>
+                                                </f:else>
+                                            </f:if>
+                                        </td>
+                                    </tr>
+                                </f:for>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </f:if>
+
         <f:if condition="{configurations -> f:count()}">
             <f:then>
                 <div class="table-fit">
@@ -57,6 +127,10 @@
                                         <strong>{config.name}</strong>
                                         <f:if condition="{config.isDefault}">
                                             <span class="badge text-bg-primary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:default" default="Default" /></span>
+                                        </f:if>
+                                        <f:comment>Checksum drift hint (ADR-056): the imported preset's declaration changed — hint only, no auto-update.</f:comment>
+                                        <f:if condition="{driftedUids.{config.uid}}">
+                                            <span class="badge text-bg-warning" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.drift.title')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.drift.badge" default="Preset changed" /></span>
                                         </f:if>
                                         <f:if condition="{config.description}">
                                             <br /><span class="text-body-secondary">{config.description}</span>

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -15,6 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { postAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 /**
  * Read the JSON error body from a rejected AjaxRequest response.
@@ -62,6 +63,15 @@ class ConfigurationList {
                 e.preventDefault();
                 e.stopPropagation();
                 this.handleTestConfig(testBtn);
+                return;
+            }
+
+            // Import a pending configuration preset (ADR-056)
+            const importBtn = e.target.closest('.js-import-preset');
+            if (importBtn) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.handleImportPreset(importBtn);
             }
         });
 
@@ -120,6 +130,21 @@ class ConfigurationList {
             .catch(async err => {
                 Notification.error('Error', await readAjaxError(err));
             });
+    }
+
+    handleImportPreset(btn) {
+        const identifier = btn.dataset.identifier;
+        const url = TYPO3.settings.ajaxUrls['nrllm_preset_import'];
+
+        if (!url) {
+            Notification.error('Error', 'AJAX URL not configured');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('identifier', identifier);
+
+        postAndReload(url, formData, btn);
     }
 
     handleTestConfig(btn) {

--- a/Resources/Public/JavaScript/Backend/ModuleAction.js
+++ b/Resources/Public/JavaScript/Backend/ModuleAction.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Shared state-changing module action: POST a FormData payload and reload
+ * the module on success.
+ *
+ * Every backend list module repeats the same flow for its row actions —
+ * disable the triggering button, POST via AjaxRequest (which injects
+ * TYPO3's CSRF token), reload on `{ success: true }`, surface the error
+ * and re-enable the button otherwise. Centralised here so new actions do
+ * not copy the boilerplate again (the older sibling modules still carry
+ * their own copies — migrating them is mechanical follow-up work).
+ */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+import Notification from '@typo3/backend/notification.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+
+/**
+ * @param {string} url Resolved AJAX endpoint URL
+ * @param {FormData} formData POST payload
+ * @param {HTMLButtonElement} btn Triggering button; disabled during flight, re-enabled on failure
+ */
+export function postAndReload(url, formData, btn) {
+    btn.disabled = true;
+    new AjaxRequest(url)
+        .post(formData)
+        .then(response => response.resolve())
+        .then(data => {
+            if (data.success) {
+                location.reload();
+            } else {
+                Notification.error('Error', data.error || 'Unknown error');
+                btn.disabled = false;
+            }
+        })
+        .catch(async err => {
+            Notification.error('Error', await readAjaxError(err));
+            btn.disabled = false;
+        });
+}

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -7,13 +7,12 @@
  * Tool state JavaScript module for the TYPO3 backend (ES6 Module).
  *
  * Toggles the global enable/disable override of a single agent tool from the
- * Tool Playground module. Mirrors SkillList.js: event delegation on the body
- * and a state-changing AJAX POST via AjaxRequest, which injects TYPO3's CSRF
- * token (and sets the request content-type) automatically.
+ * Tool Playground module. Event delegation on the body; the state-changing
+ * POST/reload flow lives in the shared ModuleAction helper (AjaxRequest
+ * underneath, which injects TYPO3's CSRF token automatically).
  */
-import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
-import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { postAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 class ToolState {
     constructor() {
@@ -57,22 +56,7 @@ class ToolState {
         formData.append('group', group);
         formData.append('enabled', String(enabled));
 
-        btn.disabled = true;
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                    btn.disabled = false;
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-                btn.disabled = false;
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleToggle(btn) {
@@ -88,22 +72,7 @@ class ToolState {
         formData.append('tool', tool);
         formData.append('enabled', String(enabled));
 
-        btn.disabled = true;
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                    btn.disabled = false;
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-                btn.disabled = false;
-            });
+        postAndReload(url, formData, btn);
     }
 }
 

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -19,6 +19,8 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
@@ -117,6 +119,9 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         $analytics = $this->get(UsageAnalyticsServiceInterface::class);
         self::assertInstanceOf(UsageAnalyticsServiceInterface::class, $analytics);
 
+        $presetRegistry = $this->getService(ConfigurationPresetRegistry::class);
+        $presetImportService = $this->getService(ConfigurationPresetImportService::class);
+
         return new ConfigurationController(
             $moduleTemplateFactory,
             $iconFactory,
@@ -131,6 +136,8 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             $testPromptResolver,
             $analytics,
             new NullLogger(),
+            $presetRegistry,
+            $presetImportService,
         );
     }
 

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -127,4 +127,21 @@ abstract class AbstractFunctionalTestCase extends FunctionalTestCase
     {
         return $this->getConnectionPool()->getConnectionForTable('tx_nrllm_configuration');
     }
+
+    /**
+     * Resolve a service from the container, narrowing its type for PHPStan.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $id
+     *
+     * @return T
+     */
+    protected function getService(string $id): object
+    {
+        $service = $this->get($id);
+        self::assertInstanceOf($id, $service);
+
+        return $service;
+    }
 }

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
@@ -124,6 +126,9 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
         $analytics = $this->get(UsageAnalyticsServiceInterface::class);
         self::assertInstanceOf(UsageAnalyticsServiceInterface::class, $analytics);
 
+        $presetRegistry = $this->getService(ConfigurationPresetRegistry::class);
+        $presetImportService = $this->getService(ConfigurationPresetImportService::class);
+
         return new ConfigurationController(
             $moduleTemplateFactory,
             $iconFactory,
@@ -138,6 +143,8 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
             $testPromptResolver,
             $analytics,
             new NullLogger(),
+            $presetRegistry,
+            $presetImportService,
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -124,6 +126,9 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
         $analytics = $this->get(UsageAnalyticsServiceInterface::class);
         self::assertInstanceOf(UsageAnalyticsServiceInterface::class, $analytics);
 
+        $presetRegistry = $this->getService(ConfigurationPresetRegistry::class);
+        $presetImportService = $this->getService(ConfigurationPresetImportService::class);
+
         return new ConfigurationController(
             $moduleTemplateFactory,
             $iconFactory,
@@ -138,6 +143,8 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
             $testPromptResolver,
             $analytics,
             new NullLogger(),
+            $presetRegistry,
+            $presetImportService,
         );
     }
 

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -21,6 +21,8 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
@@ -136,6 +138,9 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         $analytics = $this->get(UsageAnalyticsServiceInterface::class);
         self::assertInstanceOf(UsageAnalyticsServiceInterface::class, $analytics);
 
+        $presetRegistry = $this->getService(ConfigurationPresetRegistry::class);
+        $presetImportService = $this->getService(ConfigurationPresetImportService::class);
+
         return new ConfigurationController(
             $moduleTemplateFactory,
             $iconFactory,
@@ -150,6 +155,8 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             $testPromptResolver,
             $analytics,
             new NullLogger(),
+            $presetRegistry,
+            $presetImportService,
         );
     }
 

--- a/Tests/Unit/Controller/Backend/PresetControllerTest.php
+++ b/Tests/Unit/Controller/Backend/PresetControllerTest.php
@@ -154,6 +154,7 @@ final class PresetControllerTest extends TestCase
         self::assertTrue($entry['satisfiable']);
         self::assertSame('Claude Sonnet', $entry['matchedModelLabel']);
         self::assertNull($entry['missingRequirement']);
+        self::assertSame([], $body['drifted']);
     }
 
     #[Test]
@@ -164,6 +165,41 @@ final class PresetControllerTest extends TestCase
         $body = self::decode($controller->listPresetsAction(new ServerRequest()));
 
         self::assertSame([], $body['presets']);
+    }
+
+    #[Test]
+    public function listPresetsReportsDriftedImportedPresets(): void
+    {
+        // Imported record (identifier exists) whose stored checksum no longer
+        // matches the current declaration: not pending, but drifted.
+        $configuration = new LlmConfiguration();
+        $configuration->_setProperty('uid', 7);
+        $configuration->setPresetChecksum('0000000000000000000000000000000000000000000000000000000000000000');
+        $controller = $this->createController([self::preset()], existing: $configuration);
+
+        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+
+        self::assertSame([], $body['presets']);
+        assert(isset($body['drifted']) && is_array($body['drifted']));
+        self::assertCount(1, $body['drifted']);
+        $entry = $body['drifted'][0];
+        assert(is_array($entry));
+        self::assertSame('ext.chat', $entry['identifier']);
+        self::assertSame('Chat', $entry['name']);
+        self::assertSame(7, $entry['configurationUid']);
+    }
+
+    #[Test]
+    public function listPresetsOmitsImportedPresetWithUnchangedChecksumFromDrifted(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setPresetChecksum(self::preset()->checksum());
+        $controller = $this->createController([self::preset()], existing: $configuration);
+
+        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+
+        self::assertSame([], $body['presets']);
+        self::assertSame([], $body['drifted']);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Preset/ConfigurationPresetRegistryTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetRegistryTest.php
@@ -82,4 +82,62 @@ final class ConfigurationPresetRegistryTest extends TestCase
 
         self::assertSame([$pending], $registry->pending());
     }
+
+    #[Test]
+    public function driftedReturnsImportedPresetWhoseDeclarationChanged(): void
+    {
+        $preset = self::preset('ext.imported');
+        $configuration = new LlmConfiguration();
+        $configuration->setPresetChecksum('0000000000000000000000000000000000000000000000000000000000000000');
+        $repository = $this->createMock(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $registry = new ConfigurationPresetRegistry(
+            [new FixturePresetProvider([$preset])],
+            $repository,
+        );
+
+        self::assertSame(
+            [['preset' => $preset, 'configuration' => $configuration]],
+            $registry->drifted(),
+        );
+    }
+
+    #[Test]
+    public function driftedOmitsImportedPresetWithUnchangedChecksum(): void
+    {
+        $preset = self::preset('ext.imported');
+        $configuration = new LlmConfiguration();
+        $configuration->setPresetChecksum($preset->checksum());
+        $repository = $this->createMock(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $registry = new ConfigurationPresetRegistry(
+            [new FixturePresetProvider([$preset])],
+            $repository,
+        );
+
+        self::assertSame([], $registry->drifted());
+    }
+
+    #[Test]
+    public function driftedOmitsPendingPresetsAndHandCreatedRecords(): void
+    {
+        // A pending preset has no record; a hand-created record sharing a
+        // declared identifier carries no stored checksum. Neither is drift.
+        $pending = self::preset('ext.pending');
+        $handCreated = self::preset('ext.hand_created');
+        $record = new LlmConfiguration();
+        $repository = $this->createMock(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturnCallback(
+            static fn(string $identifier): ?LlmConfiguration => $identifier === 'ext.hand_created' ? $record : null,
+        );
+
+        $registry = new ConfigurationPresetRegistry(
+            [new FixturePresetProvider([$pending, $handCreated])],
+            $repository,
+        );
+
+        self::assertSame([], $registry->drifted());
+    }
 }


### PR DESCRIPTION
Implements the module-UI follow-up named in ADR-056 (#354 shipped the endpoints-only v1).

## Change

- **Pending presets panel** in the Configurations backend module (rendered only when at least one declared preset has no record): name, identifier, declaring description, per-preset preflight result — matched model label when satisfiable, the missing requirement when not — and an Import button (disabled with explanatory title when unsatisfiable) posting to the existing `nrllm_preset_import` endpoint via the module's event-delegation JS pattern.
- **Drift hint**: imported records whose stored `preset_checksum` differs from the current declaration's `checksum()` get a non-blocking "Preset changed" badge. `ConfigurationPresetRegistry::drifted()` pairs preset + record; a hand-created record that merely shares a declared identifier (empty checksum) is deliberately NOT flagged — covered by a dedicated test. The checksum-driven *update* flow remains future work per ADR-056; this is the hint only.
- `PresetController::listPresetsAction()` returns `drifted` alongside `presets` (one request serves UI and API consumers); `denyNonAdmin()` guards unchanged.
- Server-rendered panel (Fluid) mirroring the Skills module pattern; XLIFF EN+DE (11 new units); no new public services (policy count stays 45); no new CSS.

## Verification

Full local gate via `runTests.sh`: cgl, lint, phpstan, rector pass; unit 4138 tests / 9890 assertions; functional+e2e-backend 1107 / 12779 (four functional/E2E files updated for the controller's two new constructor deps compile and pass). Docs rendered with render-guides — no new warnings.

Note: no existing E2E pattern renders the module's list HTML (verified — no test calls `ConfigurationController::listAction`), so the panel render path itself has no browser-level test; panel logic is unit-covered via the registry/controller tests. The German XLIFF strings follow the file's existing register — a native-speaker glance in review wouldn't hurt.

Follow-up to #354; see ADR-056.