### PR TITLE
fix: score provider health on first-attempt reliability; document circuit-counter non-atomicity

### DIFF
--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -159,6 +159,14 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
 
     private function recordFailure(string $provider, CircuitState $state, int $now, CircuitBreakerConfig $config): void
     {
+        // Non-atomic counter — best-effort, the same posture ADR-063 accepts for
+        // the half-open probe gate. $state was loaded at the top of handle(), so
+        // concurrent failures each read the same pre-failure count and write
+        // count+1, losing increments; under heavy concurrent failure the breaker
+        // trips a little LATE (the count still climbs ~one per cooldown window)
+        // rather than never. The cache backend offers no portable atomic
+        // increment; a strict count would need \TYPO3\CMS\Core\Locking\LockFactory
+        // around this read-modify-write (hot-path contention) — deferred.
         $failures = $state->consecutiveFailures + 1;
 
         // Open when the threshold is reached, or keep it open when a half-open

--- a/Classes/Service/Health/ProviderHealthRepository.php
+++ b/Classes/Service/Health/ProviderHealthRepository.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Health;
 
-use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
 
@@ -37,20 +36,23 @@ final readonly class ProviderHealthRepository implements ProviderHealthRepositor
 
         $rows = $queryBuilder
             ->select(self::COL_PROVIDER)
+            // First-attempt reliability. Every run requested from this provider
+            // counts as a sample; a run counts as a SUCCESS only when the
+            // provider served it ITSELF (fallback_attempts = 0) and succeeded.
+            // A telemetry row names the requested PRIMARY, but `success` is the
+            // whole-pipeline outcome — so a fallback-rescued run
+            // (fallback_attempts > 0, success = 1) means the primary FAILED its
+            // first attempt: it is counted here as a primary failure (in
+            // `samples`, not `successes`), never credited to the primary on the
+            // back of the sibling that answered for it, and never dropped (which
+            // would inflate a usually-rescued primary toward 100%).
             ->addSelectLiteral('COUNT(*) AS samples')
-            ->addSelectLiteral('SUM(success) AS successes')
+            ->addSelectLiteral('SUM(CASE WHEN fallback_attempts = 0 AND success = 1 THEN 1 ELSE 0 END) AS successes')
             ->addSelectLiteral('AVG(latency_ms) AS avg_latency')
             ->from(self::TABLE)
             ->where(
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($sinceTimestamp)),
                 $queryBuilder->expr()->neq(self::COL_PROVIDER, $queryBuilder->createNamedParameter('')),
-                // Only count runs the provider served ITSELF. A telemetry row
-                // names the requested PRIMARY provider, but `success` reflects
-                // the whole pipeline outcome — a fallback may have rescued a
-                // failed primary. Excluding fallback runs (fallback_attempts > 0)
-                // stops a failing primary from being scored healthy on the back
-                // of a sibling that answered for it.
-                $queryBuilder->expr()->eq('fallback_attempts', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
             )
             ->groupBy(self::COL_PROVIDER)
             ->executeQuery()

--- a/Classes/Service/Health/ProviderHealthRepository.php
+++ b/Classes/Service/Health/ProviderHealthRepository.php
@@ -48,7 +48,11 @@ final readonly class ProviderHealthRepository implements ProviderHealthRepositor
             // would inflate a usually-rescued primary toward 100%).
             ->addSelectLiteral('COUNT(*) AS samples')
             ->addSelectLiteral('SUM(CASE WHEN fallback_attempts = 0 AND success = 1 THEN 1 ELSE 0 END) AS successes')
-            ->addSelectLiteral('AVG(latency_ms) AS avg_latency')
+            // Average latency only over self-served runs. A fallback-rescued run's
+            // latency_ms is the whole-pipeline time (the failed primary attempt
+            // plus the sibling that answered), which would distort the primary's
+            // own latency; AVG ignores the NULLs the ELSE branch yields.
+            ->addSelectLiteral('AVG(CASE WHEN fallback_attempts = 0 THEN latency_ms END) AS avg_latency')
             ->from(self::TABLE)
             ->where(
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($sinceTimestamp)),

--- a/Documentation/Adr/Adr063ProviderResilience.rst
+++ b/Documentation/Adr/Adr063ProviderResilience.rst
@@ -92,7 +92,11 @@ schema, no purge command, and no write on every call. A DB table would add write
 load on the hot path and a maintenance surface for data that is meant to be
 ephemeral. The half-open single-probe gate is pragmatic (refresh the open window
 before probing) rather than an atomic compare-and-set, which the cache backend
-cannot portably offer — a few extra probes after a cooldown is acceptable.
+cannot portably offer — a few extra probes after a cooldown is acceptable. The
+failure counter shares this posture: it is a non-atomic get-modify-set, so under
+heavy concurrent failure some increments are lost and the breaker trips a little
+late (the count still climbs about one per cooldown window) rather than never —
+acceptable for the same reasons.
 
 Provider health scoring
 -----------------------
@@ -226,6 +230,11 @@ Deferred / follow-ups
   :php:`FrontendInterface` — so two genuinely simultaneous same-key requests are
   not deduplicated; only sequential retries are (see *Consequences*). A future
   revision could gate run+store with :php:`\TYPO3\CMS\Core\Locking\LockFactory`.
+* Strict circuit-breaker failure counting under concurrency. The failure counter
+  is a non-atomic get-modify-set (best-effort, the same posture as the half-open
+  gate), so concurrent failures can lose increments and trip the breaker slightly
+  late. A future revision could make it exact with the same
+  :php:`\TYPO3\CMS\Core\Locking\LockFactory`.
 
 .. _adr-063-references:
 

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -94,6 +94,10 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
         self::assertArrayHasKey('openai', $scores);
         self::assertSame(2, $scores['openai']->sampleCount, 'Both the solo run and the rescued-failure run count');
         self::assertEqualsWithDelta(0.5, $scores['openai']->successRate, 0.0001, 'Only the solo success counts as a success');
+        // Latency averages only the self-served run (100ms), not the rescued
+        // run's whole-pipeline 150ms — otherwise the primary's latency is
+        // distorted by a sibling's serving time.
+        self::assertEqualsWithDelta(100.0, $scores['openai']->avgLatencyMs, 0.0001, 'Latency excludes fallback-rescued whole-pipeline time');
     }
 
     #[Test]

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -77,21 +77,23 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function ignoresRunsServedByAFallback(): void
+    public function countsFallbackRescuedRunsAsPrimaryFailures(): void
     {
         $now = time();
-        // openai failed serving the request itself (fallback_attempts = 0) ...
-        $this->insertRow('openai', false, 200, $now, 0);
-        // ... and a run where openai was the requested PRIMARY but a fallback
-        // rescued it (success = 1, fallback_attempts = 2). The success belongs
-        // to the fallback, not to openai — it must not credit openai's health.
+        // openai served one request itself successfully (fallback_attempts = 0) ...
+        $this->insertRow('openai', true, 100, $now, 0);
+        // ... and on another it was the requested PRIMARY but FAILED its first
+        // attempt, so a fallback rescued the whole run (success = 1,
+        // fallback_attempts = 2). The rescued success belongs to the sibling,
+        // not to openai: it counts as a primary FAILURE here, not as a success
+        // and not dropped — otherwise a usually-rescued primary scores ~100%.
         $this->insertRow('openai', true, 150, $now, 2);
 
         $scores = $this->repository->scoresSince($now - 900);
 
         self::assertArrayHasKey('openai', $scores);
-        self::assertSame(1, $scores['openai']->sampleCount, 'Only the self-served run counts');
-        self::assertSame(0.0, $scores['openai']->successRate);
+        self::assertSame(2, $scores['openai']->sampleCount, 'Both the solo run and the rescued-failure run count');
+        self::assertEqualsWithDelta(0.5, $scores['openai']->successRate, 0.0001, 'Only the solo success counts as a success');
     }
 
     #[Test]


### PR DESCRIPTION
Two ADR-063 resilience findings from an adversarial review of the health/circuit
internals, each verified against the code. One is a scoring correctness fix; the
other documents an already-accepted design limitation.

## 1. Provider health scored on first-attempt reliability (`fix`)

`ProviderHealthRepository::scoresSince()` filtered `WHERE fallback_attempts = 0`.
That correctly avoided crediting a primary for a fallback-rescued success — but it
also dropped the primary's own **failure** signal: a run where the primary failed
first and a sibling rescued it (`success=1, fallback_attempts>0`) was excluded
entirely, so a primary that constantly fails but is always rescued scored ~100%.

Now every requested run is a sample, and a success is credited only when the
primary served it itself (`fallback_attempts = 0 AND success = 1`). A
fallback-triggering run counts as a primary failure — neither credited to the
primary (the original concern) nor dropped (the new one). This is the
first-attempt reliability the opt-in health-based fallback reorder actually wants.
The existing characterization test that encoded the old behaviour is rewritten to
a discriminating case (solo-success + rescued-failure → 0.5, not the old 1.0).

## 2. Circuit-breaker failure-counter non-atomicity documented (`docs`)

`recordFailure()` does a get-modify-set over a snapshot loaded at call start, so
concurrent failures lose increments and the breaker trips slightly late. This is
the **same** best-effort cache posture ADR-063 already accepts for the half-open
probe gate — it just wasn't documented for the counter. Added a code comment and
extended the ADR; `LockFactory` is noted as the follow-up if a strict count is
ever required (a portable atomic increment isn't available through the cache
`FrontendInterface`). No behavioural change.

## Verification

cgl / PHPStan (8.2) / Rector clean; health functional test green on SQLite
(the `CASE` aggregate is standard ANSI SQL — MariaDB matrix cell left to CI, as
its container won't start in my local sandbox).
