### PR TITLE
fix: sanitize configuration identifiers in cache keys

### DIFF
--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -34,13 +34,20 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
     /**
      * Generate a cache key for LLM requests.
      *
+     * The provider segment is sanitized because it can carry an LLM
+     * configuration identifier, and those may contain characters TYPO3's
+     * cache frontends reject (valid: A-Za-z0-9_%-&). The documented preset
+     * naming scheme uses dots ("nr_ai_search.embeddings"), which otherwise
+     * made every cached call throw "not a valid cache entry identifier".
+     *
      * @param array<string, mixed> $params
      */
     public function generateCacheKey(string $provider, string $operation, array $params): string
     {
         $normalized = $this->normalizeParams($params);
         $hash = hash('xxh128', json_encode($normalized, JSON_THROW_ON_ERROR));
-        return sprintf('%s_%s_%s', $provider, $operation, $hash);
+        $providerSegment = preg_replace('/[^a-zA-Z0-9_%\-&]/', '_', $provider) ?? '';
+        return sprintf('%s_%s_%s', $providerSegment, $operation, $hash);
     }
 
     /**

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -46,8 +46,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
     {
         $normalized = $this->normalizeParams($params);
         $hash = hash('xxh128', json_encode($normalized, JSON_THROW_ON_ERROR));
-        $providerSegment = preg_replace('/[^a-zA-Z0-9_%\-&]/', '_', $provider) ?? '';
-        return sprintf('%s_%s_%s', $providerSegment, $operation, $hash);
+        return sprintf('%s_%s_%s', $this->sanitizeTagValue($provider), $operation, $hash);
     }
 
     /**
@@ -134,7 +133,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
      */
     public function flushByProvider(string $provider): void
     {
-        $this->flushByTag('nrllm_provider_' . $provider);
+        $this->flushByTag('nrllm_provider_' . $this->sanitizeTagValue($provider));
     }
 
     /**
@@ -158,7 +157,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
 
         $tags = [
             'nrllm_completion',
-            'nrllm_provider_' . $provider,
+            'nrllm_provider_' . $this->sanitizeTagValue($provider),
         ];
 
         if (isset($options['model']) && is_string($options['model'])) {
@@ -211,7 +210,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
 
         $tags = [
             'nrllm_embeddings',
-            'nrllm_provider_' . $provider,
+            'nrllm_provider_' . $this->sanitizeTagValue($provider),
         ];
 
         $this->set($cacheKey, $response, $lifetime, $tags);

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -69,6 +69,21 @@ class CacheManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function generateCacheKeyIsAValidCacheEntryIdentifierForDottedConfigurationIdentifiers(): void
+    {
+        // The provider segment can carry an LLM configuration identifier; the
+        // documented preset naming scheme uses dots (e.g. "nr_ai_search.embeddings").
+        // TYPO3 cache frontends only accept /^[a-zA-Z0-9_%\-&]{1,250}$/ - an
+        // unsanitized dot made every cached call throw
+        // "... is not a valid cache entry identifier" (found live on the first
+        // 0.18 deployment).
+        $key = $this->subject->generateCacheKey('nr_ai_search.embeddings', 'embeddings', ['input' => 'hello']);
+
+        self::assertMatchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/', $key);
+        self::assertStringStartsWith('nr_ai_search_embeddings_', $key);
+    }
+
+    #[Test]
     public function generateCacheKeyDiffersForDifferentProviders(): void
     {
         $params = ['messages' => [['role' => 'user', 'content' => 'Hello']]];

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -84,6 +84,41 @@ class CacheManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function cacheEmbeddingsProducesValidKeyAndTagsForDottedConfigurationIdentifiers(): void
+    {
+        // The full caching flow with a preset-style configuration identifier
+        // (dots are the documented naming scheme): both the entry identifier
+        // AND every tag must satisfy TYPO3's charset - the provider tag was
+        // the second crash site after the cache key (set() rejects invalid
+        // tags with an InvalidArgumentException).
+        /** @var array{subject: CacheManager, cacheFrontend: FrontendInterface&MockObject} $setup */
+        $setup = $this->createSubjectWithMockFrontend();
+        $subject = $setup['subject'];
+        $cacheFrontendMock = $setup['cacheFrontend'];
+
+        $cacheFrontendMock
+            ->expects(self::once())
+            ->method('set')
+            ->with(
+                self::matchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/'),
+                self::anything(),
+                self::callback(
+                    static function (array $tags): bool {
+                        foreach ($tags as $tag) {
+                            self::assertIsString($tag);
+                            self::assertMatchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/', $tag);
+                        }
+
+                        return in_array('nrllm_provider_nr_ai_search_embeddings', $tags, true);
+                    },
+                ),
+                self::anything(),
+            );
+
+        $subject->cacheEmbeddings('nr_ai_search.embeddings', 'hello', [], ['embeddings' => [[0.1]]]);
+    }
+
+    #[Test]
     public function generateCacheKeyDiffersForDifferentProviders(): void
     {
         $params = ['messages' => [['role' => 'user', 'content' => 'Hello']]];


### PR DESCRIPTION
Every cached LLM call crashed with `"nr_ai_search.embeddings_embeddings_…" is not a valid cache entry identifier` once a **preset-style configuration identifier** (dots are the documented naming scheme, ADR-056) reached `CacheManager::generateCacheKey()` — TYPO3 cache frontends only accept `A-Za-z0-9_%-&`. Found live on the first 0.18 deployment (the-13/BMDV, NRFE-3946).

Fix: sanitize the provider segment (non-conforming chars → `_`). Test asserts the produced key matches TYPO3's identifier pattern for a dotted identifier. No cache invalidation concern: dotted-identifier calls never produced valid entries (they threw).