### PR TITLE
feat: circuit breaker, provider health scoring and idempotency

### DIFF
--- a/Classes/Provider/CircuitBreaker/CacheCircuitBreakerStore.php
+++ b/Classes/Provider/CircuitBreaker/CacheCircuitBreakerStore.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\CircuitBreaker;
+
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+
+/**
+ * Cache-backed circuit state store (ADR-063).
+ *
+ * State lives in the `nrllm_circuit` cache (no hardcoded backend, see
+ * {@see \Configuration/Caching.php}), so it inherits whatever the instance
+ * configured — Redis/Valkey shares one circuit across every web worker, which
+ * is exactly what a circuit breaker wants (one worker seeing a provider fail
+ * protects the others). A vanilla instance falls back to the DB cache backend
+ * transparently.
+ *
+ * Fail-soft by construction: any cache error on load returns a closed circuit
+ * (fail-open — never wedge a provider shut because the cache hiccuped) and any
+ * error on save is logged and swallowed (never break the guarded call).
+ */
+final class CacheCircuitBreakerStore implements CircuitBreakerStoreInterface
+{
+    private const CACHE_IDENTIFIER = 'nrllm_circuit';
+
+    private ?FrontendInterface $cache = null;
+
+    public function __construct(
+        private readonly Typo3CacheManager $cacheManager,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function load(string $provider): CircuitState
+    {
+        try {
+            $cached = $this->getCache()->get($this->entryIdentifier($provider));
+        } catch (Throwable $e) {
+            $this->logger->warning('Circuit breaker state load failed; treating circuit as closed', [
+                'provider'  => $provider,
+                'exception' => $e,
+            ]);
+
+            return CircuitState::closed();
+        }
+
+        if (!\is_array($cached)) {
+            return CircuitState::closed();
+        }
+
+        /** @var array<string, mixed> $cached */
+        return CircuitState::fromArray($cached);
+    }
+
+    public function save(string $provider, CircuitState $state, int $lifetimeSeconds): void
+    {
+        try {
+            $this->getCache()->set(
+                $this->entryIdentifier($provider),
+                $state->toArray(),
+                [],
+                max(1, $lifetimeSeconds),
+            );
+        } catch (Throwable $e) {
+            // Observability of provider health must never break the call itself.
+            $this->logger->warning('Circuit breaker state save failed; state not persisted', [
+                'provider'  => $provider,
+                'exception' => $e,
+            ]);
+        }
+    }
+
+    /**
+     * Map a provider identifier to a valid cache entry identifier. Provider keys
+     * carry characters the cache frontend rejects (the ad-hoc scheme
+     * "ad-hoc:chat:openai" contains colons), so the readable prefix is paired
+     * with a hash of the raw provider to stay within the allowed charset
+     * without risking a collision between two providers that sanitise alike.
+     */
+    private function entryIdentifier(string $provider): string
+    {
+        $safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', $provider) ?? '';
+
+        return 'circuit_' . $safe . '_' . substr(hash('sha256', $provider), 0, 12);
+    }
+
+    private function getCache(): FrontendInterface
+    {
+        if (!$this->cache instanceof FrontendInterface) {
+            $this->cache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
+        }
+
+        return $this->cache;
+    }
+}

--- a/Classes/Provider/CircuitBreaker/CircuitBreakerConfig.php
+++ b/Classes/Provider/CircuitBreaker/CircuitBreakerConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\CircuitBreaker;
+
+/**
+ * Resolved circuit breaker tunables (ADR-063).
+ *
+ * A typed snapshot of the `circuitBreaker.*` extension settings, read once per
+ * pipeline run by {@see \Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware}
+ * so the rest of the middleware works with named properties rather than
+ * repeated string keys.
+ */
+final readonly class CircuitBreakerConfig
+{
+    public function __construct(
+        public bool $enabled,
+        public int $failureThreshold,
+        public int $cooldownSeconds,
+    ) {}
+}

--- a/Classes/Provider/CircuitBreaker/CircuitBreakerStoreInterface.php
+++ b/Classes/Provider/CircuitBreaker/CircuitBreakerStoreInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\CircuitBreaker;
+
+/**
+ * Persistence boundary for per-provider circuit state (ADR-063).
+ *
+ * Deliberately narrow: load the state for one provider, or save it. The default
+ * implementation is cache-backed ({@see CacheCircuitBreakerStore}) so the state
+ * is transient, shared across web workers via the instance's cache backend
+ * (Redis/Valkey/…), and self-decaying — a circuit the store forgets reads as
+ * closed, which is the fail-safe default.
+ */
+interface CircuitBreakerStoreInterface
+{
+    /**
+     * Load the circuit state for a provider. A never-seen or expired provider
+     * returns a fresh closed state.
+     */
+    public function load(string $provider): CircuitState;
+
+    /**
+     * Persist the circuit state for a provider with the given lifetime in
+     * seconds. Must never throw for a caller-visible reason: a store failure
+     * must not break the provider call the circuit guards.
+     */
+    public function save(string $provider, CircuitState $state, int $lifetimeSeconds): void;
+}

--- a/Classes/Provider/CircuitBreaker/CircuitState.php
+++ b/Classes/Provider/CircuitBreaker/CircuitState.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\CircuitBreaker;
+
+/**
+ * Immutable per-provider circuit state (ADR-063).
+ *
+ * Stores only what is needed to reconstruct the circuit's behaviour: the number
+ * of consecutive tripping failures and, when the circuit is open, the UNIX
+ * timestamp it opened at. The {@see CircuitStatus} (closed / open / half-open)
+ * is derived from these two fields plus the current clock and the configured
+ * cooldown — see {@see CircuitBreakerMiddleware}. Deriving rather than storing
+ * the status means a stored state cannot disagree with the clock (an "open"
+ * flag that outlived its cooldown).
+ *
+ * Persisted as a plain array via {@see self::toArray()} so it round-trips
+ * through the TYPO3 cache frontend without object-serialisation coupling.
+ */
+final readonly class CircuitState
+{
+    public function __construct(
+        public int $consecutiveFailures = 0,
+        public ?int $openedAt = null,
+    ) {}
+
+    /**
+     * A fully closed circuit: no failures recorded, not open.
+     */
+    public static function closed(): self
+    {
+        return new self(0, null);
+    }
+
+    /**
+     * Derive the circuit status against the current clock and the configured
+     * cooldown. Open while still within the cooldown window; half-open once it
+     * has elapsed (a single probe is due); closed when never opened.
+     */
+    public function status(int $now, int $cooldownSeconds): CircuitStatus
+    {
+        if ($this->openedAt === null) {
+            return CircuitStatus::Closed;
+        }
+
+        return ($now - $this->openedAt) < $cooldownSeconds
+            ? CircuitStatus::Open
+            : CircuitStatus::HalfOpen;
+    }
+
+    /**
+     * Seconds until an open circuit becomes half-open (0 once it already has, or
+     * when the circuit is not open). Used for the retry-after hint on
+     * {@see \Netresearch\NrLlm\Provider\Exception\CircuitOpenException}.
+     */
+    public function secondsUntilHalfOpen(int $now, int $cooldownSeconds): int
+    {
+        if ($this->openedAt === null) {
+            return 0;
+        }
+
+        return max(0, $cooldownSeconds - ($now - $this->openedAt));
+    }
+
+    /**
+     * Reconstruct from the cached array shape. Unknown / malformed input decays
+     * to a closed circuit (fail-safe: a corrupt entry must not wedge a provider
+     * permanently open).
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $failures = $data['consecutiveFailures'] ?? 0;
+        $openedAt = $data['openedAt'] ?? null;
+
+        return new self(
+            \is_int($failures) && $failures >= 0 ? $failures : 0,
+            \is_int($openedAt) && $openedAt > 0 ? $openedAt : null,
+        );
+    }
+
+    /**
+     * @return array{consecutiveFailures: int, openedAt: int|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'consecutiveFailures' => $this->consecutiveFailures,
+            'openedAt'            => $this->openedAt,
+        ];
+    }
+
+    /**
+     * True when this state carries nothing worth persisting — a closed circuit
+     * with no failure streak. Lets the hot success path skip a redundant cache
+     * write.
+     */
+    public function isPristine(): bool
+    {
+        return $this->consecutiveFailures === 0 && $this->openedAt === null;
+    }
+}

--- a/Classes/Provider/CircuitBreaker/CircuitStatus.php
+++ b/Classes/Provider/CircuitBreaker/CircuitStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\CircuitBreaker;
+
+/**
+ * The three states of a per-provider circuit (ADR-063).
+ *
+ *  - Closed:   normal operation; the provider call is attempted and failures
+ *              are counted.
+ *  - Open:     recent failures crossed the threshold; calls fail fast for the
+ *              cooldown window instead of waiting on a timeout.
+ *  - HalfOpen: the cooldown has elapsed; a single probe call is allowed to test
+ *              whether the provider has recovered.
+ *
+ * The status is DERIVED from {@see CircuitState} (failure count + open
+ * timestamp) against the current clock and configured cooldown — it is never
+ * persisted on its own, so there is no untrusted string to validate back into
+ * this enum.
+ */
+enum CircuitStatus: string
+{
+    case Closed   = 'closed';
+    case Open     = 'open';
+    case HalfOpen = 'half_open';
+}

--- a/Classes/Provider/Exception/CircuitOpenException.php
+++ b/Classes/Provider/Exception/CircuitOpenException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Exception;
+
+/**
+ * Thrown by {@see \Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware}
+ * when a provider's circuit is open: the call fails fast instead of waiting on a
+ * timeout against a provider that just failed repeatedly (ADR-063).
+ *
+ * Extends {@see ProviderException} so it inherits the ADR-053 marker interface.
+ * {@see \Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware} treats it as
+ * retryable (like a connection failure), so an open circuit routes the request
+ * to the next configuration in the fallback chain rather than surfacing as a
+ * hard error — the whole point of tripping fast is to free the request to try a
+ * healthy provider.
+ */
+final class CircuitOpenException extends ProviderException
+{
+    public function __construct(
+        public readonly string $provider,
+        public readonly int $retryAfterSeconds,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Circuit breaker open for provider "%s"; retry in ~%d second(s)',
+                $provider,
+                $retryAfterSeconds,
+            ),
+            1752570001,
+        );
+    }
+}

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -53,7 +53,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *
  * The default pipeline order is pinned via tag priority (Telemetry outermost
  * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
- * Usage innermost at 25).
+ * Usage at 25, CircuitBreaker innermost at 20).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 75])]
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -63,7 +63,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *       BudgetMiddleware     <-- pre-flight only on miss            (priority 75)
  *         FallbackMiddleware <-- swaps config on retryable failure  (priority 50)
  *           UsageMiddleware  <-- records the call that actually ran (priority 25)
- *             <terminal>
+ *             CircuitBreaker <-- guards the provider call           (priority 20)
+ *               <terminal>
  *
  * Callers who want cache accounting (count hits against budget / usage)
  * should assemble a custom pipeline with Cache *inside* those layers — it is

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerConfig;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitStatus;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Per-provider circuit breaker (ADR-063).
+ *
+ * Tracks consecutive failing calls per provider and, once a threshold is
+ * crossed, "opens" the circuit for a cooldown window: subsequent calls to that
+ * provider fail fast with a {@see CircuitOpenException} instead of waiting on a
+ * connection timeout. After the cooldown a single probe is allowed (half-open);
+ * a success closes the circuit, a failure re-opens it.
+ *
+ * Pipeline placement — INNERMOST, priority 20 (just above the terminal):
+ *
+ *   TelemetryMiddleware      <-- 110  observes every run
+ *     CacheMiddleware        <-- 100  short-circuits on hit
+ *       BudgetMiddleware     <--  75  pre-flight denial
+ *         FallbackMiddleware <--  50  swaps configuration on retryable failure
+ *           UsageMiddleware  <--  25  records the served call
+ *             CircuitBreaker <--  20  guards the actual provider call  (THIS)
+ *               <terminal>
+ *
+ * Two placement invariants, both load-bearing:
+ *
+ *  1. INSIDE FallbackMiddleware. An open circuit throws
+ *     {@see CircuitOpenException}, which FallbackMiddleware treats as retryable.
+ *     Because the circuit sits *inside* the fallback loop, that exception is
+ *     raised from within `$next($configuration)` on each attempt, so Fallback
+ *     catches it and advances to the next configuration/provider. Placing the
+ *     breaker OUTSIDE Fallback (e.g. between Budget and Fallback) would instead
+ *     make an open primary circuit abort the whole call before Fallback ever
+ *     ran — the opposite of the intent. This is why the breaker is inner, not
+ *     the "between 75 and 50" slot a first sketch suggests.
+ *
+ *  2. INSIDE UsageMiddleware. The breaker measures the *pure* provider call:
+ *     usage bookkeeping (which only runs on success and does its own error
+ *     handling) never contaminates the health signal, and a genuine provider
+ *     success closes the circuit before any post-processing.
+ *
+ * What trips the circuit: the same failure classes FallbackMiddleware considers
+ * retryable — {@see ProviderConnectionException} (network / timeout / 5xx /
+ * retries exhausted) and a 429 {@see ProviderResponseException} (rate limit).
+ * Client errors (4xx other than 429), misconfiguration and unsupported-feature
+ * errors mean the provider answered — they are left out of the health signal
+ * entirely (neither trip nor reset).
+ *
+ * State lives in the `nrllm_circuit` cache via
+ * {@see CircuitBreakerStoreInterface}; see ADR-063 for the storage rationale
+ * (transient, shared across workers, self-decaying, no schema).
+ *
+ * Streaming stays out of the pipeline (ADR-026), so streamed calls are never
+ * guarded here — consistent with FallbackMiddleware.
+ *
+ * Disable via the `circuitBreaker.enabled` extension setting (default ON). When
+ * disabled the middleware is a verbatim pass-through.
+ */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 20])]
+final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInterface
+{
+    private const DEFAULT_FAILURE_THRESHOLD = 5;
+    private const DEFAULT_COOLDOWN_SECONDS  = 30;
+
+    public function __construct(
+        private CircuitBreakerStoreInterface $store,
+        private ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     *
+     * @throws CircuitOpenException when the provider's circuit is open
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $config = $this->config();
+        if (!$config->enabled) {
+            return $next($configuration);
+        }
+
+        $provider = $this->circuitKey($configuration);
+        if ($provider === '') {
+            // Nothing stable to key a circuit on — do not guard.
+            return $next($configuration);
+        }
+
+        $cooldown = $config->cooldownSeconds;
+        $now      = time();
+        $state    = $this->store->load($provider);
+
+        $status = $state->status($now, $cooldown);
+        if ($status === CircuitStatus::Open) {
+            // Fail fast so FallbackMiddleware can try the next provider.
+            throw new CircuitOpenException($provider, $state->secondsUntilHalfOpen($now, $cooldown));
+        }
+        if ($status === CircuitStatus::HalfOpen) {
+            // Cooldown elapsed. Reserve the single probe by refreshing the open
+            // window up front, so any concurrent caller keeps failing fast while
+            // this probe is in flight (a pragmatic single-probe gate without
+            // needing an atomic compare-and-set on the cache backend).
+            $this->store->save(
+                $provider,
+                new CircuitState($state->consecutiveFailures, $now),
+                $this->stateLifetime($cooldown),
+            );
+        }
+
+        try {
+            $result = $next($configuration);
+        } catch (Throwable $e) {
+            if ($this->isTrippingFailure($e)) {
+                $this->recordFailure($provider, $state, $now, $config);
+            }
+
+            // Non-tripping failures (client 4xx, misconfiguration) mean the
+            // provider responded — leave the circuit untouched.
+            throw $e;
+        }
+
+        // Success closes the circuit. Skip the write on the hot path when the
+        // circuit was already fully closed with no failure streak.
+        if (!$state->isPristine()) {
+            $this->store->save($provider, CircuitState::closed(), $this->stateLifetime($cooldown));
+        }
+
+        return $result;
+    }
+
+    private function recordFailure(string $provider, CircuitState $state, int $now, CircuitBreakerConfig $config): void
+    {
+        $failures = $state->consecutiveFailures + 1;
+
+        // Open when the threshold is reached, or keep it open when a half-open
+        // probe (openedAt already set) just failed.
+        $openedAt = ($failures >= $config->failureThreshold || $state->openedAt !== null) ? $now : null;
+
+        $this->store->save(
+            $provider,
+            new CircuitState($failures, $openedAt),
+            $this->stateLifetime($config->cooldownSeconds),
+        );
+    }
+
+    /**
+     * Mirrors FallbackMiddleware's retryable set: a failure that suggests the
+     * provider itself is unhealthy (as opposed to a client-side error).
+     */
+    private function isTrippingFailure(Throwable $e): bool
+    {
+        if ($e instanceof ProviderConnectionException) {
+            return true;
+        }
+        if ($e instanceof ProviderResponseException) {
+            return $e->getCode() === 429;
+        }
+
+        return false;
+    }
+
+    /**
+     * Circuit key: the provider adapter type for configuration-backed calls,
+     * falling back to the (provider-encoding) configuration identifier for
+     * ad-hoc calls whose transient configuration carries no model. Two DB
+     * configurations on the same provider share one circuit — the provider is
+     * what is unhealthy, not the configuration.
+     */
+    private function circuitKey(LlmConfiguration $configuration): string
+    {
+        $provider = $configuration->getProviderType();
+
+        return $provider !== '' ? $provider : $configuration->getIdentifier();
+    }
+
+    /**
+     * Cache lifetime for a state write. Comfortably outlives the cooldown so an
+     * open circuit survives its window, while still decaying a stale failure
+     * streak after a period of no traffic.
+     */
+    private function stateLifetime(int $cooldownSeconds): int
+    {
+        return max($cooldownSeconds * 2, 60);
+    }
+
+    /**
+     * Read the circuit configuration from the `circuitBreaker.*` extension
+     * settings, mirroring TelemetryMiddleware's tolerant reader: any read
+     * failure or missing key falls back to the safe defaults (enabled, with the
+     * default threshold and cooldown).
+     */
+    private function config(): CircuitBreakerConfig
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            $config = [];
+        }
+
+        $circuit = \is_array($config['circuitBreaker'] ?? null) ? $config['circuitBreaker'] : [];
+
+        return new CircuitBreakerConfig(
+            enabled: !\array_key_exists('enabled', $circuit) || (bool)$circuit['enabled'],
+            failureThreshold: $this->positiveIntOr($circuit['failureThreshold'] ?? null, self::DEFAULT_FAILURE_THRESHOLD),
+            cooldownSeconds: $this->positiveIntOr($circuit['cooldownSeconds'] ?? null, self::DEFAULT_COOLDOWN_SECONDS),
+        );
+    }
+
+    private function positiveIntOr(mixed $value, int $default): int
+    {
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+        if (\is_string($value) && ctype_digit($value) && (int)$value > 0) {
+            return (int)$value;
+        }
+
+        return $default;
+    }
+}

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -110,12 +110,13 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
         $now      = time();
         $state    = $this->store->load($provider);
 
-        $status = $state->status($now, $cooldown);
+        $status        = $state->status($now, $cooldown);
+        $halfOpenProbe = $status === CircuitStatus::HalfOpen;
         if ($status === CircuitStatus::Open) {
             // Fail fast so FallbackMiddleware can try the next provider.
             throw new CircuitOpenException($provider, $state->secondsUntilHalfOpen($now, $cooldown));
         }
-        if ($status === CircuitStatus::HalfOpen) {
+        if ($halfOpenProbe) {
             // Cooldown elapsed. Reserve the single probe by refreshing the open
             // window up front, so any concurrent caller keeps failing fast while
             // this probe is in flight (a pragmatic single-probe gate without
@@ -132,10 +133,18 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
         } catch (Throwable $e) {
             if ($this->isTrippingFailure($e)) {
                 $this->recordFailure($provider, $state, $now, $config);
+            } elseif ($halfOpenProbe) {
+                // A non-tripping failure means the provider RESPONDED (a client
+                // 4xx / misconfiguration), so it is not a health signal. On a
+                // half-open probe the reservation above already moved the open
+                // window to now; restore the pre-probe state so the circuit
+                // re-derives to half-open (a further probe stays due) instead of
+                // re-arming Open for a full cooldown — otherwise recurring
+                // non-tripping probes would starve the recovery path.
+                $this->store->save($provider, $state, $this->stateLifetime($cooldown));
             }
 
-            // Non-tripping failures (client 4xx, misconfiguration) mean the
-            // provider responded — leave the circuit untouched.
+            // Non-tripping failures on a closed circuit leave it untouched.
             throw $e;
         }
 

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -11,9 +11,11 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Throwable;
@@ -39,7 +41,7 @@ use Throwable;
  *
  * The default pipeline order is pinned via tag priority (Telemetry outermost
  * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
- * Usage innermost at 25).
+ * Usage at 25, CircuitBreaker innermost at 20).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 50])]
 final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
@@ -47,6 +49,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
     public function __construct(
         private LlmConfigurationRepository $repository,
         private LoggerInterface $logger,
+        private ProviderHealthServiceInterface $health,
     ) {}
 
     /**
@@ -106,6 +109,11 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
             );
             throw $attempts[0]['error'];
         }
+
+        // Optionally prefer healthier providers among the fallback candidates
+        // (ADR-063). A stable no-op by default: the health service returns the
+        // chain untouched unless the operator opted into health-aware reorder.
+        $chain = $this->health->reorder($chain);
 
         foreach ($chain->configurationIdentifiers as $identifier) {
             $fallback = $this->repository->findOneByIdentifier($identifier);
@@ -179,6 +187,12 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
     private function isRetryable(Throwable $e): bool
     {
         if ($e instanceof ProviderConnectionException) {
+            return true;
+        }
+        if ($e instanceof CircuitOpenException) {
+            // An open circuit (ADR-063) means the provider just failed
+            // repeatedly and is being skipped; routing to the next configuration
+            // is exactly what tripping fast is for.
             return true;
         }
         if ($e instanceof ProviderResponseException) {

--- a/Classes/Provider/Middleware/IdempotencyMiddleware.php
+++ b/Classes/Provider/Middleware/IdempotencyMiddleware.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Throwable;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+
+/**
+ * Request idempotency keyed by a caller-supplied token (ADR-063).
+ *
+ * When a call carries an idempotency key (via
+ * {@see self::METADATA_IDEMPOTENCY_KEY} on the context metadata, set from an
+ * option's `withIdempotencyKey()`), the FIRST call runs normally and its result
+ * is stored under that key; a REPEAT with the same key returns the stored
+ * result without calling the provider again. This makes a retried
+ * request — a double-submitted form, a network retry — safe: it neither
+ * re-charges the budget nor produces a second, different completion.
+ *
+ * Opt-in: with no idempotency key the middleware is a verbatim pass-through, so
+ * ordinary (non-idempotent) traffic is untouched.
+ *
+ * Pipeline placement — priority 105, just inside TelemetryMiddleware (110) and
+ * OUTSIDE CacheMiddleware (100):
+ *
+ *   TelemetryMiddleware      <-- 110  observes every run, replays included
+ *     IdempotencyMiddleware  <-- 105  replays a stored result by key   (THIS)
+ *       CacheMiddleware      <-- 100  payload cache
+ *         ...                <--      budget / fallback / usage / circuit
+ *
+ * Outside Cache/Budget so a replay short-circuits the whole behavioural stack
+ * (no second budget charge), yet inside Telemetry so a replay is still recorded
+ * as a (fast) run.
+ *
+ * Why not reuse CacheMiddleware's key? CacheMiddleware is deliberately
+ * array-only (it persists `array<string, mixed>`), so it cannot round-trip the
+ * typed responses (CompletionResponse, …) the chat/completion paths return.
+ * This middleware stores over its own `nrllm_idempotency` VariableFrontend,
+ * which serialises any response value — so idempotency works for every
+ * operation, not just the array-shaped ones — while still being cache-backed
+ * (no new table): idempotency results are transient and TTL-bounded by nature.
+ *
+ * Streaming responses (Generator) are never stored: a generator cannot be
+ * serialised, and streaming stays out of the pipeline anyway (ADR-026). Failed
+ * calls are not stored either — the exception propagates and a later retry with
+ * the same key genuinely re-attempts.
+ */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 105])]
+final class IdempotencyMiddleware implements ProviderMiddlewareInterface
+{
+    public const METADATA_IDEMPOTENCY_KEY = 'idempotencyKey';
+
+    private const CACHE_IDENTIFIER = 'nrllm_idempotency';
+
+    /** Idempotency window: how long a stored result answers a repeated key. */
+    private const TTL_SECONDS = 86400;
+
+    private ?FrontendInterface $cache = null;
+
+    public function __construct(
+        private readonly Typo3CacheManager $cacheManager,
+    ) {}
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $key = $this->readKey($context);
+        if ($key === null) {
+            return $next($configuration);
+        }
+
+        $entryId = $this->entryIdentifier($key);
+
+        $stored = $this->safeGet($entryId);
+        if ($stored !== null) {
+            return $stored;
+        }
+
+        $result = $next($configuration);
+
+        if ($this->isStorable($result)) {
+            $this->safeSet($entryId, $result);
+        }
+
+        return $result;
+    }
+
+    private function readKey(ProviderCallContext $context): ?string
+    {
+        $value = $context->metadata[self::METADATA_IDEMPOTENCY_KEY] ?? null;
+        if (!\is_string($value) || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * A stored value is only ever a previously computed, non-streaming result.
+     * Generators cannot be serialised (and streaming is not routed through the
+     * pipeline anyway).
+     */
+    private function isStorable(mixed $result): bool
+    {
+        return !$result instanceof Generator;
+    }
+
+    private function safeGet(string $entryId): mixed
+    {
+        try {
+            $stored = $this->getCache()->get($entryId);
+        } catch (Throwable) {
+            return null;
+        }
+
+        // VariableFrontend::get() returns false on a miss; a stored value is
+        // never the boolean false (responses are objects/arrays).
+        return $stored === false ? null : $stored;
+    }
+
+    private function safeSet(string $entryId, mixed $result): void
+    {
+        try {
+            $this->getCache()->set($entryId, $result, [], self::TTL_SECONDS);
+        } catch (Throwable) {
+            // Idempotency is best-effort: a store failure must not break the call.
+        }
+    }
+
+    /**
+     * Map the caller-supplied key (arbitrary text) to a valid cache entry
+     * identifier: a readable, sanitised prefix plus a hash of the raw key so
+     * distinct keys that sanitise alike cannot collide.
+     */
+    private function entryIdentifier(string $key): string
+    {
+        $safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', $key) ?? '';
+
+        return 'idem_' . substr($safe, 0, 64) . '_' . substr(hash('sha256', $key), 0, 16);
+    }
+
+    private function getCache(): FrontendInterface
+    {
+        if (!$this->cache instanceof FrontendInterface) {
+            $this->cache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
+        }
+
+        return $this->cache;
+    }
+}

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -37,7 +37,8 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
  *       BudgetMiddleware     <-- pre-flight denial                 (priority 75)
  *         FallbackMiddleware <-- swaps config on retryable failure (priority 50)
  *           UsageMiddleware  <-- records the call that ran         (priority 25)
- *             <terminal>
+ *             CircuitBreaker <-- guards the provider call          (priority 20)
+ *               <terminal>
  *
  * What it records: the OPERATION and requested primary CONFIGURATION
  * (identifier, plus its provider/model). When FallbackMiddleware swaps to a

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -61,7 +61,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *
  * The default pipeline order is pinned via tag priority (Telemetry outermost
  * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
- * Usage innermost at 25).
+ * Usage at 25, CircuitBreaker innermost at 20).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 25])]
 final readonly class UsageMiddleware implements ProviderMiddlewareInterface

--- a/Classes/Service/Health/ProviderHealthRepository.php
+++ b/Classes/Service/Health/ProviderHealthRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Health;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
 
@@ -43,6 +44,13 @@ final readonly class ProviderHealthRepository implements ProviderHealthRepositor
             ->where(
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($sinceTimestamp)),
                 $queryBuilder->expr()->neq(self::COL_PROVIDER, $queryBuilder->createNamedParameter('')),
+                // Only count runs the provider served ITSELF. A telemetry row
+                // names the requested PRIMARY provider, but `success` reflects
+                // the whole pipeline outcome — a fallback may have rescued a
+                // failed primary. Excluding fallback runs (fallback_attempts > 0)
+                // stops a failing primary from being scored healthy on the back
+                // of a sibling that answered for it.
+                $queryBuilder->expr()->eq('fallback_attempts', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
             )
             ->groupBy(self::COL_PROVIDER)
             ->executeQuery()

--- a/Classes/Service/Health/ProviderHealthRepository.php
+++ b/Classes/Service/Health/ProviderHealthRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Health;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Aggregates provider health from the telemetry log (ADR-063).
+ *
+ * Reads {@sql tx_nrllm_telemetry} directly via the Doctrine ConnectionPool —
+ * the same access pattern the telemetry writer and usage analytics use —
+ * grouping recent rows by provider into a success rate and mean latency.
+ * Read-only: it never writes the table.
+ */
+final readonly class ProviderHealthRepository implements ProviderHealthRepositoryInterface, SingletonInterface
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private const COL_PROVIDER = 'provider';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function scoresSince(int $sinceTimestamp): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        $rows = $queryBuilder
+            ->select(self::COL_PROVIDER)
+            ->addSelectLiteral('COUNT(*) AS samples')
+            ->addSelectLiteral('SUM(success) AS successes')
+            ->addSelectLiteral('AVG(latency_ms) AS avg_latency')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($sinceTimestamp)),
+                $queryBuilder->expr()->neq(self::COL_PROVIDER, $queryBuilder->createNamedParameter('')),
+            )
+            ->groupBy(self::COL_PROVIDER)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $scores = [];
+        foreach ($rows as $row) {
+            $provider = is_string($row[self::COL_PROVIDER] ?? null) ? $row[self::COL_PROVIDER] : '';
+            if ($provider === '') {
+                continue;
+            }
+
+            $samples    = is_numeric($row['samples'] ?? null) ? (int)$row['samples'] : 0;
+            $successes  = is_numeric($row['successes'] ?? null) ? (int)$row['successes'] : 0;
+            $avgLatency = is_numeric($row['avg_latency'] ?? null) ? (float)$row['avg_latency'] : 0.0;
+
+            $scores[$provider] = ProviderHealthScore::fromSamples($provider, $samples, $successes, $avgLatency);
+        }
+
+        return $scores;
+    }
+}

--- a/Classes/Service/Health/ProviderHealthRepositoryInterface.php
+++ b/Classes/Service/Health/ProviderHealthRepositoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Health;
+
+/**
+ * Read boundary over the telemetry log for provider health (ADR-063).
+ *
+ * Separate from {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface},
+ * which ADR-058 deliberately keeps to append/purge only ("no read path —
+ * telemetry is append-only and analytics query the table directly"). Health
+ * scoring is exactly such an analytics reader, so it lives behind its own
+ * narrow interface rather than widening the telemetry contract.
+ */
+interface ProviderHealthRepositoryInterface
+{
+    /**
+     * Aggregate per-provider health over the rows created at or after the given
+     * UNIX timestamp. Only rows carrying a non-empty provider are considered
+     * (ad-hoc direct calls record no provider). Providers with no rows in the
+     * window are simply absent from the result.
+     *
+     * @return array<string, ProviderHealthScore> keyed by provider identifier
+     */
+    public function scoresSince(int $sinceTimestamp): array;
+}

--- a/Classes/Service/Health/ProviderHealthScore.php
+++ b/Classes/Service/Health/ProviderHealthScore.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Health;
+
+/**
+ * A provider's recent health, derived from the telemetry log (ADR-063).
+ *
+ * `successRate` is the share of successful runs in the sampled window (0.0–1.0);
+ * `avgLatencyMs` the mean end-to-end latency of those runs. `score` is a single
+ * comparable 0.0–1.0 number combining both — success rate dominates, latency is
+ * a mild secondary penalty — so two providers can be ordered by health with one
+ * comparison.
+ *
+ * A provider with no telemetry in the window is "unknown": `sampleCount === 0`
+ * and a neutral `score` of {@see self::NEUTRAL_SCORE}, so an absence of data
+ * never reads as unhealthy (it must not push a provider down the fallback order
+ * just because it has not been called yet).
+ */
+final readonly class ProviderHealthScore
+{
+    /**
+     * Neutral score for a provider with no samples — ranks between healthy and
+     * degraded so "unknown" neither jumps the queue nor sinks.
+     */
+    public const NEUTRAL_SCORE = 0.5;
+
+    /**
+     * Latency at/above which the latency component is fully penalised. Beyond a
+     * few seconds of mean latency the exact figure no longer matters for
+     * ordering — the provider is simply slow.
+     */
+    private const LATENCY_CEILING_MS = 5000.0;
+
+    public function __construct(
+        public string $provider,
+        public int $sampleCount,
+        public float $successRate,
+        public float $avgLatencyMs,
+        public float $score,
+    ) {}
+
+    /**
+     * A provider with no telemetry in the window.
+     */
+    public static function unknown(string $provider): self
+    {
+        return new self($provider, 0, 0.0, 0.0, self::NEUTRAL_SCORE);
+    }
+
+    /**
+     * Compose a score from a sampled window.
+     *
+     * score = 0.8 · successRate + 0.2 · (1 − normalisedLatency)
+     *
+     * Success rate is weighted four times the latency term: a provider that
+     * answers slowly is preferable to one that fails. Latency is normalised
+     * against {@see self::LATENCY_CEILING_MS} and clamped to [0, 1].
+     */
+    public static function fromSamples(string $provider, int $sampleCount, int $successCount, float $avgLatencyMs): self
+    {
+        if ($sampleCount <= 0) {
+            return self::unknown($provider);
+        }
+
+        $successRate = $successCount / $sampleCount;
+
+        $latencyPenalty = min(1.0, max(0.0, $avgLatencyMs) / self::LATENCY_CEILING_MS);
+        $score          = (0.8 * $successRate) + (0.2 * (1.0 - $latencyPenalty));
+
+        return new self(
+            $provider,
+            $sampleCount,
+            $successRate,
+            $avgLatencyMs,
+            $score,
+        );
+    }
+}

--- a/Classes/Service/Health/ProviderHealthService.php
+++ b/Classes/Service/Health/ProviderHealthService.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Health;
+
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Throwable;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Provider health advisor (ADR-063).
+ *
+ * Aggregates the recent telemetry window into per-provider scores
+ * ({@see ProviderHealthRepository}) and caches the result for a short spell so
+ * the opt-in fallback reorder — which runs on every retryable failure — does
+ * not re-run the aggregate on each hop while a provider is flapping.
+ *
+ * Kept private (ADR-028): the middleware and any future consumer wire against
+ * {@see ProviderHealthServiceInterface}; nothing resolves it by class name.
+ */
+final class ProviderHealthService implements ProviderHealthServiceInterface
+{
+    /** Rolling window the score reflects: the last 15 minutes of telemetry. */
+    private const WINDOW_SECONDS = 900;
+
+    private const CACHE_IDENTIFIER = 'nrllm_health';
+
+    private const CACHE_ENTRY = 'scores';
+
+    private const CACHE_LIFETIME = 60;
+
+    private ?FrontendInterface $cache = null;
+
+    public function __construct(
+        private readonly ProviderHealthRepositoryInterface $repository,
+        private readonly LlmConfigurationRepository $configurationRepository,
+        private readonly Typo3CacheManager $cacheManager,
+        private readonly ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    public function scoreFor(string $provider): ProviderHealthScore
+    {
+        return $this->all()[$provider] ?? ProviderHealthScore::unknown($provider);
+    }
+
+    public function all(): array
+    {
+        $cached = $this->readCache();
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $scores = $this->repository->scoresSince(time() - self::WINDOW_SECONDS);
+        $this->writeCache($scores);
+
+        return $scores;
+    }
+
+    public function reorder(FallbackChain $chain): FallbackChain
+    {
+        if ($chain->count() < 2 || !$this->reorderEnabled()) {
+            return $chain;
+        }
+
+        $scores = $this->all();
+
+        // Precompute each candidate's health score and its original position,
+        // then sort by descending score with the original position as a stable
+        // tie-break — so equal-health (and unknown-health) entries keep their
+        // configured order. The reorder is a hint, never a reshuffle.
+        $scoreOf = [];
+        $orderOf = [];
+        foreach ($chain->configurationIdentifiers as $position => $identifier) {
+            $provider            = $this->providerForIdentifier($identifier);
+            $scoreOf[$identifier] = ($provider !== null && isset($scores[$provider]))
+                ? $scores[$provider]->score
+                : ProviderHealthScore::NEUTRAL_SCORE;
+            $orderOf[$identifier] = $position;
+        }
+
+        $ordered = $chain->configurationIdentifiers;
+        usort(
+            $ordered,
+            static fn(string $a, string $b): int => [$scoreOf[$b], $orderOf[$a]] <=> [$scoreOf[$a], $orderOf[$b]],
+        );
+
+        return new FallbackChain($ordered);
+    }
+
+    /**
+     * Resolve the provider a configuration identifier points at, or null when
+     * the configuration is missing.
+     */
+    private function providerForIdentifier(string $identifier): ?string
+    {
+        $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
+        if ($configuration === null) {
+            return null;
+        }
+
+        $provider = $configuration->getProviderType();
+
+        return $provider !== '' ? $provider : null;
+    }
+
+    private function reorderEnabled(): bool
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            return false;
+        }
+
+        $health = \is_array($config['health'] ?? null) ? $config['health'] : [];
+
+        // Default OFF: the configured fallback order stays the default.
+        return \array_key_exists('reorderFallback', $health) && (bool)$health['reorderFallback'];
+    }
+
+    /**
+     * @return array<string, ProviderHealthScore>|null
+     */
+    private function readCache(): ?array
+    {
+        try {
+            $cached = $this->getCache()->get(self::CACHE_ENTRY);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (!\is_array($cached)) {
+            return null;
+        }
+
+        foreach ($cached as $score) {
+            if (!$score instanceof ProviderHealthScore) {
+                return null;
+            }
+        }
+
+        /** @var array<string, ProviderHealthScore> $cached */
+        return $cached;
+    }
+
+    /**
+     * @param array<string, ProviderHealthScore> $scores
+     */
+    private function writeCache(array $scores): void
+    {
+        try {
+            $this->getCache()->set(self::CACHE_ENTRY, $scores, [], self::CACHE_LIFETIME);
+        } catch (Throwable) {
+            // Health scoring must not break on a cache write failure.
+        }
+    }
+
+    private function getCache(): FrontendInterface
+    {
+        if (!$this->cache instanceof FrontendInterface) {
+            $this->cache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
+        }
+
+        return $this->cache;
+    }
+}

--- a/Classes/Service/Health/ProviderHealthServiceInterface.php
+++ b/Classes/Service/Health/ProviderHealthServiceInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Health;
+
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+
+/**
+ * Provider health, derived from recent telemetry (ADR-063).
+ *
+ * A read-only advisor over the telemetry log. It never changes provider
+ * selection on its own; callers decide whether to consult it. The one built-in
+ * consumer is {@see \Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware},
+ * which asks {@see self::reorder()} to prefer healthier providers — but only
+ * when the operator opts in (see the method contract).
+ */
+interface ProviderHealthServiceInterface
+{
+    /**
+     * Health of one provider over the recent window. A provider with no recent
+     * telemetry is reported as {@see ProviderHealthScore::unknown()} (neutral),
+     * never as unhealthy.
+     */
+    public function scoreFor(string $provider): ProviderHealthScore;
+
+    /**
+     * Health of every provider seen in the recent window, keyed by provider.
+     *
+     * @return array<string, ProviderHealthScore>
+     */
+    public function all(): array;
+
+    /**
+     * Return the fallback chain reordered by descending provider health, as a
+     * HINT — a stable sort, so configurations whose providers are equally
+     * healthy (or unknown) keep their configured order. This is the tie-break
+     * the task calls for: it never drops a candidate, only reprioritises.
+     *
+     * Gated by the `health.reorderFallback` extension setting: OFF by default,
+     * in which case the chain is returned untouched with no telemetry query, so
+     * the configured fallback order stays the default and this stays
+     * minimal-invasive. Chains shorter than two entries are returned as-is.
+     */
+    public function reorder(FallbackChain $chain): FallbackChain;
+}

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -161,7 +162,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             return $this->chatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
-                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
                 $optionsArray,
             );
         }
@@ -172,7 +173,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
             fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
 
@@ -190,7 +191,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             return $this->completeWithConfiguration(
                 $this->injectConfigSkillsIntoPrompt($prompt, $defaultConfiguration),
                 $defaultConfiguration,
-                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
                 $optionsArray,
             );
         }
@@ -199,7 +200,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
             ProviderOperation::Completion,
             fn(): CompletionResponse => $this->getProvider($providerKey)->complete($prompt, $optionsArray),
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
 
@@ -218,7 +219,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // is left out and CacheMiddleware becomes a no-op for this call. The
         // ad-hoc path keys by provider identifier.
         $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
-        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
+        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey());
         $resolvedProvider = $providerKey ?? 'default';
         $metadata += $this->embedCacheKeyBuilder->build(
             $cacheTtl,
@@ -292,7 +293,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
                 return $provider->analyzeImage($normalisedContent, $optionsArray);
             },
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
 
@@ -395,7 +396,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
                 return $provider->chatCompletionWithTools($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
             },
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
 
@@ -453,7 +454,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                     $callOptions,
                 );
             },
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
 
@@ -489,7 +490,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $optionOverrides = $options->toArray();
         unset($optionOverrides['provider']);
 
-        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost());
+        $metadata = $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey());
 
         // Cache metadata mirrors embed(), but the configuration path keys by
         // configuration identifier plus the effective model (options override
@@ -784,6 +785,24 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         }
 
         return $chars;
+    }
+
+    /**
+     * Translate an optional idempotency key (ADR-063) into the metadata key the
+     * IdempotencyMiddleware reads. Empty / absent keys produce no entry, so the
+     * middleware's pass-through branch fires and non-idempotent calls are
+     * untouched. Disjoint from {@see self::buildBudgetMetadata()} keys, so the
+     * two merge with `+` at every call site.
+     *
+     * @return array<string, mixed>
+     */
+    private function idempotencyMetadata(?string $idempotencyKey): array
+    {
+        if ($idempotencyKey === null || $idempotencyKey === '') {
+            return [];
+        }
+
+        return [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $idempotencyKey];
     }
 
     /**

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -20,11 +20,38 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
 abstract class AbstractOptions
 {
     /**
+     * Optional request idempotency key (ADR-063). A repeated call carrying the
+     * same key returns the stored result instead of calling the provider again
+     * (see IdempotencyMiddleware). NOT a provider option — it is deliberately
+     * kept out of {@see self::toArray()} so it is never sent to the provider;
+     * the service layer forwards it as call metadata.
+     */
+    protected ?string $idempotencyKey = null;
+
+    /**
      * Convert options to array format for providers.
      *
      * @return array<string, mixed>
      */
     abstract public function toArray(): array;
+
+    public function getIdempotencyKey(): ?string
+    {
+        return $this->idempotencyKey;
+    }
+
+    /**
+     * Return a copy tagged with an idempotency key. A repeat call with the same
+     * key is served from the idempotency store rather than re-hitting the
+     * provider (ADR-063).
+     */
+    public function withIdempotencyKey(string $idempotencyKey): static
+    {
+        $clone = clone $this;
+        $clone->idempotencyKey = $idempotencyKey;
+
+        return $clone;
+    }
 
     /**
      * Validate value is within numeric range.

--- a/Configuration/Caching.php
+++ b/Configuration/Caching.php
@@ -34,4 +34,35 @@ return [
         ],
         'groups' => ['nrllm'],
     ],
+    // Per-provider circuit breaker state (ADR-063). Transient by design: the
+    // store writes its own per-entry lifetime, so this default only applies to
+    // an entry written without one. Shared across web workers via the instance
+    // backend (Redis/Valkey) so one worker tripping a circuit protects them all.
+    'nrllm_circuit' => [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 300,
+        ],
+        'groups' => ['nrllm'],
+    ],
+    // Short-lived provider health snapshot (ADR-063), so the opt-in fallback
+    // reorder does not re-aggregate the telemetry log on every retryable hop.
+    'nrllm_health' => [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 60,
+        ],
+        'groups' => ['nrllm'],
+    ],
+    // Request idempotency store (ADR-063). Serialises whole typed responses
+    // (VariableFrontend), so a repeated request with the same idempotency key
+    // returns the stored result instead of calling the provider again. The
+    // middleware writes its own per-entry TTL (the idempotency window).
+    'nrllm_idempotency' => [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 86400,
+        ],
+        'groups' => ['nrllm'],
+    ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -177,6 +177,24 @@ services:
     alias: Netresearch\NrLlm\Service\Telemetry\TelemetryRepository
     public: false
 
+  # Circuit breaker state store (ADR-063) — private; consumed by
+  # CircuitBreakerMiddleware. The cache-backed default is instantiated directly
+  # in its functional test with the real core cache manager.
+  Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface:
+    alias: Netresearch\NrLlm\Provider\CircuitBreaker\CacheCircuitBreakerStore
+    public: false
+
+  # Provider health advisor (ADR-063) — private; consulted by FallbackMiddleware
+  # for the opt-in health-aware fallback reorder. The telemetry-reading
+  # repository stays private too (analytics read path, like the recorder).
+  Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface:
+    alias: Netresearch\NrLlm\Service\Health\ProviderHealthService
+    public: false
+
+  Netresearch\NrLlm\Service\Health\ProviderHealthRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Health\ProviderHealthRepository
+    public: false
+
   # Quality-evaluation subsystem (ADR-060). Everything here is private:
   # the persistence layer is instantiated directly in its functional test
   # (its only dependency is ConnectionPool), the command is made public by

--- a/Documentation/Adr/Adr063ProviderResilience.rst
+++ b/Documentation/Adr/Adr063ProviderResilience.rst
@@ -1,0 +1,237 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-063:
+
+======================================================================
+ADR-063: Provider Resilience — Circuit Breaker, Health, Idempotency
+======================================================================
+
+:Status: Accepted
+:Date: 2026-07
+:Authors: Netresearch DTT GmbH
+
+.. _adr-063-context:
+
+Context
+=======
+
+A comparison of this extension against a sibling agent framework surfaced a set
+of resilience features neither side had: a **circuit breaker** (stop hammering a
+provider that is down), **provider health scoring** (know which provider is
+currently healthy), and **request idempotency** (a retried request must not
+double-charge or produce a second, different answer). The middleware pipeline
+(:ref:`adr-026`) and the telemetry log (:ref:`adr-058`) already give the seams
+to add these without touching provider adapters.
+
+The same comparison listed **OpenTelemetry** as a gap. It is addressed here too
+— by deciding *not* to build it (see below).
+
+.. _adr-063-decision:
+
+Decision
+========
+
+Circuit breaker
+---------------
+
+A new :php:`CircuitBreakerMiddleware` tracks consecutive failing calls **per
+provider**. After ``circuitBreaker.failureThreshold`` consecutive *tripping*
+failures the circuit **opens**: for ``circuitBreaker.cooldownSeconds`` further
+calls to that provider fail fast with a :php:`CircuitOpenException` instead of
+waiting on a connection timeout. After the cooldown a single **half-open** probe
+is allowed; success **closes** the circuit, failure re-opens it.
+
+*Tripping* failures are exactly the set :php:`FallbackMiddleware` already treats
+as retryable — :php:`ProviderConnectionException` (network / timeout / 5xx /
+retries exhausted) and a ``429`` :php:`ProviderResponseException` (rate limit).
+Client errors (other 4xx), misconfiguration and unsupported-feature errors mean
+the provider *answered*; they are not a health signal and neither trip nor reset
+the circuit.
+
+**Pipeline placement — innermost, priority 20.** This is the load-bearing design
+choice, so it is spelled out:
+
+.. code-block:: text
+
+   TelemetryMiddleware      110  observes every run
+     IdempotencyMiddleware  105  replays a stored result by key
+       CacheMiddleware      100  payload cache; short-circuits on hit
+         BudgetMiddleware    75  pre-flight budget gate
+           FallbackMiddleware 50 swaps configuration on retryable failure
+             UsageMiddleware  25 records the served call
+               CircuitBreaker 20 guards the actual provider call   (THIS)
+                 <terminal>
+
+* **Inside FallbackMiddleware.** An open circuit throws
+  :php:`CircuitOpenException`, which :php:`FallbackMiddleware` now treats as
+  retryable. Because the breaker sits *inside* the fallback loop, that exception
+  is raised from within ``$next($configuration)`` on each attempt, so Fallback
+  catches it and advances to the next configuration/provider. A naïve reading
+  puts the breaker "between Budget (75) and Fallback (50)"; that would be
+  **wrong** — outside Fallback, an open primary circuit would abort the whole
+  call before any fallback ran, the opposite of the intent (skip the sick
+  provider, use a healthy one). The breaker therefore lives *below* Fallback.
+* **Inside UsageMiddleware.** The breaker wraps only the terminal, so the health
+  signal reflects the pure provider call — usage bookkeeping (success-only, with
+  its own error handling) never contaminates it, and a genuine success closes
+  the circuit before any post-processing.
+
+:php:`CircuitOpenException` extends :php:`ProviderException` (so it carries the
+:ref:`adr-053` marker interface); :php:`ProviderConnectionException` is
+``final``, so extending *that* was not an option — instead
+:php:`FallbackMiddleware::isRetryable()` gained one explicit ``instanceof``
+arm.
+
+**Circuit state storage: cache, not a table.** State
+(``consecutiveFailures`` + ``openedAt``) lives in the ``nrllm_circuit`` cache via
+:php:`CircuitBreakerStoreInterface` (no hardcoded backend — the instance's
+Redis/Valkey is shared across web workers, so one worker tripping a circuit
+protects them all). Rationale: the state is inherently transient, self-decaying
+(a forgotten entry reads as *closed*, the fail-safe default), and needs no
+schema, no purge command, and no write on every call. A DB table would add write
+load on the hot path and a maintenance surface for data that is meant to be
+ephemeral. The half-open single-probe gate is pragmatic (refresh the open window
+before probing) rather than an atomic compare-and-set, which the cache backend
+cannot portably offer — a few extra probes after a cooldown is acceptable.
+
+Provider health scoring
+-----------------------
+
+:php:`ProviderHealthService` reads the **existing** telemetry log
+(:sql:`tx_nrllm_telemetry`, :ref:`adr-058`) over a rolling window and computes a
+per-provider :php:`ProviderHealthScore` (success rate + mean latency into one
+comparable ``0.0–1.0`` number; success rate weighted 4:1 over latency). No new
+write path and no second source of truth — telemetry already records
+success/latency per run, so health is a **read model** over it. Reads go through
+a dedicated :php:`ProviderHealthRepository`; the telemetry recorder's own
+interface stays append/purge-only, as :ref:`adr-058` intended.
+
+The one built-in consumer is :php:`FallbackMiddleware`, which asks
+:php:`ProviderHealthService::reorder()` to prefer healthier providers among the
+fallback candidates. It is a **hint, opt-in, and minimal-invasive**:
+
+* Gated by ``health.reorderFallback`` — **OFF by default**. When off, the chain
+  is returned untouched with *no* telemetry query, so the configured fallback
+  order stays the default.
+* When on, it is a **stable** sort by descending health: providers of equal (or
+  unknown) health keep their configured order, and no candidate is ever dropped.
+  A provider with no telemetry scores *neutral*, never unhealthy — an
+  un-exercised provider must not sink just for lack of data.
+
+A pure config-order-primary "tie-break" would be a no-op on a totally-ordered
+chain (there are no ties to break), so health-primary reordering is offered as
+the opt-in instead; the default-off flag is what keeps existing behaviour
+identical.
+
+Idempotency keys
+----------------
+
+An optional idempotency key on any options object
+(:php:`AbstractOptions::withIdempotencyKey()`) makes a repeated request return
+the stored result instead of calling the provider again. A new
+:php:`IdempotencyMiddleware` (priority 105 — just inside Telemetry, outside
+Cache/Budget, so a replay short-circuits the behavioural stack and is not
+re-charged, yet is still observed) stores the result under the key and replays
+it on the next call with the same key. Failed calls and streaming generators are
+never stored.
+
+**Cache, not a table** — and *not* an overload of the existing cache key. The
+task hypothesis ("make it a thin layer on CacheMiddleware's key") was
+investigated and rejected: :php:`CacheMiddleware` is deliberately array-only (it
+persists ``array<string, mixed>``), so it cannot round-trip the **typed**
+responses (:php:`CompletionResponse`, …) that the chat/completion paths return —
+which is the case idempotency actually matters for. The dedicated middleware
+stores over its own ``nrllm_idempotency`` :php:`VariableFrontend`, which
+serialises any response value, so idempotency works for every operation while
+staying cache-backed: idempotency results are transient and TTL-bounded by
+nature, so a table (with its purge/TCA surface) would be the wrong store.
+
+OpenTelemetry — deliberately not built
+--------------------------------------
+
+OTel exporters/collectors are **out of scope for a TYPO3 extension**. The
+extension should not own an OTLP exporter, a collector endpoint, or trace
+sampling configuration — that is the **host instance's** observability
+responsibility (the same instance that owns logging, APM, and metrics scraping).
+What the extension *can* own — durable per-request metrics — already exists as
+:sql:`tx_nrllm_telemetry` (:ref:`adr-058`) with a correlation id per run; a host
+that runs OTel can scrape or forward that. Building an in-extension OTel pipeline
+would duplicate host infrastructure, couple the extension to an exporter SDK, and
+add configuration the operator already manages centrally.
+
+.. _adr-063-consequences:
+
+Consequences
+============
+
+* **Faster failure, healthier routing.** A downed provider is skipped within one
+  cooldown window instead of timing out on every call; with the opt-in reorder
+  on, a flapping provider is de-prioritised among fallbacks.
+* **Circuit state is cluster-wide but forgettable.** On a shared cache backend
+  every worker sees the same circuit; a cache flush resets all circuits to
+  closed (a conservative retry), which is acceptable.
+* **Health is advisory only.** With ``health.reorderFallback`` off (default),
+  provider selection is byte-for-byte unchanged. The reorder, when enabled,
+  re-loads each candidate configuration once to resolve its provider — a cost
+  paid only on the opt-in path, on the (already-failing) fallback route.
+* **Idempotency is opt-in and best-effort.** No key ⇒ no behavioural change. A
+  cache miss/flush simply re-runs the call. It does not deduplicate concurrent
+  in-flight requests — it replays a *completed* result.
+* **One new retryable exception.** :php:`FallbackMiddleware::isRetryable()` now
+  also matches :php:`CircuitOpenException`; the pipeline order test and the
+  fallback tests pin this.
+* **Three new caches** (``nrllm_circuit``, ``nrllm_health``,
+  ``nrllm_idempotency``), all without a hardcoded backend, all in the ``nrllm``
+  cache group so a group flush clears them.
+
+.. _adr-063-alternatives:
+
+Alternatives considered
+=======================
+
+* **Circuit state in a DB table** (``tx_nrllm_provider_circuit``). Rejected:
+  ephemeral, hot-path state does not want a table, a per-call write, or a purge
+  command. Cache is the natural store and shares state across workers for free.
+* **Circuit breaker outside FallbackMiddleware** (priority ~60). Rejected: an
+  open primary circuit would abort the call before fallback, defeating the
+  purpose. The breaker must be *inside* the fallback loop.
+* **Health scoring on its own rolling-window state.** Rejected: telemetry
+  already records exactly the success/latency signal; a second store would
+  duplicate it and drift. Read the log.
+* **Health as a config-order-primary tie-break** (never reorders). Rejected as a
+  no-op: a totally-ordered chain has no ties, so this would never change
+  anything. Opt-in health-primary reorder (default off) gives a real,
+  operator-controlled behaviour without changing the default.
+* **Idempotency as a thin overload of CacheMiddleware's key.** Rejected:
+  CacheMiddleware is array-only by design and cannot store the typed responses
+  the valuable (chat) case returns. A dedicated middleware over its own
+  VariableFrontend is the minimal store that works for every response type.
+* **Idempotency in a DB table.** Rejected: transient, TTL-bounded data belongs
+  in the cache, not a table with a purge/TCA surface.
+* **Build OpenTelemetry into the extension.** Rejected: host-instance
+  responsibility; the telemetry log already exposes per-request metrics a host
+  OTel stack can consume.
+
+.. _adr-063-followups:
+
+Deferred / follow-ups
+=====================
+
+* A backend readout of circuit state and health scores (a diagnostics panel).
+  The services expose the data; only a view is missing.
+* Per-operation idempotency TTL override via call metadata (the middleware uses
+  a single window today).
+
+.. _adr-063-references:
+
+References
+==========
+
+* :ref:`adr-026` — Provider Middleware Pipeline (the pipeline and ordering this
+  extends).
+* :ref:`adr-058` — Telemetry Middleware (the log health scoring reads; the
+  per-request metrics that make in-extension OTel unnecessary).
+* :ref:`adr-053` — Exception marker interface (:php:`CircuitOpenException`
+  inherits it via :php:`ProviderException`).
+* ADR-021 — Provider Fallback Chain (the chain the health reorder reprioritises).
+* ADR-028 — Public Services Policy (all new services stay private).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -361,4 +361,5 @@ Tools
    Adr060QualityEvaluation
    Adr061SkillTrustEgressAndAudit
    Adr062StreamingLifecycle
+   Adr063ProviderResilience
    Adr065ReducePublicServiceSurface

--- a/Tests/Functional/Provider/CircuitBreaker/CacheCircuitBreakerStoreTest.php
+++ b/Tests/Functional/Provider/CircuitBreaker/CacheCircuitBreakerStoreTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\CircuitBreaker;
+
+use Netresearch\NrLlm\Provider\CircuitBreaker\CacheCircuitBreakerStore;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+
+/**
+ * Round-trips circuit state through the real `nrllm_circuit` cache, proving the
+ * VariableFrontend + entry-identifier sanitisation work end to end.
+ */
+#[CoversClass(CacheCircuitBreakerStore::class)]
+#[CoversClass(CircuitState::class)]
+final class CacheCircuitBreakerStoreTest extends AbstractFunctionalTestCase
+{
+    private CacheCircuitBreakerStore $store;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The store is private in the container by design; instantiate it with
+        // the real core cache manager (the nrllm_circuit cache is registered by
+        // ext_localconf.php, which the functional bootstrap loads).
+        $cacheManager = $this->get(Typo3CacheManager::class);
+        self::assertInstanceOf(Typo3CacheManager::class, $cacheManager);
+
+        $this->store = new CacheCircuitBreakerStore($cacheManager, new NullLogger());
+    }
+
+    #[Test]
+    public function loadReturnsClosedForUnknownProvider(): void
+    {
+        $state = $this->store->load('never-seen');
+
+        self::assertTrue($state->isPristine());
+    }
+
+    #[Test]
+    public function savedStateRoundTrips(): void
+    {
+        $this->store->save('openai', new CircuitState(4, 1_700_000_000), 300);
+
+        $loaded = $this->store->load('openai');
+        self::assertSame(4, $loaded->consecutiveFailures);
+        self::assertSame(1_700_000_000, $loaded->openedAt);
+    }
+
+    #[Test]
+    public function providerIdentifiersWithReservedCharactersDoNotCollide(): void
+    {
+        // The ad-hoc scheme carries colons the cache frontend rejects; the store
+        // must map them to distinct, valid entry identifiers.
+        $this->store->save('ad-hoc:chat:openai', new CircuitState(1, null), 300);
+        $this->store->save('ad-hoc:chat:groq', new CircuitState(7, 1_700_000_500), 300);
+
+        self::assertSame(1, $this->store->load('ad-hoc:chat:openai')->consecutiveFailures);
+        self::assertSame(7, $this->store->load('ad-hoc:chat:groq')->consecutiveFailures);
+        self::assertSame(1_700_000_500, $this->store->load('ad-hoc:chat:groq')->openedAt);
+    }
+
+    #[Test]
+    public function laterSaveOverwritesEarlierState(): void
+    {
+        $this->store->save('openai', new CircuitState(5, 1_700_000_000), 300);
+        $this->store->save('openai', CircuitState::closed(), 300);
+
+        self::assertTrue($this->store->load('openai')->isPristine());
+    }
+}

--- a/Tests/Functional/Provider/Middleware/IdempotencyMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/IdempotencyMiddlewarePipelineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+
+/**
+ * Proves idempotency round-trips a real, typed CompletionResponse through the
+ * live `nrllm_idempotency` VariableFrontend — the capability that motivated a
+ * dedicated middleware over the deliberately array-only CacheMiddleware.
+ */
+#[CoversClass(IdempotencyMiddleware::class)]
+final class IdempotencyMiddlewarePipelineTest extends AbstractFunctionalTestCase
+{
+    private IdempotencyMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cacheManager = $this->get(Typo3CacheManager::class);
+        self::assertInstanceOf(Typo3CacheManager::class, $cacheManager);
+
+        $this->middleware = new IdempotencyMiddleware($cacheManager);
+    }
+
+    #[Test]
+    public function replaysAStoredTypedResponseFromTheRealCache(): void
+    {
+        $context  = new ProviderCallContext(
+            ProviderOperation::Chat,
+            'corr',
+            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => 'checkout-99'],
+        );
+        $response = new CompletionResponse(
+            content: 'idempotent answer',
+            model: 'gpt-4o',
+            usage: UsageStatistics::fromArray(['promptTokens' => 5, 'completionTokens' => 7, 'totalTokens' => 12]),
+            provider: 'openai',
+        );
+
+        // First call computes and stores.
+        $first = $this->middleware->handle(
+            $context,
+            new LlmConfiguration(),
+            static fn(LlmConfiguration $c): CompletionResponse => $response,
+        );
+        self::assertInstanceOf(CompletionResponse::class, $first);
+
+        // Second call with the same key must NOT reach the provider — a throwing
+        // terminal proves the replay is served entirely from the store.
+        $replay = $this->middleware->handle(
+            $context,
+            new LlmConfiguration(),
+            static fn(LlmConfiguration $c): CompletionResponse => throw new RuntimeException('provider must not be called', 1),
+        );
+
+        self::assertInstanceOf(CompletionResponse::class, $replay);
+        self::assertSame('idempotent answer', $replay->content);
+        self::assertSame('gpt-4o', $replay->model);
+        self::assertSame('openai', $replay->provider);
+        self::assertSame(12, $replay->usage->totalTokens);
+    }
+}

--- a/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
+++ b/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
@@ -11,7 +11,9 @@ namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
 
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
@@ -39,7 +41,7 @@ use ReflectionClass;
 final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 {
     #[Test]
-    public function pipelineIsAssembledTelemetryCacheBudgetFallbackUsage(): void
+    public function pipelineIsAssembledInDocumentedPriorityOrder(): void
     {
         $pipeline = $this->get(MiddlewarePipeline::class);
         self::assertInstanceOf(MiddlewarePipeline::class, $pipeline);
@@ -48,11 +50,13 @@ final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             [
-                TelemetryMiddleware::class, // outermost: observes every run (ADR-058)
-                CacheMiddleware::class,     // outermost behavioural layer: a cache hit short-circuits
-                BudgetMiddleware::class,    // pre-flight budget gate on a miss
-                FallbackMiddleware::class,  // swaps configuration on retryable failure
-                UsageMiddleware::class,     // innermost: records the call that ran
+                TelemetryMiddleware::class,      // 110 outermost: observes every run (ADR-058)
+                IdempotencyMiddleware::class,    // 105 replays a stored result by key (ADR-063)
+                CacheMiddleware::class,          // 100 outermost behavioural layer: a cache hit short-circuits
+                BudgetMiddleware::class,         //  75 pre-flight budget gate on a miss
+                FallbackMiddleware::class,       //  50 swaps configuration on retryable failure
+                UsageMiddleware::class,          //  25 records the served call
+                CircuitBreakerMiddleware::class, //  20 innermost: guards the provider call (ADR-063)
             ],
             $order,
         );

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -77,6 +77,24 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function ignoresRunsServedByAFallback(): void
+    {
+        $now = time();
+        // openai failed serving the request itself (fallback_attempts = 0) ...
+        $this->insertRow('openai', false, 200, $now, 0);
+        // ... and a run where openai was the requested PRIMARY but a fallback
+        // rescued it (success = 1, fallback_attempts = 2). The success belongs
+        // to the fallback, not to openai — it must not credit openai's health.
+        $this->insertRow('openai', true, 150, $now, 2);
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayHasKey('openai', $scores);
+        self::assertSame(1, $scores['openai']->sampleCount, 'Only the self-served run counts');
+        self::assertSame(0.0, $scores['openai']->successRate);
+    }
+
+    #[Test]
     public function separatesProvidersIntoDistinctScores(): void
     {
         $now = time();
@@ -91,7 +109,7 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
         self::assertSame(0.0, $scores['claude']->successRate);
     }
 
-    private function insertRow(string $provider, bool $success, int $latencyMs, int $crdate): void
+    private function insertRow(string $provider, bool $success, int $latencyMs, int $crdate, int $fallbackAttempts = 0): void
     {
         $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
             'pid'                      => 0,
@@ -105,7 +123,7 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
             'error_class'              => '',
             'latency_ms'               => $latencyMs,
             'cache_hit'                => 0,
-            'fallback_attempts'        => 0,
+            'fallback_attempts'        => $fallbackAttempts,
             'crdate'                   => $crdate,
         ]);
     }

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Health;
+
+use Netresearch\NrLlm\Service\Health\ProviderHealthRepository;
+use Netresearch\NrLlm\Service\Health\ProviderHealthScore;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+#[CoversClass(ProviderHealthRepository::class)]
+#[CoversClass(ProviderHealthScore::class)]
+final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private ProviderHealthRepository $repository;
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        $this->repository = new ProviderHealthRepository($this->connectionPool);
+    }
+
+    #[Test]
+    public function aggregatesSuccessRateAndLatencyPerProvider(): void
+    {
+        $now = time();
+        $this->insertRow('openai', true, 100, $now);
+        $this->insertRow('openai', true, 300, $now);
+        $this->insertRow('openai', false, 200, $now);
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayHasKey('openai', $scores);
+        $openai = $scores['openai'];
+        self::assertSame(3, $openai->sampleCount);
+        self::assertEqualsWithDelta(2 / 3, $openai->successRate, 0.0001);
+        self::assertEqualsWithDelta(200.0, $openai->avgLatencyMs, 0.0001);
+    }
+
+    #[Test]
+    public function excludesRowsOlderThanTheWindow(): void
+    {
+        $now = time();
+        $this->insertRow('groq', true, 50, $now - 100_000); // outside a 900s window
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayNotHasKey('groq', $scores);
+    }
+
+    #[Test]
+    public function ignoresRowsWithoutAProvider(): void
+    {
+        $now = time();
+        // Ad-hoc direct calls record an empty provider — not a health signal.
+        $this->insertRow('', true, 10, $now);
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayNotHasKey('', $scores);
+    }
+
+    #[Test]
+    public function separatesProvidersIntoDistinctScores(): void
+    {
+        $now = time();
+        $this->insertRow('openai', true, 100, $now);
+        $this->insertRow('claude', false, 400, $now);
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayHasKey('openai', $scores);
+        self::assertArrayHasKey('claude', $scores);
+        self::assertSame(1.0, $scores['openai']->successRate);
+        self::assertSame(0.0, $scores['claude']->successRate);
+    }
+
+    private function insertRow(string $provider, bool $success, int $latencyMs, int $crdate): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'correlation_id'           => 'corr-' . uniqid('', true),
+            'operation'                => 'chat',
+            'provider'                 => $provider,
+            'model'                    => '',
+            'configuration_identifier' => 'primary',
+            'be_user'                  => 0,
+            'success'                  => $success ? 1 : 0,
+            'error_class'              => '',
+            'latency_ms'               => $latencyMs,
+            'cache_hit'                => 0,
+            'fallback_attempts'        => 0,
+            'crdate'                   => $crdate,
+        ]);
+    }
+}

--- a/Tests/Unit/Fixture/InMemoryCircuitBreakerStore.php
+++ b/Tests/Unit/Fixture/InMemoryCircuitBreakerStore.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Fixture;
+
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+
+/**
+ * In-memory circuit breaker store for unit tests.
+ *
+ * Holds one state per provider (seed it via {@see self::seed()}) and captures
+ * the saved states so assertions verify what the middleware persisted — never a
+ * mock return.
+ */
+final class InMemoryCircuitBreakerStore implements CircuitBreakerStoreInterface
+{
+    /** @var array<string, CircuitState> */
+    private array $states = [];
+
+    /** @var list<array{provider: string, state: CircuitState, lifetime: int}> */
+    public array $saves = [];
+
+    public function seed(string $provider, CircuitState $state): void
+    {
+        $this->states[$provider] = $state;
+    }
+
+    public function load(string $provider): CircuitState
+    {
+        return $this->states[$provider] ?? CircuitState::closed();
+    }
+
+    public function save(string $provider, CircuitState $state, int $lifetimeSeconds): void
+    {
+        $this->states[$provider] = $state;
+        $this->saves[]           = [
+            'provider' => $provider,
+            'state'    => $state,
+            'lifetime' => $lifetimeSeconds,
+        ];
+    }
+}

--- a/Tests/Unit/Provider/CircuitBreaker/CircuitStateTest.php
+++ b/Tests/Unit/Provider/CircuitBreaker/CircuitStateTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\CircuitBreaker;
+
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitStatus;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(CircuitState::class)]
+#[CoversClass(CircuitStatus::class)]
+final class CircuitStateTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function closedFactoryHasNoFailuresAndNoOpenTimestamp(): void
+    {
+        $state = CircuitState::closed();
+
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertNull($state->openedAt);
+        self::assertTrue($state->isPristine());
+    }
+
+    #[Test]
+    public function statusIsClosedWhenNeverOpened(): void
+    {
+        $state = new CircuitState(3, null);
+
+        self::assertSame(CircuitStatus::Closed, $state->status(1_000, 30));
+        // A failure streak without an open timestamp is still "closed" — it is
+        // counting toward the threshold, not tripped.
+        self::assertFalse($state->isPristine());
+    }
+
+    #[Test]
+    public function statusIsOpenWithinCooldownAndHalfOpenAfter(): void
+    {
+        $openedAt = 1_000;
+        $state    = new CircuitState(5, $openedAt);
+
+        self::assertSame(CircuitStatus::Open, $state->status($openedAt + 29, 30));
+        // Boundary: exactly at cooldown the window has elapsed → half-open.
+        self::assertSame(CircuitStatus::HalfOpen, $state->status($openedAt + 30, 30));
+        self::assertSame(CircuitStatus::HalfOpen, $state->status($openedAt + 120, 30));
+    }
+
+    #[Test]
+    public function secondsUntilHalfOpenCountsDownAndFloorsAtZero(): void
+    {
+        $openedAt = 1_000;
+        $state    = new CircuitState(5, $openedAt);
+
+        self::assertSame(30, $state->secondsUntilHalfOpen($openedAt, 30));
+        self::assertSame(1, $state->secondsUntilHalfOpen($openedAt + 29, 30));
+        self::assertSame(0, $state->secondsUntilHalfOpen($openedAt + 30, 30));
+        self::assertSame(0, $state->secondsUntilHalfOpen($openedAt + 999, 30));
+        // Not open → no wait.
+        self::assertSame(0, (new CircuitState(0, null))->secondsUntilHalfOpen(1_000, 30));
+    }
+
+    #[Test]
+    public function roundTripsThroughArray(): void
+    {
+        $state = new CircuitState(4, 12_345);
+
+        self::assertSame(['consecutiveFailures' => 4, 'openedAt' => 12_345], $state->toArray());
+
+        $restored = CircuitState::fromArray($state->toArray());
+        self::assertSame(4, $restored->consecutiveFailures);
+        self::assertSame(12_345, $restored->openedAt);
+    }
+
+    #[Test]
+    public function fromArrayDecaysMalformedInputToClosed(): void
+    {
+        // A corrupt entry must never wedge a provider open.
+        $state = CircuitState::fromArray([
+            'consecutiveFailures' => 'not-an-int',
+            'openedAt'            => -7,
+        ]);
+
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertNull($state->openedAt);
+
+        $empty = CircuitState::fromArray([]);
+        self::assertTrue($empty->isPristine());
+    }
+}

--- a/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
@@ -1,0 +1,328 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryCircuitBreakerStore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(CircuitBreakerMiddleware::class)]
+final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
+{
+    private const PROVIDER = 'openai';
+
+    #[Test]
+    public function passesThroughWhenDisabled(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        // Even a wide-open circuit must be ignored when the breaker is off.
+        $store->seed(self::PROVIDER, new CircuitState(9, time()));
+
+        $result = $this->middleware($store, enabled: false)->handle(
+            $this->context(),
+            $this->config(self::PROVIDER),
+            static fn(LlmConfiguration $c): string => 'ok',
+        );
+
+        self::assertSame('ok', $result);
+        self::assertSame([], $store->saves);
+    }
+
+    #[Test]
+    public function passesThroughWhenConfigurationHasNoCircuitKey(): void
+    {
+        $store  = new InMemoryCircuitBreakerStore();
+        $called = false;
+
+        $result = $this->middleware($store)->handle(
+            $this->context(),
+            new LlmConfiguration(), // no identifier, no model → empty key
+            static function (LlmConfiguration $c) use (&$called): string {
+                $called = true;
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+        self::assertTrue($called);
+        self::assertSame([], $store->saves);
+    }
+
+    #[Test]
+    public function closedCircuitSuccessDoesNotWriteState(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+
+        $result = $this->middleware($store)->handle(
+            $this->context(),
+            $this->config(self::PROVIDER),
+            static fn(LlmConfiguration $c): string => 'ok',
+        );
+
+        self::assertSame('ok', $result);
+        // Hot path: a healthy closed circuit performs no redundant cache write.
+        self::assertSame([], $store->saves);
+    }
+
+    #[Test]
+    public function opensAfterThresholdConsecutiveFailures(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        $middleware = $this->middleware($store, threshold: 3, cooldown: 30);
+
+        for ($i = 0; $i < 3; $i++) {
+            try {
+                $middleware->handle(
+                    $this->context(),
+                    $this->config(self::PROVIDER),
+                    static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('down', 0),
+                );
+                self::fail('Expected the connection failure to propagate');
+            } catch (ProviderConnectionException) {
+                // expected — the breaker records and re-throws
+            }
+        }
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(3, $state->consecutiveFailures);
+        self::assertNotNull($state->openedAt, 'Circuit must be open after the threshold is reached');
+        // Cooldown 30 → lifetime max(60, 60) = 60.
+        $lastSave = end($store->saves);
+        self::assertIsArray($lastSave);
+        self::assertSame(60, $lastSave['lifetime']);
+    }
+
+    #[Test]
+    public function belowThresholdCircuitStaysClosed(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+
+        try {
+            $this->middleware($store, threshold: 3)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('down', 0),
+            );
+        } catch (ProviderConnectionException) {
+        }
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(1, $state->consecutiveFailures);
+        self::assertNull($state->openedAt);
+    }
+
+    #[Test]
+    public function openCircuitFailsFastWithoutCallingProvider(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        $store->seed(self::PROVIDER, new CircuitState(5, time())); // opened just now
+        $called = false;
+
+        try {
+            $this->middleware($store, cooldown: 30)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static function (LlmConfiguration $c) use (&$called): string {
+                    $called = true;
+
+                    return 'ok';
+                },
+            );
+            self::fail('Expected CircuitOpenException');
+        } catch (CircuitOpenException $e) {
+            self::assertSame(self::PROVIDER, $e->provider);
+            self::assertGreaterThan(0, $e->retryAfterSeconds);
+        }
+
+        self::assertFalse($called, 'An open circuit must not reach the provider');
+    }
+
+    #[Test]
+    public function halfOpenProbeSuccessClosesCircuit(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        // Opened long enough ago that the cooldown has elapsed → half-open.
+        $store->seed(self::PROVIDER, new CircuitState(5, time() - 31));
+        $called = false;
+
+        $result = $this->middleware($store, cooldown: 30)->handle(
+            $this->context(),
+            $this->config(self::PROVIDER),
+            static function (LlmConfiguration $c) use (&$called): string {
+                $called = true;
+
+                return 'recovered';
+            },
+        );
+
+        self::assertSame('recovered', $result);
+        self::assertTrue($called, 'A half-open probe must reach the provider');
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertNull($state->openedAt, 'A successful probe closes the circuit');
+    }
+
+    #[Test]
+    public function halfOpenProbeFailureReopensCircuit(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        $store->seed(self::PROVIDER, new CircuitState(5, time() - 31)); // half-open
+
+        try {
+            $this->middleware($store, cooldown: 30)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('still down', 0),
+            );
+        } catch (ProviderConnectionException) {
+        }
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(6, $state->consecutiveFailures);
+        self::assertNotNull($state->openedAt);
+        // Fresh window: reopened at ~now, not the original open time.
+        self::assertGreaterThan(time() - 5, $state->openedAt);
+    }
+
+    #[Test]
+    public function successResetsAFailureStreak(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        $store->seed(self::PROVIDER, new CircuitState(2, null)); // closed, counting
+
+        $this->middleware($store)->handle(
+            $this->context(),
+            $this->config(self::PROVIDER),
+            static fn(LlmConfiguration $c): string => 'ok',
+        );
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertNull($state->openedAt);
+    }
+
+    #[Test]
+    public function nonTrippingFailureLeavesStateUntouchedAndRethrows(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+        $store->seed(self::PROVIDER, new CircuitState(2, null));
+
+        try {
+            $this->middleware($store)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                // 401 is a client error: the provider answered, so it is not a
+                // health signal — neither trip nor reset.
+                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('unauthorized', 401),
+            );
+            self::fail('Expected the response exception to propagate');
+        } catch (ProviderResponseException $e) {
+            self::assertSame(401, $e->getCode());
+        }
+
+        self::assertSame([], $store->saves, 'A client error must not touch the circuit');
+        self::assertSame(2, $store->load(self::PROVIDER)->consecutiveFailures);
+    }
+
+    #[Test]
+    public function rateLimitCountsAsTrippingFailure(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+
+        try {
+            $this->middleware($store, threshold: 1)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('slow down', 429),
+            );
+        } catch (ProviderResponseException) {
+        }
+
+        $state = $store->load(self::PROVIDER);
+        self::assertSame(1, $state->consecutiveFailures);
+        self::assertNotNull($state->openedAt, 'A 429 trips the circuit like a connection failure');
+    }
+
+    #[Test]
+    public function nonProviderExceptionDoesNotTripTheCircuit(): void
+    {
+        $store = new InMemoryCircuitBreakerStore();
+
+        try {
+            $this->middleware($store, threshold: 1)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new RuntimeException('bug', 1),
+            );
+        } catch (RuntimeException) {
+        }
+
+        self::assertSame([], $store->saves);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function middleware(
+        InMemoryCircuitBreakerStore $store,
+        bool $enabled = true,
+        int $threshold = 3,
+        int $cooldown = 30,
+    ): CircuitBreakerMiddleware {
+        return new CircuitBreakerMiddleware(
+            $store,
+            $this->extensionConfiguration($enabled, $threshold, $cooldown),
+        );
+    }
+
+    private function extensionConfiguration(bool $enabled, int $threshold, int $cooldown): ExtensionConfiguration&MockObject
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([
+            'circuitBreaker' => [
+                'enabled'          => $enabled ? '1' : '0',
+                'failureThreshold' => $threshold,
+                'cooldownSeconds'  => $cooldown,
+            ],
+        ]);
+
+        return $extensionConfiguration;
+    }
+
+    private function context(): ProviderCallContext
+    {
+        return new ProviderCallContext(ProviderOperation::Chat, 'corr');
+    }
+
+    private function config(string $identifier): LlmConfiguration
+    {
+        // A model-less configuration has an empty provider type, so the circuit
+        // keys by identifier — which is exactly what the ad-hoc path relies on.
+        $config = new LlmConfiguration();
+        $config->setIdentifier($identifier);
+
+        return $config;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitStatus;
 use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
@@ -203,6 +204,35 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         self::assertNotNull($state->openedAt);
         // Fresh window: reopened at ~now, not the original open time.
         self::assertGreaterThan(time() - 5, $state->openedAt);
+    }
+
+    #[Test]
+    public function halfOpenProbeNonTrippingFailureKeepsCircuitHalfOpen(): void
+    {
+        $store    = new InMemoryCircuitBreakerStore();
+        $openedAt = time() - 31; // cooldown 30 elapsed → half-open
+        $store->seed(self::PROVIDER, new CircuitState(5, $openedAt));
+
+        try {
+            $this->middleware($store, cooldown: 30)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                // 401: the provider responded, so it is not a health signal.
+                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('unauthorized', 401),
+            );
+            self::fail('Expected the response exception to propagate');
+        } catch (ProviderResponseException) {
+            // expected
+        }
+
+        // The probe reservation (openedAt = now) must be rolled back, so the
+        // circuit stays half-open (a further probe is due) instead of re-arming
+        // Open for a fresh cooldown — otherwise recurring non-tripping probes
+        // would starve recovery.
+        $state = $store->load(self::PROVIDER);
+        self::assertSame($openedAt, $state->openedAt, 'The pre-probe open window must be restored');
+        self::assertSame(5, $state->consecutiveFailures);
+        self::assertSame(CircuitStatus::HalfOpen, $state->status(time(), 30));
     }
 
     #[Test]

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 use Netresearch\NrLlm\Domain\DTO\FallbackChain;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
@@ -21,6 +22,7 @@ use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -106,6 +108,36 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderConnectionException('down', 0);
+                }
+
+                return 'ok-from-alt';
+            },
+        );
+
+        self::assertSame('ok-from-alt', $result);
+        self::assertSame(['primary', 'alt'], $calls);
+    }
+
+    #[Test]
+    public function fallsBackToNextConfigurationOnOpenCircuit(): void
+    {
+        // An open circuit (ADR-063) is thrown from inside the fallback loop and
+        // must be treated as retryable so the request routes to the next
+        // provider rather than surfacing as a hard error.
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $alt     = $this->makeConfig('alt');
+        $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
+
+        $pipeline = $this->makePipeline();
+        $calls    = [];
+
+        $result = $pipeline->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            function (LlmConfiguration $config) use (&$calls): string {
+                $calls[] = $config->getIdentifier();
+                if ($config->getIdentifier() === 'primary') {
+                    throw new CircuitOpenException('openai', 12);
                 }
 
                 return 'ok-from-alt';
@@ -498,7 +530,12 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
 
     private function makeMiddleware(): FallbackMiddleware
     {
-        return new FallbackMiddleware($this->repositoryStub, new NullLogger());
+        // Health reorder is opt-in and off by default; a passthrough stub keeps
+        // these tests focused on the fallback chain-walk semantics.
+        $health = self::createStub(ProviderHealthServiceInterface::class);
+        $health->method('reorder')->willReturnArgument(0);
+
+        return new FallbackMiddleware($this->repositoryStub, new NullLogger(), $health);
     }
 
     private function makePipeline(): MiddlewarePipeline

--- a/Tests/Unit/Provider/Middleware/IdempotencyMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/IdempotencyMiddlewareTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use stdClass;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+
+#[CoversClass(IdempotencyMiddleware::class)]
+final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function passesThroughWhenNoKeyIsPresent(): void
+    {
+        $calls      = 0;
+        $middleware = $this->middleware();
+
+        $result = $middleware->handle(
+            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
+            new LlmConfiguration(),
+            function (LlmConfiguration $c) use (&$calls): string {
+                $calls++;
+
+                return 'fresh';
+            },
+        );
+
+        self::assertSame('fresh', $result);
+        self::assertSame(1, $calls);
+    }
+
+    #[Test]
+    public function replaysStoredResultForARepeatedKeyWithoutCallingTheProvider(): void
+    {
+        $middleware = $this->middleware();
+        $context    = $this->contextWithKey('order-42');
+        $response   = new stdClass();
+        $response->answer = 'generated once';
+
+        $calls = 0;
+        $next  = function (LlmConfiguration $c) use (&$calls, $response): stdClass {
+            $calls++;
+
+            return $response;
+        };
+
+        $first  = $middleware->handle($context, new LlmConfiguration(), $next);
+        $second = $middleware->handle($context, new LlmConfiguration(), $next);
+
+        self::assertSame($response, $first);
+        self::assertSame($response, $second, 'The repeat must return the stored result');
+        self::assertSame(1, $calls, 'The provider must be called only once');
+    }
+
+    #[Test]
+    public function differentKeysDoNotShareResults(): void
+    {
+        $middleware = $this->middleware();
+
+        $calls = 0;
+        $next  = function (LlmConfiguration $c) use (&$calls): string {
+            $calls++;
+
+            return 'result-' . $calls;
+        };
+
+        $middleware->handle($this->contextWithKey('key-a'), new LlmConfiguration(), $next);
+        $middleware->handle($this->contextWithKey('key-b'), new LlmConfiguration(), $next);
+
+        self::assertSame(2, $calls, 'A different key is a miss and must reach the provider');
+    }
+
+    #[Test]
+    public function doesNotStoreStreamingGenerators(): void
+    {
+        $middleware = $this->middleware();
+        $context    = $this->contextWithKey('stream-1');
+
+        // The yield lives in a separate factory, so $next itself is an ordinary
+        // closure whose $calls++ runs on invocation (a generator function's body
+        // would not execute until iterated, defeating the counter).
+        $makeGenerator = static function (): Generator {
+            yield 'chunk';
+        };
+        $calls = 0;
+        $next  = function (LlmConfiguration $c) use (&$calls, $makeGenerator): Generator {
+            $calls++;
+
+            return $makeGenerator();
+        };
+
+        $middleware->handle($context, new LlmConfiguration(), $next);
+        $middleware->handle($context, new LlmConfiguration(), $next);
+
+        // A generator cannot be stored, so the second call is a miss and re-runs.
+        self::assertSame(2, $calls);
+    }
+
+    #[Test]
+    public function doesNotStoreFailedCalls(): void
+    {
+        $middleware = $this->middleware();
+        $context    = $this->contextWithKey('will-fail');
+
+        $calls = 0;
+        $next  = function (LlmConfiguration $c) use (&$calls): never {
+            $calls++;
+
+            throw new RuntimeException('boom', 1);
+        };
+
+        for ($i = 0; $i < 2; $i++) {
+            try {
+                $middleware->handle($context, new LlmConfiguration(), $next);
+                self::fail('Expected the failure to propagate');
+            } catch (RuntimeException) {
+                // expected
+            }
+        }
+
+        // A failure is never cached: a retry with the same key genuinely re-runs.
+        self::assertSame(2, $calls);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private function middleware(): IdempotencyMiddleware
+    {
+        return new IdempotencyMiddleware($this->cacheManager());
+    }
+
+    private function contextWithKey(string $key): ProviderCallContext
+    {
+        return new ProviderCallContext(
+            ProviderOperation::Chat,
+            'corr',
+            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
+        );
+    }
+
+    /**
+     * A cache manager whose frontend is an in-memory fake, so store/replay is
+     * exercised against real read-through behaviour rather than a mock return.
+     */
+    private function cacheManager(): Typo3CacheManager
+    {
+        $storage = [];
+
+        $frontend = self::createStub(FrontendInterface::class);
+        $frontend->method('set')->willReturnCallback(
+            function (string $entryIdentifier, mixed $data) use (&$storage): void {
+                $storage[$entryIdentifier] = $data;
+            },
+        );
+        $frontend->method('get')->willReturnCallback(
+            // Regular closure (by-reference capture): an arrow fn would snapshot
+            // $storage by value at definition time and never see a stored entry.
+            function (string $entryIdentifier) use (&$storage): mixed {
+                return $storage[$entryIdentifier] ?? false;
+            },
+        );
+
+        $cacheManager = self::createStub(Typo3CacheManager::class);
+        $cacheManager->method('getCache')->willReturn($frontend);
+
+        return $cacheManager;
+    }
+}

--- a/Tests/Unit/Service/Health/ProviderHealthScoreTest.php
+++ b/Tests/Unit/Service/Health/ProviderHealthScoreTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Health;
+
+use Netresearch\NrLlm\Service\Health\ProviderHealthScore;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ProviderHealthScore::class)]
+final class ProviderHealthScoreTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function unknownProviderIsNeutralNotUnhealthy(): void
+    {
+        $score = ProviderHealthScore::unknown('openai');
+
+        self::assertSame('openai', $score->provider);
+        self::assertSame(0, $score->sampleCount);
+        self::assertSame(ProviderHealthScore::NEUTRAL_SCORE, $score->score);
+    }
+
+    #[Test]
+    public function zeroSamplesFallBackToUnknown(): void
+    {
+        $score = ProviderHealthScore::fromSamples('openai', 0, 0, 0.0);
+
+        self::assertSame(0, $score->sampleCount);
+        self::assertSame(ProviderHealthScore::NEUTRAL_SCORE, $score->score);
+    }
+
+    #[Test]
+    public function perfectHealthScoresOne(): void
+    {
+        // All successful, no latency → full score on both terms.
+        $score = ProviderHealthScore::fromSamples('openai', 5, 5, 0.0);
+
+        self::assertSame(1.0, $score->successRate);
+        self::assertEqualsWithDelta(1.0, $score->score, 0.0001);
+    }
+
+    #[Test]
+    public function successRateDominatesLatency(): void
+    {
+        // 90% success, low latency.
+        $score = ProviderHealthScore::fromSamples('openai', 10, 9, 200.0);
+
+        self::assertEqualsWithDelta(0.9, $score->successRate, 0.0001);
+        self::assertEqualsWithDelta(200.0, $score->avgLatencyMs, 0.0001);
+        // 0.8*0.9 + 0.2*(1 - 200/5000) = 0.72 + 0.192 = 0.912
+        self::assertEqualsWithDelta(0.912, $score->score, 0.0001);
+    }
+
+    #[Test]
+    public function allFailuresScoreLowEvenWhenFast(): void
+    {
+        // 0% success but fast: the failure weight (0.8) sinks it well below a
+        // healthy provider, so it will never be preferred.
+        $score = ProviderHealthScore::fromSamples('groq', 4, 0, 1000.0);
+
+        self::assertSame(0.0, $score->successRate);
+        // 0.8*0 + 0.2*(1 - 1000/5000) = 0.2*0.8 = 0.16
+        self::assertEqualsWithDelta(0.16, $score->score, 0.0001);
+    }
+
+    #[Test]
+    public function latencyPenaltyClampsAtTheCeiling(): void
+    {
+        // Latency far beyond the ceiling contributes nothing further.
+        $score = ProviderHealthScore::fromSamples('slow', 2, 2, 50_000.0);
+
+        // 0.8*1 + 0.2*(1 - min(1, 10)) = 0.8 + 0 = 0.8
+        self::assertEqualsWithDelta(0.8, $score->score, 0.0001);
+    }
+}

--- a/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
+++ b/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Health;
+
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Service\Health\ProviderHealthRepositoryInterface;
+use Netresearch\NrLlm\Service\Health\ProviderHealthScore;
+use Netresearch\NrLlm\Service\Health\ProviderHealthService;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(ProviderHealthService::class)]
+#[CoversClass(ProviderHealthScore::class)]
+final class ProviderHealthServiceTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function reorderIsANoOpWhenDisabled(): void
+    {
+        // Disabled: the chain is returned untouched and the telemetry read is
+        // never triggered.
+        $repository = $this->createMock(ProviderHealthRepositoryInterface::class);
+        $repository->expects(self::never())->method('scoresSince');
+
+        $service = $this->service($repository, [], enabled: false);
+
+        $result = $service->reorder(new FallbackChain(['a', 'b', 'c']));
+
+        self::assertSame(['a', 'b', 'c'], $result->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function reorderIsANoOpForShortChains(): void
+    {
+        $repository = $this->createMock(ProviderHealthRepositoryInterface::class);
+        $repository->expects(self::never())->method('scoresSince');
+
+        $service = $this->service($repository, [], enabled: true);
+
+        self::assertSame(['only'], $service->reorder(new FallbackChain(['only']))->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function reordersByDescendingHealthWithStableTieBreak(): void
+    {
+        $scores = [
+            'p-a' => ProviderHealthScore::fromSamples('p-a', 10, 9, 100.0),  // 0.912
+            'p-b' => ProviderHealthScore::fromSamples('p-b', 10, 9, 100.0),  // 0.912 (tie with a)
+            'p-c' => ProviderHealthScore::fromSamples('p-c', 10, 10, 0.0),   // 1.0
+        ];
+
+        $service = $this->service(
+            $this->repositoryReturning($scores),
+            ['a' => 'p-a', 'b' => 'p-b', 'c' => 'p-c'],
+            enabled: true,
+        );
+
+        // c (healthiest) first; a and b are tied, so they keep configured order.
+        $result = $service->reorder(new FallbackChain(['a', 'b', 'c']));
+
+        self::assertSame(['c', 'a', 'b'], $result->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function unknownProviderKeepsNeutralPositionNotSunk(): void
+    {
+        $scores = [
+            'p-known' => ProviderHealthScore::fromSamples('p-known', 10, 10, 0.0), // 1.0
+            'p-bad'   => ProviderHealthScore::fromSamples('p-bad', 10, 0, 0.0),    // 0.2
+        ];
+
+        $service = $this->service(
+            $this->repositoryReturning($scores),
+            ['known' => 'p-known', 'unknown' => 'p-none', 'bad' => 'p-bad'],
+            enabled: true,
+        );
+
+        // known (1.0) > unknown (neutral 0.5) > bad (0.2).
+        $result = $service->reorder(new FallbackChain(['bad', 'unknown', 'known']));
+
+        self::assertSame(['known', 'unknown', 'bad'], $result->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function missingConfigurationIsTreatedAsNeutral(): void
+    {
+        $scores  = ['p-good' => ProviderHealthScore::fromSamples('p-good', 5, 5, 0.0)];
+        // 'gone' resolves to no configuration → neutral.
+        $service = $this->service(
+            $this->repositoryReturning($scores),
+            ['good' => 'p-good', 'gone' => null],
+            enabled: true,
+        );
+
+        $result = $service->reorder(new FallbackChain(['gone', 'good']));
+
+        self::assertSame(['good', 'gone'], $result->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function scoreForReturnsUnknownWhenProviderHasNoTelemetry(): void
+    {
+        $service = $this->service($this->repositoryReturning([]), [], enabled: true);
+
+        $score = $service->scoreFor('never-seen');
+
+        self::assertSame(0, $score->sampleCount);
+        self::assertSame(ProviderHealthScore::NEUTRAL_SCORE, $score->score);
+    }
+
+    #[Test]
+    public function scoreForReturnsTheAggregatedScore(): void
+    {
+        $scores  = ['openai' => ProviderHealthScore::fromSamples('openai', 8, 8, 50.0)];
+        $service = $this->service($this->repositoryReturning($scores), [], enabled: true);
+
+        self::assertSame(1.0, $service->scoreFor('openai')->successRate);
+    }
+
+    #[Test]
+    public function allServesFromCacheWithoutQueryingTelemetry(): void
+    {
+        $cached = ['openai' => ProviderHealthScore::fromSamples('openai', 3, 3, 10.0)];
+
+        $repository = $this->createMock(ProviderHealthRepositoryInterface::class);
+        $repository->expects(self::never())->method('scoresSince');
+
+        $service = new ProviderHealthService(
+            $repository,
+            self::createStub(LlmConfigurationRepository::class),
+            $this->cacheManagerReturning($this->frontendReturning($cached)),
+            $this->extensionConfiguration(true),
+        );
+
+        self::assertSame($cached, $service->all());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * @param array<string, ProviderHealthScore> $scores
+     */
+    private function repositoryReturning(array $scores): ProviderHealthRepositoryInterface
+    {
+        $repository = self::createStub(ProviderHealthRepositoryInterface::class);
+        $repository->method('scoresSince')->willReturn($scores);
+
+        return $repository;
+    }
+
+    /**
+     * @param array<string, string|null> $identifierToProvider provider adapter
+     *                                                         type per configuration identifier;
+     *                                                         null = configuration not found
+     */
+    private function service(
+        ProviderHealthRepositoryInterface $repository,
+        array $identifierToProvider,
+        bool $enabled,
+    ): ProviderHealthService {
+        return new ProviderHealthService(
+            $repository,
+            $this->configurationRepository($identifierToProvider),
+            $this->cacheManagerReturning($this->frontendMissing()),
+            $this->extensionConfiguration($enabled),
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $identifierToProvider
+     */
+    private function configurationRepository(array $identifierToProvider): LlmConfigurationRepository
+    {
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturnCallback(
+            function (string $identifier) use ($identifierToProvider): ?LlmConfiguration {
+                if (!\array_key_exists($identifier, $identifierToProvider)) {
+                    return null;
+                }
+                $provider = $identifierToProvider[$identifier];
+                if ($provider === null) {
+                    return null;
+                }
+
+                $configuration = $this->createStub(LlmConfiguration::class);
+                $configuration->method('getProviderType')->willReturn($provider);
+
+                return $configuration;
+            },
+        );
+
+        return $repository;
+    }
+
+    private function cacheManagerReturning(FrontendInterface $frontend): Typo3CacheManager
+    {
+        $cacheManager = self::createStub(Typo3CacheManager::class);
+        $cacheManager->method('getCache')->willReturn($frontend);
+
+        return $cacheManager;
+    }
+
+    private function frontendMissing(): FrontendInterface
+    {
+        $frontend = self::createStub(FrontendInterface::class);
+        $frontend->method('get')->willReturn(false);
+
+        return $frontend;
+    }
+
+    private function frontendReturning(mixed $value): FrontendInterface
+    {
+        $frontend = self::createStub(FrontendInterface::class);
+        $frontend->method('get')->willReturn($value);
+
+        return $frontend;
+    }
+
+    private function extensionConfiguration(bool $reorderEnabled): ExtensionConfiguration
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([
+            'health' => ['reorderFallback' => $reorderEnabled ? '1' : '0'],
+        ]);
+
+        return $extensionConfiguration;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -75,6 +75,22 @@ image.fal.defaultModel = flux-schnell
 skills.minTrustLevel = untrusted
 
 # =============================================================================
+# Resilience (circuit breaker + provider health — ADR-063)
+# =============================================================================
+
+# cat=resilience; type=boolean; label=Circuit Breaker Enabled: Trip a per-provider circuit after repeated failures so calls fail fast (and fall back) instead of waiting on a timeout against a provider that is down.
+circuitBreaker.enabled = 1
+
+# cat=resilience; type=int+; label=Circuit Breaker Failure Threshold: Number of consecutive tripping failures (connection/timeout/5xx/429) before a provider's circuit opens.
+circuitBreaker.failureThreshold = 5
+
+# cat=resilience; type=int+; label=Circuit Breaker Cooldown (seconds): How long an open circuit fails fast before allowing one half-open probe call.
+circuitBreaker.cooldownSeconds = 30
+
+# cat=resilience; type=boolean; label=Health-Aware Fallback Reorder: When on, the fallback chain is reordered by recent provider health (from telemetry) so a healthier provider is preferred; configured order is the tie-break. Off (default) keeps the configured order untouched.
+health.reorderFallback = 0
+
+# =============================================================================
 # Testing
 # =============================================================================
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -39,6 +39,38 @@ defined('TYPO3') or die();
         'groups' => ['nrllm'],
     ];
 
+    // Per-provider circuit breaker state (ADR-063). The store writes its own
+    // per-entry lifetime; this default applies only to entries written without.
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nrllm_circuit'] ??= [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 300,
+        ],
+        'groups' => ['nrllm'],
+    ];
+
+    // Short-lived provider health snapshot (ADR-063).
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nrllm_health'] ??= [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 60,
+        ],
+        'groups' => ['nrllm'],
+    ];
+
+    // Request idempotency store (ADR-063). The middleware writes its own
+    // per-entry TTL (the idempotency window).
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nrllm_idempotency'] ??= [
+        'frontend' => VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 86400,
+        ],
+        'groups' => ['nrllm'],
+    ];
+
     // Register custom TCA renderType for model_id field with API fetch
     // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1741427200] = [


### PR DESCRIPTION
## Description

Resilience features from the aim-vs-nr-llm gap analysis ("what both are missing"), added as provider-middleware-pipeline concerns and documented in **ADR-063**. Everything is opt-in-safe: default configuration keeps existing behaviour byte-for-byte.

### 1. Circuit breaker (`CircuitBreakerMiddleware`)

Per-provider circuit (closed / open / half-open). After `circuitBreaker.failureThreshold` consecutive *tripping* failures (connection/timeout/5xx and 429 — the same set `FallbackMiddleware` retries) the circuit opens: for `circuitBreaker.cooldownSeconds`, calls to that provider fail fast with `CircuitOpenException` instead of waiting on a timeout. After the cooldown one half-open probe is allowed; success closes, failure re-opens.

**Onion placement — priority 20, innermost, and its interaction with Fallback:**

```
Telemetry 110 → Idempotency 105 → Cache 100 → Budget 75 → Fallback 50 → Usage 25 → CircuitBreaker 20 → terminal
```

- **Inside FallbackMiddleware.** An open circuit throws `CircuitOpenException`, which `FallbackMiddleware::isRetryable()` now matches. Because the breaker sits *inside* the fallback loop, that throw happens within `$next()` on each attempt, so Fallback catches it and advances to the next provider. Placing the breaker *outside* Fallback (the naïve "between Budget and Fallback" slot) would instead make an open primary circuit abort the whole call before fallback ran — the opposite of the intent. That is why it is innermost, not in the 75–50 band.
- **Inside UsageMiddleware.** The breaker wraps only the terminal, so the health signal is the pure provider call, uncontaminated by usage bookkeeping.

`CircuitOpenException` extends `ProviderException` (inherits the ADR-053 marker); `ProviderConnectionException` is `final`, so `FallbackMiddleware::isRetryable()` gained one explicit `instanceof` arm.

**Circuit-state storage: cache, not a table.** State lives in the `nrllm_circuit` cache (no hardcoded backend). Transient, self-decaying (a forgotten entry reads as closed), shared across workers on Redis/Valkey, no schema, no purge command, no per-call DB write.

### 2. Provider health scoring (`ProviderHealthService`)

Reads the **existing** telemetry log (`tx_nrllm_telemetry`, ADR-058) over a rolling window into a per-provider `ProviderHealthScore` (success rate + latency → one comparable score). No new write path. Reads go through a dedicated `ProviderHealthRepository`; the telemetry recorder's own interface stays append/purge-only.

Consumed by `FallbackMiddleware` as a **hint**: `reorder()` prefers healthier providers among the fallback candidates. **Opt-in, off by default** (`health.reorderFallback`) — off means the chain is returned untouched with no telemetry query, so the configured fallback order stays the default (minimal-invasive). When on it is a **stable** sort; unknown-health providers score neutral, never unhealthy.

### 3. Idempotency keys (`IdempotencyMiddleware`)

Optional key on any options object (`AbstractOptions::withIdempotencyKey()`). A repeat with the same key replays the stored result instead of calling the provider again (priority 105 — inside Telemetry so replays are still observed, outside Cache/Budget so a replay is not re-charged).

**Cache, not a table — and not a CacheMiddleware key overload.** The "thin layer on the cache key" idea was investigated and rejected: `CacheMiddleware` is deliberately array-only and cannot round-trip the typed `CompletionResponse` the chat/completion paths return (the case idempotency actually matters for). The dedicated middleware stores over its own `nrllm_idempotency` VariableFrontend, which serialises any response type. Failed calls and streaming generators are never stored.

### OpenTelemetry — deliberately not built

Documented as rejected in ADR-063: OTel exporters/collectors are the **host instance's** observability responsibility, not a TYPO3 extension's. The telemetry log (ADR-058) already exposes per-request metrics with a correlation id that a host OTel stack can scrape/forward. Building an in-extension exporter would duplicate host infrastructure and couple the extension to an SDK.

### Reported decisions

| Question | Decision |
|----------|----------|
| Circuit-state storage | Cache (`nrllm_circuit`), not a table |
| Health-scoring source | Read from `tx_nrllm_telemetry` (ADR-058), no own state |
| Idempotency approach | Dedicated middleware over `nrllm_idempotency` cache, no table |
| ADR number | 063 |

### Deferred to follow-ups (named in ADR-063)

- A backend diagnostics readout of circuit state / health scores (services expose the data; only a view is missing).
- Per-operation idempotency TTL override via call metadata.

## Related Issue

_none_

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update (ADR-063)

## Checklist

- [x] My code follows the project's coding standards
- [x] `runTests.sh` gates pass: unit, functional, cgl, phpstan (L10), architecture, rector
- [x] I have added tests that prove the feature works (unit + functional, incl. the pipeline order)
- [x] I have updated the documentation accordingly (ADR-063 + Index)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
