### PR TITLE
feat: attribute specialized-service usage to the caller-supplied beUserUid (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The specialized translators forward the caller-supplied `beUserUid` to usage tracking: `TranslationService` re-attaches the resolved uid to the options array handed to `TranslatorInterface` implementations (`beUserUid` key — budget fields are deliberately excluded from `TranslationOptions::toArray()`), and `DeepLTranslator` / `LlmTranslator` pass it on to `trackUsage()`, so translator usage rows are attributed like the middleware-pipeline paths. The speech/image services (Whisper, TTS, DALL-E, FAL) keep ambient attribution — their option shapes carry no budget fields (ADR-052).
+
 ## [0.17.0] - 2026-07-13
 
 ### Added

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -42,7 +42,10 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * path (DeepL et al.) does NOT go through `LlmServiceManager`, so
  * the BudgetMiddleware does not currently apply there; ADR / future
  * slice can route specialized translators through a similar
- * pre-flight if needed.
+ * pre-flight if needed. Usage *attribution* on that path is wired,
+ * though: the resolved uid is re-attached to the translator options
+ * array (`beUserUid` key, see `attachBeUserUid()`) and the
+ * translators forward it to `trackUsage()` (ADR-052).
  */
 final readonly class TranslationService implements TranslationServiceInterface
 {
@@ -253,7 +256,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?TranslationOptions $options = null,
     ): TranslatorResult {
         $options ??= new TranslationOptions();
-        $optionsArray = $options->toArray();
+        $optionsArray = $this->attachBeUserUid($options->toArray(), $options);
 
         if (empty($text)) {
             throw new InvalidArgumentException('Text cannot be empty', 3459949413);
@@ -291,10 +294,34 @@ final readonly class TranslationService implements TranslationServiceInterface
         }
 
         $options ??= new TranslationOptions();
-        $optionsArray = $options->toArray();
+        $optionsArray = $this->attachBeUserUid($options->toArray(), $options);
         $translator = $this->resolveTranslator($optionsArray);
 
         return $translator->translateBatch($texts, $targetLanguage, $sourceLanguage, $optionsArray);
+    }
+
+    /**
+     * Re-attach the usage-attribution uid to a translator options array.
+     *
+     * `TranslationOptions::toArray()` deliberately excludes the budget
+     * fields (pipeline metadata, not wire payload), but the translator
+     * path bypasses the middleware pipeline, so without this key the
+     * caller-supplied uid would never reach the translators'
+     * `trackUsage()` calls (ADR-052). Translators read the key and must
+     * not send it to the remote API.
+     *
+     * @param array<string, mixed> $optionsArray
+     *
+     * @return array<string, mixed>
+     */
+    private function attachBeUserUid(array $optionsArray, TranslationOptions $options): array
+    {
+        $beUserUid = $this->resolveBeUserUid($options);
+        if ($beUserUid !== null) {
+            $optionsArray['beUserUid'] = $beUserUid;
+        }
+
+        return $optionsArray;
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -457,6 +457,9 @@ final class DallEImageService extends AbstractSpecializedService
             $imageInput,
         );
 
+        // beUserUid stays ambient (null): ImageGenerationOptions carries no
+        // budget fields, so no caller-supplied uid reaches this path —
+        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'image',
             $this->getServiceProvider(),

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -99,7 +99,10 @@ final class FalImageService extends AbstractSpecializedService
 
         // FAL publishes no static price list (billing varies per hosted
         // model), so no cost is recorded — never guess (see
-        // SpecializedCostCalculatorInterface).
+        // SpecializedCostCalculatorInterface). beUserUid stays ambient
+        // (null): the generation options array carries no caller-supplied
+        // uid — ADR-052 keeps this path ambient rather than growing new
+        // option surface.
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => 1,
         ], modelUid: $this->resolveModelUid($model), modelId: $model);
@@ -176,6 +179,7 @@ final class FalImageService extends AbstractSpecializedService
             }
         }
 
+        // beUserUid stays ambient (null) — see generate().
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => count($results),
         ], modelUid: $this->resolveModelUid($model), modelId: $model);

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -105,6 +105,9 @@ final class TextToSpeechService extends AbstractSpecializedService
         $audioContent = $this->sendBinaryRequest($payload);
 
         $characterCount = mb_strlen($text);
+        // beUserUid stays ambient (null): SpeechSynthesisOptions carries no
+        // budget fields, so no caller-supplied uid reaches this path —
+        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'speech',
             $this->getServiceProvider(),

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -456,6 +456,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             $metrics['cost'] = $this->costCalculator->estimateTranscriptionCost($model, $duration);
         }
 
+        // beUserUid stays ambient (null): TranscriptionOptions carries no
+        // budget fields, so no caller-supplied uid reaches this path —
+        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'speech',
             $this->getServiceProvider(),

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -124,7 +124,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $this->usageTracker->trackUsage('translation', 'deepl', [
             'characters' => mb_strlen($text),
-        ]);
+        ], beUserUid: $this->extractBeUserUid($options));
 
         return new TranslatorResult(
             translatedText: $translation['text'],
@@ -184,7 +184,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         $this->usageTracker->trackUsage('translation', 'deepl', [
             'characters' => $totalCharacters,
             'batch_size' => count($texts),
-        ]);
+        ], beUserUid: $this->extractBeUserUid($options));
 
         return $results;
     }
@@ -589,6 +589,20 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
     private function countBilledCharacters(string $text): int
     {
         return mb_strlen($text);
+    }
+
+    /**
+     * Extract the usage-attribution uid attached by `TranslationService`
+     * (`beUserUid` options key, ADR-052). Never part of the DeepL payload;
+     * null falls back to the tracker's ambient `backend.user` context.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function extractBeUserUid(array $options): ?int
+    {
+        $beUserUid = $options['beUserUid'] ?? null;
+
+        return is_int($beUserUid) ? $beUserUid : null;
     }
 
     /**

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -116,7 +116,7 @@ final readonly class LlmTranslator implements TranslatorInterface
         $providerUsed = $provider ?? 'default';
         $this->usageTracker->trackUsage('translation', 'llm:' . $providerUsed, [
             'characters' => mb_strlen($text),
-        ], modelId: $response->model);
+        ], modelId: $response->model, beUserUid: $this->extractBeUserUid($options));
 
         // Calculate confidence from finish reason
         $confidence = match ($response->finishReason) {
@@ -200,6 +200,21 @@ final readonly class LlmTranslator implements TranslatorInterface
     {
         // LLM can translate any language pair (quality may vary)
         return true;
+    }
+
+    /**
+     * Extract the usage-attribution uid attached by `TranslationService`
+     * (`beUserUid` options key, ADR-052). Never part of the chat prompt or
+     * payload; null falls back to the tracker's ambient `backend.user`
+     * context.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function extractBeUserUid(array $options): ?int
+    {
+        $beUserUid = $options['beUserUid'] ?? null;
+
+        return is_int($beUserUid) ? $beUserUid : null;
     }
 
     /**

--- a/Classes/Specialized/Translation/TranslatorInterface.php
+++ b/Classes/Specialized/Translation/TranslatorInterface.php
@@ -51,6 +51,11 @@ interface TranslatorInterface
     /**
      * Translate a single text.
      *
+     * The `beUserUid` options key (int), when present, is usage-attribution
+     * metadata (ADR-052): implementations forward it to
+     * `UsageTrackerServiceInterface::trackUsage()` and must never send it
+     * to the remote API.
+     *
      * @param string               $text           Text to translate
      * @param string               $targetLanguage Target language code (ISO 639-1)
      * @param string|null          $sourceLanguage Source language code (auto-detect if null)
@@ -67,6 +72,9 @@ interface TranslatorInterface
 
     /**
      * Translate multiple texts efficiently.
+     *
+     * The `beUserUid` options key carries usage-attribution metadata —
+     * see `translate()`.
      *
      * @param array<int, string>   $texts          Texts to translate
      * @param string               $targetLanguage Target language code

--- a/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
+++ b/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
@@ -66,3 +66,21 @@ Consequences
   parameter (semver-minor breaking in the 0.x line, same policy as
   ``ToolInterface::getGroup()`` in 0.15.0). In-repo,
   ``UsageTrackerService`` is the only implementation.
+- The specialized translator path forwards the uid even though it
+  bypasses the middleware pipeline: ``TranslationService`` re-attaches
+  the resolved uid to the options array it hands to
+  ``TranslatorInterface`` implementations (the ``beUserUid`` key —
+  budget fields are deliberately excluded from
+  ``TranslationOptions::toArray()``), and ``DeepLTranslator`` /
+  ``LlmTranslator`` pass it on to ``trackUsage()``. The key is
+  attribution metadata only; translators never send it to the remote
+  API.
+- The remaining specialized services are ambient-only:
+  ``WhisperTranscriptionService``, ``TextToSpeechService``,
+  ``DallEImageService`` and ``FalImageService`` accept option shapes
+  without budget fields (``TranscriptionOptions``,
+  ``SpeechSynthesisOptions``, ``ImageGenerationOptions``, a plain
+  array), so no caller-supplied uid reaches their ``trackUsage()``
+  calls and attribution falls back to the ambient ``backend.user``
+  aspect. Extending those option shapes is deferred until a consumer
+  needs per-user attribution there.

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -1172,4 +1172,134 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $subject->scoreTranslationQuality('Hello', 'Hallo', 'de');
     }
+
+    // ==================== translator-path attribution tests (ADR-052) ====================
+
+    #[Test]
+    public function translateWithTranslatorAttachesBeUserUidToTranslatorOptions(): void
+    {
+        // Budget fields are excluded from TranslationOptions::toArray(),
+        // so the service re-attaches the uid as the `beUserUid` metadata
+        // key for the translator's trackUsage() call (ADR-052).
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects(self::once())
+            ->method('translate')
+            ->with(
+                'Hello World',
+                'de',
+                'en',
+                self::callback(static fn(array $options): bool => ($options['beUserUid'] ?? null) === 42),
+            )
+            ->willReturn(new TranslatorResult(
+                translatedText: 'Hallo Welt',
+                sourceLanguage: 'en',
+                targetLanguage: 'de',
+                translator: 'llm:openai',
+            ));
+
+        $this->translatorRegistryMock
+            ->method('get')
+            ->willReturn($translatorMock);
+
+        $this->subject->translateWithTranslator(
+            'Hello World',
+            'de',
+            'en',
+            (new TranslationOptions())->withBeUserUid(42),
+        );
+    }
+
+    #[Test]
+    public function translateWithTranslatorAttachesResolverUidWhenOptionsCarryNone(): void
+    {
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->method('resolveBeUserUid')->willReturn(7);
+
+        $subject = new TranslationService(
+            $this->llmManagerStub,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects(self::once())
+            ->method('translate')
+            ->with(
+                'Hello World',
+                'de',
+                'en',
+                self::callback(static fn(array $options): bool => ($options['beUserUid'] ?? null) === 7),
+            )
+            ->willReturn(new TranslatorResult(
+                translatedText: 'Hallo Welt',
+                sourceLanguage: 'en',
+                targetLanguage: 'de',
+                translator: 'llm:openai',
+            ));
+
+        $this->translatorRegistryMock
+            ->method('get')
+            ->willReturn($translatorMock);
+
+        $subject->translateWithTranslator('Hello World', 'de', 'en');
+    }
+
+    #[Test]
+    public function translateWithTranslatorOmitsBeUserUidKeyWithoutUidSource(): void
+    {
+        // No options uid and no resolver: the key stays absent so the
+        // tracker's own ambient fallback applies.
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects(self::once())
+            ->method('translate')
+            ->with(
+                'Hello World',
+                'de',
+                'en',
+                self::callback(static fn(array $options): bool => !array_key_exists('beUserUid', $options)),
+            )
+            ->willReturn(new TranslatorResult(
+                translatedText: 'Hallo Welt',
+                sourceLanguage: 'en',
+                targetLanguage: 'de',
+                translator: 'llm:openai',
+            ));
+
+        $this->translatorRegistryMock
+            ->method('get')
+            ->willReturn($translatorMock);
+
+        $this->subject->translateWithTranslator('Hello World', 'de', 'en');
+    }
+
+    #[Test]
+    public function translateBatchWithTranslatorAttachesBeUserUidToTranslatorOptions(): void
+    {
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects(self::once())
+            ->method('translateBatch')
+            ->with(
+                ['Hello', 'World'],
+                'de',
+                'en',
+                self::callback(static fn(array $options): bool => ($options['beUserUid'] ?? null) === 42),
+            )
+            ->willReturn([]);
+
+        $this->translatorRegistryMock
+            ->method('get')
+            ->willReturn($translatorMock);
+
+        $this->subject->translateBatchWithTranslator(
+            ['Hello', 'World'],
+            'de',
+            'en',
+            (new TranslationOptions())->withBeUserUid(42),
+        );
+    }
 }

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -418,6 +418,10 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'dall-e-3',
+                0,
+                // Ambient attribution: ImageGenerationOptions carries no
+                // budget fields, so no caller uid reaches this path (ADR-052).
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -461,6 +461,10 @@ class FalImageServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'flux-schnell',
+                0,
+                // Ambient attribution: the FAL options array carries no
+                // caller-supplied uid, so this path stays ambient (ADR-052).
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -360,6 +360,10 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'tts-1',
+                0,
+                // Ambient attribution: SpeechSynthesisOptions carries no
+                // budget fields, so no caller uid reaches this path (ADR-052).
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -462,6 +462,10 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
                 31,
                 0,
                 'whisper-1',
+                0,
+                // Ambient attribution: TranscriptionOptions carries no
+                // budget fields, so no caller uid reaches this path (ADR-052).
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -299,6 +299,12 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
                 'translation',
                 'deepl',
                 self::callback(fn(array $data) => $data['characters'] === mb_strlen($text)),
+                null,
+                0,
+                '',
+                0,
+                // Ambient fallback: no beUserUid option key was passed.
+                null,
             );
 
         $subject = new DeepLTranslator(
@@ -313,6 +319,95 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $subject->setHttpClient($httpClientStub);
 
         $subject->translate($text, 'de');
+    }
+
+    #[Test]
+    public function translateForwardsBeUserUidOptionToTracker(): void
+    {
+        // ADR-052: the `beUserUid` options key (attached by
+        // TranslationService) must reach the tracker for attribution.
+        $apiResponse = [
+            'translations' => [
+                ['text' => 'Hallo Welt', 'detected_source_language' => 'EN'],
+            ],
+        ];
+
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                'deepl',
+                self::anything(),
+                null,
+                0,
+                '',
+                0,
+                42,
+            );
+
+        $subject = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($this->defaultConfig),
+            $usageTrackerMock,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+        $subject->setHttpClient($httpClientStub);
+
+        $subject->translate('Hello World', 'de', null, ['beUserUid' => 42]);
+    }
+
+    #[Test]
+    public function translateBatchForwardsBeUserUidOptionToTracker(): void
+    {
+        $apiResponse = [
+            'translations' => [
+                ['text' => 'Hallo', 'detected_source_language' => 'EN'],
+                ['text' => 'Welt', 'detected_source_language' => 'EN'],
+            ],
+        ];
+
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                'deepl',
+                self::anything(),
+                null,
+                0,
+                '',
+                0,
+                42,
+            );
+
+        $subject = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($this->defaultConfig),
+            $usageTrackerMock,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+        $subject->setHttpClient($httpClientStub);
+
+        $subject->translateBatch(['Hello', 'World'], 'de', null, ['beUserUid' => 42]);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -186,6 +186,9 @@ class LlmTranslatorTest extends AbstractUnitTestCase
                 null,
                 0,
                 'gpt-5.2',
+                0,
+                // Ambient fallback: no beUserUid option key was passed.
+                null,
             );
 
         $subject = new LlmTranslator(
@@ -194,6 +197,36 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         );
 
         $subject->translate('Test text', 'de', 'en', ['provider' => 'openai']);
+    }
+
+    #[Test]
+    public function translateForwardsBeUserUidOptionToTracker(): void
+    {
+        // ADR-052: the `beUserUid` options key (attached by
+        // TranslationService) must reach the tracker for attribution.
+        $this->setResponse('Translated text');
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                self::stringStartsWith('llm:'),
+                self::anything(),
+                null,
+                0,
+                'gpt-5.2',
+                0,
+                42,
+            );
+
+        $subject = new LlmTranslator(
+            $this->llmManager,
+            $usageTrackerMock,
+        );
+
+        $subject->translate('Test text', 'de', 'en', ['provider' => 'openai', 'beUserUid' => 42]);
     }
 
     #[Test]


### PR DESCRIPTION
Closes the Specialized-services gap named in ADR-052's consequences (0.17.0 wired the middleware-pipeline path; the specialized services still recorded ambient-only).

## Change

The translator path bypasses the middleware pipeline, so the `beUserUid` the options carry never reached its `trackUsage()` calls. `TranslationService` now re-attaches the resolved uid (explicit option uid wins, `BackendUserContextResolverInterface` fallback via the existing `resolveBeUserUid()`) to the translator options array under a `beUserUid` key; `DeepLTranslator` and `LlmTranslator` read it and forward it to `trackUsage()`. The key is pipeline metadata — documented on `TranslatorInterface` as never part of the remote payload.

## Scope

Speech/image services (`WhisperTranscriptionService`, `TextToSpeechService`, `DallEImageService`, `FalImageService`) keep ambient attribution: their call paths take no `BudgetAwareOptionsInterface` object, and inventing public option surface for it is out of scope. Each such site carries a code comment; all are listed in ADR-052's updated consequences.

Known residual (documented): on the LlmTranslator path the *translation* usage row now carries the caller uid, but the underlying *chat* row (recorded by UsageMiddleware from an internally-built ChatOptions) stays ambient — noted in ADR-052.

## Verification

Full local gate: cgl, lint, phpstan, rector pass; unit 4140 tests / 9939 assertions (each touched service asserts the uid reaches the tracker when options carry one, null otherwise); functional 1107. Docs render clean.

Third-party `TranslatorInterface` implementations that blindly forward the whole options array to a remote API would leak the `beUserUid` key — the interface docblock now warns against this. See ADR-052.