### PR TITLE
chore: release 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-07-15
+
+### Fixed
+
+- **Criteria-mode configurations could not be used by `*ForConfiguration()`.** `getAdapterFromConfiguration()` read the concrete model relation directly, which is null for criteria-mode configurations (`model_selection_mode = 'criteria'`, `model_uid = 0`), so every `embedForConfiguration()` / `chatWithConfiguration()` / tool call on such a configuration threw `Configuration "…" has no model assigned`. The model is now resolved through `ModelSelectionService` (which returns the directly configured model unchanged for fixed-mode configs), covering the embed / chat / tools / complete / stream paths through the single choke point. The configuration entity is deliberately not mutated — doing so would mark a repository-managed Extbase record dirty and persist `model_uid`, silently converting a criteria-mode record into a fixed-mode one (#372).
+- The embedding cache tag built from the configuration identifier (`nrllm_configuration_<identifier>`) is now sanitized via the new `CacheManagerInterface::sanitizeCacheTag()`. A dotted preset identifier (`nr_ai_search.embeddings`) otherwise made the cache frontend reject the tag on `set()` when `cache_ttl > 0` — the same class as the cache key/tag sanitization shipped in 0.19.0 (#372).
+
 ## [0.19.0] - 2026-07-14
 
 ### Added

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.19.0"
-        release="0.19.0"
+        version="0.19.1"
+        release="0.19.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.19.0",
+            "version": "0.19.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.19.0',
+    'version' => '0.19.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Patch release. Fixes from [#372](https://github.com/netresearch/t3x-nr-llm/pull/372):

- **Criteria-mode configurations now resolve to a concrete model** in the `*ForConfiguration()` paths (embed/chat/tools/complete/stream) via `ModelSelectionService` — previously threw `has no model assigned`. Found live on the BMDV deployment (NRFE-3946).
- Embedding **cache tag** `nrllm_configuration_<identifier>` sanitized (dotted preset identifiers no longer break `set()` when caching is on).

Version surfaces (ext_emconf, composer `extra.typo3/cms.version`, guides.xml) + CHANGELOG. Unit 4177, PHPStan L10, CGL clean.