### PR TITLE
fix(retrieval): drop redundant Solr language fq that breaks per-language cores

### DIFF
--- a/Classes/Service/Retrieval/SolrSearchBackend.php
+++ b/Classes/Service/Retrieval/SolrSearchBackend.php
@@ -29,9 +29,13 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  * `{scheme}://{host}:{port}{path}/solr/{core}/select`.
  *
  * Public-only: every query carries `fq={!typo3access}0,-1` — the
- * server-side access parser EXT:solr ships in its configsets — plus a
- * language filter. Any HTTP or parse failure makes the cascade continue
- * with the next backend.
+ * server-side access parser EXT:solr ships in its configsets. The query
+ * language is selected by the per-language read core (`solr_core_read`
+ * override), not by a `language` fq: EXT:solr uses one core per language
+ * (a core is shared only across sites of the SAME language, disambiguated
+ * by siteHash) and its index schema has no `language` field, so
+ * `fq=language:X` matches nothing. Any HTTP or parse failure makes the
+ * cascade continue with the next backend.
  */
 final class SolrSearchBackend implements SearchBackendInterface
 {
@@ -86,10 +90,9 @@ final class SolrSearchBackend implements SearchBackendInterface
                 'rows' => (string)$query->maxSources,
                 'wt' => 'json',
             ];
-            $filters = [
-                '{!typo3access}0,-1',
-                'language:' . $query->languageId,
-            ];
+            // No language fq: selectUrl() already picked the per-language read
+            // core, and EXT:solr's index schema has no `language` field.
+            $filters = ['{!typo3access}0,-1'];
 
             foreach ($this->select($endpoint, $parameters, $filters) as $document) {
                 $source = $this->toEvidence($document, $site, $query);
@@ -135,10 +138,10 @@ final class SolrSearchBackend implements SearchBackendInterface
                 'wt' => 'json',
             ],
             [
+                // Language is encoded by the read core (selectUrl), not an fq.
                 '{!typo3access}0,-1',
                 'type:' . $type,
                 'uid:' . self::toInt($uid),
-                'language:' . self::toInt($languageId),
             ],
         );
 

--- a/Documentation/Adr/Adr067SolrPerLanguageCoreFilter.rst
+++ b/Documentation/Adr/Adr067SolrPerLanguageCoreFilter.rst
@@ -1,0 +1,60 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-067:
+
+============================================================
+ADR-067: Solr per-language core — no language filter query
+============================================================
+
+.. _adr-067-status:
+
+Status
+======
+**Accepted** (2026-07) — bug fix refining the Solr retrieval backend introduced
+in :ref:`ADR-049 <adr-049>`.
+
+.. _adr-067-context:
+
+Context
+=======
+``SolrSearchBackend`` (ADR-049) added ``fq=language:<id>`` to every Solr query, in
+both ``search()`` and ``fetchSource()``. EXT:solr separates languages by
+**per-language cores** (``core_de``, ``core_en``, …) whose index schema has **no**
+``language`` field. ``selectUrl()`` already selects the per-language read core via
+the site's per-language ``solr_core_read`` override, so the language dimension is
+handled by core selection. The extra ``fq=language:<id>`` therefore filtered on a
+field that does not exist — Solr returned zero results for every query, even
+against a populated core.
+
+Live-verified on the BMDV deployment: querying ``core_de`` with only
+``{!typo3access}0,-1`` returned 41 documents; adding ``fq=language:0`` returned 0,
+and the Solr schema API reports ``No such field [language]``.
+
+EXT:solr's only shared-core mode shares a core across **sites of the same
+language** (disambiguated by ``siteHash``; see ``siteScopedUrl()``), never across
+languages — so no language filter is needed there either.
+
+.. _adr-067-decision:
+
+Decision
+========
+Drop the ``fq=language:<id>`` filter from both ``search()`` and ``fetchSource()``.
+Language is selected by the per-language read core; access by
+``fq={!typo3access}0,-1``. The ``language`` field stays in ``fl`` (harmless —
+``toEvidence()`` falls back to the query's ``languageId`` when the response omits
+it).
+
+**Limitation (recorded, not a regression):** shared-core language separation is
+unsupported. EXT:solr does not produce that topology — one core per language is
+the configset default — so this is a documented boundary, not a gap.
+
+.. _adr-067-consequences:
+
+Consequences
+============
+- Solr retrieval returns results on standard EXT:solr per-language-core setups
+  (previously it was always empty).
+- The per-query filter contract is now ``{!typo3access}0,-1`` only (plus
+  ``type``/``uid`` on ``fetchSource``) — consistent with ADR-049's stated
+  public-only contract.
+- No API or configuration change; a pure query-construction fix.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -365,3 +365,4 @@ Tools
    Adr064CentralPrivacyModel
    Adr065ReducePublicServiceSurface
    Adr066CriteriaConfigurationResolution
+   Adr067SolrPerLanguageCoreFilter

--- a/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
+++ b/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
@@ -32,7 +32,7 @@ final class SolrSearchBackendTest extends TestCase
     ]}}';
 
     #[Test]
-    public function buildsSelectUrlWithAccessAndLanguageFiltersAndMapsDocuments(): void
+    public function buildsSelectUrlWithAccessFilterAndMapsDocuments(): void
     {
         $requestFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
         $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), $requestFactory);
@@ -43,7 +43,7 @@ final class SolrSearchBackendTest extends TestCase
         self::assertCount(1, $uris);
         self::assertStringStartsWith('https://solr.example:8983/solr/core_en/select?', $uris[0]);
         self::assertStringContainsString('fq=' . rawurlencode('{!typo3access}0,-1'), $uris[0]);
-        self::assertStringContainsString('fq=' . rawurlencode('language:0'), $uris[0]);
+        self::assertStringNotContainsString('fq=' . rawurlencode('language:0'), $uris[0], 'per-language read core carries no language fq');
         self::assertStringContainsString('defType=edismax', $uris[0]);
 
         self::assertCount(2, $result->sources);
@@ -139,7 +139,7 @@ final class SolrSearchBackendTest extends TestCase
         $uris = $requestFactory->requestedUris();
         self::assertCount(1, $uris);
         self::assertStringStartsWith('https://solr.example:8983/solr/core_de/select?', $uris[0]);
-        self::assertStringContainsString('fq=' . rawurlencode('language:1'), $uris[0]);
+        self::assertStringNotContainsString('fq=' . rawurlencode('language:1'), $uris[0], 'language is selected by the core, not an fq');
     }
 
     #[Test]
@@ -191,7 +191,7 @@ final class SolrSearchBackendTest extends TestCase
         // The public-only access filter must guard the FETCH path exactly
         // like the search path — a guessable uid must never bypass it.
         self::assertStringContainsString('fq=' . rawurlencode('{!typo3access}0,-1'), $uris[0]);
-        self::assertStringContainsString('fq=' . rawurlencode('language:0'), $uris[0]);
+        self::assertStringNotContainsString('fq=' . rawurlencode('language:0'), $uris[0], 'language is encoded by the core, not an fq');
     }
 
     #[Test]


### PR DESCRIPTION
## Bug

`SolrSearchBackend` (ADR-049) adds `fq=language:<id>` to every Solr query — in both `search()` and `fetchSource()`. EXT:solr separates languages by **per-language cores** (`core_de`, `core_en`, …) whose index schema has **no** `language` field. `selectUrl()` already selects the per-language read core via the site's `solr_core_read` override, so the language dimension is handled by the core. The extra `fq=language:<id>` filtered on a field that does not exist, so **every Solr retrieval returned 0** — even against a populated core.

Discovered while wiring the nr_ai_search hybrid retriever (Solr BM25 + bge-m3 vector) onto a live BMDV deployment:

```
# core_de has 41 indexed pages
curl '…/solr/core_de/select?q=*:*&fq={!typo3access}0,-1&rows=0'                 → numFound 41
curl '…/solr/core_de/select?q=*:*&fq={!typo3access}0,-1&fq=language:0&rows=0'   → numFound 0
curl '…/solr/core_de/schema/fields/language'                                    → "No such field [language]"
```

## Fix

Drop the `fq=language:<id>` filter from `search()` and `fetchSource()`. Language is selected by the per-language read core; access by `fq={!typo3access}0,-1`. `language` stays in `fl` (harmless — `toEvidence()` falls back to the query's `languageId`).

EXT:solr's only shared-core mode shares a core across **sites of the same language** (disambiguated by `siteHash` / `siteScopedUrl()`), never across languages, so no language filter is needed there either. Shared-core language separation is an unsupported (and non-producible) topology — documented as a boundary in **ADR-067**.

## Tests

`SolrSearchBackendTest`: the three `assertStringContainsString('…language:…')` assertions become `assertStringNotContainsString` (default-language search, language-override core selection — the `core_de` positive assertion stays as proof the language dim is now carried by core selection — and `fetchSource`). The `{!typo3access}0,-1`, `type`, `uid` assertions are unchanged. Unit (4469 tests), PHPStan L10, and CGL pass locally.

## Notes

- No API or configuration change; a pure query-construction fix.
- This was live vendor-hotfixed on the affected deployment to unblock; this PR is the permanent fix.
