### PR TITLE
refactor: reduce the public service surface (ADR-028 follow-up)

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -121,11 +121,18 @@ services:
     public: true
 
   # ========================================
-  # Supporting Services (PUBLIC)
+  # Supporting Services (interface aliases stay public; concretes private)
   # ========================================
-
-  Netresearch\NrLlm\Service\PromptTemplateService:
-    public: true
+  # The concrete supporting services (CacheManager, UsageTrackerService,
+  # UsageAnalyticsService, PromptTemplateService, LlmConfigurationService)
+  # are autoregistered PRIVATE by the namespace block above. Consumers
+  # wire against the public interface alias; the interface aliases below
+  # (and CacheManager/UsageTrackerService interfaces in the Core section)
+  # stay public so the DI contract holds. Functional tests that resolve a
+  # concrete by class name go through the testing-framework private
+  # container (ADR-062, supersedes ADR-028). PromptSnippetComposer has no
+  # interface and is the documented ADR-031 snippet surface, so it stays
+  # public as a concrete.
 
   Netresearch\NrLlm\Service\PromptTemplateServiceInterface:
     alias: Netresearch\NrLlm\Service\PromptTemplateService
@@ -134,20 +141,8 @@ services:
   Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer:
     public: true
 
-  Netresearch\NrLlm\Service\CacheManager:
-    public: true
-
-  Netresearch\NrLlm\Service\LlmConfigurationService:
-    public: true
-
   Netresearch\NrLlm\Service\LlmConfigurationServiceInterface:
     alias: Netresearch\NrLlm\Service\LlmConfigurationService
-    public: true
-
-  Netresearch\NrLlm\Service\UsageTrackerService:
-    public: true
-
-  Netresearch\NrLlm\Service\UsageAnalyticsService:
     public: true
 
   # ========================================
@@ -196,32 +191,17 @@ services:
     public: false
 
   # ========================================
-  # Repositories (PUBLIC)
+  # Repositories (private)
   # ========================================
-
-  Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\ProviderRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\ModelRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\TaskRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\UserBudgetRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\SkillRepository:
-    public: true
-
-  Netresearch\NrLlm\Domain\Repository\SkillSourceRepository:
-    public: true
+  # Repositories are autoregistered PRIVATE by the namespace block above.
+  # They are injected via constructor DI in production; the functional and
+  # backend-E2E tests that resolve them by class name do so through the
+  # testing-framework private container (PrivateContainerWeakRefPass makes
+  # every private service resolvable via FunctionalTestCase::get()), so no
+  # public override is needed (ADR-062, supersedes ADR-028 Category 3).
+  # PromptSnippetRepository's documented ADR-031 query surface for
+  # consuming extensions is exposed via the public PromptSnippetComposer,
+  # not the repository itself.
 
   Netresearch\NrLlm\Service\Skill\GitHubClientInterface:
     alias: Netresearch\NrLlm\Service\Skill\GitHubClient
@@ -240,9 +220,8 @@ services:
   Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface:
     alias: Netresearch\NrLlm\Service\Tool\ToolAvailabilityService
 
-  Netresearch\NrLlm\Service\BudgetService:
-    public: true
-
+  # Concrete BudgetService is private (autoregistered); consumers wire
+  # against the public BudgetServiceInterface alias.
   Netresearch\NrLlm\Service\BudgetServiceInterface:
     alias: Netresearch\NrLlm\Service\BudgetService
     public: true
@@ -275,9 +254,8 @@ services:
   # ========================================
   # Translation Registry
   # ========================================
-
-  Netresearch\NrLlm\Specialized\Translation\TranslatorRegistry:
-    public: true
+  # Concrete TranslatorRegistry is private (autoregistered); consumers wire
+  # against the public TranslatorRegistryInterface alias (Core section).
 
   # ========================================
   # Specialized Translators
@@ -315,19 +293,21 @@ services:
   # ========================================
   # Setup Wizard Services
   # ========================================
+  # ProviderDetector stays PUBLIC: it is resolved via
+  # GeneralUtility::makeInstance() in ProviderEndpointNormalizationHook
+  # (a DataHandler hook, outside DI), and makeInstance() only reuses the
+  # container-built instance for public services. ModelDiscovery and
+  # ConfigurationGenerator are private (autoregistered) — injected via DI,
+  # resolved in tests through the private container (ADR-062). The
+  # ModelDiscoveryInterface alias stays for autowiring but is private;
+  # tests resolve it through the private container too.
 
   Netresearch\NrLlm\Service\SetupWizard\ProviderDetector:
     public: true
 
-  Netresearch\NrLlm\Service\SetupWizard\ModelDiscovery:
-    public: true
-
   Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface:
     alias: Netresearch\NrLlm\Service\SetupWizard\ModelDiscovery
-    public: true
-
-  Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator:
-    public: true
+    public: false
 
   # ========================================
   # Console Commands

--- a/Documentation/Adr/Adr028PublicServicesPolicy.rst
+++ b/Documentation/Adr/Adr028PublicServicesPolicy.rst
@@ -6,9 +6,21 @@
 ADR-028: Public services policy in ``Configuration/Services.yaml``
 ================================================================
 
-:Status: Accepted
+:Status: Accepted (count and Category 3 / tail rationale superseded by :ref:`adr-065`)
 :Date: 2026-04-30
 :Slice: 25 (audit 2026-04-23 REC #9c)
+
+.. note::
+
+   :ref:`adr-065` supersedes this ADR's **count** (45 → 27) and its
+   Category 3 / class-name-resolution-tail rationale. The premise below —
+   that repositories and the tail must be public because
+   ``FunctionalTestCase::get()`` only resolves public services — is
+   incorrect: the testing framework's ``PrivateContainerWeakRefPass``
+   makes every private service resolvable through ``get()``. The policy,
+   the category framework, and the enforcement test remain in force; only
+   the expected total and the two test-driven categories changed. Read
+   ADR-065 for the current public set.
 
 Context
 =======

--- a/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
+++ b/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
@@ -1,0 +1,184 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-065:
+
+================================================================
+ADR-065: Reduce the public service surface (ADR-028 follow-up)
+================================================================
+
+:Status: Accepted
+:Date: 2026-07-15
+:Authors: Netresearch DTT GmbH
+
+.. _adr-065-context:
+
+Context
+=======
+
+ADR-028 froze the ``public: true`` overrides in
+``Configuration/Services.yaml`` at 45 and concluded "no reduction in
+count": every entry was said to be load-bearing because removing it
+would break either downstream consumers or the extension's own
+functional tests. The functional-test half of that argument rested on
+one premise:
+
+    "TYPO3 ``FunctionalTestCase::get()`` uses the Symfony container's
+    ``->get()`` lookup, which only resolves public services."
+
+That premise is wrong. The testing framework ships a fixture extension
+``typo3/testing-framework`` →
+``Resources/Core/Functional/Extensions/private_container`` whose
+``PrivateContainerWeakRefPass`` runs at ``TYPE_BEFORE_REMOVING`` and
+registers **every private service** (and private alias) into a public
+service locator. ``FunctionalTestCase::get()`` falls back to that
+locator:
+
+.. code-block:: php
+
+   public function get(string $id): mixed
+   {
+       if ($this->getContainer()->has($id)) {
+           return $this->getContainer()->get($id);
+       }
+       return $this->getPrivateContainer()->get($id);   // private services
+   }
+
+So ``$this->get(SomeConcrete::class)`` resolves a **private** service in
+functional and backend-E2E tests without any override. The repository in
+fact already relied on this: ``WizardGeneratorService`` was private
+(``public: false`` interface alias, no public concrete) yet resolved by
+class name in green functional tests. ADR-028 Category 3 ("repositories
+must be public for ``FunctionalTestCase::get()``") and the
+class-name-resolution tail were therefore public for a reason that never
+held.
+
+.. _adr-065-decision:
+
+Decision
+========
+
+Keep ``public: true`` **only** where it is genuinely required, and
+privatise everything that was public solely for test resolution. A
+service needs ``public: true`` if, and only if, it is:
+
+A. part of the documented downstream LLM-API contract that consuming
+   extensions resolve by class name or interface via
+   ``$container->get()`` / a DI type hint; or
+B. a supporting-service **interface alias** consumers wire against
+   (the concrete class is private); or
+C. a concrete-only documented surface with no interface (only
+   ``PromptSnippetComposer``, ADR-031); or
+D. a specialized standalone consumer API (speech / image in isolation);
+   or
+E. resolved **outside DI** via ``GeneralUtility::makeInstance()``, which
+   only reuses the container-built, dependency-injected instance for
+   public services.
+
+Everything else — the repositories, the setup-wizard collaborators
+``ModelDiscovery`` / ``ConfigurationGenerator``, the read-only
+``UsageAnalyticsService``, and the concrete supporting services behind a
+public interface alias — is now private (autoregistered by the
+``Netresearch\NrLlm\`` namespace block). Functional and backend-E2E
+tests resolve them unchanged through the private container. No test code
+and no runtime behaviour changed; only container visibility did.
+
+.. _adr-065-surface:
+
+The reduced public surface (27)
+===============================
+
+**A. Documented downstream LLM-API contract** — 7 concrete + 7 interface
+aliases = 14:
+
+* ``Service\LlmServiceManager`` (+ ``LlmServiceManagerInterface``)
+* ``Provider\ProviderAdapterRegistry``
+  (+ ``ProviderAdapterRegistryInterface``)
+* ``Service\Feature\CompletionService`` (+ Interface)
+* ``Service\Feature\VisionService`` (+ Interface)
+* ``Service\Feature\EmbeddingService`` (+ Interface)
+* ``Service\Feature\TranslationService`` (+ Interface)
+* ``Service\Feature\ToolCallingService`` (+ Interface, ADR-051)
+
+**B. Supporting-service interface aliases** (concrete classes now
+private) — 6:
+
+* ``Service\CacheManagerInterface``
+* ``Service\UsageTrackerServiceInterface``
+* ``Service\PromptTemplateServiceInterface``
+* ``Service\LlmConfigurationServiceInterface``
+* ``Service\BudgetServiceInterface``
+* ``Specialized\Translation\TranslatorRegistryInterface``
+
+**C. Concrete-only documented surface** — 1:
+
+* ``Service\Prompt\PromptSnippetComposer`` (ADR-031, no interface)
+
+**D. Specialized standalone consumer API** — 4:
+
+* ``Specialized\Speech\WhisperTranscriptionService``
+* ``Specialized\Speech\TextToSpeechService``
+* ``Specialized\Image\DallEImageService``
+* ``Specialized\Image\FalImageService``
+
+**E. Resolved outside DI via makeInstance()** — 2:
+
+* ``Service\Tool\ToolRegistry`` — TCA ``itemsProcFunc`` in
+  ``Form\Tca\ToolGroupItems`` (ADR-042).
+* ``Service\SetupWizard\ProviderDetector`` — the DataHandler hook
+  ``Hook\ProviderEndpointNormalizationHook``.
+
+Total: 14 + 6 + 1 + 4 + 2 = **27** (down from 45).
+
+.. _adr-065-privatised:
+
+What became private
+===================
+
+Removed from the public set (autoregistered private; injected via DI,
+resolved in tests via the private container):
+
+* Repositories (8): ``LlmConfigurationRepository``,
+  ``ProviderRepository``, ``ModelRepository``, ``TaskRepository``,
+  ``PromptSnippetRepository``, ``UserBudgetRepository``,
+  ``SkillRepository``, ``SkillSourceRepository``.
+* Setup-wizard collaborators: ``ModelDiscovery`` (concrete;
+  ``ModelDiscoveryInterface`` alias kept for autowiring, now private) and
+  ``ConfigurationGenerator``.
+* Supporting concretes behind a public interface alias:
+  ``CacheManager``, ``UsageTrackerService``, ``PromptTemplateService``,
+  ``LlmConfigurationService``, ``BudgetService``,
+  ``Specialized\Translation\TranslatorRegistry``.
+* ``Service\UsageAnalyticsService`` (read-only Analytics reporting
+  service; its interface alias was already private).
+
+.. _adr-065-consequences:
+
+Consequences
+============
+
+* The audited public surface drops from 45 to 27. The
+  ``PublicServicesPolicyTest`` count constant and this ADR are the audit
+  trail; ADR-028's "no reduction" conclusion is superseded.
+* Consuming extensions that resolved a **concrete** supporting service by
+  class name (e.g. ``$container->get(CacheManager::class)``) must switch
+  to the interface (``CacheManagerInterface``). This is a breaking change
+  for those callers, acceptable pre-1.0 and consistent with the
+  interface being the documented contract.
+* Tests are unchanged: the private container keeps ``$this->get()`` on a
+  private service working. Any future test that needs a private service
+  by class name works out of the box for the same reason.
+* Adding a new ``public: true`` still requires the three-part change from
+  ADR-028 (service definition, ADR entry, ``EXPECTED_PUBLIC_TRUE_COUNT``
+  bump) — but the bar is now "does a production, non-DI caller or a
+  documented downstream consumer need it?", not "does a test resolve it?"
+
+.. _adr-065-relation:
+
+Relation to ADR-028
+===================
+
+ADR-028 stays as the record of the original policy and the
+``public: true`` enforcement test. This ADR supersedes its **count** and
+its Category 3 / tail rationale. The enforcement mechanism
+(``Tests/Unit/Configuration/PublicServicesPolicyTest.php``) is retained;
+only the expected total changed (45 → 27).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -360,3 +360,4 @@ Tools
    Adr059DecomposeLlmServiceManager
    Adr060QualityEvaluation
    Adr061SkillTrustEgressAndAudit
+   Adr065ReducePublicServiceSurface

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -33,38 +33,39 @@ use PHPUnit\Framework\TestCase;
 final class PublicServicesPolicyTest extends TestCase
 {
     /**
-     * Audited count of `public: true` overrides (REC #9c, ADR-028).
-     * Categories per ADR-028:
+     * Audited count of `public: true` overrides (REC #9c, ADR-028,
+     * reduced by ADR-065). ADR-065 privatised every service that was
+     * public *only* so functional tests could resolve it via
+     * `FunctionalTestCase::get()` — the testing framework's
+     * private-container pass (`PrivateContainerWeakRefPass`) already
+     * makes every private service resolvable through `get()`, so those
+     * overrides were never load-bearing. Categories per ADR-065:
      *
-     * - Category 1 (Public LLM API surface): 14 concrete services
-     *   + 13 interface aliases = 27. Every Category-1 service has a
-     *   public interface alias except the concrete-only
-     *   PromptSnippetComposer (ADR-031), the snippet composition
-     *   surface for consuming extensions. Includes the
-     *   ToolCallingService feature pair (ADR-051).
-     * - Category 2 (Specialized services): 4
-     * - Category 3 (Repositories — required public for
-     *   FunctionalTestCase::get(); PromptSnippetRepository is also
-     *   the documented query surface for consuming extensions,
-     *   ADR-031): 8. Includes SkillRepository and
-     *   SkillSourceRepository, public so the skills-ingest
-     *   functional tests resolve them via FunctionalTestCase::get().
-     * - Category 4 (SetupWizard collaborators): 3 concrete +
-     *   1 interface alias = 4
-     * - Class-name-resolution tail: 2 — UsageAnalyticsService
-     *   (public solely so the Analytics functional test resolves it
-     *   via FunctionalTestCase::get()) and ToolRegistry (public so
-     *   functional tests fetch registered tools by spec name,
-     *   ADR-042).
+     * - Category A (Documented downstream LLM-API contract): 7 concrete
+     *   services + 7 interface aliases = 14 — LlmServiceManager,
+     *   ProviderAdapterRegistry, and the Completion/Vision/Embedding/
+     *   Translation/ToolCalling (ADR-051) feature pairs.
+     * - Category B (Supporting-service interface aliases; the concrete
+     *   classes are now private): 6 — CacheManagerInterface,
+     *   UsageTrackerServiceInterface, TranslatorRegistryInterface,
+     *   PromptTemplateServiceInterface, LlmConfigurationServiceInterface,
+     *   BudgetServiceInterface.
+     * - Category C (Concrete-only documented surface): 1 —
+     *   PromptSnippetComposer (ADR-031, no interface).
+     * - Category D (Specialized standalone consumer API): 4 —
+     *   Whisper, TextToSpeech, DallE, Fal.
+     * - Category E (resolved outside DI via makeInstance()): 2 —
+     *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
+     *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 27 + 4 + 8 + 4 + 2 = **45**.
+     * Total: 14 + 6 + 1 + 4 + 2 = **27**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr028PublicServicesPolicy.rst` in the
+     * `Documentation/Adr/Adr065ReducePublicServiceSurface.rst` in the
      * same PR — the diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 45;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 27;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 
@@ -102,5 +103,17 @@ final class PublicServicesPolicyTest extends TestCase
         self::assertNotFalse($contents);
         self::assertStringContainsString('REC #9c', $contents, 'ADR-028 must reference the audit recommendation it answers.');
         self::assertStringContainsString('public: true', $contents, 'ADR-028 must document the policy it locks.');
+    }
+
+    #[Test]
+    public function adr065IsPresent(): void
+    {
+        $adrPath = __DIR__ . '/../../../Documentation/Adr/Adr065ReducePublicServiceSurface.rst';
+        self::assertFileExists($adrPath, 'ADR-065 (public service surface reduction) must exist alongside this test.');
+
+        $contents = file_get_contents($adrPath);
+        self::assertNotFalse($contents);
+        self::assertStringContainsString('PrivateContainerWeakRefPass', $contents, 'ADR-065 must document the test-container mechanism it relies on.');
+        self::assertStringContainsString('27', $contents, 'ADR-065 must record the reduced public-service count.');
     }
 }


### PR DESCRIPTION
## What

Reduce the audited `public: true` surface in `Configuration/Services.yaml` from **45 to 27**, and correct the premise that kept it at 45.

## Why the previous count was inflated

ADR-028 froze the count at 45 and concluded "no reduction", because it assumed repositories and a class-name-resolution tail *must* be public so functional tests can resolve them via `FunctionalTestCase::get()`.

That premise is wrong. The testing framework ships the `private_container` fixture extension; its `PrivateContainerWeakRefPass` (runs at `TYPE_BEFORE_REMOVING`) registers **every private service and private alias** into a public service locator, and `FunctionalTestCase::get()` falls back to it. So `$this->get(SomeConcrete::class)` resolves a **private** service in both the `functional` and `e2e-backend` suites — no override, no test change. The repo already relied on this: `WizardGeneratorService` was private (only a `public: false` interface alias) yet resolved by class name in green functional tests.

## What became private

No behaviour or test-code change — container visibility only.

- **8 repositories** — `LlmConfigurationRepository`, `ProviderRepository`, `ModelRepository`, `TaskRepository`, `PromptSnippetRepository`, `UserBudgetRepository`, `SkillRepository`, `SkillSourceRepository`.
- **Wizard collaborators** — `ModelDiscovery` (its `ModelDiscoveryInterface` alias kept for autowiring, now private) and `ConfigurationGenerator`.
- **Supporting concretes behind a public interface alias** — `CacheManager`, `UsageTrackerService`, `PromptTemplateService`, `LlmConfigurationService`, `BudgetService`, `TranslatorRegistry`. The interface aliases stay public; consumers wire against the interface.
- **`UsageAnalyticsService`** — read-only Analytics reporting service (interface alias was already private).

## What stays public (and why)

- **Documented downstream LLM-API contract** (14): `LlmServiceManager` (+I), `ProviderAdapterRegistry` (+I), and the `Completion`/`Vision`/`Embedding`/`Translation`/`ToolCalling` feature pairs.
- **Supporting-service interface aliases** (6): the interfaces for the six concretes privatised above.
- **`PromptSnippetComposer`** (1): concrete-only documented surface (ADR-031), no interface to fall back to.
- **Specialized standalone consumer API** (4): `WhisperTranscriptionService`, `TextToSpeechService`, `DallEImageService`, `FalImageService`.
- **`ToolRegistry` and `ProviderDetector`** (2): resolved via `GeneralUtility::makeInstance()` outside DI (TCA itemsProcFunc / DataHandler hook), which only reuses the container instance for public services — so they must stay public.

Total kept: 14 + 6 + 1 + 4 + 2 = **27**.

## Test / docs

- `PublicServicesPolicyTest::EXPECTED_PUBLIC_TRUE_COUNT` 45 → 27, docblock breakdown updated, `adr065IsPresent` added.
- New **ADR-065** documents the reduction, the `private_container` mechanism, and the keep-public rule. **ADR-028** amended with a supersession note (kept as the historical record).

## Breaking change

Consuming extensions that resolved a **concrete** supporting service by class name (e.g. `$container->get(CacheManager::class)`) must switch to the interface (`CacheManagerInterface`). Acceptable pre-1.0; the interface is the documented contract.

## Gates (all green, via `runTests.sh`)

`-s unit`, `-s functional` (1125 tests, incl. e2e-backend), `-s cgl`, `-s phpstan` (L10), `-s architecture`, `-s rector -n`.
