### PR TITLE
fix: middleware pipeline robustness (fail-soft usage tracking; idempotency scope)

### DIFF
--- a/Classes/Provider/Middleware/IdempotencyMiddleware.php
+++ b/Classes/Provider/Middleware/IdempotencyMiddleware.php
@@ -22,10 +22,18 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
  * When a call carries an idempotency key (via
  * {@see self::METADATA_IDEMPOTENCY_KEY} on the context metadata, set from an
  * option's `withIdempotencyKey()`), the FIRST call runs normally and its result
- * is stored under that key; a REPEAT with the same key returns the stored
- * result without calling the provider again. This makes a retried
- * request — a double-submitted form, a network retry — safe: it neither
- * re-charges the budget nor produces a second, different completion.
+ * is stored under that key; a later REPEAT with the same key returns the stored
+ * result without calling the provider again. This makes a SEQUENTIAL retry — a
+ * network retry, or a re-submit after the first request already returned — safe:
+ * it neither re-charges the budget nor produces a second, different completion.
+ *
+ * Scope — sequential retries only. The lookup is a plain get-then-run-then-set
+ * with no atomic reservation, so two requests carrying the SAME key that are
+ * genuinely in flight at once (both arriving before either has stored its
+ * result) both miss and both execute; the dedup only engages once a result is
+ * stored. Closing that window needs an atomic reserve-on-miss, which TYPO3's
+ * cache {@see FrontendInterface} does not expose — a future revision could gate
+ * the run+store with {@see \TYPO3\CMS\Core\Locking\LockFactory} (ADR-063).
  *
  * Opt-in: with no idempotency key the middleware is a verbatim pass-through, so
  * ordinary (non-idempotent) traffic is untouched.

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -15,7 +15,9 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Throwable;
 
 /**
  * Records usage to tx_nrllm_service_usage after a successful provider call.
@@ -59,6 +61,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * TelemetryMiddleware (ADR-058), which wraps the whole pipeline and records
  * one row regardless of outcome.
  *
+ * Recording is fail-soft: a failure while writing to tx_nrllm_service_usage is
+ * logged and swallowed, never re-thrown, so this post-flight bookkeeping cannot
+ * turn an already-successful provider call into an error — nor be mis-recorded
+ * by TelemetryMiddleware as a provider failure.
+ *
  * The default pipeline order is pinned via tag priority (Telemetry outermost
  * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
  * Usage at 25, CircuitBreaker innermost at 20).
@@ -70,6 +77,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
 
     public function __construct(
         private UsageTrackerServiceInterface $usageTracker,
+        private LoggerInterface $logger,
     ) {}
 
     /**
@@ -82,7 +90,19 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
     ): mixed {
         $result = $next($configuration);
 
-        $this->track($context, $configuration, $result);
+        // Usage recording is post-flight bookkeeping. A tracker/DB failure here
+        // must not fail an already-successful provider call, nor propagate out to
+        // TelemetryMiddleware — which would otherwise record the served call as a
+        // provider failure (success=false, the DB exception FQCN) and re-throw to
+        // the caller. Fail soft, like every other accounting sink in the pipeline.
+        try {
+            $this->track($context, $configuration, $result);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Usage tracking failed after a successful provider call; the call result is unaffected.',
+                ['exception' => $e, 'operation' => $context->operation->value],
+            );
+        }
 
         return $result;
     }

--- a/Documentation/Adr/Adr063ProviderResilience.rst
+++ b/Documentation/Adr/Adr063ProviderResilience.rst
@@ -221,6 +221,11 @@ Deferred / follow-ups
   The services expose the data; only a view is missing.
 * Per-operation idempotency TTL override via call metadata (the middleware uses
   a single window today).
+* Concurrent-double-submit dedup. The current get-then-run-then-set has no atomic
+  reserve-on-miss — a portable one is not available through the cache
+  :php:`FrontendInterface` — so two genuinely simultaneous same-key requests are
+  not deduplicated; only sequential retries are (see *Consequences*). A future
+  revision could gate run+store with :php:`\TYPO3\CMS\Core\Locking\LockFactory`.
 
 .. _adr-063-references:
 

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -26,17 +26,22 @@ use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use ReflectionProperty;
+use RuntimeException;
 
 #[CoversClass(UsageMiddleware::class)]
 final class UsageMiddlewareTest extends AbstractUnitTestCase
 {
     private UsageTrackerServiceInterface&MockObject $tracker;
 
+    private LoggerInterface&MockObject $logger;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->tracker = $this->createMock(UsageTrackerServiceInterface::class);
+        $this->logger  = $this->createMock(LoggerInterface::class);
     }
 
     #[Test]
@@ -486,9 +491,36 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
     // Test helpers
     // -----------------------------------------------------------------------
 
+    #[Test]
+    public function usageTrackerFailureIsSwallowedAndDoesNotBreakTheCall(): void
+    {
+        $response = new CompletionResponse(
+            content: 'hi',
+            model: 'gpt-4o-mini',
+            usage: new UsageStatistics(100, 50, 150, 0.0012),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        // A post-success bookkeeping failure (e.g. a DB deadlock while writing
+        // tx_nrllm_service_usage) must be logged and swallowed, never re-thrown:
+        // the already-served provider result has to reach the caller unchanged.
+        $this->tracker->method('trackUsage')
+            ->willThrowException(new RuntimeException('DB deadlock'));
+        $this->logger->expects(self::once())->method('warning');
+
+        $result = $this->pipeline()->run(
+            context: ProviderCallContext::for(ProviderOperation::Chat),
+            configuration: $this->configuration(uid: 7),
+            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+        );
+
+        self::assertSame($response, $result);
+    }
+
     private function pipeline(): MiddlewarePipeline
     {
-        return new MiddlewarePipeline([new UsageMiddleware($this->tracker)]);
+        return new MiddlewarePipeline([new UsageMiddleware($this->tracker, $this->logger)]);
     }
 
     private function configuration(?int $uid = null): LlmConfiguration


### PR DESCRIPTION
Two robustness findings from an adversarial integration review of the
recently-merged middleware pipeline (streaming, resilience, telemetry, privacy),
each verified against the code before inclusion.

## 1. `UsageMiddleware` is now fail-soft (`fix`)

`UsageMiddleware` sits inside the pipeline that `TelemetryMiddleware` wraps. Its
`trackUsage()` call ran unguarded *after* the provider had already returned, so a
DB failure there (deadlock, connection drop, constraint violation) propagated out
and was recorded by telemetry as a **provider** failure (`success=false`, the DB
exception FQCN) and re-thrown to the caller — turning an already-served, billable
completion into an error and losing its usage row.

Every sibling accounting sink in the pipeline (`TelemetryMiddleware::safeRecord`,
`IdempotencyMiddleware::safeSet`, the streaming settle, the circuit-breaker store)
is deliberately fail-soft; `UsageMiddleware` now is too — the tracker call is
wrapped, logged on failure, and never re-thrown. Regression test added.

## 2. `IdempotencyMiddleware` docblock scoped to sequential retries (`docs`)

The class docblock promised a double-submitted form was safe, but the lookup is a
non-atomic get→run→set: two genuinely concurrent same-key requests both miss and
both execute. ADR-063's Consequences already stated this limitation; the docblock
now matches it, and both point at TYPO3's `LockFactory` as the way to close the
window (added as an ADR follow-up). No behavioural change — a portable atomic
reserve-on-miss isn't available through the cache `FrontendInterface`, so a real
concurrent guard is a deliberate follow-up rather than a silent half-fix.
