### PR TITLE
fix: attribute LlmTranslator chat rows to the calling backend user

### DIFF
--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -76,9 +76,14 @@ final readonly class LlmTranslator implements TranslatorInterface
         ?string $sourceLanguage = null,
         array $options = [],
     ): TranslatorResult {
+        // ADR-052: extract the attribution uid once — it feeds the underlying
+        // chat calls (budget enforcement + chat-row attribution in the
+        // middleware pipeline) and the translation-level tracking row alike.
+        $beUserUid = $this->extractBeUserUid($options);
+
         // Detect source language if not provided
         if ($sourceLanguage === null) {
-            $sourceLanguage = $this->detectLanguage($text);
+            $sourceLanguage = $this->detectLanguageAttributed($text, $beUserUid);
         }
 
         // Build translation prompt
@@ -98,12 +103,16 @@ final readonly class LlmTranslator implements TranslatorInterface
             ? $options['model']
             : null;
 
-        // Execute translation
+        // Execute translation. The uid rides along as pipeline metadata so
+        // BudgetMiddleware enforces the caller's budget and UsageMiddleware
+        // attributes the chat row to the same be_user as the translation row
+        // (previously the chat row always landed in the ambient bucket).
         $chatOptions = new ChatOptions(
             temperature: $temperature,
             maxTokens: $maxTokens,
             provider: $provider,
             model: $model,
+            beUserUid: $beUserUid,
         );
 
         $response = $this->llmManager->chat($prompt['messages'], $chatOptions);
@@ -116,7 +125,7 @@ final readonly class LlmTranslator implements TranslatorInterface
         $providerUsed = $provider ?? 'default';
         $this->usageTracker->trackUsage('translation', 'llm:' . $providerUsed, [
             'characters' => mb_strlen($text),
-        ], modelId: $response->model, beUserUid: $this->extractBeUserUid($options));
+        ], modelId: $response->model, beUserUid: $beUserUid);
 
         // Calculate confidence from finish reason
         $confidence = match ($response->finishReason) {
@@ -168,6 +177,20 @@ final readonly class LlmTranslator implements TranslatorInterface
 
     public function detectLanguage(string $text): string
     {
+        // Public TranslatorInterface signature carries no options, so a
+        // direct call stays ambient; translate() routes through
+        // detectLanguageAttributed() with the caller's uid instead.
+        return $this->detectLanguageAttributed($text, null);
+    }
+
+    /**
+     * Detect the language of a text, attributing the underlying chat call
+     * to the given backend user (ADR-052). The detection call is billed
+     * like any other chat request — without the uid it lands in the
+     * ambient bucket even when the translation itself is attributed.
+     */
+    private function detectLanguageAttributed(string $text, ?int $beUserUid): string
+    {
         $messages = [
             [
                 'role' => 'system',
@@ -182,6 +205,7 @@ final readonly class LlmTranslator implements TranslatorInterface
         $chatOptions = new ChatOptions(
             temperature: 0.1,
             maxTokens: 10,
+            beUserUid: $beUserUid,
         );
 
         $response = $this->llmManager->chat($messages, $chatOptions);
@@ -206,7 +230,9 @@ final readonly class LlmTranslator implements TranslatorInterface
      * Extract the usage-attribution uid attached by `TranslationService`
      * (`beUserUid` options key, ADR-052). Never part of the chat prompt or
      * payload; null falls back to the tracker's ambient `backend.user`
-     * context.
+     * context. Negative values are treated as absent: the uid feeds the
+     * `ChatOptions` constructor, whose budget-field validation would throw
+     * outside any error-mapping boundary.
      *
      * @param array<string, mixed> $options
      */
@@ -214,7 +240,7 @@ final readonly class LlmTranslator implements TranslatorInterface
     {
         $beUserUid = $options['beUserUid'] ?? null;
 
-        return is_int($beUserUid) ? $beUserUid : null;
+        return is_int($beUserUid) && $beUserUid >= 0 ? $beUserUid : null;
     }
 
     /**

--- a/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
+++ b/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
@@ -75,6 +75,14 @@ Consequences
   ``LlmTranslator`` pass it on to ``trackUsage()``. The key is
   attribution metadata only; translators never send it to the remote
   API.
+- ``LlmTranslator`` additionally threads the uid into the
+  ``ChatOptions`` of its underlying chat calls (translation and
+  language detection), so the pipeline-recorded chat row — which
+  carries the tokens and cost — lands under the same ``be_user`` as
+  the translation-level row, and ``BudgetMiddleware`` enforces the
+  caller's budget on those calls. A direct
+  ``TranslatorInterface::detectLanguage()`` call has no options
+  parameter and stays ambient.
 - The remaining specialized services are ambient-only:
   ``WhisperTranscriptionService``, ``TextToSpeechService``,
   ``DallEImageService`` and ``FalImageService`` accept option shapes

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
@@ -227,6 +229,101 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         );
 
         $subject->translate('Test text', 'de', 'en', ['provider' => 'openai', 'beUserUid' => 42]);
+    }
+
+    #[Test]
+    public function translateForwardsBeUserUidToUnderlyingChatOptions(): void
+    {
+        // ADR-052: the underlying chat call carries all tokens and cost, so
+        // it must be attributed to the same be_user as the translation row —
+        // otherwise BudgetMiddleware skips enforcement (uid 0) and the chat
+        // row lands in the ambient bucket.
+        [$llmManager, $captured] = $this->createChatCapturingManager('Hallo Welt');
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello World', 'de', 'en', ['beUserUid' => 42]);
+
+        self::assertCount(1, $captured->list);
+        self::assertSame(42, $captured->list[0]->getBeUserUid());
+    }
+
+    #[Test]
+    public function translateWithAutoDetectAttributesDetectionChatCall(): void
+    {
+        // The language-detection chat call is billed like any other request;
+        // it must carry the caller's uid, not fall back to ambient.
+        [$llmManager, $captured] = $this->createChatCapturingManager('en');
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello World', 'de', null, ['beUserUid' => 42]);
+
+        self::assertCount(2, $captured->list);
+        self::assertSame(42, $captured->list[0]->getBeUserUid(), 'detection call');
+        self::assertSame(42, $captured->list[1]->getBeUserUid(), 'translation call');
+    }
+
+    #[Test]
+    public function detectLanguageWithoutCallerContextStaysAmbient(): void
+    {
+        // Public TranslatorInterface::detectLanguage() has no options
+        // parameter — a direct call keeps the previous ambient behavior.
+        [$llmManager, $captured] = $this->createChatCapturingManager('de');
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->detectLanguage('Hallo Welt');
+
+        self::assertCount(1, $captured->list);
+        self::assertNull($captured->list[0]->getBeUserUid());
+    }
+
+    #[Test]
+    public function translateTreatsNegativeBeUserUidAsAbsent(): void
+    {
+        // A negative uid from the untrusted options array must not reach the
+        // ChatOptions constructor, whose budget-field validation throws.
+        [$llmManager, $captured] = $this->createChatCapturingManager('Hallo Welt');
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello World', 'de', 'en', ['beUserUid' => -5]);
+
+        self::assertCount(1, $captured->list);
+        self::assertNull($captured->list[0]->getBeUserUid());
+    }
+
+    /**
+     * Stub the manager interface so every ChatOptions passed to chat() is
+     * captured and answered with a fixed response.
+     *
+     * @return array{0: LlmServiceManagerInterface&Stub, 1: object{list: array<int, ChatOptions>}}
+     */
+    private function createChatCapturingManager(string $responseContent): array
+    {
+        $captured = new class {
+            /** @var array<int, ChatOptions> */
+            public array $list = [];
+        };
+
+        $response = new CompletionResponse(
+            content: $responseContent,
+            model: 'gpt-5.2',
+            usage: new UsageStatistics(100, 50, 150),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $llmManager = self::createStub(LlmServiceManagerInterface::class);
+        $llmManager
+            ->method('chat')
+            ->willReturnCallback(
+                static function (array $messages, ?ChatOptions $options = null) use ($captured, $response): CompletionResponse {
+                    self::assertInstanceOf(ChatOptions::class, $options);
+                    $captured->list[] = $options;
+
+                    return $response;
+                },
+            );
+
+        return [$llmManager, $captured];
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Closes the last gap in the ADR-052 translator path: `LlmTranslator` forwarded the caller's `beUserUid` to its own translation-level `trackUsage()` row, but built the underlying `ChatOptions` without it. The pipeline-recorded chat row — which carries **all tokens and cost** — always landed in the ambient bucket (`be_user` 0 in FE/CLI contexts), and `BudgetMiddleware` skipped per-user enforcement for those calls.

## Changes

- `translate()` extracts the uid once and threads it into the `ChatOptions` of the translation chat call and — via a new private `detectLanguageAttributed()` — the language-detection chat call.
- Public `TranslatorInterface::detectLanguage()` has no options parameter and stays ambient (unchanged behavior).
- Negative uids from the untrusted options array are treated as absent; the `ChatOptions` budget-field validation would otherwise throw outside an error boundary.
- ADR-052 consequences section documents the closed path.

## Behavior change

Translation chat calls from FE/CLI consumers that attach `beUserUid` are now subject to per-user budget enforcement that previously did not apply (`BudgetMiddleware` no longer sees uid 0). Consumers near their budget ceiling may start receiving budget refusals on translation.

## Not in scope

Row-level linkage between the translation row and the chat row: the usage table is a daily aggregate keyed on day/service_type/provider/model/be_user — matching `be_user` (this PR) is the only available correlation dimension.

## Tests

- `translateForwardsBeUserUidToUnderlyingChatOptions`
- `translateWithAutoDetectAttributesDetectionChatCall` (both chat calls attributed)
- `detectLanguageWithoutCallerContextStaysAmbient`
- `translateTreatsNegativeBeUserUidAsAbsent`