### PR TITLE
refactor: migrate remaining global InvalidArgumentException imports to the nr_llm exception (ADR-053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The specialized translators forward the caller-supplied `beUserUid` to usage tracking: `TranslationService` re-attaches the resolved uid to the options array handed to `TranslatorInterface` implementations (`beUserUid` key — budget fields are deliberately excluded from `TranslationOptions::toArray()`), and `DeepLTranslator` / `LlmTranslator` pass it on to `trackUsage()`, so translator usage rows are attributed like the middleware-pipeline paths. The speech/image services (Whisper, TTS, DALL-E, FAL) keep ambient attribution — their option shapes carry no budget fields (ADR-052).
+- The remaining validation errors thrown with PHP's global `InvalidArgumentException` (record table reader, retrieval queries, vision content, embedding responses, provider response parsing, backend response DTOs, provider vault-key checks, usage analytics) now throw nr_llm's `Exception\InvalidArgumentException`, so they are catchable via `NrLlmExceptionInterface` too. Backwards compatible: the nr_llm class extends `\InvalidArgumentException`, existing catches keep matching (ADR-053).
 
 ## [0.17.0] - 2026-07-13
 

--- a/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
+++ b/Classes/Controller/Backend/Response/DiscoveredModelsResponse.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend\Response;
 
-use InvalidArgumentException;
 use JsonSerializable;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 
 /**

--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Response object for embedding requests.

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Model;
 
-use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\DTO\ProviderOptions;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Throwable;

--- a/Classes/Domain/ValueObject/VisionContent.php
+++ b/Classes/Domain/ValueObject/VisionContent.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
-use InvalidArgumentException;
 use JsonSerializable;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Value Object describing one item in a vision-request content list.

--- a/Classes/Provider/ResponseParserTrait.php
+++ b/Classes/Provider/ResponseParserTrait.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Trait for type-safe API response parsing.

--- a/Classes/Service/Retrieval/RetrievalQuery.php
+++ b/Classes/Service/Retrieval/RetrievalQuery.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Retrieval;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * A validated retrieval request against the site-search backends (ADR-049).

--- a/Classes/Service/Task/RecordTableReader.php
+++ b/Classes/Service/Task/RecordTableReader.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;

--- a/Classes/Service/Task/RecordTableReaderInterface.php
+++ b/Classes/Service/Task/RecordTableReaderInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
-use InvalidArgumentException;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Throwable;
 
 /**

--- a/Classes/Service/UsageAnalyticsService.php
+++ b/Classes/Service/UsageAnalyticsService.php
@@ -11,9 +11,9 @@ namespace Netresearch\NrLlm\Service;
 
 use DateTimeImmutable;
 use DateTimeInterface;
-use InvalidArgumentException;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Documentation/Adr/Adr053ExceptionMarkerInterface.rst
+++ b/Documentation/Adr/Adr053ExceptionMarkerInterface.rst
@@ -60,12 +60,17 @@ arm, future-proof.
 Consequences
 ============
 
-- Remaining classes that import the global ``InvalidArgumentException``
-  for their own validation errors (response parsers, task readers,
-  backend response DTOs) are unchanged — they are not part of the
-  chat/embedding consumer surface. Migrating them onto
-  ``Exception\InvalidArgumentException`` is compatible follow-up work,
-  guarded by the same reflection test.
+- The remaining classes that imported the global
+  ``InvalidArgumentException`` for their own validation errors
+  (response parsers, task readers, backend response DTOs, value
+  objects) throw ``Exception\InvalidArgumentException`` now — the
+  compatible follow-up named here is done, guarded by the same
+  reflection test. One deliberate exception:
+  ``Service\Task\TaskInputResolver`` keeps the global import because it
+  only *catches* the exception around ``RecordTableReader::fetchAll()``
+  — narrowing that catch to the nr_llm subclass would miss a plain
+  ``\InvalidArgumentException`` raised by third-party code inside the
+  read path.
 - Catch-all remains opt-in: consumers that want to handle budget
   exhaustion differently from provider outages keep catching the
   concrete classes.

--- a/Tests/Architecture/DomainLayerTest.php
+++ b/Tests/Architecture/DomainLayerTest.php
@@ -101,6 +101,9 @@ final class DomainLayerTest
                 Selector::inNamespace('Netresearch\NrLlm\Domain\ValueObject'),
                 // Value objects and service options
                 Selector::inNamespace('Netresearch\NrLlm\Service\Option'),
+                // Dependency-free domain exceptions — validation errors are
+                // catchable via NrLlmExceptionInterface (ADR-053)
+                Selector::inNamespace('Netresearch\NrLlm\Exception'),
                 // Extbase base classes (required for entity functionality)
                 Selector::inNamespace('TYPO3\CMS\Extbase\DomainObject'),
                 Selector::inNamespace('TYPO3\CMS\Extbase\Persistence'),
@@ -129,6 +132,9 @@ final class DomainLayerTest
                 // Vault identifier rules (single source of truth for what
                 // counts as a vault identifier — UUID v7 or name-style)
                 Selector::classname(IdentifierValidator::class),
+                // Dependency-free domain exceptions — validation errors are
+                // catchable via NrLlmExceptionInterface (ADR-053)
+                Selector::inNamespace('Netresearch\NrLlm\Exception'),
                 // Extbase infrastructure
                 Selector::inNamespace('TYPO3\CMS\Extbase\DomainObject'),
                 Selector::inNamespace('TYPO3\CMS\Extbase\Persistence'),


### PR DESCRIPTION
Closes the compatible follow-up ADR-053 named (0.17.0 introduced `NrLlmExceptionInterface` and made `Exception\InvalidArgumentException` extend the SPL class).

## Change

Nine classes under `Classes/` that threw PHP's global `InvalidArgumentException` on input validation now throw `Netresearch\NrLlm\Exception\InvalidArgumentException` — a subclass of the SPL one, so every existing `catch` keeps matching, and these validation errors are now catchable via the `NrLlmExceptionInterface` marker like the rest of the public surface.

`TaskInputResolver` deliberately keeps the global import: it exists only for a `catch` around a read path where third-party code can raise the plain SPL exception, which a subclass-narrowed catch would miss. Recorded in ADR-053's consequences so a future grep sweep doesn't flag it.

Two phpat Domain-layer rules (`testDomainModelsOnlyDependOnDomainAndCore`, `testProviderModelLimitedDependencies`) are broadened to allow the `Netresearch\NrLlm\Exception` namespace — dependency-free domain exceptions — so the two migrated Domain models (`Provider`, `EmbeddingResponse`) stay within the architecture boundary.

## Verification

Full local gate: cgl, lint, phpstan, rector, architecture all pass; unit 4133 tests / 9877 assertions; functional 1107. Docs render clean. Behavioral note: exceptions from the nine migrated classes now also match `catch (NrLlmExceptionInterface)` — no existing catch in `Classes/` newly swallows them (checked). See ADR-053.