### PR TITLE
test: fix fuzzy value-preservation assertions to the model's decimal(3,2) scale

### DIFF
--- a/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
@@ -187,8 +187,11 @@ class LlmConfigurationFuzzyTest extends AbstractFuzzyTestCase
                 $config = new LlmConfiguration();
                 $config->setTemperature($temp);
 
-                // Valid values should be preserved exactly (within float precision)
-                $this->assertEqualsWithDelta($temp, $config->getTemperature(), 0.0001);
+                // An in-range value is preserved at the model's storage scale:
+                // the setter rounds to the decimal(3,2) column precision (#336),
+                // so the property is preservation-at-2-decimals, not bit-exact
+                // round-trip of a generator value that can carry 4 decimals.
+                $this->assertEqualsWithDelta(round($temp, 2), $config->getTemperature(), 0.0001);
             });
     }
 
@@ -201,7 +204,8 @@ class LlmConfigurationFuzzyTest extends AbstractFuzzyTestCase
                 $config = new LlmConfiguration();
                 $config->setTopP($topP);
 
-                $this->assertEqualsWithDelta($topP, $config->getTopP(), 0.0001);
+                // Preserved at the decimal(3,2) storage scale (see temperature).
+                $this->assertEqualsWithDelta(round($topP, 2), $config->getTopP(), 0.0001);
             });
     }
 
@@ -215,8 +219,9 @@ class LlmConfigurationFuzzyTest extends AbstractFuzzyTestCase
                 $config->setFrequencyPenalty($penalty);
                 $config->setPresencePenalty($penalty);
 
-                $this->assertEqualsWithDelta($penalty, $config->getFrequencyPenalty(), 0.0001);
-                $this->assertEqualsWithDelta($penalty, $config->getPresencePenalty(), 0.0001);
+                // Preserved at the decimal(3,2) storage scale (see temperature).
+                $this->assertEqualsWithDelta(round($penalty, 2), $config->getFrequencyPenalty(), 0.0001);
+                $this->assertEqualsWithDelta(round($penalty, 2), $config->getPresencePenalty(), 0.0001);
             });
     }
 


### PR DESCRIPTION
The `Tests/Fuzzy` (Eris property) suite was **red** — and, separately, it is not
wired into CI, so the failures were invisible. This fixes the failures so the
suite can be enabled.

## Root cause (test, not model)

`LlmConfiguration::setTemperature/setTopP/setFrequencyPenalty/setPresencePenalty`
deliberately `round(clamp($v), 2)` — matching the `decimal(3,2)` DB column so
every DBMS stores an identical value (documented, #336). The three
`…ValuesArePreserved` property tests asserted the generated value round-trips
within `0.0001`, but `floatBetween` produces 4-decimal values in range. A draw
like `top_p 0.0002 → 0.0` or `penalty −1.9996 → −2.0` is off by more than the
delta → failure.

The model is correct; the asserted property was stricter than the storage
contract. Assertions now compare against `round($value, 2)`, i.e. the real
property "an in-range value is preserved at the storage scale." All three are
fixed (temperature's test had the identical latent flaw — it just didn't draw a
sub-0.01 value in the failing run).

## Verification

`-s fuzzy` green: 79 tests, 15025 assertions. cgl + PHPStan (8.2) clean.

Not weakened: the tests still verify in-range values are preserved (not clamped
or mangled) to the model's precision — the true invariant.
