### PR TITLE
test: fix CoversClass-on-excluded-enum warnings that broke -s unitCoverage and -s mutation

### DIFF
--- a/Tests/Unit/Domain/Enum/SkillTrustLevelTest.php
+++ b/Tests/Unit/Domain/Enum/SkillTrustLevelTest.php
@@ -10,11 +10,16 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
 
 use Netresearch\NrLlm\Domain\Enum\SkillTrustLevel;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(SkillTrustLevel::class)]
+// SkillTrustLevel lives in Classes/Domain/Enum, which is excluded from the
+// coverage source set, so a covered run rejects #[CoversClass(SkillTrustLevel::class)]
+// as "not a valid target for code coverage" — a warning that fails the run under
+// failOnWarning (and aborts Infection's initial run). Declare CoversNothing, per
+// the repo convention for enum tests.
+#[CoversNothing]
 final class SkillTrustLevelTest extends TestCase
 {
     #[Test]

--- a/Tests/Unit/Domain/Enum/ToolEgressScopeTest.php
+++ b/Tests/Unit/Domain/Enum/ToolEgressScopeTest.php
@@ -10,11 +10,16 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
 
 use Netresearch\NrLlm\Domain\Enum\ToolEgressScope;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ToolEgressScope::class)]
+// ToolEgressScope lives in Classes/Domain/Enum, which is excluded from the
+// coverage source set, so a covered run rejects #[CoversClass(ToolEgressScope::class)]
+// as "not a valid target for code coverage" — a warning that fails the run under
+// failOnWarning (and aborts Infection's initial run). Declare CoversNothing, per
+// the repo convention for enum tests.
+#[CoversNothing]
 final class ToolEgressScopeTest extends TestCase
 {
     #[Test]


### PR DESCRIPTION
Root-causes why `-s mutation` errored (and, it turns out, why `-s unitCoverage`
was silently red).

## Symptom

`./Build/Scripts/runTests.sh -s mutation` aborted in ~5s with an empty `[ERROR]`
right after "Running initial tests". Infection runs an initial **covered** test
run before mutating; that run was failing.

## Root cause

`SkillTrustLevelTest` and `ToolEgressScopeTest` declared
`#[CoversClass(SkillTrustLevel::class)]` / `#[CoversClass(ToolEgressScope::class)]`,
but `Classes/Domain/Enum` is **excluded** from the coverage `<source>` set
(`Build/phpunit.xml`). Under coverage, PHPUnit reports each as *"not a valid
target for code coverage"* — 9 warnings across the two files (6 + 3 methods) — and
`failOnWarning="true"` fails the run. So:

- `-s unitCoverage` was **red** (9 warnings → FAILURE), masked in CI by
  `fail_ci_if_error: false` + informational Codecov.
- Infection's initial covered run failed → `-s mutation` aborted before starting.
- Plain `-s unit` was unaffected (no coverage → the warnings never fire), which is
  why the suite looked healthy.

## Fix

Switch both enum tests to `#[CoversNothing]`, matching the repo convention
(`Tests/AGENTS.md`: "use `#[CoversNothing]` for enums/exceptions") and the existing
`ChatMessageTest`/`MessageRoleTest` precedent. The tests still exercise and assert
the enum behaviour — they just stop claiming coverage for a class the coverage
config excludes.

## Verification

`-s unitCoverage` green (4469 tests, 0 warnings; was 9). Infection's initial run
now proceeds. cgl + PHPStan (8.2) clean. No `#[CoversClass]` on an enum remains.
