### PR TITLE
fix: resolve criteria-mode configurations to a concrete model

### DIFF
--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -128,6 +128,11 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
         return preg_replace('/\W/', '_', $value) ?? '';
     }
 
+    public function sanitizeCacheTag(string $value): string
+    {
+        return $this->sanitizeTagValue($value);
+    }
+
     /**
      * Flush cache entries by provider.
      */

--- a/Classes/Service/CacheManagerInterface.php
+++ b/Classes/Service/CacheManagerInterface.php
@@ -22,6 +22,14 @@ interface CacheManagerInterface
     public function generateCacheKey(string $provider, string $operation, array $params): string;
 
     /**
+     * Reduce a value to TYPO3's allowed cache-tag charset. Callers that build cache
+     * tags from identifiers which may contain characters the cache frontend rejects
+     * (e.g. the dotted preset naming scheme "nr_ai_search.embeddings") must run the
+     * value through this before handing the tag to the cache.
+     */
+    public function sanitizeCacheTag(string $value): string;
+
+    /**
      * @return array<string, mixed>|null
      */
     public function get(string $cacheKey): ?array;

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -57,6 +57,7 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
         private readonly CacheManagerInterface $cacheManager,
         private readonly ?LlmConfigurationRepository $configurationRepository = null,
         private readonly ?SkillInjectionService $skillInjection = null,
+        private readonly ?ModelSelectionServiceInterface $modelSelectionService = null,
     ) {
         $this->loadConfiguration();
     }
@@ -600,7 +601,10 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
                 CacheMiddleware::METADATA_CACHE_TTL  => $cacheTtl,
                 CacheMiddleware::METADATA_CACHE_TAGS => [
                     'nrllm_embeddings',
-                    'nrllm_configuration_' . $configuration->getIdentifier(),
+                    // Sanitize: configuration identifiers use the dotted preset scheme
+                    // (nr_ai_search.embeddings), and the cache frontend rejects a tag
+                    // containing a dot with an InvalidArgumentException on set().
+                    'nrllm_configuration_' . $this->cacheManager->sanitizeCacheTag($configuration->getIdentifier()),
                 ],
             ];
         }
@@ -695,12 +699,27 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
      */
     public function getAdapterFromConfiguration(LlmConfiguration $configuration): ProviderInterface
     {
-        $llmModel = $configuration->getLlmModel();
+        // Criteria-mode configurations carry no direct model relation (model_uid = 0);
+        // their model is selected at call time from the stored criteria. Resolve
+        // through ModelSelectionService — which returns the directly configured model
+        // unchanged for fixed-mode configs — so both selection modes reach a concrete
+        // model here. Without this, every *ForConfiguration() call on a criteria-mode
+        // configuration threw "has no model assigned".
+        $llmModel = $this->modelSelectionService !== null
+            ? $this->modelSelectionService->resolveModel($configuration)
+            : $configuration->getLlmModel();
         if ($llmModel === null) {
             throw new ProviderException(
                 sprintf('Configuration "%s" has no model assigned', $configuration->getIdentifier()),
                 1735300100,
             );
+        }
+
+        // Attach the resolved model to the configuration so downstream middleware
+        // (usage attribution, per-model pricing) sees the concrete model for
+        // criteria-mode configurations too, not a null relation.
+        if ($configuration->getLlmModel() === null) {
+            $configuration->setLlmModel($llmModel);
         }
 
         return $this->adapterRegistry->createAdapterFromModel($llmModel);

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -715,13 +715,13 @@ final class LlmServiceManager implements LlmServiceManagerInterface, SingletonIn
             );
         }
 
-        // Attach the resolved model to the configuration so downstream middleware
-        // (usage attribution, per-model pricing) sees the concrete model for
-        // criteria-mode configurations too, not a null relation.
-        if ($configuration->getLlmModel() === null) {
-            $configuration->setLlmModel($llmModel);
-        }
-
+        // Intentionally NOT calling $configuration->setLlmModel($llmModel): the
+        // configuration is a repository-managed Extbase entity, so mutating it
+        // would mark it dirty and Extbase would persist model_uid at end of
+        // request — silently converting a criteria-mode record into a fixed-mode
+        // one. Per-model cost analytics for criteria configs (UsageMiddleware
+        // reads getLlmModel() directly) remain a separate, non-destructive
+        // follow-up.
         return $this->adapterRegistry->createAdapterFromModel($llmModel);
     }
 

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -69,6 +69,17 @@ class CacheManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function sanitizeCacheTagReducesDottedIdentifierToTheAllowedTagCharset(): void
+    {
+        // Exposed for callers that build tags from dotted preset identifiers
+        // (e.g. LlmServiceManager's embedding cache tags).
+        $tag = 'nrllm_configuration_' . $this->subject->sanitizeCacheTag('nr_ai_search.embeddings');
+
+        self::assertSame('nrllm_configuration_nr_ai_search_embeddings', $tag);
+        self::assertMatchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/', $tag);
+    }
+
+    #[Test]
     public function generateCacheKeyIsAValidCacheEntryIdentifierForDottedConfigurationIdentifiers(): void
     {
         // The provider segment can carry an LLM configuration identifier; the

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -585,13 +585,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function getAdapterFromConfigurationResolvesCriteriaModeViaModelSelectionService(): void
     {
         // Criteria-mode configuration: no direct model relation. The concrete model
-        // is picked from the criteria by ModelSelectionService and attached back to
-        // the configuration so downstream middleware sees it.
+        // is picked from the criteria by ModelSelectionService. The configuration
+        // entity must NOT be mutated (Extbase would persist the change).
         $resolvedModel = self::createStub(Model::class);
         $config = $this->createMock(LlmConfiguration::class);
         $config->method('getLlmModel')->willReturn(null);
         $config->method('getIdentifier')->willReturn('nr_ai_search.embeddings');
-        $config->expects(self::once())->method('setLlmModel')->with($resolvedModel);
+        $config->expects(self::never())->method('setLlmModel');
 
         $selection = $this->createMock(ModelSelectionServiceInterface::class);
         $selection->expects(self::once())

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -39,6 +39,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
@@ -581,6 +582,54 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function getAdapterFromConfigurationResolvesCriteriaModeViaModelSelectionService(): void
+    {
+        // Criteria-mode configuration: no direct model relation. The concrete model
+        // is picked from the criteria by ModelSelectionService and attached back to
+        // the configuration so downstream middleware sees it.
+        $resolvedModel = self::createStub(Model::class);
+        $config = $this->createMock(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn(null);
+        $config->method('getIdentifier')->willReturn('nr_ai_search.embeddings');
+        $config->expects(self::once())->method('setLlmModel')->with($resolvedModel);
+
+        $selection = $this->createMock(ModelSelectionServiceInterface::class);
+        $selection->expects(self::once())
+            ->method('resolveModel')
+            ->with($config)
+            ->willReturn($resolvedModel);
+
+        $mockAdapter = self::createStub(ProviderInterface::class);
+        $registryMock = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $registryMock->expects(self::once())
+            ->method('createAdapterFromModel')
+            ->with($resolvedModel)
+            ->willReturn($mockAdapter);
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
+
+        self::assertSame($mockAdapter, $manager->getAdapterFromConfiguration($config));
+    }
+
+    #[Test]
+    public function getAdapterFromConfigurationThrowsWhenCriteriaResolvesToNoModel(): void
+    {
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn(null);
+        $config->method('getIdentifier')->willReturn('nr_ai_search.embeddings');
+
+        $selection = self::createStub(ModelSelectionServiceInterface::class);
+        $selection->method('resolveModel')->willReturn(null);
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('has no model assigned');
+
+        $manager->getAdapterFromConfiguration($config);
+    }
+
+    #[Test]
     public function chatWithConfigurationUsesAdapter(): void
     {
         $model = self::createStub(Model::class);
@@ -891,6 +940,48 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $metadata = $spy->calls[0]['metadata'];
         self::assertArrayNotHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_BE_USER_UID, $metadata);
+    }
+
+    #[Test]
+    public function embedForConfigurationRoutesTheConfigurationCacheTagThroughTheSanitizer(): void
+    {
+        // A dotted configuration identifier (the preset naming scheme) must not reach
+        // the cache frontend verbatim in a tag — it is rejected as an invalid tag.
+        $spy = new RecordingMiddleware();
+        $adapter = self::createStub(ProviderInterface::class);
+        $adapter->method('supportsFeature')->willReturn(true);
+        $adapter->method('embeddings')->willReturn(new EmbeddingResponse(
+            embeddings: [[0.1, 0.2]],
+            model: 'text-embedding-3-small',
+            usage: new UsageStatistics(1, 0, 1),
+            provider: 'openai',
+        ));
+        $registry = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $cacheStub = self::createStub(CacheManagerInterface::class);
+        $cacheStub->method('generateCacheKey')->willReturn('cache-key');
+        $cacheStub->method('sanitizeCacheTag')->willReturnCallback(
+            static fn(string $value): string => preg_replace('/\W/', '_', $value) ?? '',
+        );
+
+        $manager = new LlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registry, new MiddlewarePipeline([$spy]), $cacheStub);
+
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn(self::createStub(Model::class));
+        $config->method('getIdentifier')->willReturn('nr_ai_search.embeddings');
+        $config->method('getModelId')->willReturn('text-embedding-3-small');
+        $config->method('toOptionsArray')->willReturn(['model' => 'text-embedding-3-small']);
+        $config->method('getFallbackChainDTO')->willReturn(FallbackChain::fromArray([]));
+
+        // Default EmbeddingOptions keeps cacheTtl = 86400 > 0, so cache tags are built.
+        $manager->embedForConfiguration('hello', $config, new EmbeddingOptions());
+
+        $tags = $spy->calls[0]['metadata'][CacheMiddleware::METADATA_CACHE_TAGS];
+        self::assertContains('nrllm_configuration_nr_ai_search_embeddings', $tags);
+        foreach ($tags as $tag) {
+            self::assertMatchesRegularExpression('/^[a-zA-Z0-9_%\-&]{1,250}$/', $tag);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`LlmServiceManager::getAdapterFromConfiguration()` read `$configuration->getLlmModel()` directly. That relation is **null for criteria-mode configurations** (`model_selection_mode = 'criteria'`, `model_uid = 0`) — their model is meant to be picked at call time from the stored `ModelSelectionCriteria`. So **every** `embedForConfiguration()` / `chatWithConfiguration()` / tool call on a criteria-mode configuration threw `ProviderException: Configuration "…" has no model assigned`.

Found live on the BMDV deployment (NRFE-3946): after the 0.19.0 cache-identifier fix unblocked the retrieval path, the very next layer failed here — the `nr_ai_search.embeddings` preset config is criteria-mode, and `ModelSelectionService::resolveModel()` (the ready-made resolver) had **no production caller**.

## Fix

- `getAdapterFromConfiguration()` resolves the model through `ModelSelectionService::resolveModel($configuration)` — which returns the directly configured model unchanged for **fixed**-mode configs and selects from criteria for **criteria**-mode configs. This single choke point covers embed / chat / tools / complete / stream `*ForConfiguration()` paths at once. Still throws the same `ProviderException` (code `1735300100`) when resolution yields no model.
- The resolved model is **attached back** to the configuration (`setLlmModel()`) so `UsageMiddleware` (per-user attribution, per-model pricing) sees the concrete model for criteria configs too, not a null relation.
- **Latent cache-tag bug (same class as #365):** `embedForConfiguration()` built the tag `'nrllm_configuration_' . $identifier` verbatim. A dotted preset identifier (`nr_ai_search.embeddings`) makes the cache frontend reject the tag on `set()` when `cache_ttl > 0`. Now routed through the new `CacheManagerInterface::sanitizeCacheTag()`.

## Compatibility

`ModelSelectionServiceInterface` is added as a **trailing nullable** constructor param (autowired; already aliased in `Services.yaml` and injected by the preset importer) — the ~20 existing 5-arg test constructions keep compiling, and when the service is absent the method falls back to the old `getLlmModel()` behaviour.

## Tests

- `getAdapterFromConfigurationResolvesCriteriaModeViaModelSelectionService` — criteria config → resolved model, adapter built from it, model attached back.
- `getAdapterFromConfigurationThrowsWhenCriteriaResolvesToNoModel` — resolver returns null → `ProviderException`.
- `embedForConfigurationRoutesTheConfigurationCacheTagThroughTheSanitizer` — dotted identifier → sanitized tag, all tags match TYPO3's charset.
- `CacheManagerTest::sanitizeCacheTagReducesDottedIdentifierToTheAllowedTagCharset`.

Unit 4177 green, PHPStan level 10 clean, CGL clean.