### PR TITLE
ci: enable fuzzy (every event) and mutation (weekly, report-only) via ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,21 @@ jobs:
       run-phpstan: false
       run-rector: false
       run-unit-tests: false
+
+  # Property-based (fuzzy) + mutation testing. Enabled here rather than in the
+  # template-governed checks.yml because turning these on is a per-extension
+  # choice and this file is intentional-drift. Fuzzy runs on every event
+  # (~seconds); mutation runs only on the weekly schedule (~13 min, 10k+
+  # mutants) and is report-only for now — the reusable's Infection step is
+  # continue-on-error and covered MSI is still climbing toward the 70/74 target
+  # shown here, so the run surfaces the gap without blocking.
+  fuzz-mutation:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+    with:
+      run-fuzz-tests: true
+      fuzz-testsuite: fuzzy
+      run-mutation-tests: ${{ github.event_name == 'schedule' }}
+      mutation-min-msi: 70
+      mutation-min-covered-msi: 74


### PR DESCRIPTION
Enables the fuzzy and mutation test-tests that exist in the repo but were never
wired into CI. The `fuzz.yml` reusable exposes `run-fuzz-tests` /
`run-mutation-tests` inputs, but the org template calls it from the
**byte-governed, drift-enforced** `checks.yml` with none — so this goes in
`ci.yml`, the sanctioned per-extension (intentional-drift) file. `checks.yml`
stays byte-identical to the template.

- **Fuzzy (Eris)** on every event — fast (~seconds), green since #385. This
  repo's testsuite is lowercase `fuzzy` (reusable default is `Fuzz`).
- **Mutation (Infection)** on the weekly cron only — ~13 min, 10k+ mutants.
  **Report-only**: the reusable's Infection step is `continue-on-error` and
  covered MSI is ~67% (climbing toward 70/74 via #393). The thresholds surface
  the gap in the run log; a hard gate needs the reusable's `continue-on-error`
  removed (a separate org change) once MSI reaches target.

Note: the template's `checks.yml` also has a `fuzz` job that runs with the
reusable's defaults (off) — it shows as skipped alongside this active one. That
minor duplication is the accepted trade-off for keeping `checks.yml` governed.

Integration tests are a separate follow-up (`extended-testing.yml` supports them
but expects a different testsuite-naming/config layout than this repo uses).
