### PR TITLE
feat: bring streaming into the request lifecycle (budget, usage, telemetry)

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -80,6 +80,7 @@ return RectorConfig::configure()
         // required.
         AddErrorCodeToExceptionRector::class => [
             __DIR__ . '/../../Classes/Provider/Middleware/BudgetMiddleware.php',
+            __DIR__ . '/../../Classes/Service/Streaming/StreamingDispatcher.php',
         ],
         // Skip Fuzzy tests - Eris\Generator namespace functions conflict with auto-imports
         __DIR__ . '/../../Tests/Fuzzy/',

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -34,6 +34,7 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use TYPO3\CMS\Core\SingletonInterface;
 
 final readonly class LlmServiceManager implements LlmServiceManagerInterface, SingletonInterface
@@ -47,6 +48,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         private EmbedCacheKeyBuilder $embedCacheKeyBuilder,
         private ?SkillInjectionService $skillInjection = null,
         private ?ModelSelectionServiceInterface $modelSelectionService = null,
+        private ?StreamingDispatcher $streaming = null,
     ) {}
 
     /**
@@ -311,25 +313,50 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
         // Single source of truth: prefer the default DB configuration (see chat()),
         // so streaming and non-streaming calls resolve the same provider/model.
+        // Budget attribution is forwarded so the streaming lifecycle can gate the
+        // same over-budget users the non-streaming path rejects.
         $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
         if ($defaultConfiguration !== null) {
             return $this->streamChatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
                 $optionsArray,
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
             );
         }
 
-        $provider = $this->getProvider($providerKey);
+        // Ad-hoc: a pinned provider with no configuration entity — no fallback
+        // chain, provider resolved by key.
+        $open = function () use ($messages, $optionsArray, $providerKey): Generator {
+            $provider = $this->getProvider($providerKey);
+            $this->assertStreamingCapable($provider, 1581627129);
 
-        if (!$provider instanceof StreamingCapableInterface) {
-            throw new UnsupportedFeatureException(
-                sprintf('Provider "%s" does not support streaming', $provider->getIdentifier()),
-                1581627129,
+            return $provider->streamChatCompletion(
+                $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $optionsArray),
+                $optionsArray,
             );
+        };
+
+        $configuration = $this->synthesizeTransientConfiguration(ProviderOperation::Stream, $providerKey);
+
+        if ($this->streaming === null) {
+            return $open();
         }
 
-        return $provider->streamChatCompletion($this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $optionsArray), $optionsArray);
+        // Check capability eagerly so an unsupported provider throws at call time
+        // (as the legacy path and non-streaming calls do), not lazily on the
+        // first iteration inside the dispatcher.
+        $this->assertStreamingCapable($this->getProvider($providerKey), 1581627129);
+
+        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
+        $metadata[StreamingDispatcher::METADATA_PROVIDER]     = $providerKey ?? 'default';
+        $metadata[StreamingDispatcher::METADATA_PROMPT_CHARS] = $this->estimatePromptChars($messages);
+
+        return $this->streaming->stream(
+            ProviderCallContext::for(ProviderOperation::Stream, $metadata),
+            $configuration,
+            $open,
+        );
     }
 
     /**
@@ -713,6 +740,53 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     }
 
     /**
+     * Assert a resolved adapter can stream, else throw the typed
+     * UnsupportedFeatureException. Shared by both streaming entry points so the
+     * eager (call-time) check and the per-fallback opener check raise the same
+     * error; the `@phpstan-assert` narrows the adapter for the caller.
+     *
+     * @phpstan-assert StreamingCapableInterface $adapter
+     */
+    private function assertStreamingCapable(ProviderInterface $adapter, int $code): void
+    {
+        if (!$adapter instanceof StreamingCapableInterface) {
+            throw new UnsupportedFeatureException(
+                sprintf('Provider "%s" does not support streaming', $adapter->getIdentifier()),
+                $code,
+            );
+        }
+    }
+
+    /**
+     * Sum the character length of a message list's textual content, for the
+     * streaming lifecycle's prompt-token estimate (ADR-062). Computed here
+     * because the manager holds the messages; the dispatcher only sees the
+     * count, never the payload. Non-string (multimodal) content contributes
+     * nothing — the estimate is deliberately rough, matching the ≈4 chars/token
+     * heuristic the dispatcher applies to it.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function estimatePromptChars(array $messages): int
+    {
+        $chars = 0;
+        foreach ($messages as $message) {
+            if ($message instanceof ChatMessage) {
+                $chars += strlen($message->content);
+
+                continue;
+            }
+
+            $content = $message['content'] ?? '';
+            if (is_string($content)) {
+                $chars += strlen($content);
+            }
+        }
+
+        return $chars;
+    }
+
+    /**
      * Split the pinned provider key out of a call's options array.
      *
      * Every generic (provider-agnostic) entry point — chat(), complete(),
@@ -769,36 +843,61 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     /**
      * Stream chat completion using an LlmConfiguration entity.
      *
-     * Fallback chain is intentionally NOT applied to streaming: once the first
-     * chunk has been yielded to the caller we cannot swap providers mid-stream.
-     * Use chatWithConfiguration() if fallback protection is required.
+     * Routed through the streaming lifecycle (ADR-062): budget pre-flight before
+     * the first chunk, usage + telemetry settlement at stream end. Fallback IS
+     * applied, but only in the pre-first-chunk window — once a chunk has been
+     * yielded a provider swap is impossible, so a mid-stream failure surfaces to
+     * the caller rather than re-routing. Use chatWithConfiguration() for full
+     * mid-call fallback protection.
      *
      * Legacy array-shaped messages are accepted for back-compat and
      * normalised via `ChatMessage::fromArray()` before dispatch.
      *
+     * `$metadata` is threaded onto the streaming ProviderCallContext (budget
+     * attribution, task uid); it is the trailing parameter so the pre-existing
+     * three-argument callers stay source-compatible. Direct callers that omit it
+     * get an empty map, which the budget gate reads as "no budget owner —
+     * skip the check", matching chatWithConfiguration()'s contract.
+     *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
+     * @param array<string, mixed>                   $metadata        cross-cutting streaming context (budget attribution, task uid)
      *
      * @return Generator<int, string, mixed, void>
      */
-    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = []): Generator
+    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = [], array $metadata = []): Generator
     {
-        $adapter = $this->getAdapterFromConfiguration($configuration);
-        $options = array_merge($configuration->toOptionsArray(), $optionOverrides);
+        $open = function (LlmConfiguration $config) use ($messages, $optionOverrides): Generator {
+            $adapter = $this->getAdapterFromConfiguration($config);
+            $options = array_merge($config->toOptionsArray(), $optionOverrides);
 
-        // Remove provider key as we already have the adapter
-        unset($options['provider']);
+            // Remove provider key as we already have the adapter
+            unset($options['provider']);
 
-        if (!$adapter instanceof StreamingCapableInterface) {
-            throw new UnsupportedFeatureException(
-                sprintf('Provider "%s" does not support streaming', $adapter->getIdentifier()),
-                1735300101,
+            $this->assertStreamingCapable($adapter, 1735300101);
+
+            return $adapter->streamChatCompletion(
+                $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $options),
+                $options,
             );
+        };
+
+        if ($this->streaming === null) {
+            return $open($configuration);
         }
 
-        return $adapter->streamChatCompletion(
-            $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $options),
-            $options,
+        // Check the PRIMARY provider's capability eagerly so an unsupported
+        // provider throws at call time, not lazily on the first iteration inside
+        // the dispatcher; fallback candidates are still checked per-attempt in
+        // the opener above.
+        $this->assertStreamingCapable($this->getAdapterFromConfiguration($configuration), 1735300101);
+
+        $metadata[StreamingDispatcher::METADATA_PROMPT_CHARS] = $this->estimatePromptChars($messages);
+
+        return $this->streaming->stream(
+            ProviderCallContext::for(ProviderOperation::Stream, $metadata),
+            $configuration,
+            $open,
         );
     }
 

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -90,15 +90,22 @@ interface LlmServiceManagerInterface
     /**
      * Stream chat completion using a specific LLM configuration.
      *
+     * Routed through the streaming lifecycle (ADR-062): budget pre-flight before
+     * the first chunk and usage + telemetry settlement at stream end. `$metadata`
+     * is the trailing parameter so pre-existing three-argument callers stay
+     * source-compatible; omitting it skips budget enforcement (no attributed
+     * owner), matching {@see self::chatWithConfiguration()}.
+     *
      * Legacy array-shaped message fixtures are accepted for back-compat
      * and normalised via `ChatMessage::fromArray()` before dispatch.
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
+     * @param array<string, mixed>                   $metadata        cross-cutting streaming context (budget attribution, task uid)
      *
      * @return Generator<int, string, mixed, void>
      */
-    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = []): Generator;
+    public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = [], array $metadata = []): Generator;
 
     /**
      * @param string|array<int, string> $input

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -1,0 +1,546 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Streaming;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+
+/**
+ * Streaming request lifecycle (ADR-062).
+ *
+ * A streamed provider call cannot go through {@see \Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline}:
+ * a PHP generator is lazy, so wrapping it as the pipeline terminal makes every
+ * middleware run against a not-yet-started stream — Budget would gate nothing,
+ * Usage would record zero tokens, Telemetry would measure a near-zero latency.
+ * That is exactly why streaming used to bypass the pipeline (ADR-026) and,
+ * with it, budget enforcement and usage/telemetry accounting.
+ *
+ * This dispatcher restores that lifecycle for streams while keeping the public
+ * {@see Generator}<int, string, mixed, void> contract intact — it is a
+ * wrapping generator, not a replacement of the provider's:
+ *
+ *  1. **Budget pre-flight (eager).** {@see self::stream()} runs the same
+ *     {@see BudgetServiceInterface::check()} gate as {@see BudgetMiddleware}
+ *     BEFORE any generator is handed back, so an over-budget user never opens
+ *     a stream. It throws {@see BudgetExceededException} at call time, not on
+ *     first iteration.
+ *  2. **Fallback before the first chunk.** Provider selection is retried across
+ *     the configuration's fallback chain while priming the inner generator
+ *     (the pre-first-chunk window). Once a chunk has been yielded to the caller
+ *     a provider swap is impossible, so fallback stops there — this is the one
+ *     structural difference from the non-streaming pipeline.
+ *  3. **Drain accounting (lazy).** While the caller drains the stream the
+ *     wrapper counts the completion text and records the time-to-first-token.
+ *  4. **finally-block settlement.** Usage ({@see UsageTrackerServiceInterface})
+ *     and telemetry ({@see TelemetryRepositoryInterface}) are written in a
+ *     `finally`, so they land whether the stream completes, throws, or is
+ *     abandoned early (client disconnect / consumer `break`) — PHP runs the
+ *     `finally` when a suspended generator is destroyed. An abandoned stream
+ *     therefore records the PARTIAL tokens actually produced, never zero.
+ *
+ * Token counts are ESTIMATED (≈4 chars / token, the heuristic already used by
+ * {@see \Netresearch\NrLlm\Domain\Model\RenderedPrompt::estimateTokens()}):
+ * the seven streaming providers yield only text deltas and no usage frame, so a
+ * real per-token figure is not available on this path. Recording an estimate is
+ * a deliberate improvement over the previous state, which recorded nothing at
+ * all. Exact stream usage would require provider-level `include_usage` support
+ * and is tracked as a follow-up in ADR-062.
+ */
+final readonly class StreamingDispatcher
+{
+    /**
+     * The resolved provider identifier for an ad-hoc stream (no configuration
+     * entity carries a provider type). Read for usage attribution when the
+     * served configuration's provider type is empty.
+     */
+    public const METADATA_PROVIDER = 'streamProvider';
+
+    /**
+     * Character length of the prompt, computed by the caller (which holds the
+     * messages) so this dispatcher can estimate prompt tokens without seeing
+     * the payload — keeping the ADR-026 "context carries no payload" rule.
+     */
+    public const METADATA_PROMPT_CHARS = 'streamPromptChars';
+
+    private const CHARS_PER_TOKEN = 4;
+
+    public function __construct(
+        private BudgetServiceInterface $budgetService,
+        private UsageTrackerServiceInterface $usageTracker,
+        private TelemetryRepositoryInterface $telemetryRepository,
+        private LlmConfigurationRepository $repository,
+        private LoggerInterface $logger,
+        private Context $context,
+        private ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    /**
+     * Enter the streaming lifecycle.
+     *
+     * Budget is checked eagerly here (before a generator exists) so an
+     * over-budget caller is rejected at call time; the returned generator then
+     * lazily drains, accounts, and settles usage/telemetry.
+     *
+     * @param callable(LlmConfiguration): Generator<int, string, mixed, void> $open
+     *                                                                              opens a fresh inner stream for the given configuration (resolve
+     *                                                                              adapter, shape messages, merge options). Called once per fallback
+     *                                                                              candidate. Mirrors the pipeline terminal shape.
+     *
+     * @throws BudgetExceededException when the pre-flight budget check denies the call
+     *
+     * @return Generator<int, string, mixed, void>
+     */
+    public function stream(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $open,
+    ): Generator {
+        $this->assertWithinBudget($context);
+
+        return $this->drain($context, $configuration, $open);
+    }
+
+    /**
+     * @param callable(LlmConfiguration): Generator<int, string, mixed, void> $open
+     *
+     * @return Generator<int, string, mixed, void>
+     */
+    private function drain(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $open,
+    ): Generator {
+        $startNs         = hrtime(true);
+        $firstTokenNs    = null;
+        $completionBytes = 0;
+        $served          = $configuration;
+        $success         = false;
+        $errorClass      = '';
+
+        try {
+            [$inner, $served] = $this->openWithFallback($context, $configuration, $open);
+
+            while ($inner->valid()) {
+                if ($firstTokenNs === null) {
+                    $firstTokenNs = hrtime(true);
+                }
+                $chunk = $inner->current();
+                // Count bytes as they pass; never buffer the whole completion —
+                // token estimation and logging only need the length, and holding
+                // the full response would defeat streaming's memory benefit.
+                $completionBytes += \strlen($chunk);
+                yield $chunk;
+                $inner->next();
+            }
+
+            $success = true;
+        } catch (Throwable $e) {
+            $errorClass = $e::class;
+
+            throw $e;
+        } finally {
+            $this->settle(
+                $context,
+                $configuration,
+                $served,
+                $completionBytes,
+                $startNs,
+                $firstTokenNs,
+                $success,
+                $errorClass,
+            );
+        }
+    }
+
+    /**
+     * Open the first configuration whose stream primes without a retryable
+     * failure, walking the primary's fallback chain (shallow, like
+     * {@see \Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware}). Priming
+     * (`rewind()`) is the pre-first-chunk window: a connection/rate-limit error
+     * here can still be answered by a sibling provider because nothing has been
+     * yielded to the caller yet. A non-retryable error (misconfiguration,
+     * unsupported feature, client 4xx) bubbles up unchanged.
+     *
+     * @param callable(LlmConfiguration): Generator<int, string, mixed, void> $open
+     *
+     * @return array{0: Generator<int, string, mixed, void>, 1: LlmConfiguration} the primed stream and the configuration that served it
+     */
+    private function openWithFallback(
+        ProviderCallContext $context,
+        LlmConfiguration $primary,
+        callable $open,
+    ): array {
+        $candidates    = $this->candidates($context, $primary);
+        $lastRetryable = null;
+
+        foreach ($candidates as $index => $configuration) {
+            if ($index > 0) {
+                // Count every dispatched sibling BEFORE priming (the primary is
+                // not counted), so a fallback that then fails retryably or
+                // exhausts the chain is still counted — mirroring
+                // FallbackMiddleware, which records before each $next($fallback).
+                $context->telemetrySignals->recordFallbackAttempt();
+            }
+
+            $stream = $open($configuration);
+
+            try {
+                // Prime: runs the provider up to its first yield (HTTP request,
+                // first delta). The one point a stream can still be re-routed.
+                $stream->rewind();
+            } catch (Throwable $e) {
+                if (!$this->isRetryable($e)) {
+                    throw $e;
+                }
+
+                $lastRetryable = $e;
+                $this->logger->warning(
+                    'LLM streaming attempt failed before first chunk, trying next configuration',
+                    $this->logContext($context, [
+                        'configuration'  => $configuration->getIdentifier(),
+                        'exception'      => $e,
+                        'exceptionClass' => $e::class,
+                    ]),
+                );
+
+                continue;
+            }
+
+            return [$stream, $configuration];
+        }
+
+        // Every candidate failed with a retryable error. Surface the last one.
+        throw $lastRetryable ?? new ProviderConnectionException(
+            'Streaming fallback chain exhausted with no attemptable configuration',
+            5825551327,
+        );
+    }
+
+    /**
+     * Primary first, then each active, resolvable fallback configuration. The
+     * primary's own identifier is filtered out of the chain (no self-retry) and
+     * missing / inactive fallbacks are skipped with a log line, exactly as
+     * {@see \Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware} does.
+     *
+     * @return non-empty-list<LlmConfiguration>
+     */
+    private function candidates(ProviderCallContext $context, LlmConfiguration $primary): array
+    {
+        $candidates = [$primary];
+
+        $chain = $primary->getFallbackChainDTO()->without($primary->getIdentifier());
+        foreach ($chain->configurationIdentifiers as $identifier) {
+            $fallback = $this->repository->findOneByIdentifier($identifier);
+            if ($fallback === null || !$fallback->isActive()) {
+                $this->logger->warning(
+                    'LLM streaming fallback configuration missing or inactive, skipping',
+                    $this->logContext($context, ['configuration' => $identifier]),
+                );
+
+                continue;
+            }
+
+            $candidates[] = $fallback;
+        }
+
+        return $candidates;
+    }
+
+    private function isRetryable(Throwable $e): bool
+    {
+        if ($e instanceof ProviderConnectionException) {
+            return true;
+        }
+        if ($e instanceof ProviderResponseException) {
+            // Rate limit: a different provider might not be throttled.
+            return $e->getCode() === 429;
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws BudgetExceededException when the pre-flight check denies the call
+     */
+    private function assertWithinBudget(ProviderCallContext $context): void
+    {
+        $result = $this->budgetService->check(
+            $this->readInt($context, BudgetMiddleware::METADATA_BE_USER_UID),
+            $this->readFloat($context, BudgetMiddleware::METADATA_PLANNED_COST),
+        );
+
+        if (!$result->allowed) {
+            throw new BudgetExceededException($result);
+        }
+    }
+
+    /**
+     * Record usage and telemetry once the stream is done, in every exit path.
+     *
+     * Fail-soft: settlement runs inside the drain generator's `finally`, so a
+     * throwable escaping here would (per PHP `finally` semantics) replace the
+     * provider exception the caller must see. The whole body — including the
+     * logger, which can itself throw — is therefore guarded.
+     */
+    private function settle(
+        ProviderCallContext $context,
+        LlmConfiguration $requested,
+        LlmConfiguration $served,
+        int $completionBytes,
+        int|float $startNs,
+        int|float|null $firstTokenNs,
+        bool $success,
+        string $errorClass,
+    ): void {
+        try {
+            if (!$success && $errorClass === '') {
+                // finally reached without success and without an exception: the
+                // consumer abandoned the generator (client disconnect / early
+                // break) and PHP is destroying it (ADR-062 requirement 4).
+                $this->logger->info(
+                    'LLM stream aborted before completion (client disconnect or early break)',
+                    $this->logContext($context, ['completionChars' => $completionBytes]),
+                );
+            }
+
+            // Usage is recorded when the stream produced output — on success
+            // (matching the non-streaming UsageMiddleware, which records after a
+            // successful call) and on a partial/aborted stream that still
+            // yielded tokens (the "record even on abort" requirement). A total
+            // pre-first-chunk failure produced nothing to bill, so it is skipped
+            // just as a failed non-streaming call records no usage.
+            if ($success || $completionBytes > 0) {
+                $this->recordUsage($context, $served, $completionBytes);
+            }
+
+            $this->recordTelemetry(
+                $context,
+                $requested,
+                $success,
+                $errorClass,
+                $this->elapsedMs($startNs),
+                $firstTokenNs !== null ? $this->elapsedMs($startNs, $firstTokenNs) : null,
+            );
+        } catch (Throwable $e) {
+            try {
+                $this->logger->error(
+                    'Failed to settle LLM streaming usage/telemetry',
+                    $this->logContext($context, ['exception' => $e]),
+                );
+            } catch (Throwable) {
+                // Nothing safe left to do; never let accounting break the call.
+            }
+        }
+    }
+
+    private function recordUsage(
+        ProviderCallContext $context,
+        LlmConfiguration $served,
+        int $completionBytes,
+    ): void {
+        $promptTokens     = $this->estimateTokens($this->readInt($context, self::METADATA_PROMPT_CHARS));
+        $completionTokens = $this->estimateTokens($completionBytes);
+
+        $model    = $served->getLlmModel();
+        $modelUid = $model?->getUid() ?? 0;
+
+        $cost = ($model !== null && $model->hasPricing())
+            ? $model->estimateCost($promptTokens, $completionTokens)
+            : null;
+
+        /** @var array{tokens: int, promptTokens: int, completionTokens: int, cost?: float} $metrics */
+        $metrics = [
+            'tokens'           => $promptTokens + $completionTokens,
+            'promptTokens'     => $promptTokens,
+            'completionTokens' => $completionTokens,
+        ];
+        if ($cost !== null) {
+            $metrics['cost'] = $cost;
+        }
+
+        $configUid = $served->getUid();
+
+        $this->usageTracker->trackUsage(
+            serviceType: $context->operation->value,
+            provider: $this->resolveProvider($context, $served),
+            metrics: $metrics,
+            configurationUid: ($configUid !== null && $configUid > 0) ? $configUid : null,
+            modelUid: $modelUid,
+            modelId: $served->getModelId(),
+            taskUid: $this->readInt($context, UsageMiddleware::METADATA_TASK_UID),
+            beUserUid: $this->readNullableInt($context, BudgetMiddleware::METADATA_BE_USER_UID),
+        );
+    }
+
+    private function recordTelemetry(
+        ProviderCallContext $context,
+        LlmConfiguration $requested,
+        bool $success,
+        string $errorClass,
+        int $latencyMs,
+        ?int $timeToFirstTokenMs,
+    ): void {
+        if (!$this->telemetryEnabled()) {
+            return;
+        }
+
+        // Attribution mirrors the non-streaming TelemetryMiddleware: the row
+        // names the REQUESTED primary configuration; a fallback swap shows as
+        // fallback_attempts > 0, while the provider/model that actually served
+        // live in the usage table. cacheHit is always false — streaming never
+        // caches.
+        $this->telemetryRepository->record(new TelemetryRecord(
+            correlationId: $context->correlationId,
+            operation: $context->operation->value,
+            provider: $requested->getProviderType(),
+            model: $requested->getModelId(),
+            configurationIdentifier: $requested->getIdentifier(),
+            beUser: $this->resolveBeUser($context),
+            success: $success,
+            errorClass: $errorClass,
+            latencyMs: $latencyMs,
+            cacheHit: false,
+            fallbackAttempts: $context->telemetrySignals->fallbackAttempts,
+            timeToFirstTokenMs: $timeToFirstTokenMs,
+        ));
+    }
+
+    private function resolveProvider(ProviderCallContext $context, LlmConfiguration $served): string
+    {
+        $fromConfig = $served->getProviderType();
+        if ($fromConfig !== '') {
+            return $fromConfig;
+        }
+
+        $fromMetadata = $context->metadata[self::METADATA_PROVIDER] ?? null;
+        if (\is_string($fromMetadata) && $fromMetadata !== '') {
+            return $fromMetadata;
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * Backend-user attribution: caller-supplied uid (same key BudgetMiddleware
+     * enforces on), else the ambient backend.user aspect, else 0 (CLI /
+     * scheduler / unauthenticated) — mirroring TelemetryMiddleware.
+     */
+    private function resolveBeUser(ProviderCallContext $context): int
+    {
+        $fromMetadata = $context->metadata[BudgetMiddleware::METADATA_BE_USER_UID] ?? null;
+        if (\is_int($fromMetadata)) {
+            return $fromMetadata;
+        }
+
+        try {
+            return (int)$this->context->getAspect('backend.user')->get('id');
+        } catch (AspectNotFoundException) {
+            return 0;
+        }
+    }
+
+    /**
+     * The correlation id + operation every streaming log line carries, so the
+     * two keys live in one place rather than being repeated at each call site.
+     * Per-event fields merge on top.
+     *
+     * @param array<string, mixed> $extra
+     *
+     * @return array<string, mixed>
+     */
+    private function logContext(ProviderCallContext $context, array $extra = []): array
+    {
+        return [
+            'correlationId' => $context->correlationId,
+            'operation'     => $context->operation->value,
+            ...$extra,
+        ];
+    }
+
+    /**
+     * Rough token estimate from a character count (≈4 chars / token), the same
+     * heuristic RenderedPrompt / GeminiProvider already use. Streaming providers
+     * expose no exact usage frame on this path; see the class doc block.
+     */
+    private function estimateTokens(int $chars): int
+    {
+        if ($chars <= 0) {
+            return 0;
+        }
+
+        return (int)\ceil($chars / self::CHARS_PER_TOKEN);
+    }
+
+    private function elapsedMs(int|float $startNs, int|float|null $endNs = null): int
+    {
+        $endNs ??= hrtime(true);
+
+        return (int)(($endNs - $startNs) / 1_000_000);
+    }
+
+    private function readInt(ProviderCallContext $context, string $key): int
+    {
+        $value = $context->metadata[$key] ?? null;
+
+        return \is_int($value) ? $value : 0;
+    }
+
+    private function readNullableInt(ProviderCallContext $context, string $key): ?int
+    {
+        $value = $context->metadata[$key] ?? null;
+
+        return \is_int($value) ? $value : null;
+    }
+
+    private function readFloat(ProviderCallContext $context, string $key): float
+    {
+        $value = $context->metadata[$key] ?? null;
+
+        return (\is_float($value) || \is_int($value)) ? (float)$value : 0.0;
+    }
+
+    /**
+     * Telemetry defaults ON, disabled only by an explicit falsey
+     * `telemetry.enabled` extension setting — identical to TelemetryMiddleware
+     * so a streamed run and a pipelined run share one toggle.
+     */
+    private function telemetryEnabled(): bool
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            return true;
+        }
+
+        $telemetry = \is_array($config['telemetry'] ?? null) ? $config['telemetry'] : [];
+        if (!\array_key_exists('enabled', $telemetry)) {
+            return true;
+        }
+
+        return (bool)$telemetry['enabled'];
+    }
+}

--- a/Classes/Service/Telemetry/TelemetryRecord.php
+++ b/Classes/Service/Telemetry/TelemetryRecord.php
@@ -19,6 +19,15 @@ namespace Netresearch\NrLlm\Service\Telemetry;
  */
 final readonly class TelemetryRecord
 {
+    /**
+     * @param ?int $timeToFirstTokenMs wall-clock milliseconds from the start of
+     *                                 the run to the first streamed chunk. Only
+     *                                 the streaming lifecycle (ADR-062) supplies
+     *                                 it; every non-streaming pipeline run leaves
+     *                                 it null (there is no partial-response
+     *                                 milestone to measure), which is stored as
+     *                                 SQL NULL — distinct from a genuine 0 ms.
+     */
     public function __construct(
         public string $correlationId,
         public string $operation,
@@ -31,5 +40,6 @@ final readonly class TelemetryRecord
         public int $latencyMs,
         public bool $cacheHit,
         public int $fallbackAttempts,
+        public ?int $timeToFirstTokenMs = null,
     ) {}
 }

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -42,6 +42,7 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             'latency_ms'               => $record->latencyMs,
             'cache_hit'                => $record->cacheHit ? 1 : 0,
             'fallback_attempts'        => $record->fallbackAttempts,
+            'time_to_first_token_ms'   => $record->timeToFirstTokenMs,
             'crdate'                   => time(),
         ]);
     }

--- a/Documentation/Adr/Adr009StreamingImplementation.rst
+++ b/Documentation/Adr/Adr009StreamingImplementation.rst
@@ -73,3 +73,28 @@ Consequences
 
 **Net Score:** +3.5 (Positive impact - streaming UX
 benefits outweigh implementation complexity)
+
+.. _adr-009-lifecycle:
+
+Update (2026-07): streaming is in the request lifecycle
+=======================================================
+
+The generator mechanism decided here is unchanged, but streamed calls no longer
+sidestep the cross-cutting concerns the non-streaming path enforces. Originally
+a streamed call ran no budget pre-flight and produced neither a usage nor a
+telemetry row — a live budget hole.
+
+Streamed calls now run through a dedicated streaming lifecycle
+(:ref:`adr-062`): an eager budget pre-flight before the first chunk,
+pre-first-chunk provider fallback, time-to-first-token measurement, and a
+``finally`` that records usage (:sql:`tx_nrllm_service_usage`) and telemetry
+(:sql:`tx_nrllm_telemetry`) on every exit — completion, exception, or an
+abandoned generator. The lifecycle wraps the generator; the public
+:php:`Generator`\<int, string, mixed, void> contract is unchanged.
+
+Two of the "Negative" consequences above are now bounded rather than open:
+"error handling complexity" and "connection management" are handled once, in the
+lifecycle, instead of at each call site. "No response object until complete" and
+"no caching possible" remain intrinsic to streaming. Token usage on this path is
+*estimated* (providers expose no usage frame mid-stream); see :ref:`adr-062` for
+the rationale and the follow-up toward exact figures.

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -178,9 +178,12 @@ the test matrix keeps green end-to-end:
    :php:`ProviderCallContext` metadata, not from the configuration.
 
    Streaming (:php:`streamChat` / :php:`streamChatWithConfiguration`)
-   deliberately stays out of the pipeline per the ADR's original scope:
-   once the first chunk has been emitted, we cannot swap providers
-   mid-stream, and most middleware assume a single terminal result.
+   stays out of *this* pipeline — a lazy generator wrapped as the terminal
+   would make every middleware fire against a not-yet-started stream — but is
+   no longer an unaccounted bypass. It runs through an equivalent streaming
+   lifecycle (:ref:`adr-062`) that applies the same budget pre-flight, usage,
+   and telemetry, plus pre-first-chunk fallback. The single asymmetry is that
+   a provider swap is impossible once the first chunk has been emitted.
 
    **Why the centralised form rather than "every feature service owns
    glue":** the ADR's problem statement explicitly identifies direct
@@ -273,17 +276,17 @@ In every case the bypass is deliberate:
 * **Cache** — caching the result of a probe would defeat the purpose
   of probing.
 
-Together with streaming (see :ref:`adr-026-followups` step 5 — once
-the first chunk has been emitted we cannot swap providers
-mid-stream, and most middleware assume a single terminal result),
-these three diagnostic actions are the documented exemptions from
-the "productive provider calls go through the pipeline" rule. There
-are no others. New diagnostic / health-check entry points should
-follow the same pattern as the three listed here: build the adapter
-via :php:`ProviderAdapterRegistry`, call the capability method
-directly, sanitize and surface the error themselves. New
-non-streaming *productive* entry points must go through
-:php:`MiddlewarePipeline::run()`.
+These three diagnostic actions are the documented exemptions from the
+"productive provider calls are accounted for" rule — they run no budget,
+usage, telemetry, or fallback on purpose. There are no others. Streaming is
+**not** an exemption: it does not use :php:`MiddlewarePipeline::run()` (a lazy
+generator cannot be wrapped as the terminal), but it runs an equivalent
+lifecycle (:ref:`adr-062`) that applies the same accounting. New diagnostic /
+health-check entry points should follow the same pattern as the three listed
+here: build the adapter via :php:`ProviderAdapterRegistry`, call the capability
+method directly, sanitize and surface the error themselves. New non-streaming
+*productive* entry points must go through :php:`MiddlewarePipeline::run()`;
+new streaming entry points must go through the streaming lifecycle.
 
 .. _adr-026-alternatives:
 

--- a/Documentation/Adr/Adr062StreamingLifecycle.rst
+++ b/Documentation/Adr/Adr062StreamingLifecycle.rst
@@ -1,0 +1,178 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-062:
+
+==========================================
+ADR-062: Streaming Request Lifecycle
+==========================================
+
+:Status: Accepted
+:Date: 2026-07
+:Authors: Netresearch DTT GmbH
+
+.. _adr-062-context:
+
+Context
+=======
+
+Every non-streaming provider call goes through the middleware pipeline
+(:ref:`adr-026`) and so inherits budget pre-flight (:ref:`adr-025`), usage
+accounting, and telemetry (:ref:`adr-058`). Streaming did not: both
+:php:`LlmServiceManager::streamChat()` and
+:php:`streamChatWithConfiguration()` called the provider's
+:php:`streamChatCompletion()` generator directly and returned it to the caller.
+
+The consequence was a live budget hole. A streamed chat:
+
+* ran **no** budget pre-flight — an over-budget user could stream freely;
+* produced **no** usage row in :sql:`tx_nrllm_service_usage`, so streamed
+  tokens were invisible to cost dashboards and to the very budget aggregate
+  that is supposed to gate the next call;
+* produced **no** telemetry row in :sql:`tx_nrllm_telemetry`, so a streamed
+  call had no latency, no outcome, and no correlation id on record;
+* had no fallback, not even in the window where one is still possible.
+
+The pipeline cannot simply be reused. A PHP generator is **lazy**: calling
+:php:`streamChatCompletion()` returns a suspended generator without running a
+line of it. Wrapping that as the pipeline terminal makes every middleware run
+against a stream that has not started — Budget would gate nothing meaningful,
+:php:`UsageMiddleware` (which records *after* the terminal returns) would record
+zero tokens, and :php:`TelemetryMiddleware` would measure a near-zero latency.
+This laziness is exactly why :ref:`adr-026` sanctioned streaming as a documented
+pipeline bypass.
+
+.. _adr-062-decision:
+
+Decision
+========
+
+Introduce a dedicated streaming lifecycle rather than forcing streams through
+the response pipeline. A single private collaborator,
+:php:`Netresearch\NrLlm\Service\Streaming\StreamingDispatcher`, owns it; the
+manager's two streaming methods build an *opener* closure and hand off to it.
+The dispatcher is a **wrapping generator** — it never changes the public
+:php:`Generator`\<int, string, mixed, void> contract the seven providers and
+their consumers rely on.
+
+The lifecycle has four stages:
+
+1. **Budget pre-flight — eager.** :php:`StreamingDispatcher::stream()` runs the
+   same :php:`BudgetService::check()` gate as :php:`BudgetMiddleware` *before* it
+   returns a generator, so an over-budget caller is rejected at call time with a
+   typed :php:`BudgetExceededException` — not lazily on first iteration. This is
+   the one part that must be eager: a caller that never drains the stream is
+   never charged, but a caller that is already over budget must never receive a
+   stream to drain.
+
+2. **Provider selection with fallback — before the first chunk only.** The
+   dispatcher walks the primary configuration's fallback chain (shallow, exactly
+   as :php:`FallbackMiddleware` does) and *primes* each candidate generator
+   (``rewind()``) inside a try/catch. Priming runs the provider up to its first
+   yield — the HTTP request and first delta — which is the last moment a
+   provider can still be swapped. A retryable failure here
+   (:php:`ProviderConnectionException`, or a ``429``
+   :php:`ProviderResponseException`) moves to the next candidate; a non-retryable
+   failure bubbles up unchanged. Once a chunk has been handed to the caller a
+   swap is impossible, so **fallback stops at the first chunk**. That single
+   asymmetry with the non-streaming pipeline is intrinsic to streaming, not a
+   shortcut.
+
+3. **Drain accounting — lazy.** As the caller drains, the wrapper re-yields each
+   chunk, appends it to a completion buffer, and stamps the time-to-first-token
+   on the first chunk delivered.
+
+4. **Settlement — in a ``finally``.** Usage and telemetry are written in the
+   drain generator's ``finally`` block, so they land on **every** exit path:
+   normal completion, a mid-stream exception, and an abandoned generator (client
+   disconnect or a consumer ``break``). PHP runs a suspended generator's
+   ``finally`` when the generator is destroyed, which is what makes early-break
+   accounting work without a caller callback. An abandoned stream therefore
+   records the **partial** tokens actually produced, never zero and never the
+   full amount.
+
+.. _adr-062-usage-estimation:
+
+Token counts are estimated
+==========================
+
+The seven streaming adapters yield only text deltas and return ``void`` — none
+emits a usage frame at stream end. Real per-token usage is therefore *not
+available* on this path today. The dispatcher estimates it with the ≈4
+chars/token heuristic already used by
+:php:`RenderedPrompt::estimateTokens()`: the caller passes the prompt character
+count on the context metadata (it holds the messages; the dispatcher never sees
+the payload, honouring the :ref:`adr-026` "context carries no payload" rule) and
+the dispatcher counts the drained completion text.
+
+Recording an estimate is a deliberate improvement over the previous state, which
+recorded nothing at all — for budget enforcement an approximate figure is far
+better than a silent zero. Exact stream usage would require enabling
+provider-level usage frames (OpenAI ``stream_options.include_usage``, Anthropic
+``message_delta`` usage, …) and threading them out of the generator without
+breaking its ``string`` yield type — a follow-up, tracked separately, that would
+replace the estimate with the reported figure where a provider supports it.
+
+.. _adr-062-attribution:
+
+Attribution
+===========
+
+Mirroring the non-streaming split (:ref:`adr-058`):
+
+* **Telemetry** names the *requested* primary configuration; a pre-first-chunk
+  swap shows as ``fallback_attempts > 0``. ``cache_hit`` is always ``false`` —
+  streaming never caches. A new nullable ``time_to_first_token_ms`` column
+  carries the TTFT; it is ``NULL`` for every non-streaming row (there is no
+  partial-response milestone to measure), deliberately distinct from a real
+  ``0 ms``.
+* **Usage** attributes to the configuration that actually *served* — after a
+  fallback swap that is the fallback's provider/model/uid, not the primary's.
+  For an ad-hoc stream (a pinned provider with no configuration entity) the
+  served provider comes from the context metadata the manager sets.
+
+.. _adr-062-scope:
+
+Scope
+=====
+
+* New :php:`StreamingDispatcher` (private service, autowired) and the
+  :php:`LlmServiceManager` wiring for both streaming entry points.
+* :php:`streamChatWithConfiguration()` gains a trailing ``array $metadata = []``
+  parameter so streamed calls can carry budget attribution; it is additive and
+  the three-argument callers stay source-compatible.
+  :php:`LlmServiceManagerInterface` — a Category-1 public API — keeps its
+  :php:`Generator` return contract, so this is backward compatible.
+* :php:`tx_nrllm_telemetry` gains the nullable ``time_to_first_token_ms`` column
+  and :php:`TelemetryRecord` a matching trailing nullable field.
+* :ref:`adr-009` and :ref:`adr-026` updated: streaming is no longer a documented
+  bypass.
+
+.. _adr-062-alternatives:
+
+Alternatives considered
+=======================
+
+* **Route the generator through the existing pipeline.** Rejected: generator
+  laziness makes every middleware fire against a not-yet-started stream
+  (see Context). Budget, usage, and telemetry would all be wrong.
+* **Change the provider yield type to carry a final usage object**
+  (``Generator<int, string|UsageStatistics, …>``). Rejected: the ``string``
+  yield type is part of the public capability contract; every consumer would
+  have to defend against a non-string chunk. Real usage belongs on the
+  generator *return* value or a side channel, tracked as the follow-up above.
+* **Eager drain inside the manager, then hand back a plain array.** Rejected:
+  it defeats the entire point of streaming (memory efficiency, real-time
+  output) and would change the public :php:`Generator` return type.
+
+.. _adr-062-references:
+
+References
+==========
+
+* :ref:`adr-009` — Streaming Implementation (the generator mechanism this
+  lifecycle wraps).
+* :ref:`adr-025` — Per-User AI Budgets (the pre-flight gate).
+* :ref:`adr-026` — Provider Middleware Pipeline (why streaming could not use it,
+  now no longer a sanctioned bypass).
+* :ref:`adr-058` — Telemetry Middleware (the row shape and attribution model
+  streaming reuses).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -360,4 +360,5 @@ Tools
    Adr059DecomposeLlmServiceManager
    Adr060QualityEvaluation
    Adr061SkillTrustEgressAndAudit
+   Adr062StreamingLifecycle
    Adr065ReducePublicServiceSurface

--- a/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Streaming;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end proof that the streaming lifecycle lands a real row in BOTH
+ * accounting tables (ADR-062), using the production UsageTrackerService and
+ * TelemetryRepository against the test database — the persistence the previous
+ * bypass never produced.
+ */
+#[CoversClass(StreamingDispatcher::class)]
+final class StreamingDispatcherTest extends AbstractFunctionalTestCase
+{
+    private const USAGE_TABLE     = 'tx_nrllm_service_usage';
+    private const TELEMETRY_TABLE = 'tx_nrllm_telemetry';
+
+    private StreamingDispatcher $dispatcher;
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionPool = $this->getService(ConnectionPool::class);
+
+        $this->dispatcher = new StreamingDispatcher(
+            $this->getService(BudgetServiceInterface::class),
+            $this->getService(UsageTrackerServiceInterface::class),
+            new TelemetryRepository($this->connectionPool),
+            $this->getService(LlmConfigurationRepository::class),
+            new NullLogger(),
+            $this->getService(Context::class),
+            $this->getService(ExtensionConfiguration::class),
+        );
+    }
+
+    #[Test]
+    public function aStreamedCallPersistsUsageAndTelemetryRows(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('ad-hoc:stream:openai');
+
+        $context = new ProviderCallContext(
+            ProviderOperation::Stream,
+            'func-stream-corr',
+            [
+                BudgetMiddleware::METADATA_BE_USER_UID     => 5,
+                StreamingDispatcher::METADATA_PROVIDER      => 'openai',
+                StreamingDispatcher::METADATA_PROMPT_CHARS  => 8,
+            ],
+        );
+
+        $chunks = iterator_to_array($this->dispatcher->stream(
+            $context,
+            $configuration,
+            static function (): Generator {
+                yield 'Hello';
+                yield ' World';
+            },
+        ));
+
+        self::assertSame(['Hello', ' World'], $chunks);
+
+        // Usage row: tx_nrllm_service_usage.
+        $usage = $this->connectionPool
+            ->getConnectionForTable(self::USAGE_TABLE)
+            ->select(['*'], self::USAGE_TABLE, ['service_type' => 'stream'])
+            ->fetchAssociative();
+
+        self::assertIsArray($usage, 'A streamed call must write a usage row.');
+        self::assertSame('openai', $usage['service_provider']);
+        self::assertSame(5, (int)$usage['be_user']);
+        self::assertGreaterThan(0, (int)$usage['tokens_used']);
+        self::assertGreaterThan(0, (int)$usage['completion_tokens']);
+        self::assertSame(1, (int)$usage['request_count']);
+
+        // Telemetry row: tx_nrllm_telemetry.
+        $telemetry = $this->connectionPool
+            ->getConnectionForTable(self::TELEMETRY_TABLE)
+            ->select(['*'], self::TELEMETRY_TABLE, ['correlation_id' => 'func-stream-corr'])
+            ->fetchAssociative();
+
+        self::assertIsArray($telemetry, 'A streamed call must write a telemetry row.');
+        self::assertSame('stream', $telemetry['operation']);
+        self::assertSame(1, (int)$telemetry['success']);
+        self::assertSame('ad-hoc:stream:openai', $telemetry['configuration_identifier']);
+        // TTFT is populated for a streamed run (NULL only for non-streaming rows).
+        self::assertNotNull($telemetry['time_to_first_token_ms']);
+    }
+}

--- a/Tests/LlmServiceManagerTestFactory.php
+++ b/Tests/LlmServiceManagerTestFactory.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\MessageShaper;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -32,9 +33,12 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * construction into dedicated collaborators, changing the manager's
  * constructor. This factory keeps the previous test call shape — extension
  * configuration, logger, adapter registry, pipeline, cache manager, optional
- * configuration repository and optional skill injection, in that order — and
- * wires the new collaborators internally, so the existing constructions did not
- * each have to spell them out. Production wiring is autowired via Services.yaml.
+ * configuration repository, skill injection, model selection and streaming
+ * dispatcher, in that order — and wires the new collaborators internally, so the
+ * existing constructions did not each have to spell them out. A null streaming
+ * dispatcher (the default) keeps the manager on the legacy raw-generator
+ * streaming path, so tests that do not exercise the lifecycle are unaffected.
+ * Production wiring is autowired via Services.yaml.
  */
 trait LlmServiceManagerTestFactory
 {
@@ -47,6 +51,7 @@ trait LlmServiceManagerTestFactory
         ?LlmConfigurationRepository $configurationRepository = null,
         ?SkillInjectionService $skillInjection = null,
         ?ModelSelectionServiceInterface $modelSelectionService = null,
+        ?StreamingDispatcher $streaming = null,
     ): LlmServiceManager {
         return new LlmServiceManager(
             $adapterRegistry,
@@ -57,6 +62,7 @@ trait LlmServiceManagerTestFactory
             new EmbedCacheKeyBuilder($cacheManager),
             $skillInjection,
             $modelSelectionService,
+            $streaming,
         );
     }
 }

--- a/Tests/Unit/Fixture/RecordingUsageTracker.php
+++ b/Tests/Unit/Fixture/RecordingUsageTracker.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Fixture;
+
+use DateTimeInterface;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+
+/**
+ * In-memory usage tracker for unit tests.
+ *
+ * Captures each trackUsage() call so assertions verify the arguments a
+ * collaborator produced, never a mock return. The read methods return empty
+ * shapes — tests that need them should use a dedicated double.
+ */
+final class RecordingUsageTracker implements UsageTrackerServiceInterface
+{
+    /**
+     * @var list<array{
+     *     serviceType: string,
+     *     provider: string,
+     *     metrics: array<string, mixed>,
+     *     configurationUid: ?int,
+     *     modelUid: int,
+     *     modelId: string,
+     *     taskUid: int,
+     *     beUserUid: ?int,
+     * }>
+     */
+    public array $calls = [];
+
+    public function trackUsage(
+        string $serviceType,
+        string $provider,
+        array $metrics = [],
+        ?int $configurationUid = null,
+        int $modelUid = 0,
+        string $modelId = '',
+        int $taskUid = 0,
+        ?int $beUserUid = null,
+    ): void {
+        $this->calls[] = [
+            'serviceType'      => $serviceType,
+            'provider'         => $provider,
+            'metrics'          => $metrics,
+            'configurationUid' => $configurationUid,
+            'modelUid'         => $modelUid,
+            'modelId'          => $modelId,
+            'taskUid'          => $taskUid,
+            'beUserUid'        => $beUserUid,
+        ];
+    }
+
+    public function getUsageReport(string $serviceType, DateTimeInterface $from, DateTimeInterface $to): array
+    {
+        return [];
+    }
+
+    public function getUserUsage(int $beUserUid, DateTimeInterface $from, DateTimeInterface $to): array
+    {
+        return [];
+    }
+
+    public function getTodayUsage(string $serviceType, string $provider): ?array
+    {
+        return null;
+    }
+
+    public function getCurrentMonthCost(): float
+    {
+        return 0.0;
+    }
+}

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service;
 
 use Exception;
 use Generator;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\DTO\FallbackChain;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
@@ -37,6 +38,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
@@ -44,12 +46,18 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingUsageTracker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\AspectInterface;
+use TYPO3\CMS\Core\Context\Context;
 
 #[CoversClass(LlmServiceManager::class)]
 class LlmServiceManagerTest extends AbstractUnitTestCase
@@ -1419,6 +1427,112 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $this->expectExceptionMessage('does not support streaming');
 
         iterator_to_array($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config));
+    }
+
+    /**
+     * When a StreamingDispatcher is wired the manager routes streamChat through
+     * it, so a streamed call lands in the usage and telemetry tables just like a
+     * non-streaming call (ADR-062). The unwired constructions in the other
+     * streaming tests keep the legacy raw-generator path.
+     */
+    #[Test]
+    public function streamChatRoutesThroughTheStreamingLifecycleWhenWired(): void
+    {
+        $usage     = new RecordingUsageTracker();
+        $telemetry = new InMemoryTelemetryRepository();
+
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            $this->streamingDispatcher($usage, $telemetry),
+        );
+        $manager->registerProvider(new TestableStreamingProvider());
+
+        $chunks = iterator_to_array($manager->streamChat(
+            [['role' => 'user', 'content' => 'Hi']],
+            new ChatOptions(provider: 'openai-stream'),
+        ));
+
+        self::assertSame(['Hello', ' World'], $chunks);
+
+        self::assertCount(1, $usage->calls);
+        self::assertSame('stream', $usage->calls[0]['serviceType']);
+        self::assertSame('openai-stream', $usage->calls[0]['provider']);
+
+        self::assertCount(1, $telemetry->records);
+        self::assertSame('stream', $telemetry->records[0]->operation);
+        self::assertTrue($telemetry->records[0]->success);
+    }
+
+    /**
+     * The capability check must fire eagerly (at call time), not lazily on the
+     * first iteration, even in the wired path — consistent with the legacy path
+     * and non-streaming calls (ADR-062 review finding 3).
+     */
+    #[Test]
+    public function streamChatWithConfigurationRejectsANonStreamingProviderEagerlyWhenWired(): void
+    {
+        $model  = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $nonStreaming = self::createStub(ProviderInterface::class);
+        $nonStreaming->method('getIdentifier')->willReturn('non-streaming');
+        $registry = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registry->method('createAdapterFromModel')->willReturn($nonStreaming);
+
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registry,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            $this->streamingDispatcher(new RecordingUsageTracker(), new InMemoryTelemetryRepository()),
+        );
+
+        $this->expectException(UnsupportedFeatureException::class);
+        $this->expectExceptionMessage('does not support streaming');
+
+        // No iteration: the throw must come from the call itself, proving the
+        // check is eager rather than deferred into the dispatcher generator.
+        $manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hi']], $config);
+    }
+
+    private function streamingDispatcher(
+        RecordingUsageTracker $usage,
+        InMemoryTelemetryRepository $telemetry,
+    ): StreamingDispatcher {
+        $budget = self::createStub(BudgetServiceInterface::class);
+        $budget->method('check')->willReturn(BudgetCheckResult::allowed());
+
+        $aspect = self::createStub(AspectInterface::class);
+        $aspect->method('get')->willReturn(0);
+        $context = self::createStub(Context::class);
+        $context->method('getAspect')->willReturn($aspect);
+
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['telemetry' => ['enabled' => '1']]);
+
+        return new StreamingDispatcher(
+            $budget,
+            $usage,
+            $telemetry,
+            self::createStub(LlmConfigurationRepository::class),
+            new NullLogger(),
+            $context,
+            $extensionConfiguration,
+        );
     }
 
     // ====================================================================

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -1,0 +1,544 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Streaming;
+
+use Generator;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingUsageTracker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\AspectInterface;
+use TYPO3\CMS\Core\Context\Context;
+
+#[CoversClass(StreamingDispatcher::class)]
+final class StreamingDispatcherTest extends AbstractUnitTestCase
+{
+    private RecordingUsageTracker $usage;
+
+    private InMemoryTelemetryRepository $telemetry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->usage     = new RecordingUsageTracker();
+        $this->telemetry = new InMemoryTelemetryRepository();
+    }
+
+    #[Test]
+    public function drainsEveryChunkFromTheInnerStream(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['Hello', ' ', 'World']),
+        ));
+
+        self::assertSame(['Hello', ' ', 'World'], $chunks);
+    }
+
+    #[Test]
+    public function rejectsAnOverBudgetCallerEagerlyBeforeOpeningTheStream(): void
+    {
+        $opened     = false;
+        $dispatcher = $this->dispatcher($this->budget(BudgetCheckResult::denied('cost_per_day', 5.0, 4.0)));
+
+        try {
+            // Budget is checked in stream() itself, before a generator exists,
+            // so the throw happens at call time — not on first iteration.
+            $dispatcher->stream(
+                $this->context([BudgetMiddleware::METADATA_BE_USER_UID => 7]),
+                $this->configuration('primary'),
+                function () use (&$opened): Generator {
+                    $opened = true;
+                    yield 'never';
+                },
+            );
+            self::fail('Expected BudgetExceededException.');
+        } catch (BudgetExceededException) {
+            // expected
+        }
+
+        self::assertFalse($opened, 'The stream must not be opened for an over-budget caller.');
+        self::assertSame([], $this->usage->calls);
+        self::assertSame([], $this->telemetry->records);
+    }
+
+    #[Test]
+    public function recordsEstimatedUsageAndTelemetryOnSuccess(): void
+    {
+        $model = $this->model(pricing: true, cost: 0.25);
+        $dispatcher = $this->dispatcher();
+
+        // 12 prompt chars => ceil(12/4) = 3 tokens; "Hello World" = 11 chars => ceil(11/4) = 3 tokens.
+        iterator_to_array($dispatcher->stream(
+            $this->context([
+                BudgetMiddleware::METADATA_BE_USER_UID       => 42,
+                StreamingDispatcher::METADATA_PROMPT_CHARS   => 12,
+            ]),
+            $this->configuration('primary', providerType: 'openai', modelId: 'gpt-4o', model: $model, uid: 9),
+            $this->staticStream(['Hello', ' World']),
+        ));
+
+        self::assertCount(1, $this->usage->calls);
+        $call = $this->usage->calls[0];
+        self::assertSame('stream', $call['serviceType']);
+        self::assertSame('openai', $call['provider']);
+        self::assertSame(3, $call['metrics']['promptTokens']);
+        self::assertSame(3, $call['metrics']['completionTokens']);
+        self::assertSame(6, $call['metrics']['tokens']);
+        self::assertSame(0.25, $call['metrics']['cost']);
+        self::assertSame(9, $call['configurationUid']);
+        self::assertSame('gpt-4o', $call['modelId']);
+        self::assertSame(42, $call['beUserUid']);
+
+        self::assertCount(1, $this->telemetry->records);
+        $record = $this->telemetry->records[0];
+        self::assertSame('stream', $record->operation);
+        self::assertSame('corr-1', $record->correlationId);
+        self::assertSame('primary', $record->configurationIdentifier);
+        self::assertTrue($record->success);
+        self::assertSame('', $record->errorClass);
+        self::assertFalse($record->cacheHit);
+        self::assertSame(0, $record->fallbackAttempts);
+        self::assertNotNull($record->timeToFirstTokenMs);
+        self::assertGreaterThanOrEqual(0, $record->timeToFirstTokenMs);
+    }
+
+    #[Test]
+    public function omitsCostWhenTheServedModelHasNoPricing(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            $this->configuration('primary', providerType: 'ollama', model: $this->model(pricing: false)),
+            $this->staticStream(['hi']),
+        ));
+
+        self::assertCount(1, $this->usage->calls);
+        self::assertArrayNotHasKey('cost', $this->usage->calls[0]['metrics']);
+    }
+
+    #[Test]
+    public function fallsBackToTheAdHocProviderMetadataWhenTheConfigHasNoProviderType(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([
+                StreamingDispatcher::METADATA_PROMPT_CHARS => 4,
+                StreamingDispatcher::METADATA_PROVIDER      => 'groq',
+            ]),
+            // Transient ad-hoc configuration: empty provider type.
+            $this->configuration('ad-hoc:stream:groq'),
+            $this->staticStream(['x']),
+        ));
+
+        self::assertSame('groq', $this->usage->calls[0]['provider']);
+    }
+
+    #[Test]
+    public function settlesPartialUsageWhenTheConsumerBreaksEarly(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        $generator = $dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 0]),
+            $this->configuration('primary', providerType: 'openai'),
+            $this->staticStream(['aaaa', 'bbbb', 'cccc']),
+        );
+
+        $seen = [];
+        foreach ($generator as $chunk) {
+            $seen[] = $chunk;
+            break; // abandon after the first chunk
+        }
+        // Destroying the suspended generator runs its finally (settlement).
+        unset($generator);
+
+        self::assertSame(['aaaa'], $seen);
+        self::assertCount(1, $this->usage->calls, 'Partial usage must be recorded on early break.');
+        // Only the first 4-char chunk was drained => 1 completion token.
+        self::assertSame(1, $this->usage->calls[0]['metrics']['completionTokens']);
+
+        self::assertCount(1, $this->telemetry->records);
+        $record = $this->telemetry->records[0];
+        self::assertFalse($record->success, 'An abandoned stream did not complete.');
+        self::assertSame('', $record->errorClass, 'An early break is not an exception.');
+    }
+
+    #[Test]
+    public function recordsFailureTelemetryAndPartialUsageWhenTheStreamThrowsMidway(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        $open = function (): Generator {
+            yield 'partial';
+
+            throw new RuntimeException('mid-stream boom', 1495872185);
+        };
+
+        $caught = false;
+        try {
+            iterator_to_array($dispatcher->stream(
+                $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 0]),
+                $this->configuration('primary', providerType: 'openai'),
+                $open,
+            ));
+        } catch (RuntimeException $e) {
+            $caught = true;
+            self::assertSame('mid-stream boom', $e->getMessage());
+        }
+
+        self::assertTrue($caught, 'The original mid-stream exception must propagate.');
+
+        // Output was produced before the failure => partial usage is billed.
+        self::assertCount(1, $this->usage->calls);
+
+        self::assertCount(1, $this->telemetry->records);
+        $record = $this->telemetry->records[0];
+        self::assertFalse($record->success);
+        self::assertSame(RuntimeException::class, $record->errorClass);
+    }
+
+    #[Test]
+    public function swapsToAFallbackConfigurationWhenThePrimaryFailsBeforeTheFirstChunk(): void
+    {
+        $fallback = $this->configuration('fallback', providerType: 'claude', modelId: 'claude', uid: 5);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($fallback);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            modelId: 'gpt-4o',
+            fallbackChain: new FallbackChain(['primary', 'fallback']),
+        );
+
+        // A generator that fails on priming (rewind) with a retryable error;
+        // the fallback yields real chunks.
+        $open = function (LlmConfiguration $config): Generator {
+            if ($config->getIdentifier() === 'primary') {
+                throw new ProviderConnectionException('primary down', 1495872186);
+            }
+
+            yield 'served';
+            yield '-by-fallback';
+        };
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            $primary,
+            $open,
+        ));
+
+        self::assertSame(['served', '-by-fallback'], $chunks);
+
+        // Telemetry names the REQUESTED primary; the swap shows as a fallback attempt.
+        self::assertCount(1, $this->telemetry->records);
+        $record = $this->telemetry->records[0];
+        self::assertSame('primary', $record->configurationIdentifier);
+        self::assertSame('openai', $record->provider);
+        self::assertSame(1, $record->fallbackAttempts);
+        self::assertTrue($record->success);
+
+        // Usage attributes to the configuration that actually SERVED.
+        self::assertSame('claude', $this->usage->calls[0]['provider']);
+        self::assertSame(5, $this->usage->calls[0]['configurationUid']);
+    }
+
+    #[Test]
+    public function countsEveryDispatchedSiblingIncludingRetryablyFailedOnesBeforeSuccess(): void
+    {
+        $fb1 = $this->configuration('fb1', providerType: 'groq');
+        $fb2 = $this->configuration('fb2', providerType: 'claude', modelId: 'claude', uid: 7);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturnMap([['fb1', $fb1], ['fb2', $fb2]]);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            fallbackChain: new FallbackChain(['fb1', 'fb2']),
+        );
+
+        // Primary and fb1 fail priming retryably; fb2 serves. Both dispatched
+        // siblings must be counted, not only the winner.
+        $open = function (LlmConfiguration $config): Generator {
+            if ($config->getIdentifier() === 'fb2') {
+                yield 'served';
+
+                return;
+            }
+
+            throw new ProviderConnectionException($config->getIdentifier() . ' down', 1495872190);
+        };
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            $primary,
+            $open,
+        ));
+
+        self::assertSame(['served'], $chunks);
+        self::assertSame(2, $this->telemetry->records[0]->fallbackAttempts);
+        self::assertTrue($this->telemetry->records[0]->success);
+    }
+
+    #[Test]
+    public function countsEveryDispatchedSiblingOnTotalExhaustion(): void
+    {
+        $fb1 = $this->configuration('fb1', providerType: 'groq');
+        $fb2 = $this->configuration('fb2', providerType: 'claude');
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturnMap([['fb1', $fb1], ['fb2', $fb2]]);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            fallbackChain: new FallbackChain(['fb1', 'fb2']),
+        );
+
+        // Every candidate fails priming retryably: the chain is exhausted.
+        $open = static function (LlmConfiguration $config): Generator {
+            yield from [];
+
+            throw new ProviderConnectionException($config->getIdentifier() . ' down', 1495872191);
+        };
+
+        $caught = false;
+        try {
+            iterator_to_array($dispatcher->stream(
+                $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+                $primary,
+                $open,
+            ));
+        } catch (ProviderConnectionException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught, 'An exhausted streaming fallback chain must surface the last error.');
+        self::assertSame([], $this->usage->calls, 'A stream that produced nothing bills no usage.');
+        self::assertSame(2, $this->telemetry->records[0]->fallbackAttempts);
+        self::assertFalse($this->telemetry->records[0]->success);
+    }
+
+    #[Test]
+    public function doesNotFallBackAfterTheFirstChunkHasBeenYielded(): void
+    {
+        $fallback = $this->configuration('fallback', providerType: 'claude');
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($fallback);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            fallbackChain: new FallbackChain(['primary', 'fallback']),
+        );
+
+        // Fails AFTER the first chunk: a provider swap is no longer possible.
+        $open = function (LlmConfiguration $config): Generator {
+            yield 'first';
+
+            throw new ProviderConnectionException('dies mid-stream', 1495872187);
+        };
+
+        $seen   = [];
+        $caught = false;
+        try {
+            foreach ($dispatcher->stream($this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 0]), $primary, $open) as $chunk) {
+                $seen[] = $chunk;
+            }
+        } catch (ProviderConnectionException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught, 'A post-first-chunk failure must surface, not fall back.');
+        self::assertSame(['first'], $seen);
+        self::assertSame(0, $this->telemetry->records[0]->fallbackAttempts);
+        self::assertFalse($this->telemetry->records[0]->success);
+    }
+
+    #[Test]
+    public function propagatesANonRetryableFirstChunkFailureWithoutFallbackOrUsage(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        // 4xx rate-unrelated response => non-retryable. Thrown on priming
+        // (rewind) — `yield from []` makes this a generator so the throw fires
+        // when the stream is primed, exercising the isRetryable=false branch.
+        $open = static function (): Generator {
+            yield from [];
+
+            throw new ProviderResponseException('bad request', 400);
+        };
+
+        $caught = false;
+        try {
+            iterator_to_array($dispatcher->stream(
+                $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+                $this->configuration('primary', providerType: 'openai'),
+                $open,
+            ));
+        } catch (ProviderResponseException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught);
+        self::assertSame([], $this->usage->calls, 'A stream that produced nothing bills no usage.');
+        self::assertCount(1, $this->telemetry->records);
+        self::assertFalse($this->telemetry->records[0]->success);
+        self::assertSame(ProviderResponseException::class, $this->telemetry->records[0]->errorClass);
+    }
+
+    #[Test]
+    public function stillRecordsUsageWhenTelemetryIsDisabled(): void
+    {
+        $dispatcher = $this->dispatcher(extensionConfiguration: $this->extensionConfiguration(false));
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            $this->configuration('primary', providerType: 'openai'),
+            $this->staticStream(['ok']),
+        ));
+
+        self::assertCount(1, $this->usage->calls, 'Usage/budget accounting is independent of the telemetry toggle.');
+        self::assertSame([], $this->telemetry->records, 'Telemetry must honour the disabled setting.');
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function dispatcher(
+        ?BudgetServiceInterface $budget = null,
+        ?LlmConfigurationRepository $repository = null,
+        ?ExtensionConfiguration $extensionConfiguration = null,
+    ): StreamingDispatcher {
+        return new StreamingDispatcher(
+            $budget ?? $this->budget(BudgetCheckResult::allowed()),
+            $this->usage,
+            $this->telemetry,
+            $repository ?? self::createStub(LlmConfigurationRepository::class),
+            new NullLogger(),
+            $this->contextWithAmbientUser(0),
+            $extensionConfiguration ?? $this->extensionConfiguration(true),
+        );
+    }
+
+    private function budget(BudgetCheckResult $result): BudgetServiceInterface
+    {
+        $budget = self::createStub(BudgetServiceInterface::class);
+        $budget->method('check')->willReturn($result);
+
+        return $budget;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function context(array $metadata = []): ProviderCallContext
+    {
+        return new ProviderCallContext(ProviderOperation::Stream, 'corr-1', $metadata);
+    }
+
+    /**
+     * @param list<string> $chunks
+     *
+     * @return callable(LlmConfiguration): Generator<int, string, mixed, void>
+     */
+    private function staticStream(array $chunks): callable
+    {
+        return static function () use ($chunks): Generator {
+            yield from $chunks;
+        };
+    }
+
+    private function configuration(
+        string $identifier,
+        string $providerType = '',
+        string $modelId = '',
+        ?Model $model = null,
+        ?int $uid = null,
+        ?FallbackChain $fallbackChain = null,
+    ): LlmConfiguration&MockObject {
+        $configuration = $this->createMock(LlmConfiguration::class);
+        $configuration->method('getIdentifier')->willReturn($identifier);
+        $configuration->method('getProviderType')->willReturn($providerType);
+        $configuration->method('getModelId')->willReturn($modelId);
+        $configuration->method('getLlmModel')->willReturn($model);
+        $configuration->method('getUid')->willReturn($uid);
+        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('getFallbackChainDTO')->willReturn($fallbackChain ?? new FallbackChain());
+
+        return $configuration;
+    }
+
+    private function model(bool $pricing, float $cost = 0.0): Model&MockObject
+    {
+        $model = $this->createMock(Model::class);
+        $model->method('getUid')->willReturn(3);
+        $model->method('hasPricing')->willReturn($pricing);
+        $model->method('estimateCost')->willReturn($cost);
+
+        return $model;
+    }
+
+    private function extensionConfiguration(bool $enabled): ExtensionConfiguration&MockObject
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')
+            ->willReturn(['telemetry' => ['enabled' => $enabled ? '1' : '0']]);
+
+        return $extensionConfiguration;
+    }
+
+    private function contextWithAmbientUser(int $id): Context
+    {
+        $aspect = self::createStub(AspectInterface::class);
+        $aspect->method('get')->willReturn($id);
+
+        $context = self::createStub(Context::class);
+        $context->method('getAspect')->willReturn($aspect);
+
+        return $context;
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -621,6 +621,11 @@ CREATE TABLE tx_nrllm_telemetry (
     cache_hit smallint(5) unsigned DEFAULT '0' NOT NULL,
     fallback_attempts smallint(5) unsigned DEFAULT '0' NOT NULL,
 
+    -- Time-to-first-token for streamed runs (ADR-062). NULL for every
+    -- non-streaming run — there is no partial-response milestone to measure —
+    -- which is deliberately distinct from a real 0 ms first token.
+    time_to_first_token_ms int(11) unsigned DEFAULT NULL,
+
     -- Standard TYPO3 field (append-only; no tstamp — rows are never updated)
     crdate int(11) unsigned DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
## Description

Streamed chats bypassed the middleware pipeline entirely — no budget pre-flight, no usage row, no telemetry row, no fallback. An over-budget user could stream freely and the streamed tokens were invisible to the very budget aggregate that gates the next call: a live budget hole. This brings streaming into an equivalent request lifecycle while keeping the public `Generator<int, string, mixed, void>` contract untouched.

### Why streaming cannot reuse the pipeline

A PHP generator is **lazy**: calling `streamChatCompletion()` returns a suspended generator without running a line of it. Wrapping that as the `MiddlewarePipeline` terminal makes every middleware fire against a not-yet-started stream — `BudgetMiddleware` would gate nothing, `UsageMiddleware` (which records *after* the terminal returns) would record zero tokens, and `TelemetryMiddleware` would measure a near-zero latency. That laziness is exactly why streaming was a sanctioned pipeline bypass (ADR-026).

### The streaming lifecycle

A dedicated, private `StreamingDispatcher` owns a wrapping-generator lifecycle. `LlmServiceManager` builds an *opener* closure (`callable(LlmConfiguration): Generator`, the same shape as a pipeline terminal) and hands off to it:

1. **Budget pre-flight — eager.** `stream()` runs the same `BudgetService::check()` gate as `BudgetMiddleware` *before* it returns a generator, so an over-budget caller is rejected at call time with a typed `BudgetExceededException`, not lazily on first iteration. A caller that never drains the stream is never charged; a caller already over budget never receives a stream to drain.
2. **Fallback — before the first chunk only.** The dispatcher walks the configuration's fallback chain (shallow, like `FallbackMiddleware`) and *primes* each candidate generator (`rewind()` — the HTTP request and first delta) inside a try/catch. A retryable failure here moves to the next candidate. **Once a chunk has been handed to the caller a provider swap is impossible, so fallback stops at the first chunk** — the single, intrinsic asymmetry with the non-streaming pipeline.
3. **Drain accounting — lazy.** As the caller drains, the wrapper re-yields each chunk, counts the completion text, and stamps time-to-first-token on the first chunk delivered.
4. **Settlement — in a `finally`.** Usage and telemetry are written in the drain generator's `finally`, so they land on **every** exit path: normal completion, a mid-stream exception, and an abandoned generator (client disconnect or a consumer `break`). PHP runs a suspended generator's `finally` when the generator is destroyed — that is what makes early-break accounting work without a caller callback. An abandoned stream records the **partial** tokens actually produced, never zero.

### Generator lazy-evaluation, handled explicitly

- **Budget must be eager**, so it lives in `stream()` (a plain method), which then returns the lazy `drain()` generator. Everything else (open, drain, settle) is lazy inside `drain()`.
- **The abandoned-generator under-report** the design has to guard against is handled by the `finally`: an early `break` suspends the wrapper at `yield`; on destruction PHP runs the `finally`, settling the partial usage. A dedicated unit test drives exactly this path.
- Priming is done manually (`rewind()` then a `valid()`/`current()`/`next()` loop) rather than `foreach`, because `foreach` would consume the pre-first-chunk window where fallback is still possible.

### Token counts are estimated

The seven streaming adapters yield only text deltas and return `void` — none emits a usage frame. Real per-token usage is not available on this path today, so the dispatcher estimates it with the ≈4 chars/token heuristic already used by `RenderedPrompt::estimateTokens()` (the caller passes the prompt char count on the context metadata; the dispatcher counts the drained completion). Recording an estimate is a deliberate improvement over recording nothing — for budget enforcement an approximate figure beats a silent zero. ADR-062 records the rationale and the follow-up toward exact figures (provider `include_usage`).

### Backward compatibility

- `LlmServiceManagerInterface` is a Category-1 public API. `streamChat`/`streamChatWithConfiguration` keep their `Generator` return contract. `streamChatWithConfiguration()` gains a **trailing** `array $metadata = []` for budget attribution — additive, so three-argument callers stay source-compatible.
- The dispatcher is a private autowired service; when unwired (legacy unit-test constructions) the manager keeps the raw-generator path, mirroring the existing `skillInjection` / `modelSelection` precedent.
- New telemetry column `time_to_first_token_ms` is nullable — `NULL` for every non-streaming row.

### Docs

- **ADR-062** (new) — the streaming lifecycle.
- **ADR-009** — updated: streaming is now in the request lifecycle.
- **ADR-026** — updated: streaming is no longer a documented pipeline bypass; the three diagnostic actions are the only exemptions.

## Related Issue

WS5 — analysis priority 1 (streaming budget hole).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the CI gates locally (cgl, phpstan L10, architecture, rector, unit, functional) and all pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Test evidence

- Unit: `StreamingDispatcherTest` — eager over-budget rejection before opening, estimated usage + telemetry on success, TTFT recorded, partial usage on early break, failure telemetry + partial usage on mid-stream throw, pre-first-chunk fallback swap, no fallback after the first chunk, non-retryable propagation, usage still recorded when telemetry is disabled. Plus a manager-level wiring test.
- Functional: `Tests/Functional/Service/Streaming/StreamingDispatcherTest` drives a stream through the **real** `UsageTrackerService` + `TelemetryRepository` and asserts a row lands in both `tx_nrllm_service_usage` and `tx_nrllm_telemetry` with `time_to_first_token_ms` populated.
