### PR TITLE
feat: central privacy model with levels and retention (ADR-064)

### DIFF
--- a/Classes/Command/PurgePrivacyDataCommand.php
+++ b/Classes/Command/PurgePrivacyDataCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
+use Netresearch\NrLlm\Service\Skill\SkillAuditRepositoryInterface;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Enforces data retention across the per-request log tables (ADR-064).
+ *
+ * The central privacy model governs how long the extension keeps the content
+ * and metadata it logs. This command deletes rows older than the retention
+ * window from all three log tables — evaluation results, the skill audit trail
+ * and telemetry — reporting the count purged per table. The window defaults to
+ * the configured `privacy.retentionDays` and is overridable with `--days`. Run
+ * it from the scheduler or cron.
+ *
+ * The existing `nrllm:telemetry:purge` command stays as-is for backward
+ * compatibility; this command generalises it across every log table.
+ */
+#[AsCommand(
+    name: 'nrllm:privacy:purge',
+    description: 'Delete per-request log rows (eval results, skill audit, telemetry) older than the retention window.',
+)]
+final class PurgePrivacyDataCommand extends Command
+{
+    public function __construct(
+        private readonly PrivacyPolicyInterface $privacyPolicy,
+        private readonly EvaluationResultRepositoryInterface $evaluationResults,
+        private readonly SkillAuditRepositoryInterface $skillAudit,
+        private readonly TelemetryRepositoryInterface $telemetry,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'days',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Delete rows older than this many days. Defaults to the configured privacy retention window.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $days = $this->resolveDays($input);
+        if ($days < 1) {
+            $io->error('The --days option must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $cutoff = time() - ($days * 86400);
+
+        $evalDeleted      = $this->evaluationResults->purgeOlderThan($cutoff);
+        $auditDeleted     = $this->skillAudit->purgeOlderThan($cutoff);
+        $telemetryDeleted = $this->telemetry->purgeOlderThan($cutoff);
+
+        $io->success(sprintf('Purged log rows older than %d day(s).', $days));
+        $io->listing([
+            sprintf('Evaluation results: %d', $evalDeleted),
+            sprintf('Skill audit: %d', $auditDeleted),
+            sprintf('Telemetry: %d', $telemetryDeleted),
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * The retention window in days: the `--days` option when given, else the
+     * configured privacy retention default. A supplied but non-numeric value
+     * yields 0 so {@see execute()} rejects it, matching PurgeTelemetryCommand.
+     */
+    private function resolveDays(InputInterface $input): int
+    {
+        $daysOption = $input->getOption('days');
+        if ($daysOption === null) {
+            return $this->privacyPolicy->retentionDays();
+        }
+
+        return is_numeric($daysOption) ? (int)$daysOption : 0;
+    }
+}

--- a/Classes/Domain/Enum/PrivacyLevel.php
+++ b/Classes/Domain/Enum/PrivacyLevel.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * How much per-request content the extension may persist (ADR-064).
+ *
+ * The levels form a strict-to-loose scale: NONE and METADATA drop the graded
+ * output / scan payload entirely (metadata columns are always kept), REDACTED
+ * stores a bounded, credential-scrubbed copy, FULL stores it verbatim. When two
+ * levels apply, the strictest one wins — NONE is strictest, FULL loosest.
+ */
+enum PrivacyLevel: string
+{
+    case NONE = 'none';
+    case METADATA = 'metadata';
+    case REDACTED = 'redacted';
+    case FULL = 'full';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $c): string => $c->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+
+    public static function tryFromString(string $value): ?self
+    {
+        return self::tryFrom($value);
+    }
+
+    /**
+     * Whether this level stores the per-request content payload at all. Only
+     * REDACTED (bounded copy) and FULL (verbatim) persist content; NONE and
+     * METADATA drop it and keep metadata only.
+     */
+    public function persistsContent(): bool
+    {
+        return match ($this) {
+            self::REDACTED, self::FULL => true,
+            self::NONE, self::METADATA => false,
+        };
+    }
+
+    /**
+     * Whether stored content must be passed through the ContentRedactor first.
+     * True only for REDACTED — FULL keeps content verbatim, and the dropping
+     * levels store nothing to redact.
+     */
+    public function requiresRedaction(): bool
+    {
+        return $this === self::REDACTED;
+    }
+
+    /**
+     * Ordering from strictest (NONE = 0) to loosest (FULL = 3). A lower value is
+     * stricter, so {@see strictest()} can pick the more restrictive of two.
+     */
+    public function severity(): int
+    {
+        return match ($this) {
+            self::NONE => 0,
+            self::METADATA => 1,
+            self::REDACTED => 2,
+            self::FULL => 3,
+        };
+    }
+
+    /**
+     * The stricter (more restrictive) of two levels — NONE beats METADATA beats
+     * REDACTED beats FULL. Lets a global default combine with a per-scope
+     * override so tightening always wins.
+     */
+    public static function strictest(self $a, self $b): self
+    {
+        return $a->severity() <= $b->severity() ? $a : $b;
+    }
+}

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Evaluation;
 
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
@@ -29,6 +30,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
 
     public function __construct(
         private ConnectionPool $connectionPool,
+        private PrivacyPolicyInterface $privacyPolicy,
     ) {}
 
     public function save(SetEvaluationResult $result): void
@@ -43,11 +45,25 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             'passed_count' => $result->passedCount(),
             'pass_rate' => $result->passRate(),
             'mean_score' => $result->meanScore(),
-            'details' => $this->encodeDetails($result),
+            // The details snapshot is the per-prompt content payload; gate it
+            // through the central privacy policy before persisting (ADR-064).
+            // Metadata columns above are always kept.
+            'details' => $this->privacyPolicy->filterContent($this->encodeDetails($result)) ?? '',
             'run_date' => $result->runTimestamp,
             'tstamp' => $now,
             'crdate' => $now,
         ]);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+
+        return (int)$queryBuilder
+            ->delete(self::TABLE)
+            ->where($queryBuilder->expr()->lt('run_date', $queryBuilder->createNamedParameter($timestamp)))
+            ->executeStatement();
     }
 
     public function findLatest(string $setIdentifier, string $model, string $grader): ?EvaluationResultSummary

--- a/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepositoryInterface.php
@@ -49,4 +49,13 @@ interface EvaluationResultRepositoryInterface
      * comparable and must not be averaged together.
      */
     public function meanQualityScoreForModel(string $model, string $grader): ?float;
+
+    /**
+     * Delete result rows whose run date is strictly before the given UNIX
+     * timestamp. The central retention path (ADR-064), driven by
+     * `nrllm:privacy:purge`.
+     *
+     * @return int number of rows deleted
+     */
+    public function purgeOlderThan(int $timestamp): int;
 }

--- a/Classes/Service/Privacy/ContentRedactor.php
+++ b/Classes/Service/Privacy/ContentRedactor.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Privacy;
+
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+
+/**
+ * Bounded, best-effort redactor for content stored at the REDACTED privacy
+ * level (ADR-064).
+ *
+ * This is a heuristic, NOT a guaranteed PII scrubber. It masks a small set of
+ * high-signal secrets — credential-bearing URL query parameters (via the shared
+ * {@see ErrorMessageSanitizerTrait}), obvious bearer / API tokens, and email
+ * addresses — and caps the payload length. It does not attempt to find names,
+ * postal addresses, free-form personal data, or secrets in shapes it does not
+ * know. When content must not be stored at all, choose PrivacyLevel::NONE or
+ * METADATA instead of relying on this class.
+ */
+final class ContentRedactor
+{
+    use ErrorMessageSanitizerTrait;
+
+    /** Hard cap on stored length in characters; longer content is truncated. */
+    private const MAX_LENGTH = 2000;
+
+    private const TRUNCATION_MARKER = '… [truncated]';
+
+    private const MASK = '***';
+
+    public function redact(?string $content): ?string
+    {
+        if ($content === null) {
+            return null;
+        }
+
+        // 1. Credential query parameters (?key=, ?token=, …) — reuse the shared
+        //    trait rather than duplicating its regex.
+        $redacted = $this->sanitizeErrorMessage($content);
+
+        // 2. Obvious bearer / API tokens in free text.
+        $redacted = (string)preg_replace(
+            [
+                '/\bBearer\s+[A-Za-z0-9._~+\/-]+=*/i',
+                '/\bsk-[A-Za-z0-9]{20,}/',
+            ],
+            [
+                'Bearer ' . self::MASK,
+                self::MASK,
+            ],
+            $redacted,
+        );
+
+        // 3. Email addresses.
+        $redacted = (string)preg_replace(
+            '/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/',
+            self::MASK,
+            $redacted,
+        );
+
+        // 4. Cap the stored length.
+        if (mb_strlen($redacted) > self::MAX_LENGTH) {
+            return mb_substr($redacted, 0, self::MAX_LENGTH) . self::TRUNCATION_MARKER;
+        }
+
+        return $redacted;
+    }
+}

--- a/Classes/Service/Privacy/PrivacyPolicy.php
+++ b/Classes/Service/Privacy/PrivacyPolicy.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Privacy;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Reads the central privacy settings from the `nr_llm` extension configuration
+ * and applies them at the content sinks (ADR-064).
+ *
+ * Defaults are safe: metadata-only content and a 30-day retention window when a
+ * setting is unset or invalid, matching the extension's historical behaviour.
+ */
+final readonly class PrivacyPolicy implements PrivacyPolicyInterface
+{
+    private const DEFAULT_RETENTION_DAYS = 30;
+
+    public function __construct(
+        private ExtensionConfiguration $extensionConfiguration,
+        private ContentRedactor $redactor,
+    ) {}
+
+    public function level(): PrivacyLevel
+    {
+        $level = $this->privacyConfig()['level'] ?? null;
+
+        return is_string($level)
+            ? (PrivacyLevel::tryFromString($level) ?? PrivacyLevel::METADATA)
+            : PrivacyLevel::METADATA;
+    }
+
+    public function retentionDays(): int
+    {
+        $configured = $this->privacyConfig()['retentionDays'] ?? null;
+        $days       = is_numeric($configured) ? (int)$configured : 0;
+
+        // Clamp to a sane floor: an unset / zero / negative window must not
+        // purge everything immediately, so fall back to the default.
+        return $days >= 1 ? $days : self::DEFAULT_RETENTION_DAYS;
+    }
+
+    public function filterContent(?string $content): ?string
+    {
+        if ($content === null) {
+            return null;
+        }
+
+        return match ($this->level()) {
+            PrivacyLevel::NONE, PrivacyLevel::METADATA => null,
+            PrivacyLevel::REDACTED => $this->redactor->redact($content),
+            PrivacyLevel::FULL => $content,
+        };
+    }
+
+    /**
+     * The `privacy` sub-array of the extension configuration, or an empty array
+     * when the setting is unreadable or absent. Reads defensively, mirroring
+     * how TelemetryMiddleware reads its own block.
+     *
+     * @return array<array-key, mixed>
+     */
+    private function privacyConfig(): array
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            return [];
+        }
+
+        $privacy = $config['privacy'] ?? null;
+
+        return is_array($privacy) ? $privacy : [];
+    }
+}

--- a/Classes/Service/Privacy/PrivacyPolicyInterface.php
+++ b/Classes/Service/Privacy/PrivacyPolicyInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Privacy;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+
+/**
+ * Central privacy policy governing what per-request content the extension
+ * persists, and for how long (ADR-064).
+ *
+ * A single source of truth read from the extension configuration and applied at
+ * every content sink before a write. The default is metadata-only — the
+ * behaviour the extension already had by construction.
+ */
+interface PrivacyPolicyInterface
+{
+    /**
+     * The configured privacy level; PrivacyLevel::METADATA when unset or
+     * invalid (safe default: drop content, keep metadata).
+     */
+    public function level(): PrivacyLevel;
+
+    /**
+     * Retention window in days for the per-request log tables, at least 1.
+     * A missing, zero or negative setting falls back to 30 days — 0 must not
+     * mean "delete everything immediately".
+     */
+    public function retentionDays(): int;
+
+    /**
+     * Gate a content payload for persistence according to the current level:
+     * NONE/METADATA drop it (null), REDACTED returns a bounded scrubbed copy,
+     * FULL returns it unchanged. Null in, null out.
+     */
+    public function filterContent(?string $content): ?string;
+}

--- a/Classes/Service/Skill/SkillAuditRepository.php
+++ b/Classes/Service/Skill/SkillAuditRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Skill;
 
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -21,7 +22,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  * skill that can reach a prompt; a purge, if ever needed, is a separate,
  * explicitly documented retention operation — never the regular write path.
  */
-final readonly class SkillAuditRepository
+final readonly class SkillAuditRepository implements SkillAuditRepositoryInterface
 {
     use SafeCastTrait;
 
@@ -29,6 +30,7 @@ final readonly class SkillAuditRepository
 
     public function __construct(
         private ConnectionPool $connectionPool,
+        private PrivacyPolicyInterface $privacyPolicy,
     ) {}
 
     /**
@@ -54,9 +56,12 @@ final readonly class SkillAuditRepository
             'source_sha'       => $sourceSha,
             'body_checksum'    => $bodyChecksum,
             'trust_level'      => $trustLevel,
-            'scan_result'      => $scanResult,
+            // scan_result and detail are free-form content; gate them through
+            // the central privacy policy before persisting (ADR-064). All other
+            // columns are metadata and are always kept.
+            'scan_result'      => $this->privacyPolicy->filterContent($scanResult) ?? '',
             'actor_uid'        => $actorUid,
-            'detail'           => $detail,
+            'detail'           => $this->privacyPolicy->filterContent($detail) ?? '',
         ]);
     }
 
@@ -96,5 +101,21 @@ final readonly class SkillAuditRepository
             ->from(self::TABLE)
             ->executeQuery()
             ->fetchOne());
+    }
+
+    /**
+     * The one retention exception to the append-only rule (ADR-064): delete
+     * rows created strictly before the given UNIX timestamp. Driven by
+     * `nrllm:privacy:purge`, never the regular write path.
+     */
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+
+        return (int)$queryBuilder
+            ->delete(self::TABLE)
+            ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
+            ->executeStatement();
     }
 }

--- a/Classes/Service/Skill/SkillAuditRepositoryInterface.php
+++ b/Classes/Service/Skill/SkillAuditRepositoryInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Skill;
+
+/**
+ * Persistence contract for the append-only skill audit trail (ADR-061).
+ *
+ * Deliberately narrow: append one immutable row, read a source's rows, count
+ * rows, and — the one retention exception (ADR-064) — purge rows older than a
+ * cutoff. There is no update path.
+ */
+interface SkillAuditRepositoryInterface
+{
+    /**
+     * Append one immutable audit row.
+     */
+    public function record(
+        string $event,
+        int $sourceUid,
+        string $skillIdentifier,
+        string $sourceSha,
+        string $bodyChecksum,
+        string $trustLevel,
+        string $scanResult,
+        int $actorUid,
+        string $detail,
+    ): void;
+
+    /**
+     * The audit rows for a source, oldest first.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findBySourceUid(int $sourceUid): array;
+
+    /**
+     * Total number of audit rows.
+     */
+    public function countAll(): int;
+
+    /**
+     * Delete rows created strictly before the given UNIX timestamp.
+     *
+     * @return int number of rows deleted
+     */
+    public function purgeOlderThan(int $timestamp): int;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -208,6 +208,13 @@ services:
     alias: Netresearch\NrLlm\Service\Evaluation\EvaluationQualityScoreProvider
     public: false
 
+  # Central privacy model (ADR-064) — the single policy read at every content
+  # sink and by the nrllm:privacy:purge command. Private: it is a constructor
+  # collaborator, never resolved by class name from the container.
+  Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface:
+    alias: Netresearch\NrLlm\Service\Privacy\PrivacyPolicy
+    public: false
+
   # ========================================
   # Repositories (private)
   # ========================================
@@ -223,6 +230,13 @@ services:
 
   Netresearch\NrLlm\Service\Skill\GitHubClientInterface:
     alias: Netresearch\NrLlm\Service\Skill\GitHubClient
+
+  # Skill audit trail (ADR-061); the nrllm:privacy:purge command (ADR-064) wires
+  # against the interface for its retention purge. Private — functional tests
+  # instantiate the concrete directly with the real ConnectionPool.
+  Netresearch\NrLlm\Service\Skill\SkillAuditRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Skill\SkillAuditRepository
+    public: false
 
   # Built via a factory so the instance-configured minimum skill trust level
   # (skills.minTrustLevel, ADR-061) is applied. Stays private — the composer is

--- a/Documentation/Adr/Adr064CentralPrivacyModel.rst
+++ b/Documentation/Adr/Adr064CentralPrivacyModel.rst
@@ -1,0 +1,161 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-064:
+
+==========================================
+ADR-064: Central Privacy Model
+==========================================
+
+:Status: Accepted
+:Date: 2026-07
+:Authors: Netresearch DTT GmbH
+
+.. _adr-064-context:
+
+Context
+=======
+
+The extension is **metadata-only by construction** almost everywhere. Telemetry
+(:ref:`adr-058`) stores no prompts or responses — only an exception FQCN on
+failure — and already bounds its growth with a retention purge
+(:bash:`nrllm:telemetry:purge`). But two tables *do* persist per-request
+**content**, and until now they did so unconditionally:
+
+* :sql:`tx_nrllm_eval_result.details` — a JSON snapshot of the per-prompt graded
+  model output (:ref:`adr-060`). This is real model output.
+* :sql:`tx_nrllm_skill_audit.scan_result` and :sql:`detail` — the
+  prompt-injection scan output and a free-form detail string (:ref:`adr-061`).
+
+Both tables also carry pure-metadata columns (identifiers, counts, checksums,
+trust level, timestamps) that are not sensitive.
+
+ADR-058 named the gap explicitly:
+
+    The central privacy model (retention tiers none/metadata/redacted/full) is a
+    later workstream; this middleware is metadata-only by construction.
+
+So there was no single, operator-configurable answer to "how much per-request
+content does this extension keep, and for how long?", and no purge for the two
+content tables — only telemetry had one.
+
+.. _adr-064-decision:
+
+Decision
+========
+
+Introduce one central privacy model, read from the extension configuration and
+applied at every content sink before a write.
+
+**1. Four levels** — a backed :php:`PrivacyLevel` enum on a strict-to-loose
+scale:
+
+* ``none`` — drop content, keep metadata.
+* ``metadata`` — drop content, keep metadata (**the default**).
+* ``redacted`` — store a bounded, credential-scrubbed copy.
+* ``full`` — store content verbatim.
+
+The enum exposes ``persistsContent()`` (true for ``redacted``/``full``),
+``requiresRedaction()`` (true for ``redacted``) and a ``severity()`` ordering
+with ``strictest(a, b)`` so a global default and any future per-scope override
+combine with **"strictest wins"** — ``none`` is strictest, ``full`` loosest.
+
+**2. Safe default** — :php:`PrivacyPolicy::level()` returns
+:php:`PrivacyLevel::METADATA` when the setting is unset or invalid. That is the
+behaviour the extension already had by construction, so an un-configured
+instance keeps content out of the database, not in it.
+
+**3. Two governed sinks.** :php:`EvaluationResultRepository` and
+:php:`SkillAuditRepository` inject :php:`PrivacyPolicyInterface` and pass their
+content columns through ``filterContent()`` before insert
+(``details``; ``scan_result`` and ``detail``). ``null`` (dropped content) is
+stored as the empty string so the columns stay well-typed. Every metadata column
+is untouched.
+
+**4. Honest, bounded redaction.** :php:`ContentRedactor` (the ``redacted`` level)
+masks a small set of high-signal secrets — credential-bearing URL query
+parameters (reusing :php:`ErrorMessageSanitizerTrait`, not a copied regex),
+obvious bearer / API tokens, and email addresses — and caps length at 2000
+characters. Its doc block states plainly that it is a heuristic, **not** a
+guaranteed PII scrubber; operators who must not store content at all use
+``none``/``metadata``.
+
+**5. Centralised retention.** Each content repository gains a
+``purgeOlderThan(int $timestamp): int`` mirroring
+:php:`TelemetryRepository::purgeOlderThan()`
+(``run_date`` for eval results, ``crdate`` for the audit trail). A new command
+:bash:`nrllm:privacy:purge` (``--days``, defaulting to the configured
+``privacy.retentionDays``, floor 1) purges **all three** log tables — eval
+results, skill audit and telemetry — and reports the count per table. The
+retention window clamps a missing / zero / negative setting to 30 days: ``0``
+must never mean "delete everything immediately". The existing
+:bash:`nrllm:telemetry:purge` stays for backward compatibility.
+
+**6. Configuration.** Two settings under a new ``privacy`` category in
+:file:`ext_conf_template.txt`: ``privacy.level``
+(``options[None|Metadata|Redacted|Full]``, default ``metadata``) and
+``privacy.retentionDays`` (``int+``, default 30).
+
+.. _adr-064-consequences:
+
+Consequences
+============
+
+* ●● **One operator-facing answer to "what is stored".** A single setting, read
+  in one place and enforced at every content sink, replaces the previous
+  implicit, per-table behaviour.
+* ●● **Safe by default.** An un-configured instance stays metadata-only — the
+  historical behaviour — so this is not a silent behaviour change for existing
+  installs. It generalises the principle telemetry already followed.
+* ● **Bounded, purgeable growth for the content tables too.** The two content
+  logs get the retention story telemetry already had; :bash:`nrllm:privacy:purge`
+  bounds all three from the scheduler.
+* ● **Strictest-wins ordering is ready for per-scope overrides.** The
+  ``severity()`` / ``strictest()`` API expresses tightening today even though
+  only the global default is wired, so a future per-configuration override
+  composes without a rework.
+* ◐ **Redaction is deliberately shallow.** ``redacted`` removes known secret
+  shapes and caps length; it does not guarantee PII removal. The honest doc
+  block prevents a false sense of safety, and ``none``/``metadata`` remain the
+  answer when content must not be stored.
+* ✕ **Two purge commands now exist.** :bash:`nrllm:telemetry:purge` is kept for
+  backward compatibility alongside the broader :bash:`nrllm:privacy:purge`.
+  Operators scheduling the new command can retire the old one.
+* ◑ **Lossy at redacted/full boundaries.** At ``redacted`` the stored
+  ``details`` JSON may be truncated or masked and is no longer guaranteed to
+  round-trip; consumers that need the verbatim snapshot must run at ``full``.
+
+**Net Score: +6** (2×●● +4, 2×● +2, 1×◐ +0.5, 1×✕ −1.5, 1×◑ −1).
+
+.. _adr-064-alternatives:
+
+Alternatives considered
+=======================
+
+* **Per-table settings instead of one model.** Rejected: it multiplies operator
+  surface and drifts, and gives no single answer to the compliance question.
+  One enum applied at every sink is the point.
+* **A comprehensive PII scrubber.** Rejected as dishonest for the scope: robust
+  PII detection is a large, error-prone problem. A bounded heuristic with an
+  explicit "not a guarantee" contract, plus ``none``/``metadata`` for
+  store-nothing, is the truthful design.
+* **Drop content unconditionally (no ``full``/``redacted``).** Rejected: the
+  eval snapshot and injection-scan output have legitimate debugging and
+  provenance uses. Making retention a choice — with a metadata-only default —
+  serves both the privacy-first and the diagnostics case.
+* **Reuse ``nrllm:telemetry:purge`` for all tables.** Rejected: overloading a
+  command named for one table is surprising. A dedicated
+  :bash:`nrllm:privacy:purge` owns cross-table retention; the old command stays
+  for compatibility.
+
+.. _adr-064-references:
+
+References
+==========
+
+* :ref:`adr-058` — Telemetry Middleware (metadata-only by construction; named
+  this workstream as the follow-up).
+* :ref:`adr-060` — Quality Evaluation (owns :sql:`tx_nrllm_eval_result`).
+* :ref:`adr-061` — Skill Trust, Egress and Audit (owns
+  :sql:`tx_nrllm_skill_audit`).
+* ADR-017 — SafeCastTrait / ErrorMessageSanitizerTrait (the shared credential
+  redaction reused here).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -362,4 +362,5 @@ Tools
    Adr061SkillTrustEgressAndAudit
    Adr062StreamingLifecycle
    Adr063ProviderResilience
+   Adr064CentralPrivacyModel
    Adr065ReducePublicServiceSurface

--- a/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
+++ b/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
@@ -15,9 +15,12 @@ use Netresearch\NrLlm\Service\Evaluation\PromptEvaluation;
 use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
 use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
 use Netresearch\NrLlm\Service\Evaluation\SetEvaluationResult;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
@@ -43,7 +46,10 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
 
         $connectionPool = $this->get(ConnectionPool::class);
         self::assertInstanceOf(ConnectionPool::class, $connectionPool);
-        $this->repository = new EvaluationResultRepository($connectionPool);
+        // Run the persistence tests at the "full" privacy level so the details
+        // snapshot is stored verbatim; the metadata-emptying case below uses a
+        // "metadata" policy of its own (ADR-064).
+        $this->repository = new EvaluationResultRepository($connectionPool, $this->policy('full'));
     }
 
     /**
@@ -180,5 +186,36 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
         self::assertSame(1_700_000_100, $judge->runTimestamp);
         self::assertEqualsWithDelta(1.0, $deterministic->passRate, 0.0001);
         self::assertEqualsWithDelta(0.25, $judge->passRate, 0.0001);
+    }
+
+    #[Test]
+    public function saveAtMetadataLevelEmptiesDetailsButKeepsMetadata(): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $repository = new EvaluationResultRepository($connectionPool, $this->policy('metadata'));
+
+        $repository->save($this->buildResult(4, 3, 1_700_000_500));
+
+        $row = $connectionPool->getConnectionForTable(self::TABLE)->select(
+            ['prompt_count', 'passed_count', 'details'],
+            self::TABLE,
+            ['run_date' => 1_700_000_500],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        // Metadata columns are preserved...
+        self::assertSame(4, (int)$row['prompt_count']);
+        self::assertSame(3, (int)$row['passed_count']);
+        // ...but the content payload is dropped (ADR-064).
+        self::assertSame('', $row['details']);
+    }
+
+    private function policy(string $level): PrivacyPolicy
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['privacy' => ['level' => $level]]);
+
+        return new PrivacyPolicy($extensionConfiguration, new ContentRedactor());
     }
 }

--- a/Tests/Functional/Service/Privacy/PrivacyPurgeTest.php
+++ b/Tests/Functional/Service/Privacy/PrivacyPurgeTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Privacy;
+
+use Netresearch\NrLlm\Command\PurgePrivacyDataCommand;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepository;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
+use Netresearch\NrLlm\Service\Skill\SkillAuditRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional coverage for the centralised retention purge (ADR-064): each
+ * content repository deletes rows older than the cutoff and keeps fresh ones,
+ * and the purge command wires from the container with all its dependencies.
+ */
+#[CoversClass(EvaluationResultRepository::class)]
+#[CoversClass(SkillAuditRepository::class)]
+#[CoversClass(PurgePrivacyDataCommand::class)]
+final class PrivacyPurgeTest extends AbstractFunctionalTestCase
+{
+    private const EVAL_TABLE  = 'tx_nrllm_eval_result';
+    private const AUDIT_TABLE = 'tx_nrllm_skill_audit';
+
+    #[Test]
+    public function purgeOlderThanDeletesOnlyOldEvaluationResults(): void
+    {
+        $connectionPool = $this->connectionPool();
+        $repository     = new EvaluationResultRepository($connectionPool, $this->fullPolicy());
+        $connection     = $connectionPool->getConnectionForTable(self::EVAL_TABLE);
+
+        $tenDaysAgo = time() - (10 * 86400);
+        $connection->insert(self::EVAL_TABLE, $this->evalRow('old.set', $tenDaysAgo));
+        $connection->insert(self::EVAL_TABLE, $this->evalRow('fresh.set', time()));
+
+        $deleted = $repository->purgeOlderThan(time() - (5 * 86400));
+
+        self::assertSame(1, $deleted);
+        self::assertSame(0, $connection->count('*', self::EVAL_TABLE, ['set_identifier' => 'old.set']));
+        self::assertSame(1, $connection->count('*', self::EVAL_TABLE, ['set_identifier' => 'fresh.set']));
+    }
+
+    #[Test]
+    public function purgeOlderThanDeletesOnlyOldSkillAuditRows(): void
+    {
+        $connectionPool = $this->connectionPool();
+        $repository     = new SkillAuditRepository($connectionPool, $this->fullPolicy());
+        $connection     = $connectionPool->getConnectionForTable(self::AUDIT_TABLE);
+
+        $tenDaysAgo = time() - (10 * 86400);
+        $connection->insert(self::AUDIT_TABLE, $this->auditRow('old', $tenDaysAgo));
+        $connection->insert(self::AUDIT_TABLE, $this->auditRow('fresh', time()));
+
+        $deleted = $repository->purgeOlderThan(time() - (5 * 86400));
+
+        self::assertSame(1, $deleted);
+        self::assertSame(0, $connection->count('*', self::AUDIT_TABLE, ['skill_identifier' => 'old']));
+        self::assertSame(1, $connection->count('*', self::AUDIT_TABLE, ['skill_identifier' => 'fresh']));
+    }
+
+    #[Test]
+    public function purgeCommandResolvesFromContainerWithAllDependencies(): void
+    {
+        // Proves the command self-registers (autoconfigure + #[AsCommand]) and
+        // that all four injected interfaces resolve through the container.
+        $command = $this->get(PurgePrivacyDataCommand::class);
+
+        self::assertInstanceOf(PurgePrivacyDataCommand::class, $command);
+        self::assertSame('nrllm:privacy:purge', $command->getName());
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    private function evalRow(string $setIdentifier, int $runDate): array
+    {
+        return [
+            'pid'            => 0,
+            'set_identifier' => $setIdentifier,
+            'model_id'       => 'm',
+            'grader'         => 'deterministic',
+            'prompt_count'   => 1,
+            'passed_count'   => 1,
+            'pass_rate'      => 1,
+            'mean_score'     => 1,
+            'details'        => '[]',
+            'run_date'       => $runDate,
+            'tstamp'         => $runDate,
+            'crdate'         => $runDate,
+        ];
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    private function auditRow(string $skillIdentifier, int $crdate): array
+    {
+        return [
+            'pid'              => 0,
+            'crdate'           => $crdate,
+            'event'            => 'ingest_created',
+            'source_uid'       => 1,
+            'skill_identifier' => $skillIdentifier,
+            'source_sha'       => '',
+            'body_checksum'    => '',
+            'trust_level'      => 'verified',
+            'scan_result'      => '',
+            'actor_uid'        => 0,
+            'detail'           => '',
+        ];
+    }
+
+    private function fullPolicy(): PrivacyPolicy
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['privacy' => ['level' => 'full']]);
+
+        return new PrivacyPolicy($extensionConfiguration, new ContentRedactor());
+    }
+
+    private function connectionPool(): ConnectionPool
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        return $connectionPool;
+    }
+}

--- a/Tests/Functional/Service/Skill/SkillIngestIsolationTest.php
+++ b/Tests/Functional/Service/Skill/SkillIngestIsolationTest.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\SkillSource;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillSourceRepository;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
 use Netresearch\NrLlm\Service\Skill\GitHubClientInterface;
 use Netresearch\NrLlm\Service\Skill\MarketplaceParser;
 use Netresearch\NrLlm\Service\Skill\PromptInjectionScanner;
@@ -31,6 +33,7 @@ use Netresearch\NrLlm\Tests\Functional\Service\Skill\Fixtures\FakeGitHubClient;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -132,7 +135,7 @@ final class SkillIngestIsolationTest extends AbstractFunctionalTestCase
     #[Test]
     public function auditTrailIsAppendOnlyAcrossReSyncAndToggle(): void
     {
-        $audit  = new SkillAuditRepository($this->connectionPool());
+        $audit  = $this->auditRepository();
         $source = $this->persistSource(SkillTrustLevel::COMMUNITY);
 
         $this->service($this->github('First body.'))->sync($source);
@@ -176,7 +179,7 @@ final class SkillIngestIsolationTest extends AbstractFunctionalTestCase
             30,
             new PromptInjectionScanner(),
             new SkillManifestVerifier(),
-            new SkillAuditService(new SkillAuditRepository($this->connectionPool())),
+            new SkillAuditService($this->auditRepository()),
         );
     }
 
@@ -215,7 +218,7 @@ final class SkillIngestIsolationTest extends AbstractFunctionalTestCase
      */
     private function auditEvents(SkillSource $source): array
     {
-        $rows = (new SkillAuditRepository($this->connectionPool()))->findBySourceUid((int)$source->getUid());
+        $rows = $this->auditRepository()->findBySourceUid((int)$source->getUid());
 
         return array_map(
             static function (array $row): string {
@@ -232,7 +235,7 @@ final class SkillIngestIsolationTest extends AbstractFunctionalTestCase
      */
     private function auditRow(SkillSource $source, string $event): array
     {
-        foreach ((new SkillAuditRepository($this->connectionPool()))->findBySourceUid((int)$source->getUid()) as $row) {
+        foreach ($this->auditRepository()->findBySourceUid((int)$source->getUid()) as $row) {
             if (($row['event'] ?? '') === $event) {
                 return $row;
             }
@@ -247,6 +250,19 @@ final class SkillIngestIsolationTest extends AbstractFunctionalTestCase
         self::assertInstanceOf(ConnectionPool::class, $connectionPool);
 
         return $connectionPool;
+    }
+
+    /**
+     * The audit repository with a "full" privacy policy (ADR-064) so the
+     * scan-result / detail payloads are stored verbatim — these tests assert on
+     * the append-only trail, not on content filtering.
+     */
+    private function auditRepository(): SkillAuditRepository
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['privacy' => ['level' => 'full']]);
+
+        return new SkillAuditRepository($this->connectionPool(), new PrivacyPolicy($extensionConfiguration, new ContentRedactor()));
     }
 
     private function persistenceManager(): PersistenceManagerInterface

--- a/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
@@ -26,6 +26,12 @@ final class InMemoryEvaluationResultRepository implements EvaluationResultReposi
     /** @var array<string, EvaluationResultSummary> */
     public array $seeded = [];
 
+    /** The cutoff timestamp the last purgeOlderThan() was asked to delete below. */
+    public ?int $purgeCutoff = null;
+
+    /** The row count purgeOlderThan() reports as deleted. */
+    public int $purgeReturns = 0;
+
     public function seed(EvaluationResultSummary $summary): void
     {
         $this->seeded[$summary->setIdentifier . '|' . $summary->model . '|' . $summary->grader] = $summary;
@@ -51,5 +57,12 @@ final class InMemoryEvaluationResultRepository implements EvaluationResultReposi
     public function meanQualityScoreForModel(string $model, string $grader): ?float
     {
         return null;
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $this->purgeCutoff = $timestamp;
+
+        return $this->purgeReturns;
     }
 }

--- a/Tests/Unit/Command/Fixture/InMemorySkillAuditRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemorySkillAuditRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command\Fixture;
+
+use Netresearch\NrLlm\Service\Skill\SkillAuditRepositoryInterface;
+
+/**
+ * In-memory skill audit repository for command tests: captures the cutoff a
+ * purge was asked to run so the command's retention flow can be exercised
+ * without a database.
+ */
+final class InMemorySkillAuditRepository implements SkillAuditRepositoryInterface
+{
+    /** The cutoff timestamp the last purgeOlderThan() was asked to delete below. */
+    public ?int $purgeCutoff = null;
+
+    /** The row count purgeOlderThan() reports as deleted. */
+    public int $purgeReturns = 0;
+
+    public function record(
+        string $event,
+        int $sourceUid,
+        string $skillIdentifier,
+        string $sourceSha,
+        string $bodyChecksum,
+        string $trustLevel,
+        string $scanResult,
+        int $actorUid,
+        string $detail,
+    ): void {
+        // Not needed by the command tests.
+    }
+
+    public function findBySourceUid(int $sourceUid): array
+    {
+        return [];
+    }
+
+    public function countAll(): int
+    {
+        return 0;
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $this->purgeCutoff = $timestamp;
+
+        return $this->purgeReturns;
+    }
+}

--- a/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
+++ b/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\PurgePrivacyDataCommand;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryEvaluationResultRepository;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemorySkillAuditRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(PurgePrivacyDataCommand::class)]
+final class PurgePrivacyDataCommandTest extends TestCase
+{
+    #[Test]
+    public function purgesAllThreeTablesWithConfiguredRetentionDefault(): void
+    {
+        $eval               = new InMemoryEvaluationResultRepository();
+        $eval->purgeReturns = 2;
+        $audit               = new InMemorySkillAuditRepository();
+        $audit->purgeReturns = 3;
+        $telemetry               = new InMemoryTelemetryRepository();
+        $telemetry->purgeReturns = 5;
+
+        $tester = new CommandTester(new PurgePrivacyDataCommand($this->policyWithRetention(45), $eval, $audit, $telemetry));
+
+        $before = time();
+        $exit   = $tester->execute([]);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+
+        // The default window is the configured retention (45 days), applied to every table.
+        foreach ([$eval->purgeCutoff, $audit->purgeCutoff, $telemetry->purgeCutoff] as $cutoff) {
+            self::assertNotNull($cutoff);
+            self::assertGreaterThanOrEqual($before - (45 * 86400), $cutoff);
+            self::assertLessThanOrEqual($after - (45 * 86400), $cutoff);
+        }
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Evaluation results: 2', $display);
+        self::assertStringContainsString('Skill audit: 3', $display);
+        self::assertStringContainsString('Telemetry: 5', $display);
+    }
+
+    #[Test]
+    public function honoursCustomDaysOption(): void
+    {
+        $eval      = new InMemoryEvaluationResultRepository();
+        $audit     = new InMemorySkillAuditRepository();
+        $telemetry = new InMemoryTelemetryRepository();
+
+        $tester = new CommandTester(new PurgePrivacyDataCommand($this->policyWithRetention(30), $eval, $audit, $telemetry));
+
+        $before = time();
+        $exit   = $tester->execute(['--days' => '7']);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotNull($eval->purgeCutoff);
+        self::assertGreaterThanOrEqual($before - (7 * 86400), $eval->purgeCutoff);
+        self::assertLessThanOrEqual($after - (7 * 86400), $eval->purgeCutoff);
+    }
+
+    #[Test]
+    public function rejectsNonPositiveDaysAndPurgesNothing(): void
+    {
+        $eval      = new InMemoryEvaluationResultRepository();
+        $audit     = new InMemorySkillAuditRepository();
+        $telemetry = new InMemoryTelemetryRepository();
+
+        $tester = new CommandTester(new PurgePrivacyDataCommand($this->policyWithRetention(30), $eval, $audit, $telemetry));
+
+        $exit = $tester->execute(['--days' => '0']);
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertNull($eval->purgeCutoff, 'No purge runs for an invalid window.');
+        self::assertNull($audit->purgeCutoff);
+        self::assertNull($telemetry->purgeCutoff);
+        self::assertStringContainsString('positive integer', $tester->getDisplay());
+    }
+
+    private function policyWithRetention(int $days): PrivacyPolicy
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['privacy' => ['retentionDays' => (string)$days]]);
+
+        return new PrivacyPolicy($extensionConfiguration, new ContentRedactor());
+    }
+}

--- a/Tests/Unit/Domain/Enum/PrivacyLevelTest.php
+++ b/Tests/Unit/Domain/Enum/PrivacyLevelTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class PrivacyLevelTest extends TestCase
+{
+    #[Test]
+    public function casesHaveExpectedStringValues(): void
+    {
+        self::assertSame('none', PrivacyLevel::NONE->value);
+        self::assertSame('metadata', PrivacyLevel::METADATA->value);
+        self::assertSame('redacted', PrivacyLevel::REDACTED->value);
+        self::assertSame('full', PrivacyLevel::FULL->value);
+    }
+
+    #[Test]
+    public function valuesReturnsAllCasesInOrder(): void
+    {
+        self::assertSame(['none', 'metadata', 'redacted', 'full'], PrivacyLevel::values());
+    }
+
+    #[Test]
+    public function isValidAcceptsKnownAndRejectsUnknown(): void
+    {
+        self::assertTrue(PrivacyLevel::isValid('redacted'));
+        self::assertFalse(PrivacyLevel::isValid('partial'));
+        self::assertFalse(PrivacyLevel::isValid(''));
+    }
+
+    #[Test]
+    public function tryFromStringMapsKnownAndReturnsNullForUnknown(): void
+    {
+        self::assertSame(PrivacyLevel::FULL, PrivacyLevel::tryFromString('full'));
+        self::assertNull(PrivacyLevel::tryFromString('nope'));
+    }
+
+    #[Test]
+    public function persistsContentOnlyForRedactedAndFull(): void
+    {
+        self::assertFalse(PrivacyLevel::NONE->persistsContent());
+        self::assertFalse(PrivacyLevel::METADATA->persistsContent());
+        self::assertTrue(PrivacyLevel::REDACTED->persistsContent());
+        self::assertTrue(PrivacyLevel::FULL->persistsContent());
+    }
+
+    #[Test]
+    public function requiresRedactionOnlyForRedacted(): void
+    {
+        self::assertFalse(PrivacyLevel::NONE->requiresRedaction());
+        self::assertFalse(PrivacyLevel::METADATA->requiresRedaction());
+        self::assertTrue(PrivacyLevel::REDACTED->requiresRedaction());
+        self::assertFalse(PrivacyLevel::FULL->requiresRedaction());
+    }
+
+    #[Test]
+    public function strictestPicksTheMoreRestrictiveLevel(): void
+    {
+        // NONE is strictest, regardless of argument order.
+        self::assertSame(PrivacyLevel::NONE, PrivacyLevel::strictest(PrivacyLevel::NONE, PrivacyLevel::FULL));
+        self::assertSame(PrivacyLevel::NONE, PrivacyLevel::strictest(PrivacyLevel::FULL, PrivacyLevel::NONE));
+
+        self::assertSame(PrivacyLevel::METADATA, PrivacyLevel::strictest(PrivacyLevel::METADATA, PrivacyLevel::REDACTED));
+        self::assertSame(PrivacyLevel::REDACTED, PrivacyLevel::strictest(PrivacyLevel::REDACTED, PrivacyLevel::FULL));
+        self::assertSame(PrivacyLevel::FULL, PrivacyLevel::strictest(PrivacyLevel::FULL, PrivacyLevel::FULL));
+    }
+}

--- a/Tests/Unit/Service/Privacy/ContentRedactorTest.php
+++ b/Tests/Unit/Service/Privacy/ContentRedactorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Privacy;
+
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentRedactor::class)]
+final class ContentRedactorTest extends TestCase
+{
+    #[Test]
+    public function returnsNullForNull(): void
+    {
+        self::assertNull((new ContentRedactor())->redact(null));
+    }
+
+    #[Test]
+    public function stripsCredentialQueryParameters(): void
+    {
+        $out = (new ContentRedactor())->redact('GET https://api.example.com/v1/models?token=abc123secret&x=1');
+
+        self::assertIsString($out);
+        self::assertStringContainsString('token=***', $out);
+        self::assertStringNotContainsString('abc123secret', $out);
+    }
+
+    #[Test]
+    public function redactsEmailAddresses(): void
+    {
+        $out = (new ContentRedactor())->redact('contact john.doe@example.com for access');
+
+        self::assertIsString($out);
+        self::assertStringNotContainsString('john.doe@example.com', $out);
+        self::assertStringContainsString('***', $out);
+    }
+
+    #[Test]
+    public function redactsBearerTokens(): void
+    {
+        $out = (new ContentRedactor())->redact('Authorization: Bearer sk-abcDEF1234567890abcDEF12');
+
+        self::assertIsString($out);
+        self::assertStringNotContainsString('sk-abcDEF1234567890abcDEF12', $out);
+        self::assertStringContainsString('***', $out);
+    }
+
+    #[Test]
+    public function truncatesOverLongContent(): void
+    {
+        $long = str_repeat('a', 5000);
+
+        $out = (new ContentRedactor())->redact($long);
+
+        self::assertIsString($out);
+        self::assertLessThan(mb_strlen($long), mb_strlen($out));
+        self::assertStringEndsWith('[truncated]', $out);
+    }
+}

--- a/Tests/Unit/Service/Privacy/PrivacyPolicyTest.php
+++ b/Tests/Unit/Service/Privacy/PrivacyPolicyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Privacy;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(PrivacyPolicy::class)]
+final class PrivacyPolicyTest extends TestCase
+{
+    #[Test]
+    public function levelDefaultsToMetadataWhenUnset(): void
+    {
+        self::assertSame(PrivacyLevel::METADATA, $this->policy([])->level());
+    }
+
+    #[Test]
+    public function levelDefaultsToMetadataWhenInvalid(): void
+    {
+        self::assertSame(PrivacyLevel::METADATA, $this->policy(['privacy' => ['level' => 'bogus']])->level());
+    }
+
+    #[Test]
+    public function levelReadsConfiguredValue(): void
+    {
+        self::assertSame(PrivacyLevel::FULL, $this->policy(['privacy' => ['level' => 'full']])->level());
+    }
+
+    #[Test]
+    public function retentionDaysDefaultsToThirtyWhenUnset(): void
+    {
+        self::assertSame(30, $this->policy([])->retentionDays());
+    }
+
+    #[Test]
+    public function retentionDaysClampsZeroAndNegativeToDefault(): void
+    {
+        self::assertSame(30, $this->policy(['privacy' => ['retentionDays' => '0']])->retentionDays());
+        self::assertSame(30, $this->policy(['privacy' => ['retentionDays' => '-5']])->retentionDays());
+    }
+
+    #[Test]
+    public function retentionDaysReadsConfiguredValue(): void
+    {
+        self::assertSame(7, $this->policy(['privacy' => ['retentionDays' => '7']])->retentionDays());
+    }
+
+    #[Test]
+    public function filterContentReturnsNullForNullRegardlessOfLevel(): void
+    {
+        self::assertNull($this->policy(['privacy' => ['level' => 'full']])->filterContent(null));
+    }
+
+    #[Test]
+    public function filterContentDropsContentAtNoneAndMetadata(): void
+    {
+        self::assertNull($this->policy(['privacy' => ['level' => 'none']])->filterContent('secret payload'));
+        self::assertNull($this->policy(['privacy' => ['level' => 'metadata']])->filterContent('secret payload'));
+    }
+
+    #[Test]
+    public function filterContentReturnsContentVerbatimAtFull(): void
+    {
+        self::assertSame(
+            'verbatim payload',
+            $this->policy(['privacy' => ['level' => 'full']])->filterContent('verbatim payload'),
+        );
+    }
+
+    #[Test]
+    public function filterContentRedactsAtRedactedLevel(): void
+    {
+        $out = $this->policy(['privacy' => ['level' => 'redacted']])->filterContent('mail me at john@example.com');
+
+        self::assertIsString($out);
+        self::assertStringNotContainsString('john@example.com', $out);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function policy(array $config): PrivacyPolicy
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($config);
+
+        return new PrivacyPolicy($extensionConfiguration, new ContentRedactor());
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -103,3 +103,13 @@ testing.testPrompt = Say hello and introduce yourself in one sentence. Respond i
 
 # cat=telemetry; type=boolean; label=Enable Telemetry: Record one row per provider pipeline run (operation, provider, latency, success/failure, cache hit, fallback attempts) in tx_nrllm_telemetry. No prompts or responses are stored, only the exception class on failure. Purge old rows with the nrllm:telemetry:purge command. On by default.
 telemetry.enabled = 1
+
+# =============================================================================
+# Privacy & data retention (ADR-064)
+# =============================================================================
+
+# cat=privacy; type=options[None=none,Metadata=metadata,Redacted=redacted,Full=full]; label=Content Privacy Level: How much per-request content the extension stores in its log tables. "None" and "Metadata" drop the content payload and keep only metadata (identifiers, counts, timestamps); "Redacted" stores a length-capped copy with obvious credentials and email addresses masked; "Full" stores it verbatim. Metadata-only is the default and matches the extension's historical behaviour. Governs tx_nrllm_eval_result.details and tx_nrllm_skill_audit.scan_result/detail.
+privacy.level = metadata
+
+# cat=privacy; type=int+; label=Retention (days): How many days per-request log rows are kept before the nrllm:privacy:purge command deletes them (evaluation results, skill audit, telemetry). Minimum 1 day; an empty or zero value falls back to 30 days.
+privacy.retentionDays = 30


### PR DESCRIPTION
Introduces a single privacy model governing what per-request content the
extension persists, plus centralized retention (ADR-064). Closes the last
workstream from the aim-vs-nr-llm analysis.

## Levels

A `PrivacyLevel` enum (`none` / `metadata` / `redacted` / `full`), read once
from the `nr_llm` extension configuration via `PrivacyPolicy`:

- **none / metadata** — content dropped, metadata columns kept.
- **redacted** — content passed through `ContentRedactor` (bounded, best-effort:
  credential query params via the shared `ErrorMessageSanitizerTrait`, bearer/`sk-`
  tokens and emails masked, 2000-char cap). Not a guaranteed PII scrubber — the
  class docblock and ADR state its limits.
- **full** — content stored verbatim.

Default is `metadata`, matching the extension's historical metadata-only
behaviour. `strictest()` lets a stricter scope override win.

## Governed sinks

`PrivacyPolicy::filterContent()` is applied before persistence at the two tables
that hold per-request content:

- `tx_nrllm_eval_result.details` (graded output snapshot) — `EvaluationResultRepository`
- `tx_nrllm_skill_audit.scan_result` / `detail` — `SkillAuditRepository`

Telemetry (`tx_nrllm_telemetry`) was already metadata-only by construction; this
generalizes that principle.

## Retention

`purgeOlderThan()` added to the eval and skill-audit repositories (telemetry
already had it). A new `nrllm:privacy:purge` command purges all three log tables
using the configured `privacy.retentionDays` (default 30, `--days` overrides).

## Config

`ext_conf_template.txt` gains a `privacy` section: `privacy.level` (dropdown) and
`privacy.retentionDays` (int).

## Tests

Unit: `PrivacyLevelTest`, `PrivacyPolicyTest`, `ContentRedactorTest`,
`PurgePrivacyDataCommandTest`. Functional: `PrivacyPurgeTest` (per-table purge +
container-wired command DI), plus a metadata-level emptying assertion in
`EvaluationResultRepositoryTest`.
