### PR TITLE
fix: guard the remaining json_encode boundaries against invalid UTF-8

### DIFF
--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -45,7 +45,10 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
     public function generateCacheKey(string $provider, string $operation, array $params): string
     {
         $normalized = $this->normalizeParams($params);
-        $hash = hash('xxh128', json_encode($normalized, JSON_THROW_ON_ERROR));
+        // Internal hop: the key material includes user prompt/message text, so an
+        // invalid byte must substitute into a stable hash input rather than throw
+        // and abort the (otherwise cacheable) call.
+        $hash = hash('xxh128', json_encode($normalized, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         return sprintf('%s_%s_%s', $this->sanitizeTagValue($provider), $operation, $hash);
     }
 

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -170,7 +170,9 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             $result->evaluations,
         );
 
-        return json_encode($details, JSON_THROW_ON_ERROR);
+        // Graded output is provider content and may carry invalid bytes; substitute
+        // rather than throw, so persisting an eval run cannot crash on one response.
+        return json_encode($details, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
     }
 
     private function toString(mixed $value): string

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -198,7 +198,7 @@ final class ConfigurationGenerator
 
         $request = $this->requestFactory->createRequest('POST', $endpoint)
             ->withHeader('Content-Type', 'application/json')
-            ->withBody($this->streamFactory->createStream(json_encode($body, JSON_THROW_ON_ERROR)));
+            ->withBody($this->streamFactory->createStream(json_encode($body, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)));
 
         // Add auth header based on provider
         $request = match ($provider->adapterType) {

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -560,7 +560,11 @@ abstract class AbstractSpecializedService
         }
 
         if ($this->methodAllowsBody($method)) {
-            $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+            // JSON_INVALID_UTF8_SUBSTITUTE: a request payload carrying an invalid
+            // byte (e.g. a prompt pasted from a Latin-1 source) must degrade to a
+            // replacement character, never throw \JsonException and abort the call
+            // — matching AbstractProvider's request-encode guard (PR #315/#316).
+            $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
             $request = $request->withBody($body);
         }
 

--- a/Classes/Specialized/Exception/SpecializedServiceException.php
+++ b/Classes/Specialized/Exception/SpecializedServiceException.php
@@ -45,7 +45,9 @@ abstract class SpecializedServiceException extends RuntimeException
         $details = sprintf('[%s] %s', $this->service, $this->getMessage());
 
         if ($this->context !== null && $this->context !== []) {
-            $details .= ' | Context: ' . json_encode($this->context, JSON_THROW_ON_ERROR);
+            // Substitute invalid bytes: the context may echo the offending payload,
+            // and formatting the error must not throw and mask the original failure.
+            $details .= ' | Context: ' . json_encode($this->context, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
         }
 
         return $details;

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -583,7 +583,7 @@ final class FalImageService extends AbstractSpecializedService
         foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
-        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
         $submitResponse = $this->executeRequest($request);

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -448,7 +448,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             $request = $request->withHeader($name, $value);
         }
         $request = $request->withBody(
-            $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR)),
+            $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)),
         );
 
         try {

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -637,7 +637,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         if ($method === 'POST' && $payload !== []) {
             $request = $request->withBody(
-                $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR)),
+                $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)),
             );
         }
 

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -69,6 +69,19 @@ class CacheManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function generateCacheKeyWithNonUtf8ParamsDoesNotThrow(): void
+    {
+        // The key material includes user prompt/message text; an invalid byte
+        // must substitute into a stable hash input, not throw \JsonException and
+        // abort the otherwise-cacheable call.
+        $params = ['messages' => [['role' => 'user', 'content' => "caf\xE9"]]];
+
+        $key = $this->subject->generateCacheKey('openai', 'completion', $params);
+
+        self::assertStringStartsWith('openai_completion_', $key);
+    }
+
+    #[Test]
     public function sanitizeCacheTagReducesDottedIdentifierToTheAllowedTagCharset(): void
     {
         // Exposed for callers that build tags from dotted preset identifiers

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -79,6 +79,12 @@ class CacheManagerTest extends AbstractUnitTestCase
         $key = $this->subject->generateCacheKey('openai', 'completion', $params);
 
         self::assertStringStartsWith('openai_completion_', $key);
+
+        // The raw invalid byte is substituted with U+FFFD before hashing, so it
+        // yields the SAME key as the already-substituted input — proving the
+        // substitution is deterministic and the resulting key is stable.
+        $substituted = ['messages' => [['role' => 'user', 'content' => "caf\u{FFFD}"]]];
+        self::assertSame($key, $this->subject->generateCacheKey('openai', 'completion', $substituted));
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -110,16 +110,25 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // A non-UTF-8 byte in the request payload (e.g. a prompt pasted from a
         // Latin-1 source) must degrade to a replacement character, not throw a
         // \JsonException from json_encode and abort the call (PR #315/#316 class).
+        $captured = null;
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects(self::once())
             ->method('sendRequest')
-            ->willReturn($this->createJsonResponseMock(['result' => 'ok'], 200));
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+                $captured = $request;
+
+                return $this->createJsonResponseMock(['result' => 'ok'], 200);
+            });
 
         $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
 
         $result = $subject->callSendJsonRequest('endpoint', ['prompt' => "caf\xE9 scene"]);
 
         self::assertSame(['result' => 'ok'], $result);
+        // The invalid 0xE9 byte is substituted with U+FFFD in the outgoing body
+        // (JSON-escaped as �), not left to throw \JsonException.
+        self::assertNotNull($captured);
+        self::assertStringContainsString('caf\ufffd scene', (string)$captured->getBody());
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -105,6 +105,24 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function sendJsonRequestSubstitutesInvalidUtf8InPayloadInsteadOfThrowing(): void
+    {
+        // A non-UTF-8 byte in the request payload (e.g. a prompt pasted from a
+        // Latin-1 source) must degrade to a replacement character, not throw a
+        // \JsonException from json_encode and abort the call (PR #315/#316 class).
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['result' => 'ok'], 200));
+
+        $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test/v1', httpClient: $httpClient);
+
+        $result = $subject->callSendJsonRequest('endpoint', ['prompt' => "caf\xE9 scene"]);
+
+        self::assertSame(['result' => 'ok'], $result);
+    }
+
+    #[Test]
     public function sendJsonRequestReturnsDecodedSuccessResponse(): void
     {
         $httpClient = $this->createMock(ClientInterface::class);

--- a/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
@@ -44,6 +44,21 @@ class SpecializedServiceExceptionTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function getDetailedMessageWithNonUtf8ContextDoesNotThrow(): void
+    {
+        // The context may echo the offending payload; formatting the error must
+        // substitute invalid bytes, not throw \JsonException and mask the
+        // original failure.
+        $exception = new TranslatorException(
+            'Translation failed',
+            'translation',
+            ['echo' => "caf\xE9"],
+        );
+
+        self::assertStringContainsString('[translation] Translation failed', $exception->getDetailedMessage());
+    }
+
+    #[Test]
     public function getDetailedMessageExcludesEmptyContext(): void
     {
         $exception = new TranslatorException('Error', 'translation', []);

--- a/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
@@ -55,7 +55,12 @@ class SpecializedServiceExceptionTest extends AbstractUnitTestCase
             ['echo' => "caf\xE9"],
         );
 
-        self::assertStringContainsString('[translation] Translation failed', $exception->getDetailedMessage());
+        $detailed = $exception->getDetailedMessage();
+
+        self::assertStringContainsString('[translation] Translation failed', $detailed);
+        // The invalid 0xE9 byte must be substituted with U+FFFD, which the
+        // JSON-encoded context escapes as � — not dropped or left to throw.
+        self::assertStringContainsString('caf\ufffd', $detailed);
     }
 
     #[Test]


### PR DESCRIPTION
An adversarial surface review flagged that PR #315/#316's non-UTF-8 hardening
covered the main provider request path but missed the same class of boundary in
several other places. Each finding was verified against the code before fixing.

## The class

`AbstractProvider` encodes request bodies with
`JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE` so an invalid byte in
user/provider content degrades to a replacement character instead of throwing.
These boundaries only had `JSON_THROW_ON_ERROR`, and the `json_encode` sits
*outside* the surrounding `try/catch`, so a non-UTF-8 byte throws an uncaught
`\JsonException` — an HTTP 500 / "Unknown error" (or, for the exception
formatter, the original failure gets masked):

| Boundary | File |
|----------|------|
| Specialized wire (shared: DALL-E, FAL sync) | `AbstractSpecializedService::sendJsonRequest` |
| TTS request body | `TextToSpeechService::sendBinaryRequest` |
| FAL queued request body | `FalImageService::sendQueueRequest` |
| DeepL request body | `DeepLTranslator` |
| Setup-wizard provider request | `ConfigurationGenerator` |
| Cache-key hash (internal hop) | `CacheManager::generateCacheKey` |
| Evaluation details snapshot (provider content) | `EvaluationResultRepository` |
| Exception context formatter | `SpecializedServiceException::getDetailedMessage` |

All now use `JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE`.

## Scope

Deliberately *not* touched: the structured/admin serialization encodes (config
setters, DTO `toString`, preset checksum) — those serialize typed, admin-owned
data, not untrusted free-text on a crashing hot path, and changing their stored
serialization is out of scope.

## Tests

Regression tests at the three distinct boundary types (invalid `\xE9` byte,
would throw without the flag): shared wire-encode (`AbstractSpecializedServiceTest`),
cache-key hop (`CacheManagerTest`), exception formatter
(`SpecializedServiceExceptionTest`).
