### PR TITLE
refactor: migrate backend modules to shared ModuleAction helper

### DIFF
--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -180,6 +180,12 @@ final class LlmModuleController extends ActionController
             );
         }
 
+        // Wire the test form to the nrllm_test AJAX endpoint. Test.js carries
+        // top-level ES imports, so it must load through the import map rather
+        // than as a classic <script> (which would throw "Cannot use import
+        // statement outside a module").
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/Test.js');
+
         $providers = $this->llmServiceManager->getAvailableProviders();
 
         $moduleTemplate->assignMultiple([

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -8,10 +8,6 @@
 
 <f:layout name="Module" />
 
-<f:section name="HeaderAssets">
-    <f:be.pageRenderer includeJsFiles="{0: 'EXT:nr_llm/Resources/Public/JavaScript/Backend/Test.js'}" />
-</f:section>
-
 <f:section name="Content">
     <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.page.title" default="Test LLM Provider" /></h1>
 
@@ -109,8 +105,6 @@
     <footer class="text-body-secondary small mt-4">
         Provided by <a href="https://www.netresearch.de" target="_blank" rel="noopener">Netresearch DTT GmbH</a>
     </footer>
-
-    <f:comment>JS loaded via HeaderAssets section as EXT:nr_llm/Resources/Public/JavaScript/Backend/Test.js</f:comment>
 </f:section>
 
 </html>

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -15,7 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
-import { postAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 /**
  * Read the JSON error body from a rejected AjaxRequest response.
@@ -80,64 +80,37 @@ class ConfigurationList {
 
     handleToggleActive(btn) {
         const uid = btn.dataset.uid;
-        const url = TYPO3.settings.ajaxUrls['nrllm_config_toggle_active'];
+        const url = resolveAjaxUrl('nrllm_config_toggle_active');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('uid', uid);
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleSetDefault(btn) {
         const uid = btn.dataset.uid;
-        const url = TYPO3.settings.ajaxUrls['nrllm_config_set_default'];
+        const url = resolveAjaxUrl('nrllm_config_set_default');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('uid', uid);
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleImportPreset(btn) {
         const identifier = btn.dataset.identifier;
-        const url = TYPO3.settings.ajaxUrls['nrllm_preset_import'];
+        const url = resolveAjaxUrl('nrllm_preset_import');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -16,14 +16,7 @@ import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
-
-/**
- * Read the JSON error body from a rejected AjaxRequest response.
- *
- * AjaxRequest rejects with an AjaxResponse on HTTP error status; resolve it
- * to recover the `{ success: false, error: ... }` payload the controllers
- * emit. Falls back to a thrown Error's message for genuine network failures.
- */
+import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ConfigurationList {
     constructor() {
@@ -141,7 +134,7 @@ class ConfigurationList {
                 <div class="spinner-border text-primary mb-3" role="status">
                     <span class="visually-hidden">Testing configuration...</span>
                 </div>
-                <p class="text-body-secondary">Testing configuration ${this.escapeHtml(name)}...</p>
+                <p class="text-body-secondary">Testing configuration ${escapeHtml(name)}...</p>
             </div>
             <div class="config-test-success" id="config-test-success" style="display: none;">
                 <div class="text-center py-3 mb-3">
@@ -252,12 +245,6 @@ class ConfigurationList {
             const msgEl = container.querySelector('#config-test-error-message');
             if (msgEl) msgEl.textContent = message;
         }
-    }
-
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
     }
 }
 

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -15,7 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
-import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { postAndReload, postUidAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ConfigurationList {
@@ -72,31 +72,11 @@ class ConfigurationList {
     }
 
     handleToggleActive(btn) {
-        const uid = btn.dataset.uid;
-        const url = resolveAjaxUrl('nrllm_config_toggle_active');
-
-        if (!url) {
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('uid', uid);
-
-        postAndReload(url, formData, btn);
+        postUidAndReload('nrllm_config_toggle_active', btn);
     }
 
     handleSetDefault(btn) {
-        const uid = btn.dataset.uid;
-        const url = resolveAjaxUrl('nrllm_config_set_default');
-
-        if (!url) {
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('uid', uid);
-
-        postAndReload(url, formData, btn);
+        postUidAndReload('nrllm_config_set_default', btn);
     }
 
     handleImportPreset(btn) {

--- a/Resources/Public/JavaScript/Backend/ModelList.js
+++ b/Resources/Public/JavaScript/Backend/ModelList.js
@@ -16,6 +16,7 @@ import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ModelList {
     constructor() {
@@ -111,7 +112,7 @@ class ModelList {
                     <div class="spinner-border text-primary mb-3" role="status">
                         <span class="visually-hidden">Testing model...</span>
                     </div>
-                    <h5 class="mb-2">Testing model ${this.escapeHtml(name)}</h5>
+                    <h5 class="mb-2">Testing model ${escapeHtml(name)}</h5>
                 </div>
                 <div class="progress-steps small">
                     <div class="d-flex align-items-center mb-2" id="step-connect">
@@ -272,12 +273,6 @@ class ModelList {
         if (msgEl) msgEl.textContent = message;
         const elapsedEl = container.querySelector('#error-elapsed');
         if (elapsedEl) elapsedEl.textContent = elapsed.toString();
-    }
-
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
     }
 }
 

--- a/Resources/Public/JavaScript/Backend/ModelList.js
+++ b/Resources/Public/JavaScript/Backend/ModelList.js
@@ -15,6 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 class ModelList {
     constructor() {
@@ -62,56 +63,30 @@ class ModelList {
 
     handleToggleActive(btn) {
         const uid = btn.dataset.uid;
-        const url = TYPO3.settings.ajaxUrls['nrllm_model_toggle_active'];
+        const url = resolveAjaxUrl('nrllm_model_toggle_active');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('uid', uid);
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleSetDefault(btn) {
         const uid = btn.dataset.uid;
-        const url = TYPO3.settings.ajaxUrls['nrllm_model_set_default'];
+        const url = resolveAjaxUrl('nrllm_model_set_default');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('uid', uid);
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleTestModel(btn) {

--- a/Resources/Public/JavaScript/Backend/ModelList.js
+++ b/Resources/Public/JavaScript/Backend/ModelList.js
@@ -15,7 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
-import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { postUidAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ModelList {
@@ -63,31 +63,11 @@ class ModelList {
     }
 
     handleToggleActive(btn) {
-        const uid = btn.dataset.uid;
-        const url = resolveAjaxUrl('nrllm_model_toggle_active');
-
-        if (!url) {
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('uid', uid);
-
-        postAndReload(url, formData, btn);
+        postUidAndReload('nrllm_model_toggle_active', btn);
     }
 
     handleSetDefault(btn) {
-        const uid = btn.dataset.uid;
-        const url = resolveAjaxUrl('nrllm_model_set_default');
-
-        if (!url) {
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('uid', uid);
-
-        postAndReload(url, formData, btn);
+        postUidAndReload('nrllm_model_set_default', btn);
     }
 
     handleTestModel(btn) {

--- a/Resources/Public/JavaScript/Backend/ModuleAction.js
+++ b/Resources/Public/JavaScript/Backend/ModuleAction.js
@@ -11,25 +11,47 @@
  * disable the triggering button, POST via AjaxRequest (which injects
  * TYPO3's CSRF token), reload on `{ success: true }`, surface the error
  * and re-enable the button otherwise. Centralised here so new actions do
- * not copy the boilerplate again (the older sibling modules still carry
- * their own copies — migrating them is mechanical follow-up work).
+ * not copy the boilerplate again.
  */
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 
 /**
+ * Resolve a registered backend AJAX endpoint URL.
+ *
+ * The endpoints live in `TYPO3.settings.ajaxUrls`. When one is missing the
+ * module cannot proceed, so surface the same error every handler used to
+ * raise inline and return a falsy value for the caller to bail on.
+ *
+ * @param {string} key AJAX route identifier
+ * @returns {string|undefined} the endpoint URL, or a falsy value if not registered
+ */
+export function resolveAjaxUrl(key) {
+    const url = TYPO3.settings.ajaxUrls[key];
+    if (!url) {
+        Notification.error('Error', 'AJAX URL not configured');
+    }
+    return url;
+}
+
+/**
  * @param {string} url Resolved AJAX endpoint URL
  * @param {FormData} formData POST payload
  * @param {HTMLButtonElement} btn Triggering button; disabled during flight, re-enabled on failure
+ * @param {(data: object) => void} [onSuccess] Optional callback run with the resolved response
+ *        payload before the reload — e.g. to show a success notification with result statistics
  */
-export function postAndReload(url, formData, btn) {
+export function postAndReload(url, formData, btn, onSuccess) {
     btn.disabled = true;
     new AjaxRequest(url)
         .post(formData)
         .then(response => response.resolve())
         .then(data => {
             if (data.success) {
+                if (onSuccess) {
+                    onSuccess(data);
+                }
                 location.reload();
             } else {
                 Notification.error('Error', data.error || 'Unknown error');

--- a/Resources/Public/JavaScript/Backend/ModuleAction.js
+++ b/Resources/Public/JavaScript/Backend/ModuleAction.js
@@ -36,6 +36,25 @@ export function resolveAjaxUrl(key) {
 }
 
 /**
+ * Standard list-row action: resolve the AJAX route, POST the row's
+ * `data-uid`, reload on success. The toggle-active / set-default
+ * handlers of the list modules are all this exact shape.
+ *
+ * @param {string} urlKey AJAX route identifier
+ * @param {HTMLButtonElement} btn Triggering button carrying `data-uid`
+ */
+export function postUidAndReload(urlKey, btn) {
+    const url = resolveAjaxUrl(urlKey);
+    if (!url) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('uid', btn.dataset.uid);
+    postAndReload(url, formData, btn);
+}
+
+/**
  * @param {string} url Resolved AJAX endpoint URL
  * @param {FormData} formData POST payload
  * @param {HTMLButtonElement} btn Triggering button; disabled during flight, re-enabled on failure

--- a/Resources/Public/JavaScript/Backend/ModuleAction.js
+++ b/Resources/Public/JavaScript/Backend/ModuleAction.js
@@ -28,7 +28,7 @@ import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
  * @returns {string|undefined} the endpoint URL, or a falsy value if not registered
  */
 export function resolveAjaxUrl(key) {
-    const url = TYPO3.settings.ajaxUrls[key];
+    const url = globalThis.TYPO3?.settings?.ajaxUrls?.[key];
     if (!url) {
         Notification.error('Error', 'AJAX URL not configured');
     }

--- a/Resources/Public/JavaScript/Backend/ProviderList.js
+++ b/Resources/Public/JavaScript/Backend/ProviderList.js
@@ -15,7 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
-import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { postUidAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ProviderList {
@@ -54,17 +54,7 @@ class ProviderList {
     }
 
     handleToggleActive(btn) {
-        const uid = btn.dataset.uid;
-        const url = resolveAjaxUrl('nrllm_provider_toggle_active');
-
-        if (!url) {
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('uid', uid);
-
-        postAndReload(url, formData, btn);
+        postUidAndReload('nrllm_provider_toggle_active', btn);
     }
 
     handleTestConnection(btn) {

--- a/Resources/Public/JavaScript/Backend/ProviderList.js
+++ b/Resources/Public/JavaScript/Backend/ProviderList.js
@@ -16,6 +16,7 @@ import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
 import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class ProviderList {
     constructor() {
@@ -87,7 +88,7 @@ class ProviderList {
                 <div class="spinner-border text-primary mb-3" role="status">
                     <span class="visually-hidden">Testing connection...</span>
                 </div>
-                <p class="text-body-secondary">Testing connection to ${this.escapeHtml(name)}...</p>
+                <p class="text-body-secondary">Testing connection to ${escapeHtml(name)}...</p>
             </div>
             <div class="modal-success text-center py-4" id="provider-test-success" style="display: none;">
                 <div class="mb-3">
@@ -163,12 +164,6 @@ class ProviderList {
                 if (msgEl) msgEl.textContent = await readAjaxError(err);
             }
         });
-    }
-
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
     }
 }
 

--- a/Resources/Public/JavaScript/Backend/ProviderList.js
+++ b/Resources/Public/JavaScript/Backend/ProviderList.js
@@ -15,6 +15,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 class ProviderList {
     constructor() {
@@ -53,29 +54,16 @@ class ProviderList {
 
     handleToggleActive(btn) {
         const uid = btn.dataset.uid;
-        const url = TYPO3.settings.ajaxUrls['nrllm_provider_toggle_active'];
+        const url = resolveAjaxUrl('nrllm_provider_toggle_active');
 
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('uid', uid);
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleTestConnection(btn) {

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -13,6 +13,7 @@
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { escapeHtml } from '@netresearch/nr-llm/Backend/HtmlEscape.js';
 
 class SetupWizard {
     currentStep = 1;
@@ -28,36 +29,12 @@ class SetupWizard {
             configurations: [],
         };
 
-        // Create reusable element for HTML escaping
-        this._escapeEl = document.createElement('div');
-
         // Wait for DOM to be ready before initializing
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', () => this.init());
         } else {
             this.init();
         }
-    }
-
-    /**
-     * Escape HTML entities to prevent XSS attacks.
-     * External API data (model names, descriptions, etc.) is untrusted content.
-     * The escaped value is also interpolated into quoted HTML attributes (e.g.
-     * aria-label), so `"` and `'` must be escaped too — the textContent ->
-     * innerHTML round-trip alone leaves quotes intact and would allow attribute
-     * breakout.
-     *
-     * @param {string} text - The text to escape
-     * @returns {string} - HTML-escaped text, safe for text and attribute contexts
-     */
-    escapeHtml(text) {
-        if (typeof text !== 'string') {
-            return '';
-        }
-        this._escapeEl.textContent = text;
-        return this._escapeEl.innerHTML
-            .replaceAll('"', '&quot;')
-            .replaceAll('\'', '&#39;');
     }
 
     init() {
@@ -287,7 +264,7 @@ class SetupWizard {
         } catch (e) {
             document.getElementById('models-loading').style.display = 'none';
             // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
-            const discoverError = this.escapeHtml(await readAjaxError(e));
+            const discoverError = escapeHtml(await readAjaxError(e));
             document.getElementById('models-list').innerHTML =
                 '<div class="alert alert-danger">Failed to discover models: ' + discoverError + '</div>';
         }
@@ -299,12 +276,12 @@ class SetupWizard {
 
         models.forEach((model, index) => {
             // SECURITY: Escape all external data to prevent XSS
-            const safeName = this.escapeHtml(model.name);
-            const safeModelId = this.escapeHtml(model.modelId);
-            const safeDescription = model.description ? this.escapeHtml(model.description) : '';
+            const safeName = escapeHtml(model.name);
+            const safeModelId = escapeHtml(model.modelId);
+            const safeDescription = model.description ? escapeHtml(model.description) : '';
 
             const capabilities = (model.capabilities || ['chat']).map(cap =>
-                `<span class="badge bg-secondary">${this.escapeHtml(cap)}</span>`
+                `<span class="badge bg-secondary">${escapeHtml(cap)}</span>`
             ).join('');
 
             let contextStr = '-';
@@ -404,7 +381,7 @@ class SetupWizard {
         } catch (e) {
             document.getElementById('configs-loading').style.display = 'none';
             // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
-            const generateError = this.escapeHtml(await readAjaxError(e));
+            const generateError = escapeHtml(await readAjaxError(e));
             document.getElementById('configs-list').innerHTML =
                 '<div class="alert alert-danger">Failed to generate configurations: ' + generateError + '</div>';
         }
@@ -416,8 +393,8 @@ class SetupWizard {
 
         configurations.forEach((config, index) => {
             // SECURITY: Escape all external data to prevent XSS
-            const safeName = this.escapeHtml(config.name);
-            const safeDescription = this.escapeHtml(config.description);
+            const safeName = escapeHtml(config.name);
+            const safeDescription = escapeHtml(config.description);
             // temperature and maxTokens are numbers, safe to use directly
             const safeTemp = Number.parseFloat(config.temperature) || 0;
             const safeMaxTokens = Number.parseInt(config.maxTokens, 10) || 0;
@@ -492,9 +469,9 @@ class SetupWizard {
         };
 
         // SECURITY: Escape all external data to prevent XSS
-        const safeProviderName = this.escapeHtml(providerInfo.suggestedName);
-        const safeAdapterType = this.escapeHtml(providerInfo.adapterType);
-        const safeEndpoint = this.escapeHtml(providerInfo.endpoint);
+        const safeProviderName = escapeHtml(providerInfo.suggestedName);
+        const safeAdapterType = escapeHtml(providerInfo.adapterType);
+        const safeEndpoint = escapeHtml(providerInfo.endpoint);
 
         document.getElementById('review-provider').innerHTML = `
             <div class="provider-icon">
@@ -518,8 +495,8 @@ class SetupWizard {
         const modelsUl = document.getElementById('review-models');
         modelsUl.innerHTML = selectedModels.map(m => `
             <li class="list-group-item">
-                <span class="badge bg-primary">${this.escapeHtml(m.modelId)}</span>
-                <span>${this.escapeHtml(m.name)}</span>
+                <span class="badge bg-primary">${escapeHtml(m.modelId)}</span>
+                <span>${escapeHtml(m.name)}</span>
             </li>
         `).join('');
 
@@ -528,8 +505,8 @@ class SetupWizard {
         const configsUl = document.getElementById('review-configs');
         configsUl.innerHTML = selectedConfigs.map(c => `
             <li class="list-group-item">
-                <span class="badge bg-info">${this.escapeHtml(c.identifier)}</span>
-                <span>${this.escapeHtml(c.name)}</span>
+                <span class="badge bg-info">${escapeHtml(c.identifier)}</span>
+                <span>${escapeHtml(c.name)}</span>
             </li>
         `).join('');
 

--- a/Resources/Public/JavaScript/Backend/SkillList.js
+++ b/Resources/Public/JavaScript/Backend/SkillList.js
@@ -16,6 +16,7 @@
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 class SkillList {
     constructor() {
@@ -57,43 +58,27 @@ class SkillList {
 
     handleSync(btn) {
         const source = btn.dataset.source;
-        const url = TYPO3.settings.ajaxUrls['nrllm_skill_sync'];
+        const url = resolveAjaxUrl('nrllm_skill_sync');
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
         const formData = new FormData();
         formData.append('source', source);
 
-        btn.disabled = true;
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    Notification.success(
-                        'Sync complete',
-                        `Status: ${data.status}, created: ${data.created}, updated: ${data.updated}, auto-disabled: ${data.disabledOnChange}, orphaned: ${data.orphaned}`
-                    );
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                    btn.disabled = false;
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-                btn.disabled = false;
-            });
+        postAndReload(url, formData, btn, (data) => {
+            Notification.success(
+                'Sync complete',
+                `Status: ${data.status}, created: ${data.created}, updated: ${data.updated}, auto-disabled: ${data.disabledOnChange}, orphaned: ${data.orphaned}`
+            );
+        });
     }
 
     handleToggle(btn) {
         const skill = btn.dataset.skill;
         const enabled = btn.dataset.enabled === '1' ? 0 : 1;
-        const url = TYPO3.settings.ajaxUrls['nrllm_skill_toggle'];
+        const url = resolveAjaxUrl('nrllm_skill_toggle');
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
@@ -101,26 +86,13 @@ class SkillList {
         formData.append('skill', skill);
         formData.append('enabled', String(enabled));
 
-        new AjaxRequest(url)
-            .post(formData)
-            .then(response => response.resolve())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else {
-                    Notification.error('Error', data.error || 'Unknown error');
-                }
-            })
-            .catch(async err => {
-                Notification.error('Error', await readAjaxError(err));
-            });
+        postAndReload(url, formData, btn);
     }
 
     handleSetToken(btn) {
         const source = btn.dataset.source;
-        const url = TYPO3.settings.ajaxUrls['nrllm_skill_token'];
+        const url = resolveAjaxUrl('nrllm_skill_token');
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 

--- a/Resources/Public/JavaScript/Backend/Test.js
+++ b/Resources/Public/JavaScript/Backend/Test.js
@@ -7,10 +7,11 @@
  * Wires the test prompt form to the nrllm_test AJAX endpoint and renders
  * the response (success, error, usage details).
  *
- * Loaded as an external module to satisfy CSP (no inline <script>).
- * The script is included via HeaderAssets, so it runs before <body> is
- * parsed — wrap in DOMContentLoaded and bail out if required elements
- * or the AJAX URL are missing.
+ * Loaded as an ES module via PageRenderer::loadJavaScriptModule — the bare
+ * @typo3/... and @netresearch/... imports below are resolved through TYPO3's
+ * import map, so a classic <script> include would not work. Module scripts
+ * are deferred, so wrap in DOMContentLoaded and bail out if the required
+ * elements or the AJAX URL are missing.
  *
  * State-changing AJAX uses AjaxRequest, which injects TYPO3's CSRF token.
  */

--- a/Resources/Public/JavaScript/Backend/ToolState.js
+++ b/Resources/Public/JavaScript/Backend/ToolState.js
@@ -11,8 +11,7 @@
  * POST/reload flow lives in the shared ModuleAction helper (AjaxRequest
  * underneath, which injects TYPO3's CSRF token automatically).
  */
-import Notification from '@typo3/backend/notification.js';
-import { postAndReload } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
 
 class ToolState {
     constructor() {
@@ -46,9 +45,8 @@ class ToolState {
     handleGroupToggle(btn) {
         const group = btn.dataset.group;
         const enabled = btn.dataset.enabled === '1' ? 0 : 1;
-        const url = TYPO3.settings.ajaxUrls['nrllm_toolgroup_toggle'];
+        const url = resolveAjaxUrl('nrllm_toolgroup_toggle');
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 
@@ -62,9 +60,8 @@ class ToolState {
     handleToggle(btn) {
         const tool = btn.dataset.tool;
         const enabled = btn.dataset.enabled === '1' ? 0 : 1;
-        const url = TYPO3.settings.ajaxUrls['nrllm_tool_toggle'];
+        const url = resolveAjaxUrl('nrllm_tool_toggle');
         if (!url) {
-            Notification.error('Error', 'AJAX URL not configured');
             return;
         }
 


### PR DESCRIPTION
## Description

Migrates the remaining backend list modules onto the shared `ModuleAction.js` helper, folds in the adjacent duplication those handlers still carried, and fixes the Test module's JavaScript never running.

### Migration to `postAndReload`

The provider, model, configuration and skill list modules each carried their own copy of the "POST a FormData payload, reload on `{success:true}`, otherwise show the error" flow. They now call the shared `postAndReload(url, formData, btn)` helper already used by `ToolState.js` and the configuration preset import.

Behaviour delta: the hand-rolled copies did not disable the triggering button while the request was in flight; the helper does. This prevents a double-submit on a slow toggle / set-default / sync click.

`SkillList.handleSync` shows a "Sync complete" notification with the sync statistics before reloading. `postAndReload` gained an optional fourth `onSuccess(data)` callback — purely additive, existing callers unchanged — that runs with the resolved payload before the reload; `handleSync` uses it to keep that notification.

The modal test flows (`handleTestConnection` / `handleTestModel` / `handleTestConfig`) and `SkillList.handleSetToken` (a POST without reload) are intentionally left as-is: different shape, separate scope.

### Deduplication

- `resolveAjaxUrl(key)` added to `ModuleAction.js` for the repeated `TYPO3.settings.ajaxUrls[key]` lookup plus "AJAX URL not configured" guard; adopted across the migrated handlers and `ToolState.js`.
- The per-module `escapeHtml` copies in the provider, model, configuration and setup-wizard modules are replaced by the shared `HtmlEscape.js`. The provider/model/configuration copies escaped only `&`, `<`, `>`; the shared helper also escapes quotes, so the interpolated values are safe in attribute contexts too.
- Removed an orphaned `readAjaxError` docblock left in `ConfigurationList.js` after that helper was extracted to `AjaxError.js`.

### Fix: Test module JavaScript never ran

`Test.js` gained top-level ES imports (`AjaxRequest`, `readAjaxError`) in the CSRF-token security fix (8ba0841) that replaced its `fetch()` call, but it stayed loaded via `<f:be.pageRenderer includeJsFiles>` — a classic `<script>`, which cannot execute `import` statements ("Cannot use import statement outside a module"). The test form's submit handler therefore never bound.

It now loads through `PageRenderer::loadJavaScriptModule('@netresearch/nr-llm/Backend/Test.js')` in `LlmModuleController::testAction` — the same import-map mechanism every other backend module uses — and the `includeJsFiles` include is dropped from `Test.html`. `WizardChainPreview.js` is the only other `includeJsFiles`-loaded script; it has no top-level imports and runs correctly as a classic script, so it is left untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — Test.js loading
- [x] Refactoring — migration + dedup (aside from the in-flight button-disabling behaviour delta noted above)

## Testing

CI runs the Playwright E2E suite (`Tests/E2E/Playwright/ajax-controllers.spec.ts`), which exercises the provider, model and configuration toggle-active / set-default AJAX flows migrated here. The skill and tool toggles (`SkillList.js`, `ToolState.js`) have no E2E coverage.

The repo has no JS lint/unit gate; each edited JS file was checked with `node --input-type=module --check`. For the PHP change, `composerUpdate`, `cgl` and `phpstan` (level 10) pass.
