### PR TITLE
feat: checksum-driven preset update flow (ADR-056 follow-up)

### DIFF
--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -99,6 +99,8 @@ final class ConfigurationController extends ActionController
             'nrllm_config_set_default' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_config_set_default'),
             'nrllm_config_test' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_config_test'),
             'nrllm_preset_import' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_preset_import'),
+            'nrllm_preset_diff' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_preset_diff'),
+            'nrllm_preset_update' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_preset_update'),
         ]);
 
         // Load JavaScript for configuration list actions (ES6 module)
@@ -139,7 +141,7 @@ final class ConfigurationController extends ActionController
             'reqByConfig' => $usage['requests'],
             'tokByConfig' => $usage['tokens'],
             'pendingPresets' => $this->buildPendingPresetRows(),
-            'driftedUids' => $this->buildDriftedUidMap(),
+            'driftedIdentifiers' => $this->buildDriftedIdentifierMap(),
         ]);
 
         if (method_exists($this->moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
@@ -583,22 +585,24 @@ final class ConfigurationController extends ActionController
     }
 
     /**
-     * Configuration UIDs whose imported preset declaration drifted
-     * (checksum mismatch, ADR-056) — keyed by UID for O(1) template lookup.
+     * Preset identifiers of configuration records whose imported preset
+     * declaration drifted (checksum mismatch, ADR-056) — keyed by record UID
+     * for O(1) template lookup. The template renders both the drift hint and
+     * the "Review update" button, which needs the identifier to fetch the diff.
      *
-     * @return array<int, bool>
+     * @return array<int, string>
      */
-    private function buildDriftedUidMap(): array
+    private function buildDriftedIdentifierMap(): array
     {
-        $driftedUids = [];
+        $driftedIdentifiers = [];
         foreach ($this->presetRegistry->drifted() as $drift) {
             $uid = $drift['configuration']->getUid();
             if ($uid !== null) {
-                $driftedUids[$uid] = true;
+                $driftedIdentifiers[$uid] = $drift['preset']->identifier;
             }
         }
 
-        return $driftedUids;
+        return $driftedIdentifiers;
     }
 
     /**

--- a/Classes/Controller/Backend/PresetController.php
+++ b/Classes/Controller/Backend/PresetController.php
@@ -9,9 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
+use Netresearch\NrLlm\Service\Preset\PresetDiff;
+use Netresearch\NrLlm\Service\Preset\PresetFieldDiff;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -40,6 +44,8 @@ final class PresetController extends ActionController
     public function __construct(
         private readonly ConfigurationPresetRegistry $presetRegistry,
         private readonly ConfigurationPresetImportService $importService,
+        private readonly ConfigurationPresetDiffService $diffService,
+        private readonly LlmConfigurationRepository $configurationRepository,
     ) {}
 
     /**
@@ -51,7 +57,10 @@ final class PresetController extends ActionController
      * `missingRequirement` (string|null), `matchedModelLabel` (string|null).
      * `drifted` — one entry per imported preset whose declaration changed
      * since import (checksum mismatch, ADR-056): `identifier`, `name`,
-     * `configurationUid` (int|null). Detection only — no update flow.
+     * `configurationUid` (int|null), and `changedFields` (list<string>, the
+     * machine names of the fields an update would overwrite; may be empty when
+     * only an optional seed was removed from the declaration). Consuming
+     * clients drive the diff/update flow from these.
      */
     public function listPresetsAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -77,6 +86,7 @@ final class PresetController extends ActionController
                 'identifier' => $drift['preset']->identifier,
                 'name' => $drift['preset']->name,
                 'configurationUid' => $drift['configuration']->getUid(),
+                'changedFields' => $this->diffService->diff($drift['preset'], $drift['configuration'])->changedFields(),
             ];
         }
         return new JsonResponse(['success' => true, 'presets' => $presets, 'drifted' => $drifted]);
@@ -110,6 +120,114 @@ final class PresetController extends ActionController
             'identifier' => $configuration->getIdentifier(),
             'uid' => $configuration->getUid(),
         ]);
+    }
+
+    /**
+     * Diff a drifted imported preset against its record (AJAX GET, admin-gated).
+     *
+     * Returns the field-level changes an update would apply so the admin can
+     * review before confirming: 404 for an unknown identifier, 422 when no
+     * drifted record can be updated (not imported, up to date, mode switched,
+     * or the updated criteria unsatisfiable), 200 with the diff otherwise.
+     */
+    public function diffAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+        $identifier = $this->stringFromBody($request->getQueryParams(), 'identifier');
+        $preset = $this->presetRegistry->findByIdentifier($identifier);
+        if ($preset === null) {
+            return $this->unknownPresetResponse();
+        }
+        $record = $this->configurationRepository->findOneByIdentifier($identifier);
+        if ($record === null) {
+            return $this->notDriftedResponse();
+        }
+        try {
+            $diff = $this->importService->previewUpdate($preset, $record);
+        } catch (InvalidArgumentException $e) {
+            return $this->refusalResponse($e);
+        }
+        return new JsonResponse([
+            'success' => true,
+            'identifier' => $diff->identifier,
+            'name' => $diff->name,
+            'changes' => $this->serializeChanges($diff),
+        ]);
+    }
+
+    /**
+     * Apply a reviewed preset update to its record (AJAX POST, admin-gated).
+     *
+     * Same 404/422 refusals as {@see diffAction}; on success re-stamps the
+     * record's checksum (clearing the drift hint) and returns the machine names
+     * of the fields that were applied.
+     */
+    public function updateAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+        $identifier = $this->stringFromBody($request->getParsedBody(), 'identifier');
+        $preset = $this->presetRegistry->findByIdentifier($identifier);
+        if ($preset === null) {
+            return $this->unknownPresetResponse();
+        }
+        $record = $this->configurationRepository->findOneByIdentifier($identifier);
+        if ($record === null) {
+            return $this->notDriftedResponse();
+        }
+        try {
+            $diff = $this->importService->update($preset, $record);
+        } catch (InvalidArgumentException $e) {
+            return $this->refusalResponse($e);
+        }
+        return new JsonResponse([
+            'success' => true,
+            'identifier' => $diff->identifier,
+            'changedFields' => $diff->changedFields(),
+        ]);
+    }
+
+    /**
+     * @return list<array{field: string, current: string, declared: string}>
+     */
+    private function serializeChanges(PresetDiff $diff): array
+    {
+        return array_map(
+            static fn(PresetFieldDiff $change): array => [
+                'field' => $change->field,
+                'current' => $change->current,
+                'declared' => $change->declared,
+            ],
+            $diff->changes,
+        );
+    }
+
+    private function unknownPresetResponse(): ResponseInterface
+    {
+        return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.preset.unknown', 'Unknown preset')], 404);
+    }
+
+    private function notDriftedResponse(): ResponseInterface
+    {
+        return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.preset.notDrifted', 'This configuration is up to date; there is nothing to update.')], 422);
+    }
+
+    /**
+     * Map an update refusal to a 422 response, localising the static reasons and
+     * surfacing the dynamic (missing-requirement) message for an unsatisfiable
+     * update, mirroring how the import flow surfaces its reason.
+     */
+    private function refusalResponse(InvalidArgumentException $e): ResponseInterface
+    {
+        $message = match ($e->getCode()) {
+            ConfigurationPresetImportService::CODE_UPDATE_NOT_DRIFTED => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.preset.notDrifted', 'This configuration is up to date; there is nothing to update.'),
+            ConfigurationPresetImportService::CODE_UPDATE_MODE_SWITCHED => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.preset.modeSwitched', 'This configuration was switched to fixed model selection; the preset update is refused.'),
+            default => $e->getMessage(),
+        };
+        return new JsonResponse(['success' => false, 'error' => $message], 422);
     }
 
     private function stringFromBody(mixed $body, string $key): string

--- a/Classes/Service/Preset/ConfigurationPreset.php
+++ b/Classes/Service/Preset/ConfigurationPreset.php
@@ -105,34 +105,41 @@ final readonly class ConfigurationPreset
                 1789347005,
             );
         }
-        // Validate the numeric seeds against the range LlmConfiguration's
-        // setters accept. Without this, an out-of-range declared seed is
-        // silently clamped on import/update (e.g. temperature 2.5 -> 2.0,
-        // maxTokens 0 -> 1) while the diff dialog and checksum show the raw
-        // declared value the update never stores. Fail fast at registration.
-        if ($temperature !== null && ($temperature < 0.0 || $temperature > 2.0)) {
+        $this->validateSeeds();
+    }
+
+    /**
+     * Validate the numeric seeds against the range LlmConfiguration's setters
+     * accept. Without this, an out-of-range declared seed is silently clamped
+     * on import/update (e.g. temperature 2.5 -> 2.0, maxTokens 0 -> 1) while
+     * the diff dialog and checksum show the raw declared value the update
+     * never stores. Fail fast at registration.
+     */
+    private function validateSeeds(): void
+    {
+        if ($this->temperature !== null && ($this->temperature < 0.0 || $this->temperature > 2.0)) {
             throw new InvalidArgumentException(
-                sprintf('Preset "%s" temperature must be between 0.0 and 2.0; got %s.', $identifier, $temperature),
+                sprintf('Preset "%s" temperature must be between 0.0 and 2.0; got %s.', $this->identifier, $this->temperature),
                 1789347006,
             );
         }
-        if ($maxTokens !== null && $maxTokens < 1) {
+        if ($this->maxTokens !== null && $this->maxTokens < 1) {
             throw new InvalidArgumentException(
-                sprintf('Preset "%s" maxTokens must be >= 1; got %d.', $identifier, $maxTokens),
+                sprintf('Preset "%s" maxTokens must be >= 1; got %d.', $this->identifier, $this->maxTokens),
                 1789347007,
             );
         }
-        foreach (['maxRequestsPerDay' => $maxRequestsPerDay, 'maxTokensPerDay' => $maxTokensPerDay] as $field => $value) {
+        foreach (['maxRequestsPerDay' => $this->maxRequestsPerDay, 'maxTokensPerDay' => $this->maxTokensPerDay] as $field => $value) {
             if ($value !== null && $value < 0) {
                 throw new InvalidArgumentException(
-                    sprintf('Preset "%s" %s must be >= 0; got %d.', $identifier, $field, $value),
+                    sprintf('Preset "%s" %s must be >= 0; got %d.', $this->identifier, $field, $value),
                     1789347008,
                 );
             }
         }
-        if ($maxCostPerDay !== null && $maxCostPerDay < 0.0) {
+        if ($this->maxCostPerDay !== null && $this->maxCostPerDay < 0.0) {
             throw new InvalidArgumentException(
-                sprintf('Preset "%s" maxCostPerDay must be >= 0.0; got %s.', $identifier, $maxCostPerDay),
+                sprintf('Preset "%s" maxCostPerDay must be >= 0.0; got %s.', $this->identifier, $this->maxCostPerDay),
                 1789347009,
             );
         }

--- a/Classes/Service/Preset/ConfigurationPreset.php
+++ b/Classes/Service/Preset/ConfigurationPreset.php
@@ -108,14 +108,15 @@ final readonly class ConfigurationPreset
     }
 
     /**
-     * SHA-256 checksum over a canonical JSON encoding (recursively sorted
-     * keys) of every declared field, so a changed declaration in the
-     * consuming extension is detectable against the stored checksum of an
-     * already-imported record.
+     * The canonical representation of every declared field, used both for the
+     * checksum and for the update diff so the two can never disagree on which
+     * fields make up a preset.
+     *
+     * @return array<string, mixed>
      */
-    public function checksum(): string
+    public function toCanonicalArray(): array
     {
-        $data = [
+        return [
             'allowedToolGroups' => $this->allowedToolGroups,
             'criteria' => $this->criteria->toArray(),
             'description' => $this->description,
@@ -128,7 +129,17 @@ final readonly class ConfigurationPreset
             'systemPrompt' => $this->systemPrompt,
             'temperature' => $this->temperature,
         ];
-        return hash('sha256', json_encode($this->sortKeysRecursively($data), JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * SHA-256 checksum over a canonical JSON encoding (recursively sorted
+     * keys) of every declared field, so a changed declaration in the
+     * consuming extension is detectable against the stored checksum of an
+     * already-imported record.
+     */
+    public function checksum(): string
+    {
+        return hash('sha256', json_encode($this->sortKeysRecursively($this->toCanonicalArray()), JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/Classes/Service/Preset/ConfigurationPreset.php
+++ b/Classes/Service/Preset/ConfigurationPreset.php
@@ -105,6 +105,37 @@ final readonly class ConfigurationPreset
                 1789347005,
             );
         }
+        // Validate the numeric seeds against the range LlmConfiguration's
+        // setters accept. Without this, an out-of-range declared seed is
+        // silently clamped on import/update (e.g. temperature 2.5 -> 2.0,
+        // maxTokens 0 -> 1) while the diff dialog and checksum show the raw
+        // declared value the update never stores. Fail fast at registration.
+        if ($temperature !== null && ($temperature < 0.0 || $temperature > 2.0)) {
+            throw new InvalidArgumentException(
+                sprintf('Preset "%s" temperature must be between 0.0 and 2.0; got %s.', $identifier, $temperature),
+                1789347006,
+            );
+        }
+        if ($maxTokens !== null && $maxTokens < 1) {
+            throw new InvalidArgumentException(
+                sprintf('Preset "%s" maxTokens must be >= 1; got %d.', $identifier, $maxTokens),
+                1789347007,
+            );
+        }
+        foreach (['maxRequestsPerDay' => $maxRequestsPerDay, 'maxTokensPerDay' => $maxTokensPerDay] as $field => $value) {
+            if ($value !== null && $value < 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Preset "%s" %s must be >= 0; got %d.', $identifier, $field, $value),
+                    1789347008,
+                );
+            }
+        }
+        if ($maxCostPerDay !== null && $maxCostPerDay < 0.0) {
+            throw new InvalidArgumentException(
+                sprintf('Preset "%s" maxCostPerDay must be >= 0.0; got %s.', $identifier, $maxCostPerDay),
+                1789347009,
+            );
+        }
     }
 
     /**

--- a/Classes/Service/Preset/ConfigurationPresetDiffService.php
+++ b/Classes/Service/Preset/ConfigurationPresetDiffService.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Preset;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+
+/**
+ * Computes the field-level diff between a declared configuration preset and
+ * the imported record it manages (ADR-056 update flow).
+ *
+ * The diff is one-directional: declared value versus the record's *current*
+ * value, so it names exactly what a re-confirmed update would overwrite. It
+ * only ever touches fields an update applies:
+ *
+ * * name, description and the model-selection criteria are core fields — the
+ *   declaration always wins, so any difference is reported.
+ * * the optional seeds (system prompt, temperature, max tokens, the three
+ *   daily budgets, allowed tool groups) are reported only when the
+ *   declaration carries a value (non-null, non-empty list): a seed the
+ *   declaration left open never resets the record, so it is not a change.
+ *
+ * Admin-owned fields (active state, default flag, backend groups, fallback
+ * chain) are structurally absent — the preset value object has no field for
+ * them, so they can never appear here.
+ */
+final readonly class ConfigurationPresetDiffService
+{
+    /**
+     * Temperatures and cost ceilings are stored as `decimal(_,2)` columns, so
+     * compare at that scale: a declared value is a change only when it differs
+     * from the stored value in the second decimal place or beyond.
+     */
+    private const FLOAT_SCALE = 2;
+
+    public function diff(ConfigurationPreset $preset, LlmConfiguration $record): PresetDiff
+    {
+        $changes = [];
+
+        $this->addStringChange($changes, 'name', $record->getName(), $preset->name);
+        $this->addStringChange($changes, 'description', $record->getDescription(), $preset->description);
+
+        $this->addCriteriaChanges($changes, $preset, $record);
+
+        if ($preset->systemPrompt !== null) {
+            $this->addStringChange($changes, 'systemPrompt', $record->getSystemPrompt(), $preset->systemPrompt);
+        }
+        if ($preset->temperature !== null) {
+            $this->addFloatChange($changes, 'temperature', $record->getTemperature(), $preset->temperature);
+        }
+        if ($preset->maxTokens !== null) {
+            $this->addIntChange($changes, 'maxTokens', $record->getMaxTokens(), $preset->maxTokens);
+        }
+        if ($preset->maxRequestsPerDay !== null) {
+            $this->addIntChange($changes, 'maxRequestsPerDay', $record->getMaxRequestsPerDay(), $preset->maxRequestsPerDay);
+        }
+        if ($preset->maxTokensPerDay !== null) {
+            $this->addIntChange($changes, 'maxTokensPerDay', $record->getMaxTokensPerDay(), $preset->maxTokensPerDay);
+        }
+        if ($preset->maxCostPerDay !== null) {
+            $this->addFloatChange($changes, 'maxCostPerDay', $record->getMaxCostPerDay(), $preset->maxCostPerDay);
+        }
+        if ($preset->allowedToolGroups !== []) {
+            $this->addToolGroupsChange($changes, $record->getAllowedToolGroupsList(), $preset->allowedToolGroups);
+        }
+
+        return new PresetDiff($preset->identifier, $preset->name, $changes);
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private function addCriteriaChanges(array &$changes, ConfigurationPreset $preset, LlmConfiguration $record): void
+    {
+        $declared = $preset->criteria->toArray();
+        $current = $record->getModelSelectionCriteriaDTO()->toArray();
+
+        $this->addListChange($changes, 'criteria.capabilities', $current['capabilities'], $declared['capabilities']);
+        $this->addListChange($changes, 'criteria.adapterTypes', $current['adapterTypes'], $declared['adapterTypes']);
+        $this->addIntChange($changes, 'criteria.minContextLength', $current['minContextLength'], $declared['minContextLength']);
+        $this->addIntChange($changes, 'criteria.maxCostInput', $current['maxCostInput'], $declared['maxCostInput']);
+        $this->addBoolChange($changes, 'criteria.preferLowestCost', $current['preferLowestCost'], $declared['preferLowestCost']);
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private function addStringChange(array &$changes, string $field, string $current, string $declared): void
+    {
+        if ($current !== $declared) {
+            $changes[] = new PresetFieldDiff($field, $current, $declared);
+        }
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private function addIntChange(array &$changes, string $field, int $current, int $declared): void
+    {
+        if ($current !== $declared) {
+            $changes[] = new PresetFieldDiff($field, (string)$current, (string)$declared);
+        }
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private function addBoolChange(array &$changes, string $field, bool $current, bool $declared): void
+    {
+        if ($current !== $declared) {
+            $changes[] = new PresetFieldDiff($field, $current ? 'true' : 'false', $declared ? 'true' : 'false');
+        }
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private function addFloatChange(array &$changes, string $field, float $current, float $declared): void
+    {
+        $currentScaled = round($current, self::FLOAT_SCALE);
+        $declaredScaled = round($declared, self::FLOAT_SCALE);
+        if (abs($currentScaled - $declaredScaled) >= 0.5 * 10 ** -self::FLOAT_SCALE) {
+            $changes[] = new PresetFieldDiff(
+                $field,
+                number_format($currentScaled, self::FLOAT_SCALE),
+                number_format($declaredScaled, self::FLOAT_SCALE),
+            );
+        }
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     * @param list<string>          $current
+     * @param list<string>          $declared
+     */
+    private function addListChange(array &$changes, string $field, array $current, array $declared): void
+    {
+        if ($current !== $declared) {
+            $changes[] = new PresetFieldDiff($field, implode(', ', $current), implode(', ', $declared));
+        }
+    }
+
+    /**
+     * The record stores tool groups as a CSV column, the declaration as a
+     * list; normalise both to a sorted list before comparing so a pure
+     * reordering is not reported. The display keeps each side's own order.
+     *
+     * @param list<PresetFieldDiff> $changes
+     * @param list<string>          $current
+     * @param list<string>          $declared
+     */
+    private function addToolGroupsChange(array &$changes, array $current, array $declared): void
+    {
+        $currentSorted = $current;
+        $declaredSorted = $declared;
+        sort($currentSorted);
+        sort($declaredSorted);
+        if ($currentSorted !== $declaredSorted) {
+            $changes[] = new PresetFieldDiff('allowedToolGroups', implode(', ', $current), implode(', ', $declared));
+        }
+    }
+}

--- a/Classes/Service/Preset/ConfigurationPresetImportService.php
+++ b/Classes/Service/Preset/ConfigurationPresetImportService.php
@@ -28,13 +28,34 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * duplicate identifier and an unsatisfiable preset, then creates the record
  * in criteria selection mode with the preset's checksum stored for
  * change detection.
+ *
+ * `previewUpdate()` / `update()` implement the drift resolution flow: when a
+ * consuming extension changes a preset declaration, the admin reviews the
+ * diff against the imported record and re-confirms. An update applies the
+ * declared name, description, criteria and non-null seeds, then re-stamps the
+ * checksum so the drift hint clears; it never touches admin-owned fields
+ * (active state, default flag, backend groups, fallback chain) and refuses a
+ * record whose selection mode the admin switched away from criteria.
  */
 final readonly class ConfigurationPresetImportService
 {
+    /** An update was asked for a record whose identifier is not the preset's. */
+    public const CODE_UPDATE_IDENTIFIER_MISMATCH = 1789347007;
+
+    /** The record is up to date or not preset-managed — nothing to update. */
+    public const CODE_UPDATE_NOT_DRIFTED = 1789347008;
+
+    /** The admin switched the record off criteria mode; an update is refused. */
+    public const CODE_UPDATE_MODE_SWITCHED = 1789347009;
+
+    /** No active model satisfies the updated criteria. */
+    public const CODE_UPDATE_UNSATISFIABLE = 1789347010;
+
     public function __construct(
         private ModelSelectionServiceInterface $modelSelectionService,
         private LlmConfigurationRepository $configurationRepository,
         private PersistenceManagerInterface $persistenceManager,
+        private ConfigurationPresetDiffService $diffService,
     ) {}
 
     /**
@@ -114,6 +135,123 @@ final readonly class ConfigurationPresetImportService
         $this->persistenceManager->persistAll();
 
         return $configuration;
+    }
+
+    /**
+     * Diff the declared preset against the imported record, refusing when an
+     * update could not be applied (record not drifted, mode switched away from
+     * criteria, or the updated criteria unsatisfiable). Read-only — for the
+     * re-confirm preview.
+     *
+     * @throws InvalidArgumentException with one of the CODE_UPDATE_* codes
+     */
+    public function previewUpdate(ConfigurationPreset $preset, LlmConfiguration $record): PresetDiff
+    {
+        $this->assertUpdatable($preset, $record);
+
+        return $this->diffService->diff($preset, $record);
+    }
+
+    /**
+     * Apply a changed preset declaration to its imported record after the
+     * admin re-confirmed the diff.
+     *
+     * Applies the declared name, description and criteria (the declaration
+     * always wins) and each non-null seed, then re-stamps the record's stored
+     * checksum to the current declaration so the drift hint clears. Admin-owned
+     * fields (active state, default flag, backend groups, fallback chain) are
+     * left untouched. Returns the diff that was applied.
+     *
+     * @throws InvalidArgumentException with one of the CODE_UPDATE_* codes
+     */
+    public function update(ConfigurationPreset $preset, LlmConfiguration $record): PresetDiff
+    {
+        $this->assertUpdatable($preset, $record);
+
+        $diff = $this->diffService->diff($preset, $record);
+
+        $record->setName($preset->name);
+        $record->setDescription($preset->description);
+        $record->setModelSelectionCriteriaDTO($preset->criteria);
+        if ($preset->systemPrompt !== null) {
+            $record->setSystemPrompt($preset->systemPrompt);
+        }
+        if ($preset->temperature !== null) {
+            $record->setTemperature($preset->temperature);
+        }
+        if ($preset->maxTokens !== null) {
+            $record->setMaxTokens($preset->maxTokens);
+        }
+        if ($preset->maxRequestsPerDay !== null) {
+            $record->setMaxRequestsPerDay($preset->maxRequestsPerDay);
+        }
+        if ($preset->maxTokensPerDay !== null) {
+            $record->setMaxTokensPerDay($preset->maxTokensPerDay);
+        }
+        if ($preset->maxCostPerDay !== null) {
+            $record->setMaxCostPerDay($preset->maxCostPerDay);
+        }
+        if ($preset->allowedToolGroups !== []) {
+            $record->setAllowedToolGroups(implode(',', $preset->allowedToolGroups));
+        }
+        $record->setPresetChecksum($preset->checksum());
+
+        $this->configurationRepository->update($record);
+        $this->persistenceManager->persistAll();
+
+        return $diff;
+    }
+
+    /**
+     * Refuse an update the flow must not perform.
+     *
+     * @throws InvalidArgumentException with one of the CODE_UPDATE_* codes
+     */
+    private function assertUpdatable(ConfigurationPreset $preset, LlmConfiguration $record): void
+    {
+        if ($record->getIdentifier() !== $preset->identifier) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Configuration "%s" does not belong to preset "%s".',
+                    $record->getIdentifier(),
+                    $preset->identifier,
+                ),
+                self::CODE_UPDATE_IDENTIFIER_MISMATCH,
+            );
+        }
+
+        $storedChecksum = $record->getPresetChecksum();
+        if ($storedChecksum === '' || $storedChecksum === $preset->checksum()) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Preset "%s" has no drifted configuration to update: the record is up to date or was not imported from a preset.',
+                    $preset->identifier,
+                ),
+                self::CODE_UPDATE_NOT_DRIFTED,
+            );
+        }
+
+        if (!$record->usesCriteriaSelection()) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Configuration "%s" was switched to fixed model selection; updating the preset would override the administrator\'s model choice and is refused.',
+                    $preset->identifier,
+                ),
+                self::CODE_UPDATE_MODE_SWITCHED,
+            );
+        }
+
+        $preflight = $this->preflight($preset);
+        if (!$preflight->satisfiable) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Preset "%s" cannot be updated: no active model satisfies the requirement (%s).',
+                    $preset->identifier,
+                    (string)$preflight->missingRequirement,
+                ),
+                self::CODE_UPDATE_UNSATISFIABLE,
+            );
+        }
     }
 
     /**

--- a/Classes/Service/Preset/PresetDiff.php
+++ b/Classes/Service/Preset/PresetDiff.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Preset;
+
+/**
+ * The set of field-level deltas between a declared preset and the imported
+ * record it manages (ADR-056 update flow).
+ *
+ * The diff is computed against the record's *current* values, so it names
+ * exactly what an update would overwrite. Admin-owned fields (active state,
+ * default flag, backend groups, fallback chain) are never part of it — an
+ * update leaves them untouched. An empty diff on a drifted record is
+ * possible (e.g. the declaration only removed an optional seed, which an
+ * update does not reset): applying it just re-stamps the checksum and clears
+ * the drift hint.
+ */
+final readonly class PresetDiff
+{
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    public function __construct(
+        public string $identifier,
+        public string $name,
+        public array $changes,
+    ) {}
+
+    public function hasChanges(): bool
+    {
+        return $this->changes !== [];
+    }
+
+    /**
+     * The machine names of the changed fields, in diff order.
+     *
+     * @return list<string>
+     */
+    public function changedFields(): array
+    {
+        return array_map(static fn(PresetFieldDiff $change): string => $change->field, $this->changes);
+    }
+}

--- a/Classes/Service/Preset/PresetFieldDiff.php
+++ b/Classes/Service/Preset/PresetFieldDiff.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Preset;
+
+/**
+ * A single field-level delta between a declared preset and the imported
+ * record it manages (ADR-056 update flow).
+ *
+ * `field` is the machine name of the changed field (e.g. `temperature` or
+ * `criteria.capabilities`); `current` and `declared` are the display strings
+ * of the record's current value and the declaration's value, in the column
+ * order the re-confirm modal renders (Field, Current, Declared).
+ */
+final readonly class PresetFieldDiff
+{
+    public function __construct(
+        public string $field,
+        public string $current,
+        public string $declared,
+    ) {}
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -128,7 +128,9 @@ return [
 
     // Configuration preset routes (ADR-056): pending presets declared by
     // consuming extensions (GET, incl. preflight result per preset) and
-    // the admin-confirmed import of one preset by identifier (POST).
+    // the admin-confirmed import of one preset by identifier (POST). The
+    // diff (GET) and update (POST) endpoints drive drift resolution: review
+    // the field changes against the imported record, then re-confirm.
     'nrllm_preset_list' => [
         'path' => '/nrllm/preset/list',
         'target' => PresetController::class . '::listPresetsAction',
@@ -136,6 +138,14 @@ return [
     'nrllm_preset_import' => [
         'path' => '/nrllm/preset/import',
         'target' => PresetController::class . '::importAction',
+    ],
+    'nrllm_preset_diff' => [
+        'path' => '/nrllm/preset/diff',
+        'target' => PresetController::class . '::diffAction',
+    ],
+    'nrllm_preset_update' => [
+        'path' => '/nrllm/preset/update',
+        'target' => PresetController::class . '::updateAction',
     ],
 
     // Skill routes

--- a/Documentation/Administration/Configurations.rst
+++ b/Documentation/Administration/Configurations.rst
@@ -91,9 +91,20 @@ The panel disappears once no presets are pending.
 If a consuming extension later changes its preset
 declaration, the imported configuration is flagged
 with a :guilabel:`Preset changed` badge in the
-list. This is a hint only — the record is never
-updated automatically; review and adjust it
-manually if needed.
+list. The record is never updated automatically.
+
+Next to the badge, :guilabel:`Review update` opens
+a dialog that lists, field by field, the record's
+current value against the changed declaration.
+Confirming with :guilabel:`Apply update` overwrites
+those record fields with the declared values and
+clears the badge. Your own settings are preserved:
+whether the configuration is active or the default,
+its backend-group assignment, and its fallback chain
+are never changed. If you switched the configuration
+to fixed model selection, or the changed
+requirements no longer match any active model, the
+update is refused with the reason shown.
 
 .. _administration-configurations-test:
 

--- a/Documentation/Adr/Adr056ConfigurationPresets.rst
+++ b/Documentation/Adr/Adr056ConfigurationPresets.rst
@@ -18,8 +18,8 @@ ADR-056: Configuration presets — consumer-declared, admin-imported records
    ``nrllm_preset_import`` endpoint, and imported records whose
    declaration checksum drifted are flagged with a non-blocking hint
    (see :ref:`administration-configurations-presets`). The
-   checksum-driven *update flow* (diff + re-confirm) remains future
-   work.
+   checksum-driven *update flow* (diff + re-confirm) has also been
+   implemented — see :ref:`the amendment below <adr-056-amendment-update-flow>`.
 
 .. _adr-056-context:
 
@@ -121,9 +121,9 @@ Negative
 * v1 has no backend-module UI; admins need the AJAX endpoints (or the
   follow-up module) to see and import pending presets. *(Implemented
   since — see the note above.)*
-* The stored checksum only *detects* declaration drift; an update flow
-  (diff + re-confirm) is deliberately deferred. *(Still the case: the
-  module UI shows a drift hint, nothing more.)*
+* The stored checksum only *detects* declaration drift. *(Superseded: the
+  diff + re-confirm update flow is now implemented — see the amendment
+  below.)*
 
 .. _adr-056-alternatives:
 
@@ -143,3 +143,46 @@ and gives compile-time class references instead of stringly-typed files.
 **Fixed-mode presets naming a concrete model.** Rejected outright: it
 would invert the three-tier ownership (:ref:`ADR-001 <adr-001>`) and break
 on every instance whose admin chose a different provider.
+
+.. _adr-056-amendment-update-flow:
+
+Amendment (2026-07-14): checksum-driven update flow
+===================================================
+
+The update flow the original decision deferred is now implemented as a
+diff + re-confirm step on top of the existing drift detection, in the same
+scope (no schema change, no new ADR).
+
+**Diff is declared-versus-current.** The as-imported declaration is not
+reconstructable (only the checksum is stored), so the diff compares the
+current declaration against the record's *current* values. That is exactly
+the right basis for the admin's decision: it shows the record values an
+update would overwrite. ``ConfigurationPresetDiffService`` produces a
+``PresetDiff`` of per-field deltas; ``ConfigurationPreset::toCanonicalArray()``
+is the single field list both the checksum and the diff read, so the two
+can never disagree.
+
+**What an update applies.** Name, description and the model-selection
+criteria always follow the declaration; the optional seeds (system prompt,
+temperature, max tokens, the three daily budgets, allowed tool groups) are
+applied only when the declaration carries a value. A seed the declaration
+left ``null`` never resets the record — seeds are initial values, so the
+diff shows only fields the declaration has a value for that differ. After
+applying, the record's stored checksum is re-stamped to the current
+declaration, which clears the drift hint (an update always resolves the
+drift, even when the diff was empty because only a seed was removed).
+
+**What an update never touches.** ``is_active``, ``is_default``,
+``be_groups`` and the fallback chain are the admin's — the record stays a
+normal row (per point 3 above). If the admin switched the record to
+``fixed`` model selection, the update is refused (a typed 422): applying the
+declared criteria would override the admin's supply-side model choice.
+Updating also runs the same preflight as import, so a changed, currently
+unsatisfiable criteria set is refused with the missing requirement named.
+
+**Surface.** Two more admin-gated AJAX endpoints (``nrllm_preset_diff``
+GET, ``nrllm_preset_update`` POST; guard per :ref:`ADR-037 <adr-037>`).
+The Configurations module renders a "Review update" action next to the
+drift hint that opens the diff in a re-confirm modal;
+``nrllm_preset_list``'s ``drifted`` entries additively gained a
+``changedFields`` summary (existing keys unchanged).

--- a/Documentation/Developer/ConfigurationPresets.rst
+++ b/Documentation/Developer/ConfigurationPresets.rst
@@ -122,10 +122,41 @@ Change detection
 ``nrllm_preset_list`` additionally returns a ``drifted`` list: imported
 presets whose current declaration checksum no longer matches the
 ``preset_checksum`` stored at import time. Each entry carries
-``identifier``, ``name``, and ``configurationUid``. The Configurations
-module flags such records with a non-blocking "Preset changed" hint.
+``identifier``, ``name``, ``configurationUid``, and ``changedFields`` — the
+machine names of the fields an update would overwrite (an additive summary;
+may be empty when the declaration only dropped an optional seed). The
+Configurations module flags such records with a non-blocking "Preset
+changed" hint next to a :guilabel:`Review update` action.
 
-Detection only: nr_llm never updates an imported record automatically.
-If your extension changes a preset declaration, document what admins
-should adjust — the checksum-driven update flow (diff + re-confirm) is
-deliberately deferred (:ref:`ADR-056 <adr-056>`).
+nr_llm never updates an imported record automatically, but the admin can
+review and apply a changed declaration.
+
+.. _developer-configuration-presets-update:
+
+Update flow
+===========
+
+Two further admin-gated AJAX endpoints resolve drift:
+
+#. ``nrllm_preset_diff`` (GET, ``identifier``) returns the field-level
+   ``changes`` an update would apply — each a ``field`` (machine name, e.g.
+   ``temperature`` or ``criteria.capabilities``), the record's ``current``
+   value, and the ``declared`` value. It refuses (422) when there is nothing
+   to update: the record is up to date, was not imported from a preset, was
+   switched to ``fixed`` model selection, or the changed criteria are
+   currently unsatisfiable.
+#. ``nrllm_preset_update`` (POST, ``identifier``) applies a reviewed update
+   after the admin re-confirmed, then returns the ``changedFields`` that were
+   applied.
+
+An update follows the declaration for name, description and criteria, and
+for each optional seed that carries a value; a seed the declaration left
+``null`` does not reset the record. It leaves the admin-owned fields
+untouched — active state, default flag, backend groups, and the fallback
+chain — and re-stamps the stored checksum so the drift hint clears. See
+:ref:`ADR-056 <adr-056>` for the design.
+
+When your extension changes a preset declaration, ship the change; admins
+see the drift hint and re-confirm the diff. Document only anything the flow
+cannot carry (for example a change that also needs a new provider or model
+configured first).

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1014,6 +1014,10 @@
                 <source>The preset declaration changed since this configuration was imported. Review the record; it is not updated automatically.</source>
                 <target>Die Preset-Deklaration hat sich seit dem Import dieser Konfiguration geändert. Prüfen Sie den Datensatz; er wird nicht automatisch aktualisiert.</target>
             </trans-unit>
+            <trans-unit id="configuration.presets.update.review">
+                <source>Review update</source>
+                <target>Aktualisierung prüfen</target>
+            </trans-unit>
             <trans-unit id="task.empty.title">
                 <source>No Tasks Configured</source>
                 <target>Keine Aufgaben konfiguriert</target>
@@ -2171,6 +2175,14 @@
             <trans-unit id="error.preset.unknown">
                 <source>Unknown preset</source>
                 <target>Unbekanntes Preset</target>
+            </trans-unit>
+            <trans-unit id="error.preset.notDrifted">
+                <source>This configuration is up to date; there is nothing to update.</source>
+                <target>Diese Konfiguration ist aktuell; es gibt nichts zu aktualisieren.</target>
+            </trans-unit>
+            <trans-unit id="error.preset.modeSwitched">
+                <source>This configuration was switched to fixed model selection; the preset update is refused so the administrator's model choice is not overridden.</source>
+                <target>Diese Konfiguration wurde auf feste Modellauswahl umgestellt; die Preset-Aktualisierung wird abgelehnt, damit die Modellwahl des Administrators nicht überschrieben wird.</target>
             </trans-unit>
             <trans-unit id="error.model.noModelUid">
                 <source>No model UID specified</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -770,6 +770,9 @@
             <trans-unit id="configuration.presets.drift.title">
                 <source>The preset declaration changed since this configuration was imported. Review the record; it is not updated automatically.</source>
             </trans-unit>
+            <trans-unit id="configuration.presets.update.review">
+                <source>Review update</source>
+            </trans-unit>
             <trans-unit id="task.empty.title">
                 <source>No Tasks Configured</source>
             </trans-unit>
@@ -1642,6 +1645,12 @@
             </trans-unit>
             <trans-unit id="error.preset.unknown">
                 <source>Unknown preset</source>
+            </trans-unit>
+            <trans-unit id="error.preset.notDrifted">
+                <source>This configuration is up to date; there is nothing to update.</source>
+            </trans-unit>
+            <trans-unit id="error.preset.modeSwitched">
+                <source>This configuration was switched to fixed model selection; the preset update is refused so the administrator's model choice is not overridden.</source>
             </trans-unit>
             <trans-unit id="error.model.noModelUid">
                 <source>No model UID specified</source>

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -128,9 +128,17 @@
                                         <f:if condition="{config.isDefault}">
                                             <span class="badge text-bg-primary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:default" default="Default" /></span>
                                         </f:if>
-                                        <f:comment>Checksum drift hint (ADR-056): the imported preset's declaration changed — hint only, no auto-update.</f:comment>
-                                        <f:if condition="{driftedUids.{config.uid}}">
+                                        <f:comment>Checksum drift hint (ADR-056): the imported preset's declaration changed. The "Review update" button opens the diff + re-confirm flow.</f:comment>
+                                        <f:if condition="{driftedIdentifiers.{config.uid}}">
                                             <span class="badge text-bg-warning" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.drift.title')}"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.drift.badge" default="Preset changed" /></span>
+                                            <button type="button" class="btn btn-warning btn-sm js-review-preset-update"
+                                                    data-identifier="{driftedIdentifiers.{config.uid}}"
+                                                    data-name="{config.name}"
+                                                    title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.update.review')}"
+                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.update.review')}">
+                                                <core:icon identifier="actions-refresh" size="small" />
+                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.update.review" default="Review update" />
+                                            </button>
                                         </f:if>
                                         <f:if condition="{config.description}">
                                             <br /><span class="text-body-secondary">{config.description}</span>

--- a/Resources/Public/JavaScript/Backend/ConfigurationList.js
+++ b/Resources/Public/JavaScript/Backend/ConfigurationList.js
@@ -65,6 +65,15 @@ class ConfigurationList {
                 e.preventDefault();
                 e.stopPropagation();
                 this.handleImportPreset(importBtn);
+                return;
+            }
+
+            // Review + apply a drifted preset update (ADR-056)
+            const reviewBtn = e.target.closest('.js-review-preset-update');
+            if (reviewBtn) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.handleReviewPresetUpdate(reviewBtn);
             }
         });
 
@@ -91,6 +100,136 @@ class ConfigurationList {
         formData.append('identifier', identifier);
 
         postAndReload(url, formData, btn);
+    }
+
+    handleReviewPresetUpdate(btn) {
+        const identifier = btn.dataset.identifier;
+        const name = btn.dataset.name || 'Configuration';
+        const diffUrl = TYPO3.settings.ajaxUrls['nrllm_preset_diff'];
+        const updateUrl = TYPO3.settings.ajaxUrls['nrllm_preset_update'];
+
+        if (!diffUrl || !updateUrl) {
+            Notification.error('Error', 'AJAX URL not configured');
+            return;
+        }
+
+        new AjaxRequest(diffUrl)
+            .withQueryArguments({ identifier })
+            .get()
+            .then(response => response.resolve())
+            .then(data => {
+                if (!data.success) {
+                    Notification.error('Error', data.error || 'Unknown error');
+                    return;
+                }
+                this.openPresetUpdateModal(name, identifier, data.changes || [], updateUrl);
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
+    }
+
+    openPresetUpdateModal(name, identifier, changes, updateUrl) {
+        Modal.advanced({
+            title: `Review preset update: ${name}`,
+            content: this.buildPresetDiffContent(changes),
+            severity: Severity.warning,
+            size: Modal.sizes.medium,
+            buttons: [
+                {
+                    text: 'Cancel',
+                    btnClass: 'btn-default',
+                    trigger: () => Modal.dismiss(),
+                },
+                {
+                    text: 'Apply update',
+                    btnClass: 'btn-warning',
+                    trigger: () => this.applyPresetUpdate(identifier, updateUrl),
+                },
+            ],
+        });
+    }
+
+    /**
+     * Build the diff table as a DOM element. Every declared/current value is a
+     * text node (textContent), so untrusted preset content cannot execute as
+     * markup.
+     */
+    buildPresetDiffContent(changes) {
+        const container = document.createElement('div');
+
+        const intro = document.createElement('p');
+        intro.textContent = 'Applying this update overwrites the current record values shown below with the '
+            + 'declared values. Your activation, default flag, backend-group assignment and fallback chain are preserved.';
+        container.appendChild(intro);
+
+        if (changes.length === 0) {
+            const note = document.createElement('p');
+            note.className = 'text-body-secondary mb-0';
+            note.textContent = 'The declaration changed but no record field differs; applying will clear the change hint.';
+            container.appendChild(note);
+            return container;
+        }
+
+        const wrap = document.createElement('div');
+        wrap.className = 'table-fit mb-0';
+        const table = document.createElement('table');
+        table.className = 'table table-striped';
+
+        const thead = document.createElement('thead');
+        const headRow = document.createElement('tr');
+        ['Field', 'Current value', 'Declared value'].forEach(label => {
+            const th = document.createElement('th');
+            th.scope = 'col';
+            th.textContent = label;
+            headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+        changes.forEach(change => {
+            const row = document.createElement('tr');
+
+            const fieldCell = document.createElement('td');
+            const code = document.createElement('code');
+            code.textContent = change.field;
+            fieldCell.appendChild(code);
+            row.appendChild(fieldCell);
+
+            [change.current, change.declared].forEach(value => {
+                const cell = document.createElement('td');
+                cell.textContent = value;
+                row.appendChild(cell);
+            });
+
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+        wrap.appendChild(table);
+        container.appendChild(wrap);
+
+        return container;
+    }
+
+    applyPresetUpdate(identifier, updateUrl) {
+        const formData = new FormData();
+        formData.append('identifier', identifier);
+
+        new AjaxRequest(updateUrl)
+            .post(formData)
+            .then(response => response.resolve())
+            .then(data => {
+                if (data.success) {
+                    Modal.dismiss();
+                    location.reload();
+                } else {
+                    Notification.error('Error', data.error || 'Unknown error');
+                }
+            })
+            .catch(async err => {
+                Notification.error('Error', await readAjaxError(err));
+            });
     }
 
     handleTestConfig(btn) {

--- a/Tests/Unit/Controller/Backend/PresetControllerTest.php
+++ b/Tests/Unit/Controller/Backend/PresetControllerTest.php
@@ -11,11 +11,13 @@ namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\PresetController;
 use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
+use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Tests\Unit\Service\Preset\Fixtures\FixturePresetProvider;
@@ -91,13 +93,32 @@ final class PresetControllerTest extends TestCase
         $modelSelection->method('findCandidates')->willReturn([]);
 
         $registry = new ConfigurationPresetRegistry([new FixturePresetProvider($presets)], $repository);
+        $diffService = new ConfigurationPresetDiffService();
         $importService = new ConfigurationPresetImportService(
             $modelSelection,
             $repository,
             $this->createMock(PersistenceManagerInterface::class),
+            $diffService,
         );
 
-        return new PresetController($registry, $importService);
+        return new PresetController($registry, $importService, $diffService, $repository);
+    }
+
+    /**
+     * A criteria-mode record for the {@see preset()} identifier whose stored
+     * checksum differs from the current declaration — i.e. drifted. Its name
+     * differs so an update produces a non-empty diff.
+     */
+    private static function driftedRecord(): LlmConfiguration
+    {
+        $record = new LlmConfiguration();
+        $record->setIdentifier('ext.chat');
+        $record->setModelSelectionMode(ModelSelectionMode::CRITERIA->value);
+        $record->setModelSelectionCriteriaDTO(new ModelSelectionCriteria(capabilities: ['chat']));
+        $record->setName('Old chat');
+        $record->setPresetChecksum('0000000000000000000000000000000000000000000000000000000000000000');
+
+        return $record;
     }
 
     /**
@@ -245,5 +266,127 @@ final class PresetControllerTest extends TestCase
         self::assertFalse($body['success']);
         assert(isset($body['error']) && is_string($body['error']));
         self::assertStringContainsString('capabilities: chat', $body['error']);
+    }
+
+    #[Test]
+    public function listPresetsSummarisesDriftedChangedFields(): void
+    {
+        $configuration = self::driftedRecord();
+        $configuration->_setProperty('uid', 7);
+        $controller = $this->createController([self::preset()], existing: $configuration);
+
+        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+
+        assert(isset($body['drifted']) && is_array($body['drifted']));
+        $entry = $body['drifted'][0];
+        assert(is_array($entry) && isset($entry['changedFields']) && is_array($entry['changedFields']));
+        self::assertContains('name', $entry['changedFields']);
+    }
+
+    #[Test]
+    public function diffDeniesNonAdmin(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        $controller = $this->createController([]);
+
+        self::assertSame(403, $controller->diffAction(new ServerRequest())->getStatusCode());
+    }
+
+    #[Test]
+    public function updateDeniesNonAdmin(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        $controller = $this->createController([]);
+
+        self::assertSame(403, $controller->updateAction(new ServerRequest())->getStatusCode());
+    }
+
+    #[Test]
+    public function diffReturns404ForUnknownIdentifier(): void
+    {
+        $controller = $this->createController([self::preset()]);
+        $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.unknown']);
+
+        self::assertSame(404, $controller->diffAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function diffReturns422WhenNothingImported(): void
+    {
+        $controller = $this->createController([self::preset()], existing: null);
+        $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.chat']);
+
+        self::assertSame(422, $controller->diffAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function diffReturnsChangesForDriftedRecord(): void
+    {
+        $controller = $this->createController([self::preset()], existing: self::driftedRecord(), matchedModel: new Model());
+        $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.chat']);
+
+        $response = $controller->diffAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = self::decode($response);
+        self::assertTrue($body['success']);
+        self::assertSame('ext.chat', $body['identifier']);
+        assert(isset($body['changes']) && is_array($body['changes']));
+        $fields = [];
+        foreach ($body['changes'] as $change) {
+            assert(is_array($change) && isset($change['field']) && is_string($change['field']));
+            $fields[] = $change['field'];
+        }
+        self::assertContains('name', $fields);
+    }
+
+    #[Test]
+    public function updateAppliesDriftedRecordAndReturnsChangedFields(): void
+    {
+        $controller = $this->createController([self::preset()], existing: self::driftedRecord(), matchedModel: new Model());
+        $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
+
+        $response = $controller->updateAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = self::decode($response);
+        self::assertTrue($body['success']);
+        self::assertSame('ext.chat', $body['identifier']);
+        assert(isset($body['changedFields']) && is_array($body['changedFields']));
+        self::assertContains('name', $body['changedFields']);
+    }
+
+    #[Test]
+    public function updateReturns422WhenModeSwitchedToFixed(): void
+    {
+        $record = self::driftedRecord();
+        $record->setModelSelectionMode(ModelSelectionMode::FIXED->value);
+        $controller = $this->createController([self::preset()], existing: $record, matchedModel: new Model());
+        $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
+
+        $response = $controller->updateAction($request);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertFalse(self::decode($response)['success']);
+    }
+
+    #[Test]
+    public function updateReturns422WhenRecordNotDrifted(): void
+    {
+        $record = self::driftedRecord();
+        $record->setPresetChecksum(self::preset()->checksum());
+        $controller = $this->createController([self::preset()], existing: $record, matchedModel: new Model());
+        $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
+
+        self::assertSame(422, $controller->updateAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function updateReturns404ForUnknownIdentifier(): void
+    {
+        $controller = $this->createController([self::preset()]);
+        $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.unknown']);
+
+        self::assertSame(404, $controller->updateAction($request)->getStatusCode());
     }
 }

--- a/Tests/Unit/Service/Preset/ConfigurationPresetDiffServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetDiffServiceTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Preset;
+
+use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
+use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
+use Netresearch\NrLlm\Service\Preset\PresetFieldDiff;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigurationPresetDiffService::class)]
+final class ConfigurationPresetDiffServiceTest extends TestCase
+{
+    private ConfigurationPresetDiffService $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new ConfigurationPresetDiffService();
+    }
+
+    /**
+     * A record whose values match {@see baselinePreset()} field for field.
+     */
+    private static function baselineRecord(): LlmConfiguration
+    {
+        $record = new LlmConfiguration();
+        $record->setIdentifier('ext.chat');
+        $record->setName('Chat');
+        $record->setDescription('A chat preset.');
+        $record->setModelSelectionMode(ModelSelectionMode::CRITERIA->value);
+        $record->setModelSelectionCriteriaDTO(new ModelSelectionCriteria(capabilities: ['chat']));
+        $record->setSystemPrompt('You are helpful.');
+        $record->setTemperature(0.2);
+        $record->setMaxTokens(2000);
+        $record->setAllowedToolGroups('rag,content');
+
+        return $record;
+    }
+
+    private static function baselinePreset(): ConfigurationPreset
+    {
+        return new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.2,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+    }
+
+    /**
+     * @param list<PresetFieldDiff> $changes
+     */
+    private static function change(array $changes, string $field): PresetFieldDiff
+    {
+        foreach ($changes as $change) {
+            if ($change->field === $field) {
+                return $change;
+            }
+        }
+        self::fail(sprintf('No diff entry for field "%s".', $field));
+    }
+
+    #[Test]
+    public function reportsNoChangeWhenDeclarationMatchesRecord(): void
+    {
+        $diff = $this->subject->diff(self::baselinePreset(), self::baselineRecord());
+
+        self::assertFalse($diff->hasChanges());
+        self::assertSame([], $diff->changedFields());
+        self::assertSame('ext.chat', $diff->identifier);
+    }
+
+    #[Test]
+    public function reportsNameAndDescriptionChanges(): void
+    {
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat v2',
+            description: 'Updated.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.2,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+
+        $changes = $this->subject->diff($preset, self::baselineRecord())->changes;
+
+        self::assertSame('Chat', self::change($changes, 'name')->current);
+        self::assertSame('Chat v2', self::change($changes, 'name')->declared);
+        self::assertSame('Updated.', self::change($changes, 'description')->declared);
+    }
+
+    #[Test]
+    public function reportsTemperatureChangeAtColumnScale(): void
+    {
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.9,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+
+        $change = self::change($this->subject->diff($preset, self::baselineRecord())->changes, 'temperature');
+
+        self::assertSame('0.20', $change->current);
+        self::assertSame('0.90', $change->declared);
+    }
+
+    #[Test]
+    public function ignoresSubScaleTemperatureDifference(): void
+    {
+        // 0.201 rounds to the decimal(3,2) column value 0.20 the record holds.
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.201,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+
+        $diff = $this->subject->diff($preset, self::baselineRecord());
+
+        self::assertNotContains('temperature', $diff->changedFields());
+    }
+
+    #[Test]
+    public function reportsCriteriaSubfieldChanges(): void
+    {
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(
+                capabilities: ['chat', 'vision'],
+                minContextLength: 8000,
+                preferLowestCost: true,
+            ),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.2,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+
+        $changes = $this->subject->diff($preset, self::baselineRecord())->changes;
+
+        self::assertSame('chat', self::change($changes, 'criteria.capabilities')->current);
+        self::assertSame('chat, vision', self::change($changes, 'criteria.capabilities')->declared);
+        self::assertSame('0', self::change($changes, 'criteria.minContextLength')->current);
+        self::assertSame('8000', self::change($changes, 'criteria.minContextLength')->declared);
+        self::assertSame('false', self::change($changes, 'criteria.preferLowestCost')->current);
+        self::assertSame('true', self::change($changes, 'criteria.preferLowestCost')->declared);
+    }
+
+    #[Test]
+    public function normalizesToolGroupsOrderBetweenCsvAndList(): void
+    {
+        // Declared list order differs from the record's CSV order, but the
+        // sets are equal, so it is not a change.
+        $record = self::baselineRecord();
+        $record->setAllowedToolGroups('content,rag');
+
+        $diff = $this->subject->diff(self::baselinePreset(), $record);
+
+        self::assertNotContains('allowedToolGroups', $diff->changedFields());
+    }
+
+    #[Test]
+    public function reportsToolGroupsSetChange(): void
+    {
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.2,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag'],
+        );
+
+        $diff = $this->subject->diff($preset, self::baselineRecord());
+
+        self::assertContains('allowedToolGroups', $diff->changedFields());
+    }
+
+    #[Test]
+    public function nullSeedIsNeverReportedEvenWhenRecordDiffers(): void
+    {
+        // The declaration carries no temperature seed: even though the record
+        // holds 0.2, the update would not reset it, so it is not a change.
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            systemPrompt: 'You are helpful.',
+            temperature: null,
+            maxTokens: 2000,
+            allowedToolGroups: ['rag', 'content'],
+        );
+
+        $diff = $this->subject->diff($preset, self::baselineRecord());
+
+        self::assertNotContains('temperature', $diff->changedFields());
+    }
+
+    #[Test]
+    public function adminOwnedFieldsNeverAffectTheDiff(): void
+    {
+        // Flipping the record's activation / default flags produces no diff
+        // entry: those fields are structurally absent from a preset.
+        $record = self::baselineRecord();
+        $record->setIsActive(true);
+        $record->setIsDefault(true);
+
+        $diff = $this->subject->diff(self::baselinePreset(), $record);
+
+        self::assertFalse($diff->hasChanges());
+    }
+}

--- a/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -44,6 +45,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
             $this->modelSelectionService,
             $this->configurationRepository,
             $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
         );
     }
 
@@ -202,5 +204,212 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->expectExceptionCode(1789347006);
 
         $this->subject->import(self::preset());
+    }
+
+    /**
+     * A changed declaration for the same identifier: name, description,
+     * temperature and criteria all differ from {@see preset()}.
+     */
+    private static function changedPreset(): ConfigurationPreset
+    {
+        return new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat v2',
+            description: 'An updated chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat', 'tools', 'vision'], minContextLength: 16000),
+            systemPrompt: 'You are very helpful.',
+            temperature: 0.9,
+            maxTokens: 4000,
+            maxRequestsPerDay: 100,
+            maxTokensPerDay: 50000,
+            maxCostPerDay: 5.0,
+            allowedToolGroups: ['rag', 'content'],
+        );
+    }
+
+    /**
+     * A criteria-mode record as imported from $importedFrom: its stored
+     * checksum is that declaration's, so passing a *different* declaration to
+     * update() makes it drifted.
+     */
+    private static function recordImportedFrom(ConfigurationPreset $importedFrom): LlmConfiguration
+    {
+        $record = new LlmConfiguration();
+        $record->setIdentifier($importedFrom->identifier);
+        $record->setModelSelectionMode(ModelSelectionMode::CRITERIA->value);
+        $record->setModelSelectionCriteriaDTO($importedFrom->criteria);
+        $record->setName($importedFrom->name);
+        $record->setDescription($importedFrom->description);
+        if ($importedFrom->systemPrompt !== null) {
+            $record->setSystemPrompt($importedFrom->systemPrompt);
+        }
+        if ($importedFrom->temperature !== null) {
+            $record->setTemperature($importedFrom->temperature);
+        }
+        if ($importedFrom->maxTokens !== null) {
+            $record->setMaxTokens($importedFrom->maxTokens);
+        }
+        if ($importedFrom->maxRequestsPerDay !== null) {
+            $record->setMaxRequestsPerDay($importedFrom->maxRequestsPerDay);
+        }
+        if ($importedFrom->maxTokensPerDay !== null) {
+            $record->setMaxTokensPerDay($importedFrom->maxTokensPerDay);
+        }
+        if ($importedFrom->maxCostPerDay !== null) {
+            $record->setMaxCostPerDay($importedFrom->maxCostPerDay);
+        }
+        if ($importedFrom->allowedToolGroups !== []) {
+            $record->setAllowedToolGroups(implode(',', $importedFrom->allowedToolGroups));
+        }
+        $record->setPresetChecksum($importedFrom->checksum());
+
+        return $record;
+    }
+
+    #[Test]
+    public function updateAppliesDeclaredFieldsAndRestampsChecksum(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
+        $this->configurationRepository->expects(self::once())->method('update')->with($record);
+        $this->persistenceManager->expects(self::once())->method('persistAll');
+
+        $diff = $this->subject->update($preset, $record);
+
+        self::assertSame('Chat v2', $record->getName());
+        self::assertSame('An updated chat preset.', $record->getDescription());
+        self::assertSame(0.9, $record->getTemperature());
+        self::assertSame(4000, $record->getMaxTokens());
+        self::assertSame($preset->criteria->toArray(), $record->getModelSelectionCriteriaDTO()->toArray());
+        self::assertSame($preset->checksum(), $record->getPresetChecksum());
+        self::assertContains('name', $diff->changedFields());
+        self::assertContains('temperature', $diff->changedFields());
+        self::assertContains('criteria.capabilities', $diff->changedFields());
+    }
+
+    #[Test]
+    public function updateLeavesAdminOwnedFieldsUntouched(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $record->setIsActive(true);
+        $record->setIsDefault(true);
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
+
+        $this->subject->update($preset, $record);
+
+        self::assertTrue($record->getIsActive());
+        self::assertTrue($record->getIsDefault());
+    }
+
+    #[Test]
+    public function updateDoesNotResetRecordValueForNullSeed(): void
+    {
+        // The changed declaration removed the temperature seed (null): the
+        // record keeps its imported temperature, and temperature is not in the
+        // diff — yet the checksum change still resolves the drift.
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat', 'tools'], minContextLength: 8000),
+            systemPrompt: 'You are helpful.',
+            temperature: null,
+            maxTokens: 2000,
+        );
+        $record = self::recordImportedFrom(self::preset());
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
+
+        $diff = $this->subject->update($preset, $record);
+
+        self::assertSame(0.2, $record->getTemperature());
+        self::assertNotContains('temperature', $diff->changedFields());
+        self::assertSame($preset->checksum(), $record->getPresetChecksum());
+    }
+
+    #[Test]
+    public function updateRefusesWhenRecordIsNotDrifted(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom($preset); // stored checksum equals current declaration
+        $this->configurationRepository->expects(self::never())->method('update');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ConfigurationPresetImportService::CODE_UPDATE_NOT_DRIFTED);
+
+        $this->subject->update($preset, $record);
+    }
+
+    #[Test]
+    public function updateRefusesWhenRecordCarriesNoStoredChecksum(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $record->setPresetChecksum('');
+        $this->configurationRepository->expects(self::never())->method('update');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ConfigurationPresetImportService::CODE_UPDATE_NOT_DRIFTED);
+
+        $this->subject->update($preset, $record);
+    }
+
+    #[Test]
+    public function updateRefusesWhenModeSwitchedToFixed(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $record->setModelSelectionMode(ModelSelectionMode::FIXED->value);
+        $this->configurationRepository->expects(self::never())->method('update');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ConfigurationPresetImportService::CODE_UPDATE_MODE_SWITCHED);
+
+        $this->subject->update($preset, $record);
+    }
+
+    #[Test]
+    public function updateRefusesWhenUpdatedCriteriaUnsatisfiable(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+        $this->configurationRepository->expects(self::never())->method('update');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ConfigurationPresetImportService::CODE_UPDATE_UNSATISFIABLE);
+
+        $this->subject->update($preset, $record);
+    }
+
+    #[Test]
+    public function updateRefusesWhenRecordBelongsToAnotherIdentifier(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $record->setIdentifier('ext.other');
+        $this->configurationRepository->expects(self::never())->method('update');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ConfigurationPresetImportService::CODE_UPDATE_IDENTIFIER_MISMATCH);
+
+        $this->subject->update($preset, $record);
+    }
+
+    #[Test]
+    public function previewUpdateReturnsDiffWithoutPersisting(): void
+    {
+        $preset = self::changedPreset();
+        $record = self::recordImportedFrom(self::preset());
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
+        $this->configurationRepository->expects(self::never())->method('update');
+        $this->persistenceManager->expects(self::never())->method('persistAll');
+
+        $diff = $this->subject->previewUpdate($preset, $record);
+
+        self::assertTrue($diff->hasChanges());
+        self::assertContains('description', $diff->changedFields());
     }
 }

--- a/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
@@ -142,12 +142,12 @@ final class ConfigurationPresetTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode($expectedCode);
 
-        new ConfigurationPreset(...([
+        self::assertInstanceOf(ConfigurationPreset::class, new ConfigurationPreset(...([
             'identifier' => 'ext.chat',
             'name' => 'Name',
             'description' => '',
             'criteria' => self::chatCriteria(),
-        ] + $seed));
+        ] + $seed)));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
@@ -114,6 +114,42 @@ final class ConfigurationPresetTest extends TestCase
         );
     }
 
+    /**
+     * @return array<string, array{array<string, mixed>, int}>
+     */
+    public static function outOfRangeSeeds(): array
+    {
+        return [
+            'temperature above 2.0' => [['temperature' => 2.5], 1789347006],
+            'temperature below 0.0' => [['temperature' => -0.1], 1789347006],
+            'maxTokens zero'        => [['maxTokens' => 0], 1789347007],
+            'negative requests'     => [['maxRequestsPerDay' => -1], 1789347008],
+            'negative tokens/day'   => [['maxTokensPerDay' => -1], 1789347008],
+            'negative cost/day'     => [['maxCostPerDay' => -0.01], 1789347009],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $seed
+     */
+    #[Test]
+    #[DataProvider('outOfRangeSeeds')]
+    public function rejectsOutOfRangeSeed(array $seed, int $expectedCode): void
+    {
+        // A declared seed outside the range LlmConfiguration's setters accept
+        // would be silently clamped on import/update while the diff dialog and
+        // checksum show the raw value — reject it at registration instead.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode($expectedCode);
+
+        new ConfigurationPreset(...([
+            'identifier' => 'ext.chat',
+            'name' => 'Name',
+            'description' => '',
+            'criteria' => self::chatCriteria(),
+        ] + $seed));
+    }
+
     #[Test]
     public function acceptsMultibyteNameUpToTheCharacterLimit(): void
     {

--- a/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
@@ -210,4 +210,70 @@ final class ConfigurationPresetTest extends TestCase
         self::assertNotSame($base->checksum(), $changedCriteria->checksum());
         self::assertNotSame($base->checksum(), $changedOptional->checksum());
     }
+
+    #[Test]
+    public function canonicalArrayCarriesEveryDeclaredField(): void
+    {
+        $preset = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat', 'tools']),
+            systemPrompt: 'You are helpful.',
+            temperature: 0.2,
+            maxTokens: 2000,
+            maxRequestsPerDay: 100,
+            maxTokensPerDay: 50000,
+            maxCostPerDay: 5.0,
+            allowedToolGroups: ['rag'],
+        );
+
+        $canonical = $preset->toCanonicalArray();
+
+        self::assertSame([
+            'allowedToolGroups' => ['rag'],
+            'criteria' => $preset->criteria->toArray(),
+            'description' => 'A chat preset.',
+            'identifier' => 'ext.chat',
+            'maxCostPerDay' => 5.0,
+            'maxRequestsPerDay' => 100,
+            'maxTokens' => 2000,
+            'maxTokensPerDay' => 50000,
+            'name' => 'Chat',
+            'systemPrompt' => 'You are helpful.',
+            'temperature' => 0.2,
+        ], $canonical);
+    }
+
+    #[Test]
+    public function checksumTracksTheCanonicalArray(): void
+    {
+        // The checksum and the canonical array are computed from the same
+        // field list: a preset whose canonical array differs must have a
+        // different checksum, and vice versa.
+        $base = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+        );
+        $same = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+        );
+        $changed = new ConfigurationPreset(
+            identifier: 'ext.chat',
+            name: 'Chat',
+            description: 'A chat preset.',
+            criteria: new ModelSelectionCriteria(capabilities: ['chat']),
+            maxTokens: 1234,
+        );
+
+        self::assertSame($base->toCanonicalArray(), $same->toCanonicalArray());
+        self::assertSame($base->checksum(), $same->checksum());
+        self::assertNotSame($base->toCanonicalArray(), $changed->toCanonicalArray());
+        self::assertNotSame($base->checksum(), $changed->checksum());
+    }
 }


### PR DESCRIPTION
## Summary

Implements the checksum-driven preset **update flow** ADR-056 marked as future work. Until now a drifted configuration preset (declaration checksum ≠ stored checksum) showed only an inert "Preset changed" badge; admins had no way to review or apply the change short of deleting and re-importing.

## Design decisions

1. **Diff = declared preset vs. record's CURRENT values.** Only the checksum is persisted, not the as-imported payload, so the diff is computed against the live record. This is deliberately correct: the re-confirm modal shows exactly the record values an update would overwrite.
2. **`ConfigurationPreset::toCanonicalArray()` extracted** and shared by `checksum()` and the diff, so the field list cannot diverge.
3. **`update()` never touches admin-owned fields** — `is_active`, `is_default`, `be_groups`, `fallback_chain` stay as the admin set them (ADR-056 guarantees the record is a normal, editable row).
4. **Refuses if `model_selection_mode` was switched away from criteria** (422) — re-applying criteria would override the admin's supply-side decision.
5. **Null-seed rule:** a declared seed that is null does not reset the record column; only fields the declaration has a value for and that differ appear in the diff and are applied. `update()` re-stamps the checksum, clearing the drift hint.
6. **Preflight before apply:** the new criteria run through the real `ModelSelectionService`; unsatisfiable criteria refuse with a reason.

## Changes

- `ConfigurationPresetImportService::update()` + diff computation; new `PresetDiff` DTO.
- `PresetController::diffAction` (GET) + `updateAction` (POST), admin-gated first (ADR-037); drifted list entries carry a diff summary (additive, BC).
- Routes `nrllm_preset_diff` / `nrllm_preset_update`.
- Review-update button on drifted rows → diff modal (Modal.advanced + HtmlEscape) → confirm → `postAndReload`.
- XLIFF EN + DE.
- ADR-056 amendment; Developer + Administration docs updated.

## Tests

- `toCanonicalArray`/checksum coherence.
- Diff per field type: string, float epsilon, criteria sub-fields, toolGroups CSV↔list normalization, null-seed omission, admin-owned fields never in diff.
- `update()`: apply + checksum re-stamp; refusals (not drifted, mode switched, unsatisfiable); admin-owned untouched; null-seed leaves record value.
- `PresetControllerTest`: non-admin denial, 404, 422 variants, success shape.

Gates run locally: unit, functional (SQLite), cgl, phpstan (level 10).