### PR TITLE
test: strengthen assertions to raise mutation MSI, batch 2 (~70% combined)

### DIFF
--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
@@ -27,6 +28,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(GeminiProvider::class)]
@@ -1548,5 +1550,453 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $this->expectException(ProviderResponseException::class);
 
         $this->subject->testConnection();
+    }
+
+    // ===== Outgoing-request assertions =====
+    //
+    // The tests below pin the exact request the provider constructs (method,
+    // relative URI, decoded JSON body) rather than only the parsed response.
+    // The subject is built with baseUrl '' (mirroring setUp), so the captured
+    // URI is the RELATIVE path AbstractProvider::sendRequest() produces
+    // (rtrim('', '/') . '/' . ltrim($endpoint, '/')), never the production
+    // https://generativelanguage.googleapis.com/... base URL.
+
+    /**
+     * Build a subject whose request-factory / stream-factory capture the
+     * outgoing method, URI and JSON body, and whose HTTP client returns the
+     * given decoded response.
+     *
+     * @param array<string, mixed> $apiResponse
+     */
+    private function createCapturingSubject(
+        array $apiResponse,
+        ?string &$capturedMethod,
+        ?string &$capturedUri,
+        ?string &$capturedBody,
+    ): GeminiProvider {
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')
+            ->willReturnCallback(function (string $method, string $uri) use (
+                &$capturedMethod,
+                &$capturedUri,
+            ): RequestInterface {
+                $capturedMethod = $method;
+                $capturedUri    = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            });
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')
+            ->willReturnCallback(function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream       = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            });
+
+        $subject = new GeminiProvider(
+            $requestFactory,
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gemini-3-flash-preview',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        $subject->setHttpClient($this->createJsonHttpClient($apiResponse));
+
+        return $subject;
+    }
+
+    /**
+     * @param array<string, mixed> $apiResponse
+     */
+    private function createJsonHttpClient(array $apiResponse): ClientInterface
+    {
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($this->createJsonResponseMock($apiResponse));
+
+        return $httpClient;
+    }
+
+    /**
+     * Decode a captured JSON request body into an array for assertions.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedBody(?string $capturedBody): array
+    {
+        self::assertIsString($capturedBody);
+        $decoded = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    #[Test]
+    public function chatCompletionSendsExactRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+            ],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'Hello']]);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/models/gemini-3-flash-preview:generateContent', $capturedUri);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Hello']]]],
+            $body['contents'],
+        );
+        self::assertIsArray($body['generationConfig']);
+        self::assertArrayHasKey('temperature', $body['generationConfig']);
+        self::assertSame(0.7, $body['generationConfig']['temperature']);
+        self::assertArrayHasKey('maxOutputTokens', $body['generationConfig']);
+        self::assertSame(4096, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    #[Test]
+    public function chatCompletionConvertsChatMessageObjectsToArrays(): void
+    {
+        // A ChatMessage instance (not a plain array) must be normalised via
+        // toArray() before conversion; without that map the value object reaches
+        // asArray() as an object → [] → an empty user turn.
+        $capturedBody = null;
+        $capturedUri  = null;
+        $capturedMethod = null;
+
+        $subject = $this->createCapturingSubject(
+            [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+            ],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([new ChatMessage('user', 'Hello from VO')]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Hello from VO']]]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsExactToolPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+            ],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => [
+                    'name' => 'get_weather',
+                    'description' => 'Get current weather',
+                    'parameters' => ['type' => 'object', 'properties' => ['location' => ['type' => 'string']]],
+                ],
+            ]),
+        ];
+
+        $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'Weather?']], $tools);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/models/gemini-3-flash-preview:generateContent', $capturedUri);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Weather?']]]],
+            $body['contents'],
+        );
+        self::assertSame(
+            [[
+                'functionDeclarations' => [[
+                    'name' => 'get_weather',
+                    'description' => 'Get current weather',
+                    'parameters' => ['type' => 'object', 'properties' => ['location' => ['type' => 'string']]],
+                ]],
+            ]],
+            $body['tools'],
+        );
+        self::assertIsArray($body['generationConfig']);
+        self::assertArrayHasKey('temperature', $body['generationConfig']);
+        self::assertSame(0.7, $body['generationConfig']['temperature']);
+        self::assertArrayHasKey('maxOutputTokens', $body['generationConfig']);
+        self::assertSame(4096, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsConvertsChatMessageObjectsToArrays(): void
+    {
+        $capturedBody   = null;
+        $capturedUri    = null;
+        $capturedMethod = null;
+
+        $subject = $this->createCapturingSubject(
+            [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+            ],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'noop', 'description' => 'x', 'parameters' => ['type' => 'object']],
+            ]),
+        ];
+
+        $subject->chatCompletionWithTools([new ChatMessage('user', 'VO message')], $tools);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'VO message']]]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsRejectsInvalidModelId(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'noop', 'description' => 'x', 'parameters' => ['type' => 'object']],
+            ]),
+        ];
+
+        $this->subject->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'hi']],
+            $tools,
+            ['model' => '../../secret'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsConcatenatesMultipleTextParts(): void
+    {
+        // Two text parts in one candidate exercise the `$rawContent .= $text`
+        // accumulation; a plain assignment would keep only the last part.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'get_weather', 'description' => 'x', 'parameters' => ['type' => 'object']],
+            ]),
+        ];
+
+        $apiResponse = [
+            'candidates' => [[
+                'content' => [
+                    'parts' => [
+                        ['text' => 'Part one. '],
+                        ['text' => 'Part two.'],
+                    ],
+                    'role' => 'model',
+                ],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => ['promptTokenCount' => 5, 'candidatesTokenCount' => 5],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'hi']], $tools);
+
+        self::assertSame('Part one. Part two.', $result->content);
+    }
+
+    #[Test]
+    public function embeddingsSendsExactRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            ['embedding' => ['values' => [0.1, 0.2, 0.3]]],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->embeddings('Test text');
+
+        self::assertSame('POST', $capturedMethod);
+        // embeddings() defaults to the EMBEDDING_MODEL constant, not the
+        // configured chat defaultModel.
+        self::assertSame('/models/gemini-embedding-2:embedContent', $capturedUri);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame('models/gemini-embedding-2', $body['model']);
+        self::assertSame(
+            ['parts' => [['text' => 'Test text']]],
+            $body['content'],
+        );
+    }
+
+    #[Test]
+    public function embeddingsReportsPromptTokensFromTextLength(): void
+    {
+        // 'Test text' is 9 characters → 9/4 = 2.25 → (int) 2 prompt tokens;
+        // completion tokens are always 0 for the embeddings endpoint.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['embedding' => ['values' => [0.1, 0.2]]]));
+
+        $result = $subject->embeddings('Test text');
+
+        self::assertSame(2, $result->usage->promptTokens);
+        self::assertSame(0, $result->usage->completionTokens);
+    }
+
+    #[Test]
+    public function embeddingsAccumulatesPromptTokensAcrossInputs(): void
+    {
+        // 'First text' (10) + 'Second text' (11): 10/4 + 11/4 = 2.5 + 2.75
+        // = 5.25 → (int) 5. A non-accumulating assignment would report 2.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $httpClientMock
+            ->expects(self::exactly(2))
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['embedding' => ['values' => [0.1]]]));
+
+        $result = $subject->embeddings(['First text', 'Second text']);
+
+        self::assertSame(5, $result->usage->promptTokens);
+    }
+
+    #[Test]
+    public function embeddingsCastsStringValuesToFloat(): void
+    {
+        // Gemini can return numeric-string components; they must be cast to
+        // float so the vector is a list<float>, not a list<string>.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['embedding' => ['values' => ['0.1', '0.2', '0.3']]]));
+
+        $result = $subject->embeddings('Test text');
+
+        self::assertSame([0.1, 0.2, 0.3], $result->embeddings[0]);
+    }
+
+    #[Test]
+    public function analyzeImageSendsExactRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'desc']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+            ],
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this image']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,/9j/4AAQ']]),
+        ];
+
+        $subject->analyzeImage($content);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/models/gemini-3-flash-preview:generateContent', $capturedUri);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [[
+                'role' => 'user',
+                'parts' => [
+                    ['text' => 'Describe this image'],
+                    ['inlineData' => ['mimeType' => 'image/jpeg', 'data' => '/9j/4AAQ']],
+                ],
+            ]],
+            $body['contents'],
+        );
+        self::assertIsArray($body['generationConfig']);
+        self::assertArrayHasKey('maxOutputTokens', $body['generationConfig']);
+        self::assertSame(4096, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    #[Test]
+    public function analyzeImageRejectsInvalidModelId(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe']),
+        ];
+
+        $this->subject->analyzeImage($content, ['model' => '../../secret']);
     }
 }

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -20,9 +20,11 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -1399,5 +1401,520 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         self::assertNotEmpty($result);
         self::assertEquals('embedded-config', $result[0]->identifier);
+    }
+
+    // ==================== outgoing request capture ====================
+
+    /**
+     * Install capturing callbacks on the request/stream factory stubs so a
+     * test can assert on the exact HTTP request the generator builds
+     * (method, URI, headers, JSON body). The request stub records every
+     * withHeader() call and returns itself for chaining, mirroring the real
+     * PSR-7 immutable-with pattern closely enough for assertions.
+     *
+     * @param array<string, mixed> $capturedHeaders
+     */
+    private function captureOutgoingRequest(
+        string &$capturedMethod,
+        string &$capturedUri,
+        array &$capturedHeaders,
+        string &$capturedBody,
+    ): void {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturnCallback(
+                function (string $method, string $uri) use (&$capturedMethod, &$capturedUri, &$capturedHeaders): RequestInterface {
+                    $capturedMethod = $method;
+                    $capturedUri    = $uri;
+
+                    $uriStub = self::createStub(UriInterface::class);
+                    $uriStub->method('getHost')->willReturn((string)(parse_url($uri, PHP_URL_HOST) ?? ''));
+
+                    $request = self::createStub(RequestInterface::class);
+                    $request->method('getMethod')->willReturn($method);
+                    $request->method('getUri')->willReturn($uriStub);
+                    $request->method('withHeader')->willReturnCallback(
+                        function (string $name, mixed $value) use (&$capturedHeaders, $request): RequestInterface {
+                            $capturedHeaders[$name] = $value;
+                            return $request;
+                        },
+                    );
+                    $request->method('withBody')->willReturnCallback(fn(): RequestInterface => $request);
+
+                    return $request;
+                },
+            );
+
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturnCallback(
+                function (string $content) use (&$capturedBody): StreamInterface {
+                    $capturedBody = $content;
+                    $stream       = self::createStub(StreamInterface::class);
+                    $stream->method('getContents')->willReturn($content);
+                    return $stream;
+                },
+            );
+    }
+
+    #[Test]
+    public function generateSendsExpectedOpenAiRequest(): void
+    {
+        $provider = $this->createOpenAiProvider();
+        $models   = $this->createTestModels();
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        // Method + endpoint (endpoint helper builds it from the provider URL).
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('https://api.openai.com/chat/completions', $capturedUri);
+
+        // Headers: content type + bearer auth, no anthropic key.
+        self::assertArrayHasKey('Content-Type', $capturedHeaders);
+        $contentType = $capturedHeaders['Content-Type'];
+        self::assertIsString($contentType);
+        self::assertSame('application/json', $contentType);
+
+        self::assertArrayHasKey('Authorization', $capturedHeaders);
+        $authorization = $capturedHeaders['Authorization'];
+        self::assertIsString($authorization);
+        self::assertSame('Bearer test-key', $authorization);
+
+        self::assertArrayNotHasKey('x-api-key', $capturedHeaders);
+        self::assertArrayNotHasKey('anthropic-version', $capturedHeaders);
+
+        // Body: OpenAI chat-completions shape.
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+
+        // Selected model is the recommended, higher-context one (gpt-5.2).
+        self::assertSame('gpt-5.2', $body['model'] ?? null);
+        self::assertSame(0.7, $body['temperature'] ?? null);
+        self::assertSame(4096, $body['max_tokens'] ?? null);
+        self::assertSame(['type' => 'json_object'], $body['response_format'] ?? null);
+
+        self::assertArrayHasKey('messages', $body);
+        $messages = $body['messages'];
+        self::assertIsArray($messages);
+        self::assertCount(2, $messages);
+
+        self::assertSame('system', $messages[0]['role'] ?? null);
+        $systemContent = $messages[0]['content'] ?? null;
+        self::assertIsString($systemContent);
+        self::assertStringStartsWith('You are an expert at configuring LLM integrations.', $systemContent);
+
+        self::assertSame('user', $messages[1]['role'] ?? null);
+        self::assertSame(
+            "Available models:\n"
+            . "- GPT-5.2 (gpt-5.2): Advanced model\n"
+            . "- GPT-4o (gpt-4o): Multimodal model\n\n"
+            . 'Generate configuration presets that work well with these models.',
+            $messages[1]['content'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function generateStripsTrailingSlashFromOpenAiEndpoint(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com/',
+            suggestedName: 'OpenAI',
+        );
+        $models = $this->createTestModels();
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        // rtrim() removes exactly one trailing slash — no double slash.
+        self::assertSame('https://api.openai.com/chat/completions', $capturedUri);
+    }
+
+    #[Test]
+    public function generateSendsExpectedAnthropicRequest(): void
+    {
+        $provider = $this->createAnthropicProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'claude-opus-4-5',
+                name: 'Claude Opus 4.5',
+                description: 'Most capable',
+                capabilities: ['chat'],
+                contextLength: 200000,
+                recommended: true,
+            ),
+        ];
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('https://api.anthropic.com/messages', $capturedUri);
+
+        // Anthropic auth headers, not a bearer token.
+        self::assertArrayHasKey('x-api-key', $capturedHeaders);
+        $apiKeyHeader = $capturedHeaders['x-api-key'];
+        self::assertIsString($apiKeyHeader);
+        self::assertSame('test-key', $apiKeyHeader);
+
+        self::assertArrayHasKey('anthropic-version', $capturedHeaders);
+        $versionHeader = $capturedHeaders['anthropic-version'];
+        self::assertIsString($versionHeader);
+        self::assertSame('2023-06-01', $versionHeader);
+
+        self::assertArrayHasKey('Content-Type', $capturedHeaders);
+        $contentType = $capturedHeaders['Content-Type'];
+        self::assertIsString($contentType);
+        self::assertSame('application/json', $contentType);
+
+        self::assertArrayNotHasKey('Authorization', $capturedHeaders);
+
+        // Body: Anthropic messages shape (system top-level, no response_format).
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+        self::assertSame('claude-opus-4-5', $body['model'] ?? null);
+        self::assertSame(0.7, $body['temperature'] ?? null);
+        self::assertSame(4096, $body['max_tokens'] ?? null);
+        self::assertArrayNotHasKey('response_format', $body);
+        self::assertArrayNotHasKey('contents', $body);
+
+        $system = $body['system'] ?? null;
+        self::assertIsString($system);
+        self::assertStringStartsWith('You are an expert at configuring LLM integrations.', $system);
+
+        self::assertArrayHasKey('messages', $body);
+        $messages = $body['messages'];
+        self::assertIsArray($messages);
+        self::assertCount(1, $messages);
+        self::assertSame('user', $messages[0]['role'] ?? null);
+        self::assertSame(
+            "Available models:\n"
+            . "- Claude Opus 4.5 (claude-opus-4-5): Most capable\n\n"
+            . "Generate configuration presets that work well with these models.\n\n"
+            . 'Respond with valid JSON only.',
+            $messages[0]['content'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function generateSendsExpectedGeminiRequest(): void
+    {
+        $provider = $this->createGeminiProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'gemini-3-flash',
+                name: 'Gemini 3 Flash',
+                description: 'Fast model',
+                capabilities: ['chat'],
+                contextLength: 1000000,
+                recommended: true,
+            ),
+        ];
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame(
+            'https://generativelanguage.googleapis.com/models/gemini-3-flash:generateContent',
+            $capturedUri,
+        );
+
+        // Gemini carries the key in the URL — no auth headers are added.
+        self::assertArrayHasKey('Content-Type', $capturedHeaders);
+        $contentType = $capturedHeaders['Content-Type'];
+        self::assertIsString($contentType);
+        self::assertSame('application/json', $contentType);
+        self::assertArrayNotHasKey('Authorization', $capturedHeaders);
+        self::assertArrayNotHasKey('x-api-key', $capturedHeaders);
+
+        // Body: Gemini contents/generationConfig shape.
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+        self::assertArrayNotHasKey('model', $body);
+        self::assertArrayNotHasKey('messages', $body);
+
+        self::assertArrayHasKey('generationConfig', $body);
+        $generationConfig = $body['generationConfig'];
+        self::assertIsArray($generationConfig);
+        self::assertSame(0.7, $generationConfig['temperature'] ?? null);
+        self::assertSame(4096, $generationConfig['maxOutputTokens'] ?? null);
+        self::assertSame('application/json', $generationConfig['responseMimeType'] ?? null);
+
+        self::assertArrayHasKey('contents', $body);
+        $contents = $body['contents'];
+        self::assertIsArray($contents);
+        $text = $contents[0]['parts'][0]['text'] ?? null;
+        self::assertIsString($text);
+        self::assertStringStartsWith('You are an expert at configuring LLM integrations.', $text);
+        self::assertStringContainsString(
+            "Available models:\n- Gemini 3 Flash (gemini-3-flash): Fast model",
+            $text,
+        );
+        self::assertStringEndsWith("\n\nRespond with valid JSON only.", $text);
+    }
+
+    #[Test]
+    public function generatePromptListsAtMostFirstFiveModels(): void
+    {
+        $provider = $this->createOpenAiProvider();
+        $models   = [];
+        for ($i = 1; $i <= 6; $i++) {
+            $models[] = new DiscoveredModel(
+                modelId: 'model-' . $i,
+                name: 'Model ' . $i,
+                description: 'Description ' . $i,
+                capabilities: ['chat'],
+                contextLength: 1000 - $i, // strictly descending, first stays first
+                recommended: false,
+            );
+        }
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+        $messages = $body['messages'] ?? null;
+        self::assertIsArray($messages);
+        $userContent = $messages[1]['content'] ?? null;
+        self::assertIsString($userContent);
+
+        // First five models are listed, in order; the sixth is dropped.
+        self::assertStringContainsString('- Model 1 (model-1): Description 1', $userContent);
+        self::assertStringContainsString('- Model 5 (model-5): Description 5', $userContent);
+        self::assertStringNotContainsString('Model 6', $userContent);
+    }
+
+    #[Test]
+    public function generateSelectsHigherContextModelAmongRecommended(): void
+    {
+        $provider = $this->createOpenAiProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'small-context',
+                name: 'Small',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 100000,
+                recommended: true,
+            ),
+            new DiscoveredModel(
+                modelId: 'large-context',
+                name: 'Large',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 200000,
+                recommended: true,
+            ),
+        ];
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+        // Descending sort by context length picks the 200k model.
+        self::assertSame('large-context', $body['model'] ?? null);
+    }
+
+    #[Test]
+    public function generatePrefersRecommendedOverHigherContextNonRecommended(): void
+    {
+        $provider = $this->createOpenAiProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'huge-non-recommended',
+                name: 'Huge',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 900000,
+                recommended: false,
+            ),
+            new DiscoveredModel(
+                modelId: 'recommended-model',
+                name: 'Recommended',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 100000,
+                recommended: true,
+            ),
+        ];
+
+        $capturedMethod  = '';
+        $capturedUri     = '';
+        $capturedHeaders = [];
+        $capturedBody    = '';
+        $this->captureOutgoingRequest($capturedMethod, $capturedUri, $capturedHeaders, $capturedBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, '{}'));
+
+        $this->subject->generate($provider, 'test-key', $models);
+
+        $body = json_decode($capturedBody, true);
+        self::assertIsArray($body);
+        // The recommended filter wins even though a non-recommended model has
+        // a much larger context length.
+        self::assertSame('recommended-model', $body['model'] ?? null);
+    }
+
+    #[Test]
+    public function generateUsesAvailableModelAndParsesWhenNoneRecommended(): void
+    {
+        // With no recommended models, selectGenerationModel falls back to the
+        // full list (rather than returning null): the API call still runs and
+        // its parsed result is returned instead of the static fallback.
+        $provider = $this->createOpenAiProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'only-model',
+                name: 'Only Model',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 50000,
+                recommended: false,
+            ),
+        ];
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturn($streamStub);
+
+        $llmResponse = (string)json_encode([
+            'choices' => [
+                [
+                    'message' => [
+                        'content' => json_encode([
+                            [
+                                'identifier' => 'parsed-from-non-recommended',
+                                'name' => 'Parsed',
+                                'description' => 'Test',
+                                'systemPrompt' => 'Help.',
+                            ],
+                        ]),
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator(200, $llmResponse));
+
+        $result = $this->subject->generate($provider, 'test-key', $models);
+
+        self::assertCount(1, $result);
+        self::assertSame('parsed-from-non-recommended', $result[0]->identifier);
+        self::assertSame('only-model', $result[0]->recommendedModelId);
+    }
+
+    #[Test]
+    public function generateLogsSanitizedWarningContextOnFailure(): void
+    {
+        $provider = $this->createAnthropicProvider();
+        $models   = $this->createTestModels();
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturn($streamStub);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM setup-wizard configuration generation failed; using fallback presets',
+                self::callback(static function (mixed $context): bool {
+                    self::assertIsArray($context);
+                    self::assertArrayHasKey('provider', $context);
+                    self::assertArrayHasKey('exception', $context);
+                    self::assertSame('anthropic', $context['provider']);
+                    return true;
+                }),
+            );
+
+        $subject = new ConfigurationGenerator(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $loggerMock,
+        );
+        $subject->setHttpClient($this->httpClientStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('Network error'));
+
+        $result = $subject->generate($provider, 'test-key', $models);
+
+        self::assertNotEmpty($result);
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 }

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -1589,6 +1589,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'gpt-image-2',
+                0,
+                null,
             );
 
         $subject = $this->buildService(
@@ -1635,6 +1637,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'gpt-image-2',
+                0,
+                null,
             );
 
         $subject = $this->buildService(
@@ -1949,6 +1953,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
                 null,
                 0,
                 'gpt-image-2',
+                0,
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -952,6 +952,14 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         self::assertCount(1, $results);
         self::assertInstanceOf(ImageGenerationResult::class, $results[0]);
         self::assertEquals('dall-e-2', $results[0]->model);
+        // The response URL is mapped onto the result, and the variation
+        // metadata tag is preserved.
+        self::assertSame('https://example.com/variation.png', $results[0]->url);
+        self::assertSame('[variation of uploaded image]', $results[0]->prompt);
+        self::assertSame('1024x1024', $results[0]->size);
+        /** @var array<string, mixed> $metadata */
+        $metadata = $results[0]->metadata;
+        self::assertSame('variation', $metadata['type'] ?? null);
     }
 
     #[Test]
@@ -1068,6 +1076,13 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         self::assertInstanceOf(ImageGenerationResult::class, $result);
         self::assertEquals('Add a hat', $result->prompt);
         self::assertEquals('dall-e-2', $result->model);
+        // The first response entry's URL is mapped onto the result, and the
+        // edit metadata tag is preserved.
+        self::assertSame('https://example.com/edited.png', $result->url);
+        self::assertSame('1024x1024', $result->size);
+        /** @var array<string, mixed> $metadata */
+        $metadata = $result->metadata;
+        self::assertSame('edit', $metadata['type'] ?? null);
     }
 
     #[Test]
@@ -1193,6 +1208,8 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             self::assertStringContainsString('DALL-E API error: Invalid request', $e->getMessage());
             self::assertIsArray($e->context);
             self::assertSame('validation', $e->context['type'] ?? null);
+            // The 400 branch keeps the provider tag in the exception payload.
+            self::assertSame('dall-e', $e->context['provider'] ?? null);
         }
     }
 
@@ -1285,6 +1302,25 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         self::assertIsInt($timeout);
 
         return $timeout;
+    }
+
+    /**
+     * Extract a scalar form-field value from an encoded multipart/form-data
+     * body (the shape produced by MultipartBodyBuilderTrait): a field part is
+     * `Content-Disposition: form-data; name="<name>"\r\n\r\n<value>\r\n`.
+     * File parts carry an extra `; filename="..."` and are therefore skipped
+     * by this name-anchored pattern.
+     */
+    private function multipartFieldValue(string $body, string $name): string
+    {
+        $pattern = sprintf(
+            '/Content-Disposition: form-data; name="%s"\r\n\r\n(.*?)\r\n/s',
+            preg_quote($name, '/'),
+        );
+        self::assertMatchesRegularExpression($pattern, $body);
+        preg_match($pattern, $body, $matches);
+
+        return is_string($matches[1] ?? null) ? $matches[1] : '';
     }
 
     #[Test]
@@ -1656,5 +1692,274 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $this->expectExceptionMessageMatches('/Image file not found/');
 
         $subject->edit($imageFile, 'Add a hat', '/non/existent/mask.png');
+    }
+
+    // ==================== generateMultiple guards + request shaping ====================
+
+    #[Test]
+    public function generateMultipleDefaultsToSingleImage(): void
+    {
+        // The default count is 1: with the default model (dall-e-3) the loop
+        // runs exactly once and returns a single result.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'data' => [['url' => 'https://example.com/image.png']],
+        ]);
+
+        $results = $subject->generateMultiple('A cat');
+
+        self::assertCount(1, $results);
+    }
+
+    #[Test]
+    public function generateMultipleThrowsWhenServiceUnavailable(): void
+    {
+        // The dall-e-2 batch path is guarded by ensureAvailable() before it
+        // ever builds a request; a dall-e-2 model avoids the dall-e-3 loop's
+        // own generate() guard so this pins generateMultiple()'s own check.
+        $subject = $this->createSubjectWithoutApiKey();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/is not configured/');
+
+        $subject->generateMultiple('A cat', 2, new ImageGenerationOptions(model: 'dall-e-2', size: '512x512'));
+    }
+
+    #[Test]
+    public function generateMultipleWithDallE2ValidatesPrompt(): void
+    {
+        // The dall-e-2 batch path validates the prompt before dispatching.
+        // A successful transport is wired so that, were the validation removed,
+        // the call would return normally instead of throwing.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest(['data' => []]);
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Prompt cannot be empty');
+
+        $subject->generateMultiple('   ', 2, new ImageGenerationOptions(model: 'dall-e-2', size: '512x512'));
+    }
+
+    #[Test]
+    public function generateMultipleWithDallE2SendsClampedNAndMapsResultFields(): void
+    {
+        // The dall-e-2 batch sends a single request with n clamped to 10 and
+        // maps every response entry onto a result (URL, revised prompt, size,
+        // metadata).
+        $captured = null;
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturnCallback(
+            function (string $json) use (&$captured, $streamStub): StreamInterface {
+                $captured = $json;
+                return $streamStub;
+            },
+        );
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode([
+            'data' => array_fill(0, 10, ['url' => 'https://example.com/i.png', 'revised_prompt' => 'rev']),
+        ]));
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+        $this->httpClientStub->method('sendRequest')->willReturn($responseStub);
+
+        $options = new ImageGenerationOptions(model: 'dall-e-2', size: '512x512');
+        $results = $this->createSubject()->generateMultiple('A cat', 20, $options);
+
+        self::assertIsString($captured);
+        $payload = json_decode($captured, true);
+        self::assertIsArray($payload);
+        // Count 20 is clamped to the dall-e-2 maximum of 10 in the request body.
+        self::assertSame(10, $payload['n']);
+        self::assertSame('dall-e-2', $payload['model']);
+        self::assertSame('512x512', $payload['size']);
+
+        self::assertCount(10, $results);
+        self::assertSame('https://example.com/i.png', $results[0]->url);
+        self::assertSame('rev', $results[0]->revisedPrompt);
+        self::assertSame('A cat', $results[0]->prompt);
+        self::assertSame('512x512', $results[0]->size);
+        /** @var array<string, mixed> $metadata */
+        $metadata = $results[0]->metadata;
+        self::assertSame('standard', $metadata['quality'] ?? null);
+    }
+
+    // ==================== createVariations / edit guards + request shaping ====================
+
+    #[Test]
+    public function createVariationsThrowsWhenServiceUnavailable(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+        $imageFile = $this->createTestImageFile();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/is not configured/');
+
+        $subject->createVariations($imageFile);
+    }
+
+    #[Test]
+    public function createVariationsSendsClampedCountAndFieldsInMultipartBody(): void
+    {
+        // n is clamped to [1, 10] and shipped as a string form field alongside
+        // size and response_format.
+        $bodies = [];
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturnCallback(
+            function (string $body) use (&$bodies, $streamStub): StreamInterface {
+                $bodies[] = $body;
+                return $streamStub;
+            },
+        );
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode([
+            'data' => [['url' => 'https://example.com/v.png']],
+        ]));
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+        $this->httpClientStub->method('sendRequest')->willReturn($responseStub);
+
+        $subject = $this->createSubject();
+        $imageFile = $this->createTestImageFile();
+
+        $subject->createVariations($imageFile);       // default count -> clamped to 1
+        $subject->createVariations($imageFile, 0);    // clamped up to 1
+        $subject->createVariations($imageFile, 99);   // clamped down to 10
+
+        self::assertCount(3, $bodies);
+        self::assertSame('1', $this->multipartFieldValue($bodies[0], 'n'));
+        self::assertSame('1', $this->multipartFieldValue($bodies[1], 'n'));
+        self::assertSame('10', $this->multipartFieldValue($bodies[2], 'n'));
+        self::assertSame('1024x1024', $this->multipartFieldValue($bodies[0], 'size'));
+        self::assertSame('url', $this->multipartFieldValue($bodies[0], 'response_format'));
+    }
+
+    #[Test]
+    public function editThrowsWhenServiceUnavailable(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+        $imageFile = $this->createTestImageFile();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/is not configured/');
+
+        $subject->edit($imageFile, 'Add a hat');
+    }
+
+    #[Test]
+    public function editThrowsWhenSourceImageFileNotFound(): void
+    {
+        // The source image is validated before dispatch: a missing file yields
+        // the "not found" message, distinct from the later read failure.
+        $subject = $this->createSubject();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/Image file not found/');
+
+        $subject->edit('/non/existent/source.png', 'Add a hat');
+    }
+
+    #[Test]
+    public function editSendsPromptAndFieldsInMultipartBody(): void
+    {
+        // The prompt, size and response_format ride along as form fields.
+        $captured = null;
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturnCallback(
+            function (string $body) use (&$captured, $streamStub): StreamInterface {
+                $captured = $body;
+                return $streamStub;
+            },
+        );
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn((string)json_encode([
+            'data' => [['url' => 'https://example.com/edited.png']],
+        ]));
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+        $this->httpClientStub->method('sendRequest')->willReturn($responseStub);
+
+        $subject = $this->createSubject();
+        $imageFile = $this->createTestImageFile();
+        $subject->edit($imageFile, 'Add a red hat');
+
+        self::assertIsString($captured);
+        self::assertSame('Add a red hat', $this->multipartFieldValue($captured, 'prompt'));
+        self::assertSame('1024x1024', $this->multipartFieldValue($captured, 'size'));
+        self::assertSame('url', $this->multipartFieldValue($captured, 'response_format'));
+    }
+
+    // ==================== gpt-image usage: numeric-string token coercion ====================
+
+    #[Test]
+    public function generateWithGptImageModelCoercesNumericStringTokensToInt(): void
+    {
+        // A usage object may serialise token counts as numeric strings; the
+        // service casts them to ints so the recorded metrics stay strictly
+        // integer.
+        $this->setupSuccessfulRequest([
+            'data' => [['b64_json' => base64_encode('png-bytes')]],
+            'usage' => [
+                'input_tokens' => '50',
+                'output_tokens' => '1000',
+                'total_tokens' => '1050',
+                'input_tokens_details' => ['image_tokens' => 10],
+            ],
+        ]);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
+            ]);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'image',
+                'dall-e',
+                self::callback(
+                    static fn(array $metrics): bool => $metrics['tokens'] === 1050
+                        && $metrics['promptTokens'] === 50
+                        && $metrics['completionTokens'] === 1000,
+                ),
+                null,
+                0,
+                'gpt-image-2',
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $subject->generate('A cat', ['model' => 'gpt-image-2']);
     }
 }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -35,6 +35,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
@@ -211,6 +212,61 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
     }
 
+    /**
+     * Wire the shared factory/client stubs so the outgoing request is captured
+     * verbatim: method + URI passed to createRequest(), each withHeader() name
+     * and value, and the JSON body handed to createStream(). Callers MUST
+     * initialise the by-ref array with all four keys before invoking (see the
+     * call sites) so PHPStan sees a concrete shape and no offset is undefined.
+     *
+     * @param array{method: string, url: string, body: string, headers: array<string, string>} $captured
+     */
+    private function setupCapturingRequest(array &$captured, string $audioContent = 'audio-binary-content'): void
+    {
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnCallback(
+            static function (string $name, string $value) use (&$captured, $requestStub): RequestInterface {
+                $captured['headers'][$name] = $value;
+
+                return $requestStub;
+            },
+        );
+        $requestStub->method('withBody')->willReturnSelf();
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturnCallback(
+                static function (string $method, UriInterface|string $uri) use (&$captured, $requestStub): RequestInterface {
+                    $captured['method'] = $method;
+                    $captured['url']    = (string)$uri;
+
+                    return $requestStub;
+                },
+            );
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturnCallback(
+                static function (string $content) use (&$captured, $streamStub): StreamInterface {
+                    $captured['body'] = $content;
+
+                    return $streamStub;
+                },
+            );
+
+        $responseBodyStub = self::createStub(StreamInterface::class);
+        $responseBodyStub->method('__toString')->willReturn($audioContent);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($responseBodyStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+    }
+
     // ==================== isAvailable tests ====================
 
     #[Test]
@@ -303,6 +359,10 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubjectWithoutApiKey();
 
         $this->expectException(ServiceUnavailableException::class);
+        // ensureAvailable() fires FIRST, before any request is built — the
+        // not-configured message is distinct from the generic API-error
+        // message the send path would otherwise raise.
+        $this->expectExceptionMessage('Tts service is not configured');
 
         $subject->synthesize('Hello world');
     }
@@ -313,6 +373,9 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
 
         $this->expectException(ServiceUnavailableException::class);
+        // trim('   ') is empty, so validateInput() rejects it with this exact
+        // message — pins both the trim() unwrap and the throw itself.
+        $this->expectExceptionMessage('Input text cannot be empty');
 
         $subject->synthesize('   ');
     }
@@ -324,6 +387,9 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $longText = str_repeat('a', 4097);
 
         $this->expectException(ServiceUnavailableException::class);
+        // Over-length input is rejected by validateInput() before any request
+        // — pins the throw against the generic send-path error message.
+        $this->expectExceptionMessage('Input text exceeds maximum length');
 
         $subject->synthesize($longText);
     }
@@ -1248,5 +1314,246 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $result = $subject->synthesizeLong($text);
 
         self::assertGreaterThanOrEqual(1, count($result));
+    }
+
+    // ==================== outgoing-request payload tests ====================
+
+    #[Test]
+    public function synthesizeSendsExactPostPayloadWithDefaults(): void
+    {
+        $subject = $this->createSubject();
+
+        $captured = ['method' => '', 'url' => '', 'body' => '', 'headers' => []];
+        $this->setupCapturingRequest($captured);
+
+        $subject->synthesize('Hello world');
+
+        self::assertSame('POST', $captured['method']);
+        // Default config leaves speech.tts.baseUrl unset, so the base falls back
+        // to getDefaultBaseUrl(); buildEndpointUrl('') is that base verbatim.
+        self::assertSame('https://api.openai.com/v1/audio/speech', $captured['url']);
+        self::assertSame('application/json', $captured['headers']['Content-Type']);
+
+        $decoded = json_decode($captured['body'], true);
+        self::assertIsArray($decoded);
+        self::assertSame('tts-1', $decoded['model']);
+        self::assertSame('Hello world', $decoded['input']);
+        self::assertSame('alloy', $decoded['voice']);
+        self::assertSame('mp3', $decoded['response_format']);
+        self::assertEqualsWithDelta(1.0, $decoded['speed'], 1e-9);
+    }
+
+    #[Test]
+    public function synthesizeSendsProvidedOptionValuesInPayload(): void
+    {
+        $subject = $this->createSubject();
+
+        $captured = ['method' => '', 'url' => '', 'body' => '', 'headers' => []];
+        $this->setupCapturingRequest($captured);
+
+        $options = new SpeechSynthesisOptions(
+            model: 'tts-1-hd',
+            voice: 'nova',
+            format: 'opus',
+            speed: 1.5,
+        );
+
+        $subject->synthesize('Hello world', $options);
+
+        $decoded = json_decode($captured['body'], true);
+        self::assertIsArray($decoded);
+        self::assertSame('tts-1-hd', $decoded['model']);
+        self::assertSame('Hello world', $decoded['input']);
+        self::assertSame('nova', $decoded['voice']);
+        self::assertSame('opus', $decoded['response_format']);
+        self::assertEqualsWithDelta(1.5, $decoded['speed'], 1e-9);
+    }
+
+    #[Test]
+    public function synthesizeTargetsConfiguredCustomBaseUrl(): void
+    {
+        $subject = $this->createSubject([
+            'speech' => [
+                'tts' => [
+                    'baseUrl' => 'https://custom-api.example.com/v1/audio/speech',
+                ],
+            ],
+        ]);
+
+        $captured = ['method' => '', 'url' => '', 'body' => '', 'headers' => []];
+        $this->setupCapturingRequest($captured);
+
+        $subject->synthesize('Hello world');
+
+        // The custom base URL only reaches the request when the config is read
+        // from the speech.tts branch; a wrong service path silently falls back
+        // to the default endpoint.
+        self::assertSame('https://custom-api.example.com/v1/audio/speech', $captured['url']);
+    }
+
+    #[Test]
+    public function synthesizeCountsMultibyteCharactersByCodepoint(): void
+    {
+        $this->setupSuccessfulRequest();
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        // 3000 two-byte characters: mb_strlen 3000, strlen 6000. A byte-length
+        // count would over-report AND trip the 4096 length guard.
+        $text = str_repeat('ü', 3000);
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'speech',
+                'tts',
+                self::callback(static fn(array $metrics): bool => $metrics['characters'] === 3000),
+            );
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $usageTrackerMock,
+            $this->loggerStub,
+        );
+
+        $result = $subject->synthesize($text);
+
+        self::assertSame(3000, $result->characterCount);
+    }
+
+    #[Test]
+    public function getDefaultTimeoutReturnsSixtySeconds(): void
+    {
+        $subject = $this->createSubject();
+
+        $reflection = new ReflectionClass($subject);
+        $timeout = $reflection->getMethod('getDefaultTimeout')->invoke($subject);
+
+        self::assertSame(60, $timeout);
+    }
+
+    #[Test]
+    public function resolveDefaultModelSkipsModelIdOutsideTtsVocabulary(): void
+    {
+        // A registry record carrying the text_to_speech capability but whose
+        // model id is neither tts-*  nor *-tts must be skipped: this service
+        // cannot speak it, so resolution falls back to the given default.
+        $foreign = new Model();
+        $foreign->setModelId('dall-e-3');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')->willReturn(new InMemoryQueryResult([$foreign]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('tts-1', $subject->resolveDefaultModel('tts-1'));
+    }
+
+    #[Test]
+    public function synthesizeLongAcceptsOptionsObjectForShortText(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest();
+
+        $result = $subject->synthesizeLong('Short text', new SpeechSynthesisOptions(voice: 'nova'));
+
+        self::assertCount(1, $result);
+        // The already-normalised options object must pass through untouched;
+        // re-running fromArray() on it would be a type error.
+        self::assertSame('nova', $result[0]->voice);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksJoinsSentencesWithSingleSpace(): void
+    {
+        $subject = $this->createSubject();
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, 'Aa. Bb.');
+
+        // Two sentences that fit within the limit are re-joined with exactly one
+        // space between them — pins the concatenation order and separator.
+        self::assertSame(['Aa. Bb.'], $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksCombinesUpToTheCharacterLimit(): void
+    {
+        $subject = $this->createSubject();
+
+        // Two sentences whose combined length (2048 + 1 space + 2047) is exactly
+        // MAX_INPUT_LENGTH: with `<=` they merge into one chunk; a strict `<`
+        // would split them.
+        $first  = str_repeat('a', 2047) . '.';
+        $second = str_repeat('b', 2046) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $first . ' ' . $second);
+
+        self::assertIsArray($chunks);
+        self::assertCount(1, $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksMeasuresCombinedLengthByCodepoint(): void
+    {
+        $subject = $this->createSubject();
+
+        // Two multibyte sentences: combined codepoint length 3003 (<= limit, so
+        // one chunk), but combined byte length 6003 would exceed it. A byte-wise
+        // measure would wrongly split them.
+        $first  = str_repeat('ü', 1500) . '.';
+        $second = str_repeat('ü', 1500) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $first . ' ' . $second);
+
+        self::assertIsArray($chunks);
+        self::assertCount(1, $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksSplitsAtSentenceBoundariesNotFixedWidth(): void
+    {
+        $subject = $this->createSubject();
+
+        // Two 4001-char sentences (8003 chars total) split at the sentence
+        // boundary: the first chunk is the whole first sentence (4001 chars),
+        // not a blind 4096-char slice.
+        $first  = str_repeat('a', 4000) . '.';
+        $second = str_repeat('b', 4000) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $first . ' ' . $second);
+
+        self::assertIsArray($chunks);
+        self::assertCount(2, $chunks);
+        self::assertIsString($chunks[0]);
+        self::assertSame(4001, mb_strlen($chunks[0]));
+    }
+
+    #[Test]
+    public function splitTextIntoChunksMeasuresSentenceLengthByCodepoint(): void
+    {
+        $subject = $this->createSubject();
+
+        // A 3001-codepoint multibyte sentence (6001 bytes) is within the limit
+        // and combines with the short tail into a single chunk. A byte-wise
+        // over-limit check would hard-split it and yield two chunks.
+        $sentence = str_repeat('ü', 3000) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $sentence . ' Tail.');
+
+        self::assertIsArray($chunks);
+        self::assertCount(1, $chunks);
     }
 }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -1413,6 +1413,11 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
                 'speech',
                 'tts',
                 self::callback(static fn(array $metrics): bool => $metrics['characters'] === 3000),
+                null,
+                0,
+                'tts-1',
+                0,
+                null,
             );
 
         $subject = $this->buildService(

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -64,6 +64,22 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
     private string $lastRequestUrl = '';
 
+    /**
+     * The exact multipart/form-data body the service handed to the stream
+     * factory in the last `setupSuccessfulRequest()` flow — lets tests
+     * inspect the encoded parts (file, model, language, …) without a real
+     * HTTP request.
+     */
+    private string $lastRequestBody = '';
+
+    /**
+     * Headers set on the last request built through `setupSuccessfulRequest()`,
+     * keyed by header name (e.g. `Content-Type`).
+     *
+     * @var array<string, mixed>
+     */
+    private array $lastRequestHeaders = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -185,7 +201,13 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     private function setupSuccessfulRequest(string $responseBody): void
     {
         $requestStub = self::createStub(RequestInterface::class);
-        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withHeader')->willReturnCallback(
+            function (string $name, mixed $value) use ($requestStub): RequestInterface {
+                $this->lastRequestHeaders[$name] = $value;
+
+                return $requestStub;
+            },
+        );
         $requestStub->method('withBody')->willReturnSelf();
 
         $this->requestFactoryStub
@@ -202,7 +224,13 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $streamStub = self::createStub(StreamInterface::class);
         $this->streamFactoryStub
             ->method('createStream')
-            ->willReturn($streamStub);
+            ->willReturnCallback(
+                function (string $content = '') use ($streamStub): StreamInterface {
+                    $this->lastRequestBody = $content;
+
+                    return $streamStub;
+                },
+            );
 
         $responseBodyStub = self::createStub(StreamInterface::class);
         $responseBodyStub->method('__toString')->willReturn($responseBody);
@@ -547,7 +575,10 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubjectWithoutApiKey();
         $audioFile = $this->createTestAudioFile();
 
+        // The availability guard runs before any request work; without it the
+        // path would later surface a generic connection failure instead.
         $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Whisper service is not configured');
 
         $subject->transcribe($audioFile);
     }
@@ -732,6 +763,8 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $largeContent = str_repeat('a', 26 * 1024 * 1024); // > 25MB
 
         $this->expectException(UnsupportedFormatException::class);
+        // 25 * 1024 * 1024 / 1024 / 1024 = 25 MB in the limit message.
+        $this->expectExceptionMessage('Audio content exceeds maximum size of 25 MB');
 
         $subject->transcribeFromContent($largeContent, 'test.mp3');
     }
@@ -1158,6 +1191,13 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $result = $subject->transcribe($audioFile);
 
         self::assertInstanceOf(TranscriptionResult::class, $result);
+        // The configured `speech.whisper.baseUrl` must be the base the endpoint
+        // path is appended to (config is read at [speech][whisper], not
+        // elsewhere), so the request targets the custom host.
+        self::assertSame(
+            'https://custom-whisper.example.com/api/transcriptions',
+            $this->lastRequestUrl,
+        );
     }
 
     #[Test]
@@ -1175,5 +1215,273 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         self::assertEquals('Text without language', $result->text);
         // Should default to 'en'
         self::assertEquals('en', $result->language);
+    }
+
+    // ==================== outgoing request shape tests ====================
+
+    #[Test]
+    public function transcribePostsMultipartRequestToTranscriptionsEndpoint(): void
+    {
+        // Default createSubject() carries no baseUrl override, so the OpenAI
+        // default base (proven by emptyStringBaseUrlFallsBackToApiUrl) applies
+        // and the transcription endpoint is appended to it.
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $subject->transcribe($audioFile);
+
+        self::assertSame('POST', $this->lastRequestMethod);
+        self::assertSame('https://api.openai.com/v1/audio/transcriptions', $this->lastRequestUrl);
+
+        // The Content-Type carries the multipart boundary, prefixed `whisper-`.
+        self::assertArrayHasKey('Content-Type', $this->lastRequestHeaders);
+        $contentType = $this->lastRequestHeaders['Content-Type'];
+        self::assertIsString($contentType);
+        self::assertStringStartsWith('multipart/form-data; boundary=whisper-', $contentType);
+
+        // The boundary is `whisper-` concatenated with a uniqid() suffix; the
+        // body's first boundary line therefore has hex/dot chars after the
+        // prefix (rules out a bare, dropped, or reordered concatenation).
+        self::assertStringContainsString('--whisper-', $this->lastRequestBody);
+        self::assertMatchesRegularExpression('#^--whisper-[0-9a-f.]+\r\n#', $this->lastRequestBody);
+
+        // File part first, then the mandatory model field — both must survive.
+        self::assertStringContainsString(
+            'Content-Disposition: form-data; name="file"; filename="',
+            $this->lastRequestBody,
+        );
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-1\r\n",
+            $this->lastRequestBody,
+        );
+    }
+
+    #[Test]
+    public function transcribeSendsConfiguredModelValueInBody(): void
+    {
+        // The model field value is `$options->model ?? DEFAULT` — a caller model
+        // distinct from the `whisper-1` default proves the coalesce direction.
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $subject->transcribe($audioFile, new TranscriptionOptions(model: 'gpt-4o-transcribe'));
+
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"model\"\r\n\r\ngpt-4o-transcribe\r\n",
+            $this->lastRequestBody,
+        );
+    }
+
+    #[Test]
+    public function transcribeEncodesOptionalFieldPartsWithNamesAndValues(): void
+    {
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Bonjour']));
+
+        $options = new TranscriptionOptions(
+            language: 'fr',
+            format: 'json',
+            prompt: 'Tech talk',
+            temperature: 0.5,
+        );
+
+        $subject->transcribe($audioFile, $options);
+
+        // Each optional field is added only when set, keyed by its API name and
+        // carrying its exact value (temperature is string-cast).
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"language\"\r\n\r\nfr\r\n",
+            $this->lastRequestBody,
+        );
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"response_format\"\r\n\r\njson\r\n",
+            $this->lastRequestBody,
+        );
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"prompt\"\r\n\r\nTech talk\r\n",
+            $this->lastRequestBody,
+        );
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"temperature\"\r\n\r\n0.5\r\n",
+            $this->lastRequestBody,
+        );
+    }
+
+    #[Test]
+    public function transcribeOmitsOptionalFieldPartsWhenUnset(): void
+    {
+        // With language/prompt/temperature unset (and format explicitly null so
+        // no response_format part is emitted), only the file and model parts
+        // remain — the `!== null` guards must skip the absent fields.
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $subject->transcribe($audioFile, new TranscriptionOptions(format: null));
+
+        self::assertStringNotContainsString('name="language"', $this->lastRequestBody);
+        self::assertStringNotContainsString('name="response_format"', $this->lastRequestBody);
+        self::assertStringNotContainsString('name="prompt"', $this->lastRequestBody);
+        self::assertStringNotContainsString('name="temperature"', $this->lastRequestBody);
+    }
+
+    #[Test]
+    public function transcribeFromContentEncodesFilePartWithFilenameAndContent(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $subject->transcribeFromContent('fake audio content', 'test.mp3');
+
+        self::assertStringContainsString(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"test.mp3\"\r\n"
+            . "Content-Type: application/octet-stream\r\n\r\n"
+            . "fake audio content\r\n",
+            $this->lastRequestBody,
+        );
+    }
+
+    #[Test]
+    public function translateToEnglishPostsToTranslationsEndpoint(): void
+    {
+        // Translation dispatches to the `translations` endpoint, distinct from
+        // transcription's `transcriptions`.
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $subject->translateToEnglish($audioFile);
+
+        self::assertSame('POST', $this->lastRequestMethod);
+        self::assertSame('https://api.openai.com/v1/audio/translations', $this->lastRequestUrl);
+    }
+
+    #[Test]
+    public function transcribeFromContentThrowsWhenServiceUnavailable(): void
+    {
+        // The availability guard runs before any content work; without it the
+        // path would later surface a generic connection failure instead.
+        $subject = $this->createSubjectWithoutApiKey();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Whisper service is not configured');
+
+        $subject->transcribeFromContent('fake audio content', 'test.mp3');
+    }
+
+    #[Test]
+    public function translateToEnglishThrowsWhenServiceUnavailable(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+        $audioFile = $this->createTestAudioFile();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Whisper service is not configured');
+
+        $subject->translateToEnglish($audioFile);
+    }
+
+    #[Test]
+    public function translateToEnglishValidatesAudioFileBeforeSending(): void
+    {
+        // The file validation runs before the request; a missing file must
+        // raise the format exception rather than a downstream read failure.
+        $subject = $this->createSubject();
+
+        $this->expectException(UnsupportedFormatException::class);
+
+        $subject->translateToEnglish('/non/existent/file.mp3');
+    }
+
+    #[Test]
+    public function transcribeThrowsWhenFileExceedsMaxSize(): void
+    {
+        // A file larger than the limit must be rejected by the size guard; the
+        // check is an OR of the read-failure and over-size conditions.
+        $subject = $this->createSubject();
+        $largeFile = tempnam(sys_get_temp_dir(), 'whisper_big_') . '.mp3';
+        file_put_contents($largeFile, str_repeat('a', 26 * 1024 * 1024)); // > 25MB
+        $this->tempFile = $largeFile;
+
+        $this->expectException(UnsupportedFormatException::class);
+        $this->expectExceptionMessage('Audio file exceeds maximum size of 25 MB');
+
+        $subject->transcribe($largeFile);
+    }
+
+    #[Test]
+    public function transcribeFromContentAcceptsUppercaseExtension(): void
+    {
+        // The extension is lower-cased before the supported-format check, so an
+        // uppercase `.MP3` filename is accepted like its lowercase form.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $result = $subject->transcribeFromContent('fake audio content', 'test.MP3');
+
+        self::assertInstanceOf(TranscriptionResult::class, $result);
+    }
+
+    #[Test]
+    public function transcribeAcceptsUppercaseFileExtension(): void
+    {
+        $subject = $this->createSubject();
+        $uppercaseFile = tempnam(sys_get_temp_dir(), 'whisper_upper_') . '.MP3';
+        file_put_contents($uppercaseFile, 'fake audio content');
+        $this->tempFile = $uppercaseFile;
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $result = $subject->transcribe($uppercaseFile);
+
+        self::assertInstanceOf(TranscriptionResult::class, $result);
+    }
+
+    #[Test]
+    public function resolveDefaultModelSkipsModelIdsThisServiceCannotSpeak(): void
+    {
+        // The registry query is provider-agnostic; a record whose model id is
+        // neither `whisper-*` nor `*-transcribe` must be skipped, so resolution
+        // falls back rather than returning that foreign id.
+        $foreign = new Model();
+        $foreign->setModelId('some-other-model');
+
+        $modelRepository = $this->createMock(ModelRepository::class);
+        $modelRepository->method('findByCapability')
+            ->willReturn(new InMemoryQueryResult([$foreign]));
+
+        $subject = $this->createSubject(modelRepository: $modelRepository);
+
+        self::assertSame('whisper-1', $subject->resolveDefaultModel('whisper-1'));
+    }
+
+    #[Test]
+    public function transcribeWithVerboseJsonExposesEveryParsedResponseField(): void
+    {
+        $subject = $this->createSubject();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode([
+            'text' => 'Hello world',
+            'language' => 'de',
+            'duration' => 5.5,
+            'task' => 'transcribe',
+            'segments' => [
+                ['id' => 0, 'text' => 'Hello', 'start' => 0.0, 'end' => 2.5],
+                ['id' => 1, 'text' => 'world', 'start' => 2.5, 'end' => 5.5],
+            ],
+        ]));
+
+        $result = $subject->transcribe($audioFile, new TranscriptionOptions(format: 'verbose_json'));
+
+        self::assertSame('Hello world', $result->text);
+        self::assertSame('de', $result->language);
+        self::assertSame(5.5, $result->duration);
+        self::assertNotNull($result->segments);
+        self::assertCount(2, $result->segments);
+        self::assertNotNull($result->metadata);
+        self::assertSame('verbose_json', $result->metadata['format'] ?? null);
+        self::assertSame('transcribe', $result->metadata['task'] ?? null);
     }
 }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -25,7 +25,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use ReflectionClass;
 
 #[CoversClass(DeepLTranslator::class)]
@@ -106,6 +110,97 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $translator->setHttpClient($httpClient);
 
         return $translator;
+    }
+
+    /**
+     * Build a DeepLTranslator whose request factory records the outgoing
+     * method, URI, and (POST) JSON body into $captured so a test can assert the
+     * exact request DeepLTranslator constructs. Uses the default config
+     * (non-`:fx` vault secret → Pro host) unless a config override is supplied.
+     *
+     * @param array<string, mixed>      $captured Populated in place; initialize to [] at the call site.
+     * @param array<string, mixed>|null $config
+     */
+    private function createCapturingSubject(
+        ResponseInterface $response,
+        array &$captured,
+        ?array $config = null,
+    ): DeepLTranslator {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($response);
+
+        $translator = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createCapturingRequestFactory($captured),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($config ?? $this->defaultConfig),
+            $this->usageTrackerStub,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+        $translator->setHttpClient($httpClientStub);
+
+        return $translator;
+    }
+
+    /**
+     * A request factory that mirrors the base createRequestFactoryMock() but
+     * records the method/URI it is asked to build and the body streamed onto
+     * the request. This is the seam the exact-transformation assertions read.
+     *
+     * @param array<string, mixed> $captured Populated in place; initialize to [] at the call site.
+     */
+    private function createCapturingRequestFactory(array &$captured): RequestFactoryInterface
+    {
+        $stub = self::createStub(RequestFactoryInterface::class);
+        $stub->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$captured): RequestInterface {
+                $captured['method'] = $method;
+                $captured['uri'] = $uri;
+
+                $uriStub = self::createStub(UriInterface::class);
+                $uriStub->method('__toString')->willReturn($uri);
+                $uriStub->method('getHost')->willReturn(parse_url($uri, PHP_URL_HOST) ?? '');
+                $uriStub->method('getPath')->willReturn(parse_url($uri, PHP_URL_PATH) ?? '');
+
+                $request = self::createStub(RequestInterface::class);
+                $request->method('withHeader')->willReturnCallback(fn() => $request);
+                $request->method('withoutHeader')->willReturnCallback(fn() => $request);
+                $request->method('withBody')->willReturnCallback(
+                    function (StreamInterface $body) use (&$captured, &$request): RequestInterface {
+                        $captured['body'] = (string)$body;
+
+                        return $request;
+                    },
+                );
+                $request->method('getMethod')->willReturn($method);
+                $request->method('getUri')->willReturn($uriStub);
+
+                return $request;
+            },
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Decode the captured JSON request body into an associative array.
+     *
+     * @param array<string, mixed> $captured
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedBody(array $captured): array
+    {
+        self::assertArrayHasKey('body', $captured);
+        $body = $captured['body'];
+        self::assertIsString($body);
+
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     #[Test]
@@ -529,6 +624,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             'english does not' => ['en', false],
             'chinese does not' => ['zh', false],
             'portuguese-br supports' => ['pt-br', true],
+            // Base lang 'fr' is formality-supported though 'fr-ca' is not listed:
+            // the `||` on base OR full code must hold (an `&&` mutant would fail).
+            'french-ca supports via base' => ['fr-ca', true],
         ];
     }
 
@@ -653,5 +751,479 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $result = $subject->translate('Hello', 'de');
 
         self::assertEquals(0.95, $result->confidence);
+    }
+
+    #[Test]
+    public function translatePostsExactPayloadToProV2TranslateEndpoint(): void
+    {
+        $captured = [];
+        $subject = $this->createCapturingSubject(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'Hallo Welt', 'detected_source_language' => 'DE']],
+            ]),
+            $captured,
+        );
+
+        $subject->translate('Hello World', 'de');
+
+        self::assertSame('POST', $captured['method'] ?? null);
+        self::assertSame('https://api.deepl.com/v2/translate', $captured['uri'] ?? null);
+        self::assertSame(
+            ['text' => ['Hello World'], 'target_lang' => 'DE'],
+            $this->decodeCapturedBody($captured),
+        );
+    }
+
+    #[Test]
+    public function translateNormalizesChineseTargetToZhHans(): void
+    {
+        $captured = [];
+        $subject = $this->createCapturingSubject(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'x', 'detected_source_language' => 'EN']],
+            ]),
+            $captured,
+        );
+
+        $result = $subject->translate('Hello', 'zh');
+
+        $body = $this->decodeCapturedBody($captured);
+        self::assertSame('ZH-HANS', $body['target_lang'] ?? null);
+        self::assertSame('zh-hans', $result->targetLanguage);
+    }
+
+    #[Test]
+    public function translateNormalizesChineseSourceToZh(): void
+    {
+        $captured = [];
+        $subject = $this->createCapturingSubject(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'x', 'detected_source_language' => 'EN']],
+            ]),
+            $captured,
+        );
+
+        $subject->translate('Hello', 'de', 'zh');
+
+        $body = $this->decodeCapturedBody($captured);
+        self::assertSame('ZH', $body['source_lang'] ?? null);
+    }
+
+    #[Test]
+    public function translateFallsBackToProvidedSourceWhenNotDetected(): void
+    {
+        // Response omits detected_source_language → the provided (normalized)
+        // source language wins over the 'en' literal fallback.
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock(['translations' => [['text' => 'Hallo']]]),
+        );
+
+        $result = $subject->translate('Hello', 'de', 'fr');
+
+        self::assertSame('fr', $result->sourceLanguage);
+    }
+
+    #[Test]
+    public function translatePrefersDetectedSourceOverProvided(): void
+    {
+        // detected_source_language must win over the provided source language.
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'Hallo', 'detected_source_language' => 'ES']],
+            ]),
+        );
+
+        $result = $subject->translate('Hello', 'de', 'fr');
+
+        self::assertSame('es', $result->sourceLanguage);
+    }
+
+    #[Test]
+    public function translateTracksMultibyteCharacterCount(): void
+    {
+        // Multibyte text: mb_strlen (character count) differs from strlen (bytes).
+        $text = 'Héllo Wörld';
+
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock([
+                'translations' => [['text' => 'x', 'detected_source_language' => 'EN']],
+            ]));
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                'deepl',
+                self::callback(fn(array $data) => $data['characters'] === mb_strlen($text)),
+                null,
+                0,
+                '',
+                0,
+                null,
+            );
+
+        $subject = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($this->defaultConfig),
+            $usageTrackerMock,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+        $subject->setHttpClient($httpClientStub);
+
+        $subject->translate($text, 'de');
+    }
+
+    #[Test]
+    public function translateEmptyResponseExceptionCarriesProviderContext(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock(['translations' => []]),
+        );
+
+        try {
+            $subject->translate('Hello', 'de');
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame(['provider' => 'deepl'], $e->context);
+        }
+    }
+
+    #[Test]
+    public function translateThrowsWhenUnavailableEvenWithSuccessfulResponse(): void
+    {
+        // A valid response is wired so the availability guard is the ONLY reason
+        // to throw: if the guard were skipped the call would succeed instead.
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'translations' => [['text' => 'x', 'detected_source_language' => 'EN']],
+        ]));
+        $translator = $this->buildTranslator(
+            $httpClientStub,
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]],
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $translator->translate('Hello', 'de');
+    }
+
+    #[Test]
+    public function translateBatchThrowsWhenUnavailableEvenWithSuccessfulResponse(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'translations' => [['text' => 'x', 'detected_source_language' => 'EN']],
+        ]));
+        $translator = $this->buildTranslator(
+            $httpClientStub,
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]],
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $translator->translateBatch(['Hello'], 'de');
+    }
+
+    #[Test]
+    public function translateBatchDoesNotCallHttpForEmptyInput(): void
+    {
+        $httpClientMock = $this->createMock(ClientInterface::class);
+        $httpClientMock->expects(self::never())->method('sendRequest');
+
+        $translator = $this->buildTranslator($httpClientMock, $this->defaultConfig);
+
+        $results = $translator->translateBatch([], 'de');
+
+        self::assertSame([], $results);
+    }
+
+    #[Test]
+    public function translateBatchBuildsPayloadWithNormalizedCodes(): void
+    {
+        $captured = [];
+        $subject = $this->createCapturingSubject(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'a', 'detected_source_language' => 'EN']],
+            ]),
+            $captured,
+        );
+
+        $subject->translateBatch(['Hello', 'World'], 'zh', 'zh');
+
+        self::assertSame('POST', $captured['method'] ?? null);
+        self::assertSame('https://api.deepl.com/v2/translate', $captured['uri'] ?? null);
+        self::assertSame(
+            ['text' => ['Hello', 'World'], 'target_lang' => 'ZH-HANS', 'source_lang' => 'ZH'],
+            $this->decodeCapturedBody($captured),
+        );
+    }
+
+    #[Test]
+    public function translateBatchResultUsesLowercaseTargetAndMetadata(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'Ni hao', 'detected_source_language' => 'EN']],
+            ]),
+        );
+
+        $results = $subject->translateBatch(['Hello'], 'zh');
+
+        self::assertSame('zh-hans', $results[0]->targetLanguage);
+        self::assertSame('en', $results[0]->sourceLanguage);
+        self::assertNotNull($results[0]->metadata);
+        self::assertArrayHasKey('detected_source_language', $results[0]->metadata);
+    }
+
+    #[Test]
+    public function translateBatchFallsBackToProvidedSourceWhenNotDetected(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock(['translations' => [['text' => 'Hallo']]]),
+        );
+
+        $results = $subject->translateBatch(['Hello'], 'de', 'fr');
+
+        self::assertSame('fr', $results[0]->sourceLanguage);
+    }
+
+    #[Test]
+    public function translateBatchPrefersDetectedSourceOverProvided(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'Hallo', 'detected_source_language' => 'ES']],
+            ]),
+        );
+
+        $results = $subject->translateBatch(['Hello'], 'de', 'fr');
+
+        self::assertSame('es', $results[0]->sourceLanguage);
+    }
+
+    #[Test]
+    public function translateBatchTracksMultibyteTotalCharacters(): void
+    {
+        $texts = ['Héllo', 'Wörld'];
+        $expectedCharacters = array_sum(array_map(mb_strlen(...), $texts));
+
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock([
+                'translations' => [
+                    ['text' => 'a', 'detected_source_language' => 'EN'],
+                    ['text' => 'b', 'detected_source_language' => 'EN'],
+                ],
+            ]));
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                'deepl',
+                self::callback(
+                    fn(array $data) => $data['characters'] === $expectedCharacters && $data['batch_size'] === 2,
+                ),
+                null,
+                0,
+                '',
+                0,
+                null,
+            );
+
+        $subject = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($this->defaultConfig),
+            $usageTrackerMock,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+        );
+        $subject->setHttpClient($httpClientStub);
+
+        $subject->translateBatch($texts, 'de');
+    }
+
+    #[Test]
+    public function getSupportedLanguagesStripsRegionalTargetVariants(): void
+    {
+        $languages = $this->subject->getSupportedLanguages();
+
+        // Target codes are base-stripped (en-gb → en), so no regional variant leaks through.
+        self::assertNotContains('en-gb', $languages);
+        self::assertNotContains('pt-br', $languages);
+        self::assertNotContains('zh-hans', $languages);
+    }
+
+    #[Test]
+    public function detectLanguageSendsTruncatedTextPayload(): void
+    {
+        // 150 distinct-position chars so every substr offset/length mutant differs.
+        $text = str_repeat('0123456789', 15);
+
+        $captured = [];
+        $subject = $this->createCapturingSubject(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'x', 'detected_source_language' => 'DE']],
+            ]),
+            $captured,
+        );
+
+        $subject->detectLanguage($text);
+
+        self::assertSame('POST', $captured['method'] ?? null);
+        self::assertSame('https://api.deepl.com/v2/translate', $captured['uri'] ?? null);
+        self::assertSame(
+            ['text' => [substr($text, 0, 100)], 'target_lang' => 'EN'],
+            $this->decodeCapturedBody($captured),
+        );
+    }
+
+    #[Test]
+    public function detectLanguageReturnsEnForEmptyTranslations(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock(['translations' => []]),
+        );
+
+        self::assertSame('en', $subject->detectLanguage('anything'));
+    }
+
+    #[Test]
+    public function detectLanguageThrowsWhenUnavailableEvenWithSuccessfulResponse(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'translations' => [['text' => 'x', 'detected_source_language' => 'DE']],
+        ]));
+        $translator = $this->buildTranslator(
+            $httpClientStub,
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]],
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $translator->detectLanguage('Hello');
+    }
+
+    #[Test]
+    public function getUsageThrowsWhenUnavailableEvenWithSuccessfulResponse(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'character_count' => 1,
+            'character_limit' => 2,
+        ]));
+        $translator = $this->buildTranslator(
+            $httpClientStub,
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]],
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $translator->getUsage();
+    }
+
+    #[Test]
+    public function getUsageReturnsZeroForNonIntegerValues(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'character_count' => 'not-an-int',
+                'character_limit' => 'also-not',
+            ]),
+        );
+
+        $usage = $subject->getUsage();
+
+        self::assertSame(0, $usage['character_count']);
+        self::assertSame(0, $usage['character_limit']);
+    }
+
+    #[Test]
+    public function getGlossariesThrowsWhenUnavailableEvenWithSuccessfulResponse(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'glossaries' => [],
+        ]));
+        $translator = $this->buildTranslator(
+            $httpClientStub,
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => '']]],
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $translator->getGlossaries();
+    }
+
+    #[Test]
+    public function getGlossariesReturnsAllGlossaries(): void
+    {
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'glossaries' => [
+                    ['glossary_id' => 'gls_1', 'name' => 'A', 'source_lang' => 'en', 'target_lang' => 'de'],
+                    ['glossary_id' => 'gls_2', 'name' => 'B', 'source_lang' => 'de', 'target_lang' => 'en'],
+                ],
+            ]),
+        );
+
+        $glossaries = $subject->getGlossaries();
+
+        self::assertCount(2, $glossaries);
+        self::assertSame('gls_1', $glossaries[0]['glossary_id']);
+        self::assertSame('gls_2', $glossaries[1]['glossary_id']);
+    }
+
+    #[Test]
+    public function defaultTimeoutIsThirtySecondsWhenConfigOmitsIt(): void
+    {
+        $translator = $this->buildTranslator(
+            $this->createHttpClientMock(),
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => $this->apiKeyIdentifier]]],
+        );
+
+        $timeout = (new ReflectionClass($translator))->getProperty('timeout')->getValue($translator);
+
+        self::assertSame(30, $timeout);
+    }
+
+    #[Test]
+    public function configuredTimeoutIsCastToInteger(): void
+    {
+        $translator = $this->buildTranslator(
+            $this->createHttpClientMock(),
+            ['translators' => ['deepl' => ['apiKeyIdentifier' => $this->apiKeyIdentifier, 'timeout' => '45']]],
+        );
+
+        $timeout = (new ReflectionClass($translator))->getProperty('timeout')->getValue($translator);
+
+        self::assertSame(45, $timeout);
+    }
+
+    #[Test]
+    public function nonArrayDeeplConfigIsIgnored(): void
+    {
+        // translators is an array but its deepl entry is not: the service must
+        // treat the config as absent (empty api key → unavailable), not read
+        // into the scalar.
+        $translator = $this->buildTranslator(
+            $this->createHttpClientMock(),
+            ['translators' => ['deepl' => 123]],
+        );
+
+        self::assertFalse($translator->isAvailable());
     }
 }


### PR DESCRIPTION
Second batch of the mutation-MSI climb (batch 1 was #393: 62.8% → 67%).

Strengthens the next hotspot tier by asserting the exact request/response
transformation instead of just the happy path:

- **GeminiProvider** — redone correctly after batch 1's revert: the test builds
  the provider with an empty base URL, so the assertions pin the **relative**
  request URIs the test actually produces (derived from `AbstractProvider::
  sendRequest`), not the production constant.
- **ConfigurationGenerator** — per-provider endpoint construction, auth headers,
  request bodies, prompt assembly, model selection.
- **DeepLTranslator**, **TextToSpeechService**, **DallEImageService**,
  **WhisperTranscriptionService** — request payloads (text/voice/size/format,
  language codes) and response parsing.

## MSI

Measured independently off the pre-batch-1 baseline, batch 2 killed **+325**
mutants (62.8% → 66% on that branch). Batches 1 and 2 target **disjoint** files,
so combined on main the covered MSI is ~70% (the exact combined figure is being
confirmed by a mutation run on the rebased branch). The remaining escaped
mutants left unkilled are documented as equivalent (identical-outcome return
removals, no-op `array_values`, out-of-range numerics clamped to the same value).

## Verification

Full unit suite green on both batches (bulk-verified — no "argued" kills trusted),
cgl + PHPStan L10 clean. Batch 2 passed bulk-verification on the first attempt.
