### PR TITLE
chore: release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-14
+
 ### Added
 
 - **Configuration presets module UI** (the ADR-056 follow-up): the Configurations backend module surfaces pending presets — one row per preset with name, identifier, description, and the preflight result (the model the criteria currently match, or the missing requirement) — and imports one via the existing `nrllm_preset_import` endpoint with a single click; the panel renders only while presets are pending. Imported records whose declaration changed since import are flagged with a non-blocking "Preset changed" hint (checksum comparison via the new `ConfigurationPresetRegistry::drifted()`), and `nrllm_preset_list` returns these as a new `drifted` list. The checksum-driven update flow remains future work (ADR-056).

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.17.0"
-        release="0.17.0"
+        version="0.18.0"
+        release="0.18.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.17.0",
+            "version": "0.18.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.17.0',
+    'version' => '0.18.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release preparation for v0.18.0 — the ADR-named follow-ups of the 0.17.0 consumer-integration release.

## Contents (see CHANGELOG)

### Added
- Configuration presets module UI: pending-presets panel with per-preset preflight + one-click import, and a checksum-based "Preset changed" drift hint on imported records (ADR-056, #357)

### Changed
- Specialized translators forward the caller-supplied `beUserUid` to usage tracking; speech/image services stay ambient (no budget-bearing options) (ADR-052, #358)
- Remaining global `InvalidArgumentException` validation throws migrated to nr_llm's marker-covered exception; `TaskInputResolver` deliberately keeps the SPL import (catch-only around third-party code) (ADR-053, #359)

Also in the range: the shared `ModuleAction.js` POST/reload helper now used by ConfigurationList and ToolState (introduced while clearing real new-code duplication in #357).

## Version bumps
`composer.json` (extra), `ext_emconf.php`, `Documentation/guides.xml` (version + release), CHANGELOG section `0.18.0 - 2026-07-14`.

No interface members added this release; the `TranslatorInterface` options-array contract gained the optional documented `beUserUid` key (additive).

Pre-tag issue triage: only the Renovate dependency dashboard (#80) remains open.

After merge: signed tag `v0.18.0` on the merge commit triggers the release workflow (SBOM, cosign, SLSA).