### PR TITLE
test: assert captured chat messages are non-empty

### DIFF
--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -316,6 +316,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
             ->method('chat')
             ->willReturnCallback(
                 static function (array $messages, ?ChatOptions $options = null) use ($captured, $response): CompletionResponse {
+                    self::assertNotSame([], $messages);
                     self::assertInstanceOf(ChatOptions::class, $options);
                     $captured->list[] = $options;
 


### PR DESCRIPTION
SonarCloud flagged the capture callback's `$messages` parameter as unused (php:S1172) on #361, which was already in the merge queue and could not take the fix. Asserting the invariant uses the parameter and tightens the capture helper.