### PR TITLE
feat: telemetry middleware records every pipeline run (failures included)

### DIFF
--- a/Classes/Command/PurgeTelemetryCommand.php
+++ b/Classes/Command/PurgeTelemetryCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Prunes old rows from the telemetry log (ADR-058).
+ *
+ * Telemetry appends one row per provider pipeline run, so the table grows with
+ * traffic. This command bounds that growth by deleting rows older than a
+ * retention window (default 30 days). Run it from the scheduler or cron.
+ */
+#[AsCommand(
+    name: 'nrllm:telemetry:purge',
+    description: 'Delete provider telemetry rows older than the retention window (default 30 days).',
+)]
+final class PurgeTelemetryCommand extends Command
+{
+    private const DEFAULT_DAYS = 30;
+
+    public function __construct(
+        private readonly TelemetryRepositoryInterface $repository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'days',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Delete telemetry rows older than this many days.',
+            self::DEFAULT_DAYS,
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $daysOption = $input->getOption('days');
+        $days       = is_numeric($daysOption) ? (int)$daysOption : 0;
+
+        if ($days < 1) {
+            $io->error('The --days option must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $cutoff  = time() - ($days * 86400);
+        $deleted = $this->repository->purgeOlderThan($cutoff);
+
+        $io->success(sprintf('Deleted %d telemetry row(s) older than %d day(s).', $deleted, $days));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -51,8 +51,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.
  *
- * The default pipeline order is pinned via tag priority (Cache outermost at
- * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
+ * The default pipeline order is pinned via tag priority (Telemetry outermost
+ * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
+ * Usage innermost at 25).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 75])]
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -50,16 +50,20 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *
  * Pipeline ordering
  * -----------------
- * Cache must be the OUTERMOST layer so a cache hit skips even the fallback
- * attempt and is NOT counted against a user's budget. This order is pinned
- * via the tag priority below (highest priority = first in the autowired
+ * Cache is the outermost BEHAVIOURAL layer so a cache hit skips even the
+ * fallback attempt and is NOT counted against a user's budget. Only the
+ * observation-only TelemetryMiddleware (priority 110) sits further out, so a
+ * cache-served response still produces a telemetry row; on a hit this
+ * middleware flags that row via the shared telemetry signals. This order is
+ * pinned via the tag priority below (highest priority = first in the autowired
  * iterator = outermost in the pipeline):
  *
- *   CacheMiddleware          <-- outermost; short-circuits on hit (priority 100)
- *     BudgetMiddleware       <-- pre-flight only on miss            (priority 75)
- *       FallbackMiddleware   <-- swaps config on retryable failure  (priority 50)
- *         UsageMiddleware    <-- records the call that actually ran (priority 25)
- *           <terminal>
+ *   TelemetryMiddleware      <-- outermost; observation only        (priority 110)
+ *     CacheMiddleware        <-- short-circuits on hit              (priority 100)
+ *       BudgetMiddleware     <-- pre-flight only on miss            (priority 75)
+ *         FallbackMiddleware <-- swaps config on retryable failure  (priority 50)
+ *           UsageMiddleware  <-- records the call that actually ran (priority 25)
+ *             <terminal>
  *
  * Callers who want cache accounting (count hits against budget / usage)
  * should assemble a custom pipeline with Cache *inside* those layers — it is
@@ -93,6 +97,11 @@ final readonly class CacheMiddleware implements ProviderMiddlewareInterface
 
         $cached = $this->cache->get($key);
         if ($cached !== null) {
+            // Signal the outer TelemetryMiddleware (ADR-058) that this run was
+            // served from cache. The context is shared across the pipeline, so
+            // annotating its mutable signal sink is visible after the unwind.
+            $context->telemetrySignals->recordCacheHit();
+
             return $cached;
         }
 

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -37,8 +37,9 @@ use Throwable;
  * Fallback is shallow: a fallback configuration's own chain is ignored to
  * prevent recursion and cycles.
  *
- * The default pipeline order is pinned via tag priority (Cache outermost at
- * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
+ * The default pipeline order is pinned via tag priority (Telemetry outermost
+ * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
+ * Usage innermost at 25).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 50])]
 final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
@@ -130,6 +131,12 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
                 );
                 continue;
             }
+
+            // Count this as a fallback attempt for the outer TelemetryMiddleware
+            // (ADR-058): a real dispatch to a sibling configuration, after the
+            // not-found / inactive skips above. The primary attempt is not
+            // counted.
+            $context->telemetrySignals->recordFallbackAttempt();
 
             try {
                 $result = $next($fallback);

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -22,14 +22,24 @@ use Symfony\Component\Uid\Uuid;
 final readonly class ProviderCallContext
 {
     /**
-     * @param array<string, mixed> $metadata additional cross-cutting data
-     *                                       (e.g. user id for budget checks,
-     *                                       cache-key inputs, trace tags)
+     * @param array<string, mixed> $metadata         additional cross-cutting data
+     *                                               (e.g. user id for budget checks,
+     *                                               cache-key inputs, trace tags)
+     * @param TelemetrySignals     $telemetrySignals mutable scratchpad an inner
+     *                                               middleware uses to signal the
+     *                                               outer TelemetryMiddleware within
+     *                                               this run (cache hit, fallback
+     *                                               attempts). Default-constructed
+     *                                               per call so every pipeline run
+     *                                               has its own; the `new` default
+     *                                               is evaluated fresh on each call,
+     *                                               never shared across contexts.
      */
     public function __construct(
         public ProviderOperation $operation,
         public string $correlationId,
         public array $metadata = [],
+        public TelemetrySignals $telemetrySignals = new TelemetrySignals(),
     ) {}
 
     /**
@@ -64,6 +74,10 @@ final readonly class ProviderCallContext
             operation: $this->operation,
             correlationId: $this->correlationId,
             metadata: [...$this->metadata, ...$metadata],
+            // Carry the SAME signal sink forward: a context re-derived mid-run
+            // (e.g. to annotate downstream metadata) must not silently drop the
+            // cache-hit / fallback signals collected against the original.
+            telemetrySignals: $this->telemetrySignals,
         );
     }
 }

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+
+/**
+ * Outermost pipeline layer: records one telemetry row per run, ALWAYS (ADR-058).
+ *
+ * This is the failure-rate / latency observer the UsageMiddleware doc block
+ * leaves open ("The middleware never runs when $next throws: failed calls are
+ * not tracked here. If failure-rate telemetry is needed later, a dedicated
+ * middleware can wrap and record regardless of outcome."). It wraps the entire
+ * pipeline and writes exactly one row on both success and failure, then
+ * re-throws the original exception untouched.
+ *
+ * Pipeline ordering — Telemetry sits OUTSIDE Cache so the measured latency
+ * includes the cache lookup and a cache-served response still produces a row:
+ *
+ *   TelemetryMiddleware      <-- outermost; pure observer          (priority 110)
+ *     CacheMiddleware        <-- short-circuits on hit             (priority 100)
+ *       BudgetMiddleware     <-- pre-flight denial                 (priority 75)
+ *         FallbackMiddleware <-- swaps config on retryable failure (priority 50)
+ *           UsageMiddleware  <-- records the call that ran         (priority 25)
+ *             <terminal>
+ *
+ * What it records: the OPERATION and requested primary CONFIGURATION
+ * (identifier, plus its provider/model). When FallbackMiddleware swaps to a
+ * sibling configuration the swap is captured as `fallback_attempts > 0`; the
+ * provider/model/cost of the configuration that actually SERVED live in the
+ * usage table (UsageMiddleware sees the served config). Ad-hoc direct calls
+ * carry no attached model, so provider/model are empty and the provider is
+ * encoded in the `ad-hoc:<operation>:<provider>` identifier.
+ *
+ * Privacy: no prompt, no response, no exception message — only the exception
+ * FQCN (`error_class`), because messages can carry payload fragments. The
+ * central privacy model (retention tiers) is a later workstream; this
+ * middleware is metadata-only by construction.
+ *
+ * Fail-soft: a telemetry write error is logged and swallowed. Observability
+ * must never break the call it observes.
+ *
+ * Streaming stays out of the pipeline (ADR-026), so streamed responses produce
+ * no telemetry row here; a streaming lifecycle is a separate workstream.
+ *
+ * Disable via the `telemetry.enabled` extension setting (default ON). When
+ * disabled the middleware is a verbatim pass-through.
+ */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 110])]
+final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
+{
+    public function __construct(
+        private TelemetryRepositoryInterface $repository,
+        private Context $context,
+        private ExtensionConfiguration $extensionConfiguration,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        if (!$this->isEnabled()) {
+            return $next($configuration);
+        }
+
+        $start      = hrtime(true);
+        $success    = false;
+        $errorClass = '';
+
+        try {
+            $result  = $next($configuration);
+            $success = true;
+
+            return $result;
+        } catch (Throwable $e) {
+            $errorClass = $e::class;
+
+            throw $e;
+        } finally {
+            $this->safeRecord($context, $configuration, $success, $errorClass, $this->elapsedMs($start));
+        }
+    }
+
+    /**
+     * Wall-clock milliseconds since the given hrtime() reading. Integer ms is
+     * enough resolution for latency buckets and keeps the column an int.
+     */
+    private function elapsedMs(int|float $startNs): int
+    {
+        return (int)((hrtime(true) - $startNs) / 1_000_000);
+    }
+
+    private function safeRecord(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        bool $success,
+        string $errorClass,
+        int $latencyMs,
+    ): void {
+        try {
+            $this->repository->record(new TelemetryRecord(
+                correlationId: $context->correlationId,
+                operation: $context->operation->value,
+                provider: $configuration->getProviderType(),
+                model: $configuration->getModelId(),
+                configurationIdentifier: $configuration->getIdentifier(),
+                beUser: $this->resolveBeUser($context),
+                success: $success,
+                errorClass: $errorClass,
+                latencyMs: $latencyMs,
+                cacheHit: $context->telemetrySignals->cacheHit,
+                fallbackAttempts: $context->telemetrySignals->fallbackAttempts,
+            ));
+        } catch (Throwable $e) {
+            // Observability must not break the call it observes.
+            $this->logger->error(
+                'Failed to record LLM telemetry',
+                [
+                    'correlationId' => $context->correlationId,
+                    'operation'     => $context->operation->value,
+                    'exception'     => $e,
+                ],
+            );
+        }
+    }
+
+    /**
+     * Attribution: the caller-supplied backend user (BudgetMiddleware reads the
+     * same key for enforcement), else the ambient backend.user aspect, else 0
+     * (CLI / scheduler / unauthenticated) — mirroring UsageTrackerService.
+     */
+    private function resolveBeUser(ProviderCallContext $context): int
+    {
+        $fromMetadata = $context->metadata[BudgetMiddleware::METADATA_BE_USER_UID] ?? null;
+        if (\is_int($fromMetadata)) {
+            return $fromMetadata;
+        }
+
+        try {
+            return (int)$this->context->getAspect('backend.user')->get('id');
+        } catch (AspectNotFoundException) {
+            return 0;
+        }
+    }
+
+    /**
+     * Telemetry defaults ON (observability by default). Any read failure or a
+     * missing setting is treated as enabled; only an explicit falsey
+     * `telemetry.enabled` turns it off.
+     */
+    private function isEnabled(): bool
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            return true;
+        }
+
+        $telemetry = \is_array($config['telemetry'] ?? null) ? $config['telemetry'] : [];
+        if (!\array_key_exists('enabled', $telemetry)) {
+            return true;
+        }
+
+        // Extension configuration delivers booleans as '0' / '1' strings;
+        // (bool) maps '0' and '' to false, everything else to true.
+        return (bool)$telemetry['enabled'];
+    }
+}

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -132,15 +132,24 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
                 fallbackAttempts: $context->telemetrySignals->fallbackAttempts,
             ));
         } catch (Throwable $e) {
-            // Observability must not break the call it observes.
-            $this->logger->error(
-                'Failed to record LLM telemetry',
-                [
-                    'correlationId' => $context->correlationId,
-                    'operation'     => $context->operation->value,
-                    'exception'     => $e,
-                ],
-            );
+            // Observability must not break the call it observes. safeRecord()
+            // runs inside handle()'s finally, so a Throwable escaping here would
+            // (per PHP finally semantics) replace the provider exception the
+            // caller is meant to see. The logger itself can throw (e.g. TYPO3's
+            // FileWriter on a full/read-only var/log), so the log call is
+            // guarded too — a logging failure is swallowed as a last resort.
+            try {
+                $this->logger->error(
+                    'Failed to record LLM telemetry',
+                    [
+                        'correlationId' => $context->correlationId,
+                        'operation'     => $context->operation->value,
+                        'exception'     => $e,
+                    ],
+                );
+            } catch (Throwable) {
+                // Nothing safe left to do; never let observability break the call.
+            }
         }
     }
 

--- a/Classes/Provider/Middleware/TelemetrySignals.php
+++ b/Classes/Provider/Middleware/TelemetrySignals.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+/**
+ * Mutable scratchpad an inner middleware uses to signal an outer one within a
+ * single pipeline run.
+ *
+ * The pipeline threads ONE immutable ProviderCallContext through every layer
+ * and the `$next` callable only forwards the LlmConfiguration -- never a
+ * context. An inner middleware therefore cannot hand a modified context back
+ * out to a middleware that already captured the original. The one channel that
+ * survives the unwind is a mutable object reachable from the shared context:
+ * this class. ProviderCallContext carries exactly one instance (default-
+ * constructed per call, see ProviderCallContext), so CacheMiddleware and
+ * FallbackMiddleware can annotate it on the way in and TelemetryMiddleware --
+ * the outermost layer -- reads the result on the way out.
+ *
+ * Deliberately NOT readonly: recording a signal is the whole point. It holds
+ * only cross-cutting observability state, never payload, so it does not
+ * weaken the "context carries no payload" rule of ADR-026.
+ *
+ * A fresh, un-annotated instance reads as "nothing happened" (no cache hit,
+ * zero fallback attempts), which is the correct default for any pipeline run
+ * that never touches those layers.
+ */
+final class TelemetrySignals
+{
+    public bool $cacheHit = false;
+
+    public int $fallbackAttempts = 0;
+
+    /**
+     * CacheMiddleware calls this when it serves a stored response instead of
+     * invoking the terminal.
+     */
+    public function recordCacheHit(): void
+    {
+        $this->cacheHit = true;
+    }
+
+    /**
+     * FallbackMiddleware calls this once per fallback configuration it actually
+     * dispatches (the primary attempt is not counted).
+     */
+    public function recordFallbackAttempt(): void
+    {
+        ++$this->fallbackAttempts;
+    }
+}

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -55,11 +55,13 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * is used when present; otherwise the middleware records 'unknown'.
  *
  * The middleware never runs when $next throws: failed calls are not
- * tracked here. If failure-rate telemetry is needed later, a dedicated
- * middleware can wrap and record regardless of outcome.
+ * tracked here. Failure-rate telemetry is handled by the dedicated
+ * TelemetryMiddleware (ADR-058), which wraps the whole pipeline and records
+ * one row regardless of outcome.
  *
- * The default pipeline order is pinned via tag priority (Cache outermost at
- * 100, then Budget at 75, Fallback at 50, Usage innermost at 25).
+ * The default pipeline order is pinned via tag priority (Telemetry outermost
+ * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
+ * Usage innermost at 25).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 25])]
 final readonly class UsageMiddleware implements ProviderMiddlewareInterface

--- a/Classes/Service/Telemetry/TelemetryRecord.php
+++ b/Classes/Service/Telemetry/TelemetryRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Telemetry;
+
+/**
+ * One immutable telemetry row, produced by TelemetryMiddleware and written by
+ * TelemetryRepository (ADR-058).
+ *
+ * Privacy by construction: this DTO has no field for a prompt, a response, or
+ * an exception message. `errorClass` is the exception FQCN only — messages can
+ * carry payload fragments, so they are never captured here.
+ */
+final readonly class TelemetryRecord
+{
+    public function __construct(
+        public string $correlationId,
+        public string $operation,
+        public string $provider,
+        public string $model,
+        public string $configurationIdentifier,
+        public int $beUser,
+        public bool $success,
+        public string $errorClass,
+        public int $latencyMs,
+        public bool $cacheHit,
+        public int $fallbackAttempts,
+    ) {}
+}

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Telemetry;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Writes and prunes provider pipeline telemetry rows (ADR-058).
+ *
+ * Uses the Doctrine ConnectionPool directly — the table is a UI-less append-only
+ * log with no Extbase persistence needs, mirroring how UsageTrackerService
+ * writes the usage table.
+ */
+final readonly class TelemetryRepository implements TelemetryRepositoryInterface, SingletonInterface
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function record(TelemetryRecord $record): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'correlation_id'           => $record->correlationId,
+            'operation'                => $record->operation,
+            'provider'                 => $record->provider,
+            'model'                    => $record->model,
+            'configuration_identifier' => $record->configurationIdentifier,
+            'be_user'                  => $record->beUser,
+            'success'                  => $record->success ? 1 : 0,
+            'error_class'              => $record->errorClass,
+            'latency_ms'               => $record->latencyMs,
+            'cache_hit'                => $record->cacheHit ? 1 : 0,
+            'fallback_attempts'        => $record->fallbackAttempts,
+            'crdate'                   => time(),
+        ]);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+
+        return (int)$queryBuilder
+            ->delete(self::TABLE)
+            ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
+            ->executeStatement();
+    }
+}

--- a/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
+++ b/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Telemetry;
+
+/**
+ * Persistence boundary for provider pipeline telemetry rows (ADR-058).
+ *
+ * Deliberately narrow: append one row, or purge old rows. There is no update
+ * or read path — telemetry is append-only and analytics query the table
+ * directly.
+ */
+interface TelemetryRepositoryInterface
+{
+    /**
+     * Append one telemetry row. Never throws for a caller-visible reason:
+     * telemetry must not break the call it observes (see TelemetryMiddleware).
+     */
+    public function record(TelemetryRecord $record): void;
+
+    /**
+     * Delete rows created strictly before the given UNIX timestamp.
+     *
+     * @return int number of rows deleted
+     */
+    public function purgeOlderThan(int $timestamp): int;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -175,6 +175,13 @@ services:
     alias: Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator
     public: false
 
+  # Telemetry recorder (ADR-058) — private; used by TelemetryMiddleware and the
+  # nrllm:telemetry:purge command. The concrete repository stays private too;
+  # functional tests instantiate it directly with the real ConnectionPool.
+  Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Telemetry\TelemetryRepository
+    public: false
+
   # ========================================
   # Repositories (PUBLIC)
   # ========================================

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -98,6 +98,25 @@ Contributors can add behaviour without touching :code:`Services.yaml` —
 implement the interface, drop the class under
 :code:`Classes/Provider/Middleware/`, you are done.
 
+.. _adr-026-ordering:
+
+Default ordering
+================
+
+The shipped middleware are pinned by tag ``priority`` (highest priority =
+first in the autowired iterator = outermost layer of the onion):
+
+* ``110`` — :php:`TelemetryMiddleware`: observation only; one row per run
+  (:ref:`adr-058`).
+* ``100`` — :php:`CacheMiddleware`: short-circuits on a cache hit.
+* ``75`` — :php:`BudgetMiddleware`: pre-flight budget denial (miss only).
+* ``50`` — :php:`FallbackMiddleware`: swaps configuration on a retryable failure.
+* ``25`` — :php:`UsageMiddleware`: records the call that actually ran.
+
+Telemetry sits *outside* Cache so measured latency includes the cache lookup
+and a cache-served response still produces a telemetry row. It never
+short-circuits, swaps, or denies — it only observes and re-throws.
+
 .. _adr-026-scope:
 
 Scope of this ADR

--- a/Documentation/Adr/Adr058TelemetryMiddleware.rst
+++ b/Documentation/Adr/Adr058TelemetryMiddleware.rst
@@ -1,0 +1,160 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-058:
+
+==========================================
+ADR-058: Telemetry Middleware
+==========================================
+
+:Status: Accepted
+:Date: 2026-07
+:Authors: Netresearch DTT GmbH
+
+.. _adr-058-context:
+
+Context
+=======
+
+The middleware pipeline (:ref:`adr-026`) records cost and tokens through
+:php:`UsageMiddleware`, but only for calls that *succeed*. Its own doc block
+names the gap:
+
+    The middleware never runs when ``$next`` throws: failed calls are not
+    tracked here. If failure-rate telemetry is needed later, a dedicated
+    middleware can wrap and record regardless of outcome.
+
+So today there is no durable record of:
+
+* how often a provider call *fails*, and with which exception type;
+* how long a call takes (latency), including the cache lookup;
+* whether a response was served from cache;
+* how many fallback configurations had to be tried before one answered.
+
+:php:`UsageMiddleware` writes to :sql:`tx_nrllm_service_usage`, which is a
+**daily aggregate** keyed by service/provider/model/user — it cannot answer
+"which correlation id failed at 14:03 and why". Correlation ids exist on the
+:php:`ProviderCallContext` and are already logged by
+:php:`FallbackMiddleware`, but logs are not queryable telemetry.
+
+.. _adr-058-decision:
+
+Decision
+========
+
+Add a dedicated :php:`TelemetryMiddleware` and a per-request log table.
+
+**1. Table** :sql:`tx_nrllm_telemetry` — one immutable row per pipeline run
+(not an aggregate). Columns: ``correlation_id``, ``operation``, ``provider``,
+``model``, ``configuration_identifier``, ``be_user``, ``success``,
+``error_class``, ``latency_ms``, ``cache_hit``, ``fallback_attempts``,
+``crdate``. No TCA / backend UI — it is a log read via SQL / analytics, like
+the other UI-less tables (:sql:`tx_nrllm_service_usage`,
+:sql:`tx_nrllm_tool_state`).
+
+**2.** :php:`TelemetryMiddleware` **at priority 110** — the outermost layer,
+*outside* Cache. It measures wall-clock latency with :php:`hrtime()` around
+``$next``, catches any :php:`Throwable`, writes **exactly one** row on both
+success and failure, and re-throws the exception unchanged. Latency therefore
+includes the cache lookup, and a cache-served response still produces a row.
+
+**3. Cache-hit signal.** The pipeline threads one immutable
+:php:`ProviderCallContext` through every layer and the ``$next`` callable only
+forwards the :php:`LlmConfiguration` — never a context. An inner middleware
+thus cannot hand a modified context back to an outer one. The one channel that
+survives the unwind is a mutable object reachable from the shared context:
+:php:`TelemetrySignals`. The context default-constructs one per call.
+:php:`CacheMiddleware` calls ``recordCacheHit()`` on a hit; the outer
+:php:`TelemetryMiddleware` reads it.
+
+**4. Fallback count.** :php:`FallbackMiddleware` calls
+``recordFallbackAttempt()`` on :php:`TelemetrySignals` once per fallback
+configuration it actually dispatches (the primary attempt is not counted); the
+middleware reads it (``0`` when it was never set).
+
+**5. Attribution.** ``be_user`` is the caller-supplied
+:php:`BudgetMiddleware::METADATA_BE_USER_UID` when present, else the ambient
+``backend.user`` context aspect, else ``0`` — the same resolution
+:php:`UsageTrackerService` uses.
+
+**6. Persistence** goes through a narrow
+:php:`TelemetryRepository` (Doctrine :php:`ConnectionPool` directly, no Extbase
+repository), mirroring how :php:`UsageTrackerService` writes. The service is
+**private** (ADR-028); nothing resolves it by class name from the container.
+
+**7. Purge command** :bash:`nrllm:telemetry:purge` (``--days``, default 30)
+deletes rows older than the retention window. Registered via the native
+:php:`#[AsCommand]` attribute (autoconfigured), like TYPO3 core commands.
+
+**8. Deactivation.** The extension setting ``telemetry.enabled`` (default
+**on** — observability by default) turns the middleware into a verbatim
+pass-through when disabled.
+
+.. _adr-058-consequences:
+
+Consequences
+============
+
+* **One row per request = growth.** Unlike the usage aggregate, the log grows
+  with traffic. The :bash:`nrllm:telemetry:purge` command bounds it; run it
+  from the scheduler.
+* **error_class, not message — a deliberate privacy trade-off.** Only the
+  exception FQCN is stored. Exception messages can carry payload fragments
+  (a prompt substring, a URL with a token), so they are never persisted here.
+  No prompts and no responses are stored either. The central privacy model
+  (retention tiers none/metadata/redacted/full) is a later workstream; this
+  middleware is metadata-only by construction.
+* **Latency includes the cache lookup.** Because Telemetry sits outside Cache,
+  ``latency_ms`` measures the whole pipeline as the caller experiences it,
+  cache hits included. That is the intended semantic (end-to-end latency), not
+  provider-only time.
+* **provider / model reflect the requested primary configuration.** Telemetry
+  sits outside :php:`FallbackMiddleware`, so it records the configuration the
+  caller *asked for*. A fallback swap shows up as ``fallback_attempts > 0``;
+  the provider/model/cost of the configuration that actually *served* live in
+  the usage table (:php:`UsageMiddleware` sees the served config). Ad-hoc
+  direct calls carry no attached model, so provider/model are empty and the
+  provider is encoded in the ``ad-hoc:<operation>:<provider>`` identifier.
+* **Fail-soft.** A telemetry write error is logged and swallowed; it never
+  breaks the call it observes.
+* **Streaming produces no telemetry row.** Streaming deliberately stays out of
+  the pipeline (:ref:`adr-026`) — once the first chunk is emitted a provider
+  cannot be swapped mid-stream. A streaming lifecycle (with its own
+  telemetry) is a separate workstream.
+* **Mutable state on an "immutable" context.** :php:`TelemetrySignals` is the
+  one mutable object the otherwise-immutable :php:`ProviderCallContext`
+  carries. It holds only cross-cutting observability state, never payload, so
+  it does not weaken ADR-026's "payload stays in the terminal closure" rule.
+  A dedicated typed property (rather than a magic metadata key seeded by every
+  caller) means every pipeline run — present and future entry points — captures
+  cache/fallback signals with no per-caller wiring.
+
+.. _adr-058-alternatives:
+
+Alternatives considered
+=======================
+
+* **Extend** :php:`UsageMiddleware` **to also record failures.** Rejected:
+  usage is an aggregate keyed for cost roll-ups; per-request failure/latency
+  rows have a different shape, lifetime (purged) and index set. Overloading one
+  table would break both.
+* **Log-only (PSR-3), no table.** Rejected: logs are not queryable telemetry.
+  Failure-rate and latency questions need a table an analytics view can group.
+* **Seed a mutable signal bag into the metadata map at each pipeline entry
+  point.** Rejected: it pushes telemetry wiring into every caller and silently
+  loses cache/fallback signals for any future entry point that forgets to seed.
+  A default-constructed context property covers all runs by construction.
+* **Record provider/model from the response.** Rejected for the outer layer:
+  there is no response on the failure path, and duplicating
+  :php:`UsageMiddleware`'s response-shape extraction at the outermost layer
+  couples telemetry to every response type. Sourcing from the requested
+  configuration is deterministic on success *and* failure.
+
+.. _adr-058-references:
+
+References
+==========
+
+* :ref:`adr-026` — Provider Middleware Pipeline (the pipeline and ordering this
+  extends; :php:`UsageMiddleware`'s open failure-telemetry note).
+* ADR-025 — Per-User AI Budgets (``be_user`` attribution key reused here).
+* ADR-028 — Public Services Policy (the recorder stays private).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -356,3 +356,4 @@ Tools
    Adr055EmbeddingConfigurationPath
    Adr056ConfigurationPresets
    Adr057SpecializedServiceAttribution
+   Adr058TelemetryMiddleware

--- a/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
+++ b/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -24,18 +25,21 @@ use ReflectionClass;
  * Verifies that the provider middleware pipeline is assembled in the
  * documented order via the autowired tagged iterator.
  *
- * The order is security-relevant: CacheMiddleware must be the OUTERMOST
- * layer so that a cache hit short-circuits the pipeline before any budget
- * is consumed (CacheMiddleware / BudgetMiddleware docblocks). Symfony orders
- * a tagged iterator by descending tag priority; this test resolves the real
- * MiddlewarePipeline from the DI container and asserts the resolved order
- * empirically, so the priority *direction* is proven rather than assumed.
+ * The order is security-relevant: CacheMiddleware must be the outermost
+ * BEHAVIOURAL layer so that a cache hit short-circuits the pipeline before any
+ * budget is consumed (CacheMiddleware / BudgetMiddleware docblocks). Only the
+ * observation-only TelemetryMiddleware (ADR-058) sits further out, so measured
+ * latency includes the cache lookup and a cache-served response still produces
+ * a telemetry row. Symfony orders a tagged iterator by descending tag priority;
+ * this test resolves the real MiddlewarePipeline from the DI container and
+ * asserts the resolved order empirically, so the priority *direction* is proven
+ * rather than assumed.
  */
 #[CoversClass(MiddlewarePipeline::class)]
 final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 {
     #[Test]
-    public function pipelineIsAssembledCacheBudgetFallbackUsage(): void
+    public function pipelineIsAssembledTelemetryCacheBudgetFallbackUsage(): void
     {
         $pipeline = $this->get(MiddlewarePipeline::class);
         self::assertInstanceOf(MiddlewarePipeline::class, $pipeline);
@@ -44,10 +48,11 @@ final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             [
-                CacheMiddleware::class,    // outermost: a cache hit short-circuits
-                BudgetMiddleware::class,   // pre-flight budget gate on a miss
-                FallbackMiddleware::class, // swaps configuration on retryable failure
-                UsageMiddleware::class,    // innermost: records the call that ran
+                TelemetryMiddleware::class, // outermost: observes every run (ADR-058)
+                CacheMiddleware::class,     // outermost behavioural layer: a cache hit short-circuits
+                BudgetMiddleware::class,    // pre-flight budget gate on a miss
+                FallbackMiddleware::class,  // swaps configuration on retryable failure
+                UsageMiddleware::class,     // innermost: records the call that ran
             ],
             $order,
         );

--- a/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
+++ b/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Telemetry;
+
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+#[CoversClass(TelemetryRepository::class)]
+#[CoversClass(TelemetryRecord::class)]
+final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private TelemetryRepository $repository;
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        // The repository is private in the container by design; instantiate it
+        // directly with the real ConnectionPool.
+        $this->repository = new TelemetryRepository($this->connectionPool);
+    }
+
+    #[Test]
+    public function recordInsertsOneRowWithAllFields(): void
+    {
+        $this->repository->record(new TelemetryRecord(
+            correlationId: 'corr-123',
+            operation: 'chat',
+            provider: 'openai',
+            model: 'gpt-4o',
+            configurationIdentifier: 'ad-hoc:chat:openai',
+            beUser: 42,
+            success: false,
+            errorClass: 'RuntimeException',
+            latencyMs: 1234,
+            cacheHit: true,
+            fallbackAttempts: 2,
+        ));
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(['*'], self::TABLE, ['correlation_id' => 'corr-123'])->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertSame('chat', $row['operation']);
+        self::assertSame('openai', $row['provider']);
+        self::assertSame('gpt-4o', $row['model']);
+        self::assertSame('ad-hoc:chat:openai', $row['configuration_identifier']);
+        self::assertSame(42, (int)$row['be_user']);
+        self::assertSame(0, (int)$row['success']);
+        self::assertSame('RuntimeException', $row['error_class']);
+        self::assertSame(1234, (int)$row['latency_ms']);
+        self::assertSame(1, (int)$row['cache_hit']);
+        self::assertSame(2, (int)$row['fallback_attempts']);
+        self::assertGreaterThan(0, (int)$row['crdate']);
+    }
+
+    #[Test]
+    public function recordStoresBooleansAsZeroOrOne(): void
+    {
+        $this->repository->record(new TelemetryRecord(
+            correlationId: 'corr-ok',
+            operation: 'embed',
+            provider: '',
+            model: '',
+            configurationIdentifier: 'primary',
+            beUser: 0,
+            success: true,
+            errorClass: '',
+            latencyMs: 5,
+            cacheHit: false,
+            fallbackAttempts: 0,
+        ));
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(['success', 'cache_hit'], self::TABLE, ['correlation_id' => 'corr-ok'])->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertSame(1, (int)$row['success']);
+        self::assertSame(0, (int)$row['cache_hit']);
+    }
+
+    #[Test]
+    public function purgeOlderThanDeletesOnlyOlderRows(): void
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+
+        // An old row (10 days ago) inserted directly with a controlled crdate...
+        $tenDaysAgo = time() - (10 * 86400);
+        $connection->insert(self::TABLE, [
+            'pid'                      => 0,
+            'correlation_id'           => 'old-row',
+            'operation'                => 'chat',
+            'provider'                 => '',
+            'model'                    => '',
+            'configuration_identifier' => 'primary',
+            'be_user'                  => 0,
+            'success'                  => 1,
+            'error_class'              => '',
+            'latency_ms'               => 1,
+            'cache_hit'                => 0,
+            'fallback_attempts'        => 0,
+            'crdate'                   => $tenDaysAgo,
+        ]);
+
+        // ...and a fresh row via the repository (crdate = now).
+        $this->repository->record(new TelemetryRecord(
+            correlationId: 'fresh-row',
+            operation: 'chat',
+            provider: '',
+            model: '',
+            configurationIdentifier: 'primary',
+            beUser: 0,
+            success: true,
+            errorClass: '',
+            latencyMs: 1,
+            cacheHit: false,
+            fallbackAttempts: 0,
+        ));
+
+        // Purge everything older than 5 days: removes the old row, keeps the fresh one.
+        $cutoff  = time() - (5 * 86400);
+        $deleted = $this->repository->purgeOlderThan($cutoff);
+
+        self::assertSame(1, $deleted);
+        self::assertSame(0, $connection->count('*', self::TABLE, ['correlation_id' => 'old-row']));
+        self::assertSame(1, $connection->count('*', self::TABLE, ['correlation_id' => 'fresh-row']));
+    }
+
+    #[Test]
+    public function purgeOlderThanReturnsZeroWhenNothingMatches(): void
+    {
+        $this->repository->record(new TelemetryRecord(
+            correlationId: 'fresh-only',
+            operation: 'chat',
+            provider: '',
+            model: '',
+            configurationIdentifier: 'primary',
+            beUser: 0,
+            success: true,
+            errorClass: '',
+            latencyMs: 1,
+            cacheHit: false,
+            fallbackAttempts: 0,
+        ));
+
+        // Cutoff far in the past: the only row is newer, so nothing is deleted.
+        $deleted = $this->repository->purgeOlderThan(time() - (365 * 86400));
+
+        self::assertSame(0, $deleted);
+    }
+}

--- a/Tests/Unit/Command/PurgeTelemetryCommandTest.php
+++ b/Tests/Unit/Command/PurgeTelemetryCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\PurgeTelemetryCommand;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(PurgeTelemetryCommand::class)]
+final class PurgeTelemetryCommandTest extends TestCase
+{
+    #[Test]
+    public function purgesWithThirtyDayDefaultWindow(): void
+    {
+        $repository = $this->spyRepository(deleted: 5);
+        $tester     = new CommandTester(new PurgeTelemetryCommand($repository));
+
+        $before = time();
+        $exit   = $tester->execute([]);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotNull($repository->purgeCutoff);
+        // Cutoff is "now minus 30 days" computed inside execute().
+        self::assertGreaterThanOrEqual($before - (30 * 86400), $repository->purgeCutoff);
+        self::assertLessThanOrEqual($after - (30 * 86400), $repository->purgeCutoff);
+        self::assertStringContainsString('5 telemetry row(s)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function honoursCustomDaysOption(): void
+    {
+        $repository = $this->spyRepository(deleted: 0);
+        $tester     = new CommandTester(new PurgeTelemetryCommand($repository));
+
+        $before = time();
+        $exit   = $tester->execute(['--days' => '7']);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotNull($repository->purgeCutoff);
+        self::assertGreaterThanOrEqual($before - (7 * 86400), $repository->purgeCutoff);
+        self::assertLessThanOrEqual($after - (7 * 86400), $repository->purgeCutoff);
+    }
+
+    #[Test]
+    public function rejectsNonPositiveDays(): void
+    {
+        $repository = $this->spyRepository(deleted: 0);
+        $tester     = new CommandTester(new PurgeTelemetryCommand($repository));
+
+        $exit = $tester->execute(['--days' => '0']);
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertNull($repository->purgeCutoff, 'No purge must run for an invalid window.');
+        self::assertStringContainsString('positive integer', $tester->getDisplay());
+    }
+
+    private function spyRepository(int $deleted): InMemoryTelemetryRepository
+    {
+        $repository               = new InMemoryTelemetryRepository();
+        $repository->purgeReturns = $deleted;
+
+        return $repository;
+    }
+}

--- a/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
+++ b/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Fixture;
+
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use Throwable;
+
+/**
+ * In-memory telemetry repository for unit tests.
+ *
+ * Captures the DTOs a collaborator builds (so assertions verify the produced
+ * record, never a mock return) and the cutoff a purge was asked to run.
+ */
+final class InMemoryTelemetryRepository implements TelemetryRepositoryInterface
+{
+    /** @var list<TelemetryRecord> */
+    public array $records = [];
+
+    /** When set, record() throws it — to exercise the fail-soft path. */
+    public ?Throwable $failOnRecord = null;
+
+    /** The cutoff timestamp the last purgeOlderThan() was asked to delete below. */
+    public ?int $purgeCutoff = null;
+
+    /** The row count purgeOlderThan() reports as deleted. */
+    public int $purgeReturns = 0;
+
+    public function record(TelemetryRecord $record): void
+    {
+        if ($this->failOnRecord !== null) {
+            throw $this->failOnRecord;
+        }
+
+        $this->records[] = $record;
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $this->purgeCutoff = $timestamp;
+
+        return $this->purgeReturns;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -106,6 +106,36 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function flagsCacheHitOnTelemetrySignals(): void
+    {
+        $this->cache->method('get')->willReturn(['vector' => [0.1]]);
+
+        $context = $this->context(key: 'embed:abc');
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['vector' => [0.9]],
+        );
+
+        self::assertTrue($context->telemetrySignals->cacheHit, 'A cache hit must be flagged for TelemetryMiddleware.');
+    }
+
+    #[Test]
+    public function doesNotFlagCacheHitOnMiss(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+
+        $context = $this->context(key: 'embed:new');
+        $this->pipeline()->run(
+            context: $context,
+            configuration: $this->configuration(),
+            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+        );
+
+        self::assertFalse($context->telemetrySignals->cacheHit);
+    }
+
+    #[Test]
     public function storesArrayResultOnMiss(): void
     {
         $produced = ['vector' => [0.4, 0.5]];

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -117,6 +117,56 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function recordsOneFallbackAttemptPerDispatchedFallback(): void
+    {
+        // primary fails, first fallback fails, second fallback succeeds =>
+        // two real fallback dispatches; the primary attempt is not counted.
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt1', 'alt2']));
+        $alt1    = $this->makeConfig('alt1');
+        $alt2    = $this->makeConfig('alt2');
+
+        $this->repositoryStub->method('findOneByIdentifier')->willReturnMap([
+            ['alt1', $alt1],
+            ['alt2', $alt2],
+        ]);
+
+        $context  = ProviderCallContext::for(ProviderOperation::Chat);
+        $pipeline = $this->makePipeline();
+
+        $result = $pipeline->run(
+            $context,
+            $primary,
+            static function (LlmConfiguration $config): string {
+                if ($config->getIdentifier() !== 'alt2') {
+                    throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok-from-alt2';
+            },
+        );
+
+        self::assertSame('ok-from-alt2', $result);
+        self::assertSame(2, $context->telemetrySignals->fallbackAttempts);
+        self::assertFalse($context->telemetrySignals->cacheHit);
+    }
+
+    #[Test]
+    public function recordsNoFallbackAttemptWhenPrimarySucceeds(): void
+    {
+        $primary  = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $context  = ProviderCallContext::for(ProviderOperation::Chat);
+        $pipeline = $this->makePipeline();
+
+        $pipeline->run(
+            $context,
+            $primary,
+            static fn(LlmConfiguration $config): string => 'ok',
+        );
+
+        self::assertSame(0, $context->telemetrySignals->fallbackAttempts);
+    }
+
+    #[Test]
     public function retriesOnRateLimitResponse(): void
     {
         $primary = $this->makeConfig('primary', new FallbackChain(['alt']));

--- a/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
+++ b/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\TelemetrySignals;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProviderCallContext::class)]
+final class ProviderCallContextTest extends TestCase
+{
+    #[Test]
+    public function forGeneratesRfc4122CorrelationId(): void
+    {
+        $context = ProviderCallContext::for(ProviderOperation::Chat);
+
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $context->correlationId,
+        );
+    }
+
+    #[Test]
+    public function eachContextGetsItsOwnFreshSignalSink(): void
+    {
+        $a = ProviderCallContext::for(ProviderOperation::Chat);
+        $b = ProviderCallContext::for(ProviderOperation::Chat);
+
+        // The `new TelemetrySignals()` default must be evaluated per call, not
+        // shared — otherwise one run's cache hit would bleed into the next.
+        self::assertNotSame($a->telemetrySignals, $b->telemetrySignals);
+
+        $a->telemetrySignals->recordCacheHit();
+        self::assertTrue($a->telemetrySignals->cacheHit);
+        self::assertFalse($b->telemetrySignals->cacheHit);
+    }
+
+    #[Test]
+    public function withMetadataMergesAndKeepsTheSameSignalSink(): void
+    {
+        $base = new ProviderCallContext(
+            operation: ProviderOperation::Embedding,
+            correlationId: 'corr-1',
+            metadata: ['a' => 1],
+        );
+        $base->telemetrySignals->recordFallbackAttempt();
+
+        $derived = $base->withMetadata(['b' => 2]);
+
+        self::assertSame(['a' => 1, 'b' => 2], $derived->metadata);
+        self::assertSame('corr-1', $derived->correlationId);
+        // A context re-derived mid-run must carry the SAME signal sink so
+        // signals collected against the original survive.
+        self::assertSame($base->telemetrySignals, $derived->telemetrySignals);
+        self::assertSame(1, $derived->telemetrySignals->fallbackAttempts);
+    }
+
+    #[Test]
+    public function defaultSignalSinkReadsAsNothingHappened(): void
+    {
+        $context = ProviderCallContext::for(ProviderOperation::Vision);
+
+        self::assertInstanceOf(TelemetrySignals::class, $context->telemetrySignals);
+        self::assertFalse($context->telemetrySignals->cacheHit);
+        self::assertSame(0, $context->telemetrySignals->fallbackAttempts);
+    }
+}

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -76,7 +76,7 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
                 $context,
                 $this->configuration('primary'),
                 static function (LlmConfiguration $c): string {
-                    throw new RuntimeException('boom');
+                    throw new RuntimeException('boom', 1495872184);
                 },
             );
         } catch (RuntimeException $e) {

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\AspectInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+
+#[CoversClass(TelemetryMiddleware::class)]
+#[CoversClass(TelemetryRecord::class)]
+final class TelemetryMiddlewareTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function recordsOneSuccessRowWithTheExpectedFields(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(ProviderOperation::Chat, 'corr-success');
+        $result  = $this->pipeline($repository)->run(
+            $context,
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'answer',
+        );
+
+        self::assertSame('answer', $result);
+        self::assertCount(1, $repository->records);
+
+        $record = $repository->records[0];
+        self::assertTrue($record->success);
+        self::assertSame('', $record->errorClass);
+        self::assertSame('chat', $record->operation);
+        self::assertSame('corr-success', $record->correlationId);
+        self::assertSame('primary', $record->configurationIdentifier);
+        // Bare transient configuration carries no model, so provider/model are
+        // empty — the sourcing path (getProviderType/getModelId) is exercised.
+        self::assertSame('', $record->provider);
+        self::assertSame('', $record->model);
+        self::assertGreaterThanOrEqual(0, $record->latencyMs);
+        self::assertFalse($record->cacheHit);
+        self::assertSame(0, $record->fallbackAttempts);
+    }
+
+    #[Test]
+    public function recordsFailureRowWithExceptionFqcnAndReThrows(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(ProviderOperation::Completion, 'corr-fail');
+
+        $caught = false;
+        try {
+            $this->pipeline($repository)->run(
+                $context,
+                $this->configuration('primary'),
+                static function (LlmConfiguration $c): string {
+                    throw new RuntimeException('boom');
+                },
+            );
+        } catch (RuntimeException $e) {
+            $caught = true;
+            self::assertSame('boom', $e->getMessage());
+        }
+
+        self::assertTrue($caught, 'The original exception must propagate.');
+        self::assertCount(1, $repository->records);
+        $record = $repository->records[0];
+        self::assertFalse($record->success);
+        // The exception FQCN is stored, never the message (privacy).
+        self::assertSame(RuntimeException::class, $record->errorClass);
+    }
+
+    #[Test]
+    public function readsCacheHitSignalSetByAnInnerLayer(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(ProviderOperation::Embedding, 'corr');
+        $context->telemetrySignals->recordCacheHit();
+
+        $this->pipeline($repository)->run(
+            $context,
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'x',
+        );
+
+        self::assertTrue($repository->records[0]->cacheHit);
+    }
+
+    #[Test]
+    public function readsFallbackAttemptsSignalSetByAnInnerLayer(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(ProviderOperation::Chat, 'corr');
+        $context->telemetrySignals->recordFallbackAttempt();
+        $context->telemetrySignals->recordFallbackAttempt();
+
+        $this->pipeline($repository)->run(
+            $context,
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'x',
+        );
+
+        self::assertSame(2, $repository->records[0]->fallbackAttempts);
+    }
+
+    #[Test]
+    public function isNoOpWhenDisabled(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $result = $this->pipeline($repository, enabled: false)->run(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'answer',
+        );
+
+        self::assertSame('answer', $result, 'The terminal must still run when telemetry is disabled.');
+        self::assertCount(0, $repository->records);
+    }
+
+    #[Test]
+    public function telemetryWriteFailureDoesNotBreakTheCall(): void
+    {
+        $failingRepository               = new InMemoryTelemetryRepository();
+        $failingRepository->failOnRecord = new RuntimeException('db down');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error');
+
+        $middleware = new TelemetryMiddleware(
+            $failingRepository,
+            $this->contextWithAmbientUser(0),
+            $this->extensionConfiguration(true),
+            $logger,
+        );
+
+        $result = (new MiddlewarePipeline([$middleware]))->run(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'answer',
+        );
+
+        self::assertSame('answer', $result);
+    }
+
+    #[Test]
+    public function resolvesBeUserFromMetadata(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(
+            ProviderOperation::Chat,
+            'corr',
+            [BudgetMiddleware::METADATA_BE_USER_UID => 42],
+        );
+
+        $this->pipeline($repository)->run(
+            $context,
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'x',
+        );
+
+        self::assertSame(42, $repository->records[0]->beUser);
+    }
+
+    #[Test]
+    public function resolvesBeUserFromAmbientAspectWhenMetadataAbsent(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $middleware = new TelemetryMiddleware(
+            $repository,
+            $this->contextWithAmbientUser(7),
+            $this->extensionConfiguration(true),
+            new NullLogger(),
+        );
+
+        (new MiddlewarePipeline([$middleware]))->run(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'x',
+        );
+
+        self::assertSame(7, $repository->records[0]->beUser);
+    }
+
+    #[Test]
+    public function resolvesBeUserToZeroWhenNoBackendUserAspect(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = self::createStub(Context::class);
+        $context->method('getAspect')->willThrowException(new AspectNotFoundException('no aspect', 1234567890));
+
+        $middleware = new TelemetryMiddleware(
+            $repository,
+            $context,
+            $this->extensionConfiguration(true),
+            new NullLogger(),
+        );
+
+        (new MiddlewarePipeline([$middleware]))->run(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'x',
+        );
+
+        self::assertSame(0, $repository->records[0]->beUser);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * In-memory repository that captures the DTOs the middleware builds, so the
+     * assertions verify what TelemetryMiddleware produced — never a mock return.
+     */
+    private function recordingRepository(): InMemoryTelemetryRepository
+    {
+        return new InMemoryTelemetryRepository();
+    }
+
+    private function pipeline(InMemoryTelemetryRepository $repository, bool $enabled = true): MiddlewarePipeline
+    {
+        $middleware = new TelemetryMiddleware(
+            $repository,
+            $this->contextWithAmbientUser(0),
+            $this->extensionConfiguration($enabled),
+            new NullLogger(),
+        );
+
+        return new MiddlewarePipeline([$middleware]);
+    }
+
+    private function extensionConfiguration(bool $enabled): ExtensionConfiguration&MockObject
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')
+            ->willReturn(['telemetry' => ['enabled' => $enabled ? '1' : '0']]);
+
+        return $extensionConfiguration;
+    }
+
+    private function contextWithAmbientUser(int $id): Context
+    {
+        $aspect = self::createStub(AspectInterface::class);
+        $aspect->method('get')->willReturn($id);
+
+        $context = self::createStub(Context::class);
+        $context->method('getAspect')->willReturn($aspect);
+
+        return $context;
+    }
+
+    private function configuration(string $identifier): LlmConfiguration
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier($identifier);
+
+        return $configuration;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -168,6 +168,35 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function loggerFailureDuringTelemetryDoesNotBreakTheCall(): void
+    {
+        // safeRecord() runs inside handle()'s finally; a throw escaping the
+        // catch would replace the observed call's result/exception. The
+        // logger can itself throw (e.g. TYPO3 FileWriter on a full disk), so
+        // even a failing logger must not surface.
+        $failingRepository               = new InMemoryTelemetryRepository();
+        $failingRepository->failOnRecord = new RuntimeException('db down');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->method('error')->willThrowException(new RuntimeException('log disk full'));
+
+        $middleware = new TelemetryMiddleware(
+            $failingRepository,
+            $this->contextWithAmbientUser(0),
+            $this->extensionConfiguration(true),
+            $logger,
+        );
+
+        $result = (new MiddlewarePipeline([$middleware]))->run(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            $this->configuration('primary'),
+            static fn(LlmConfiguration $c): string => 'answer',
+        );
+
+        self::assertSame('answer', $result);
+    }
+
+    #[Test]
     public function resolvesBeUserFromMetadata(): void
     {
         $repository = $this->recordingRepository();

--- a/Tests/Unit/Provider/Middleware/TelemetrySignalsTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetrySignalsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Provider\Middleware\TelemetrySignals;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TelemetrySignals::class)]
+final class TelemetrySignalsTest extends TestCase
+{
+    #[Test]
+    public function freshInstanceReadsAsNothingHappened(): void
+    {
+        $signals = new TelemetrySignals();
+
+        self::assertFalse($signals->cacheHit);
+        self::assertSame(0, $signals->fallbackAttempts);
+    }
+
+    #[Test]
+    public function recordCacheHitIsIdempotentlyTrue(): void
+    {
+        $signals = new TelemetrySignals();
+        $signals->recordCacheHit();
+        $signals->recordCacheHit();
+
+        self::assertTrue($signals->cacheHit);
+    }
+
+    #[Test]
+    public function recordFallbackAttemptCountsEachCall(): void
+    {
+        $signals = new TelemetrySignals();
+        $signals->recordFallbackAttempt();
+        $signals->recordFallbackAttempt();
+        $signals->recordFallbackAttempt();
+
+        self::assertSame(3, $signals->fallbackAttempts);
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -73,3 +73,10 @@ image.fal.defaultModel = flux-schnell
 
 # cat=testing; type=string; label=Test Prompt: Prompt used when testing configurations and models. Use {lang} as placeholder for the backend user's language.
 testing.testPrompt = Say hello and introduce yourself in one sentence. Respond in {lang}.
+
+# =============================================================================
+# Telemetry
+# =============================================================================
+
+# cat=telemetry; type=boolean; label=Enable Telemetry: Record one row per provider pipeline run (operation, provider, latency, success/failure, cache hit, fallback attempts) in tx_nrllm_telemetry. No prompts or responses are stored, only the exception class on failure. Purge old rows with the nrllm:telemetry:purge command. On by default.
+telemetry.enabled = 1

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -572,3 +572,57 @@ CREATE TABLE tx_nrllm_tool_group_state (
     PRIMARY KEY (uid),
     UNIQUE KEY group_name (group_name)
 );
+
+#
+# Table structure for table 'tx_nrllm_telemetry'
+# One row per provider middleware pipeline run (ADR-058). Unlike
+# tx_nrllm_service_usage (a daily cost AGGREGATE) this is a per-request log:
+# every run appends exactly one immutable row, success or failure. It stores
+# only cross-cutting observability fields — NO prompts, NO responses, and the
+# exception FQCN (error_class) rather than the message, because messages can
+# carry payload fragments. Growth is bounded by the nrllm:telemetry:purge
+# command. No TCA / backend UI (reads happen via SQL / analytics), matching
+# the other UI-less log tables in this extension.
+#
+CREATE TABLE tx_nrllm_telemetry (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Trace correlation (UUID v4, RFC 4122 = 36 chars)
+    correlation_id varchar(36) DEFAULT '' NOT NULL,
+
+    -- What ran: operation kind + the requested primary configuration
+    operation varchar(32) DEFAULT '' NOT NULL,
+    provider varchar(64) DEFAULT '' NOT NULL,
+    model varchar(128) DEFAULT '' NOT NULL,
+    configuration_identifier varchar(150) DEFAULT '' NOT NULL,
+
+    -- Attribution (backend user; 0 for CLI / scheduler / unauthenticated)
+    be_user int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Outcome. error_class is the exception FQCN on failure ('' on success);
+    -- the message is deliberately NOT stored (privacy).
+    success smallint(5) unsigned DEFAULT '0' NOT NULL,
+    error_class varchar(255) DEFAULT '' NOT NULL,
+
+    -- Wall-clock latency around the whole pipeline (includes cache lookup)
+    latency_ms int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Pipeline signals collected on the way out
+    cache_hit smallint(5) unsigned DEFAULT '0' NOT NULL,
+    fallback_attempts smallint(5) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 field (append-only; no tstamp — rows are never updated)
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- Fetch every hop of one traced call.
+    KEY correlation (correlation_id),
+    -- Purge and time-range analytics scan by crdate only.
+    KEY crdate (crdate),
+    -- Failure-rate / latency breakdowns filter by operation over a window.
+    KEY operation_lookup (operation, crdate),
+    -- "which provider fails most" breakdowns.
+    KEY provider_lookup (provider, success, crdate)
+);


### PR DESCRIPTION
## Summary

Adds a dedicated `TelemetryMiddleware` (priority 110, outermost) to the provider
middleware pipeline that records **one row per pipeline run — success *and*
failure** — closing the failure-rate gap that `UsageMiddleware` explicitly left
open ("If failure-rate telemetry is needed later, a dedicated middleware can
wrap and record regardless of outcome").

Implements ADR-058.

## What it records

A new append-only table `tx_nrllm_telemetry` (one immutable row per run, *not* a
daily aggregate like `tx_nrllm_service_usage`):

`correlation_id`, `operation`, `provider`, `model`, `configuration_identifier`,
`be_user`, `success`, `error_class`, `latency_ms`, `cache_hit`,
`fallback_attempts`, `crdate`.

## Design notes

- **Privacy trade-off:** only the exception **FQCN** is stored in `error_class`,
  never the message (messages can carry payload fragments). No prompts, no
  responses. The central privacy model (retention tiers) is a later workstream;
  this middleware is metadata-only by construction.
- **Latency includes the cache lookup** — Telemetry sits *outside* Cache, so
  `latency_ms` is the end-to-end time the caller experiences, and a
  cache-served response still produces a row.
- **provider/model reflect the requested primary configuration.** A fallback
  swap shows up as `fallback_attempts > 0`; the provider/model/cost that
  actually *served* live in the usage table (`UsageMiddleware`).
- **Growth → purge.** One row per request grows with traffic; the
  `nrllm:telemetry:purge --days=N` command (default 30) bounds it. Run it from
  the scheduler.
- **Streaming produces no telemetry row** — streaming deliberately stays out of
  the pipeline (ADR-026); a streaming lifecycle is a separate workstream.
- **Fail-soft:** a telemetry write error is logged and swallowed; it never
  breaks the call it observes.
- **Disable** via the `telemetry.enabled` extension setting (default ON).

### Cross-layer signalling

The pipeline threads one immutable `ProviderCallContext` and `$next` forwards
only the `LlmConfiguration`, so an inner middleware cannot hand a modified
context back to an outer one. Cache-hit and fallback-attempt signals therefore
travel on a small mutable `TelemetrySignals` object the context default-
constructs per run: `CacheMiddleware` flags a hit, `FallbackMiddleware`
increments per dispatched fallback, `TelemetryMiddleware` reads both on the way
out. This keeps every pipeline entry point (present and future) covered with no
per-caller wiring, and holds only observability state — never payload.

## Deliberate deviations from the brief

- Signals live on a **typed `TelemetrySignals` property** of the context rather
  than a magic metadata-map key. Same "mutable-carrier-in-the-shared-context"
  mechanics, but type-safe and seeded once by the context itself, so no
  pipeline entry point can forget to seed it. `LlmServiceManager` is untouched.
- `success` / `cache_hit` use `smallint(5) unsigned` (the existing boolean-flag
  column type in this extension: `tx_nrllm_tool_state.enabled` etc.) rather than
  `tinyint`.
- ADR number is **058** (057 is claimed by PR #362; 059 by the LlmServiceManager
  split, per team coordination).

## Tests

- Unit `TelemetryMiddlewareTest`: success row, failure row (FQCN stored,
  exception propagates), cache-hit/fallback signals read, disabled no-op,
  write-failure does not break the call, be_user from metadata / ambient aspect / 0.
- Unit `TelemetrySignalsTest`, `ProviderCallContextTest` (fresh-per-run sink,
  `withMetadata` preserves it), `PurgeTelemetryCommandTest`.
- Functional `TelemetryRepositoryTest`: insert shape + selective purge.
- Extended `CacheMiddlewareTest` / `FallbackMiddlewareTest` for the new signals,
  and `MiddlewarePipelineOrderTest` for the new outermost layer.

## Docs

ADR-058 (new), ADR-026 ordering updated to include Telemetry@110, toctree entry.
