### PR TITLE
feat: per-user usage attribution for speech and image services (ADR-057)

### DIFF
--- a/Classes/Service/Option/BudgetAwareOptionsInterface.php
+++ b/Classes/Service/Option/BudgetAwareOptionsInterface.php
@@ -13,7 +13,13 @@ namespace Netresearch\NrLlm\Service\Option;
  * Marker for option types that carry budget pre-flight metadata
  * (REC #4). Implemented by every option type whose call path reaches
  * `BudgetMiddleware`: `ChatOptions` (and subclass `ToolOptions`),
- * `EmbeddingOptions`, `VisionOptions`, `TranslationOptions`.
+ * `EmbeddingOptions`, `VisionOptions`, `TranslationOptions` — and,
+ * for usage ATTRIBUTION only, by the specialized option types
+ * `TranscriptionOptions`, `SpeechSynthesisOptions` and
+ * `ImageGenerationOptions`: their services bypass the middleware
+ * pipeline, so `beUserUid` feeds `trackUsage()` there while
+ * `plannedCost` is carried for a potential future enforcement path
+ * (see ADR-057).
  *
  * The interface lets shared infrastructure (e.g. resolver-driven
  * auto-population in feature services, or `LlmServiceManager`'s

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -107,7 +107,7 @@ final class DallEImageService extends AbstractSpecializedService
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        $this->trackImageUsage($model, $size, $quality, 1, $response, $options->configuration);
+        $this->trackImageUsage($model, $size, $quality, 1, $response, $options->configuration, $options->getBeUserUid());
 
         return new ImageGenerationResult(
             url: $data['url'] ?? '',
@@ -191,7 +191,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $this->trackImageUsage($model, $size, $quality, count($results), $response, $options->configuration);
+        $this->trackImageUsage($model, $size, $quality, count($results), $response, $options->configuration, $options->getBeUserUid());
 
         return $results;
     }
@@ -199,9 +199,14 @@ final class DallEImageService extends AbstractSpecializedService
     /**
      * Create variations of an image (DALL-E 2 only).
      *
-     * @param string $imagePath Path to source image (PNG, max 4MB, square)
-     * @param int    $count     Number of variations (1-10)
-     * @param string $size      Output size
+     * @param string   $imagePath Path to source image (PNG, max 4MB, square)
+     * @param int      $count     Number of variations (1-10)
+     * @param string   $size      Output size
+     * @param int|null $beUserUid Backend user the usage row is attributed to
+     *                            (ADR-052/ADR-057); this endpoint takes no
+     *                            options object, so the uid is a scalar
+     *                            parameter. Null falls back to the ambient
+     *                            backend.user context.
      *
      * @throws ServiceUnavailableException
      *
@@ -211,6 +216,7 @@ final class DallEImageService extends AbstractSpecializedService
         string $imagePath,
         int $count = 1,
         string $size = self::DEFAULT_SIZE,
+        ?int $beUserUid = null,
     ): array {
         $this->ensureAvailable();
 
@@ -241,7 +247,7 @@ final class DallEImageService extends AbstractSpecializedService
             );
         }
 
-        $this->trackImageUsage('dall-e-2', $size, 'standard', count($results), $response);
+        $this->trackImageUsage('dall-e-2', $size, 'standard', count($results), $response, beUserUid: $beUserUid);
 
         return $results;
     }
@@ -253,6 +259,11 @@ final class DallEImageService extends AbstractSpecializedService
      * @param string      $prompt    Description of the edit
      * @param string|null $maskPath  Path to mask image (transparent areas will be edited)
      * @param string      $size      Output size
+     * @param int|null    $beUserUid Backend user the usage row is attributed to
+     *                               (ADR-052/ADR-057); this endpoint takes no
+     *                               options object, so the uid is a scalar
+     *                               parameter. Null falls back to the ambient
+     *                               backend.user context.
      *
      * @throws ServiceUnavailableException
      *
@@ -263,6 +274,7 @@ final class DallEImageService extends AbstractSpecializedService
         string $prompt,
         ?string $maskPath = null,
         string $size = self::DEFAULT_SIZE,
+        ?int $beUserUid = null,
     ): ImageGenerationResult {
         $this->ensureAvailable();
 
@@ -282,7 +294,7 @@ final class DallEImageService extends AbstractSpecializedService
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? [];
 
-        $this->trackImageUsage('dall-e-2', $size, 'standard', 1, $response);
+        $this->trackImageUsage('dall-e-2', $size, 'standard', 1, $response, beUserUid: $beUserUid);
 
         return new ImageGenerationResult(
             url: $data['url'] ?? '',
@@ -423,6 +435,7 @@ final class DallEImageService extends AbstractSpecializedService
         int $imageCount,
         array $response,
         ?string $configuration = null,
+        ?int $beUserUid = null,
     ): void {
         // gpt-image-* responses include a `usage` token object;
         // dall-e-2/3 never send one — token metrics are omitted then
@@ -457,9 +470,6 @@ final class DallEImageService extends AbstractSpecializedService
             $imageInput,
         );
 
-        // beUserUid stays ambient (null): ImageGenerationOptions carries no
-        // budget fields, so no caller-supplied uid reaches this path —
-        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'image',
             $this->getServiceProvider(),
@@ -467,6 +477,7 @@ final class DallEImageService extends AbstractSpecializedService
             configurationUid: $this->resolveConfigurationUid($configuration),
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
+            beUserUid: $beUserUid,
         );
     }
 

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -71,6 +71,11 @@ final class FalImageService extends AbstractSpecializedService
      *                                      - seed: int Random seed for reproducibility
      *                                      - negative_prompt: string Things to avoid
      *                                      - enable_safety_checker: bool Safety filter
+     *                                      - beUserUid: int Backend user the usage row
+     *                                      is attributed to (ADR-052/ADR-057) —
+     *                                      attribution metadata only, never part of
+     *                                      the FAL payload (the payload builder is an
+     *                                      explicit allowlist)
      *
      * @throws ServiceUnavailableException
      *
@@ -99,13 +104,10 @@ final class FalImageService extends AbstractSpecializedService
 
         // FAL publishes no static price list (billing varies per hosted
         // model), so no cost is recorded — never guess (see
-        // SpecializedCostCalculatorInterface). beUserUid stays ambient
-        // (null): the generation options array carries no caller-supplied
-        // uid — ADR-052 keeps this path ambient rather than growing new
-        // option surface.
+        // SpecializedCostCalculatorInterface).
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => 1,
-        ], modelUid: $this->resolveModelUid($model), modelId: $model);
+        ], modelUid: $this->resolveModelUid($model), modelId: $model, beUserUid: $this->extractBeUserUid($options));
 
         $imageUrl = isset($image['url']) && is_string($image['url']) ? $image['url'] : '';
 
@@ -179,10 +181,9 @@ final class FalImageService extends AbstractSpecializedService
             }
         }
 
-        // beUserUid stays ambient (null) — see generate().
         $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
             'images' => count($results),
-        ], modelUid: $this->resolveModelUid($model), modelId: $model);
+        ], modelUid: $this->resolveModelUid($model), modelId: $model, beUserUid: $this->extractBeUserUid($options));
 
         return $results;
     }
@@ -413,6 +414,22 @@ final class FalImageService extends AbstractSpecializedService
         $fastModels = ['flux-schnell'];
 
         return !in_array($model, $fastModels, true);
+    }
+
+    /**
+     * Extract the usage-attribution uid from the plain options array
+     * (`beUserUid` key, ADR-052/ADR-057 — the DeepL/LlmTranslator array
+     * pattern; FAL has no typed options DTO). Attribution metadata only:
+     * `buildGeneratePayload()` is an explicit allowlist, so the key never
+     * reaches the FAL API. Negative values are treated as absent.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function extractBeUserUid(array $options): ?int
+    {
+        $beUserUid = $options['beUserUid'] ?? null;
+
+        return is_int($beUserUid) && $beUserUid >= 0 ? $beUserUid : null;
     }
 
     /**

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -11,12 +11,16 @@ namespace Netresearch\NrLlm\Specialized\Option;
 
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Option\AbstractOptions;
+use Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface;
+use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for image generation (DALL-E).
  */
-final class ImageGenerationOptions extends AbstractOptions
+final class ImageGenerationOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const SIZE_SQUARE = '1024x1024';
     private const VALID_MODELS = ['dall-e-2', 'dall-e-3'];
     private const VALID_QUALITIES = ['standard', 'hd'];
@@ -61,7 +65,15 @@ final class ImageGenerationOptions extends AbstractOptions
         public readonly ?string $style = 'vivid',
         public readonly ?string $format = 'url',
         public readonly ?string $configuration = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
+        $this->validate();
+    }
+
+    private function validate(): void
+    {
         if ($this->model !== null) {
             $this->validateModel($this->model);
         }
@@ -75,6 +87,7 @@ final class ImageGenerationOptions extends AbstractOptions
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
         }
         $this->validateSize();
+        $this->validateBudgetFields();
     }
 
     /**
@@ -198,8 +211,9 @@ final class ImageGenerationOptions extends AbstractOptions
 
     public function toArray(): array
     {
-        // `configuration` is deliberately absent: it is consumer metadata
-        // for usage attribution, not an Images API parameter.
+        // `configuration` and the budget fields are deliberately absent:
+        // they are consumer metadata for usage attribution, not Images API
+        // parameters, and must never reach the provider.
         return $this->filterNull([
             'model' => $this->model,
             'size' => $this->size,
@@ -220,6 +234,8 @@ final class ImageGenerationOptions extends AbstractOptions
         $style = $options['style'] ?? null;
         $format = $options['format'] ?? $options['response_format'] ?? null;
         $configuration = $options['configuration'] ?? null;
+        $beUserUid = $options['beUserUid'] ?? null;
+        $plannedCost = $options['plannedCost'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
@@ -228,6 +244,8 @@ final class ImageGenerationOptions extends AbstractOptions
             style: is_string($style) ? $style : null,
             format: is_string($format) ? $format : null,
             configuration: is_string($configuration) ? $configuration : null,
+            beUserUid: is_int($beUserUid) ? $beUserUid : null,
+            plannedCost: is_float($plannedCost) || is_int($plannedCost) ? (float)$plannedCost : null,
         );
     }
 

--- a/Classes/Specialized/Option/SpeechSynthesisOptions.php
+++ b/Classes/Specialized/Option/SpeechSynthesisOptions.php
@@ -10,12 +10,16 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Option;
 
 use Netresearch\NrLlm\Service\Option\AbstractOptions;
+use Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface;
+use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for text-to-speech synthesis (OpenAI TTS).
  */
-final class SpeechSynthesisOptions extends AbstractOptions
+final class SpeechSynthesisOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const VALID_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
     private const VALID_MODELS = ['tts-1', 'tts-1-hd'];
     private const VALID_FORMATS = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];
@@ -36,7 +40,15 @@ final class SpeechSynthesisOptions extends AbstractOptions
         public readonly ?string $format = 'mp3',
         public readonly ?float $speed = 1.0,
         public readonly ?string $configuration = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
+        $this->validate();
+    }
+
+    private function validate(): void
+    {
         if ($this->model !== null) {
             self::validateEnum($this->model, self::VALID_MODELS, 'model');
         }
@@ -49,12 +61,14 @@ final class SpeechSynthesisOptions extends AbstractOptions
         if ($this->speed !== null) {
             self::validateRange($this->speed, 0.25, 4.0, 'speed');
         }
+        $this->validateBudgetFields();
     }
 
     public function toArray(): array
     {
-        // `configuration` is deliberately absent: it is consumer metadata
-        // for usage attribution, not a TTS API parameter.
+        // `configuration` and the budget fields are deliberately absent:
+        // they are consumer metadata for usage attribution, not TTS API
+        // parameters, and must never reach the provider.
         return $this->filterNull([
             'model' => $this->model,
             'voice' => $this->voice,
@@ -73,6 +87,8 @@ final class SpeechSynthesisOptions extends AbstractOptions
         $format = $options['format'] ?? $options['response_format'] ?? null;
         $speed = $options['speed'] ?? null;
         $configuration = $options['configuration'] ?? null;
+        $beUserUid = $options['beUserUid'] ?? null;
+        $plannedCost = $options['plannedCost'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
@@ -80,6 +96,8 @@ final class SpeechSynthesisOptions extends AbstractOptions
             format: is_string($format) ? $format : null,
             speed: is_float($speed) || is_int($speed) ? (float)$speed : null,
             configuration: is_string($configuration) ? $configuration : null,
+            beUserUid: is_int($beUserUid) ? $beUserUid : null,
+            plannedCost: is_float($plannedCost) || is_int($plannedCost) ? (float)$plannedCost : null,
         );
     }
 

--- a/Classes/Specialized/Option/TranscriptionOptions.php
+++ b/Classes/Specialized/Option/TranscriptionOptions.php
@@ -10,12 +10,16 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Option;
 
 use Netresearch\NrLlm\Service\Option\AbstractOptions;
+use Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface;
+use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for speech-to-text transcription (Whisper).
  */
-final class TranscriptionOptions extends AbstractOptions
+final class TranscriptionOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {
+    use BudgetFieldsTrait;
+
     private const VALID_FORMATS = ['json', 'text', 'srt', 'vtt', 'verbose_json'];
 
     /**
@@ -35,19 +39,29 @@ final class TranscriptionOptions extends AbstractOptions
         public readonly ?string $prompt = null,
         public readonly ?float $temperature = null,
         public readonly ?string $configuration = null,
+        ?int $beUserUid = null,
+        ?float $plannedCost = null,
     ) {
+        $this->setBudgetFields($beUserUid, $plannedCost);
+        $this->validate();
+    }
+
+    private function validate(): void
+    {
         if ($this->format !== null) {
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
         }
         if ($this->temperature !== null) {
             self::validateRange($this->temperature, 0.0, 1.0, 'temperature');
         }
+        $this->validateBudgetFields();
     }
 
     public function toArray(): array
     {
-        // `configuration` is deliberately absent: it is consumer metadata
-        // for usage attribution, not a transcription API parameter.
+        // `configuration` and the budget fields are deliberately absent:
+        // they are consumer metadata for usage attribution, not
+        // transcription API parameters, and must never reach the provider.
         return $this->filterNull([
             'model' => $this->model,
             'language' => $this->language,
@@ -68,6 +82,8 @@ final class TranscriptionOptions extends AbstractOptions
         $prompt = $options['prompt'] ?? null;
         $temperature = $options['temperature'] ?? null;
         $configuration = $options['configuration'] ?? null;
+        $beUserUid = $options['beUserUid'] ?? null;
+        $plannedCost = $options['plannedCost'] ?? null;
 
         return new self(
             model: is_string($model) ? $model : null,
@@ -76,6 +92,8 @@ final class TranscriptionOptions extends AbstractOptions
             prompt: is_string($prompt) ? $prompt : null,
             temperature: is_float($temperature) || is_int($temperature) ? (float)$temperature : null,
             configuration: is_string($configuration) ? $configuration : null,
+            beUserUid: is_int($beUserUid) ? $beUserUid : null,
+            plannedCost: is_float($plannedCost) || is_int($plannedCost) ? (float)$plannedCost : null,
         );
     }
 

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -105,9 +105,6 @@ final class TextToSpeechService extends AbstractSpecializedService
         $audioContent = $this->sendBinaryRequest($payload);
 
         $characterCount = mb_strlen($text);
-        // beUserUid stays ambient (null): SpeechSynthesisOptions carries no
-        // budget fields, so no caller-supplied uid reaches this path —
-        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'speech',
             $this->getServiceProvider(),
@@ -118,6 +115,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             configurationUid: $this->resolveConfigurationUid($options->configuration),
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
+            beUserUid: $options->getBeUserUid(),
         );
 
         return new SpeechSynthesisResult(

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -395,7 +395,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                     // Raw-string formats expose no duration — record the
                     // request without audio seconds (cost stays 0 rather
                     // than guessed).
-                    $this->trackTranscriptionUsage($model, null, $options->configuration);
+                    $this->trackTranscriptionUsage($model, null, $options->configuration, $options->getBeUserUid());
                     return $responseBody;
                 }
 
@@ -407,7 +407,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                 $duration = isset($decoded['duration']) && is_numeric($decoded['duration'])
                     ? (float)$decoded['duration']
                     : null;
-                $this->trackTranscriptionUsage($model, $duration, $options->configuration);
+                $this->trackTranscriptionUsage($model, $duration, $options->configuration, $options->getBeUserUid());
 
                 return $decoded;
             }
@@ -446,8 +446,12 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
      * that configuration record (resolved fail-soft) so Analytics can
      * aggregate spend per configuration.
      */
-    private function trackTranscriptionUsage(string $model, ?float $duration, ?string $configuration): void
-    {
+    private function trackTranscriptionUsage(
+        string $model,
+        ?float $duration,
+        ?string $configuration,
+        ?int $beUserUid = null,
+    ): void {
         $metrics = [];
         if ($duration !== null && $duration > 0.0) {
             // Floor of 1: a sub-half-second clip must not round to 0 seconds while
@@ -456,9 +460,6 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             $metrics['cost'] = $this->costCalculator->estimateTranscriptionCost($model, $duration);
         }
 
-        // beUserUid stays ambient (null): TranscriptionOptions carries no
-        // budget fields, so no caller-supplied uid reaches this path —
-        // ADR-052 keeps it ambient rather than growing new option surface.
         $this->usageTracker->trackUsage(
             'speech',
             $this->getServiceProvider(),
@@ -466,6 +467,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             configurationUid: $this->resolveConfigurationUid($configuration),
             modelUid: $this->resolveModelUid($model),
             modelId: $model,
+            beUserUid: $beUserUid,
         );
     }
 

--- a/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
+++ b/Documentation/Adr/Adr052UsageAttributionViaOptions.rst
@@ -83,12 +83,11 @@ Consequences
   caller's budget on those calls. A direct
   ``TranslatorInterface::detectLanguage()`` call has no options
   parameter and stays ambient.
-- The remaining specialized services are ambient-only:
-  ``WhisperTranscriptionService``, ``TextToSpeechService``,
-  ``DallEImageService`` and ``FalImageService`` accept option shapes
-  without budget fields (``TranscriptionOptions``,
-  ``SpeechSynthesisOptions``, ``ImageGenerationOptions``, a plain
-  array), so no caller-supplied uid reaches their ``trackUsage()``
-  calls and attribution falls back to the ambient ``backend.user``
-  aspect. Extending those option shapes is deferred until a consumer
-  needs per-user attribution there.
+- The speech and image services were initially deferred and are now
+  covered by :ref:`ADR-057 <adr-057>`: ``TranscriptionOptions``,
+  ``SpeechSynthesisOptions`` and ``ImageGenerationOptions`` implement
+  ``BudgetAwareOptionsInterface``, ``FalImageService`` reads the
+  documented ``beUserUid`` array key, and all four services forward
+  the uid to their ``trackUsage()`` calls. Attribution only — those
+  services bypass the middleware pipeline, so no budget enforcement
+  happens there.

--- a/Documentation/Adr/Adr057SpecializedServiceAttribution.rst
+++ b/Documentation/Adr/Adr057SpecializedServiceAttribution.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-057:
+
+===============================================================
+ADR-057: Speech and image services carry attribution in options
+===============================================================
+
+:Status: Accepted
+:Date: 2026-07-14
+:Authors: Netresearch DTT GmbH
+
+.. _adr-057-context:
+
+Context
+=======
+
+:ref:`ADR-052 <adr-052>` made the caller-supplied ``beUserUid`` win
+over the ambient ``backend.user`` aspect for usage attribution, but
+deferred the four specialized speech/image services: their option
+shapes (``TranscriptionOptions``, ``SpeechSynthesisOptions``,
+``ImageGenerationOptions``, and ``FalImageService``'s plain array)
+carried no budget fields, so every transcription, synthesis and image
+generation landed in the ambient bucket — ``be_user = 0`` for
+frontend, CLI and worker callers — with no way for a consumer to
+attribute the spend.
+
+Unlike chat/completion/embedding/vision, these services do not run
+through the middleware pipeline (they dispatch HTTP directly via
+``AbstractSpecializedService``), so neither ``BudgetMiddleware`` nor
+``UsageMiddleware`` can supply the uid; the services call
+``trackUsage()`` themselves.
+
+.. _adr-057-decision:
+
+Decision
+========
+
+Extend the options-based attribution of ADR-052 to the specialized
+services — attribution only, no enforcement:
+
+- ``TranscriptionOptions``, ``SpeechSynthesisOptions`` and
+  ``ImageGenerationOptions`` implement ``BudgetAwareOptionsInterface``
+  via ``BudgetFieldsTrait``: optional trailing ``beUserUid`` /
+  ``plannedCost`` constructor parameters, ``fromArray()`` keys of the
+  same names, validation rejecting negative values. The fields stay
+  out of ``toArray()`` — the services build their wire payload from
+  ``toArray()``, so a missed exclusion would leak the uid to the
+  remote API.
+- ``WhisperTranscriptionService``, ``TextToSpeechService`` and
+  ``DallEImageService`` forward ``getBeUserUid()`` to their
+  ``trackUsage()`` calls.
+- ``FalImageService`` keeps its plain options array (no DTO exists)
+  and reads a documented ``beUserUid`` key — the same array pattern
+  ``TranslationService`` uses for translators. The payload builder is
+  an explicit allowlist, so the key never reaches the FAL API.
+- ``DallEImageService::createVariations()`` and ``edit()`` take no
+  options object; they gain an optional trailing ``?int $beUserUid``
+  scalar parameter instead of growing a new options type for two
+  DALL-E-2-only endpoints.
+
+.. _adr-057-consequences:
+
+Consequences
+============
+
+- Consumers can attribute speech and image spend per backend user from
+  any context; without the uid the ambient fallback keeps the previous
+  behaviour.
+- Attribution and enforcement remain decoupled: the specialized
+  services still bypass the middleware pipeline, so per-user budget
+  ceilings are NOT enforced on speech/image calls. ``plannedCost`` is
+  carried but unused there. Routing these services through a budget
+  pre-flight is a separate decision with its own trade-offs (no
+  token-based cost model for FAL, multipart request flows) and gets
+  its own ADR if a consumer needs it.
+- The three option DTOs and the two DALL-E signatures are public
+  surface; the additions are optional trailing parameters
+  (semver-minor in the 0.x line, same policy as the ADR-052
+  ``trackUsage()`` change).
+- ``BudgetAwareOptionsInterface``'s docblock now names the
+  attribution-only consumers so the "reaches BudgetMiddleware"
+  assumption is not silently wrong.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -355,3 +355,4 @@ Tools
    Adr054TypedToolTurnMessages
    Adr055EmbeddingConfigurationPath
    Adr056ConfigurationPresets
+   Adr057SpecializedServiceAttribution

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -419,8 +419,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 0,
                 'dall-e-3',
                 0,
-                // Ambient attribution: ImageGenerationOptions carries no
-                // budget fields, so no caller uid reaches this path (ADR-052).
+                // Ambient fallback: no beUserUid option was passed (ADR-057).
                 null,
             );
 
@@ -434,6 +433,47 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         );
 
         $subject->generate('A cat');
+    }
+
+    #[Test]
+    public function generateAttributesUsageToOptionUid(): void
+    {
+        // ADR-057: a caller-supplied beUserUid in the options reaches the
+        // usage row instead of the ambient fallback.
+        $this->setupSuccessfulRequest([
+            'data' => [['url' => 'https://example.com/image.png']],
+        ]);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(static fn(array $metrics): bool => $metrics['images'] === 1),
+                null,
+                0,
+                'dall-e-3',
+                0,
+                42,
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A cat', new ImageGenerationOptions(beUserUid: 42));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -462,8 +462,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
                 0,
                 'flux-schnell',
                 0,
-                // Ambient attribution: the FAL options array carries no
-                // caller-supplied uid, so this path stays ambient (ADR-052).
+                // Ambient fallback: no beUserUid options key was passed (ADR-057).
                 null,
             );
 
@@ -477,6 +476,47 @@ class FalImageServiceTest extends AbstractUnitTestCase
         );
 
         $subject->generate('A sunset');
+    }
+
+    #[Test]
+    public function generateAttributesUsageToOptionsKeyUid(): void
+    {
+        // ADR-057: the documented `beUserUid` options key reaches the usage
+        // row; the payload builder's allowlist keeps it off the wire.
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://fal.ai/image.png']],
+        ]);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['image' => ['fal' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'fal',
+                ['images' => 1],
+                null,
+                0,
+                'flux-schnell',
+                0,
+                42,
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A sunset', options: ['beUserUid' => 42]);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -579,4 +579,65 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
         self::assertIsString($options->style);
         self::assertIsString($options->format);
     }
+    // ============ Budget / attribution fields (ADR-057) ============
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new ImageGenerationOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function fromArrayParsesBudgetFields(): void
+    {
+        $options = ImageGenerationOptions::fromArray(['beUserUid' => 7, 'plannedCost' => 0.42]);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(beUserUid: -1));
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(plannedCost: -0.01));
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneWithFieldSet(): void
+    {
+        $original = new ImageGenerationOptions();
+        $modified = $original->withBeUserUid(11);
+
+        self::assertNull($original->getBeUserUid());
+        self::assertSame(11, $modified->getBeUserUid());
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        // Attribution metadata, not wire payload: the service builds its
+        // provider payload from toArray(), so a leak here would send the
+        // uid to the remote API (ADR-057).
+        $options = new ImageGenerationOptions(beUserUid: 7, plannedCost: 0.5);
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('beUserUid', $array);
+        self::assertArrayNotHasKey('plannedCost', $array);
+    }
 }

--- a/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
@@ -360,4 +360,65 @@ class SpeechSynthesisOptionsTest extends AbstractUnitTestCase
         self::assertContains('nova', $voices);
         self::assertContains('shimmer', $voices);
     }
+    // ============ Budget / attribution fields (ADR-057) ============
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new SpeechSynthesisOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function fromArrayParsesBudgetFields(): void
+    {
+        $options = SpeechSynthesisOptions::fromArray(['beUserUid' => 7, 'plannedCost' => 0.42]);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        self::assertInstanceOf(SpeechSynthesisOptions::class, new SpeechSynthesisOptions(beUserUid: -1));
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        self::assertInstanceOf(SpeechSynthesisOptions::class, new SpeechSynthesisOptions(plannedCost: -0.01));
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneWithFieldSet(): void
+    {
+        $original = new SpeechSynthesisOptions();
+        $modified = $original->withBeUserUid(11);
+
+        self::assertNull($original->getBeUserUid());
+        self::assertSame(11, $modified->getBeUserUid());
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        // Attribution metadata, not wire payload: the service builds its
+        // provider payload from toArray(), so a leak here would send the
+        // uid to the remote API (ADR-057).
+        $options = new SpeechSynthesisOptions(beUserUid: 7, plannedCost: 0.5);
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('beUserUid', $array);
+        self::assertArrayNotHasKey('plannedCost', $array);
+    }
 }

--- a/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
@@ -298,4 +298,66 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
         self::assertEquals('srt', $options->format);
         self::assertEquals('de', $options->language);
     }
+
+    // ============ Budget / attribution fields (ADR-057) ============
+
+    #[Test]
+    public function constructorAcceptsBudgetFields(): void
+    {
+        $options = new TranscriptionOptions(beUserUid: 7, plannedCost: 0.42);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function fromArrayParsesBudgetFields(): void
+    {
+        $options = TranscriptionOptions::fromArray(['beUserUid' => 7, 'plannedCost' => 0.42]);
+
+        self::assertSame(7, $options->getBeUserUid());
+        self::assertSame(0.42, $options->getPlannedCost());
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeBeUserUid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('be_user_uid must be >= 0');
+
+        self::assertInstanceOf(TranscriptionOptions::class, new TranscriptionOptions(beUserUid: -1));
+    }
+
+    #[Test]
+    public function constructorRejectsNegativePlannedCost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+
+        self::assertInstanceOf(TranscriptionOptions::class, new TranscriptionOptions(plannedCost: -0.01));
+    }
+
+    #[Test]
+    public function withBeUserUidReturnsCloneWithFieldSet(): void
+    {
+        $original = new TranscriptionOptions();
+        $modified = $original->withBeUserUid(11);
+
+        self::assertNull($original->getBeUserUid());
+        self::assertSame(11, $modified->getBeUserUid());
+    }
+
+    #[Test]
+    public function budgetFieldsAreOmittedFromToArray(): void
+    {
+        // Attribution metadata, not wire payload: the service builds its
+        // provider payload from toArray(), so a leak here would send the
+        // uid to the remote API (ADR-057).
+        $options = new TranscriptionOptions(beUserUid: 7, plannedCost: 0.5);
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('beUserUid', $array);
+        self::assertArrayNotHasKey('plannedCost', $array);
+    }
 }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -361,8 +361,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 0,
                 'tts-1',
                 0,
-                // Ambient attribution: SpeechSynthesisOptions carries no
-                // budget fields, so no caller uid reaches this path (ADR-052).
+                // Ambient fallback: no beUserUid option was passed (ADR-057).
                 null,
             );
 
@@ -376,6 +375,45 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         );
 
         $subject->synthesize('Test text');
+    }
+
+    #[Test]
+    public function synthesizeAttributesUsageToOptionUid(): void
+    {
+        // ADR-057: a caller-supplied beUserUid in the options reaches the
+        // usage row instead of the ambient fallback.
+        $this->setupSuccessfulRequest();
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'tts',
+                self::callback(static fn(array $metrics): bool => $metrics['characters'] === 9),
+                null,
+                0,
+                'tts-1',
+                0,
+                42,
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->synthesize('Test text', new SpeechSynthesisOptions(beUserUid: 42));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -463,8 +463,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
                 0,
                 'whisper-1',
                 0,
-                // Ambient attribution: TranscriptionOptions carries no
-                // budget fields, so no caller uid reaches this path (ADR-052).
+                // Ambient fallback: no beUserUid option was passed (ADR-057).
                 null,
             );
 
@@ -479,6 +478,46 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         );
 
         $subject->transcribe($audioFile, ['configuration' => 'meeting-minutes']);
+    }
+
+    #[Test]
+    public function transcribeAttributesUsageToOptionUid(): void
+    {
+        // ADR-057: a caller-supplied beUserUid in the options reaches the
+        // usage row instead of the ambient fallback.
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'whisper',
+                [],
+                null,
+                0,
+                'whisper-1',
+                0,
+                42,
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->transcribe($audioFile, new TranscriptionOptions(beUserUid: 42));
     }
 
     // ==================== transcribe tests ====================


### PR DESCRIPTION
## Summary

ADR-052 made caller-supplied `beUserUid` win for usage attribution but deferred the four specialized speech/image services — their option shapes carried no budget fields, so every transcription, synthesis and image generation landed in the ambient bucket (`be_user` 0 for FE/CLI/worker callers). This PR extends the options-based attribution to those services and records the decision as **ADR-057**.

## Changes

- `TranscriptionOptions`, `SpeechSynthesisOptions`, `ImageGenerationOptions` implement `BudgetAwareOptionsInterface` via `BudgetFieldsTrait`: optional trailing `beUserUid`/`plannedCost` constructor parameters, `fromArray()` keys, negative-value validation. The fields stay out of `toArray()` — the services build their wire payload from it, so a leak would send the uid to the remote API.
- `WhisperTranscriptionService`, `TextToSpeechService`, `DallEImageService` forward `getBeUserUid()` to their `trackUsage()` calls.
- `FalImageService` (plain options array, no DTO) reads a documented `beUserUid` key — same pattern as the translator path; the payload builder is an explicit allowlist, so the key never reaches the FAL API.
- `DallEImageService::createVariations()`/`edit()` take no options object and gain an optional trailing `?int $beUserUid` scalar parameter (two DALL-E-2-only endpoints; a new options type for them would be overkill).
- ADR-052's consequences section updated; `BudgetAwareOptionsInterface` docblock now names the attribution-only consumers.

## Scope boundary

Attribution only. The specialized services bypass the middleware pipeline, so per-user budget ceilings are **not** enforced on speech/image calls; `plannedCost` is carried but unused there. Routing them through a budget pre-flight is a separate decision (no token cost model for FAL, multipart flows) — see ADR-057's consequences.

## Tests

- Per-DTO: budget-field construction, `fromArray` parsing, negative-value rejection, clone-setter, `toArray` exclusion (wire-leak guard).
- Per-service: attribution test asserting `trackUsage()` receives the option uid (Whisper, TTS, DALL-E, FAL options-key).