### PR TITLE
perf: collapse two N+1 query paths (analytics budget aggregate; Ollama discovery)

### DIFF
--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -51,6 +51,22 @@ final class ModelDiscovery implements ModelDiscoveryInterface
     private const AUTH_BEARER_PREFIX = 'Bearer ';
 
     /**
+     * Cap on Ollama `/api/show` enrichment calls per discovery run. Each is a
+     * blocking round-trip; a host with dozens of pulled models would otherwise
+     * fire that many sequentially inside the wizard request and risk exceeding
+     * its timeout. Models past the cap are still listed, with default metadata.
+     */
+    private const MAX_OLLAMA_DETAIL_LOOKUPS = 20;
+
+    /** @var array{description: string, capabilities: array<string>, contextLength: int, maxOutputTokens: int} */
+    private const OLLAMA_DEFAULT_DETAILS = [
+        'description' => 'Local Ollama model',
+        'capabilities' => ['chat'],
+        'contextLength' => 0,
+        'maxOutputTokens' => 0,
+    ];
+
+    /**
      * Whether the most recent discover() call substituted a static fallback
      * catalog for live API data (failed request, unexpected status, or
      * malformed/empty response).
@@ -992,6 +1008,8 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 ? $data['models']
                 : [];
 
+            $detailLookups = 0;
+            $detailsTruncated = false;
             foreach ($modelList as $model) {
                 if (!is_array($model)) {
                     continue;
@@ -1001,8 +1019,18 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                     continue;
                 }
 
-                // Get model details via /api/show to retrieve context length
-                $modelDetails = $this->getOllamaModelDetails($endpoint, $modelId);
+                // Enrich context length / capabilities via one /api/show call
+                // per model — but cap the number of these blocking round-trips
+                // so a host with many models cannot stall the wizard past its
+                // timeout. Models beyond the cap are still listed, with default
+                // metadata.
+                if ($detailLookups < self::MAX_OLLAMA_DETAIL_LOOKUPS) {
+                    $modelDetails = $this->getOllamaModelDetails($endpoint, $modelId);
+                    ++$detailLookups;
+                } else {
+                    $modelDetails = self::OLLAMA_DEFAULT_DETAILS;
+                    $detailsTruncated = true;
+                }
 
                 $models[] = new DiscoveredModel(
                     modelId: $modelId,
@@ -1014,6 +1042,13 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                     costInput: 0,
                     costOutput: 0,
                     recommended: true,
+                );
+            }
+
+            if ($detailsTruncated) {
+                $this->logger->info(
+                    'Ollama discovery exceeded the per-run /api/show detail-lookup cap; remaining models are listed with default metadata.',
+                    ['cap' => self::MAX_OLLAMA_DETAIL_LOOKUPS, 'discovered' => count($models)],
                 );
             }
 
@@ -1032,12 +1067,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      */
     private function getOllamaModelDetails(string $endpoint, string $modelId): array
     {
-        $defaults = [
-            'description' => 'Local Ollama model',
-            'capabilities' => ['chat'],
-            'contextLength' => 0,
-            'maxOutputTokens' => 0,
-        ];
+        $defaults = self::OLLAMA_DEFAULT_DETAILS;
 
         try {
             // Create body with model name

--- a/Classes/Service/UsageAnalyticsService.php
+++ b/Classes/Service/UsageAnalyticsService.php
@@ -14,7 +14,6 @@ use DateTimeInterface;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
-use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -55,7 +54,6 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
     public function __construct(
         private ConnectionPool $connectionPool,
         private UserBudgetRepository $userBudgetRepository,
-        private BudgetUsageWindowsInterface $budgetUsageWindows,
     ) {}
 
     public function getKpiTotals(DateTimeInterface $from, DateTimeInterface $to): array
@@ -179,13 +177,18 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
 
         $now = new DateTimeImmutable();
         $monthStart = $now->modify('first day of this month')->setTime(0, 0, 0)->getTimestamp();
+        // Batch the month-to-date cost for every user in one grouped query
+        // instead of one aggregate SUM per budgeted user inside the loop (N+1).
+        $monthlyCosts = $this->monthlyCostByUser(
+            array_map(static fn(array $entry): int => $entry['beUserUid'], $merged),
+            $monthStart,
+            $now->getTimestamp(),
+        );
         $result = [];
         foreach ($merged as $entry) {
             $entry['budget'] = $this->budgetConsumption(
-                $entry['beUserUid'],
                 $budgets[$entry['beUserUid']] ?? null,
-                $monthStart,
-                $now->getTimestamp(),
+                $monthlyCosts[$entry['beUserUid']] ?? 0.0,
             );
             $result[] = $entry;
         }
@@ -378,27 +381,64 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
     }
 
     /**
-     * @param UserBudget|null $budget Pre-fetched budget for $beUserUid (batch-loaded by the caller).
+     * @param UserBudget|null $budget   Pre-fetched budget for the user (batch-loaded by the caller).
+     * @param float           $usedCost Pre-fetched month-to-date cost for the user (batch-loaded by the caller).
      *
      * @return array{usedCost: float, limitCost: float, percent: float}|null
      */
-    private function budgetConsumption(int $beUserUid, ?UserBudget $budget, int $monthStart, int $now): ?array
+    private function budgetConsumption(?UserBudget $budget, float $usedCost): ?array
     {
-        if ($beUserUid <= 0) {
-            return null;
-        }
         if ($budget === null || !$budget->isActive() || $budget->getMaxCostPerMonth() <= 0.0) {
             return null;
         }
 
-        $windows = $this->budgetUsageWindows->aggregate($beUserUid, null, $monthStart, $now);
-        $used = $windows['monthly']['cost'];
         $limit = $budget->getMaxCostPerMonth();
 
         return [
-            'usedCost'  => $used,
+            'usedCost'  => $usedCost,
             'limitCost' => $limit,
-            'percent'   => $limit > 0.0 ? min(100.0, ($used / $limit) * 100.0) : 0.0,
+            'percent'   => $limit > 0.0 ? min(100.0, ($usedCost / $limit) * 100.0) : 0.0,
         ];
+    }
+
+    /**
+     * Month-to-date cost per backend user, in one grouped query.
+     *
+     * Collapses what was an N+1 (one SUM per budgeted user) into a single
+     * `GROUP BY be_user` over the same rollup table the per-user view reads.
+     * Returns a uid => cost map; users with no rows in the window are absent.
+     *
+     * @param list<int> $beUserUids
+     *
+     * @return array<int, float>
+     */
+    private function monthlyCostByUser(array $beUserUids, int $monthStart, int $now): array
+    {
+        $beUserUids = array_values(array_unique(array_filter($beUserUids, static fn(int $uid): bool => $uid > 0)));
+        if ($beUserUids === []) {
+            return [];
+        }
+
+        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $qb
+            ->select('be_user')
+            ->addSelectLiteral('SUM(estimated_cost) AS cost')
+            ->from(self::TABLE)
+            ->where(
+                $qb->expr()->in('be_user', $qb->createNamedParameter($beUserUids, Connection::PARAM_INT_ARRAY)),
+                $qb->expr()->gte('request_date', $qb->createNamedParameter($monthStart)),
+                $qb->expr()->lte('request_date', $qb->createNamedParameter($now)),
+            )
+            ->groupBy('be_user')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $costs = [];
+        foreach ($rows as $row) {
+            $uid = is_numeric($row['be_user'] ?? null) ? (int)$row['be_user'] : 0;
+            $costs[$uid] = is_numeric($row['cost'] ?? null) ? (float)$row['cost'] : 0.0;
+        }
+
+        return $costs;
     }
 }


### PR DESCRIPTION
Two N+1s from an adversarial performance review, each verified against the code.
(The same review's feature-logic pass found nothing that survived verification.)

## 1. Analytics per-user budget aggregate (`perf`)

`UsageAnalyticsService::getPerUserUsage()` batch-loaded budgets in one query but
then called `budgetUsageWindows->aggregate()` once per budgeted user in the loop
— one SUM query per user on every analytics-dashboard load, scaling with the
number of budgeted users. Now the month-to-date cost for all users is computed in
a single `GROUP BY be_user` query over the same rollup table and passed in;
`budgetConsumption()` takes the pre-fetched cost. The existing functional test
characterises the unchanged budget-consumption output (`usedCost`/`percent`).

Bounded in practice (admin-only view, indexed rollup table, only *budgeted* users
were affected) — but a clean collapse.

## 2. Ollama discovery per-model detail lookups (`perf`)

`discoverOllama()` called `/api/show` once per model with no cap — sequential,
blocking, synchronous inside the wizard request. A host with dozens of pulled
models could block the step for seconds and exceed the request timeout. The
enrichment round-trips are now capped per run (models past the cap are still
listed, with default metadata) and the truncation is logged. Only the Ollama
branch pays per-model HTTP; the static-spec provider branches are unaffected.

Test note: the cap is deterministic counter logic covered by the static gate and
the existing discovery tests (no regression). A call-count assertion would need a
new HTTP-mock harness for `ModelDiscovery` (none exists today); deferred rather
than build a disproportionate one for a trivially-correct bound.
