### PR TITLE
feat: quality evaluation with golden prompt sets, grading and regression detection

### DIFF
--- a/Classes/Command/EvalRunCommand.php
+++ b/Classes/Command/EvalRunCommand.php
@@ -80,12 +80,20 @@ final class EvalRunCommand extends Command
 
         $graderOption = $input->getOption('grader');
         $graderId = is_string($graderOption) ? $graderOption : DeterministicGrader::IDENTIFIER;
+        $availableGraders = $this->evaluationService->availableGraders();
+        if (!in_array($graderId, $availableGraders, true)) {
+            $io->error(sprintf('Unknown grader "%s".', $graderId));
+            $io->writeln('Available graders: ' . implode(', ', $availableGraders));
+
+            return Command::FAILURE;
+        }
+
         $result = $this->evaluationService->run($set, $graderId, $this->buildBaseOptions($input));
 
         $io->title(sprintf('Evaluation: %s', $set->identifier));
         $this->renderEvaluations($io, $result);
 
-        $previous = $this->repository->findLatest($result->setIdentifier, $result->model);
+        $previous = $this->repository->findLatest($result->setIdentifier, $result->model, $result->grader);
         $this->repository->save($result);
 
         $report = $this->regressionDetector->compare(

--- a/Classes/Command/EvalRunCommand.php
+++ b/Classes/Command/EvalRunCommand.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetRegistry;
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
+use Netresearch\NrLlm\Service\Evaluation\SetEvaluationResult;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Runs a golden prompt set against a model, prints the per-prompt gradings
+ * and the set aggregate, then compares the run against the previous one for
+ * the same (set, model) and reports any regression (ADR-060).
+ *
+ * Explicitly invoked — nothing here runs in the request pipeline. The
+ * deterministic grader is the default; `--grader llm_judge` opts into the
+ * token-spending LLM judge.
+ */
+#[AsCommand(
+    name: 'nrllm:eval:run',
+    description: 'Run a golden prompt set against a model and report grading and regression.',
+)]
+final class EvalRunCommand extends Command
+{
+    public function __construct(
+        private readonly GoldenPromptSetRegistry $registry,
+        private readonly EvaluationService $evaluationService,
+        private readonly EvaluationResultRepositoryInterface $repository,
+        private readonly RegressionDetector $regressionDetector,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('set', InputArgument::REQUIRED, 'Golden prompt set identifier (e.g. nr_llm.smoke)')
+            ->addOption('grader', null, InputOption::VALUE_REQUIRED, 'Grader: deterministic or llm_judge', DeterministicGrader::IDENTIFIER)
+            ->addOption('model', null, InputOption::VALUE_REQUIRED, 'Model id to evaluate; defaults to the configured default')
+            ->addOption('provider', null, InputOption::VALUE_REQUIRED, 'Provider id to evaluate against')
+            ->addOption('max-pass-rate-drop', null, InputOption::VALUE_REQUIRED, 'Pass-rate drop (0..1) that counts as a regression', '0.1')
+            ->addOption('max-mean-score-drop', null, InputOption::VALUE_REQUIRED, 'Mean-score drop (0..1) that counts as a regression', '0.1')
+            ->addOption('fail-on-regression', null, InputOption::VALUE_NONE, 'Exit with a non-zero status when a regression is detected');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $setArgument = $input->getArgument('set');
+        $setIdentifier = is_string($setArgument) ? $setArgument : '';
+        $set = $this->registry->findByIdentifier($setIdentifier);
+        if ($set === null) {
+            $io->error(sprintf('Unknown golden prompt set "%s".', $setIdentifier));
+            $available = $this->registry->identifiers();
+            if ($available !== []) {
+                $io->writeln('Available sets: ' . implode(', ', $available));
+            }
+
+            return Command::FAILURE;
+        }
+
+        $graderOption = $input->getOption('grader');
+        $graderId = is_string($graderOption) ? $graderOption : DeterministicGrader::IDENTIFIER;
+        $result = $this->evaluationService->run($set, $graderId, $this->buildBaseOptions($input));
+
+        $io->title(sprintf('Evaluation: %s', $set->identifier));
+        $this->renderEvaluations($io, $result);
+
+        $previous = $this->repository->findLatest($result->setIdentifier, $result->model);
+        $this->repository->save($result);
+
+        $report = $this->regressionDetector->compare(
+            $result->toSummary(),
+            $previous,
+            new RegressionThresholds(
+                $this->floatOption($input, 'max-pass-rate-drop', 0.1),
+                $this->floatOption($input, 'max-mean-score-drop', 0.1),
+            ),
+        );
+
+        $io->section('Regression check');
+        $io->writeln($report->summary);
+
+        if ($report->isRegression) {
+            $io->warning('Quality regression detected against the previous run.');
+            if ($input->getOption('fail-on-regression') === true) {
+                return Command::FAILURE;
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderEvaluations(SymfonyStyle $io, SetEvaluationResult $result): void
+    {
+        $rows = [];
+        foreach ($result->evaluations as $evaluation) {
+            $rows[] = [
+                $evaluation->promptId,
+                $evaluation->result->passed ? 'pass' : 'FAIL',
+                sprintf('%.2f', $evaluation->result->score),
+                (string)$evaluation->latencyMs,
+                $evaluation->result->reason,
+            ];
+        }
+        $io->table(['Prompt', 'Result', 'Score', 'Latency (ms)', 'Detail'], $rows);
+
+        $io->writeln(sprintf('Model:      %s', $result->model !== '' ? $result->model : '(unknown)'));
+        $io->writeln(sprintf('Grader:     %s', $result->grader));
+        $io->writeln(sprintf('Pass rate:  %.1f%% (%d/%d)', $result->passRate() * 100, $result->passedCount(), $result->promptCount()));
+        $io->writeln(sprintf('Mean score: %.3f', $result->meanScore()));
+    }
+
+    private function buildBaseOptions(InputInterface $input): ?ChatOptions
+    {
+        $model = $input->getOption('model');
+        $provider = $input->getOption('provider');
+        if (!is_string($model) && !is_string($provider)) {
+            return null;
+        }
+
+        $options = new ChatOptions();
+        if (is_string($model) && $model !== '') {
+            $options = $options->withModel($model);
+        }
+        if (is_string($provider) && $provider !== '') {
+            $options = $options->withProvider($provider);
+        }
+
+        return $options;
+    }
+
+    private function floatOption(InputInterface $input, string $name, float $default): float
+    {
+        $value = $input->getOption($name);
+
+        return is_numeric($value) ? (float)$value : $default;
+    }
+}

--- a/Classes/Domain/Enum/AssertionType.php
+++ b/Classes/Domain/Enum/AssertionType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * The deterministic assertion strategies a golden prompt can declare.
+ *
+ * Each assertion carries a `type` and a `value`; the DeterministicGrader
+ * matches the model response against the value according to the type:
+ *
+ * - EXACT       trimmed response equals the value verbatim
+ * - CONTAINS    the value is a substring of the response
+ * - REGEX       the value is a PCRE pattern the response matches
+ * - JSON_SCHEMA the response parses as JSON and satisfies a lightweight
+ *               structural schema (required keys + per-key type), NOT a
+ *               full JSON Schema draft validator (ADR-060)
+ */
+enum AssertionType: string
+{
+    case EXACT = 'exact';
+    case CONTAINS = 'contains';
+    case REGEX = 'regex';
+    case JSON_SCHEMA = 'json_schema';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn(self $case): string => $case->value,
+            self::cases(),
+        );
+    }
+}

--- a/Classes/Service/Evaluation/Assertion.php
+++ b/Classes/Service/Evaluation/Assertion.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\AssertionType;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * A single deterministic expectation on a model response (ADR-060).
+ *
+ * The `value` is interpreted according to `type`: a literal string for
+ * EXACT / CONTAINS, a PCRE pattern for REGEX, or a JSON structural schema
+ * for JSON_SCHEMA. A REGEX value must be a compilable pattern; an empty
+ * value is rejected for every type because it can never express a
+ * meaningful assertion.
+ */
+final readonly class Assertion
+{
+    public function __construct(
+        public AssertionType $type,
+        public string $value,
+    ) {
+        if ($value === '') {
+            throw new InvalidArgumentException(
+                sprintf('Assertion of type "%s" must declare a non-empty value.', $type->value),
+                1794000001,
+            );
+        }
+        if ($type === AssertionType::REGEX && !self::isValidPattern($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Assertion regex "%s" is not a valid PCRE pattern.', $value),
+                1794000002,
+            );
+        }
+    }
+
+    /**
+     * Whether the string is a compilable PCRE pattern, checked without the
+     * `@` suppression operator (a temporary error handler swallows the
+     * warning an invalid pattern would emit).
+     */
+    private static function isValidPattern(string $pattern): bool
+    {
+        set_error_handler(static fn(): bool => true);
+        try {
+            return preg_match($pattern, '') !== false;
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public static function exact(string $value): self
+    {
+        return new self(AssertionType::EXACT, $value);
+    }
+
+    public static function contains(string $value): self
+    {
+        return new self(AssertionType::CONTAINS, $value);
+    }
+
+    public static function regex(string $pattern): self
+    {
+        return new self(AssertionType::REGEX, $pattern);
+    }
+
+    public static function jsonSchema(string $schemaJson): self
+    {
+        return new self(AssertionType::JSON_SCHEMA, $schemaJson);
+    }
+}

--- a/Classes/Service/Evaluation/BuiltinGoldenPromptSetProvider.php
+++ b/Classes/Service/Evaluation/BuiltinGoldenPromptSetProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+
+/**
+ * The example golden set nr_llm ships so `nrllm:eval:run` has a runnable
+ * target out of the box and consuming extensions have a concrete pattern to
+ * copy (ADR-060).
+ *
+ * The set is intentionally small and provider-agnostic: three factual
+ * prompts graded deterministically (contains / regex / exact). It exercises
+ * the machinery, not a specific model's knowledge — nothing here runs unless
+ * the eval command is invoked.
+ */
+final readonly class BuiltinGoldenPromptSetProvider implements GoldenPromptSetProviderInterface
+{
+    public const SET_IDENTIFIER = 'nr_llm.smoke';
+
+    public function getGoldenPromptSets(): array
+    {
+        return [
+            new GoldenPromptSet(
+                identifier: self::SET_IDENTIFIER,
+                name: 'nr_llm smoke evaluation',
+                description: 'A minimal provider-agnostic set that checks the model answers three simple factual prompts. Ships as the example pattern for consumer golden sets.',
+                prompts: [
+                    new GoldenPrompt(
+                        id: 'capital-of-france',
+                        prompt: 'What is the capital of France? Answer with the city name only.',
+                        assertions: [Assertion::contains('Paris')],
+                        systemPrompt: 'You are a concise factual assistant. Answer in as few words as possible.',
+                        reference: 'Paris',
+                    ),
+                    new GoldenPrompt(
+                        id: 'two-plus-two',
+                        prompt: 'Compute 2 + 2 and reply with the digit only.',
+                        assertions: [Assertion::regex('/\b4\b/')],
+                        reference: '4',
+                    ),
+                    new GoldenPrompt(
+                        id: 'echo-token',
+                        prompt: 'Reply with exactly the single word: ACKNOWLEDGED',
+                        assertions: [Assertion::contains('ACKNOWLEDGED')],
+                        reference: 'ACKNOWLEDGED',
+                    ),
+                ],
+                criteria: new ModelSelectionCriteria(capabilities: [ModelCapability::CHAT->value]),
+            ),
+        ];
+    }
+}

--- a/Classes/Service/Evaluation/EvaluationQualityScoreProvider.php
+++ b/Classes/Service/Evaluation/EvaluationQualityScoreProvider.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Evaluation;
 
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+
 /**
  * The default ModelQualityScoreProvider: reads a model's quality score from
  * stored evaluation results (ADR-060).
@@ -28,6 +30,9 @@ final readonly class EvaluationQualityScoreProvider implements ModelQualityScore
             return null;
         }
 
-        return $this->repository->meanQualityScoreForModel($modelId);
+        // Routing uses the deterministic grader's scores only: LLM-judge
+        // scores are on a different, non-comparable scale, so averaging the
+        // two would produce a meaningless routing signal.
+        return $this->repository->meanQualityScoreForModel($modelId, DeterministicGrader::IDENTIFIER);
     }
 }

--- a/Classes/Service/Evaluation/EvaluationQualityScoreProvider.php
+++ b/Classes/Service/Evaluation/EvaluationQualityScoreProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The default ModelQualityScoreProvider: reads a model's quality score from
+ * stored evaluation results (ADR-060).
+ *
+ * A thin adapter over EvaluationResultRepository so routing depends only on
+ * the quality-score interface, not on the persistence layer.
+ */
+final readonly class EvaluationQualityScoreProvider implements ModelQualityScoreProviderInterface
+{
+    public function __construct(
+        private EvaluationResultRepositoryInterface $repository,
+    ) {}
+
+    public function getQualityScore(string $modelId): ?float
+    {
+        if ($modelId === '') {
+            return null;
+        }
+
+        return $this->repository->meanQualityScoreForModel($modelId);
+    }
+}

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -75,7 +75,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             ->executeQuery()
             ->fetchAllAssociative();
 
-        return array_map(fn(array $row): EvaluationResultSummary => $this->mapRow($row), $rows);
+        return array_map($this->mapRow(...), $rows);
     }
 
     public function meanQualityScoreForModel(string $model): ?float

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -50,14 +50,14 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
         ]);
     }
 
-    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary
+    public function findLatest(string $setIdentifier, string $model, string $grader): ?EvaluationResultSummary
     {
-        $recent = $this->findRecent($setIdentifier, $model, 1);
+        $recent = $this->findRecent($setIdentifier, $model, $grader, 1);
 
         return $recent[0] ?? null;
     }
 
-    public function findRecent(string $setIdentifier, string $model, int $limit): array
+    public function findRecent(string $setIdentifier, string $model, string $grader, int $limit): array
     {
         if ($limit < 1) {
             return [];
@@ -68,6 +68,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             ->where(
                 $queryBuilder->expr()->eq('set_identifier', $queryBuilder->createNamedParameter($setIdentifier)),
                 $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($model)),
+                $queryBuilder->expr()->eq('grader', $queryBuilder->createNamedParameter($grader)),
             )
             ->orderBy('run_date', 'DESC')
             ->addOrderBy('uid', 'DESC')
@@ -78,7 +79,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
         return array_map($this->mapRow(...), $rows);
     }
 
-    public function meanQualityScoreForModel(string $model): ?float
+    public function meanQualityScoreForModel(string $model, string $grader): ?float
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $rows = $queryBuilder
@@ -86,6 +87,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             ->from(self::TABLE)
             ->where(
                 $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($model)),
+                $queryBuilder->expr()->eq('grader', $queryBuilder->createNamedParameter($grader)),
             )
             ->orderBy('run_date', 'DESC')
             ->addOrderBy('uid', 'DESC')

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Stores and reads evaluation run summaries in `tx_nrllm_eval_result`
+ * (ADR-060).
+ *
+ * A UI-less result log — no TCA, mirroring `tx_nrllm_service_usage`. Each
+ * run is one row carrying the aggregate metrics plus a JSON snapshot of the
+ * per-prompt outcomes for later inspection. Direct DBAL, like
+ * UsageTrackerService; nothing resolves this class from the container by
+ * name (the command autowires the interface), so it stays off the public
+ * service surface.
+ */
+final readonly class EvaluationResultRepository implements EvaluationResultRepositoryInterface
+{
+    private const TABLE = 'tx_nrllm_eval_result';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function save(SetEvaluationResult $result): void
+    {
+        $now = time();
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid' => 0,
+            'set_identifier' => $result->setIdentifier,
+            'model_id' => $result->model,
+            'grader' => $result->grader,
+            'prompt_count' => $result->promptCount(),
+            'passed_count' => $result->passedCount(),
+            'pass_rate' => $result->passRate(),
+            'mean_score' => $result->meanScore(),
+            'details' => $this->encodeDetails($result),
+            'run_date' => $result->runTimestamp,
+            'tstamp' => $now,
+            'crdate' => $now,
+        ]);
+    }
+
+    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary
+    {
+        $recent = $this->findRecent($setIdentifier, $model, 1);
+
+        return $recent[0] ?? null;
+    }
+
+    public function findRecent(string $setIdentifier, string $model, int $limit): array
+    {
+        if ($limit < 1) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $this->baseSelect($queryBuilder)
+            ->where(
+                $queryBuilder->expr()->eq('set_identifier', $queryBuilder->createNamedParameter($setIdentifier)),
+                $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($model)),
+            )
+            ->orderBy('run_date', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(fn(array $row): EvaluationResultSummary => $this->mapRow($row), $rows);
+    }
+
+    public function meanQualityScoreForModel(string $model): ?float
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->select('set_identifier', 'mean_score')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('model_id', $queryBuilder->createNamedParameter($model)),
+            )
+            ->orderBy('run_date', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $seenSets = [];
+        $scores = [];
+        foreach ($rows as $row) {
+            $setIdentifier = $this->toString($row['set_identifier'] ?? '');
+            if (isset($seenSets[$setIdentifier])) {
+                continue;
+            }
+            $seenSets[$setIdentifier] = true;
+            $scores[] = $this->toFloat($row['mean_score'] ?? 0);
+        }
+
+        if ($scores === []) {
+            return null;
+        }
+
+        return array_sum($scores) / count($scores);
+    }
+
+    private function baseSelect(QueryBuilder $queryBuilder): QueryBuilder
+    {
+        return $queryBuilder
+            ->select(
+                'uid',
+                'set_identifier',
+                'model_id',
+                'grader',
+                'prompt_count',
+                'passed_count',
+                'pass_rate',
+                'mean_score',
+                'run_date',
+            )
+            ->from(self::TABLE);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): EvaluationResultSummary
+    {
+        return new EvaluationResultSummary(
+            $this->toString($row['set_identifier'] ?? ''),
+            $this->toString($row['model_id'] ?? ''),
+            $this->toString($row['grader'] ?? ''),
+            $this->toInt($row['prompt_count'] ?? 0),
+            $this->toInt($row['passed_count'] ?? 0),
+            $this->toFloat($row['pass_rate'] ?? 0),
+            $this->toFloat($row['mean_score'] ?? 0),
+            $this->toInt($row['run_date'] ?? 0),
+            $this->toInt($row['uid'] ?? 0),
+        );
+    }
+
+    private function encodeDetails(SetEvaluationResult $result): string
+    {
+        $details = array_map(
+            static fn(PromptEvaluation $evaluation): array => $evaluation->toArray(),
+            $result->evaluations,
+        );
+
+        return json_encode($details, JSON_THROW_ON_ERROR);
+    }
+
+    private function toString(mixed $value): string
+    {
+        return is_scalar($value) ? (string)$value : '';
+    }
+
+    private function toInt(mixed $value): int
+    {
+        return is_numeric($value) ? (int)$value : 0;
+    }
+
+    private function toFloat(mixed $value): float
+    {
+        return is_numeric($value) ? (float)$value : 0.0;
+    }
+}

--- a/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
@@ -25,23 +25,28 @@ interface EvaluationResultRepositoryInterface
     public function save(SetEvaluationResult $result): void;
 
     /**
-     * The most recent stored summary for a (set, model), or null if none.
+     * The most recent stored summary for a (set, model, grader), or null if
+     * none. The grader is part of the key: a pass rate / mean score only
+     * means the same thing when compared against a run graded the same way.
      */
-    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary;
+    public function findLatest(string $setIdentifier, string $model, string $grader): ?EvaluationResultSummary;
 
     /**
-     * The most recent stored summaries for a (set, model), newest first.
+     * The most recent stored summaries for a (set, model, grader), newest
+     * first.
      *
      * @return list<EvaluationResultSummary>
      */
-    public function findRecent(string $setIdentifier, string $model, int $limit): array;
+    public function findRecent(string $setIdentifier, string $model, string $grader, int $limit): array;
 
     /**
-     * Mean quality score for a model across its golden sets (0.0-1.0), or
-     * null when the model has no stored results.
+     * Mean quality score for a model across its golden sets (0.0-1.0) for a
+     * single grader, or null when the model has no stored results for it.
      *
      * Averages the latest run per set for the model, so one heavily-evaluated
-     * set does not dominate and stale runs are ignored.
+     * set does not dominate and stale runs are ignored. Scoped to one grader
+     * because deterministic assertion fractions and LLM-judge scores are not
+     * comparable and must not be averaged together.
      */
-    public function meanQualityScoreForModel(string $model): ?float;
+    public function meanQualityScoreForModel(string $model, string $grader): ?float;
 }

--- a/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * Persistence contract for evaluation run results (ADR-060).
+ *
+ * Stores aggregate summaries in `tx_nrllm_eval_result` and exposes the
+ * reads regression detection and quality-aware routing need. Extracted as
+ * an interface so the eval command and quality-score provider can be tested
+ * against an in-memory double without a database.
+ */
+interface EvaluationResultRepositoryInterface
+{
+    /**
+     * Persist one set run as a new result row.
+     */
+    public function save(SetEvaluationResult $result): void;
+
+    /**
+     * The most recent stored summary for a (set, model), or null if none.
+     */
+    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary;
+
+    /**
+     * The most recent stored summaries for a (set, model), newest first.
+     *
+     * @return list<EvaluationResultSummary>
+     */
+    public function findRecent(string $setIdentifier, string $model, int $limit): array;
+
+    /**
+     * Mean quality score for a model across its golden sets (0.0-1.0), or
+     * null when the model has no stored results.
+     *
+     * Averages the latest run per set for the model, so one heavily-evaluated
+     * set does not dominate and stale runs are ignored.
+     */
+    public function meanQualityScoreForModel(string $model): ?float;
+}

--- a/Classes/Service/Evaluation/EvaluationResultSummary.php
+++ b/Classes/Service/Evaluation/EvaluationResultSummary.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The persisted, aggregate-only view of a set evaluation run (ADR-060).
+ *
+ * This is what the eval_result table stores and what regression detection
+ * compares: pass rate and mean score for one (set, model) at a point in
+ * time, without the per-prompt detail. `uid` is 0 for a summary that has not
+ * been read back from the database.
+ */
+final readonly class EvaluationResultSummary
+{
+    public function __construct(
+        public string $setIdentifier,
+        public string $model,
+        public string $grader,
+        public int $promptCount,
+        public int $passedCount,
+        public float $passRate,
+        public float $meanScore,
+        public int $runTimestamp,
+        public int $uid = 0,
+    ) {}
+}

--- a/Classes/Service/Evaluation/EvaluationService.php
+++ b/Classes/Service/Evaluation/EvaluationService.php
@@ -32,6 +32,17 @@ final readonly class EvaluationService
     ) {}
 
     /**
+     * The grader identifiers this service can run, for callers that need to
+     * validate a requested grader before invoking run().
+     *
+     * @return list<string>
+     */
+    public function availableGraders(): array
+    {
+        return $this->gradingService->availableGraders();
+    }
+
+    /**
      * Execute the set and return the aggregated result.
      *
      * @param string           $graderId    Grader identifier (default: deterministic; llm_judge is opt-in)

--- a/Classes/Service/Evaluation/EvaluationService.php
+++ b/Classes/Service/Evaluation/EvaluationService.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+
+/**
+ * Runs a golden prompt set against a model and aggregates the per-prompt
+ * gradings into a set result (ADR-060).
+ *
+ * This is an explicitly invoked, out-of-request operation: it calls the
+ * model once per prompt via the existing CompletionService, grades each
+ * response through GradingService, and records the wall-clock latency. It
+ * neither persists nor compares — that is the caller's job (the eval
+ * command wires persistence and regression detection around it), which
+ * keeps this orchestrator unit-testable without a database.
+ */
+final readonly class EvaluationService
+{
+    public function __construct(
+        private CompletionServiceInterface $completionService,
+        private GradingService $gradingService,
+    ) {}
+
+    /**
+     * Execute the set and return the aggregated result.
+     *
+     * @param string           $graderId    Grader identifier (default: deterministic; llm_judge is opt-in)
+     * @param ChatOptions|null $baseOptions Options applied to every call (e.g. the model/provider to evaluate);
+     *                                      a prompt's own system prompt overrides the base system prompt
+     */
+    public function run(
+        GoldenPromptSet $set,
+        string $graderId = DeterministicGrader::IDENTIFIER,
+        ?ChatOptions $baseOptions = null,
+    ): SetEvaluationResult {
+        $evaluations = [];
+        $model = $baseOptions?->getModel() ?? '';
+
+        foreach ($set->prompts as $prompt) {
+            $options = $baseOptions ?? new ChatOptions();
+            if ($prompt->systemPrompt !== null) {
+                $options = $options->withSystemPrompt($prompt->systemPrompt);
+            }
+
+            $startedAt = microtime(true);
+            $response = $this->completionService->complete($prompt->prompt, $options);
+            $latencyMs = (int)round((microtime(true) - $startedAt) * 1000);
+
+            if ($response->model !== '') {
+                $model = $response->model;
+            }
+
+            $grading = $this->gradingService->grade($response->content, $prompt, $graderId);
+            $evaluations[] = new PromptEvaluation($prompt->id, $grading, $latencyMs);
+        }
+
+        return new SetEvaluationResult($set->identifier, $model, $graderId, $evaluations, time());
+    }
+}

--- a/Classes/Service/Evaluation/GoldenPrompt.php
+++ b/Classes/Service/Evaluation/GoldenPrompt.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * A single graded prompt inside a golden set (ADR-060).
+ *
+ * The `id` is unique within its set and identifies the prompt in run
+ * results and regression comparisons. `assertions` drive the
+ * deterministic grader; `reference` is an optional ideal answer the
+ * LLM-as-a-judge grader uses as its grading reference. A prompt needs at
+ * least one assertion OR a reference, otherwise there is nothing to grade
+ * against.
+ */
+final readonly class GoldenPrompt
+{
+    /**
+     * @param list<Assertion> $assertions Deterministic expectations on the response
+     */
+    public function __construct(
+        public string $id,
+        public string $prompt,
+        public array $assertions = [],
+        public ?string $systemPrompt = null,
+        public ?string $reference = null,
+    ) {
+        if ($id === '') {
+            throw new InvalidArgumentException('Golden prompt id must not be empty.', 1794000010);
+        }
+        if ($prompt === '') {
+            throw new InvalidArgumentException(
+                sprintf('Golden prompt "%s" must declare a non-empty prompt.', $id),
+                1794000011,
+            );
+        }
+        if ($assertions === [] && ($reference === null || $reference === '')) {
+            throw new InvalidArgumentException(
+                sprintf('Golden prompt "%s" must declare at least one assertion or a reference answer.', $id),
+                1794000012,
+            );
+        }
+    }
+}

--- a/Classes/Service/Evaluation/GoldenPromptSet.php
+++ b/Classes/Service/Evaluation/GoldenPromptSet.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * A named collection of golden prompts a consuming extension declares for
+ * quality evaluation (ADR-060).
+ *
+ * The identifier is namespaced (e.g. `nr_ai_search.chat`) so sets from
+ * different extensions cannot collide, mirroring the ConfigurationPreset
+ * identifier convention (ADR-056). The optional `criteria` document the
+ * model requirements the set is meant to exercise; they are metadata for
+ * consumers and future criteria-based routing — the evaluation itself runs
+ * against whatever model the caller selects.
+ */
+final readonly class GoldenPromptSet
+{
+    /**
+     * Lowercase dot-namespaced identifier: segments of `[a-z0-9_]`
+     * separated by single dots, e.g. `nr_ai_search.chat`.
+     */
+    private const IDENTIFIER_PATTERN = '/^[a-z0-9_]+(?:\.[a-z0-9_]+)*$/';
+
+    /**
+     * @param list<GoldenPrompt> $prompts
+     */
+    public function __construct(
+        public string $identifier,
+        public string $name,
+        public string $description,
+        public array $prompts,
+        public ?ModelSelectionCriteria $criteria = null,
+    ) {
+        if ($identifier === '' || preg_match(self::IDENTIFIER_PATTERN, $identifier) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid golden set identifier "%s": expected lowercase segments of [a-z0-9_] separated by dots, e.g. "nr_ai_search.chat".',
+                    $identifier,
+                ),
+                1794000020,
+            );
+        }
+        if ($name === '') {
+            throw new InvalidArgumentException(
+                sprintf('Golden set "%s" must declare a non-empty name.', $identifier),
+                1794000021,
+            );
+        }
+        if ($prompts === []) {
+            throw new InvalidArgumentException(
+                sprintf('Golden set "%s" must declare at least one prompt.', $identifier),
+                1794000022,
+            );
+        }
+        $seen = [];
+        foreach ($prompts as $prompt) {
+            if (isset($seen[$prompt->id])) {
+                throw new InvalidArgumentException(
+                    sprintf('Golden set "%s" declares duplicate prompt id "%s".', $identifier, $prompt->id),
+                    1794000023,
+                );
+            }
+            $seen[$prompt->id] = true;
+        }
+    }
+}

--- a/Classes/Service/Evaluation/GoldenPromptSetProviderInterface.php
+++ b/Classes/Service/Evaluation/GoldenPromptSetProviderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A provider of golden prompt sets a consuming extension contributes for
+ * quality evaluation (ADR-060).
+ *
+ * Implementations are discovered via the `nr_llm.golden_prompt_set` DI tag
+ * (auto-applied by AutoconfigureTag, mirroring
+ * ConfigurationPresetProviderInterface / ToolInterface) and collected by
+ * GoldenPromptSetRegistry through a tagged iterator. A consuming extension
+ * only needs to implement this interface and register its class as a
+ * service — no further wiring.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface GoldenPromptSetProviderInterface
+{
+    public const TAG_NAME = 'nr_llm.golden_prompt_set';
+
+    /**
+     * The golden prompt sets this extension declares.
+     *
+     * @return list<GoldenPromptSet>
+     */
+    public function getGoldenPromptSets(): array;
+}

--- a/Classes/Service/Evaluation/GoldenPromptSetRegistry.php
+++ b/Classes/Service/Evaluation/GoldenPromptSetRegistry.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Collects every DI-tagged GoldenPromptSetProviderInterface and exposes the
+ * declared golden prompt sets (ADR-060).
+ *
+ * Providers are injected through the `nr_llm.golden_prompt_set` tagged
+ * iterator (mirroring ConfigurationPresetRegistry / ToolRegistry) and their
+ * sets indexed by identifier; a duplicate identifier across providers is a
+ * developer error and fails fast with a LogicException at construction time.
+ */
+final class GoldenPromptSetRegistry
+{
+    /** @var array<string, GoldenPromptSet> */
+    private array $byIdentifier = [];
+
+    /**
+     * @param iterable<GoldenPromptSetProviderInterface> $providers
+     */
+    public function __construct(
+        #[AutowireIterator(GoldenPromptSetProviderInterface::TAG_NAME)]
+        iterable $providers,
+    ) {
+        foreach ($providers as $provider) {
+            foreach ($provider->getGoldenPromptSets() as $set) {
+                if (isset($this->byIdentifier[$set->identifier])) {
+                    throw new LogicException(
+                        sprintf('Duplicate golden prompt set identifier "%s".', $set->identifier),
+                        1794000030,
+                    );
+                }
+                $this->byIdentifier[$set->identifier] = $set;
+            }
+        }
+    }
+
+    /**
+     * @return list<GoldenPromptSet>
+     */
+    public function all(): array
+    {
+        return array_values($this->byIdentifier);
+    }
+
+    public function findByIdentifier(string $identifier): ?GoldenPromptSet
+    {
+        return $this->byIdentifier[$identifier] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function identifiers(): array
+    {
+        return array_keys($this->byIdentifier);
+    }
+}

--- a/Classes/Service/Evaluation/Grader/DeterministicGrader.php
+++ b/Classes/Service/Evaluation/Grader/DeterministicGrader.php
@@ -104,7 +104,10 @@ final readonly class DeterministicGrader implements GraderInterface
         }
 
         if (isset($schema['required']) && is_array($schema['required'])) {
-            if (!is_array($data) || array_is_list($data)) {
+            // An empty JSON object decodes to []; treat it as an object here
+            // (consistent with matchesType()) so an empty object is not
+            // mistaken for a list and the required-key checks still run.
+            if (!is_array($data) || ($data !== [] && array_is_list($data))) {
                 return false;
             }
             foreach ($schema['required'] as $key) {

--- a/Classes/Service/Evaluation/Grader/DeterministicGrader.php
+++ b/Classes/Service/Evaluation/Grader/DeterministicGrader.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation\Grader;
+
+use Netresearch\NrLlm\Domain\Enum\AssertionType;
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+
+/**
+ * Grades a response by evaluating a golden prompt's deterministic
+ * assertions (exact / contains / regex / json_schema) — no LLM call, no
+ * tokens (ADR-060).
+ *
+ * The score is the fraction of assertions satisfied; the response passes
+ * only when every assertion holds. json_schema uses a lightweight
+ * structural matcher (required keys + per-key type), not a full JSON Schema
+ * draft validator, to avoid a runtime dependency.
+ */
+final readonly class DeterministicGrader implements GraderInterface
+{
+    public const IDENTIFIER = 'deterministic';
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function grade(string $response, GoldenPrompt $prompt): GradingResult
+    {
+        if ($prompt->assertions === []) {
+            return new GradingResult(
+                false,
+                0.0,
+                self::IDENTIFIER,
+                'No deterministic assertions declared; use the llm_judge grader for reference-only prompts.',
+            );
+        }
+
+        $total = count($prompt->assertions);
+        $passedCount = 0;
+        $failures = [];
+        foreach ($prompt->assertions as $assertion) {
+            if ($this->matches($assertion, $response)) {
+                ++$passedCount;
+            } else {
+                $failures[] = sprintf('%s(%s)', $assertion->type->value, $this->summarise($assertion->value));
+            }
+        }
+
+        $passed = $passedCount === $total;
+        $reason = $passed
+            ? sprintf('All %d assertion(s) satisfied.', $total)
+            : sprintf('Failed %d/%d assertion(s): %s', $total - $passedCount, $total, implode(', ', $failures));
+
+        return new GradingResult($passed, $passedCount / $total, self::IDENTIFIER, $reason);
+    }
+
+    private function matches(Assertion $assertion, string $response): bool
+    {
+        return match ($assertion->type) {
+            AssertionType::EXACT => trim($response) === trim($assertion->value),
+            AssertionType::CONTAINS => str_contains($response, $assertion->value),
+            AssertionType::REGEX => preg_match($assertion->value, $response) === 1,
+            AssertionType::JSON_SCHEMA => $this->matchesJsonSchema($response, $assertion->value),
+        };
+    }
+
+    /**
+     * Lightweight structural JSON match: valid JSON whose shape satisfies a
+     * subset schema (top-level `type`, object `required` keys, and recursive
+     * `properties` types). Extra keys are allowed; this is deliberately not a
+     * full JSON Schema draft validator.
+     */
+    private function matchesJsonSchema(string $response, string $schemaJson): bool
+    {
+        $data = json_decode($response, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return false;
+        }
+        $schema = json_decode($schemaJson, true);
+        if (!is_array($schema)) {
+            return false;
+        }
+
+        return $this->validateAgainstSchema($data, $schema);
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function validateAgainstSchema(mixed $data, array $schema): bool
+    {
+        $type = $schema['type'] ?? null;
+        if (is_string($type) && !$this->matchesType($data, $type)) {
+            return false;
+        }
+
+        if (isset($schema['required']) && is_array($schema['required'])) {
+            if (!is_array($data) || array_is_list($data)) {
+                return false;
+            }
+            foreach ($schema['required'] as $key) {
+                if (!is_string($key) || !array_key_exists($key, $data)) {
+                    return false;
+                }
+            }
+        }
+
+        if (isset($schema['properties']) && is_array($schema['properties']) && is_array($data)) {
+            foreach ($schema['properties'] as $key => $propSchema) {
+                if (is_array($propSchema) && array_key_exists($key, $data)
+                    && !$this->validateAgainstSchema($data[$key], $propSchema)
+                ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function matchesType(mixed $data, string $type): bool
+    {
+        return match ($type) {
+            // An empty JSON object and array both decode to []; ambiguity is
+            // accepted for this lightweight matcher.
+            'object' => is_array($data) && (!array_is_list($data) || $data === []),
+            'array' => is_array($data) && array_is_list($data),
+            'string' => is_string($data),
+            'number' => is_int($data) || is_float($data),
+            'integer' => is_int($data),
+            'boolean' => is_bool($data),
+            'null' => $data === null,
+            default => true,
+        };
+    }
+
+    private function summarise(string $value): string
+    {
+        $value = trim($value);
+        return mb_strlen($value) > 40 ? mb_substr($value, 0, 37) . '...' : $value;
+    }
+}

--- a/Classes/Service/Evaluation/Grader/GraderInterface.php
+++ b/Classes/Service/Evaluation/Grader/GraderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation\Grader;
+
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+
+/**
+ * A grading strategy that scores a model response against a golden prompt
+ * (ADR-060).
+ *
+ * Implementations are selected by identifier through GradingService. The
+ * deterministic grader is the default; the LLM-as-a-judge grader is opt-in
+ * because it spends tokens on a judge call.
+ */
+interface GraderInterface
+{
+    /**
+     * Stable identifier used to select this grader (e.g. `deterministic`).
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * Grade the given response against the prompt's expectations.
+     */
+    public function grade(string $response, GoldenPrompt $prompt): GradingResult;
+}

--- a/Classes/Service/Evaluation/Grader/LlmJudgeGrader.php
+++ b/Classes/Service/Evaluation/Grader/LlmJudgeGrader.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation\Grader;
+
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Throwable;
+
+/**
+ * Grades a response by asking an LLM judge to score it 0.0-1.0 with a
+ * justification (ADR-060).
+ *
+ * Opt-in: unlike the deterministic grader it spends tokens. The judge runs
+ * through the existing CompletionService — so it uses the default chat
+ * configuration the admin has set up; selecting a dedicated judge model is a
+ * documented follow-up. The judge is asked for strict JSON; any deviation,
+ * transport error, or out-of-range score is handled defensively so a single
+ * bad judge response fails that one grading rather than aborting the run.
+ */
+final readonly class LlmJudgeGrader implements GraderInterface
+{
+    public const IDENTIFIER = 'llm_judge';
+
+    public function __construct(
+        private CompletionServiceInterface $completionService,
+        private float $passThreshold = 0.6,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function grade(string $response, GoldenPrompt $prompt): GradingResult
+    {
+        $options = (new ChatOptions())
+            ->withResponseFormat('json')
+            ->withTemperature(0.0)
+            ->withSystemPrompt(
+                'You are a strict evaluation judge. You score how well an AI response fulfils a task '
+                . 'on a scale from 0.0 (completely fails) to 1.0 (perfect). '
+                . 'Respond ONLY with a JSON object: {"score": <number 0..1>, "reason": "<short justification>"}.',
+            );
+
+        try {
+            $judgeResponse = $this->completionService->complete($this->buildJudgePrompt($response, $prompt), $options);
+        } catch (Throwable $e) {
+            return new GradingResult(false, 0.0, self::IDENTIFIER, 'Judge call failed: ' . $e->getMessage());
+        }
+
+        return $this->parseVerdict($judgeResponse->content);
+    }
+
+    private function buildJudgePrompt(string $response, GoldenPrompt $prompt): string
+    {
+        $parts = [
+            'TASK PROMPT:',
+            $prompt->prompt,
+        ];
+        if ($prompt->reference !== null && $prompt->reference !== '') {
+            $parts[] = '';
+            $parts[] = 'REFERENCE ANSWER (an ideal response):';
+            $parts[] = $prompt->reference;
+        }
+        $parts[] = '';
+        $parts[] = 'RESPONSE TO GRADE:';
+        $parts[] = $response;
+
+        return implode("\n", $parts);
+    }
+
+    private function parseVerdict(string $content): GradingResult
+    {
+        $decoded = json_decode($content, true);
+        if (!is_array($decoded) || !isset($decoded['score']) || !is_numeric($decoded['score'])) {
+            return new GradingResult(
+                false,
+                0.0,
+                self::IDENTIFIER,
+                'Judge response was not parseable as {"score", "reason"} JSON.',
+            );
+        }
+
+        $score = max(0.0, min(1.0, (float)$decoded['score']));
+        $reason = isset($decoded['reason']) && is_string($decoded['reason']) ? $decoded['reason'] : '';
+
+        return new GradingResult($score >= $this->passThreshold, $score, self::IDENTIFIER, $reason);
+    }
+}

--- a/Classes/Service/Evaluation/GradingResult.php
+++ b/Classes/Service/Evaluation/GradingResult.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The outcome of grading one response against one golden prompt (ADR-060).
+ *
+ * `score` is normalised to 0.0-1.0. `passed` is the pass/fail verdict a
+ * grader derives from that score (all assertions satisfied for the
+ * deterministic grader; score above the judge's threshold for the LLM
+ * judge). `grader` records which strategy produced the verdict and `reason`
+ * carries a short human-readable justification for run output and audit.
+ */
+final readonly class GradingResult
+{
+    public function __construct(
+        public bool $passed,
+        public float $score,
+        public string $grader,
+        public string $reason = '',
+    ) {}
+}

--- a/Classes/Service/Evaluation/GradingService.php
+++ b/Classes/Service/Evaluation/GradingService.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Evaluation\Grader\GraderInterface;
+use Netresearch\NrLlm\Service\Evaluation\Grader\LlmJudgeGrader;
+
+/**
+ * Selects a grading strategy and grades a response against a golden prompt
+ * (ADR-060).
+ *
+ * The deterministic grader is the default; the LLM judge is opt-in via the
+ * grader identifier because it spends tokens. An unknown identifier falls
+ * back to the deterministic grader — evaluation must never silently invoke
+ * the token-spending judge.
+ */
+final readonly class GradingService
+{
+    public function __construct(
+        private DeterministicGrader $deterministicGrader,
+        private LlmJudgeGrader $llmJudgeGrader,
+    ) {}
+
+    public function grade(string $response, GoldenPrompt $prompt, string $graderId = DeterministicGrader::IDENTIFIER): GradingResult
+    {
+        return $this->resolveGrader($graderId)->grade($response, $prompt);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function availableGraders(): array
+    {
+        return [DeterministicGrader::IDENTIFIER, LlmJudgeGrader::IDENTIFIER];
+    }
+
+    private function resolveGrader(string $graderId): GraderInterface
+    {
+        return match ($graderId) {
+            LlmJudgeGrader::IDENTIFIER => $this->llmJudgeGrader,
+            default => $this->deterministicGrader,
+        };
+    }
+}

--- a/Classes/Service/Evaluation/ModelQualityScoreProviderInterface.php
+++ b/Classes/Service/Evaluation/ModelQualityScoreProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * Supplies an aggregated quality score per model for quality-aware routing
+ * (ADR-060).
+ *
+ * The score is derived from stored evaluation results and normalised to
+ * 0.0-1.0; null means the model has no evaluation data and therefore no
+ * quality signal. Kept as an interface so routing can be tested without a
+ * database and so an extension can substitute a different quality source.
+ */
+interface ModelQualityScoreProviderInterface
+{
+    public function getQualityScore(string $modelId): ?float;
+}

--- a/Classes/Service/Evaluation/PromptEvaluation.php
+++ b/Classes/Service/Evaluation/PromptEvaluation.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The evaluation of one golden prompt within a run (ADR-060): the grading
+ * verdict plus the wall-clock latency of the model call that produced the
+ * graded response.
+ */
+final readonly class PromptEvaluation
+{
+    public function __construct(
+        public string $promptId,
+        public GradingResult $result,
+        public int $latencyMs,
+    ) {}
+
+    /**
+     * @return array{promptId: string, passed: bool, score: float, grader: string, reason: string, latencyMs: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'promptId' => $this->promptId,
+            'passed' => $this->result->passed,
+            'score' => $this->result->score,
+            'grader' => $this->result->grader,
+            'reason' => $this->result->reason,
+            'latencyMs' => $this->latencyMs,
+        ];
+    }
+}

--- a/Classes/Service/Evaluation/QualityAwareModelSelector.php
+++ b/Classes/Service/Evaluation/QualityAwareModelSelector.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
+
+/**
+ * The opt-in quality dimension for model routing (ADR-060).
+ *
+ * This is a documented HOOK, not a change to ModelSelectionService: it takes
+ * that service's existing candidate list for a criteria set and re-ranks it
+ * by measured quality score. Nothing calls it unless a consumer explicitly
+ * routes through it, so the established cost/latency selection modes are
+ * untouched. Wiring quality into ModelSelectionService as a first-class sort
+ * key is a deliberate follow-up (see ADR-060).
+ *
+ * Ranking: candidates with a quality score sort highest-first; candidates
+ * without a score keep their original (base-selection) order behind the
+ * scored ones. With no scores at all and no minimum, this degrades exactly
+ * to the base selection's first candidate.
+ */
+final readonly class QualityAwareModelSelector
+{
+    public function __construct(
+        private ModelSelectionServiceInterface $modelSelectionService,
+        private ModelQualityScoreProviderInterface $qualityScoreProvider,
+    ) {}
+
+    /**
+     * Select the highest-quality model among those matching the criteria.
+     *
+     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param float                                                                                                                        $minQuality Minimum acceptable quality (0.0 disables the filter); candidates below it,
+     *                                                                                                                                                 or without any quality data, are excluded when this is greater than 0.0
+     */
+    public function selectByQuality(array $criteria, float $minQuality = 0.0): ?Model
+    {
+        $candidates = $this->modelSelectionService->findCandidates($criteria);
+        if ($candidates === []) {
+            return null;
+        }
+
+        $ranked = [];
+        foreach (array_values($candidates) as $order => $model) {
+            $score = $this->qualityScoreProvider->getQualityScore($model->getModelId());
+            if ($minQuality > 0.0 && ($score === null || $score < $minQuality)) {
+                continue;
+            }
+            $ranked[] = ['model' => $model, 'score' => $score, 'order' => $order];
+        }
+
+        if ($ranked === []) {
+            return null;
+        }
+
+        usort($ranked, static function (array $a, array $b): int {
+            // Scored candidates outrank unscored ones; among scored, higher first.
+            if ($a['score'] === null && $b['score'] === null) {
+                return $a['order'] <=> $b['order'];
+            }
+            if ($a['score'] === null) {
+                return 1;
+            }
+            if ($b['score'] === null) {
+                return -1;
+            }
+            if ($a['score'] === $b['score']) {
+                return $a['order'] <=> $b['order'];
+            }
+
+            return $b['score'] <=> $a['score'];
+        });
+
+        return $ranked[0]['model'];
+    }
+}

--- a/Classes/Service/Evaluation/RegressionDetector.php
+++ b/Classes/Service/Evaluation/RegressionDetector.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * Compares a current set result against the previous run for the same
+ * (set, model) and flags a regression when a metric falls beyond the
+ * configured tolerance (ADR-060).
+ *
+ * Pure logic: no persistence, no side effects — the caller supplies the
+ * previous summary (or null for the first run).
+ */
+final readonly class RegressionDetector
+{
+    public function compare(
+        EvaluationResultSummary $current,
+        ?EvaluationResultSummary $previous,
+        RegressionThresholds $thresholds,
+    ): RegressionReport {
+        if ($previous === null) {
+            return new RegressionReport(
+                $current->setIdentifier,
+                $current->model,
+                false,
+                0.0,
+                0.0,
+                false,
+                'No previous run for this set and model — recorded as the baseline.',
+            );
+        }
+
+        $passRateDelta = $current->passRate - $previous->passRate;
+        $meanScoreDelta = $current->meanScore - $previous->meanScore;
+
+        $passRateRegressed = -$passRateDelta > $thresholds->maxPassRateDrop;
+        $meanScoreRegressed = -$meanScoreDelta > $thresholds->maxMeanScoreDrop;
+        $isRegression = $passRateRegressed || $meanScoreRegressed;
+
+        return new RegressionReport(
+            $current->setIdentifier,
+            $current->model,
+            true,
+            $passRateDelta,
+            $meanScoreDelta,
+            $isRegression,
+            $this->summarise($passRateDelta, $meanScoreDelta, $passRateRegressed, $meanScoreRegressed),
+        );
+    }
+
+    private function summarise(
+        float $passRateDelta,
+        float $meanScoreDelta,
+        bool $passRateRegressed,
+        bool $meanScoreRegressed,
+    ): string {
+        if (!$passRateRegressed && !$meanScoreRegressed) {
+            return sprintf(
+                'No regression: pass rate %+.1f pp, mean score %+.3f versus the previous run.',
+                $passRateDelta * 100,
+                $meanScoreDelta,
+            );
+        }
+
+        $causes = [];
+        if ($passRateRegressed) {
+            $causes[] = sprintf('pass rate dropped %.1f pp', -$passRateDelta * 100);
+        }
+        if ($meanScoreRegressed) {
+            $causes[] = sprintf('mean score dropped %.3f', -$meanScoreDelta);
+        }
+
+        return 'Regression: ' . implode(' and ', $causes) . ' beyond the configured tolerance.';
+    }
+}

--- a/Classes/Service/Evaluation/RegressionReport.php
+++ b/Classes/Service/Evaluation/RegressionReport.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The verdict of comparing a run against its predecessor for one
+ * (set, model) (ADR-060).
+ *
+ * The deltas are current minus previous, so a negative value is a decline.
+ * `hasBaseline` is false for the first ever run of a (set, model), in which
+ * case there is nothing to compare and `isRegression` is false.
+ */
+final readonly class RegressionReport
+{
+    public function __construct(
+        public string $setIdentifier,
+        public string $model,
+        public bool $hasBaseline,
+        public float $passRateDelta,
+        public float $meanScoreDelta,
+        public bool $isRegression,
+        public string $summary,
+    ) {}
+}

--- a/Classes/Service/Evaluation/RegressionThresholds.php
+++ b/Classes/Service/Evaluation/RegressionThresholds.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * The tolerances that separate normal run-to-run variance from a regression
+ * (ADR-060).
+ *
+ * A drop is a regression only when it exceeds the threshold: a pass-rate
+ * fall greater than `maxPassRateDrop` or a mean-score fall greater than
+ * `maxMeanScoreDrop`. Both are absolute deltas on the 0.0-1.0 scale and
+ * default to 0.1.
+ */
+final readonly class RegressionThresholds
+{
+    public function __construct(
+        public float $maxPassRateDrop = 0.1,
+        public float $maxMeanScoreDrop = 0.1,
+    ) {
+        if ($maxPassRateDrop < 0.0 || $maxMeanScoreDrop < 0.0) {
+            throw new InvalidArgumentException('Regression thresholds must be non-negative.', 1794000040);
+        }
+    }
+}

--- a/Classes/Service/Evaluation/SetEvaluationResult.php
+++ b/Classes/Service/Evaluation/SetEvaluationResult.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The rich result of running a golden set against one model (ADR-060):
+ * every per-prompt evaluation plus the aggregate pass rate and mean score
+ * derived from them.
+ *
+ * `toSummary()` collapses it to the aggregate-only EvaluationResultSummary
+ * that gets persisted and compared for regression detection.
+ */
+final readonly class SetEvaluationResult
+{
+    /**
+     * @param list<PromptEvaluation> $evaluations
+     */
+    public function __construct(
+        public string $setIdentifier,
+        public string $model,
+        public string $grader,
+        public array $evaluations,
+        public int $runTimestamp,
+    ) {}
+
+    public function promptCount(): int
+    {
+        return count($this->evaluations);
+    }
+
+    public function passedCount(): int
+    {
+        $passed = 0;
+        foreach ($this->evaluations as $evaluation) {
+            if ($evaluation->result->passed) {
+                ++$passed;
+            }
+        }
+
+        return $passed;
+    }
+
+    /**
+     * Fraction of prompts that passed (0.0-1.0); 0.0 for an empty set.
+     */
+    public function passRate(): float
+    {
+        if ($this->evaluations === []) {
+            return 0.0;
+        }
+
+        return $this->passedCount() / $this->promptCount();
+    }
+
+    /**
+     * Mean grading score across all prompts (0.0-1.0); 0.0 for an empty set.
+     */
+    public function meanScore(): float
+    {
+        if ($this->evaluations === []) {
+            return 0.0;
+        }
+
+        $sum = 0.0;
+        foreach ($this->evaluations as $evaluation) {
+            $sum += $evaluation->result->score;
+        }
+
+        return $sum / $this->promptCount();
+    }
+
+    public function toSummary(int $uid = 0): EvaluationResultSummary
+    {
+        return new EvaluationResultSummary(
+            $this->setIdentifier,
+            $this->model,
+            $this->grader,
+            $this->promptCount(),
+            $this->passedCount(),
+            $this->passRate(),
+            $this->meanScore(),
+            $this->runTimestamp,
+            $uid,
+        );
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -329,3 +329,17 @@ services:
   Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator:
     public: true
 
+  # ========================================
+  # Console Commands
+  # ========================================
+  # The console.command tag registers the command with TYPO3's
+  # CommandRegistry and is made public by ConsoleCommandPass — it does not
+  # add a `public: true` override to the audited surface (ADR-028 / ADR-060).
+
+  Netresearch\NrLlm\Command\EvalRunCommand:
+    tags:
+      - name: 'console.command'
+        command: 'nrllm:eval:run'
+        description: 'Run a golden prompt set against a model and report grading and regression.'
+        schedulable: false
+

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -182,6 +182,19 @@ services:
     alias: Netresearch\NrLlm\Service\Telemetry\TelemetryRepository
     public: false
 
+  # Quality-evaluation subsystem (ADR-060). Everything here is private:
+  # the persistence layer is instantiated directly in its functional test
+  # (its only dependency is ConnectionPool), the command is made public by
+  # the console.command tag below, and the golden-set provider interface is
+  # discovered via the nr_llm.golden_prompt_set tag (AutoconfigureTag).
+  Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepository
+    public: false
+
+  Netresearch\NrLlm\Service\Evaluation\ModelQualityScoreProviderInterface:
+    alias: Netresearch\NrLlm\Service\Evaluation\EvaluationQualityScoreProvider
+    public: false
+
   # ========================================
   # Repositories (PUBLIC)
   # ========================================

--- a/Documentation/Adr/Adr060QualityEvaluation.rst
+++ b/Documentation/Adr/Adr060QualityEvaluation.rst
@@ -1,0 +1,154 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-060:
+
+===========================================================================
+ADR-060: Quality evaluation — golden sets, grading and regression detection
+===========================================================================
+
+:Status: Accepted
+:Date: 2026-07-14
+:Authors: Netresearch DTT GmbH
+
+.. _adr-060-context:
+
+Context
+=======
+
+nr_llm had no way to measure the quality of the answers it produces. There
+were connectivity probes (``TestPromptResolverService``) and a property-based
+fuzzing suite, but no golden prompts, no graders, and no regression harness —
+so a model or configuration change could silently degrade answer quality with
+nothing to catch it. The reference extension ``aim`` runs LLM-as-a-judge
+grading and routes by grade; nr_llm had neither the measurement nor the
+feedback loop.
+
+Two constraints shaped the design. First, evaluation must never run in the
+request path: it is an operator activity that spends time and, for the judge,
+tokens. Second, it must not enlarge the audited public service surface
+(:ref:`ADR-028 <adr-028>`) without cause.
+
+The building blocks already existed: DI-tag discovery with a tagged-iterator
+registry (``nr_llm.configuration_preset`` — :ref:`ADR-056 <adr-056>`), the
+``CompletionService`` for model calls, and ``ModelSelectionService`` for
+criteria-based routing.
+
+.. _adr-060-decision:
+
+Decision
+========
+
+**Add an opt-in evaluation layer — declarative golden sets, pluggable graders,
+a run/aggregate service, result persistence with regression detection, and a
+CLI — none of which touches the request pipeline.**
+
+1. **Golden sets via DI tag.** A consumer implements
+   ``GoldenPromptSetProviderInterface`` (tag ``nr_llm.golden_prompt_set``,
+   auto-applied by ``AutoconfigureTag``, mirroring
+   :ref:`ADR-056 <adr-056>`) and returns ``GoldenPromptSet`` value objects.
+   ``GoldenPromptSetRegistry`` collects them through a tagged iterator and
+   fails fast on duplicate identifiers. Each ``GoldenPrompt`` carries
+   deterministic ``Assertion`` s (exact / contains / regex / json_schema)
+   and an optional reference answer. nr_llm ships one example set
+   (``nr_llm.smoke``) as the pattern to copy and a runnable target.
+
+2. **Graders behind an interface.** ``GraderInterface`` has two
+   implementations. ``DeterministicGrader`` (the default) evaluates the
+   assertions with no LLM call and no tokens; its json_schema matcher is a
+   lightweight structural check (required keys + per-key type), deliberately
+   not a full JSON Schema draft validator, to avoid a runtime dependency.
+   ``LlmJudgeGrader`` is opt-in: it asks a judge model through the existing
+   ``CompletionService`` for a ``{"score", "reason"}`` verdict and handles a
+   malformed or failed judge response defensively. ``GradingService`` selects
+   the grader by identifier and falls back to the deterministic grader for an
+   unknown one, so evaluation never silently spends tokens.
+
+3. **Run and aggregate.** ``EvaluationService`` runs a set against a model —
+   one ``CompletionService`` call per prompt — grades each response, records
+   the wall-clock latency, and aggregates to a pass rate and mean score. It
+   neither persists nor compares, which keeps it unit-testable without a
+   database.
+
+4. **Persistence + regression detection.** Runs are stored in the new
+   ``tx_nrllm_eval_result`` table (a UI-less result log, no TCA, mirroring
+   ``tx_nrllm_service_usage``) as aggregate summaries plus a JSON snapshot of
+   the per-prompt outcomes. ``RegressionDetector`` compares a run against the
+   previous run for the same (set, model) and flags a regression when the
+   pass rate or mean score falls beyond a configurable ``RegressionThresholds``
+   tolerance (default 0.1 absolute).
+
+5. **Quality dimension as a routing hook.** The quality signal is exposed as
+   an opt-in hook, not a change to ``ModelSelectionService``.
+   ``EvaluationQualityScoreProvider`` derives a per-model quality score from
+   stored results (latest run per set, averaged), and
+   ``QualityAwareModelSelector`` re-ranks that service's existing candidate
+   list by score. ``ModelSelectionService`` is unchanged, so the cost/latency
+   selection modes behave exactly as before; nothing routes through the hook
+   unless a consumer opts in. See *Consequences* for why the deeper
+   integration is deferred.
+
+6. **CLI, not request path.** ``nrllm:eval:run`` runs a set, prints the
+   per-prompt gradings and the aggregate, saves the run, and reports the
+   regression verdict (``--fail-on-regression`` makes a regression a non-zero
+   exit for CI). Registration is via the ``console.command`` tag — made public
+   by TYPO3's ``ConsoleCommandPass``, so it adds no ``public: true`` override
+   to the audited surface (:ref:`ADR-028 <adr-028>`).
+
+7. **No public-surface growth.** The persistence class is instantiated
+   directly in its functional test (its only dependency is ``ConnectionPool``)
+   and autowired as an interface into the command elsewhere, so nothing in the
+   subsystem needs to be a public service.
+
+.. _adr-060-consequences:
+
+Consequences
+============
+
+Positive
+--------
+
+* Answer quality becomes measurable and regressions become detectable, on an
+  operator's schedule, without any per-request cost.
+* Consumer extensions declare their own golden sets through the same tested
+  discovery mechanism they already use for presets and tools.
+* The deterministic default spends no tokens; the judge is a conscious opt-in.
+* The public service surface is unchanged.
+
+Negative / limitations
+-----------------------
+
+* The LLM judge spends tokens and uses whatever default chat configuration the
+  admin has set up; selecting a dedicated judge model is a follow-up.
+* The json_schema grader is a structural matcher, not a full JSON Schema draft
+  validator.
+* Quality routing is a hook only: ``QualityAwareModelSelector`` re-ranks
+  candidates on demand, but quality is not yet a first-class sort key inside
+  ``ModelSelectionService``. Making it one — alongside provider priority and
+  cost — is a deliberate follow-up, because pulling the eval subsystem into the
+  core selection path would invert the layering (selection must not depend on
+  the opt-in evaluation store) and change existing selection behaviour.
+* ``tx_nrllm_eval_result`` grows by one row per run; a retention/pruning policy
+  is a documented follow-up.
+
+.. _adr-060-alternatives:
+
+Alternatives considered
+=======================
+
+**Golden sets as YAML files under Configuration/.** Rejected for the same
+reasons as :ref:`ADR-056 <adr-056>`: the DI tag reuses the established
+discovery mechanism, needs zero per-extension configuration, and gives
+compile-time class references instead of stringly-typed files.
+
+**A full JSON Schema draft validator for structured assertions.** Rejected:
+it would add a runtime dependency for a capability the lightweight structural
+matcher already covers for practical golden-set assertions.
+
+**Wiring quality directly into ModelSelectionService now.** Rejected for this
+slice: it inverts the layering and risks changing the behaviour of the
+existing selection modes. Delivered instead as an additive, opt-in hook with
+the full integration marked as a follow-up.
+
+**Storing results as file snapshots instead of a table.** Rejected: a table
+fits TYPO3, is queryable for the per-model quality aggregate the routing hook
+needs, and matches the precedent of ``tx_nrllm_service_usage``.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -357,4 +357,5 @@ Tools
    Adr056ConfigurationPresets
    Adr057SpecializedServiceAttribution
    Adr058TelemetryMiddleware
+   Adr060QualityEvaluation
    Adr061SkillTrustEgressAndAudit

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -238,5 +238,6 @@ Best practices
    FallbackChain
    CapabilityPermissions
    ConfigurationPresets
+   QualityEvaluation
    IntegrationGuide
    FeatureServices/Index

--- a/Documentation/Developer/QualityEvaluation.rst
+++ b/Documentation/Developer/QualityEvaluation.rst
@@ -1,0 +1,176 @@
+.. include:: /Includes.rst.txt
+
+.. _developer-quality-evaluation:
+
+==================
+Quality evaluation
+==================
+
+nr_llm can measure the quality of the answers a model produces against
+**golden prompt sets** and detect regressions between runs. Evaluation is an
+explicitly triggered, out-of-request operation — it never runs in the request
+pipeline and, with the default grader, spends no tokens. See
+:ref:`ADR-060 <adr-060>` for the design rationale.
+
+A golden set is a collection of prompts, each with the expectations it should
+satisfy. A run executes the set against a model, grades every response,
+aggregates the results to a pass rate and mean score, stores the run, and
+compares it against the previous run for the same set and model.
+
+.. _developer-quality-evaluation-declaring:
+
+Declaring a golden set in your extension
+========================================
+
+Implement :php:`GoldenPromptSetProviderInterface`. The
+``nr_llm.golden_prompt_set`` DI tag is applied automatically when your
+extension's :file:`Services.yaml` has ``autoconfigure: true`` (the TYPO3
+default):
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace Vendor\NrAiSearch\Evaluation;
+
+    use Netresearch\NrLlm\Service\Evaluation\Assertion;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetProviderInterface;
+
+    final class AiSearchGoldenSetProvider implements GoldenPromptSetProviderInterface
+    {
+        public function getGoldenPromptSets(): array
+        {
+            return [
+                new GoldenPromptSet(
+                    identifier: 'nr_ai_search.faq',
+                    name: 'AI Search FAQ answers',
+                    description: 'Checks the model answers common FAQ prompts correctly.',
+                    prompts: [
+                        new GoldenPrompt(
+                            id: 'opening-hours',
+                            prompt: 'When is the office open? Answer with the days.',
+                            assertions: [
+                                Assertion::contains('Monday'),
+                                Assertion::regex('/9(:00)?\s*(am|–|-)/i'),
+                            ],
+                            reference: 'Monday to Friday, 9am to 5pm.',
+                        ),
+                        new GoldenPrompt(
+                            id: 'contact-json',
+                            prompt: 'Return the contact as JSON with an "email" field.',
+                            assertions: [
+                                Assertion::jsonSchema('{"type":"object","required":["email"],"properties":{"email":{"type":"string"}}}'),
+                            ],
+                        ),
+                    ],
+                ),
+            ];
+        }
+    }
+
+The identifier is namespaced (``vendor_extension.set``) so sets from different
+extensions cannot collide. Each prompt needs at least one assertion or a
+reference answer.
+
+.. _developer-quality-evaluation-assertions:
+
+Assertion types
+===============
+
+The deterministic grader supports four assertion types; a prompt passes only
+when **all** of its assertions hold, and the score is the fraction satisfied.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Factory
+     - Passes when
+   * - Exact
+     - :php:`Assertion::exact($value)`
+     - the trimmed response equals ``$value``
+   * - Contains
+     - :php:`Assertion::contains($value)`
+     - ``$value`` is a substring of the response
+   * - Regex
+     - :php:`Assertion::regex($pattern)`
+     - the response matches the PCRE ``$pattern``
+   * - JSON schema
+     - :php:`Assertion::jsonSchema($schemaJson)`
+     - the response is valid JSON satisfying the structural schema
+
+The ``json_schema`` matcher is a lightweight structural check — a top-level
+``type``, object ``required`` keys, and recursive ``properties`` types. Extra
+keys are allowed. It is intentionally not a full JSON Schema draft validator.
+
+.. _developer-quality-evaluation-graders:
+
+Graders
+=======
+
+Two grading strategies sit behind :php:`GraderInterface`:
+
+* **deterministic** (default) — evaluates the assertions with no LLM call and
+  no tokens.
+* **llm_judge** (opt-in) — asks a judge model through :php:`CompletionService`
+  to score the response ``0.0``–``1.0`` with a justification. It uses the
+  reference answer when one is declared. Because it spends tokens, it runs only
+  when explicitly selected; an unknown grader name falls back to the
+  deterministic grader.
+
+.. _developer-quality-evaluation-running:
+
+Running an evaluation
+=====================
+
+Use the ``nrllm:eval:run`` command:
+
+.. code-block:: bash
+
+    # Deterministic grading against the configured default model
+    vendor/bin/typo3 nrllm:eval:run nr_ai_search.faq
+
+    # Evaluate a specific model with the LLM judge
+    vendor/bin/typo3 nrllm:eval:run nr_ai_search.faq --model gpt-5.2 --grader llm_judge
+
+    # Fail (non-zero exit) if quality regressed against the previous run — for CI
+    vendor/bin/typo3 nrllm:eval:run nr_ai_search.faq --fail-on-regression
+
+The command prints the per-prompt gradings and the aggregate (pass rate, mean
+score), stores the run in ``tx_nrllm_eval_result``, and reports whether the run
+regressed against the previous run for the same set and model. The regression
+tolerance is configurable with ``--max-pass-rate-drop`` and
+``--max-mean-score-drop`` (both default to ``0.1``).
+
+nr_llm ships an example set, ``nr_llm.smoke``, so the command is runnable out
+of the box.
+
+.. _developer-quality-evaluation-quality-routing:
+
+Quality-aware routing (opt-in)
+==============================
+
+Stored evaluation results feed an **opt-in** routing hook. The existing
+cost/latency selection modes of :php:`ModelSelectionService` are unchanged;
+nothing routes by quality unless you call the hook explicitly:
+
+.. code-block:: php
+
+    use Netresearch\NrLlm\Service\Evaluation\QualityAwareModelSelector;
+
+    // Inject QualityAwareModelSelector, then:
+    $model = $selector->selectByQuality(
+        ['capabilities' => ['chat']],
+        minQuality: 0.7,
+    );
+
+``selectByQuality()`` takes the candidates :php:`ModelSelectionService` would
+return for the criteria and re-ranks them by measured quality score (latest run
+per set, averaged). Candidates without evaluation data keep their base order
+behind the scored ones; with ``minQuality`` set, candidates below it (or
+without data) are excluded. Making quality a first-class sort key inside
+:php:`ModelSelectionService` is a planned follow-up (see :ref:`ADR-060 <adr-060>`).

--- a/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
+++ b/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepository;
+use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+use Netresearch\NrLlm\Service\Evaluation\PromptEvaluation;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
+use Netresearch\NrLlm\Service\Evaluation\SetEvaluationResult;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for evaluation-result persistence and the two-run
+ * regression comparison (ADR-060).
+ *
+ * The repository is instantiated directly with the container's ConnectionPool
+ * — its only dependency — so it does not need to be a public service.
+ */
+#[CoversClass(EvaluationResultRepository::class)]
+final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
+{
+    private const SET = 'nr_llm.smoke';
+    private const MODEL = 'gpt-test';
+    private const TABLE = 'tx_nrllm_eval_result';
+
+    private EvaluationResultRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->repository = new EvaluationResultRepository($connectionPool);
+    }
+
+    /**
+     * Build a result with `$total` prompts of which `$passed` pass and whose
+     * mean score equals `$passed / $total`.
+     */
+    private function buildResult(int $total, int $passed, int $runTimestamp, string $model = self::MODEL): SetEvaluationResult
+    {
+        $evaluations = [];
+        for ($i = 0; $i < $total; ++$i) {
+            $didPass = $i < $passed;
+            $evaluations[] = new PromptEvaluation(
+                'p' . $i,
+                new GradingResult($didPass, $didPass ? 1.0 : 0.0, 'deterministic'),
+                5,
+            );
+        }
+
+        return new SetEvaluationResult(self::SET, $model, 'deterministic', $evaluations, $runTimestamp);
+    }
+
+    #[Test]
+    public function saveStoresAggregatesAndDetails(): void
+    {
+        $this->repository->save($this->buildResult(4, 3, 1_700_000_000));
+
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable(self::TABLE);
+        $row = $connection->select(
+            ['set_identifier', 'model_id', 'grader', 'prompt_count', 'passed_count', 'pass_rate', 'mean_score', 'details'],
+            self::TABLE,
+            ['set_identifier' => self::SET],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertSame(self::MODEL, $row['model_id']);
+        self::assertSame('deterministic', $row['grader']);
+        self::assertSame(4, (int)$row['prompt_count']);
+        self::assertSame(3, (int)$row['passed_count']);
+        self::assertIsNumeric($row['pass_rate']);
+        self::assertIsNumeric($row['mean_score']);
+        self::assertEqualsWithDelta(0.75, (float)$row['pass_rate'], 0.0001);
+        self::assertEqualsWithDelta(0.75, (float)$row['mean_score'], 0.0001);
+
+        self::assertIsString($row['details']);
+        $details = json_decode($row['details'], true);
+        self::assertIsArray($details);
+        self::assertCount(4, $details);
+    }
+
+    #[Test]
+    public function findLatestReturnsMostRecentRun(): void
+    {
+        $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
+        $this->repository->save($this->buildResult(4, 1, 1_700_000_100));
+
+        $latest = $this->repository->findLatest(self::SET, self::MODEL);
+
+        self::assertNotNull($latest);
+        self::assertSame(1_700_000_100, $latest->runTimestamp);
+        self::assertEqualsWithDelta(0.25, $latest->passRate, 0.0001);
+    }
+
+    #[Test]
+    public function findRecentReturnsRunsNewestFirst(): void
+    {
+        $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
+        $this->repository->save($this->buildResult(4, 2, 1_700_000_100));
+
+        $recent = $this->repository->findRecent(self::SET, self::MODEL, 2);
+
+        self::assertCount(2, $recent);
+        self::assertSame(1_700_000_100, $recent[0]->runTimestamp);
+        self::assertSame(1_700_000_000, $recent[1]->runTimestamp);
+    }
+
+    #[Test]
+    public function findLatestIsNullForUnknownSetModel(): void
+    {
+        self::assertNull($this->repository->findLatest('no.such.set', 'no-model'));
+    }
+
+    #[Test]
+    public function regressionIsDetectedAcrossTwoPersistedRuns(): void
+    {
+        // First (baseline) run: all pass. Second run: quality collapses.
+        $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
+
+        $previous = $this->repository->findLatest(self::SET, self::MODEL);
+        self::assertNotNull($previous);
+
+        $current = $this->buildResult(4, 1, 1_700_000_100);
+        $this->repository->save($current);
+
+        $report = (new RegressionDetector())->compare($current->toSummary(), $previous, new RegressionThresholds());
+
+        self::assertTrue($report->hasBaseline);
+        self::assertTrue($report->isRegression);
+        self::assertEqualsWithDelta(-0.75, $report->passRateDelta, 0.0001);
+    }
+
+    #[Test]
+    public function meanQualityScoreAveragesLatestRunPerSet(): void
+    {
+        // Older run should be ignored in favour of the latest for the same set.
+        $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
+        $this->repository->save($this->buildResult(4, 2, 1_700_000_100));
+
+        $score = $this->repository->meanQualityScoreForModel(self::MODEL);
+
+        self::assertNotNull($score);
+        self::assertEqualsWithDelta(0.5, $score, 0.0001);
+    }
+
+    #[Test]
+    public function meanQualityScoreIsNullForModelWithoutResults(): void
+    {
+        self::assertNull($this->repository->meanQualityScoreForModel('unseen-model'));
+    }
+}

--- a/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
+++ b/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
@@ -32,6 +32,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
 {
     private const SET = 'nr_llm.smoke';
     private const MODEL = 'gpt-test';
+    private const GRADER = 'deterministic';
     private const TABLE = 'tx_nrllm_eval_result';
 
     private EvaluationResultRepository $repository;
@@ -49,19 +50,19 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
      * Build a result with `$total` prompts of which `$passed` pass and whose
      * mean score equals `$passed / $total`.
      */
-    private function buildResult(int $total, int $passed, int $runTimestamp, string $model = self::MODEL): SetEvaluationResult
+    private function buildResult(int $total, int $passed, int $runTimestamp, string $model = self::MODEL, string $grader = self::GRADER): SetEvaluationResult
     {
         $evaluations = [];
         for ($i = 0; $i < $total; ++$i) {
             $didPass = $i < $passed;
             $evaluations[] = new PromptEvaluation(
                 'p' . $i,
-                new GradingResult($didPass, $didPass ? 1.0 : 0.0, 'deterministic'),
+                new GradingResult($didPass, $didPass ? 1.0 : 0.0, $grader),
                 5,
             );
         }
 
-        return new SetEvaluationResult(self::SET, $model, 'deterministic', $evaluations, $runTimestamp);
+        return new SetEvaluationResult(self::SET, $model, $grader, $evaluations, $runTimestamp);
     }
 
     #[Test]
@@ -98,7 +99,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
         $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
         $this->repository->save($this->buildResult(4, 1, 1_700_000_100));
 
-        $latest = $this->repository->findLatest(self::SET, self::MODEL);
+        $latest = $this->repository->findLatest(self::SET, self::MODEL, self::GRADER);
 
         self::assertNotNull($latest);
         self::assertSame(1_700_000_100, $latest->runTimestamp);
@@ -111,7 +112,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
         $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
         $this->repository->save($this->buildResult(4, 2, 1_700_000_100));
 
-        $recent = $this->repository->findRecent(self::SET, self::MODEL, 2);
+        $recent = $this->repository->findRecent(self::SET, self::MODEL, self::GRADER, 2);
 
         self::assertCount(2, $recent);
         self::assertSame(1_700_000_100, $recent[0]->runTimestamp);
@@ -121,7 +122,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
     #[Test]
     public function findLatestIsNullForUnknownSetModel(): void
     {
-        self::assertNull($this->repository->findLatest('no.such.set', 'no-model'));
+        self::assertNull($this->repository->findLatest('no.such.set', 'no-model', self::GRADER));
     }
 
     #[Test]
@@ -130,7 +131,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
         // First (baseline) run: all pass. Second run: quality collapses.
         $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
 
-        $previous = $this->repository->findLatest(self::SET, self::MODEL);
+        $previous = $this->repository->findLatest(self::SET, self::MODEL, self::GRADER);
         self::assertNotNull($previous);
 
         $current = $this->buildResult(4, 1, 1_700_000_100);
@@ -150,7 +151,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
         $this->repository->save($this->buildResult(4, 4, 1_700_000_000));
         $this->repository->save($this->buildResult(4, 2, 1_700_000_100));
 
-        $score = $this->repository->meanQualityScoreForModel(self::MODEL);
+        $score = $this->repository->meanQualityScoreForModel(self::MODEL, self::GRADER);
 
         self::assertNotNull($score);
         self::assertEqualsWithDelta(0.5, $score, 0.0001);
@@ -159,6 +160,25 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
     #[Test]
     public function meanQualityScoreIsNullForModelWithoutResults(): void
     {
-        self::assertNull($this->repository->meanQualityScoreForModel('unseen-model'));
+        self::assertNull($this->repository->meanQualityScoreForModel('unseen-model', self::GRADER));
+    }
+    #[Test]
+    public function findLatestSegregatesByGrader(): void
+    {
+        // A deterministic run and an llm_judge run for the SAME (set, model)
+        // must not be treated as the same series — their pass_rate/mean_score
+        // are not comparable, so regression detection must not pair them.
+        $this->repository->save($this->buildResult(4, 4, 1_700_000_000, self::MODEL, 'deterministic'));
+        $this->repository->save($this->buildResult(4, 1, 1_700_000_100, self::MODEL, 'llm_judge'));
+
+        $deterministic = $this->repository->findLatest(self::SET, self::MODEL, 'deterministic');
+        $judge = $this->repository->findLatest(self::SET, self::MODEL, 'llm_judge');
+
+        self::assertNotNull($deterministic);
+        self::assertNotNull($judge);
+        self::assertSame(1_700_000_000, $deterministic->runTimestamp);
+        self::assertSame(1_700_000_100, $judge->runTimestamp);
+        self::assertEqualsWithDelta(1.0, $deterministic->passRate, 0.0001);
+        self::assertEqualsWithDelta(0.25, $judge->passRate, 0.0001);
     }
 }

--- a/Tests/Functional/Service/Evaluation/GoldenPromptSetRegistryTest.php
+++ b/Tests/Functional/Service/Evaluation/GoldenPromptSetRegistryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\BuiltinGoldenPromptSetProvider;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Verifies the golden-set DI wiring end-to-end (ADR-060): the
+ * AutoconfigureTag on GoldenPromptSetProviderInterface plus the
+ * AutowireIterator in GoldenPromptSetRegistry must collect the built-in
+ * provider from the real container.
+ *
+ * The registry is private but injected into the public eval command, so the
+ * testing framework resolves it through its non-public container without the
+ * registry needing to be a public service.
+ */
+#[CoversClass(GoldenPromptSetRegistry::class)]
+#[CoversClass(BuiltinGoldenPromptSetProvider::class)]
+final class GoldenPromptSetRegistryTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function builtinProviderIsCollectedViaDiTag(): void
+    {
+        $registry = $this->get(GoldenPromptSetRegistry::class);
+        self::assertInstanceOf(GoldenPromptSetRegistry::class, $registry);
+
+        $set = $registry->findByIdentifier(BuiltinGoldenPromptSetProvider::SET_IDENTIFIER);
+
+        self::assertNotNull($set, 'The built-in smoke set must be discoverable through the DI tag.');
+        self::assertNotEmpty($set->prompts);
+    }
+}

--- a/Tests/Unit/Command/EvalRunCommandTest.php
+++ b/Tests/Unit/Command/EvalRunCommandTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\EvalRunCommand;
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultSummary;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetProviderInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetRegistry;
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Evaluation\Grader\LlmJudgeGrader;
+use Netresearch\NrLlm\Service\Evaluation\GradingService;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryEvaluationResultRepository;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticCompletionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(EvalRunCommand::class)]
+final class EvalRunCommandTest extends TestCase
+{
+    private const SET_IDENTIFIER = 'nr_llm.test';
+
+    private function registry(): GoldenPromptSetRegistry
+    {
+        $set = new GoldenPromptSet(self::SET_IDENTIFIER, 'Test set', 'desc', [
+            new GoldenPrompt('ack', 'Reply ACK', [Assertion::contains('ACK')]),
+        ]);
+        $provider = new class ([$set]) implements GoldenPromptSetProviderInterface {
+            /**
+             * @param list<GoldenPromptSet> $sets
+             */
+            public function __construct(private readonly array $sets) {}
+
+            public function getGoldenPromptSets(): array
+            {
+                return $this->sets;
+            }
+        };
+
+        return new GoldenPromptSetRegistry([$provider]);
+    }
+
+    private function command(StaticCompletionService $completion, InMemoryEvaluationResultRepository $repository): EvalRunCommand
+    {
+        $evaluationService = new EvaluationService(
+            $completion,
+            new GradingService(new DeterministicGrader(), new LlmJudgeGrader($completion)),
+        );
+
+        return new EvalRunCommand($this->registry(), $evaluationService, $repository, new RegressionDetector());
+    }
+
+    private function perfectBaseline(): EvaluationResultSummary
+    {
+        return new EvaluationResultSummary(self::SET_IDENTIFIER, 'test-model', 'deterministic', 1, 1, 1.0, 1.0, 1_700_000_000);
+    }
+
+    #[Test]
+    public function unknownSetFailsWithHint(): void
+    {
+        $tester = new CommandTester($this->command(new StaticCompletionService('ACK'), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => 'does.not.exist']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Unknown golden prompt set', $tester->getDisplay());
+        self::assertStringContainsString(self::SET_IDENTIFIER, $tester->getDisplay());
+    }
+
+    #[Test]
+    public function passingRunSucceedsAndPersists(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $tester = new CommandTester($this->command(new StaticCompletionService('ACK'), $repository));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Pass rate', $tester->getDisplay());
+        self::assertStringContainsString('100.0%', $tester->getDisplay());
+        self::assertCount(1, $repository->saved);
+    }
+
+    #[Test]
+    public function firstRunHasNoBaselineAndSucceeds(): void
+    {
+        $tester = new CommandTester($this->command(new StaticCompletionService('nope'), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('baseline', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function regressionWithFailFlagExitsNonZero(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $repository->seed($this->perfectBaseline());
+
+        // Current run fails the assertion (response lacks "ACK") → pass rate 0.0.
+        $tester = new CommandTester($this->command(new StaticCompletionService('nope'), $repository));
+
+        $exitCode = $tester->execute([
+            'set' => self::SET_IDENTIFIER,
+            '--fail-on-regression' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('regression', strtolower($tester->getDisplay()));
+    }
+
+    #[Test]
+    public function regressionWithoutFailFlagStillSucceeds(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $repository->seed($this->perfectBaseline());
+
+        $tester = new CommandTester($this->command(new StaticCompletionService('nope'), $repository));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+}

--- a/Tests/Unit/Command/EvalRunCommandTest.php
+++ b/Tests/Unit/Command/EvalRunCommandTest.php
@@ -82,6 +82,18 @@ final class EvalRunCommandTest extends TestCase
     }
 
     #[Test]
+    public function unknownGraderFailsWithHint(): void
+    {
+        $tester = new CommandTester($this->command(new StaticCompletionService('ACK'), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, '--grader' => 'llm_judg']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Unknown grader', $tester->getDisplay());
+        self::assertStringContainsString('llm_judg', $tester->getDisplay());
+    }
+
+    #[Test]
     public function passingRunSucceedsAndPersists(): void
     {
         $repository = new InMemoryEvaluationResultRepository();

--- a/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command\Fixture;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultSummary;
+use Netresearch\NrLlm\Service\Evaluation\SetEvaluationResult;
+
+/**
+ * In-memory EvaluationResultRepository for command tests: records what was
+ * saved and returns pre-seeded baselines, so the command's persistence and
+ * regression flow can be exercised without a database.
+ */
+final class InMemoryEvaluationResultRepository implements EvaluationResultRepositoryInterface
+{
+    /** @var list<SetEvaluationResult> */
+    public array $saved = [];
+
+    /** @var array<string, EvaluationResultSummary> */
+    public array $seeded = [];
+
+    public function seed(EvaluationResultSummary $summary): void
+    {
+        $this->seeded[$summary->setIdentifier . '|' . $summary->model] = $summary;
+    }
+
+    public function save(SetEvaluationResult $result): void
+    {
+        $this->saved[] = $result;
+    }
+
+    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary
+    {
+        return $this->seeded[$setIdentifier . '|' . $model] ?? null;
+    }
+
+    public function findRecent(string $setIdentifier, string $model, int $limit): array
+    {
+        $latest = $this->findLatest($setIdentifier, $model);
+
+        return $latest === null ? [] : [$latest];
+    }
+
+    public function meanQualityScoreForModel(string $model): ?float
+    {
+        return null;
+    }
+}

--- a/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
@@ -28,7 +28,7 @@ final class InMemoryEvaluationResultRepository implements EvaluationResultReposi
 
     public function seed(EvaluationResultSummary $summary): void
     {
-        $this->seeded[$summary->setIdentifier . '|' . $summary->model] = $summary;
+        $this->seeded[$summary->setIdentifier . '|' . $summary->model . '|' . $summary->grader] = $summary;
     }
 
     public function save(SetEvaluationResult $result): void
@@ -36,19 +36,19 @@ final class InMemoryEvaluationResultRepository implements EvaluationResultReposi
         $this->saved[] = $result;
     }
 
-    public function findLatest(string $setIdentifier, string $model): ?EvaluationResultSummary
+    public function findLatest(string $setIdentifier, string $model, string $grader): ?EvaluationResultSummary
     {
-        return $this->seeded[$setIdentifier . '|' . $model] ?? null;
+        return $this->seeded[$setIdentifier . '|' . $model . '|' . $grader] ?? null;
     }
 
-    public function findRecent(string $setIdentifier, string $model, int $limit): array
+    public function findRecent(string $setIdentifier, string $model, string $grader, int $limit): array
     {
-        $latest = $this->findLatest($setIdentifier, $model);
+        $latest = $this->findLatest($setIdentifier, $model, $grader);
 
         return $latest === null ? [] : [$latest];
     }
 
-    public function meanQualityScoreForModel(string $model): ?float
+    public function meanQualityScoreForModel(string $model, string $grader): ?float
     {
         return null;
     }

--- a/Tests/Unit/Service/Evaluation/AssertionTest.php
+++ b/Tests/Unit/Service/Evaluation/AssertionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\AssertionType;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Assertion::class)]
+final class AssertionTest extends TestCase
+{
+    #[Test]
+    public function factoriesSetTheMatchingType(): void
+    {
+        self::assertSame(AssertionType::EXACT, Assertion::exact('a')->type);
+        self::assertSame(AssertionType::CONTAINS, Assertion::contains('a')->type);
+        self::assertSame(AssertionType::REGEX, Assertion::regex('/a/')->type);
+        self::assertSame(AssertionType::JSON_SCHEMA, Assertion::jsonSchema('{"type":"object"}')->type);
+    }
+
+    #[Test]
+    public function emptyValueIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000001);
+        Assertion::contains('');
+    }
+
+    #[Test]
+    public function invalidRegexIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000002);
+        Assertion::regex('/(unclosed');
+    }
+
+    #[Test]
+    public function validRegexIsAccepted(): void
+    {
+        $assertion = Assertion::regex('/\d+/');
+        self::assertSame('/\d+/', $assertion->value);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/EvaluationQualityScoreProviderTest.php
+++ b/Tests/Unit/Service/Evaluation/EvaluationQualityScoreProviderTest.php
@@ -24,7 +24,7 @@ final class EvaluationQualityScoreProviderTest extends TestCase
         $repository = $this->createMock(EvaluationResultRepositoryInterface::class);
         $repository->expects(self::once())
             ->method('meanQualityScoreForModel')
-            ->with('gpt-test')
+            ->with('gpt-test', 'deterministic')
             ->willReturn(0.82);
 
         $provider = new EvaluationQualityScoreProvider($repository);

--- a/Tests/Unit/Service/Evaluation/EvaluationQualityScoreProviderTest.php
+++ b/Tests/Unit/Service/Evaluation/EvaluationQualityScoreProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationQualityScoreProvider;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EvaluationQualityScoreProvider::class)]
+final class EvaluationQualityScoreProviderTest extends TestCase
+{
+    #[Test]
+    public function delegatesToRepositoryForKnownModel(): void
+    {
+        $repository = $this->createMock(EvaluationResultRepositoryInterface::class);
+        $repository->expects(self::once())
+            ->method('meanQualityScoreForModel')
+            ->with('gpt-test')
+            ->willReturn(0.82);
+
+        $provider = new EvaluationQualityScoreProvider($repository);
+
+        self::assertSame(0.82, $provider->getQualityScore('gpt-test'));
+    }
+
+    #[Test]
+    public function emptyModelIdShortCircuitsWithoutQuerying(): void
+    {
+        $repository = $this->createMock(EvaluationResultRepositoryInterface::class);
+        $repository->expects(self::never())->method('meanQualityScoreForModel');
+
+        $provider = new EvaluationQualityScoreProvider($repository);
+
+        self::assertNull($provider->getQualityScore(''));
+    }
+
+    #[Test]
+    public function returnsNullWhenModelHasNoResults(): void
+    {
+        $repository = $this->createMock(EvaluationResultRepositoryInterface::class);
+        $repository->method('meanQualityScoreForModel')->willReturn(null);
+
+        $provider = new EvaluationQualityScoreProvider($repository);
+
+        self::assertNull($provider->getQualityScore('unknown-model'));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/EvaluationServiceTest.php
+++ b/Tests/Unit/Service/Evaluation/EvaluationServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Evaluation\Grader\LlmJudgeGrader;
+use Netresearch\NrLlm\Service\Evaluation\GradingService;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticCompletionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EvaluationService::class)]
+final class EvaluationServiceTest extends TestCase
+{
+    private function evaluationService(StaticCompletionService $completion): EvaluationService
+    {
+        return new EvaluationService(
+            $completion,
+            new GradingService(new DeterministicGrader(), new LlmJudgeGrader($completion)),
+        );
+    }
+
+    private function set(): GoldenPromptSet
+    {
+        return new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', [
+            new GoldenPrompt('says-ack', 'Reply ACK', [Assertion::contains('ACK')]),
+            new GoldenPrompt('says-paris', 'Capital of France?', [Assertion::contains('Paris')]),
+        ]);
+    }
+
+    #[Test]
+    public function runGradesEveryPromptAndAggregates(): void
+    {
+        // Response contains "ACK" (first prompt passes) but not "Paris" (second fails).
+        $completion = new StaticCompletionService('ACK', 'gpt-test');
+        $result = $this->evaluationService($completion)->run($this->set());
+
+        self::assertSame('nr_llm.smoke', $result->setIdentifier);
+        self::assertSame('gpt-test', $result->model);
+        self::assertSame('deterministic', $result->grader);
+        self::assertSame(2, $result->promptCount());
+        self::assertSame(1, $result->passedCount());
+        self::assertSame(0.5, $result->passRate());
+        self::assertSame(0.5, $result->meanScore());
+    }
+
+    #[Test]
+    public function runCallsTheModelOncePerPrompt(): void
+    {
+        $completion = new StaticCompletionService('ACK Paris');
+        $this->evaluationService($completion)->run($this->set());
+
+        self::assertCount(2, $completion->receivedPrompts);
+        self::assertSame(['Reply ACK', 'Capital of France?'], $completion->receivedPrompts);
+    }
+
+    #[Test]
+    public function runRecordsNonNegativeLatencyPerPrompt(): void
+    {
+        $completion = new StaticCompletionService('ACK Paris');
+        $result = $this->evaluationService($completion)->run($this->set());
+
+        foreach ($result->evaluations as $evaluation) {
+            self::assertGreaterThanOrEqual(0, $evaluation->latencyMs);
+        }
+    }
+
+    #[Test]
+    public function allPassingSetHasFullPassRate(): void
+    {
+        $completion = new StaticCompletionService('ACK and Paris');
+        $result = $this->evaluationService($completion)->run($this->set());
+
+        self::assertSame(1.0, $result->passRate());
+        self::assertSame(1.0, $result->meanScore());
+    }
+}

--- a/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
+++ b/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use RuntimeException;
+
+/**
+ * A CompletionService test double that returns a fixed response, records the
+ * prompts it received, and can be told to throw — so grading, aggregation,
+ * and the command can be exercised without a live LLM.
+ *
+ * The concrete CompletionService is `final readonly` and cannot be mocked by
+ * PHPUnit, so this hand-written double implements the interface instead.
+ */
+final class StaticCompletionService implements CompletionServiceInterface
+{
+    /** @var list<string> */
+    public array $receivedPrompts = [];
+
+    public function __construct(
+        private readonly string $content,
+        private readonly string $model = 'test-model',
+        private readonly bool $throw = false,
+    ) {}
+
+    public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->receivedPrompts[] = $prompt;
+        if ($this->throw) {
+            throw new RuntimeException('provider unavailable', 1794000099);
+        }
+
+        return new CompletionResponse(
+            $this->content,
+            $this->model,
+            new UsageStatistics(0, 0, 0),
+        );
+    }
+
+    public function completeJson(string $prompt, ?ChatOptions $options = null): array
+    {
+        return [];
+    }
+
+    public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string
+    {
+        return $this->content;
+    }
+
+    public function completeFactual(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->complete($prompt, $options);
+    }
+
+    public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->complete($prompt, $options);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/GoldenPromptSetRegistryTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenPromptSetRegistryTest.php
@@ -66,9 +66,9 @@ final class GoldenPromptSetRegistryTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionCode(1794000030);
-        new GoldenPromptSetRegistry([
+        self::assertInstanceOf(GoldenPromptSetRegistry::class, new GoldenPromptSetRegistry([
             $this->provider($this->set('a.one')),
             $this->provider($this->set('a.one')),
-        ]);
+        ]));
     }
 }

--- a/Tests/Unit/Service/Evaluation/GoldenPromptSetRegistryTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenPromptSetRegistryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use LogicException;
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetProviderInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GoldenPromptSetRegistry::class)]
+final class GoldenPromptSetRegistryTest extends TestCase
+{
+    private function set(string $identifier): GoldenPromptSet
+    {
+        return new GoldenPromptSet(
+            $identifier,
+            'Name',
+            'Description',
+            [new GoldenPrompt('p1', 'Say hi.', [Assertion::contains('hi')])],
+        );
+    }
+
+    private function provider(GoldenPromptSet ...$sets): GoldenPromptSetProviderInterface
+    {
+        return new class (array_values($sets)) implements GoldenPromptSetProviderInterface {
+            /**
+             * @param list<GoldenPromptSet> $sets
+             */
+            public function __construct(private readonly array $sets) {}
+
+            public function getGoldenPromptSets(): array
+            {
+                return $this->sets;
+            }
+        };
+    }
+
+    #[Test]
+    public function collectsSetsFromAllProviders(): void
+    {
+        $registry = new GoldenPromptSetRegistry([
+            $this->provider($this->set('a.one')),
+            $this->provider($this->set('b.two')),
+        ]);
+
+        self::assertCount(2, $registry->all());
+        self::assertSame(['a.one', 'b.two'], $registry->identifiers());
+        self::assertNotNull($registry->findByIdentifier('a.one'));
+        self::assertNull($registry->findByIdentifier('missing'));
+    }
+
+    #[Test]
+    public function duplicateIdentifierFailsFast(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(1794000030);
+        new GoldenPromptSetRegistry([
+            $this->provider($this->set('a.one')),
+            $this->provider($this->set('a.one')),
+        ]);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/GoldenPromptSetTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenPromptSetTest.php
@@ -56,7 +56,7 @@ final class GoldenPromptSetTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1794000020);
-        new GoldenPromptSet($identifier, 'Chat', 'A set', [$this->prompt()]);
+        self::assertInstanceOf(GoldenPromptSet::class, new GoldenPromptSet($identifier, 'Chat', 'A set', [$this->prompt()]));
     }
 
     #[Test]
@@ -64,7 +64,7 @@ final class GoldenPromptSetTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1794000022);
-        new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', []);
+        self::assertInstanceOf(GoldenPromptSet::class, new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', []));
     }
 
     #[Test]
@@ -72,7 +72,7 @@ final class GoldenPromptSetTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1794000023);
-        new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', [$this->prompt('dup'), $this->prompt('dup')]);
+        self::assertInstanceOf(GoldenPromptSet::class, new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', [$this->prompt('dup'), $this->prompt('dup')]));
     }
 
     #[Test]
@@ -80,7 +80,7 @@ final class GoldenPromptSetTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1794000012);
-        new GoldenPrompt('p', 'prompt without expectations');
+        self::assertInstanceOf(GoldenPrompt::class, new GoldenPrompt('p', 'prompt without expectations'));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Evaluation/GoldenPromptSetTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenPromptSetTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GoldenPromptSet::class)]
+#[CoversClass(GoldenPrompt::class)]
+final class GoldenPromptSetTest extends TestCase
+{
+    private function prompt(string $id = 'p1'): GoldenPrompt
+    {
+        return new GoldenPrompt($id, 'Say hi.', [Assertion::contains('hi')]);
+    }
+
+    #[Test]
+    public function validSetIsConstructed(): void
+    {
+        $set = new GoldenPromptSet('nr_ai_search.chat', 'Chat', 'A set', [$this->prompt()]);
+
+        self::assertSame('nr_ai_search.chat', $set->identifier);
+        self::assertCount(1, $set->prompts);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidIdentifierProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'uppercase' => ['NrAiSearch.chat'],
+            'leading dot' => ['.chat'],
+            'trailing dot' => ['chat.'],
+            'spaces' => ['nr ai search'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidIdentifierProvider')]
+    public function invalidIdentifierIsRejected(string $identifier): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000020);
+        new GoldenPromptSet($identifier, 'Chat', 'A set', [$this->prompt()]);
+    }
+
+    #[Test]
+    public function emptyPromptsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000022);
+        new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', []);
+    }
+
+    #[Test]
+    public function duplicatePromptIdsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000023);
+        new GoldenPromptSet('nr_llm.smoke', 'Smoke', 'desc', [$this->prompt('dup'), $this->prompt('dup')]);
+    }
+
+    #[Test]
+    public function promptRequiresAssertionOrReference(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000012);
+        new GoldenPrompt('p', 'prompt without expectations');
+    }
+
+    #[Test]
+    public function promptWithOnlyReferenceIsValid(): void
+    {
+        $prompt = new GoldenPrompt('p', 'prompt', [], null, 'reference answer');
+        self::assertSame('reference answer', $prompt->reference);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/Grader/DeterministicGraderTest.php
+++ b/Tests/Unit/Service/Evaluation/Grader/DeterministicGraderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Grader;
+
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeterministicGrader::class)]
+final class DeterministicGraderTest extends TestCase
+{
+    private DeterministicGrader $grader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->grader = new DeterministicGrader();
+    }
+
+    private function promptWith(Assertion ...$assertions): GoldenPrompt
+    {
+        return new GoldenPrompt('p', 'irrelevant', array_values($assertions));
+    }
+
+    #[Test]
+    public function identifierIsDeterministic(): void
+    {
+        self::assertSame('deterministic', $this->grader->getIdentifier());
+    }
+
+    #[Test]
+    public function exactMatchPasses(): void
+    {
+        $result = $this->grader->grade('  Paris  ', $this->promptWith(Assertion::exact('Paris')));
+
+        self::assertTrue($result->passed);
+        self::assertSame(1.0, $result->score);
+        self::assertSame('deterministic', $result->grader);
+    }
+
+    #[Test]
+    public function exactMismatchFails(): void
+    {
+        $result = $this->grader->grade('London', $this->promptWith(Assertion::exact('Paris')));
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.0, $result->score);
+    }
+
+    #[Test]
+    public function containsPassesAndFails(): void
+    {
+        self::assertTrue($this->grader->grade('The capital is Paris.', $this->promptWith(Assertion::contains('Paris')))->passed);
+        self::assertFalse($this->grader->grade('The capital is London.', $this->promptWith(Assertion::contains('Paris')))->passed);
+    }
+
+    #[Test]
+    public function regexPassesAndFails(): void
+    {
+        self::assertTrue($this->grader->grade('Result: 4', $this->promptWith(Assertion::regex('/\b4\b/')))->passed);
+        self::assertFalse($this->grader->grade('Result: five', $this->promptWith(Assertion::regex('/\b4\b/')))->passed);
+    }
+
+    #[Test]
+    public function jsonSchemaPassesForMatchingStructure(): void
+    {
+        $schema = '{"type":"object","required":["name","age"],"properties":{"name":{"type":"string"},"age":{"type":"integer"}}}';
+        $result = $this->grader->grade('{"name":"Ada","age":36,"extra":true}', $this->promptWith(Assertion::jsonSchema($schema)));
+
+        self::assertTrue($result->passed);
+    }
+
+    #[Test]
+    public function jsonSchemaFailsForMissingRequiredKey(): void
+    {
+        $schema = '{"type":"object","required":["name","age"]}';
+        $result = $this->grader->grade('{"name":"Ada"}', $this->promptWith(Assertion::jsonSchema($schema)));
+
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
+    public function jsonSchemaFailsForWrongPropertyType(): void
+    {
+        $schema = '{"type":"object","properties":{"age":{"type":"integer"}}}';
+        $result = $this->grader->grade('{"age":"not-a-number"}', $this->promptWith(Assertion::jsonSchema($schema)));
+
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
+    public function jsonSchemaFailsForInvalidJson(): void
+    {
+        $result = $this->grader->grade('not json at all', $this->promptWith(Assertion::jsonSchema('{"type":"object"}')));
+
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
+    public function scoreIsFractionOfSatisfiedAssertions(): void
+    {
+        $result = $this->grader->grade(
+            'Paris',
+            $this->promptWith(Assertion::contains('Paris'), Assertion::contains('missing')),
+        );
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.5, $result->score);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/Grader/DeterministicGraderTest.php
+++ b/Tests/Unit/Service/Evaluation/Grader/DeterministicGraderTest.php
@@ -90,6 +90,27 @@ final class DeterministicGraderTest extends TestCase
     }
 
     #[Test]
+    public function jsonSchemaAcceptsEmptyObjectWhenNoKeysRequired(): void
+    {
+        // An empty JSON object decodes to [], which array_is_list() reports
+        // as a list — the required-key gate must still treat it as an object
+        // (matchesType already does), so a schema requiring no keys passes.
+        $schema = '{"type":"object","required":[]}';
+        $result = $this->grader->grade('{}', $this->promptWith(Assertion::jsonSchema($schema)));
+
+        self::assertTrue($result->passed);
+    }
+
+    #[Test]
+    public function jsonSchemaFailsForEmptyObjectMissingRequiredKey(): void
+    {
+        $schema = '{"type":"object","required":["name"]}';
+        $result = $this->grader->grade('{}', $this->promptWith(Assertion::jsonSchema($schema)));
+
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
     public function jsonSchemaFailsForWrongPropertyType(): void
     {
         $schema = '{"type":"object","properties":{"age":{"type":"integer"}}}';

--- a/Tests/Unit/Service/Evaluation/Grader/LlmJudgeGraderTest.php
+++ b/Tests/Unit/Service/Evaluation/Grader/LlmJudgeGraderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Grader;
+
+use Netresearch\NrLlm\Service\Evaluation\Assertion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\Grader\LlmJudgeGrader;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticCompletionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LlmJudgeGrader::class)]
+final class LlmJudgeGraderTest extends TestCase
+{
+    private function prompt(): GoldenPrompt
+    {
+        return new GoldenPrompt('p', 'What is 2+2?', [Assertion::contains('4')], null, '4');
+    }
+
+    private function grader(string $judgeContent, bool $throw = false, float $threshold = 0.6): LlmJudgeGrader
+    {
+        return new LlmJudgeGrader(new StaticCompletionService($judgeContent, 'judge-model', $throw), $threshold);
+    }
+
+    #[Test]
+    public function identifierIsLlmJudge(): void
+    {
+        self::assertSame('llm_judge', $this->grader('{"score":1}')->getIdentifier());
+    }
+
+    #[Test]
+    public function parsesScoreAndReason(): void
+    {
+        $result = $this->grader('{"score": 0.8, "reason": "mostly correct"}')->grade('4', $this->prompt());
+
+        self::assertTrue($result->passed);
+        self::assertSame(0.8, $result->score);
+        self::assertSame('mostly correct', $result->reason);
+        self::assertSame('llm_judge', $result->grader);
+    }
+
+    #[Test]
+    public function scoreBelowThresholdDoesNotPass(): void
+    {
+        $result = $this->grader('{"score": 0.3}')->grade('nope', $this->prompt());
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.3, $result->score);
+    }
+
+    #[Test]
+    public function scoreAboveOneIsClampedToOne(): void
+    {
+        $result = $this->grader('{"score": 1.7}')->grade('4', $this->prompt());
+
+        self::assertSame(1.0, $result->score);
+        self::assertTrue($result->passed);
+    }
+
+    #[Test]
+    public function negativeScoreIsClampedToZero(): void
+    {
+        $result = $this->grader('{"score": -0.4}')->grade('4', $this->prompt());
+
+        self::assertSame(0.0, $result->score);
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
+    public function unparseableJudgeResponseFailsGracefully(): void
+    {
+        $result = $this->grader('the response looks fine to me')->grade('4', $this->prompt());
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.0, $result->score);
+        self::assertStringContainsString('parseable', $result->reason);
+    }
+
+    #[Test]
+    public function jsonWithoutScoreKeyFailsGracefully(): void
+    {
+        $result = $this->grader('{"verdict": "good"}')->grade('4', $this->prompt());
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.0, $result->score);
+    }
+
+    #[Test]
+    public function judgeTransportErrorFailsGracefully(): void
+    {
+        $result = $this->grader('irrelevant', throw: true)->grade('4', $this->prompt());
+
+        self::assertFalse($result->passed);
+        self::assertSame(0.0, $result->score);
+        self::assertStringContainsString('Judge call failed', $result->reason);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/GradingServiceTest.php
+++ b/Tests/Unit/Service/Evaluation/GradingServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
+use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
+use Netresearch\NrLlm\Service\Evaluation\Grader\LlmJudgeGrader;
+use Netresearch\NrLlm\Service\Evaluation\GradingService;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticCompletionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GradingService::class)]
+final class GradingServiceTest extends TestCase
+{
+    private function service(string $judgeContent = '{"score":0.9}'): GradingService
+    {
+        return new GradingService(
+            new DeterministicGrader(),
+            new LlmJudgeGrader(new StaticCompletionService($judgeContent)),
+        );
+    }
+
+    private function prompt(): GoldenPrompt
+    {
+        return new GoldenPrompt('p', 'prompt', [], null, 'reference');
+    }
+
+    #[Test]
+    public function defaultsToDeterministicGrader(): void
+    {
+        // The prompt has no assertions, so the deterministic grader reports its
+        // "nothing to grade" verdict — proving it, not the judge, was used.
+        $result = $this->service()->grade('any response', $this->prompt());
+
+        self::assertSame('deterministic', $result->grader);
+        self::assertFalse($result->passed);
+    }
+
+    #[Test]
+    public function unknownGraderFallsBackToDeterministic(): void
+    {
+        $result = $this->service()->grade('any', $this->prompt(), 'does-not-exist');
+
+        self::assertSame('deterministic', $result->grader);
+    }
+
+    #[Test]
+    public function llmJudgeIsUsedWhenRequested(): void
+    {
+        $result = $this->service('{"score":0.9,"reason":"good"}')->grade('any', $this->prompt(), 'llm_judge');
+
+        self::assertSame('llm_judge', $result->grader);
+        self::assertSame(0.9, $result->score);
+    }
+
+    #[Test]
+    public function availableGradersListsBothStrategies(): void
+    {
+        self::assertSame(['deterministic', 'llm_judge'], $this->service()->availableGraders());
+    }
+}

--- a/Tests/Unit/Service/Evaluation/QualityAwareModelSelectorTest.php
+++ b/Tests/Unit/Service/Evaluation/QualityAwareModelSelectorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Service\Evaluation\ModelQualityScoreProviderInterface;
+use Netresearch\NrLlm\Service\Evaluation\QualityAwareModelSelector;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QualityAwareModelSelector::class)]
+final class QualityAwareModelSelectorTest extends TestCase
+{
+    private function model(string $modelId): Model
+    {
+        $model = new Model();
+        $model->setModelId($modelId);
+
+        return $model;
+    }
+
+    /**
+     * @param list<Model> $candidates
+     */
+    private function selectionService(array $candidates): ModelSelectionServiceInterface
+    {
+        $stub = self::createStub(ModelSelectionServiceInterface::class);
+        $stub->method('findCandidates')->willReturn($candidates);
+
+        return $stub;
+    }
+
+    /**
+     * @param array<string, float|null> $scores
+     */
+    private function qualityProvider(array $scores): ModelQualityScoreProviderInterface
+    {
+        return new class ($scores) implements ModelQualityScoreProviderInterface {
+            /**
+             * @param array<string, float|null> $scores
+             */
+            public function __construct(private readonly array $scores) {}
+
+            public function getQualityScore(string $modelId): ?float
+            {
+                return $this->scores[$modelId] ?? null;
+            }
+        };
+    }
+
+    #[Test]
+    public function returnsNullWhenNoCandidatesMatch(): void
+    {
+        $selector = new QualityAwareModelSelector($this->selectionService([]), $this->qualityProvider([]));
+
+        self::assertNull($selector->selectByQuality(['capabilities' => ['chat']]));
+    }
+
+    #[Test]
+    public function ranksHighestQualityFirst(): void
+    {
+        $selector = new QualityAwareModelSelector(
+            $this->selectionService([$this->model('a'), $this->model('b'), $this->model('c')]),
+            $this->qualityProvider(['a' => 0.5, 'b' => 0.9, 'c' => 0.7]),
+        );
+
+        $selected = $selector->selectByQuality(['capabilities' => ['chat']]);
+
+        self::assertNotNull($selected);
+        self::assertSame('b', $selected->getModelId());
+    }
+
+    #[Test]
+    public function minQualityFiltersOutLowAndUnscoredModels(): void
+    {
+        $selector = new QualityAwareModelSelector(
+            $this->selectionService([$this->model('a'), $this->model('b'), $this->model('c')]),
+            $this->qualityProvider(['a' => 0.5, 'b' => 0.9]),
+        );
+
+        $selected = $selector->selectByQuality(['capabilities' => ['chat']], 0.8);
+
+        self::assertNotNull($selected);
+        self::assertSame('b', $selected->getModelId());
+    }
+
+    #[Test]
+    public function returnsNullWhenNoCandidateMeetsMinQuality(): void
+    {
+        $selector = new QualityAwareModelSelector(
+            $this->selectionService([$this->model('a'), $this->model('b')]),
+            $this->qualityProvider(['a' => 0.5, 'b' => 0.6]),
+        );
+
+        self::assertNull($selector->selectByQuality(['capabilities' => ['chat']], 0.9));
+    }
+
+    #[Test]
+    public function fallsBackToBaseOrderWhenNoScoresExist(): void
+    {
+        // No quality data and no minimum → degrades to the base selection's first candidate.
+        $selector = new QualityAwareModelSelector(
+            $this->selectionService([$this->model('first'), $this->model('second')]),
+            $this->qualityProvider([]),
+        );
+
+        $selected = $selector->selectByQuality(['capabilities' => ['chat']]);
+
+        self::assertNotNull($selected);
+        self::assertSame('first', $selected->getModelId());
+    }
+
+    #[Test]
+    public function scoredModelsOutrankUnscoredEvenWhenListedLater(): void
+    {
+        $selector = new QualityAwareModelSelector(
+            $this->selectionService([$this->model('unscored'), $this->model('scored')]),
+            $this->qualityProvider(['scored' => 0.4]),
+        );
+
+        $selected = $selector->selectByQuality(['capabilities' => ['chat']]);
+
+        self::assertNotNull($selected);
+        self::assertSame('scored', $selected->getModelId());
+    }
+}

--- a/Tests/Unit/Service/Evaluation/RegressionDetectorTest.php
+++ b/Tests/Unit/Service/Evaluation/RegressionDetectorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultSummary;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RegressionDetector::class)]
+final class RegressionDetectorTest extends TestCase
+{
+    private RegressionDetector $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new RegressionDetector();
+    }
+
+    private function summary(float $passRate, float $meanScore): EvaluationResultSummary
+    {
+        return new EvaluationResultSummary('nr_llm.smoke', 'gpt-test', 'deterministic', 10, (int)round($passRate * 10), $passRate, $meanScore, 1_700_000_000);
+    }
+
+    #[Test]
+    public function noBaselineIsNotARegression(): void
+    {
+        $report = $this->detector->compare($this->summary(0.5, 0.5), null, new RegressionThresholds());
+
+        self::assertFalse($report->hasBaseline);
+        self::assertFalse($report->isRegression);
+        self::assertSame(0.0, $report->passRateDelta);
+    }
+
+    #[Test]
+    public function largePassRateDropIsARegression(): void
+    {
+        $report = $this->detector->compare($this->summary(0.5, 0.5), $this->summary(1.0, 0.9), new RegressionThresholds());
+
+        self::assertTrue($report->hasBaseline);
+        self::assertTrue($report->isRegression);
+        self::assertEqualsWithDelta(-0.5, $report->passRateDelta, 0.0001);
+        self::assertStringContainsString('Regression', $report->summary);
+    }
+
+    #[Test]
+    public function improvementIsNotARegression(): void
+    {
+        $report = $this->detector->compare($this->summary(1.0, 0.95), $this->summary(0.5, 0.5), new RegressionThresholds());
+
+        self::assertFalse($report->isRegression);
+        self::assertEqualsWithDelta(0.5, $report->passRateDelta, 0.0001);
+    }
+
+    #[Test]
+    public function smallDropWithinToleranceIsStable(): void
+    {
+        $report = $this->detector->compare($this->summary(0.85, 0.85), $this->summary(0.9, 0.9), new RegressionThresholds());
+
+        self::assertFalse($report->isRegression);
+        self::assertStringContainsString('No regression', $report->summary);
+    }
+
+    #[Test]
+    public function meanScoreDropAloneTriggersRegression(): void
+    {
+        // Pass rate stable, mean score falls beyond tolerance.
+        $report = $this->detector->compare($this->summary(0.9, 0.6), $this->summary(0.9, 0.9), new RegressionThresholds());
+
+        self::assertTrue($report->isRegression);
+        self::assertStringContainsString('mean score', $report->summary);
+    }
+
+    #[Test]
+    public function customThresholdWidensTolerance(): void
+    {
+        // A 0.3 pass-rate drop is a regression by default but tolerated at 0.5.
+        $lenient = new RegressionThresholds(maxPassRateDrop: 0.5, maxMeanScoreDrop: 0.5);
+        $report = $this->detector->compare($this->summary(0.6, 0.6), $this->summary(0.9, 0.9), $lenient);
+
+        self::assertFalse($report->isRegression);
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -663,3 +663,45 @@ CREATE TABLE tx_nrllm_skill_audit (
     KEY source_uid (source_uid),
     KEY event (event)
 );
+
+#
+# Table structure for table 'tx_nrllm_eval_result'
+# Quality-evaluation run results (ADR-060). One row per golden-set run
+# against a model: aggregate pass rate / mean score plus a JSON snapshot of
+# the per-prompt outcomes. UI-less result log (no TCA), like
+# tx_nrllm_service_usage; written only by the nrllm:eval:run command and read
+# for regression comparison and quality-aware routing. Grows per run;
+# retention is a documented follow-up (ADR-060).
+#
+CREATE TABLE tx_nrllm_eval_result (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Run identity
+    set_identifier varchar(190) DEFAULT '' NOT NULL,
+    model_id varchar(150) DEFAULT '' NOT NULL,
+    grader varchar(50) DEFAULT '' NOT NULL,
+
+    -- Aggregate metrics (pass_rate / mean_score normalised 0.0000-1.0000)
+    prompt_count int(11) unsigned DEFAULT '0' NOT NULL,
+    passed_count int(11) unsigned DEFAULT '0' NOT NULL,
+    pass_rate decimal(5,4) DEFAULT '0.0000' NOT NULL,
+    mean_score decimal(5,4) DEFAULT '0.0000' NOT NULL,
+
+    -- Per-prompt outcomes snapshot (JSON) for later inspection
+    details mediumtext,
+
+    -- Time tracking
+    run_date int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- Regression read path: latest run(s) for a (set, model), newest first.
+    KEY set_model (set_identifier, model_id, run_date),
+    -- Quality-routing read path: latest runs per set for a model.
+    KEY model_lookup (model_id, run_date)
+);


### PR DESCRIPTION
## What this adds

A greenfield, opt-in quality-evaluation layer for LLM answers (analysis point 6 — the gap versus `aim`). Nothing runs in the request pipeline; evaluation is an explicitly triggered operator activity and, with the default grader, spends no tokens.

- **Golden prompt sets** — consumers declare `GoldenPromptSet`s via `GoldenPromptSetProviderInterface` (DI tag `nr_llm.golden_prompt_set`, `AutoconfigureTag`, mirroring ADR-056). `GoldenPromptSetRegistry` collects them and fails fast on duplicate identifiers. Each prompt carries deterministic assertions (exact / contains / regex / json_schema) and an optional reference answer. An example set (`nr_llm.smoke`) ships as the pattern to copy and a runnable target.
- **Grading** — `GraderInterface` with two strategies: `DeterministicGrader` (default, no tokens; its json_schema matcher is a lightweight structural check, not a full JSON Schema validator, to avoid a runtime dependency) and the opt-in `LlmJudgeGrader` (scores 0..1 with a reason via `CompletionService`; malformed or failed judge responses are handled defensively). `GradingService` selects by identifier and falls back to deterministic for an unknown one, so evaluation never silently spends tokens.
- **Run + aggregate** — `EvaluationService` runs a set against a model (one `CompletionService` call per prompt), grades each response, records latency, and aggregates to pass rate and mean score. It neither persists nor compares, so it is unit-testable without a database.
- **Persistence + regression detection** — runs are stored in the new `tx_nrllm_eval_result` table (UI-less result log, no TCA, mirroring `tx_nrllm_service_usage`) as aggregate summaries plus a JSON snapshot of the per-prompt outcomes. `RegressionDetector` compares a run against the previous run for the same (set, model) and flags a regression when pass rate or mean score falls beyond a configurable `RegressionThresholds` tolerance (default 0.1).
- **Quality-aware routing (hook only)** — `EvaluationQualityScoreProvider` derives a per-model quality score from stored results; `QualityAwareModelSelector` re-ranks `ModelSelectionService`'s existing candidate list by that score. `ModelSelectionService` is unchanged — the cost/latency modes behave exactly as before, and nothing routes by quality unless a consumer opts in.
- **CLI** — `nrllm:eval:run <set>` runs a set, prints per-prompt gradings and the aggregate, saves the run, and reports the regression verdict (`--fail-on-regression` for CI). Options: `--grader`, `--model`, `--provider`, `--max-pass-rate-drop`, `--max-mean-score-drop`.

## Routing-integration boundary

Quality is delivered as an additive, opt-in hook, not a change to `ModelSelectionService`. Making quality a first-class sort key inside the core selector (alongside provider priority and cost) is a deliberate follow-up: pulling the eval store into the core selection path would invert the layering and risk changing the existing selection modes. This boundary is documented in ADR-060.

## Public surface

No new `public: true` services. The DBAL persistence class is instantiated directly in its functional test (its only dependency is `ConnectionPool`) and autowired as an interface into the command elsewhere; the command is registered via the `console.command` tag (made public by TYPO3's `ConsoleCommandPass`, not by a `public: true` override). `PublicServicesPolicyTest` count is unchanged (45), so ADR-028 needs no edit.

## Storage decision

A table (`tx_nrllm_eval_result`), not file snapshots: it fits TYPO3, is queryable for the per-model quality aggregate the routing hook needs, and matches the `tx_nrllm_service_usage` precedent for UI-less log tables (no TCA). Growth is one row per run; a retention policy is a documented follow-up.

## Tests

- Unit: each deterministic assertion type (pass + fail), the json-schema structural matcher, the LLM judge (score parsing, clamping, malformed response, transport error) with a stubbed completion service, grader selection, evaluation aggregation and latency capture, regression detection (fall / rise / stable / no-baseline / custom tolerance), the quality-routing hook (rank / filter / fallback), and the CLI command (unknown set, passing run, no-baseline, regression exit code).
- Functional: eval-result persistence and the two-run regression comparison against the database, plus DI-tag collection of the built-in golden set.

## Docs

ADR-060 (added to the ADR toctree) and a developer guide, `Documentation/Developer/QualityEvaluation.rst` (added to the developer toctree), covering how to declare a golden set and use `nrllm:eval:run`.

## Not done here (follow-ups, in ADR-060)

- Full quality integration into `ModelSelectionService` as a first-class sort key.
- A dedicated judge-model selection (the judge currently uses the default chat configuration).
- A retention / pruning policy for `tx_nrllm_eval_result`.
