### PR TITLE
refactor: extract provider registry, config resolver and message shaping from LlmServiceManager

### DIFF
--- a/Classes/Service/ConfigurationResolver.php
+++ b/Classes/Service/ConfigurationResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+
+/**
+ * Resolves the backend-module-managed default configuration for generic
+ * (provider-agnostic) completion / chat / stream calls.
+ *
+ * Extracted from {@see LlmServiceManager} so the "which configuration drives
+ * this call" decision — and the guards around an access-restricted or
+ * model-less default — live in one collaborator that the generic dispatch
+ * methods share. The repository is optional so unit constructions that do not
+ * exercise the default-configuration path can omit it (matching the manager's
+ * former nullable dependency).
+ */
+final readonly class ConfigurationResolver
+{
+    public function __construct(
+        private ?LlmConfigurationRepository $configurationRepository = null,
+    ) {}
+
+    /**
+     * Resolve the effective configuration for a configuration-driven completion.
+     *
+     * Returns the explicitly passed configuration when set, otherwise the
+     * backend-module-managed active default — resolved through the very same
+     * guards the generic complete()/chat() path uses (see
+     * {@see self::resolveDefaultConfiguration()}), so callers never duplicate
+     * that logic. Returns null when neither resolves; the caller must then
+     * dispatch through the generic path so the existing "no provider specified"
+     * error is raised.
+     */
+    public function resolveEffectiveConfiguration(?LlmConfiguration $configuration = null): ?LlmConfiguration
+    {
+        return $configuration ?? $this->resolveDefaultConfiguration(null);
+    }
+
+    /**
+     * Resolve the backend-module-managed default configuration for a generic
+     * (provider-agnostic) completion/chat call. Returns null when the caller
+     * pinned an explicit provider, when no repository is wired (unit tests), or
+     * when no active default configuration exists — in which case the generic
+     * path requires a per-call pinned provider and otherwise throws (there is
+     * no extension-config default-provider fallback; see ADR-034).
+     *
+     * Uses the repository directly rather than LlmConfigurationService, whose
+     * getDefaultConfiguration() enforces a backend-user access check that the
+     * CLI worker (Symfony Messenger consumer) has no user for.
+     */
+    public function resolveDefaultConfiguration(?string $providerKey): ?LlmConfiguration
+    {
+        if ($providerKey !== null) {
+            return null;
+        }
+
+        $configuration = $this->configurationRepository?->findDefault();
+
+        // Treat as "no default" when the default configuration is missing, has no model
+        // (getAdapterFromConfiguration() would throw), or is access-restricted to specific BE
+        // groups. Returning null here means the generic call needs a per-call pinned provider —
+        // otherwise getProvider(null) throws. The generic chat()/complete()/streamChat()
+        // path has no backend-user context to enforce group membership against (notably the CLI
+        // worker), so an access-restricted default must not be auto-applied to arbitrary callers.
+        if ($configuration === null
+            || $configuration->getLlmModel() === null
+            || $configuration->hasAccessRestrictions()
+        ) {
+            return null;
+        }
+
+        return $configuration;
+    }
+}

--- a/Classes/Service/EmbedCacheKeyBuilder.php
+++ b/Classes/Service/EmbedCacheKeyBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+
+/**
+ * Builds the `CacheMiddleware` metadata for an embeddings call.
+ *
+ * Both embedding entry points ({@see LlmServiceManager::embed()} and
+ * {@see LlmServiceManager::embedForConfiguration()}) carried an inline copy of
+ * the same structure — guard on a positive `cache_ttl`, then attach a cache
+ * key, ttl and tags so `CacheMiddleware` can short-circuit. The two copies
+ * intentionally derive the key from different things (the ad-hoc path keys by
+ * provider identifier, the configuration path by configuration identifier plus
+ * the effective model), so only the *shape* is shared here: each caller passes
+ * its own namespace, key payload and scope tag. A `cache_ttl` of zero (the
+ * `EmbeddingOptions::noCache()` contract) yields an empty array so the caller's
+ * metadata is left untouched and the middleware becomes a no-op.
+ */
+final readonly class EmbedCacheKeyBuilder
+{
+    public function __construct(
+        private CacheManagerInterface $cacheManager,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $keyPayload the fields that make two calls
+     *                                         share (or not share) a cache entry
+     *
+     * @return array<string, mixed> cache metadata to merge onto the call
+     *                              context, or an empty array when caching is off
+     */
+    public function build(int $cacheTtl, string $namespace, array $keyPayload, string $scopeTag): array
+    {
+        if ($cacheTtl <= 0) {
+            return [];
+        }
+
+        return [
+            CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
+                $namespace,
+                'embeddings',
+                $keyPayload,
+            ),
+            CacheMiddleware::METADATA_CACHE_TTL  => $cacheTtl,
+            CacheMiddleware::METADATA_CACHE_TAGS => [
+                'nrllm_embeddings',
+                // Sanitize the scope tag: configuration/provider identifiers can
+                // use the dotted preset scheme (nr_ai_search.embeddings), and the
+                // cache frontend rejects a tag containing a dot on set().
+                $this->cacheManager->sanitizeCacheTag($scopeTag),
+            ],
+        ];
+    }
+}

--- a/Classes/Service/KeyedProviderRegistry.php
+++ b/Classes/Service/KeyedProviderRegistry.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Exception;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Holds the keyed, ExtensionConfiguration-backed provider registry.
+ *
+ * Extracted from {@see LlmServiceManager} (which now delegates its
+ * provider-management methods here). Keeps the mutable map of registered
+ * providers plus the loaded extension configuration, so — like the manager
+ * before it — this is a {@see SingletonInterface}: providers are registered
+ * once at container build time (via `ProviderCompilerPass`, which adds
+ * `registerProvider` method calls on the manager, which forward here) and read
+ * back for the lifetime of the request.
+ *
+ * This is the legacy keyed path: providers are looked up by their string
+ * identifier and configured from the `nr_llm` extension configuration. The
+ * database-backed adapter path (Provider/Model entities) lives elsewhere on
+ * the manager.
+ */
+final class KeyedProviderRegistry implements SingletonInterface
+{
+    /** @var array<string, ProviderInterface> */
+    private array $providers = [];
+
+    /** @var array<string, mixed> */
+    private array $configuration = [];
+
+    public function __construct(
+        private readonly ExtensionConfiguration $extensionConfiguration,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->loadConfiguration();
+    }
+
+    public function registerProvider(ProviderInterface $provider): void
+    {
+        $identifier = $provider->getIdentifier();
+        $this->providers[$identifier] = $provider;
+
+        // Configure provider if configuration exists
+        /** @var array<string, array<string, mixed>> $providers */
+        $providers = is_array($this->configuration['providers'] ?? null) ? $this->configuration['providers'] : [];
+        $providerConfig = $providers[$identifier] ?? [];
+        if ($providerConfig !== []) {
+            $provider->configure($providerConfig);
+        }
+
+        $this->logger->debug('Registered LLM provider', ['provider' => $identifier]);
+    }
+
+    public function getProvider(?string $identifier = null): ProviderInterface
+    {
+        if ($identifier === null) {
+            throw new ProviderException(
+                'No provider specified and no default provider configured. '
+                . 'Set up a default in the LLM backend module: create a Provider, a Model and a '
+                . 'Configuration, then mark that Configuration active and default. '
+                . '(The plugin.tx_nrllm TypoScript settings are not evaluated — provider configuration is database-backed.)',
+                4867297358,
+            );
+        }
+
+        if (!isset($this->providers[$identifier])) {
+            throw new ProviderException(sprintf('Provider "%s" not found', $identifier), 6273324883);
+        }
+
+        return $this->providers[$identifier];
+    }
+
+    /**
+     * @return array<string, ProviderInterface>
+     */
+    public function getAvailableProviders(): array
+    {
+        return array_filter(
+            $this->providers,
+            static fn(ProviderInterface $provider) => $provider->isAvailable(),
+        );
+    }
+
+    /**
+     * Check if at least one provider is available.
+     */
+    public function hasAvailableProvider(): bool
+    {
+        return $this->getAvailableProviders() !== [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getProviderList(): array
+    {
+        $list = [];
+        foreach ($this->providers as $identifier => $provider) {
+            $list[$identifier] = $provider->getName();
+        }
+        return $list;
+    }
+
+    /**
+     * Check if a specific feature is supported by a provider.
+     */
+    public function supportsFeature(string $feature, ?string $provider = null): bool
+    {
+        try {
+            $providerInstance = $this->getProvider($provider);
+            return $providerInstance->supportsFeature($feature);
+        } catch (ProviderException) {
+            return false;
+        }
+    }
+
+    /**
+     * Get configuration for a provider.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProviderConfiguration(string $identifier): array
+    {
+        /** @var array<string, array<string, mixed>> $providers */
+        $providers = is_array($this->configuration['providers'] ?? null) ? $this->configuration['providers'] : [];
+        return $providers[$identifier] ?? [];
+    }
+
+    /**
+     * Dynamically configure a provider.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function configureProvider(string $identifier, array $config): void
+    {
+        if (!isset($this->providers[$identifier])) {
+            throw new ProviderException(sprintf('Provider "%s" not found', $identifier), 5332497319);
+        }
+
+        $this->providers[$identifier]->configure($config);
+    }
+
+    private function loadConfiguration(): void
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+            $this->configuration = $config;
+        } catch (Exception $e) {
+            $this->logger->warning('Failed to load extension configuration', ['exception' => $e]);
+            $this->configuration = [];
+        }
+    }
+}

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -36,17 +36,17 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use TYPO3\CMS\Core\SingletonInterface;
 
-final class LlmServiceManager implements LlmServiceManagerInterface, SingletonInterface
+final readonly class LlmServiceManager implements LlmServiceManagerInterface, SingletonInterface
 {
     public function __construct(
-        private readonly ProviderAdapterRegistryInterface $adapterRegistry,
-        private readonly MiddlewarePipeline $pipeline,
-        private readonly KeyedProviderRegistry $providerRegistry,
-        private readonly ConfigurationResolver $configurationResolver,
-        private readonly MessageShaper $messageShaper,
-        private readonly EmbedCacheKeyBuilder $embedCacheKeyBuilder,
-        private readonly ?SkillInjectionService $skillInjection = null,
-        private readonly ?ModelSelectionServiceInterface $modelSelectionService = null,
+        private ProviderAdapterRegistryInterface $adapterRegistry,
+        private MiddlewarePipeline $pipeline,
+        private KeyedProviderRegistry $providerRegistry,
+        private ConfigurationResolver $configurationResolver,
+        private MessageShaper $messageShaper,
+        private EmbedCacheKeyBuilder $embedCacheKeyBuilder,
+        private ?SkillInjectionService $skillInjection = null,
+        private ?ModelSelectionServiceInterface $modelSelectionService = null,
     ) {}
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -9,14 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;
 
-use Exception;
 use Generator;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
-use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
@@ -27,7 +25,6 @@ use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
-use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -37,30 +34,20 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
-use Psr\Log\LoggerInterface;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\SingletonInterface;
 
 final class LlmServiceManager implements LlmServiceManagerInterface, SingletonInterface
 {
-    /** @var array<string, ProviderInterface> */
-    private array $providers = [];
-
-    /** @var array<string, mixed> */
-    private array $configuration = [];
-
     public function __construct(
-        private readonly ExtensionConfiguration $extensionConfiguration,
-        private readonly LoggerInterface $logger,
         private readonly ProviderAdapterRegistryInterface $adapterRegistry,
         private readonly MiddlewarePipeline $pipeline,
-        private readonly CacheManagerInterface $cacheManager,
-        private readonly ?LlmConfigurationRepository $configurationRepository = null,
+        private readonly KeyedProviderRegistry $providerRegistry,
+        private readonly ConfigurationResolver $configurationResolver,
+        private readonly MessageShaper $messageShaper,
+        private readonly EmbedCacheKeyBuilder $embedCacheKeyBuilder,
         private readonly ?SkillInjectionService $skillInjection = null,
         private readonly ?ModelSelectionServiceInterface $modelSelectionService = null,
-    ) {
-        $this->loadConfiguration();
-    }
+    ) {}
 
     /**
      * Prepend the resolved configuration's attached skills to a plain prompt.
@@ -105,102 +92,24 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
-     * Resolve the backend-module-managed default configuration for a generic
-     * (provider-agnostic) completion/chat call. Returns null when the caller
-     * pinned an explicit provider, when no repository is wired (unit tests), or
-     * when no active default configuration exists — in which case the generic
-     * path requires a per-call pinned provider and otherwise throws (there is
-     * no extension-config default-provider fallback; see ADR-034).
-     *
-     * Uses the repository directly rather than LlmConfigurationService, whose
-     * getDefaultConfiguration() enforces a backend-user access check that the
-     * CLI worker (Symfony Messenger consumer) has no user for.
-     */
-    private function resolveDefaultConfiguration(?string $providerKey): ?LlmConfiguration
-    {
-        if ($providerKey !== null) {
-            return null;
-        }
-
-        $configuration = $this->configurationRepository?->findDefault();
-
-        // Treat as "no default" when the default configuration is missing, has no model
-        // (getAdapterFromConfiguration() would throw), or is access-restricted to specific BE
-        // groups. Returning null here means the generic call needs a per-call pinned provider —
-        // otherwise getProvider(null) throws. The generic chat()/complete()/streamChat()
-        // path has no backend-user context to enforce group membership against (notably the CLI
-        // worker), so an access-restricted default must not be auto-applied to arbitrary callers.
-        if ($configuration === null
-            || $configuration->getLlmModel() === null
-            || $configuration->hasAccessRestrictions()
-        ) {
-            return null;
-        }
-
-        return $configuration;
-    }
-
-    /**
      * Resolve the effective configuration for a configuration-driven completion.
      *
-     * Returns the explicitly passed configuration when set, otherwise the
-     * backend-module-managed active default — resolved through the very same
-     * guards the generic complete()/chat() path uses (see
-     * {@see self::resolveDefaultConfiguration()}), so callers never duplicate
-     * that logic. Returns null when neither resolves; the caller must then
-     * dispatch through the generic path so the existing "no provider specified"
-     * error is raised.
+     * Delegates to {@see ConfigurationResolver}; retained on the manager
+     * because it is part of {@see LlmServiceManagerInterface}.
      */
     public function resolveEffectiveConfiguration(?LlmConfiguration $configuration = null): ?LlmConfiguration
     {
-        return $configuration ?? $this->resolveDefaultConfiguration(null);
-    }
-
-    private function loadConfiguration(): void
-    {
-        try {
-            /** @var array<string, mixed> $config */
-            $config = $this->extensionConfiguration->get('nr_llm');
-            $this->configuration = $config;
-        } catch (Exception $e) {
-            $this->logger->warning('Failed to load extension configuration', ['exception' => $e]);
-            $this->configuration = [];
-        }
+        return $this->configurationResolver->resolveEffectiveConfiguration($configuration);
     }
 
     public function registerProvider(ProviderInterface $provider): void
     {
-        $identifier = $provider->getIdentifier();
-        $this->providers[$identifier] = $provider;
-
-        // Configure provider if configuration exists
-        /** @var array<string, array<string, mixed>> $providers */
-        $providers = is_array($this->configuration['providers'] ?? null) ? $this->configuration['providers'] : [];
-        $providerConfig = $providers[$identifier] ?? [];
-        if ($providerConfig !== []) {
-            $provider->configure($providerConfig);
-        }
-
-        $this->logger->debug('Registered LLM provider', ['provider' => $identifier]);
+        $this->providerRegistry->registerProvider($provider);
     }
 
     public function getProvider(?string $identifier = null): ProviderInterface
     {
-        if ($identifier === null) {
-            throw new ProviderException(
-                'No provider specified and no default provider configured. '
-                . 'Set up a default in the LLM backend module: create a Provider, a Model and a '
-                . 'Configuration, then mark that Configuration active and default. '
-                . '(The plugin.tx_nrllm TypoScript settings are not evaluated — provider configuration is database-backed.)',
-                4867297358,
-            );
-        }
-
-        if (!isset($this->providers[$identifier])) {
-            throw new ProviderException(sprintf('Provider "%s" not found', $identifier), 6273324883);
-        }
-
-        return $this->providers[$identifier];
+        return $this->providerRegistry->getProvider($identifier);
     }
 
     /**
@@ -208,10 +117,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function getAvailableProviders(): array
     {
-        return array_filter(
-            $this->providers,
-            static fn(ProviderInterface $provider) => $provider->isAvailable(),
-        );
+        return $this->providerRegistry->getAvailableProviders();
     }
 
     /**
@@ -219,7 +125,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function hasAvailableProvider(): bool
     {
-        return $this->getAvailableProviders() !== [];
+        return $this->providerRegistry->hasAvailableProvider();
     }
 
     /**
@@ -227,11 +133,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function getProviderList(): array
     {
-        $list = [];
-        foreach ($this->providers as $identifier => $provider) {
-            $list[$identifier] = $provider->getName();
-        }
-        return $list;
+        return $this->providerRegistry->getProviderList();
     }
 
     /**
@@ -245,16 +147,14 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function chat(array $messages, ?ChatOptions $options = null): CompletionResponse
     {
         $options ??= new ChatOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
         // Single source of truth: with no explicit provider pinned, prefer the
         // backend-module-managed default DB configuration so it drives generation.
         // The per-call options override the configuration's stored defaults. When
         // no default configuration resolves and no provider is pinned, the call
         // throws (no extension-config fallback; see ADR-034).
-        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
         if ($defaultConfiguration !== null) {
             return $this->chatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
@@ -264,12 +164,12 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedMessages = $this->messageShaper->normalise($messages);
 
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
-            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->applySystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
+            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
     }
@@ -280,12 +180,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse
     {
         $options ??= new ChatOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
         // Single source of truth: prefer the default DB configuration (see chat()).
-        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
         if ($defaultConfiguration !== null) {
             return $this->completeWithConfiguration(
                 $this->injectConfigSkillsIntoPrompt($prompt, $defaultConfiguration),
@@ -311,32 +209,21 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function embed(string|array $input, ?EmbeddingOptions $options = null): EmbeddingResponse
     {
         $options ??= new EmbeddingOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
-        // Cache metadata: CacheMiddleware short-circuits when it sees a key.
-        // Callers pass cache_ttl: 0 (via EmbeddingOptions::noCache()) to
-        // disable caching for ephemeral content — we honour that by leaving
-        // the key out of metadata so the middleware becomes a no-op for
-        // this call.
+        // Cache metadata: EmbedCacheKeyBuilder returns an empty array when
+        // cache_ttl <= 0 (the EmbeddingOptions::noCache() contract), so the key
+        // is left out and CacheMiddleware becomes a no-op for this call. The
+        // ad-hoc path keys by provider identifier.
         $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
         $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
-        if ($cacheTtl > 0) {
-            $resolvedProvider = $providerKey ?? 'default';
-            $metadata += [
-                CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
-                    $resolvedProvider,
-                    'embeddings',
-                    ['input' => $input, 'options' => $optionsArray],
-                ),
-                CacheMiddleware::METADATA_CACHE_TTL  => $cacheTtl,
-                CacheMiddleware::METADATA_CACHE_TAGS => [
-                    'nrllm_embeddings',
-                    'nrllm_provider_' . $resolvedProvider,
-                ],
-            ];
-        }
+        $resolvedProvider = $providerKey ?? 'default';
+        $metadata += $this->embedCacheKeyBuilder->build(
+            $cacheTtl,
+            $resolvedProvider,
+            ['input' => $input, 'options' => $optionsArray],
+            'nrllm_provider_' . $resolvedProvider,
+        );
 
         // Terminal returns an array-shaped payload so CacheMiddleware (which
         // persists `array<string, mixed>`) can round-trip through the TYPO3
@@ -381,9 +268,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function vision(array $content, ?VisionOptions $options = null): VisionResponse
     {
         $options ??= new VisionOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
         $normalisedContent = array_values(array_map(
             static fn(VisionContent|array $item): VisionContent
@@ -422,13 +307,11 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function streamChat(array $messages, ?ChatOptions $options = null): Generator
     {
         $options ??= new ChatOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
         // Single source of truth: prefer the default DB configuration (see chat()),
         // so streaming and non-streaming calls resolve the same provider/model.
-        $defaultConfiguration = $this->resolveDefaultConfiguration($providerKey);
+        $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
         if ($defaultConfiguration !== null) {
             return $this->streamChatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
@@ -446,7 +329,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        return $provider->streamChatCompletion($this->applySystemPrompt($this->normaliseMessages($messages), $optionsArray), $optionsArray);
+        return $provider->streamChatCompletion($this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $optionsArray), $optionsArray);
     }
 
     /**
@@ -463,11 +346,9 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
     {
         $options ??= new ToolOptions();
-        $optionsArray = $options->toArray();
-        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider']) ? $optionsArray['provider'] : null;
-        unset($optionsArray['provider']);
+        [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
-        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
             $tools,
@@ -485,7 +366,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                     );
                 }
 
-                return $provider->chatCompletionWithTools($this->applySystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
+                return $provider->chatCompletionWithTools($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
             },
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
         );
@@ -518,7 +399,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         $optionOverrides = $options->toArray();
         unset($optionOverrides['provider']);
 
-        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
             $tools,
@@ -540,7 +421,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 unset($callOptions['provider']);
 
                 return $adapter->chatCompletionWithTools(
-                    $this->applySystemPrompt($normalisedMessages, $callOptions),
+                    $this->messageShaper->applySystemPrompt($normalisedMessages, $callOptions),
                     $normalisedTools,
                     $callOptions,
                 );
@@ -583,31 +464,25 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
 
         $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
 
-        // Cache metadata: CacheMiddleware short-circuits when it sees a key;
-        // cache_ttl: 0 (EmbeddingOptions::noCache()) leaves the key out so
-        // the middleware becomes a no-op for this call — same contract as
-        // embed().
+        // Cache metadata mirrors embed(), but the configuration path keys by
+        // configuration identifier plus the effective model (options override
+        // or the configuration's model id) so two configurations pointing at
+        // different models never share entries. EmbedCacheKeyBuilder returns an
+        // empty array for cache_ttl <= 0 (EmbeddingOptions::noCache()).
         $cacheTtl = is_int($optionOverrides['cache_ttl'] ?? null) ? $optionOverrides['cache_ttl'] : 0;
-        if ($cacheTtl > 0) {
-            $effectiveModel = is_string($optionOverrides['model'] ?? null)
-                ? $optionOverrides['model']
-                : $configuration->getModelId();
-            $metadata += [
-                CacheMiddleware::METADATA_CACHE_KEY => $this->cacheManager->generateCacheKey(
-                    $configuration->getIdentifier(),
-                    'embeddings',
-                    ['input' => $input, 'options' => $optionOverrides, 'model' => $effectiveModel],
-                ),
-                CacheMiddleware::METADATA_CACHE_TTL  => $cacheTtl,
-                CacheMiddleware::METADATA_CACHE_TAGS => [
-                    'nrllm_embeddings',
-                    // Sanitize: configuration identifiers use the dotted preset scheme
-                    // (nr_ai_search.embeddings), and the cache frontend rejects a tag
-                    // containing a dot with an InvalidArgumentException on set().
-                    'nrllm_configuration_' . $this->cacheManager->sanitizeCacheTag($configuration->getIdentifier()),
-                ],
-            ];
-        }
+        $effectiveModel = is_string($optionOverrides['model'] ?? null)
+            ? $optionOverrides['model']
+            : $configuration->getModelId();
+        // EmbedCacheKeyBuilder sanitizes the scope tag: configuration
+        // identifiers use the dotted preset scheme (nr_ai_search.embeddings),
+        // and the cache frontend rejects a tag containing a dot with an
+        // InvalidArgumentException on set().
+        $metadata += $this->embedCacheKeyBuilder->build(
+            $cacheTtl,
+            $configuration->getIdentifier(),
+            ['input' => $input, 'options' => $optionOverrides, 'model' => $effectiveModel],
+            'nrllm_configuration_' . $configuration->getIdentifier(),
+        );
 
         // Terminal returns an array-shaped payload so CacheMiddleware (which
         // persists `array<string, mixed>`) can round-trip through the TYPO3
@@ -646,12 +521,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function supportsFeature(string $feature, ?string $provider = null): bool
     {
-        try {
-            $providerInstance = $this->getProvider($provider);
-            return $providerInstance->supportsFeature($feature);
-        } catch (ProviderException) {
-            return false;
-        }
+        return $this->providerRegistry->supportsFeature($feature, $provider);
     }
 
     /**
@@ -661,9 +531,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function getProviderConfiguration(string $identifier): array
     {
-        /** @var array<string, array<string, mixed>> $providers */
-        $providers = is_array($this->configuration['providers'] ?? null) ? $this->configuration['providers'] : [];
-        return $providers[$identifier] ?? [];
+        return $this->providerRegistry->getProviderConfiguration($identifier);
     }
 
     /**
@@ -673,11 +541,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function configureProvider(string $identifier, array $config): void
     {
-        if (!isset($this->providers[$identifier])) {
-            throw new ProviderException(sprintf('Provider "%s" not found', $identifier), 5332497319);
-        }
-
-        $this->providers[$identifier]->configure($config);
+        $this->providerRegistry->configureProvider($identifier, $config);
     }
 
     // ========================================
@@ -741,7 +605,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse
     {
-        $normalisedMessages = $this->normaliseMessages($messages);
+        $normalisedMessages = $this->messageShaper->normalise($messages);
 
         return $this->runThroughPipeline(
             $configuration,
@@ -750,7 +614,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 $adapter = $this->getAdapterFromConfiguration($config);
                 $options = array_merge($config->toOptionsArray(), $optionOverrides);
                 unset($options['provider']);
-                return $adapter->chatCompletion($this->applySystemPrompt($normalisedMessages, $options), $options);
+                return $adapter->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $options), $options);
             },
             $metadata,
         );
@@ -849,84 +713,26 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
     }
 
     /**
-     * Prepend the effective system prompt (from the merged call options) as a
-     * system message when the caller has not already supplied one.
+     * Split the pinned provider key out of a call's options array.
      *
-     * The provider adapters read the system instruction from the message list,
-     * NOT from `options['system_prompt']`. A configuration's stored system
-     * prompt is surfaced via {@see LlmConfiguration::toOptionsArray()} under
-     * that option key, so without this step it would be silently dropped on
-     * every chat and tool-loop call. An explicit system message already present
-     * in $messages always wins (per-call precedence over the configuration).
+     * Every generic (provider-agnostic) entry point — chat(), complete(),
+     * embed(), vision(), streamChat(), chatWithTools() — reads the pinned
+     * provider from the options, then strips it so the remaining options can be
+     * forwarded to the adapter. Returns the nullable provider key and the
+     * options array with `provider` removed.
      *
-     * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param array<string, mixed>                   $options
+     * @param array<string, mixed> $optionsArray
      *
-     * @return list<ChatMessage|array<string, mixed>>
+     * @return array{0: ?string, 1: array<string, mixed>}
      */
-    private function applySystemPrompt(array $messages, array $options): array
+    private function splitProviderKey(array $optionsArray): array
     {
-        $systemPrompt = $options['system_prompt'] ?? null;
-        if (!is_string($systemPrompt) || $systemPrompt === '') {
-            return $messages;
-        }
+        $providerKey = isset($optionsArray['provider']) && is_string($optionsArray['provider'])
+            ? $optionsArray['provider']
+            : null;
+        unset($optionsArray['provider']);
 
-        foreach ($messages as $message) {
-            $isSystem = $message instanceof ChatMessage
-                ? $message->isSystem()
-                : (is_array($message) && ($message['role'] ?? null) === 'system');
-            if ($isSystem) {
-                return $messages;
-            }
-        }
-
-        array_unshift($messages, ChatMessage::system($systemPrompt));
-
-        return $messages;
-    }
-
-    /**
-     * Normalise a public-API messages list for forwarding to providers.
-     *
-     * Simple legacy fixtures matching the `ChatMessage` shape (`{role: string,
-     * content: string}` only) are routed through `ChatMessage::fromArray()`
-     * so providers downstream see typed VOs whenever the sender used the
-     * documented shape. Richer provider-specific arrays carrying
-     * `tool_call_id`, `tool_calls`, `name`, or multimodal `content` arrays
-     * are passed through unchanged so their additional fields survive the
-     * round-trip. `ChatMessage` models the tool-turn keys (`tool_calls`,
-     * `tool_call_id`) since #345 — typed tool turns pass through as VOs and
-     * serialise those fields in `toArray()` — but `name` and multimodal
-     * `content` arrays remain array-only shapes, and eagerly running them
-     * through `fromArray()` would silently drop the extra keys (and break
-     * `ClaudeProvider::convertMessagesForClaude()` for multimodal messages).
-     *
-     * @param list<ChatMessage|array<string, mixed>> $messages
-     *
-     * @return list<ChatMessage|array<string, mixed>>
-     */
-    private function normaliseMessages(array $messages): array
-    {
-        return array_values(array_map(
-            static function (ChatMessage|array $message): ChatMessage|array {
-                if ($message instanceof ChatMessage) {
-                    return $message;
-                }
-
-                if (
-                    count($message) === 2
-                    && array_key_exists('role', $message)
-                    && array_key_exists('content', $message)
-                    && is_string($message['role'])
-                    && is_string($message['content'])
-                ) {
-                    return ChatMessage::fromArray($message);
-                }
-
-                return $message;
-            },
-            $messages,
-        ));
+        return [$providerKey, $optionsArray];
     }
 
     /**
@@ -991,7 +797,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         }
 
         return $adapter->streamChatCompletion(
-            $this->applySystemPrompt($this->normaliseMessages($messages), $options),
+            $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $options),
             $options,
         );
     }

--- a/Classes/Service/MessageShaper.php
+++ b/Classes/Service/MessageShaper.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+
+/**
+ * Shapes a public-API messages list for forwarding to provider adapters.
+ *
+ * Extracted from {@see LlmServiceManager} so the message-normalisation and
+ * system-prompt rules live in one stateless collaborator that the manager
+ * (and, later, the per-operation dispatchers) share instead of carrying
+ * private copies.
+ */
+final readonly class MessageShaper
+{
+    /**
+     * Normalise a public-API messages list for forwarding to providers.
+     *
+     * Simple legacy fixtures matching the `ChatMessage` shape (`{role: string,
+     * content: string}` only) are routed through `ChatMessage::fromArray()`
+     * so providers downstream see typed VOs whenever the sender used the
+     * documented shape. Richer provider-specific arrays carrying
+     * `tool_call_id`, `tool_calls`, `name`, or multimodal `content` arrays
+     * are passed through unchanged so their additional fields survive the
+     * round-trip. `ChatMessage` models the tool-turn keys (`tool_calls`,
+     * `tool_call_id`) since #345 — typed tool turns pass through as VOs and
+     * serialise those fields in `toArray()` — but `name` and multimodal
+     * `content` arrays remain array-only shapes, and eagerly running them
+     * through `fromArray()` would silently drop the extra keys (and break
+     * `ClaudeProvider::convertMessagesForClaude()` for multimodal messages).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    public function normalise(array $messages): array
+    {
+        return array_values(array_map(
+            static function (ChatMessage|array $message): ChatMessage|array {
+                if ($message instanceof ChatMessage) {
+                    return $message;
+                }
+
+                if (
+                    count($message) === 2
+                    && array_key_exists('role', $message)
+                    && array_key_exists('content', $message)
+                    && is_string($message['role'])
+                    && is_string($message['content'])
+                ) {
+                    return ChatMessage::fromArray($message);
+                }
+
+                return $message;
+            },
+            $messages,
+        ));
+    }
+
+    /**
+     * Prepend the effective system prompt (from the merged call options) as a
+     * system message when the caller has not already supplied one.
+     *
+     * The provider adapters read the system instruction from the message list,
+     * NOT from `options['system_prompt']`. A configuration's stored system
+     * prompt is surfaced via {@see \Netresearch\NrLlm\Domain\Model\LlmConfiguration::toOptionsArray()}
+     * under that option key, so without this step it would be silently dropped
+     * on every chat and tool-loop call. An explicit system message already
+     * present in $messages always wins (per-call precedence over the
+     * configuration).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    public function applySystemPrompt(array $messages, array $options): array
+    {
+        $systemPrompt = $options['system_prompt'] ?? null;
+        if (!is_string($systemPrompt) || $systemPrompt === '') {
+            return $messages;
+        }
+
+        foreach ($messages as $message) {
+            $isSystem = $message instanceof ChatMessage
+                ? $message->isSystem()
+                : (is_array($message) && ($message['role'] ?? null) === 'system');
+            if ($isSystem) {
+                return $messages;
+            }
+        }
+
+        array_unshift($messages, ChatMessage::system($systemPrompt));
+
+        return $messages;
+    }
+}

--- a/Documentation/Adr/Adr059DecomposeLlmServiceManager.rst
+++ b/Documentation/Adr/Adr059DecomposeLlmServiceManager.rst
@@ -1,0 +1,116 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-059:
+
+===============================================================
+ADR-059: Decompose LlmServiceManager into focused collaborators
+===============================================================
+
+:Status: Accepted
+:Date: 2026-07-14
+:Authors: Netresearch DTT GmbH
+
+.. _adr-059-context:
+
+Context
+=======
+
+:php:`LlmServiceManager` had grown to 987 lines. It is the extension's central
+entry point — a :php:`SingletonInterface` implementing
+:php:`LlmServiceManagerInterface`, which :ref:`ADR-028 <adr-028>` classifies as
+a Category-1 public API. A responsibility scan found nine distinct groups in one
+class:
+
+1. Skill-injection glue (delegates to :php:`SkillInjectionService`).
+2. Default-configuration resolution.
+3. Loading the ``nr_llm`` extension configuration.
+4. The keyed, ExtensionConfiguration-backed provider registry (register / look
+   up / list / configure providers by string identifier).
+5. Generic dispatch (``chat``, ``complete``, ``embed``, ``vision``,
+   ``streamChat``, ``chatWithTools``).
+6. Configuration-backed dispatch (the ``*WithConfiguration`` methods).
+7. The database-backed adapter factory facade.
+8. Pipeline plumbing (``runThroughPipeline``, budget metadata, transient
+   configuration synthesis).
+9. Message shaping (system-prompt injection and message normalisation).
+
+Two of these groups additionally carried duplicated code: the two embedding
+entry points each held an inline copy of the cache-metadata block, and six
+generic entry points repeated the same options / provider-key extraction
+preamble.
+
+.. _adr-059-decision:
+
+Decision
+========
+
+Decompose the manager in stages. This ADR records **stage 1**, which extracts
+the self-contained groups while leaving the dispatch logic in place. The manager
+remains ``final`` and keeps implementing the unchanged
+:php:`LlmServiceManagerInterface`; every former public method is retained as a
+thin delegation, so the Category-1 contract, the class name, ``registerProvider``
+and the three non-interface public methods (``getAdapterFromModel``,
+``getAdapterFromConfiguration``, ``getAdapterRegistry``) are unchanged.
+
+Extracted collaborators (all private, autowired via the ``Classes/*`` resource
+block in :file:`Services.yaml`):
+
+- :php:`KeyedProviderRegistry` — groups 3 + 4. Holds the mutable provider map
+  and the loaded extension configuration, so it is itself a
+  :php:`SingletonInterface`. ``ProviderCompilerPass`` still adds its
+  ``registerProvider`` method calls to the manager service, which forward here.
+- :php:`ConfigurationResolver` — group 2. ``readonly``; resolves the
+  backend-managed default configuration through the repository.
+- :php:`MessageShaper` — group 9. ``readonly``, stateless message normalisation
+  and system-prompt injection.
+- :php:`EmbedCacheKeyBuilder` — deduplicates the two inline embed cache-metadata
+  blocks. The blocks are **not** identical: the ad-hoc :php:`embed()` path keys
+  by provider identifier with the payload ``{input, options}`` and a
+  ``nrllm_provider_<id>`` tag, while :php:`embedForConfiguration()` keys by
+  configuration identifier plus the *effective* model (options override or the
+  configuration's model id) with a ``nrllm_configuration_<id>`` tag, so two
+  configurations pointing at different models never share entries. The builder
+  therefore shares only the *structure* (the positive-ttl guard and the
+  ``{cacheKey, cacheTtl, cacheTags}`` shape with the common ``nrllm_embeddings``
+  tag); each caller supplies its own namespace, key payload and scope tag. This
+  difference is intentional, not a defect.
+
+The repeated options / provider-key preamble becomes a private
+``splitProviderKey()`` on the manager (the six callers all remain on the manager
+in stage 1).
+
+The manager's constructor changes accordingly — it drops
+:php:`ExtensionConfiguration`, :php:`LoggerInterface`,
+:php:`CacheManagerInterface` and the :php:`LlmConfigurationRepository` (now
+owned by the collaborators) and gains the four collaborators. The constructor is
+not part of the interface contract; production wiring is autowired.
+
+.. _adr-059-consequences:
+
+Consequences
+============
+
+- Behaviour is unchanged. The interface signatures, the provider-resolution
+  error messages and their exception codes, and the two embed cache-keying
+  strategies are all preserved. The existing manager / integration / e2e tests
+  continue to exercise the behaviour through the facade; they construct the
+  manager through a test factory (``LlmServiceManagerTestFactory``) that accepts
+  the previous leaf-dependency shape and wires the new collaborators, so the call
+  sites did not each have to change shape. The extracted classes additionally get
+  their own unit tests.
+- New private services keep the documented public-service set stable
+  (:ref:`ADR-028 <adr-028>`); the ``PublicServicesPolicyTest`` count is
+  unchanged.
+- The manager drops from 987 to roughly 790 lines.
+
+Stage 2 (not in this change)
+----------------------------
+
+Groups 5 and 6 (generic and configuration-backed dispatch) plus the pipeline
+plumbing (group 8) remain on the manager. Extracting per-operation dispatchers
+(completion, embedding, streaming, tool-calling) is deferred to a follow-up so
+this change stays reviewable and behaviour-preserving. It remains worthwhile:
+after stage 1 the manager is still dominated by the dispatch methods, and those
+are the natural seam for the privacy-model entry point work
+(:ref:`ADR-026 <adr-026>` payload constraint). Stage 2 should be taken up when
+that work needs the seam.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -357,5 +357,6 @@ Tools
    Adr056ConfigurationPresets
    Adr057SpecializedServiceAttribution
    Adr058TelemetryMiddleware
+   Adr059DecomposeLlmServiceManager
    Adr060QualityEvaluation
    Adr061SkillTrustEgressAndAudit

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\CompletionService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -33,6 +34,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 {
+    use LlmServiceManagerTestFactory;
     private const FAKE_CLAUDE_VAULT_ID = '019650a0-1234-7abc-8def-0123456789ab';
 
     #[Test]
@@ -62,7 +64,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -108,7 +110,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -152,7 +154,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
@@ -207,7 +209,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($clientSetup['client']);
@@ -259,7 +261,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -303,7 +305,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -364,7 +366,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($openAiProvider);
         $serviceManager->registerProvider($claudeProvider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -17,8 +17,8 @@ use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Feature\EmbeddingService;
-use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -33,6 +33,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(EmbeddingService::class)]
 class EmbeddingWorkflowTest extends AbstractE2ETestCase
 {
+    use LlmServiceManagerTestFactory;
     #[Test]
     public function completeEmbeddingWorkflow(): void
     {
@@ -57,7 +58,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -107,7 +108,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager(
+        $serviceManager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,
@@ -180,7 +181,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);
@@ -244,7 +245,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         ]);
 
         $adapterRegistry = self::createStub(ProviderAdapterRegistryInterface::class);
-        $serviceManager = new LlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $serviceManager = $this->createLlmServiceManager($extensionConfig, new NullLogger(), $adapterRegistry, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
         $serviceManager->registerProvider($provider);
         // setHttpClient must be called AFTER registerProvider() since it calls configure()
         $provider->setHttpClient($httpClient);

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -21,7 +21,6 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
-use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
@@ -33,6 +32,7 @@ use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -62,6 +62,7 @@ use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 #[CoversClass(ToolPlaygroundController::class)]
 final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 {
+    use LlmServiceManagerTestFactory;
     protected function tearDown(): void
     {
         unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
@@ -188,7 +189,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([]);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,
@@ -281,7 +282,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([]);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,
@@ -373,7 +374,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([]);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,
@@ -507,7 +508,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([]);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,

--- a/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
+++ b/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\RecordingToolAdapter;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -39,6 +40,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 final class LlmServiceManagerToolsConfigurationTest extends AbstractFunctionalTestCase
 {
+    use LlmServiceManagerTestFactory;
     #[Test]
     public function chatWithToolsForConfigurationResolvesAdapterFromConfigurationAndReturnsToolCall(): void
     {
@@ -77,7 +79,7 @@ final class LlmServiceManagerToolsConfigurationTest extends AbstractFunctionalTe
         $extensionConfig = self::createStub(ExtensionConfiguration::class);
         $extensionConfig->method('get')->willReturn([]);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $extensionConfig,
             new NullLogger(),
             $adapterRegistry,

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Tests\Integration\AbstractIntegrationTestCase;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,6 +36,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
 {
+    use LlmServiceManagerTestFactory;
     private LlmServiceManager $subject;
     private ExtensionConfiguration&MockObject $extensionConfigStub;
     private ProviderAdapterRegistryInterface&Stub $adapterRegistryStub;
@@ -61,7 +63,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
 
         $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
-        $this->subject = new LlmServiceManager(
+        $this->subject = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             new NullLogger(),
             $this->adapterRegistryStub,
@@ -234,7 +236,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
             'providers' => [],
         ]);
 
-        $manager = new LlmServiceManager($configMock, new NullLogger(), $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($configMock, new NullLogger(), $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('No provider specified and no default provider configured');

--- a/Tests/LlmServiceManagerTestFactory.php
+++ b/Tests/LlmServiceManagerTestFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests;
+
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Service\EmbedCacheKeyBuilder;
+use Netresearch\NrLlm\Service\KeyedProviderRegistry;
+use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\MessageShaper;
+use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Builds a {@see LlmServiceManager} from the leaf collaborators the tests used
+ * to pass directly to its constructor.
+ *
+ * Stage 1 of the manager decomposition (ADR-059) moved provider registration,
+ * default-configuration resolution, message shaping and embed cache-key
+ * construction into dedicated collaborators, changing the manager's
+ * constructor. This factory keeps the previous test call shape — extension
+ * configuration, logger, adapter registry, pipeline, cache manager, optional
+ * configuration repository and optional skill injection, in that order — and
+ * wires the new collaborators internally, so the existing constructions did not
+ * each have to spell them out. Production wiring is autowired via Services.yaml.
+ */
+trait LlmServiceManagerTestFactory
+{
+    protected function createLlmServiceManager(
+        ExtensionConfiguration $extensionConfiguration,
+        LoggerInterface $logger,
+        ProviderAdapterRegistryInterface $adapterRegistry,
+        MiddlewarePipeline $pipeline,
+        CacheManagerInterface $cacheManager,
+        ?LlmConfigurationRepository $configurationRepository = null,
+        ?SkillInjectionService $skillInjection = null,
+    ): LlmServiceManager {
+        return new LlmServiceManager(
+            $adapterRegistry,
+            $pipeline,
+            new KeyedProviderRegistry($extensionConfiguration, $logger),
+            new ConfigurationResolver($configurationRepository),
+            new MessageShaper(),
+            new EmbedCacheKeyBuilder($cacheManager),
+            $skillInjection,
+        );
+    }
+}

--- a/Tests/LlmServiceManagerTestFactory.php
+++ b/Tests/LlmServiceManagerTestFactory.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\EmbedCacheKeyBuilder;
 use Netresearch\NrLlm\Service\KeyedProviderRegistry;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\MessageShaper;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -45,6 +46,7 @@ trait LlmServiceManagerTestFactory
         CacheManagerInterface $cacheManager,
         ?LlmConfigurationRepository $configurationRepository = null,
         ?SkillInjectionService $skillInjection = null,
+        ?ModelSelectionServiceInterface $modelSelectionService = null,
     ): LlmServiceManager {
         return new LlmServiceManager(
             $adapterRegistry,
@@ -54,6 +56,7 @@ trait LlmServiceManagerTestFactory
             new MessageShaper(),
             new EmbedCacheKeyBuilder($cacheManager),
             $skillInjection,
+            $modelSelectionService,
         );
     }
 }

--- a/Tests/Unit/Service/ConfigurationResolverTest.php
+++ b/Tests/Unit/Service/ConfigurationResolverTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ConfigurationResolver::class)]
+class ConfigurationResolverTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function resolveDefaultConfigurationReturnsNullWhenProviderPinned(): void
+    {
+        $repository = self::createMock(LlmConfigurationRepository::class);
+        $repository->expects(self::never())->method('findDefault');
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertNull($subject->resolveDefaultConfiguration('openai'));
+    }
+
+    #[Test]
+    public function resolveDefaultConfigurationReturnsNullWhenNoRepositoryWired(): void
+    {
+        $subject = new ConfigurationResolver();
+
+        self::assertNull($subject->resolveDefaultConfiguration(null));
+    }
+
+    #[Test]
+    public function resolveDefaultConfigurationReturnsNullWhenNoDefaultExists(): void
+    {
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findDefault')->willReturn(null);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertNull($subject->resolveDefaultConfiguration(null));
+    }
+
+    #[Test]
+    public function resolveDefaultConfigurationReturnsNullWhenDefaultHasNoModel(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getLlmModel')->willReturn(null);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findDefault')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertNull($subject->resolveDefaultConfiguration(null));
+    }
+
+    #[Test]
+    public function resolveDefaultConfigurationReturnsNullWhenDefaultIsAccessRestricted(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getLlmModel')->willReturn(self::createStub(Model::class));
+        $configuration->method('hasAccessRestrictions')->willReturn(true);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findDefault')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertNull($subject->resolveDefaultConfiguration(null));
+    }
+
+    #[Test]
+    public function resolveDefaultConfigurationReturnsUnrestrictedDefaultWithModel(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getLlmModel')->willReturn(self::createStub(Model::class));
+        $configuration->method('hasAccessRestrictions')->willReturn(false);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findDefault')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertSame($configuration, $subject->resolveDefaultConfiguration(null));
+    }
+
+    #[Test]
+    public function resolveEffectiveConfigurationReturnsExplicitConfigurationWithoutConsultingRepository(): void
+    {
+        $explicit = self::createStub(LlmConfiguration::class);
+
+        $repository = self::createMock(LlmConfigurationRepository::class);
+        $repository->expects(self::never())->method('findDefault');
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertSame($explicit, $subject->resolveEffectiveConfiguration($explicit));
+    }
+
+    #[Test]
+    public function resolveEffectiveConfigurationFallsBackToDefaultWhenNoneGiven(): void
+    {
+        $default = self::createStub(LlmConfiguration::class);
+        $default->method('getLlmModel')->willReturn(self::createStub(Model::class));
+        $default->method('hasAccessRestrictions')->willReturn(false);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findDefault')->willReturn($default);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertSame($default, $subject->resolveEffectiveConfiguration());
+    }
+}

--- a/Tests/Unit/Service/EmbedCacheKeyBuilderTest.php
+++ b/Tests/Unit/Service/EmbedCacheKeyBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\EmbedCacheKeyBuilder;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(EmbedCacheKeyBuilder::class)]
+class EmbedCacheKeyBuilderTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function buildReturnsEmptyMetadataWhenTtlIsZero(): void
+    {
+        $cacheManager = self::createMock(CacheManagerInterface::class);
+        $cacheManager->expects(self::never())->method('generateCacheKey');
+
+        $subject = new EmbedCacheKeyBuilder($cacheManager);
+
+        self::assertSame([], $subject->build(0, 'openai', ['input' => 'x'], 'nrllm_provider_openai'));
+    }
+
+    #[Test]
+    public function buildReturnsEmptyMetadataWhenTtlIsNegative(): void
+    {
+        $cacheManager = self::createMock(CacheManagerInterface::class);
+        $cacheManager->expects(self::never())->method('generateCacheKey');
+
+        $subject = new EmbedCacheKeyBuilder($cacheManager);
+
+        self::assertSame([], $subject->build(-1, 'openai', ['input' => 'x'], 'nrllm_provider_openai'));
+    }
+
+    #[Test]
+    public function buildReturnsCacheMetadataWhenTtlIsPositive(): void
+    {
+        $cacheManager = self::createMock(CacheManagerInterface::class);
+        $cacheManager->expects(self::once())
+            ->method('generateCacheKey')
+            ->with('config-42', 'embeddings', ['input' => 'x', 'model' => 'm'])
+            ->willReturn('generated-key');
+
+        $subject = new EmbedCacheKeyBuilder($cacheManager);
+
+        $result = $subject->build(3600, 'config-42', ['input' => 'x', 'model' => 'm'], 'nrllm_configuration_config-42');
+
+        self::assertSame([
+            CacheMiddleware::METADATA_CACHE_KEY  => 'generated-key',
+            CacheMiddleware::METADATA_CACHE_TTL  => 3600,
+            CacheMiddleware::METADATA_CACHE_TAGS => ['nrllm_embeddings', 'nrllm_configuration_config-42'],
+        ], $result);
+    }
+}

--- a/Tests/Unit/Service/EmbedCacheKeyBuilderTest.php
+++ b/Tests/Unit/Service/EmbedCacheKeyBuilderTest.php
@@ -49,6 +49,7 @@ class EmbedCacheKeyBuilderTest extends AbstractUnitTestCase
             ->method('generateCacheKey')
             ->with('config-42', 'embeddings', ['input' => 'x', 'model' => 'm'])
             ->willReturn('generated-key');
+        $cacheManager->method('sanitizeCacheTag')->willReturnArgument(0);
 
         $subject = new EmbedCacheKeyBuilder($cacheManager);
 
@@ -59,5 +60,26 @@ class EmbedCacheKeyBuilderTest extends AbstractUnitTestCase
             CacheMiddleware::METADATA_CACHE_TTL  => 3600,
             CacheMiddleware::METADATA_CACHE_TAGS => ['nrllm_embeddings', 'nrllm_configuration_config-42'],
         ], $result);
+    }
+
+    #[Test]
+    public function buildSanitizesTheScopeTag(): void
+    {
+        // Configuration identifiers use the dotted preset scheme
+        // (nr_ai_search.embeddings); the cache frontend rejects a tag with a
+        // dot, so the scope tag must be sanitized before it reaches the tags.
+        $cacheManager = self::createMock(CacheManagerInterface::class);
+        $cacheManager->method('generateCacheKey')->willReturn('generated-key');
+        $cacheManager->method('sanitizeCacheTag')
+            ->willReturnCallback(static fn(string $value): string => str_replace('.', '_', $value));
+
+        $subject = new EmbedCacheKeyBuilder($cacheManager);
+
+        $result = $subject->build(3600, 'nr_ai_search.embeddings', ['input' => 'x'], 'nrllm_configuration_nr_ai_search.embeddings');
+
+        self::assertSame(
+            ['nrllm_embeddings', 'nrllm_configuration_nr_ai_search_embeddings'],
+            $result[CacheMiddleware::METADATA_CACHE_TAGS],
+        );
     }
 }

--- a/Tests/Unit/Service/KeyedProviderRegistryTest.php
+++ b/Tests/Unit/Service/KeyedProviderRegistryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Exception;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Service\KeyedProviderRegistry;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(KeyedProviderRegistry::class)]
+class KeyedProviderRegistryTest extends AbstractUnitTestCase
+{
+    /**
+     * @param array<string, mixed> $extensionConfig
+     */
+    private function createRegistry(array $extensionConfig = ['providers' => []], ?LoggerInterface $logger = null): KeyedProviderRegistry
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($extensionConfig);
+
+        return new KeyedProviderRegistry($extensionConfiguration, $logger ?? self::createStub(LoggerInterface::class));
+    }
+
+    private function providerStub(string $identifier, string $name = 'Test', bool $available = true, bool $supports = true): ProviderInterface&Stub
+    {
+        $provider = self::createStub(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn($identifier);
+        $provider->method('getName')->willReturn($name);
+        $provider->method('isAvailable')->willReturn($available);
+        $provider->method('supportsFeature')->willReturn($supports);
+
+        return $provider;
+    }
+
+    #[Test]
+    public function registerProviderExposesItInTheProviderList(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerProvider($this->providerStub('openai', 'OpenAI'));
+
+        self::assertSame(['openai' => 'OpenAI'], $registry->getProviderList());
+    }
+
+    #[Test]
+    public function getProviderReturnsTheRegisteredInstance(): void
+    {
+        $registry = $this->createRegistry();
+        $provider = $this->providerStub('openai');
+        $registry->registerProvider($provider);
+
+        self::assertSame($provider, $registry->getProvider('openai'));
+    }
+
+    #[Test]
+    public function getProviderThrowsForUnknownIdentifier(): void
+    {
+        $registry = $this->createRegistry();
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionCode(6273324883);
+        $this->expectExceptionMessage('Provider "nope" not found');
+
+        $registry->getProvider('nope');
+    }
+
+    #[Test]
+    public function getProviderThrowsWhenNoIdentifierGiven(): void
+    {
+        $registry = $this->createRegistry();
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionCode(4867297358);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
+
+        $registry->getProvider();
+    }
+
+    #[Test]
+    public function getAvailableProvidersFiltersOutUnavailableOnes(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerProvider($this->providerStub('up', 'Up', true));
+        $registry->registerProvider($this->providerStub('down', 'Down', false));
+
+        $available = $registry->getAvailableProviders();
+
+        self::assertArrayHasKey('up', $available);
+        self::assertArrayNotHasKey('down', $available);
+    }
+
+    #[Test]
+    public function hasAvailableProviderReflectsAvailability(): void
+    {
+        $registry = $this->createRegistry();
+        self::assertFalse($registry->hasAvailableProvider());
+
+        $registry->registerProvider($this->providerStub('down', 'Down', false));
+        self::assertFalse($registry->hasAvailableProvider());
+
+        $registry->registerProvider($this->providerStub('up', 'Up', true));
+        self::assertTrue($registry->hasAvailableProvider());
+    }
+
+    #[Test]
+    public function supportsFeatureReturnsTrueWhenProviderSupportsIt(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerProvider($this->providerStub('openai', 'OpenAI', true, true));
+
+        self::assertTrue($registry->supportsFeature('vision', 'openai'));
+    }
+
+    #[Test]
+    public function supportsFeatureReturnsFalseWhenProviderDoesNotSupportIt(): void
+    {
+        $registry = $this->createRegistry();
+        $registry->registerProvider($this->providerStub('openai', 'OpenAI', true, false));
+
+        self::assertFalse($registry->supportsFeature('vision', 'openai'));
+    }
+
+    #[Test]
+    public function supportsFeatureReturnsFalseForUnknownProvider(): void
+    {
+        $registry = $this->createRegistry();
+
+        self::assertFalse($registry->supportsFeature('vision', 'unknown'));
+    }
+
+    #[Test]
+    public function getProviderConfigurationReturnsTheEntryFromExtensionConfiguration(): void
+    {
+        $registry = $this->createRegistry([
+            'providers' => ['openai' => ['apiKey' => 'k', 'defaultModel' => 'gpt']],
+        ]);
+
+        self::assertSame(['apiKey' => 'k', 'defaultModel' => 'gpt'], $registry->getProviderConfiguration('openai'));
+    }
+
+    #[Test]
+    public function getProviderConfigurationReturnsEmptyArrayForUnknownProvider(): void
+    {
+        $registry = $this->createRegistry(['providers' => []]);
+
+        self::assertSame([], $registry->getProviderConfiguration('unknown'));
+    }
+
+    #[Test]
+    public function registerProviderConfiguresProviderFromExtensionConfiguration(): void
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([
+            'providers' => ['openai' => ['apiKey' => 'from-config']],
+        ]);
+        $registry = new KeyedProviderRegistry($extensionConfiguration, self::createStub(LoggerInterface::class));
+
+        $provider = self::createMock(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('openai');
+        $provider->expects(self::once())->method('configure')->with(['apiKey' => 'from-config']);
+
+        $registry->registerProvider($provider);
+    }
+
+    #[Test]
+    public function configureProviderDelegatesToTheRegisteredProvider(): void
+    {
+        $registry = $this->createRegistry();
+        $provider = self::createMock(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('openai');
+        $registry->registerProvider($provider);
+
+        $provider->expects(self::once())->method('configure')->with(['apiKey' => 'runtime']);
+
+        $registry->configureProvider('openai', ['apiKey' => 'runtime']);
+    }
+
+    #[Test]
+    public function configureProviderThrowsForUnknownProvider(): void
+    {
+        $registry = $this->createRegistry();
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionCode(5332497319);
+        $this->expectExceptionMessage('Provider "unknown" not found');
+
+        $registry->configureProvider('unknown', []);
+    }
+
+    #[Test]
+    public function constructorLogsWarningAndKeepsEmptyConfigurationWhenExtensionConfigThrows(): void
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willThrowException(new Exception('boom'));
+
+        $logger = self::createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')->with('Failed to load extension configuration', self::anything());
+
+        $registry = new KeyedProviderRegistry($extensionConfiguration, $logger);
+
+        // Configuration failed to load, so no provider configuration is available.
+        self::assertSame([], $registry->getProviderConfiguration('openai'));
+    }
+}

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -26,6 +27,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 class LlmServiceManagerMutationTest extends AbstractUnitTestCase
 {
+    use LlmServiceManagerTestFactory;
     /**
      * @param array<string, mixed> $config
      */
@@ -38,7 +40,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $loggerStub = self::createStub(LoggerInterface::class);
         $adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
-        return new LlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        return $this->createLlmServiceManager($extensionConfigStub, $loggerStub, $adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
     }
 
     private function createProviderStub(string $identifier, string $name = 'Test'): ProviderInterface

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -608,7 +608,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($resolvedModel)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
 
         self::assertSame($mockAdapter, $manager->getAdapterFromConfiguration($config));
     }
@@ -623,7 +623,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $selection = self::createStub(ModelSelectionServiceInterface::class);
         $selection->method('resolveModel')->willReturn(null);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('has no model assigned');
@@ -967,7 +967,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             static fn(string $value): string => preg_replace('/\W/', '_', $value) ?? '',
         );
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registry, new MiddlewarePipeline([$spy]), $cacheStub);
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registry, new MiddlewarePipeline([$spy]), $cacheStub);
 
         $config = self::createStub(LlmConfiguration::class);
         $config->method('getLlmModel')->willReturn(self::createStub(Model::class));

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -44,6 +44,7 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -53,6 +54,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 class LlmServiceManagerTest extends AbstractUnitTestCase
 {
+    use LlmServiceManagerTestFactory;
     private LlmServiceManager $subject;
     private ExtensionConfiguration $extensionConfigStub;
     private LoggerInterface $loggerStub;
@@ -73,7 +75,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $this->loggerStub = self::createStub(LoggerInterface::class);
         $this->adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
 
-        $this->subject = new LlmServiceManager(
+        $this->subject = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -121,7 +123,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('No provider specified and no default provider configured');
@@ -270,7 +272,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
         $config = $manager->getProviderConfiguration('openai');
 
         self::assertArrayHasKey('apiKeyIdentifier', $config);
@@ -319,7 +321,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn(['providers' => []]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         // Register only an unavailable provider
         $unavailableProvider = new TestableProvider('test', 'Test', false);
@@ -481,7 +483,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->willThrowException(new Exception('Config not found'));
 
         // Should not throw, but log warning
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         // Manager should construct and operate without configuration: no
         // providers registered yet, so the provider list is empty.
@@ -515,7 +517,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 ],
             ]);
 
-        $manager = new LlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $configurableProvider = new TestableProvider('configurable', 'Configurable', true);
         $manager->registerProvider($configurableProvider);
@@ -538,7 +540,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromModel($model);
 
@@ -561,7 +563,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ->with($model)
             ->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->getAdapterFromConfiguration($config);
 
@@ -658,7 +660,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->chatWithConfiguration(
             [['role' => 'user', 'content' => 'Hello']],
@@ -705,7 +707,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config);
     }
@@ -746,7 +748,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $manager->chatWithConfiguration(
             [
@@ -783,7 +785,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->completeWithConfiguration('Test prompt', $config);
 
@@ -825,7 +827,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $result = $manager->embedForConfiguration('Some text', $config);
 
@@ -869,7 +871,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $manager->embedForConfiguration('text', $config, (new EmbeddingOptions())->withModel('override-model'));
 
@@ -893,7 +895,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('Provider "chat-only" does not support embeddings');
@@ -1005,7 +1007,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registry = self::createStub(ProviderAdapterRegistryInterface::class);
         $registry->method('createAdapterFromModel')->willReturn($adapter);
 
-        return new LlmServiceManager(
+        return $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $registry,
@@ -1066,7 +1068,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn($config);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $registryStub,
@@ -1098,7 +1100,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // A pinned provider must short-circuit before the default-config lookup.
         $configRepo->expects(self::never())->method('findDefault');
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1122,7 +1124,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn(null);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1150,7 +1152,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn($config);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1181,7 +1183,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn($config);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1236,7 +1238,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn($config);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $registryStub,
@@ -1259,7 +1261,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->expects(self::never())->method('findDefault');
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1280,7 +1282,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn(null);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,
@@ -1311,7 +1313,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $chunks = [];
         foreach ($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config) as $chunk) {
@@ -1338,7 +1340,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($adapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         iterator_to_array($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config));
 
@@ -1372,7 +1374,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
         $configRepo->method('findDefault')->willReturn($config);
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $registryStub,
@@ -1411,7 +1413,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
         $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
 
-        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('does not support streaming');
@@ -1715,7 +1717,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         array $middleware,
         ?TestableProvider $provider = null,
     ): LlmServiceManager {
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub,
             $this->loggerStub,
             $this->adapterRegistryStub,

--- a/Tests/Unit/Service/MessageShaperTest.php
+++ b/Tests/Unit/Service/MessageShaperTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\MessageShaper;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(MessageShaper::class)]
+class MessageShaperTest extends AbstractUnitTestCase
+{
+    private MessageShaper $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new MessageShaper();
+    }
+
+    #[Test]
+    public function normalisePassesTypedMessagesThroughUnchanged(): void
+    {
+        $message = ChatMessage::user('Hello');
+
+        $result = $this->subject->normalise([$message]);
+
+        self::assertSame([$message], $result);
+    }
+
+    #[Test]
+    public function normaliseConvertsSimpleRoleContentArrayToChatMessage(): void
+    {
+        $result = $this->subject->normalise([['role' => 'user', 'content' => 'Hi']]);
+
+        self::assertInstanceOf(ChatMessage::class, $result[0]);
+        self::assertSame('user', $result[0]->role);
+        self::assertSame('Hi', $result[0]->content);
+    }
+
+    #[Test]
+    public function normaliseLeavesRichArraysUntouched(): void
+    {
+        // A third key (name) means the shape is richer than {role, content};
+        // it must survive as an array so provider-specific fields are not lost.
+        $rich = ['role' => 'tool', 'content' => 'result', 'name' => 'fetch_logs'];
+
+        $result = $this->subject->normalise([$rich]);
+
+        self::assertSame([$rich], $result);
+    }
+
+    #[Test]
+    public function normaliseLeavesNonStringRoleContentArraysUntouched(): void
+    {
+        $message = ['role' => 'user', 'content' => ['type' => 'text']];
+
+        $result = $this->subject->normalise([$message]);
+
+        self::assertSame([$message], $result);
+    }
+
+    #[Test]
+    public function normaliseReindexesTheList(): void
+    {
+        $result = $this->subject->normalise([5 => ['role' => 'user', 'content' => 'Hi']]);
+
+        self::assertArrayHasKey(0, $result);
+    }
+
+    #[Test]
+    public function applySystemPromptReturnsMessagesUnchangedWhenNoSystemPromptOption(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'Hi']];
+
+        self::assertSame($messages, $this->subject->applySystemPrompt($messages, []));
+    }
+
+    #[Test]
+    public function applySystemPromptReturnsMessagesUnchangedWhenPromptIsEmpty(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'Hi']];
+
+        self::assertSame($messages, $this->subject->applySystemPrompt($messages, ['system_prompt' => '']));
+    }
+
+    #[Test]
+    public function applySystemPromptPrependsSystemMessageWhenNonePresent(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'Hi']];
+
+        $result = $this->subject->applySystemPrompt($messages, ['system_prompt' => 'Be terse.']);
+
+        self::assertCount(2, $result);
+        self::assertInstanceOf(ChatMessage::class, $result[0]);
+        self::assertTrue($result[0]->isSystem());
+        self::assertSame('Be terse.', $result[0]->content);
+    }
+
+    #[Test]
+    public function applySystemPromptDoesNotPrependWhenArraySystemMessagePresent(): void
+    {
+        $messages = [
+            ['role' => 'system', 'content' => 'Caller prompt'],
+            ['role' => 'user', 'content' => 'Hi'],
+        ];
+
+        $result = $this->subject->applySystemPrompt($messages, ['system_prompt' => 'Config prompt']);
+
+        self::assertSame($messages, $result);
+    }
+
+    #[Test]
+    public function applySystemPromptDoesNotPrependWhenTypedSystemMessagePresent(): void
+    {
+        $messages = [ChatMessage::system('Caller prompt'), ChatMessage::user('Hi')];
+
+        $result = $this->subject->applySystemPrompt($messages, ['system_prompt' => 'Config prompt']);
+
+        self::assertSame($messages, $result);
+    }
+}

--- a/Tests/Unit/Service/SkillConfigInjectionTest.php
+++ b/Tests/Unit/Service/SkillConfigInjectionTest.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,6 +45,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(LlmServiceManager::class)]
 final class SkillConfigInjectionTest extends AbstractUnitTestCase
 {
+    use LlmServiceManagerTestFactory;
     private const SKILL_NEEDLE = '### Skill: Config Skill';
 
     private const SYSTEM_PROMPT = 'You are a translator.';
@@ -116,7 +118,7 @@ final class SkillConfigInjectionTest extends AbstractUnitTestCase
             },
         );
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub(),
             self::createStub(LoggerInterface::class),
             self::createStub(ProviderAdapterRegistryInterface::class),
@@ -154,7 +156,7 @@ final class SkillConfigInjectionTest extends AbstractUnitTestCase
             },
         );
 
-        $manager = new LlmServiceManager(
+        $manager = $this->createLlmServiceManager(
             $this->extensionConfigStub(),
             self::createStub(LoggerInterface::class),
             self::createStub(ProviderAdapterRegistryInterface::class),
@@ -185,7 +187,7 @@ final class SkillConfigInjectionTest extends AbstractUnitTestCase
         $registry = self::createStub(ProviderAdapterRegistryInterface::class);
         $registry->method('createAdapterFromModel')->willReturn($adapter);
 
-        return new LlmServiceManager(
+        return $this->createLlmServiceManager(
             $this->extensionConfigStub(),
             self::createStub(LoggerInterface::class),
             $registry,

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -36,6 +37,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(TranslatorResult::class)]
 class LlmTranslatorTest extends AbstractUnitTestCase
 {
+    use LlmServiceManagerTestFactory;
     private LlmServiceManager $llmManager;
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LlmTranslator $subject;
@@ -79,7 +81,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         $adapterRegistryStub = self::createStub(ProviderAdapterRegistryInterface::class);
         $adapterRegistryStub->method('createAdapterFromModel')->willReturn($this->provider);
 
-        $this->llmManager = new LlmServiceManager(
+        $this->llmManager = $this->createLlmServiceManager(
             $extensionConfigStub,
             $loggerStub,
             $adapterRegistryStub,


### PR DESCRIPTION
## Description

Stage 1 of decomposing `LlmServiceManager` (987 lines, a `SingletonInterface` implementing the Category-1 public API `LlmServiceManagerInterface`, see ADR-028). The manager stays a `final` thin facade — the interface, class name, `registerProvider` and the three non-interface public methods (`getAdapterFromModel`, `getAdapterFromConfiguration`, `getAdapterRegistry`) are unchanged — while the self-contained responsibility groups move into dedicated, private, autowired collaborators.

Responsibility map (9 groups): skill-injection glue, default-config resolution, extension-config loading, keyed provider registry, generic dispatch, configuration-backed dispatch, adapter-factory facade, pipeline plumbing, message shaping.

### Extracted in this PR

- **`KeyedProviderRegistry`** (groups 3 + 4) — owns the mutable provider map and the loaded extension configuration; `SingletonInterface`. `ProviderCompilerPass` is untouched: it still adds `registerProvider` method calls on the manager, which forward here.
- **`ConfigurationResolver`** (group 2) — `readonly`; default/effective configuration resolution against the repository.
- **`MessageShaper`** (group 9) — `readonly`, stateless message normalisation + system-prompt injection.
- **`EmbedCacheKeyBuilder`** — deduplicates the two inline embed cache-metadata blocks.
- **`splitProviderKey()`** — the options/provider-key preamble repeated by the six generic dispatch methods (kept private on the manager, since those callers stay in stage 1).

The manager's constructor drops `ExtensionConfiguration`, `LoggerInterface`, `CacheManagerInterface` and `LlmConfigurationRepository` (now owned by the collaborators) and gains the four collaborators. The constructor is not part of the interface contract and is autowired in production.

### Embed cache-key finding

The two embed cache-key blocks are **intentionally different**, not a bug:

- `embed()` (ad-hoc): namespace = provider id, payload `{input, options}`, tag `nrllm_provider_<id>`.
- `embedForConfiguration()`: namespace = configuration id, payload `{input, options, model: <effectiveModel>}` (so two configs on different models never collide), tag `nrllm_configuration_<id>`.

`EmbedCacheKeyBuilder` therefore shares only the structure (the positive-ttl guard and the `{cacheKey, cacheTtl, cacheTags}` shape with the common `nrllm_embeddings` tag); each caller passes its own namespace, payload and scope tag. The configuration variant's behaviour is preserved exactly.

### Deliberately NOT in this PR — dispatcher extraction (stage 2)

Generic + configuration-backed dispatch (11 methods) and the pipeline plumbing stay on the manager, which is still ~792 lines and dominated by those methods. Extracting per-operation dispatchers (completion / embedding / streaming / tool-calling) is deferred so this change stays reviewable and behaviour-preserving. Recommendation: stage 2 is worthwhile and is the natural seam for the privacy-model entry-point work (the ADR-026 payload constraint); take it up when that work needs the seam.

## Behaviour equality — how it's secured

- Interface signatures, the provider-resolution error messages and their exception codes, and the two embed cache-keying strategies are preserved unchanged.
- The existing manager / integration / e2e tests exercise the behaviour through the facade. They construct the manager via a new test-only factory (`Tests/LlmServiceManagerTestFactory`) that accepts the previous leaf-dependency shape and wires the new collaborators, so ~50 construction sites did not each have to change shape (production wiring is autowired, not service-located).
- The four extracted classes get their own unit tests.
- New collaborators are private → `PublicServicesPolicyTest` count unchanged.

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

`unit`, `functional`, `architecture` (PHPat layering), `cgl` and `phpstan` (level 10) pass locally via `runTests.sh`. Mutation (`-s mutation`) is left to CI given its runtime; the extracted classes have dedicated unit tests plus the facade coverage.
