### PR TITLE
test: strengthen assertions to raise mutation MSI (62.8% → 67%)

### DIFF
--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
@@ -1434,5 +1435,402 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         $this->expectException(ProviderResponseException::class);
 
         $this->subject->testConnection();
+    }
+
+    // ===== Request-payload transformation tests =====
+
+    /**
+     * Capture the JSON-encoded request body produced by $invoke and return it
+     * decoded. Mirrors captureChatPayload() but works for any endpoint (chat,
+     * tools, vision) by delegating the provider call to the caller.
+     *
+     * @param callable(ClaudeProvider): void $invoke
+     *
+     * @return array<string, mixed>
+     */
+    private function captureRequestPayload(callable $invoke): array
+    {
+        $capturedBody = null;
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $subject = new ClaudeProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'claude-sonnet-4-20250514',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        $subject->setHttpClient($this->httpClientStub);
+
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [['type' => 'text', 'text' => 'Response']],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ];
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $invoke($subject);
+
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * Pin down the exact chat request payload: model, default max_tokens, the
+     * top-level system field, the converted messages list and the merged
+     * sampling params (temperature + stop_sequences).
+     */
+    #[Test]
+    public function chatCompletionRequestPayloadHasExactShape(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion(
+                    [
+                        ['role' => 'system', 'content' => 'You are helpful.'],
+                        ['role' => 'user', 'content' => 'Hello'],
+                    ],
+                    ['temperature' => 0.4, 'stop_sequences' => ['END']],
+                );
+            },
+        );
+
+        self::assertSame('claude-sonnet-4-20250514', $payload['model']);
+        self::assertSame(4096, $payload['max_tokens']);
+        self::assertSame('You are helpful.', $payload['system']);
+        self::assertSame([['role' => 'user', 'content' => 'Hello']], $payload['messages']);
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertIsNumeric($payload['temperature']);
+        self::assertEqualsWithDelta(0.4, (float)$payload['temperature'], 1e-9);
+        self::assertSame(['END'], $payload['stop_sequences']);
+    }
+
+    #[Test]
+    public function chatCompletionHonoursExplicitMaxTokens(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion(
+                    [['role' => 'user', 'content' => 'Hello']],
+                    ['max_tokens' => 2048],
+                );
+            },
+        );
+
+        self::assertSame(2048, $payload['max_tokens']);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsSystemKeyWithoutSystemMessage(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion([['role' => 'user', 'content' => 'Hello']]);
+            },
+        );
+
+        self::assertArrayNotHasKey('system', $payload);
+    }
+
+    #[Test]
+    public function chatCompletionConvertsChatMessageObjectsToArrays(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion([ChatMessage::user('Hello from VO')]);
+            },
+        );
+
+        self::assertSame([['role' => 'user', 'content' => 'Hello from VO']], $payload['messages']);
+    }
+
+    #[Test]
+    public function chatCompletionCombinesNativeAndInlineThinking(): void
+    {
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => 'native reason'],
+                ['type' => 'text', 'text' => '<think>inline reason</think>Answer'],
+            ],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 20],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
+
+        self::assertSame('Answer', $result->content);
+        self::assertSame("native reason\ninline reason", $result->thinking);
+    }
+
+    /**
+     * Pin down the exact tool-calling request payload: model, default
+     * max_tokens, system field, converted messages, the Claude-shaped tools
+     * (name/description/input_schema) and the merged sampling params.
+     */
+    #[Test]
+    public function chatCompletionWithToolsRequestPayloadHasExactShape(): void
+    {
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => [
+                    'name' => 'get_weather',
+                    'description' => 'Get weather',
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => ['location' => ['type' => 'string']],
+                    ],
+                ],
+            ]),
+        ];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($tools): void {
+                $s->chatCompletionWithTools(
+                    [
+                        ['role' => 'system', 'content' => 'You are helpful.'],
+                        ['role' => 'user', 'content' => 'Weather?'],
+                    ],
+                    $tools,
+                    ['temperature' => 0.4, 'stop_sequences' => ['STOP']],
+                );
+            },
+        );
+
+        self::assertSame('claude-sonnet-4-20250514', $payload['model']);
+        self::assertSame(4096, $payload['max_tokens']);
+        self::assertSame('You are helpful.', $payload['system']);
+        self::assertSame([['role' => 'user', 'content' => 'Weather?']], $payload['messages']);
+        self::assertSame([
+            [
+                'name'         => 'get_weather',
+                'description'  => 'Get weather',
+                'input_schema' => [
+                    'type'       => 'object',
+                    'properties' => ['location' => ['type' => 'string']],
+                ],
+            ],
+        ], $payload['tools']);
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertIsNumeric($payload['temperature']);
+        self::assertEqualsWithDelta(0.4, (float)$payload['temperature'], 1e-9);
+        self::assertSame(['STOP'], $payload['stop_sequences']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsConvertsChatMessageObjectsToArrays(): void
+    {
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($tools): void {
+                $s->chatCompletionWithTools([ChatMessage::user('VO message')], $tools);
+            },
+        );
+
+        self::assertSame([['role' => 'user', 'content' => 'VO message']], $payload['messages']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsConcatenatesTextBlocks(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'test']];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
+
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'text', 'text' => 'First part. '],
+                ['type' => 'text', 'text' => 'Second part.'],
+            ],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 15],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletionWithTools($messages, $tools);
+
+        self::assertSame('First part. Second part.', $result->content);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsCombinesNativeAndInlineThinking(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'test']];
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'Test', 'parameters' => []]])];
+
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => 'native reason'],
+                ['type' => 'text', 'text' => '<think>inline reason</think>Answer'],
+                ['type' => 'tool_use', 'id' => 'call_1', 'name' => 'test', 'input' => []],
+            ],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 20],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletionWithTools($messages, $tools);
+
+        self::assertSame('Answer', $result->content);
+        self::assertSame("native reason\ninline reason", $result->thinking);
+    }
+
+    #[Test]
+    public function embeddingsExceptionCarriesStableCode(): void
+    {
+        $this->expectException(UnsupportedFeatureException::class);
+        $this->expectExceptionCode(8109610521);
+
+        $this->subject->embeddings('test text');
+    }
+
+    /**
+     * Pin down the exact vision request payload: the hardcoded default model,
+     * default max_tokens, the user message envelope, the converted vision
+     * content blocks (text + plain-URL image) and the system prompt.
+     */
+    #[Test]
+    public function analyzeImageRequestPayloadHasExactShape(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/x.png']]),
+        ];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($content): void {
+                $s->analyzeImage($content, ['system_prompt' => 'Be brief']);
+            },
+        );
+
+        self::assertSame('claude-sonnet-4-5-20250929', $payload['model']);
+        self::assertSame(4096, $payload['max_tokens']);
+        self::assertSame('Be brief', $payload['system']);
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Describe this'],
+                    [
+                        'type' => 'image',
+                        'source' => ['type' => 'url', 'url' => 'https://example.com/x.png'],
+                    ],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    #[Test]
+    public function analyzeImageOmitsSystemKeyWithoutSystemPrompt(): void
+    {
+        $content = [VisionContent::fromArray(['type' => 'text', 'text' => 'Describe'])];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($content): void {
+                $s->analyzeImage($content);
+            },
+        );
+
+        self::assertArrayNotHasKey('system', $payload);
+    }
+
+    #[Test]
+    public function analyzeImageConvertsBase64DataUrlToImageBlock(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,iVBORw0KGgo=']]),
+        ];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($content): void {
+                $s->analyzeImage($content);
+            },
+        );
+
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type' => 'image',
+                        'source' => [
+                            'type'       => 'base64',
+                            'media_type' => 'image/png',
+                            'data'       => 'iVBORw0KGgo=',
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    #[Test]
+    public function analyzeImageSkipsNonImageDataUrl(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:application/pdf;base64,JVBERi0=']]),
+        ];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($content): void {
+                $s->analyzeImage($content);
+            },
+        );
+
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'What is this?'],
+                ],
+            ],
+        ], $payload['messages']);
     }
 }

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -22,9 +22,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 #[CoversClass(OpenRouterProvider::class)]
 class OpenRouterProviderTest extends AbstractUnitTestCase
@@ -1371,5 +1373,570 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $this->expectException(ProviderException::class);
 
         $this->subject->testConnection();
+    }
+
+    // ---------------------------------------------------------------------
+    // Request-transformation assertions
+    //
+    // The tests below capture the outgoing PSR-7 request and assert the exact
+    // URL, method, headers and decoded JSON payload the provider constructs,
+    // plus the exact fields it parses back from the response. This pins down
+    // the request/response transformation that the happy-path tests above only
+    // exercise without asserting.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Build a provider whose request factory records every outgoing request
+     * (method, URI, headers, JSON body) into $captured.
+     *
+     * @param array<string, mixed>                                                                   $config
+     * @param list<array{method: string, uri: string, headers: array<string, string>, body: string}> $captured
+     */
+    private function createCapturingProvider(
+        array $config,
+        ResponseInterface $response,
+        array &$captured,
+    ): OpenRouterProvider {
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$captured): RequestInterface {
+                $index            = count($captured);
+                $captured[$index] = ['method' => $method, 'uri' => $uri, 'headers' => [], 'body' => ''];
+
+                $uriStub = self::createStub(UriInterface::class);
+                $uriStub->method('__toString')->willReturn($uri);
+
+                $request = self::createStub(RequestInterface::class);
+                $request->method('getMethod')->willReturn($method);
+                $request->method('getUri')->willReturn($uriStub);
+                $request->method('withoutHeader')->willReturnCallback(static fn(): RequestInterface => $request);
+                $request->method('withHeader')->willReturnCallback(
+                    function (string $name, $value) use (&$captured, $index, $request): RequestInterface {
+                        $captured[$index]['headers'][$name] = is_array($value)
+                            ? implode(',', $value)
+                            : (is_string($value) ? $value : '');
+                        return $request;
+                    },
+                );
+                $request->method('withBody')->willReturnCallback(
+                    function (StreamInterface $body) use (&$captured, $index, $request): RequestInterface {
+                        $captured[$index]['body'] = $body->getContents();
+                        return $request;
+                    },
+                );
+
+                return $request;
+            },
+        );
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($response);
+
+        $provider = new OpenRouterProvider(
+            $requestFactory,
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $defaultConfig = [
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'anthropic/claude-3.5-sonnet',
+            'timeout' => 60,
+        ];
+
+        $provider->configure(array_merge($defaultConfig, $config));
+        $provider->setHttpClient($httpClient);
+
+        return $provider;
+    }
+
+    /**
+     * @param array<string, mixed> $response
+     */
+    private function chatResponse(array $response = []): ResponseInterface
+    {
+        return $this->createJsonResponseMock($response + [
+            'id' => 'gen-test',
+            'model' => 'test-model',
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedBody(string $body): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+
+    #[Test]
+    public function getAvailableModelsReturnsExactCuratedList(): void
+    {
+        self::assertSame(
+            [
+                'anthropic/claude-opus-4-5' => 'Claude Opus 4.5 (Anthropic)',
+                'anthropic/claude-sonnet-4-5' => 'Claude Sonnet 4.5 (Anthropic)',
+                'anthropic/claude-opus-4-1' => 'Claude Opus 4.1 (Anthropic)',
+                'openai/gpt-5.2' => 'GPT-5.2 (OpenAI)',
+                'openai/gpt-5.2-pro' => 'GPT-5.2 Pro (OpenAI)',
+                'openai/o3' => 'O3 Reasoning (OpenAI)',
+                'openai/o4-mini' => 'O4 Mini (OpenAI)',
+                'google/gemini-3-flash' => 'Gemini 3 Flash (Google)',
+                'google/gemini-3-pro' => 'Gemini 3 Pro (Google)',
+                'google/gemini-2.5-flash' => 'Gemini 2.5 Flash (Google)',
+                'meta-llama/llama-3.3-70b-instruct' => 'Llama 3.3 70B (Meta)',
+                'meta-llama/llama-3.1-405b-instruct' => 'Llama 3.1 405B (Meta)',
+                'mistralai/mistral-large' => 'Mistral Large (Mistral AI)',
+                'mistralai/pixtral-large' => 'Pixtral Large (Mistral AI)',
+                'cohere/command-r-plus' => 'Command R+ (Cohere)',
+            ],
+            $this->subject->getAvailableModels(),
+        );
+    }
+
+    #[Test]
+    public function chatCompletionBuildsExactRequest(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [
+                'siteUrl' => 'https://example.com',
+                'appName' => 'Test App',
+            ],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'openai/gpt-4o'],
+        );
+
+        self::assertCount(1, $captured);
+        $request = $captured[0];
+
+        self::assertSame('POST', $request['method']);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions', $request['uri']);
+        self::assertSame('application/json', $request['headers']['Content-Type'] ?? null);
+        self::assertSame('https://example.com', $request['headers']['HTTP-Referer'] ?? null);
+        self::assertSame('Test App', $request['headers']['X-Title'] ?? null);
+
+        $body = $this->decodeCapturedBody($request['body']);
+
+        self::assertSame('openai/gpt-4o', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Hi']], $body['messages']);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertSame(4096, $body['max_tokens']);
+        self::assertSame('fallback', $body['route']);
+        self::assertArrayNotHasKey('models', $body);
+        self::assertArrayNotHasKey('stop', $body);
+        self::assertArrayNotHasKey('transforms', $body);
+        self::assertArrayNotHasKey('top_p', $body);
+    }
+
+    #[Test]
+    public function chatCompletionPayloadHonorsProvidedOptions(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            [
+                'model' => 'openai/gpt-4o',
+                'temperature' => 0.2,
+                'max_tokens' => 123,
+                'top_p' => 0.9,
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+                'stop' => ['STOP'],
+                'transforms' => ['middle-out'],
+            ],
+        );
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame(0.2, $body['temperature']);
+        self::assertSame(123, $body['max_tokens']);
+        self::assertSame(0.9, $body['top_p']);
+        self::assertSame(0.5, $body['frequency_penalty']);
+        self::assertSame(0.3, $body['presence_penalty']);
+        self::assertSame(['STOP'], $body['stop']);
+        self::assertSame(['middle-out'], $body['transforms']);
+    }
+
+    #[Test]
+    public function chatCompletionMapsStopSequencesToStop(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'openai/gpt-4o', 'stop_sequences' => ['END']],
+        );
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame(['END'], $body['stop']);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsStopForEmptyStopSequences(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'openai/gpt-4o', 'stop_sequences' => []],
+        );
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertArrayNotHasKey('stop', $body);
+    }
+
+    #[Test]
+    public function chatCompletionIncludesFallbackModelsInPayload(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [
+                'autoFallback' => true,
+                'fallbackModels' => 'openai/gpt-4o, anthropic/claude-3-opus',
+            ],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        );
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame('fallback', $body['route']);
+        self::assertSame(
+            ['primary/model', 'openai/gpt-4o', 'anthropic/claude-3-opus'],
+            $body['models'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionOmitsRouteWhenAutoFallbackDisabled(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            ['autoFallback' => false, 'fallbackModels' => 'openai/gpt-4o'],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        );
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertArrayNotHasKey('route', $body);
+        self::assertArrayNotHasKey('models', $body);
+    }
+
+    #[Test]
+    public function chatCompletionParsesResponseFields(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createJsonResponseMock([
+                'id' => 'gen-test',
+                'model' => 'resolved/model',
+                'choices' => [[
+                    'message' => ['content' => 'the answer'],
+                    'finish_reason' => 'length',
+                ]],
+                'usage' => ['prompt_tokens' => 11, 'completion_tokens' => 22, 'total_tokens' => 33],
+            ]),
+            $captured,
+        );
+
+        $result = $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'requested/model'],
+        );
+
+        self::assertSame('the answer', $result->content);
+        self::assertSame('resolved/model', $result->model);
+        self::assertSame('length', $result->finishReason);
+        self::assertSame(11, $result->usage->promptTokens);
+        self::assertSame(22, $result->usage->completionTokens);
+    }
+
+    #[Test]
+    public function chatCompletionDefaultsModelAndFinishReasonWhenAbsent(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createJsonResponseMock([
+                'id' => 'gen-test',
+                'choices' => [['message' => ['content' => 'x']]],
+                'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+            ]),
+            $captured,
+        );
+
+        $result = $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'requested/model'],
+        );
+
+        self::assertSame('requested/model', $result->model);
+        self::assertSame('stop', $result->finishReason);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsBuildsExactRequest(): void
+    {
+        $spec = ToolSpec::fromArray([
+            'type' => 'function',
+            'function' => ['name' => 'get_weather', 'description' => 'w'],
+        ]);
+
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->chatResponse(['provider' => 'anthropic']),
+            $captured,
+        );
+
+        $provider->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'Hi']],
+            [$spec],
+            ['model' => 'openai/gpt-4o', 'tool_choice' => 'auto'],
+        );
+
+        self::assertSame('POST', $captured[0]['method']);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions', $captured[0]['uri']);
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame('openai/gpt-4o', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Hi']], $body['messages']);
+        self::assertSame([$spec->toArray()], $body['tools']);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertSame(4096, $body['max_tokens']);
+        self::assertSame('auto', $body['tool_choice']);
+        self::assertSame('fallback', $body['route']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsMetadataIncludesActualProvider(): void
+    {
+        $spec = ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'f']]);
+
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createJsonResponseMock([
+                'id' => 'gen-test',
+                'model' => 'test-model',
+                'provider' => 'openai',
+                'total_cost' => 0.0042,
+                'choices' => [['message' => ['content' => 'x', 'tool_calls' => []], 'finish_reason' => 'stop']],
+                'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+            ]),
+            $captured,
+        );
+
+        $result = $provider->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'Hi']],
+            [$spec],
+            ['model' => 'openai/gpt-4o'],
+        );
+
+        /** @var array{actual_provider: string, cost: float} $metadata */
+        $metadata = $result->metadata;
+        self::assertSame('openai', $metadata['actual_provider']);
+        self::assertSame(0.0042, $metadata['cost']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsMetadataDefaultsActualProviderToUnknown(): void
+    {
+        $spec = ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'f']]);
+
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createJsonResponseMock([
+                'id' => 'gen-test',
+                'model' => 'test-model',
+                'choices' => [['message' => ['content' => 'x', 'tool_calls' => []], 'finish_reason' => 'stop']],
+                'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+            ]),
+            $captured,
+        );
+
+        $result = $provider->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'Hi']],
+            [$spec],
+            ['model' => 'openai/gpt-4o'],
+        );
+
+        /** @var array{actual_provider: string} $metadata */
+        $metadata = $result->metadata;
+        self::assertSame('unknown', $metadata['actual_provider']);
+    }
+
+    #[Test]
+    public function embeddingsBuildsExactRequestForStringInput(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createJsonResponseMock([
+                'model' => 'openai/text-embedding-3-small',
+                'data' => [['index' => 0, 'embedding' => [0.1, 0.2]]],
+                'usage' => ['prompt_tokens' => 5, 'total_tokens' => 5],
+            ]),
+            $captured,
+        );
+
+        $provider->embeddings('hello', ['dimensions' => 256]);
+
+        self::assertSame('POST', $captured[0]['method']);
+        self::assertSame('https://openrouter.ai/api/v1/embeddings', $captured[0]['uri']);
+
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame('openai/text-embedding-3-small', $body['model']);
+        self::assertSame(['hello'], $body['input']);
+        self::assertSame(256, $body['dimensions']);
+    }
+
+    #[Test]
+    public function fetchAvailableModelsParsesEveryFieldExactly(): void
+    {
+        $modelsResponse = [
+            'data' => [
+                [
+                    'id' => 'anthropic/claude-x',
+                    'name' => 'Claude X',
+                    'context_length' => 200000,
+                    'architecture' => ['modality' => 'multimodal'],
+                    'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
+                    'supports_function_calling' => true,
+                ],
+                [
+                    // No name, no pricing keys, text modality, no function calling.
+                    'id' => 'openai/gpt',
+                    'context_length' => 8000,
+                    'architecture' => ['modality' => 'text'],
+                ],
+            ],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($modelsResponse));
+
+        $result = $this->subject->fetchAvailableModels();
+
+        self::assertCount(2, $result);
+
+        self::assertSame(
+            [
+                'name' => 'Claude X',
+                'context_length' => 200000,
+                'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
+                'capabilities' => ['vision' => true, 'function_calling' => true],
+                'provider' => 'anthropic',
+            ],
+            $result['anthropic/claude-x'],
+        );
+
+        self::assertSame(
+            [
+                'name' => 'openai/gpt',
+                'context_length' => 8000,
+                'pricing' => ['prompt' => 0.0, 'completion' => 0.0],
+                'capabilities' => ['vision' => false, 'function_calling' => false],
+                'provider' => 'openai',
+            ],
+            $result['openai/gpt'],
+        );
+    }
+
+    #[Test]
+    public function fetchAvailableModelsReturnsCachedResultWithoutRefetching(): void
+    {
+        $firstResponse = [
+            'data' => [[
+                'id' => 'first/model',
+                'name' => 'First',
+                'context_length' => 8000,
+                'architecture' => ['modality' => 'text'],
+                'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
+                'supports_function_calling' => false,
+            ]],
+        ];
+        $secondResponse = [
+            'data' => [[
+                'id' => 'second/model',
+                'name' => 'Second',
+                'context_length' => 8000,
+                'architecture' => ['modality' => 'text'],
+                'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
+                'supports_function_calling' => false,
+            ]],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls(
+                $this->createJsonResponseMock($firstResponse),
+                $this->createJsonResponseMock($secondResponse),
+            );
+
+        $first  = $this->subject->fetchAvailableModels();
+        $second = $this->subject->fetchAvailableModels();
+
+        self::assertArrayHasKey('first/model', $first);
+        // The second call must hit the cache, not the (differing) second response.
+        self::assertArrayHasKey('first/model', $second);
+        self::assertArrayNotHasKey('second/model', $second);
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function getCreditsDefaultsMissingFieldsToZero(): void
+    {
+        $creditsResponse = [
+            'data' => [
+                'is_free_tier' => true,
+                'rate_limit' => ['requests' => 200, 'interval' => '10s'],
+            ],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($creditsResponse));
+
+        $result = $this->subject->getCredits();
+
+        self::assertSame(0.0, $result['balance']);
+        self::assertSame(0.0, $result['usage']);
+        self::assertTrue($result['is_free_tier']);
+        self::assertSame(['requests' => 200, 'interval' => '10s'], $result['rate_limit']);
     }
 }

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -2767,4 +2767,591 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // No 'data' key → modelList is [] → no models found
         self::assertEmpty($models);
     }
+
+    // ==================== outgoing-request pinning (URL / method / headers) ====================
+
+    /**
+     * Configure the request-factory stub to record the exact method, URI and
+     * every header set on the outgoing request, so a test can assert the exact
+     * request the service built (endpoint construction, HTTP verb, auth headers).
+     *
+     * @param array{method: ?string, uri: ?string, headers: array<string, string>} $captured
+     */
+    private function configureCapturingRequestFactory(array &$captured): void
+    {
+        $captured = ['method' => null, 'uri' => null, 'headers' => []];
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturnCallback(function (string $method, string $uri) use (&$captured): RequestInterface {
+                $captured['method'] = $method;
+                $captured['uri'] = $uri;
+
+                $request = self::createStub(RequestInterface::class);
+                $request->method('withHeader')->willReturnCallback(
+                    function (string $name, mixed $value) use (&$captured, $request): RequestInterface {
+                        $captured['headers'][$name] = is_array($value) ? implode(', ', $value) : (is_string($value) ? $value : '');
+
+                        return $request;
+                    },
+                );
+                $request->method('withBody')->willReturnCallback(static fn(): RequestInterface => $request);
+                $request->method('getMethod')->willReturn($method);
+
+                return $request;
+            });
+    }
+
+    #[Test]
+    public function testConnectionBuildsModelsUrlWithBearerAuthForOpenAi(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, 'test-api-key');
+
+        self::assertSame('GET', $captured['method']);
+        self::assertSame('https://api.openai.com/models', $captured['uri']);
+        self::assertSame('Bearer test-api-key', $captured['headers']['Authorization'] ?? null);
+    }
+
+    #[Test]
+    public function testConnectionStripsTrailingSlashFromEndpoint(): void
+    {
+        // A user-entered trailing slash must not produce "https://…//models".
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com/',
+            suggestedName: 'OpenAI',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, 'test-api-key');
+
+        self::assertSame('https://api.openai.com/models', $captured['uri']);
+    }
+
+    #[Test]
+    public function testConnectionSendsAnthropicKeyAndVersionHeaders(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com',
+            suggestedName: 'Anthropic',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, 'test-api-key');
+
+        self::assertSame('https://api.anthropic.com/models', $captured['uri']);
+        self::assertSame('test-api-key', $captured['headers']['x-api-key'] ?? null);
+        self::assertSame('2023-06-01', $captured['headers']['anthropic-version'] ?? null);
+        // Anthropic must NOT get a Bearer Authorization header.
+        self::assertArrayNotHasKey('Authorization', $captured['headers']);
+    }
+
+    #[Test]
+    public function testConnectionSendsGeminiApiKeyHeader(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
+            suggestedName: 'Google Gemini',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, 'test-api-key');
+
+        self::assertSame('https://generativelanguage.googleapis.com/models', $captured['uri']);
+        self::assertSame('test-api-key', $captured['headers']['x-goog-api-key'] ?? null);
+        self::assertArrayNotHasKey('Authorization', $captured['headers']);
+    }
+
+    #[Test]
+    public function testConnectionUsesTagsEndpointAndNoAuthForOllama(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'ollama',
+            endpoint: 'http://localhost:11434',
+            suggestedName: 'Ollama',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, '');
+
+        self::assertSame('http://localhost:11434/api/tags', $captured['uri']);
+        // Ollama needs no authentication — no headers at all.
+        self::assertSame([], $captured['headers']);
+    }
+
+    #[Test]
+    public function testConnectionStripsTrailingApiSegmentForOllama(): void
+    {
+        // A legacy/user-entered trailing "/api" must be stripped so the tags URL
+        // does not become ".../api/api/tags".
+        $provider = new DetectedProvider(
+            adapterType: 'ollama',
+            endpoint: 'http://localhost:11434/api',
+            suggestedName: 'Ollama',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{}'));
+
+        $this->subject->testConnection($provider, '');
+
+        self::assertSame('http://localhost:11434/api/tags', $captured['uri']);
+    }
+
+    #[Test]
+    public function testConnectionTreatsStatus300AsFailure(): void
+    {
+        // The success window is 200–299; 300 must be reported as a failure.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(300, '{}'));
+
+        $result = $this->subject->testConnection($provider, 'test-key');
+
+        self::assertFalse($result['success']);
+        self::assertStringContainsString('status code 300', $result['message']);
+    }
+
+    #[Test]
+    public function discoverOpenAiBuildsModelsUrlWithBearerAndContentTypeHeaders(): void
+    {
+        // Trailing slash also exercises discover()'s rtrim: the URL must be a
+        // single ".../models", never ".../…//models".
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com/',
+            suggestedName: 'OpenAI',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{"data": []}'));
+
+        $this->subject->discover($provider, 'test-key');
+
+        self::assertSame('GET', $captured['method']);
+        self::assertSame('https://api.openai.com/models', $captured['uri']);
+        self::assertSame('Bearer test-key', $captured['headers']['Authorization'] ?? null);
+        self::assertSame('application/json', $captured['headers']['Content-Type'] ?? null);
+    }
+
+    // ==================== discoverOpenAI transformation pinning ====================
+
+    #[Test]
+    public function discoverOpenAiReturnsFallbackOnNonOkStatusEvenWithParseableBody(): void
+    {
+        // A non-200 status must short-circuit to the fallback catalog and NOT
+        // parse the (otherwise valid) body — proven by a body whose model id is
+        // absent from the fallback list.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                500,
+                (string)json_encode(['data' => [['id' => 'gpt-4.1']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-5.5', $modelIds);
+        self::assertNotContains('gpt-4.1', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiSortsRecommendedModelsFirst(): void
+    {
+        // Insertion order is [non-recommended, recommended]; the usort must move
+        // the recommended model to the front. Kills both the removed-sort and the
+        // flipped-comparison mutants.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [['id' => 'gpt-4o'], ['id' => 'gpt-5.5']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertSame('gpt-5.5', $models[0]->modelId);
+        self::assertTrue($models[0]->recommended);
+    }
+
+    #[Test]
+    public function discoverOpenAiContinuesPastNonArrayItemsWithoutStopping(): void
+    {
+        // A non-array entry must be skipped (continue), NOT terminate the loop
+        // (break). A trailing, fallback-absent model id proves the loop kept
+        // going after the bad entry.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => ['not-an-array', ['id' => 'gpt-4.1']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-4.1', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiEnrichesEverySpecWithExactValues(): void
+    {
+        // Pin every field of the June-2026 OpenAI spec table so that a change to
+        // any name/description/capability/context/token/cost/recommended value is
+        // caught. Values mirror ModelDiscovery::openAIModelSpecs().
+        // [name, description, capabilities, contextLength, maxOutputTokens, costInput, costOutput, recommended]
+        $expected = [
+            'gpt-5.5' => ['GPT-5.5', 'Latest flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 500, 3000, true],
+            'gpt-5.3' => ['GPT-5.3', 'Flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 175, 1400, true],
+            'gpt-5.3-chat-latest' => ['GPT-5.3 Chat', 'Fast responses for interactive use', ['chat', 'vision', 'tools', 'streaming'], 400000, 32000, 100, 400, true],
+            'gpt-5.3-mini' => ['GPT-5.3 Mini', 'Small, fast, cost-effective', ['chat', 'vision', 'tools', 'streaming'], 200000, 32000, 30, 120, true],
+            'gpt-5.2' => ['GPT-5.2 Thinking', 'Flagship model for coding, reasoning, and agentic tasks', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 175, 1400, false],
+            'gpt-5.2-pro' => ['GPT-5.2 Pro', 'Extended thinking for complex tasks', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 350, 2800, false],
+            'gpt-5.2-chat-latest' => ['GPT-5.2 Instant', 'Fast responses for interactive use', ['chat', 'vision', 'tools', 'streaming'], 400000, 32000, 100, 400, false],
+            'gpt-5' => ['GPT-5', 'Previous generation flagship model', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 200000, 64000, 150, 600, false],
+            'gpt-5-mini' => ['GPT-5 Mini', 'Smaller, faster, cost-effective', ['chat', 'vision', 'tools', 'streaming'], 128000, 32000, 30, 120, false],
+            'o4-mini' => ['O4 Mini', 'Fast reasoning for math, coding, visual tasks', ['chat', 'vision', 'tools', 'reasoning'], 200000, 100000, 110, 440, false],
+            'o3' => ['O3', 'Advanced reasoning model', ['chat', 'vision', 'tools', 'reasoning'], 200000, 100000, 200, 800, false],
+            'gpt-4o' => ['GPT-4o', 'Legacy multimodal model', ['chat', 'vision', 'tools', 'streaming'], 128000, 16384, 250, 1000, false],
+            'gpt-4.1' => ['GPT-4.1', 'Coding and instruction-following model', ['chat', 'vision', 'tools', 'streaming'], 1047576, 32768, 200, 800, false],
+            'gpt-4.1-mini' => ['GPT-4.1 Mini', 'Fast coding model', ['chat', 'vision', 'tools', 'streaming'], 1047576, 32768, 40, 160, false],
+            'gpt-image-2' => ['GPT Image 2', 'Image generation model', ['image'], 0, 0, 0, 0, false],
+            'tts-1' => ['TTS-1', 'Text-to-speech model optimized for speed', ['text_to_speech'], 0, 0, 0, 0, false],
+            'tts-1-hd' => ['TTS-1 HD', 'Text-to-speech model optimized for quality', ['text_to_speech'], 0, 0, 0, 0, false],
+            'whisper-1' => ['Whisper', 'Speech-to-text transcription model', ['transcription'], 0, 0, 0, 0, false],
+        ];
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $data = array_map(static fn(string $id): array => ['id' => $id], array_keys($expected));
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => $data]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $byId = [];
+        foreach ($models as $model) {
+            $byId[$model->modelId] = $model;
+        }
+
+        foreach ($expected as $id => $spec) {
+            self::assertArrayHasKey($id, $byId, sprintf('Model %s missing from discovery result', $id));
+            $model = $byId[$id];
+            self::assertSame($spec[0], $model->name, $id . ' name');
+            self::assertSame($spec[1], $model->description, $id . ' description');
+            self::assertSame($spec[2], $model->capabilities, $id . ' capabilities');
+            self::assertSame($spec[3], $model->contextLength, $id . ' contextLength');
+            self::assertSame($spec[4], $model->maxOutputTokens, $id . ' maxOutputTokens');
+            self::assertSame($spec[5], $model->costInput, $id . ' costInput');
+            self::assertSame($spec[6], $model->costOutput, $id . ' costOutput');
+            self::assertSame($spec[7], $model->recommended, $id . ' recommended');
+        }
+    }
+
+    #[Test]
+    public function discoverOpenAiEnrichesUnspecifiedModelWithDefaults(): void
+    {
+        // A relevant model with no spec entry falls back to modelId-as-name,
+        // a generic description, chat capability and zeroed numeric fields.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [['id' => 'chatgpt-4o-latest']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $model = $models[0];
+        self::assertSame('chatgpt-4o-latest', $model->modelId);
+        self::assertSame('chatgpt-4o-latest', $model->name);
+        self::assertSame('OpenAI model', $model->description);
+        self::assertSame(['chat'], $model->capabilities);
+        self::assertSame(0, $model->contextLength);
+        self::assertSame(0, $model->maxOutputTokens);
+        self::assertSame(0, $model->costInput);
+        self::assertSame(0, $model->costOutput);
+        self::assertFalse($model->recommended);
+    }
+
+    #[Test]
+    public function discoverOpenAiDerivesDefaultCapabilitiesFromModelIdShape(): void
+    {
+        // Unspecified models get their capability from the id shape
+        // (defaultOpenAICapabilities): image / text_to_speech / transcription.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [
+                    ['id' => 'dall-e-3'],
+                    ['id' => 'gpt-image-1'],
+                    ['id' => 'gpt-4o-mini-tts'],
+                    ['id' => 'gpt-4o-transcribe'],
+                ]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $byId = [];
+        foreach ($models as $model) {
+            $byId[$model->modelId] = $model;
+        }
+
+        self::assertSame(['image'], $byId['dall-e-3']->capabilities);
+        self::assertSame(['image'], $byId['gpt-image-1']->capabilities);
+        self::assertSame(['text_to_speech'], $byId['gpt-4o-mini-tts']->capabilities);
+        self::assertSame(['transcription'], $byId['gpt-4o-transcribe']->capabilities);
+    }
+
+    // ==================== diagnostic logging pinning ====================
+
+    private function makeSubjectWithLogger(LoggerInterface $logger): ModelDiscovery
+    {
+        $subject = new ModelDiscovery(
+            $this->vaultStub,
+            $this->httpClientFactory,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $logger,
+        );
+        $subject->setHttpClient($this->httpClientStub);
+
+        return $subject;
+    }
+
+    #[Test]
+    public function discoverOpenAiLogsHttpErrorWithProviderAndStatus(): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(503, '{}'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM model discovery returned an unexpected HTTP status',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'openai' && ($ctx['status'] ?? null) === 503),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $subject->discover($provider, 'test-key');
+    }
+
+    #[Test]
+    public function discoverOpenAiLogsRequestFailureWithExceptionClass(): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM model discovery request failed',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'openai'
+                    && ($ctx['exception'] ?? null) === RuntimeException::class
+                    && ($ctx['message'] ?? null) === 'boom'),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $subject->discover($provider, 'test-key');
+    }
+
+    #[Test]
+    public function testConnectionLogsSanitizedExceptionWithProvider(): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('network detail'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM setup-wizard connection test failed',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'openai'
+                    && array_key_exists('exception', $ctx)),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $subject->testConnection($provider, 'test-key');
+    }
+
+    #[Test]
+    public function discoverOpenAiLogsMalformedJsonWithProviderAndBodySample(): void
+    {
+        // The malformed-JSON warning records the provider and a 200-char sample
+        // taken from the START of the body.
+        $body = 'A' . str_repeat('x', 300);
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, $body));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM model discovery received a malformed JSON response',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'openai'
+                    && ($ctx['sample'] ?? null) === substr($body, 0, 200)),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $subject->discover($provider, 'test-key');
+    }
 }

--- a/Tests/Unit/Service/WizardGeneratorServiceTest.php
+++ b/Tests/Unit/Service/WizardGeneratorServiceTest.php
@@ -23,8 +23,10 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use stdClass;
+use Throwable;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 #[CoversClass(WizardGeneratorService::class)]
@@ -181,6 +183,13 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
     {
         $defaultConfig = $this->createConfigurationWithModel();
         $this->stubDefaultConfig($defaultConfig);
+
+        // A uid of 0 must NOT trigger a repository lookup: the guard is `> 0`, not `>= 0`,
+        // and it is an AND with the null check. Both mutations (`>= 0`, `||`) would let 0
+        // through to findByUid().
+        $this->configurationRepository
+            ->expects(self::never())
+            ->method('findByUid');
 
         $result = $this->subject->resolveConfiguration(0);
 
@@ -1702,5 +1711,381 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
         $result = $this->subject->generateConfiguration('limit test', $config);
 
         self::assertTrue($result['generated']);
+    }
+
+    // ==================== Outgoing request payload assertions ====================
+
+    /**
+     * Configure the LLM manager mock to capture the outgoing messages array and
+     * return $response. Captures into $captured by reference.
+     *
+     * @param array<int, mixed>|null $captured
+     */
+    private function stubChatCapturing(CompletionResponse $response, ?array &$captured): void
+    {
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturnCallback(
+                function (array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []) use (&$captured, $response): CompletionResponse {
+                    $captured = $messages;
+
+                    return $response;
+                },
+            );
+    }
+
+    /**
+     * Assert the message at $index has the expected role and a string 'content',
+     * returning that content for further inspection.
+     *
+     * @param array<int, mixed>|null $messages
+     */
+    private function messageContent(?array $messages, int $index, string $expectedRole): string
+    {
+        self::assertIsArray($messages);
+        self::assertCount(2, $messages);
+        self::assertArrayHasKey($index, $messages);
+
+        $message = $messages[$index];
+        self::assertIsArray($message);
+        self::assertArrayHasKey('role', $message);
+        self::assertSame($expectedRole, $message['role']);
+        self::assertArrayHasKey('content', $message);
+
+        $content = $message['content'];
+        self::assertIsString($content);
+
+        return $content;
+    }
+
+    private function assertOccursBefore(string $haystack, string $first, string $second): void
+    {
+        $posFirst = strpos($haystack, $first);
+        $posSecond = strpos($haystack, $second);
+        self::assertIsInt($posFirst, "'{$first}' not found in prompt");
+        self::assertIsInt($posSecond, "'{$second}' not found in prompt");
+        self::assertLessThan($posSecond, $posFirst, "'{$first}' should occur before '{$second}'");
+    }
+
+    #[Test]
+    public function testGenerateConfigurationSendsSystemAndUserMessages(): void
+    {
+        $config = $this->createConfigurationWithModel();
+
+        // 12 active models so the array_slice(…, 0, 10) window is observable.
+        $models = [];
+        for ($i = 1; $i <= 12; ++$i) {
+            $m = $this->createActiveModel('model-' . $i, 'Model ' . $i);
+            $m->setDescription('Description ' . $i);
+            $models[] = $m;
+        }
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub($models));
+
+        // Non-LlmConfiguration item FIRST: with `continue` the valid one is still collected;
+        // a `break` mutation would drop it.
+        $existingConfig = new LlmConfiguration();
+        $existingConfig->setName('Existing One');
+        $existingConfig->setDescription('Avoid me');
+        $this->configurationRepository->method('findAll')->willReturn([new stdClass(), $existingConfig]);
+
+        $llmJson = json_encode([
+            'identifier' => 'payload-config',
+            'name' => 'Payload Config',
+            'description' => 'Payload check.',
+            'system_prompt' => 'Be helpful.',
+        ], JSON_THROW_ON_ERROR);
+
+        $captured = null;
+        $this->stubChatCapturing($this->createCompletionResponse($llmJson), $captured);
+
+        $result = $this->subject->generateConfiguration('generate config capture', $config);
+
+        self::assertTrue($result['generated']);
+
+        // System message: exact role + the distinctive configuration-prompt text.
+        $systemContent = $this->messageContent($captured, 0, 'system');
+        self::assertStringContainsString('You are an expert at configuring LLM integrations', $systemContent);
+
+        // User message: description + full built context.
+        $userContent = $this->messageContent($captured, 1, 'user');
+        self::assertStringContainsString('User request: generate config capture', $userContent);
+
+        // Models section: label present, slice window [0,10) — models 1-10 in, 11-12 out.
+        self::assertStringContainsString('Available models:', $userContent);
+        self::assertStringContainsString('(model-1)', $userContent);
+        self::assertStringContainsString('(model-10)', $userContent);
+        self::assertStringNotContainsString('(model-11)', $userContent);
+        self::assertStringNotContainsString('(model-12)', $userContent);
+        $this->assertOccursBefore($userContent, 'Available models:', '(model-1)');
+
+        // Configs section: label present, collected config kept, correct concat order.
+        self::assertStringContainsString('Existing configurations (avoid duplicates):', $userContent);
+        self::assertStringContainsString('Existing One', $userContent);
+        $this->assertOccursBefore($userContent, 'Existing configurations (avoid duplicates):', 'Existing One');
+    }
+
+    #[Test]
+    public function testGenerateTaskSendsSystemAndUserMessages(): void
+    {
+        $config = $this->createConfigurationWithModel();
+
+        // Non-LlmConfiguration item FIRST so a `break` mutation drops the valid config.
+        $existingConfig = new LlmConfiguration();
+        $existingConfig->setName('Task Cfg');
+        $existingConfig->setIdentifier('task-cfg');
+        $this->configurationRepository->method('findAll')->willReturn([new stdClass(), $existingConfig]);
+
+        $llmJson = json_encode([
+            'identifier' => 'payload-task',
+            'name' => 'Payload Task',
+            'description' => 'Payload check.',
+            'category' => 'content',
+            'prompt_template' => '{{input}}',
+            'output_format' => 'markdown',
+        ], JSON_THROW_ON_ERROR);
+
+        $captured = null;
+        $this->stubChatCapturing($this->createCompletionResponse($llmJson), $captured);
+
+        $result = $this->subject->generateTask('generate task capture', $config);
+
+        self::assertTrue($result['generated']);
+
+        $systemContent = $this->messageContent($captured, 0, 'system');
+        self::assertStringContainsString('You are an expert at creating LLM task templates', $systemContent);
+
+        $userContent = $this->messageContent($captured, 1, 'user');
+        self::assertStringContainsString('User request: generate task capture', $userContent);
+        self::assertStringContainsString('Task categories: content, log_analysis, system, developer, general', $userContent);
+        self::assertStringContainsString('Output formats: markdown, json, plain, html', $userContent);
+        self::assertStringContainsString('Available configurations:', $userContent);
+        self::assertStringContainsString('Task Cfg (identifier: task-cfg)', $userContent);
+        $this->assertOccursBefore($userContent, 'Available configurations:', 'Task Cfg (identifier: task-cfg)');
+    }
+
+    #[Test]
+    public function testGenerateTaskWithChainSendsSystemAndUserMessages(): void
+    {
+        $config = $this->createConfigurationWithModel();
+
+        $model = $this->createActiveModel('gpt-5.2', 'GPT-5.2');
+        $model->setDescription('Flagship');
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([$model]));
+
+        $existingConfig = new LlmConfiguration();
+        $existingConfig->setName('Chain Existing');
+        $existingConfig->setIdentifier('chain-existing');
+        $existingConfig->setDescription('Reference config');
+        $this->configurationRepository->method('findAll')->willReturn([new stdClass(), $existingConfig]);
+
+        $llmJson = json_encode([
+            'task' => [
+                'identifier' => 'chain-payload',
+                'name' => 'Chain Payload',
+                'description' => 'Payload check.',
+                'category' => 'general',
+                'prompt_template' => '{{input}}',
+                'output_format' => 'markdown',
+            ],
+            'configuration' => [
+                'identifier' => 'chain-payload-config',
+                'name' => 'Chain Payload Config',
+                'description' => 'Config.',
+                'system_prompt' => 'Help.',
+                'temperature' => 0.7,
+                'max_tokens' => 4096,
+                'top_p' => 1.0,
+                'frequency_penalty' => 0.0,
+                'presence_penalty' => 0.0,
+            ],
+            'recommended_model_id' => 'gpt-5.2',
+            'suggested_model' => [
+                'name' => 'GPT-5.2',
+                'model_id' => 'gpt-5.2',
+                'description' => 'Fit',
+                'capabilities' => 'chat',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $captured = null;
+        $this->stubChatCapturing($this->createCompletionResponse($llmJson), $captured);
+
+        $result = $this->subject->generateTaskWithChain('generate chain capture', $config);
+
+        self::assertTrue($result['generated']);
+
+        $systemContent = $this->messageContent($captured, 0, 'system');
+        self::assertStringContainsString('You are an expert at creating complete LLM task setups', $systemContent);
+
+        $userContent = $this->messageContent($captured, 1, 'user');
+        self::assertStringContainsString('User request: generate chain capture', $userContent);
+        self::assertStringContainsString('Available models (prefer these):', $userContent);
+        self::assertStringContainsString('(gpt-5.2)', $userContent);
+        self::assertStringContainsString('Existing configurations (for reference, avoid duplicate names):', $userContent);
+        self::assertStringContainsString('Chain Existing', $userContent);
+    }
+
+    // ==================== Exception path logs the cause ====================
+
+    #[Test]
+    public function testGenerateConfigurationLogsExceptionCauseOnFailure(): void
+    {
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willThrowException(new RuntimeException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Wizard configuration generation failed; using fallback',
+                self::callback(
+                    static fn(array $context): bool => array_key_exists('exception', $context)
+                        && $context['exception'] instanceof Throwable,
+                ),
+            );
+
+        $subject = new WizardGeneratorService(
+            $this->llmServiceManager,
+            $this->configurationRepository,
+            $this->modelRepository,
+            $logger,
+        );
+
+        $result = $subject->generateConfiguration('log config', $this->createConfigurationWithModel());
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testGenerateTaskLogsExceptionCauseOnFailure(): void
+    {
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willThrowException(new RuntimeException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Wizard task generation failed; using fallback',
+                self::callback(
+                    static fn(array $context): bool => array_key_exists('exception', $context)
+                        && $context['exception'] instanceof Throwable,
+                ),
+            );
+
+        $subject = new WizardGeneratorService(
+            $this->llmServiceManager,
+            $this->configurationRepository,
+            $this->modelRepository,
+            $logger,
+        );
+
+        $result = $subject->generateTask('log task', $this->createConfigurationWithModel());
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testGenerateTaskWithChainLogsExceptionCauseOnFailure(): void
+    {
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willThrowException(new RuntimeException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Wizard task-chain generation failed; using fallback',
+                self::callback(
+                    static fn(array $context): bool => array_key_exists('exception', $context)
+                        && $context['exception'] instanceof Throwable,
+                ),
+            );
+
+        $subject = new WizardGeneratorService(
+            $this->llmServiceManager,
+            $this->configurationRepository,
+            $this->modelRepository,
+            $logger,
+        );
+
+        $result = $subject->generateTaskWithChain('log chain', $this->createConfigurationWithModel());
+
+        self::assertFalse($result['generated']);
+    }
+
+    // ==================== findBestExistingModel loop stops at first match ====================
+
+    #[Test]
+    public function testFindBestExistingModelExactMatchStopsAtFirst(): void
+    {
+        $first = $this->createActiveModel('dup-model', 'First');
+        $second = $this->createActiveModel('dup-model', 'Second');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResultStub([$first, $second]));
+
+        $result = $this->subject->findBestExistingModel('dup-model');
+
+        // `break` returns the first exact match; a `continue` mutation would overwrite
+        // it with the second.
+        self::assertSame($first, $result);
+    }
+
+    #[Test]
+    public function testFindBestExistingModelPartialMatchStopsAtFirst(): void
+    {
+        $first = $this->createActiveModel('gpt-4-alpha', 'Alpha');
+        $second = $this->createActiveModel('gpt-4-beta', 'Beta');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResultStub([$first, $second]));
+
+        // No exact match on 'gpt-4'; both partially match. `break` returns the first.
+        $result = $this->subject->findBestExistingModel('gpt-4');
+
+        self::assertSame($first, $result);
+    }
+
+    // ==================== getDefaultConfiguration requires instanceof AND active AND model ====================
+
+    #[Test]
+    public function testGenerateConfigurationSkipsInactiveConfigWithModel(): void
+    {
+        $model = new Model();
+        $model->setModelId('gpt-5.2');
+
+        $inactiveWithModel = new LlmConfiguration();
+        $inactiveWithModel->_setProperty('llmModel', $model);
+        $inactiveWithModel->_setProperty('isActive', false);
+        $inactiveWithModel->_setProperty('isDefault', false);
+
+        $this->configurationRepository->method('findDefault')->willReturn(null);
+        $this->configurationRepository->method('findAll')->willReturn([$inactiveWithModel]);
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+
+        // The only candidate is inactive: getDefaultConfiguration() must return null and the
+        // wizard must fall back WITHOUT ever calling the LLM. Both `&&`→`||` mutations would
+        // wrongly accept this config and reach chatWithConfiguration().
+        $this->llmServiceManager
+            ->expects(self::never())
+            ->method('chatWithConfiguration');
+
+        $result = $this->subject->generateConfiguration('inactive only');
+
+        self::assertFalse($result['generated']);
     }
 }

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
@@ -32,6 +33,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
@@ -48,6 +50,12 @@ class FalImageServiceTest extends AbstractUnitTestCase
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
     private LoggerInterface&Stub $loggerStub;
     private VaultServiceInterface $vaultStub;
+
+    /** @var list<array{method: string, uri: string}> */
+    private array $capturedRequests = [];
+
+    /** @var list<string> */
+    private array $capturedBodies = [];
 
     protected function setUp(): void
     {
@@ -348,6 +356,147 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->httpClientStub
             ->method('sendRequest')
             ->willReturn($responseStub);
+    }
+
+    /**
+     * Wire the request/stream factory stubs to record every outgoing request
+     * (method + URI) and every serialized request body, so a test can assert
+     * the exact URL the service constructed and the exact JSON payload it sent.
+     * The recorded data lands in $this->capturedRequests / $this->capturedBodies.
+     */
+    private function installCapturingFactories(): void
+    {
+        $this->capturedRequests = [];
+        $this->capturedBodies = [];
+
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturnCallback(function (string $method, UriInterface|string $uri) use ($requestStub): RequestInterface {
+                $this->capturedRequests[] = ['method' => $method, 'uri' => (string)$uri];
+
+                return $requestStub;
+            });
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturnCallback(function (string $content = '') use ($streamStub): StreamInterface {
+                $this->capturedBodies[] = $content;
+
+                return $streamStub;
+            });
+    }
+
+    /**
+     * Queue a single successful JSON (non-queue path) response. Pairs with
+     * installCapturingFactories() — it does not touch the request/stream
+     * factories, so the capturing callbacks stay in place.
+     *
+     * @param array<string, mixed> $responseData
+     */
+    private function respondWithJson(array $responseData): void
+    {
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode($responseData));
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+    }
+
+    /**
+     * Queue the submit -> COMPLETED status -> result sequence a queue-based
+     * model drives. Pairs with installCapturingFactories().
+     *
+     * @param array<string, mixed> $finalResponseData
+     */
+    private function respondWithQueue(array $finalResponseData): void
+    {
+        $submitBody = self::createStub(StreamInterface::class);
+        $submitBody->method('__toString')->willReturn((string)json_encode(['request_id' => 'test-request-123']));
+        $submitResponse = self::createStub(ResponseInterface::class);
+        $submitResponse->method('getStatusCode')->willReturn(200);
+        $submitResponse->method('getBody')->willReturn($submitBody);
+
+        $statusBody = self::createStub(StreamInterface::class);
+        $statusBody->method('__toString')->willReturn((string)json_encode(['status' => 'COMPLETED']));
+        $statusResponse = self::createStub(ResponseInterface::class);
+        $statusResponse->method('getStatusCode')->willReturn(200);
+        $statusResponse->method('getBody')->willReturn($statusBody);
+
+        $resultBody = self::createStub(StreamInterface::class);
+        $resultBody->method('__toString')->willReturn((string)json_encode($finalResponseData));
+        $resultResponse = self::createStub(ResponseInterface::class);
+        $resultResponse->method('getStatusCode')->willReturn(200);
+        $resultResponse->method('getBody')->willReturn($resultBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls($submitResponse, $statusResponse, $resultResponse);
+    }
+
+    /**
+     * Set up a non-2xx response carrying the given (already-structured) JSON
+     * error body, so error-decoding branches can be asserted precisely.
+     *
+     * @param array<string, mixed> $bodyData
+     */
+    private function setupFailedRequestRaw(int $statusCode, array $bodyData): void
+    {
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturn($streamStub);
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode($bodyData));
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn($statusCode);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+    }
+
+    /**
+     * Read a (possibly non-public) property off the subject via reflection.
+     */
+    private function readProperty(FalImageService $subject, string $property): mixed
+    {
+        return (new ReflectionClass($subject))->getProperty($property)->getValue($subject);
+    }
+
+    /**
+     * Decode the JSON body the service sent for the request at the given index.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodedBody(int $index = 0): array
+    {
+        self::assertArrayHasKey($index, $this->capturedBodies, 'no request body was captured');
+        $decoded = json_decode($this->capturedBodies[$index], true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     // ==================== isAvailable tests ====================
@@ -785,8 +934,9 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->setupFailedRequest(422, 'Invalid prompt');
 
         $this->expectException(ServiceUnavailableException::class);
-        // FAL surfaces 422 with its own validation wording (see mapErrorStatus()).
-        $this->expectExceptionMessage('FAL API validation error');
+        // FAL surfaces 422 with its own validation wording (see mapErrorStatus()):
+        // the prefix and the decoded detail in that exact order.
+        $this->expectExceptionMessage('FAL API validation error: Invalid prompt');
 
         $subject->generate('A sunset');
     }
@@ -1248,5 +1398,439 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $results = $subject->generateMultiple('A sunset', 0); // Should be set to 1
 
         self::assertCount(1, $results);
+    }
+
+    // ==================== request URL / endpoint construction ====================
+
+    #[Test]
+    public function generateBuildsQueueUrlFromMappedModelEndpoint(): void
+    {
+        // flux-pro maps to fal-ai/flux-pro (self::MODELS) and is not a "fast"
+        // model, so it takes the queue path. Pins resolveModelEndpoint()'s
+        // mapped-model branch and the queue-URL assembly.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-pro');
+
+        self::assertSame('POST', $this->capturedRequests[0]['method']);
+        self::assertSame('https://queue.fal.run/fal-ai/flux-pro', $this->capturedRequests[0]['uri']);
+    }
+
+    #[Test]
+    public function generateUsesFullEndpointPathVerbatimInQueueUrl(): void
+    {
+        // A slash-bearing model id is an explicit endpoint and must be used
+        // verbatim (resolveModelEndpoint()'s str_contains branch), never
+        // rewritten to the flux-schnell fallback.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'fal-ai/custom-model');
+
+        self::assertSame('POST', $this->capturedRequests[0]['method']);
+        self::assertSame('https://queue.fal.run/fal-ai/custom-model', $this->capturedRequests[0]['uri']);
+    }
+
+    #[Test]
+    public function generateSendsPromptAndDefaultImageSizeInPayload(): void
+    {
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A beautiful sunset');
+
+        $payload = $this->decodedBody();
+        self::assertSame('A beautiful sunset', $payload['prompt']);
+        self::assertSame('square_hd', $payload['image_size']);
+    }
+
+    // ==================== num_images clamping (payload) ====================
+
+    /**
+     * @return array<string, array{int, int}>
+     */
+    public static function numImagesClampProvider(): array
+    {
+        return [
+            'one stays one'        => [1, 1],
+            'zero clamps up to one' => [0, 1],
+            'two stays two'        => [2, 2],
+            'four stays four'      => [4, 4],
+            'ten clamps to four'   => [10, 4],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('numImagesClampProvider')]
+    public function generateMultipleClampsNumImagesInPayload(int $inputCount, int $expectedNumImages): void
+    {
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generateMultiple('A sunset', $inputCount);
+
+        self::assertSame($expectedNumImages, $this->decodedBody()['num_images']);
+    }
+
+    #[Test]
+    public function generateMultipleDefaultsToASingleImageInPayload(): void
+    {
+        // Default $count (omitted) must resolve to num_images = 1.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generateMultiple('A sunset');
+
+        self::assertSame(1, $this->decodedBody()['num_images']);
+    }
+
+    // ==================== availability guards ====================
+
+    #[Test]
+    public function generateMultipleThrowsWhenServiceUnavailable(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->generateMultiple('A sunset', 2);
+    }
+
+    #[Test]
+    public function imageToImageThrowsWhenServiceUnavailable(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->imageToImage('https://example.com/source.png', 'Make it colorful');
+    }
+
+    // ==================== imageToImage payload ====================
+
+    #[Test]
+    public function imageToImageKeepsCallerStrengthInPayload(): void
+    {
+        // The caller-supplied strength must survive (`??=` keeps it); it is
+        // only defaulted when absent.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/transformed.png']]]);
+
+        $subject->imageToImage(
+            'https://example.com/source.png',
+            'Make it darker',
+            'flux-dev',
+            ['strength' => 0.5],
+        );
+
+        $payload = $this->decodedBody();
+        self::assertSame('https://example.com/source.png', $payload['image_url']);
+        self::assertSame(0.5, $payload['strength']);
+    }
+
+    #[Test]
+    public function imageToImageAppliesDefaultStrengthInPayload(): void
+    {
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/transformed.png']]]);
+
+        $subject->imageToImage('https://example.com/source.png', 'Make it colorful');
+
+        self::assertSame(0.75, $this->decodedBody()['strength']);
+    }
+
+    // ==================== response parsing: metadata / url / size ====================
+
+    #[Test]
+    public function generatePrefersResponseSeedOverImageSeedInMetadata(): void
+    {
+        // metadata seed = $response['seed'] ?? $image['seed']: the top-level
+        // response seed wins over the per-image seed.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://example.com/image.png', 'seed' => 222]],
+            'seed'   => 111,
+        ]);
+
+        $result = $subject->generate('A sunset');
+
+        assert(isset($result->metadata['seed']));
+        self::assertSame(111, $result->metadata['seed']);
+    }
+
+    #[Test]
+    public function generateFallsBackToImageSeedWhenResponseSeedMissing(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://example.com/image.png', 'seed' => 222]],
+        ]);
+
+        $result = $subject->generate('A sunset');
+
+        assert(isset($result->metadata['seed']));
+        self::assertSame(222, $result->metadata['seed']);
+    }
+
+    #[Test]
+    public function generateReturnsEmptyImageWhenFirstImageIsNotAnArray(): void
+    {
+        // images is a list, but images[0] is a scalar: the guard
+        // (is_array($images) && isset($images[0]) && is_array($images[0]))
+        // must fall to the empty-image branch, yielding an empty URL and the
+        // default size rather than dereferencing the scalar.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => ['not-an-array-element'],
+        ]);
+
+        $result = $subject->generate('A sunset');
+
+        self::assertSame('', $result->url);
+        self::assertSame('1024x1024', $result->size);
+    }
+
+    #[Test]
+    public function generateMultipleExposesImageUrls(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [
+                ['url' => 'https://example.com/image1.png'],
+                ['url' => 'https://example.com/image2.png'],
+            ],
+        ]);
+
+        $results = $subject->generateMultiple('A sunset', 2);
+
+        self::assertSame('https://example.com/image1.png', $results[0]->url);
+        self::assertSame('https://example.com/image2.png', $results[1]->url);
+    }
+
+    #[Test]
+    public function generateMultipleYieldsEmptyUrlForNonStringUrl(): void
+    {
+        // A non-string url must be rejected by the
+        // isset() && is_string() guard, leaving an empty URL.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [
+                ['url' => 12345],
+            ],
+        ]);
+
+        $results = $subject->generateMultiple('A sunset', 1);
+
+        self::assertCount(1, $results);
+        self::assertSame('', $results[0]->url);
+    }
+
+    #[Test]
+    public function generateMultipleIncludesPerImageSeedInMetadata(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [
+                ['url' => 'https://example.com/image.png', 'seed' => 987],
+            ],
+        ]);
+
+        $results = $subject->generateMultiple('A sunset', 1);
+
+        assert(isset($results[0]->metadata['seed']));
+        self::assertSame(987, $results[0]->metadata['seed']);
+    }
+
+    #[Test]
+    public function generateMultipleContinuesPastLeadingInvalidImageData(): void
+    {
+        // The invalid (non-array) entry comes FIRST: the loop must `continue`
+        // past it and still collect the trailing valid image (a `break` here
+        // would drop it).
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [
+                'invalid',
+                ['url' => 'https://example.com/image.png'],
+            ],
+        ]);
+
+        $results = $subject->generateMultiple('A sunset', 2);
+
+        self::assertCount(1, $results);
+        self::assertSame('https://example.com/image.png', $results[0]->url);
+    }
+
+    // ==================== usage attribution (beUserUid) ====================
+
+    #[Test]
+    public function generateAttributesUsageToZeroBeUserUid(): void
+    {
+        // uid 0 is a valid backend user id (>= 0), so it must reach the usage
+        // row rather than being treated as absent.
+        $this->setupSuccessfulRequest(['images' => [['url' => 'https://fal.ai/image.png']]]);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['image' => ['fal' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with('image', 'fal', ['images' => 1], null, 0, 'flux-schnell', 0, 0);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A sunset', options: ['beUserUid' => 0]);
+    }
+
+    #[Test]
+    public function generateTreatsNegativeBeUserUidAsAbsent(): void
+    {
+        // A negative uid is not a real backend user: extractBeUserUid() must
+        // drop it (is_int AND >= 0), so attribution falls back to null.
+        $this->setupSuccessfulRequest(['images' => [['url' => 'https://fal.ai/image.png']]]);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['image' => ['fal' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with('image', 'fal', ['images' => 1], null, 0, 'flux-schnell', 0, null);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A sunset', options: ['beUserUid' => -5]);
+    }
+
+    // ==================== error decoding / mapping ====================
+
+    #[Test]
+    public function generateSurfacesErrorDetailInMessage(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupFailedRequest(500, 'Boom detail');
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Boom detail');
+
+        $subject->generate('A sunset');
+    }
+
+    #[Test]
+    public function generateUsesUnknownLabelWhenDetailAndMessageEmpty(): void
+    {
+        // An empty detail AND empty message must not be surfaced verbatim —
+        // decodeErrorMessage() falls through to the unknown-error label.
+        $subject = $this->createSubject();
+        $this->setupFailedRequestRaw(500, ['detail' => '', 'message' => '']);
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Unknown FAL API error');
+
+        $subject->generate('A sunset');
+    }
+
+    #[Test]
+    public function validationErrorCarriesProviderContext(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupFailedRequest(422, 'Invalid prompt');
+
+        try {
+            $subject->generate('A sunset');
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame(['provider' => 'fal'], $e->context);
+        }
+    }
+
+    // ==================== configuration: timeout / pollInterval ====================
+
+    #[Test]
+    public function defaultTimeoutIsTwoMinutes(): void
+    {
+        $subject = $this->createSubject();
+
+        $method = (new ReflectionClass($subject))->getMethod('getDefaultTimeout');
+
+        self::assertSame(120, $method->invoke($subject));
+    }
+
+    #[Test]
+    public function loadConfigurationCastsNumericStringTimeoutToInt(): void
+    {
+        $subject = $this->createSubject([
+            'image' => ['fal' => ['timeout' => '180']],
+        ]);
+
+        self::assertSame(180, $this->readProperty($subject, 'timeout'));
+    }
+
+    #[Test]
+    public function loadConfigurationDefaultsPollIntervalToOneThousand(): void
+    {
+        $subject = $this->createSubject(); // no pollInterval configured
+
+        self::assertSame(1000, $this->readProperty($subject, 'pollInterval'));
+    }
+
+    #[Test]
+    public function loadConfigurationCastsNumericStringPollIntervalToInt(): void
+    {
+        $subject = $this->createSubject([
+            'image' => ['fal' => ['pollInterval' => '2000']],
+        ]);
+
+        self::assertSame(2000, $this->readProperty($subject, 'pollInterval'));
+    }
+
+    #[Test]
+    public function loadConfigurationDefaultsPollIntervalWhenNonNumeric(): void
+    {
+        $subject = $this->createSubject([
+            'image' => ['fal' => ['pollInterval' => 'not-a-number']],
+        ]);
+
+        self::assertSame(1000, $this->readProperty($subject, 'pollInterval'));
+    }
+
+    #[Test]
+    public function loadConfigurationClampsPollIntervalToAtLeastOne(): void
+    {
+        // A configured 1ms interval must pass through unchanged (max(1, …)).
+        $subject = $this->createSubject([
+            'image' => ['fal' => ['pollInterval' => 1]],
+        ]);
+
+        self::assertSame(1, $this->readProperty($subject, 'pollInterval'));
     }
 }

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -1562,7 +1562,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
 
         $result = $subject->generate('A sunset');
 
-        assert(isset($result->metadata['seed']));
+        self::assertIsArray($result->metadata);
         self::assertSame(111, $result->metadata['seed']);
     }
 
@@ -1576,7 +1576,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
 
         $result = $subject->generate('A sunset');
 
-        assert(isset($result->metadata['seed']));
+        self::assertIsArray($result->metadata);
         self::assertSame(222, $result->metadata['seed']);
     }
 
@@ -1645,7 +1645,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
 
         $results = $subject->generateMultiple('A sunset', 1);
 
-        assert(isset($results[0]->metadata['seed']));
+        self::assertIsArray($results[0]->metadata);
         self::assertSame(987, $results[0]->metadata['seed']);
     }
 


### PR DESCRIPTION
Raises mutation coverage on the top escaped-mutant hotspots. Measured on the full
Infection run (10,217 mutants): **covered MSI 62.8% → 67%** — 6397→6847 killed,
3789→3341 escaped (~450 mutants newly killed).

## What escaped, and why

Infection showed the provider adapters and setup wizard leaking hundreds of
escaped mutants: the tests mocked the HTTP client and asserted the happy path but
never asserted the *transformation* — the constructed endpoint/URL, method, JSON
body keys+values, headers, and the parsed response fields. So mutations to
endpoint construction (`rtrim` trailing-slash, match arms, concat swaps), numeric
payload defaults, array items, and response parsing all survived.

## Strengthened (5 files, ~300 assertions)

- `ModelDiscoveryTest` (was 539 escaped) — endpoint construction per provider,
  auth headers, the full model-spec table via an exact-value loop, diagnostic
  logging.
- `OpenRouterProviderTest`, `ClaudeProviderTest` — exact request payload/headers
  and response parsing.
- `WizardGeneratorServiceTest` — the composed user-prompt structure and context
  sections.
- `FalImageServiceTest` — request payload and seed/metadata parsing.

## Deferred (honest)

- **GeminiProvider** (169 escaped): the agent-drafted tests asserted the
  production base URL, but the test constructs the provider with an empty one —
  reverted rather than ship 6 brittle exact-string assertions; needs a careful
  pass.
- Equivalent mutants (e.g. `json_decode` depth 512→511, unreachable guard
  branches) left unkilled by design.

Pattern established to continue toward 74%: assert the request/response
transformation, not just "it didn't throw".

## Verification

Full unit suite green (bulk-verified — this caught 13 real issues in the drafted
assertions before merge), cgl + PHPStan L10 clean.
