### PR TITLE
test: strengthen assertions to raise mutation MSI, batch 3 (~73% combined)

### DIFF
--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\MistralProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -20,7 +21,10 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(MistralProvider::class)]
@@ -776,5 +780,588 @@ class MistralProviderTest extends AbstractUnitTestCase
         $this->expectException(ProviderResponseException::class);
 
         $this->subject->testConnection();
+    }
+
+    // ==================== Request-shape (payload / URL) assertions ====================
+
+    /**
+     * Build a MistralProvider whose request/stream factories capture the
+     * outgoing HTTP method, URL and JSON body so a test can assert the exact
+     * transformation the provider performs.
+     *
+     * The captured variables MUST be initialised (to null) at the call site.
+     *
+     * @param string|null $capturedMethod receives the last createRequest() method
+     * @param string|null $capturedUrl    receives the last createRequest() URL
+     * @param string|null $capturedBody   receives the last createStream() JSON body
+     *
+     * @return array{subject: MistralProvider, httpClient: ClientInterface&MockObject}
+     */
+    private function createCapturingSubject(
+        ?string &$capturedMethod,
+        ?string &$capturedUrl,
+        ?string &$capturedBody,
+        string $baseUrl = '',
+    ): array {
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$capturedMethod, &$capturedUrl): RequestInterface {
+                $capturedMethod = $method;
+                $capturedUrl    = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            },
+        );
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+
+        $subject = new MistralProvider(
+            $requestFactory,
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'baseUrl' => $baseUrl,
+            'timeout' => 30,
+        ]);
+
+        $subject->setHttpClient($httpClientMock);
+
+        return ['subject' => $subject, 'httpClient' => $httpClientMock];
+    }
+
+    /**
+     * Decode a captured JSON request body into an associative array.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedBody(?string $body): array
+    {
+        self::assertIsString($body, 'expected a JSON request body to have been captured');
+
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    #[Test]
+    public function chatCompletionSendsExpectedRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $apiResponse = [
+            'model' => 'mistral-large-latest',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'Ping']]);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        // ArrayItemRemoval on 'model' / ArrayItem `=>`→`>` on temperature+max_tokens.
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('mistral-large-latest', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Ping']], $body['messages']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+    }
+
+    #[Test]
+    public function chatCompletionSendsOverriddenOptionValues(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $apiResponse = [
+            'model' => 'mistral-small-latest',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Ping']],
+            ['model' => 'mistral-small-latest', 'temperature' => 0.25, 'max_tokens' => 128],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertSame('mistral-small-latest', $body['model']);
+        self::assertSame(0.25, $body['temperature']);
+        self::assertSame(128, $body['max_tokens']);
+    }
+
+    #[Test]
+    public function chatCompletionMapsStopSequencesToStop(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $apiResponse = [
+            'model' => 'mistral-large-latest',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Ping']],
+            ['stop_sequences' => ['STOP1', 'STOP2']],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        // A non-empty stop_sequences array is copied verbatim to the `stop` key.
+        self::assertArrayHasKey('stop', $body);
+        self::assertSame(['STOP1', 'STOP2'], $body['stop']);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsStopForEmptyStopSequences(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $apiResponse = [
+            'model' => 'mistral-large-latest',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        // An empty stop_sequences array must NOT produce a `stop` key: this pins
+        // the `&& $stopSequences !== []` guard against the `||` mutant, which
+        // would emit `stop => []`.
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Ping']],
+            ['stop_sequences' => []],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayNotHasKey('stop', $body);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsExpectedRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $spec = ToolSpec::fromArray([
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_weather',
+                'description' => 'Get current weather',
+                'parameters' => ['type' => 'object', 'properties' => []],
+            ],
+        ]);
+
+        $apiResponse = [
+            'model' => 'mistral-large-latest',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'Ping']], [$spec]);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('mistral-large-latest', $body['model']);
+        // Normalise the expected through the same JSON round-trip the body went
+        // through (decodeCapturedBody uses assoc=true), so an empty `properties`
+        // object ({}) compares equal on both sides rather than stdClass vs [].
+        self::assertSame(json_decode((string)json_encode([$spec->toArray()]), true), $body['tools']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+    }
+
+    #[Test]
+    public function embeddingsSendsExpectedRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $apiResponse = [
+            'model' => 'mistral-embed',
+            'data' => [['index' => 0, 'object' => 'embedding', 'embedding' => [0.1, 0.2]]],
+            'usage' => ['prompt_tokens' => 5, 'total_tokens' => 5],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $subject->embeddings('Test text');
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/embeddings', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        // A scalar input is wrapped into a single-element list (`[$input]`), not
+        // dropped (`[]`) nor left bare (ternary swap).
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('mistral-embed', $body['model']);
+        self::assertSame(['Test text'], $body['input']);
+    }
+
+    #[Test]
+    public function embeddingsParsesIntegerVectorsAsFloatsWithZeroCompletionTokens(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        // Integer vector components force the `array_map(asFloat)` cast to be
+        // observable: without it the values stay ints and assertSame() fails.
+        $apiResponse = [
+            'model' => 'mistral-embed',
+            'data' => [['index' => 0, 'object' => 'embedding', 'embedding' => [1, 2, 3]]],
+            'usage' => ['prompt_tokens' => 7, 'total_tokens' => 7],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $subject->embeddings('Test text');
+
+        self::assertSame([1.0, 2.0, 3.0], $result->embeddings[0]);
+        // completionTokens is hardcoded to 0 for embeddings.
+        self::assertSame(0, $result->usage->completionTokens);
+        self::assertSame(7, $result->usage->promptTokens);
+    }
+
+    // ==================== Streaming request-shape assertions ====================
+
+    /**
+     * Build a stream response stub that emits the given SSE payload as a
+     * single read.
+     */
+    private function createStreamResponseStub(string $streamContent, int $statusCode = 200): ResponseInterface
+    {
+        $streamStub = self::createStub(StreamInterface::class);
+        $streamStub->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $streamStub->method('read')->willReturn($streamContent);
+        $streamStub->method('__toString')->willReturn($streamContent);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn($statusCode);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        return $responseStub;
+    }
+
+    #[Test]
+    public function streamChatCompletionSendsExpectedRequestAndUrl(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        // Trailing slash on the base URL makes the rtrim() observable: without
+        // it the URL would contain a double slash.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+            'https://api.mistral.ai/v1/',
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+                . "data: [DONE]\n",
+            ));
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Hi'], $chunks);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('https://api.mistral.ai/v1/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('mistral-large-latest', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Test']], $body['messages']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+        self::assertArrayHasKey('stream', $body);
+        self::assertTrue($body['stream']);
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+            'https://api.mistral.ai/v1',
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+                . "data: [DONE]\n",
+            ));
+
+        // An invalid UTF-8 byte must be substituted (JSON_INVALID_UTF8_SUBSTITUTE),
+        // never abort the encode: the `|` flag combination is what enables this,
+        // so the `&` mutant makes json_encode() return false and breaks the call.
+        $chunks = iterator_to_array($subject->streamChatCompletion(
+            [['role' => 'user', 'content' => "Bad \xB1 byte"]],
+        ));
+
+        self::assertSame(['Hi'], $chunks);
+
+        self::assertIsString($capturedBody);
+        // json_encode() (no JSON_UNESCAPED_UNICODE) escapes U+FFFD as the
+        // literal six-character ASCII sequence backslash-u-f-f-f-d.
+        self::assertStringContainsString('\ufffd', $capturedBody);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeStreaming(): void
+    {
+        $subject = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        // Empty API key identifier: validateConfiguration() must throw before
+        // any request is built.
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'mistral-large-latest',
+            'baseUrl' => 'https://api.mistral.ai/v1',
+            'timeout' => 30,
+        ]);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->method('sendRequest')->willReturn($this->createStreamResponseStub(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+            . "data: [DONE]\n",
+        ));
+        $subject->setHttpClient($httpClientMock);
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnHttpErrorStatus(): void
+    {
+        $subject = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'baseUrl' => 'https://api.mistral.ai/v1',
+            'timeout' => 30,
+        ]);
+
+        // A 4xx streaming response must surface a typed exception: this pins the
+        // assertStreamingResponseOk() call against its MethodCallRemoval mutant.
+        $errorStream = self::createStub(StreamInterface::class);
+        $errorStream->method('eof')->willReturn(true);
+        $errorStream->method('read')->willReturn('');
+        $errorStream->method('__toString')->willReturn('{"error":{"message":"Unauthorized"}}');
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(401);
+        $responseStub->method('getBody')->willReturn($errorStream);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $this->expectException(ProviderResponseException::class);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+    }
+
+    #[Test]
+    public function streamChatCompletionAccumulatesBufferAcrossReads(): void
+    {
+        $subject = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'baseUrl' => 'https://api.mistral.ai/v1',
+            'timeout' => 30,
+        ]);
+
+        // A single SSE line split across two reads: the first chunk carries no
+        // newline, so it is only usable once appended to the second chunk. This
+        // pins `$buffer .= $chunk` against the `$buffer = $chunk` mutant, which
+        // would discard the first chunk and yield nothing.
+        $chunk1 = 'data: {"choices":[{"delta":{"content":"Hello"';
+        $chunk2 = "}}]}\n\ndata: [DONE]\n";
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $streamStub->method('eof')->willReturnOnConsecutiveCalls(false, false, true);
+        $streamStub->method('read')->willReturnOnConsecutiveCalls($chunk1, $chunk2);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Hello'], $chunks);
     }
 }

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -11,6 +11,9 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OllamaProvider;
@@ -20,7 +23,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -489,6 +494,9 @@ class OllamaProviderTest extends AbstractUnitTestCase
         self::assertCount(2, $result->embeddings);
         self::assertEquals([0.1, 0.2, 0.3], $result->embeddings[0]);
         self::assertEquals([0.4, 0.5, 0.6], $result->embeddings[1]);
+        // Token counts of every input are summed into the prompt total
+        // (init 0, `+=` accumulation): 5 + 6 = 11.
+        self::assertSame(11, $result->usage->promptTokens);
     }
 
     #[Test]
@@ -857,5 +865,589 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $result = $subject->chatCompletion([['role' => 'user', 'content' => 'Test']]);
 
         self::assertInstanceOf(CompletionResponse::class, $result);
+    }
+
+    // ------------------------------------------------------------------
+    // Request-shape characterisation tests.
+    //
+    // The tests above assert the parsed response; the ones below pin the
+    // exact request the provider puts on the wire — endpoint URL, HTTP
+    // method, and every JSON body key/value — by capturing the body handed
+    // to the stream factory and the URI/method of the request handed to the
+    // HTTP client. Values asserted are derived from the fixed subject setUp
+    // (baseUrl http://localhost:11434, defaultModel llama3.2) plus the
+    // options each test passes.
+    // ------------------------------------------------------------------
+
+    /**
+     * Stream factory stub that records the JSON body passed to createStream().
+     */
+    private function capturingStreamFactory(string &$capturedBody): StreamFactoryInterface
+    {
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream       = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        return $streamFactory;
+    }
+
+    /**
+     * Build a keyless Ollama subject whose outgoing request body is captured
+     * by the given stream factory.
+     */
+    private function configuredSubject(
+        StreamFactoryInterface $streamFactory,
+        string $baseUrl = 'http://localhost:11434',
+    ): OllamaProvider {
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel'     => 'llama3.2',
+            'baseUrl'          => $baseUrl,
+            'timeout'          => 30,
+        ]);
+
+        return $subject;
+    }
+
+    /**
+     * Build a subject that captures the request body, URL and method sent
+     * through the sendRequest() path (chat / tools / embeddings) and answers
+     * with the given decoded JSON response.
+     *
+     * @param array<string, mixed> $apiResponse
+     */
+    private function subjectCapturingRequest(
+        array $apiResponse,
+        string &$capturedBody,
+        string &$capturedUrl,
+        string &$capturedMethod,
+        string $baseUrl = 'http://localhost:11434',
+    ): OllamaProvider {
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody), $baseUrl);
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(
+                function (RequestInterface $request) use (&$capturedUrl, &$capturedMethod, $apiResponse): ResponseInterface {
+                    $capturedUrl    = (string)$request->getUri();
+                    $capturedMethod = $request->getMethod();
+
+                    return $this->createJsonResponseMock($apiResponse);
+                },
+            );
+        $subject->setHttpClient($httpClient);
+
+        return $subject;
+    }
+
+    /**
+     * A response stub whose body yields exactly one newline-terminated chunk
+     * before signalling EOF — enough for the streaming reader to consume.
+     */
+    private function streamingResponseStub(string $body, int $status = 200): ResponseInterface
+    {
+        $stream = self::createStub(StreamInterface::class);
+        $stream->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $stream->method('read')->willReturn($body);
+        $stream->method('__toString')->willReturn($body);
+        $stream->method('getContents')->willReturn($body);
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($status);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
+    }
+
+    /**
+     * Decode a captured request body into an associative array.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedPayload(string $body): array
+    {
+        $payload = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        /** @var array<string, mixed> $payload */
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function payloadArray(array $payload, string $key): array
+    {
+        self::assertArrayHasKey($key, $payload);
+        self::assertIsArray($payload[$key]);
+
+        /** @var array<string, mixed> $sub */
+        $sub = $payload[$key];
+
+        return $sub;
+    }
+
+    #[Test]
+    public function chatCompletionSendsExpectedRequestWithoutOptions(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'Hi'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        // ChatMessage input forces the array_map(toArray) translation (a bare
+        // array would make the map an identity no-op and hide its removal).
+        $subject->chatCompletion([ChatMessage::user('Hello capture')]);
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('http://localhost:11434/api/chat', $capturedUrl);
+        self::assertSame('llama3.2', $payload['model']);
+        self::assertFalse($payload['stream']);
+        self::assertSame([['role' => 'user', 'content' => 'Hello capture']], $payload['messages']);
+        // No options given: neither an `options` block nor a `think` flag is
+        // emitted (kills the "add empty options" / "add num_predict default"
+        // mutants that fire when the guards are inverted).
+        self::assertArrayNotHasKey('options', $payload);
+        self::assertArrayNotHasKey('think', $payload);
+    }
+
+    #[Test]
+    public function chatCompletionSendsNumPredictOption(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'Hi'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'Test']], ['num_predict' => 1000]);
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+        $options = $this->payloadArray($payload, 'options');
+
+        self::assertSame(1000, $options['num_predict']);
+    }
+
+    #[Test]
+    public function chatCompletionSendsTemperatureTopPAndThink(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'Hi'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Test']],
+            ['temperature' => 0.7, 'top_p' => 0.9, 'think' => true],
+        );
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+        $options = $this->payloadArray($payload, 'options');
+
+        self::assertSame(0.7, $options['temperature']);
+        self::assertSame(0.9, $options['top_p']);
+        // `think` is a top-level field (not an `options` entry) and is only
+        // emitted when it is a real bool.
+        self::assertTrue($payload['think']);
+    }
+
+    #[Test]
+    public function chatCompletionNormalisesToolTurnKeepsFollowingMessages(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'Hi'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $subject->chatCompletion([
+            ['role' => 'tool', 'tool_call_id' => 'call_9', 'content' => '42'],
+            ['role' => 'user', 'content' => 'and now'],
+        ]);
+
+        $payload  = $this->decodeCapturedPayload($capturedBody);
+        $messages = $this->payloadArray($payload, 'messages');
+
+        // The tool turn is normalised (tool_call_id dropped) and the loop
+        // CONTINUES so the following user turn survives (a `break` mutant would
+        // truncate the list to a single message).
+        self::assertCount(2, $messages);
+        self::assertArrayHasKey(0, $messages);
+        self::assertIsArray($messages[0]);
+        self::assertArrayNotHasKey('tool_call_id', $messages[0]);
+        self::assertSame(['role' => 'tool', 'content' => '42'], $messages[0]);
+        self::assertSame(['role' => 'user', 'content' => 'and now'], $messages[1]);
+    }
+
+    #[Test]
+    public function chatCompletionLeavesNonObjectToolCallArgumentsUntouched(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'Hi'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        // A replayed assistant turn whose function.arguments decodes to a
+        // scalar (not object/array): decodeToolCallArguments must leave the
+        // raw JSON string in place. Inverting either half of the
+        // `is_object || is_array` guard would rewrite it to the decoded scalar.
+        $subject->chatCompletion([
+            [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    ['id' => 'call_0', 'type' => 'function', 'function' => ['name' => 'foo', 'arguments' => '"scalar"']],
+                ],
+            ],
+        ]);
+
+        $payload  = $this->decodeCapturedPayload($capturedBody);
+        $messages = $this->payloadArray($payload, 'messages');
+
+        self::assertArrayHasKey(0, $messages);
+        self::assertIsArray($messages[0]);
+        self::assertArrayHasKey('tool_calls', $messages[0]);
+        self::assertIsArray($messages[0]['tool_calls']);
+        self::assertIsArray($messages[0]['tool_calls'][0]);
+        self::assertIsArray($messages[0]['tool_calls'][0]['function']);
+        self::assertSame('"scalar"', $messages[0]['tool_calls'][0]['function']['arguments']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsExpectedRequestAndIndexesCalls(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $tool = ToolSpec::function(
+            'get_weather',
+            'Get weather',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+        );
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    ['function' => ['name' => 'get_weather', 'arguments' => ['city' => 'Berlin']]],
+                    ['function' => ['name' => 'get_time', 'arguments' => []]],
+                ],
+            ],
+            'done'        => true,
+            'done_reason' => 'stop',
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        // ChatMessage input forces the array_map(toArray) translation.
+        $result = $subject->chatCompletionWithTools([ChatMessage::user('Weather?')], [$tool]);
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        self::assertSame('http://localhost:11434/api/chat', $capturedUrl);
+        self::assertSame([['role' => 'user', 'content' => 'Weather?']], $payload['messages']);
+        self::assertSame('llama3.2', $payload['model']);
+        self::assertFalse($payload['stream']);
+        self::assertArrayNotHasKey('options', $payload);
+
+        $tools = $this->payloadArray($payload, 'tools');
+        self::assertCount(1, $tools);
+        // Each ToolSpec is serialised via toArray() (kept identical by its
+        // JsonSerializable::jsonSerialize()).
+        self::assertArrayHasKey(0, $tools);
+        self::assertSame($tool->toArray(), $tools[0]);
+
+        // Ollama returns no call id; a stable `call_<index>` is synthesised,
+        // the index incrementing 0, 1, … across the returned calls.
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(2, $result->toolCalls);
+        $first  = $result->toolCalls[0];
+        $second = $result->toolCalls[1];
+        self::assertInstanceOf(ToolCall::class, $first);
+        self::assertInstanceOf(ToolCall::class, $second);
+        self::assertSame('call_0', $first->id);
+        self::assertSame('call_1', $second->id);
+        self::assertSame('get_weather', $first->name);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsNumPredictOption(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $tool = ToolSpec::function('noop', 'No op', ['type' => 'object', 'properties' => []]);
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => 'ok'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $subject->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'Test']],
+            [$tool],
+            ['num_predict' => 500],
+        );
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+        $options = $this->payloadArray($payload, 'options');
+
+        self::assertSame(500, $options['num_predict']);
+    }
+
+    #[Test]
+    public function embeddingsSendsExpectedRequestAndCastsValuesToFloat(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        // Whole-number JSON components decode to ints; the (float) cast must
+        // turn them into floats (assertSame is type-strict: 0 !== 0.0).
+        $apiResponse = [
+            'embedding'         => [0, 1, -1],
+            'prompt_eval_count' => 5,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $result = $subject->embeddings('Test text');
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        self::assertSame('http://localhost:11434/api/embeddings', $capturedUrl);
+        self::assertSame('nomic-embed-text', $payload['model']);
+        self::assertSame('Test text', $payload['prompt']);
+
+        self::assertInstanceOf(EmbeddingResponse::class, $result);
+        self::assertSame([[0.0, 1.0, -1.0]], $result->embeddings);
+        // totalTokens starts at 0 and accumulates prompt_eval_count.
+        self::assertSame(5, $result->usage->promptTokens);
+    }
+
+    #[Test]
+    public function embeddingsSumsPresentCountsAndDefaultsMissingToZero(): void
+    {
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $httpClientMock
+            ->expects(self::exactly(2))
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls(
+                $this->createJsonResponseMock(['embedding' => [0.1], 'prompt_eval_count' => 5]),
+                // Second input's prompt_eval_count is absent -> defaults to 0.
+                $this->createJsonResponseMock(['embedding' => [0.2]]),
+            );
+
+        $result = $subject->embeddings(['first', 'second']);
+
+        // 5 (present) + 0 (missing default) = 5. Pins the 0 default and the
+        // `+=` accumulation past a missing second count (a -1/+1 default or a
+        // `=`/`-=` mutant would shift this).
+        self::assertSame(5, $result->usage->promptTokens);
+        // completionTokens is the fixed literal 0.
+        self::assertSame(0, $result->usage->completionTokens);
+    }
+
+    #[Test]
+    public function streamChatCompletionSendsExpectedRequest(): void
+    {
+        $capturedBody = '';
+        $capturedUrl  = '';
+
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody));
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(
+                function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
+                    $capturedUrl = (string)$request->getUri();
+
+                    return $this->streamingResponseStub("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+                },
+            );
+        $subject->setHttpClient($httpClient);
+
+        $chunks = iterator_to_array(
+            $subject->streamChatCompletion(
+                [['role' => 'user', 'content' => 'Test']],
+                ['temperature' => 0.5, 'think' => true],
+            ),
+        );
+
+        self::assertSame(['ok'], $chunks);
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        self::assertSame('http://localhost:11434/api/chat', $capturedUrl);
+        self::assertSame('llama3.2', $payload['model']);
+        self::assertTrue($payload['stream']);
+        self::assertTrue($payload['think']);
+
+        $options = $this->payloadArray($payload, 'options');
+        self::assertSame(0.5, $options['temperature']);
+    }
+
+    #[Test]
+    public function streamChatCompletionTrimsTrailingSlashFromBaseUrl(): void
+    {
+        $capturedBody = '';
+        $capturedUrl  = '';
+
+        // Trailing slash on the base URL exercises the rtrim() in the URL
+        // assembly — without it the URL would carry a double slash.
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody), 'http://localhost:11434/');
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(
+                function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
+                    $capturedUrl = (string)$request->getUri();
+
+                    return $this->streamingResponseStub("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+                },
+            );
+        $subject->setHttpClient($httpClient);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame('http://localhost:11434/api/chat', $capturedUrl);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeStreaming(): void
+    {
+        $capturedBody = '';
+        $capturedUrl  = '';
+
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody));
+
+        // Force an empty base URL AFTER configure(): the streaming path must
+        // call validateConfiguration() first, which restores the default —
+        // otherwise the URL would collapse to "/api/chat".
+        $reflection = new ReflectionClass($subject);
+        $reflection->getProperty('baseUrl')->setValue($subject, '');
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(
+                function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
+                    $capturedUrl = (string)$request->getUri();
+
+                    return $this->streamingResponseStub("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+                },
+            );
+        $subject->setHttpClient($httpClient);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame('http://localhost:11434/api/chat', $capturedUrl);
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $capturedBody = '';
+
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody));
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->streamingResponseStub("{\"message\":{\"content\":\"ok\"},\"done\":true}\n"));
+        $subject->setHttpClient($httpClient);
+
+        // The lone 0xB1 byte is invalid UTF-8; JSON_INVALID_UTF8_SUBSTITUTE
+        // must let json_encode degrade it instead of returning false (which a
+        // bitwise-& of the flags would cause, breaking createStream()).
+        $chunks = iterator_to_array(
+            $subject->streamChatCompletion([['role' => 'user', 'content' => "bad\xB1byte"]]),
+        );
+
+        self::assertSame(['ok'], $chunks);
+        self::assertStringContainsString('"stream":true', $capturedBody);
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnErrorStatus(): void
+    {
+        $capturedBody = '';
+
+        $subject = $this->configuredSubject($this->capturingStreamFactory($capturedBody));
+
+        $httpClient = $this->createHttpClientWithExpectations();
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->streamingResponseStub('{"error":"boom"}', 404));
+        $subject->setHttpClient($httpClient);
+
+        $this->expectException(ProviderResponseException::class);
+
+        // The streaming path must assert the response is OK before yielding;
+        // dropping that assertion would silently yield an empty stream.
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
     }
 }

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
@@ -26,6 +27,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -1455,5 +1458,565 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         // OpenAI provider passes messages verbatim — no conversion needed.
         // Payload assertion deferred: the stub-based test pattern does not support
         // request capture. The test verifies multimodal input is accepted without errors.
+    }
+
+    // ===== Request payload shaping (chatCompletion) =====
+
+    #[Test]
+    public function chatCompletionSendsModelMessagesTokensAndTemperature(): void
+    {
+        $payload = $this->captureChatCompletionPayload([]);
+
+        // Configured defaultModel is `gpt-4o`; captureChatCompletionPayload() sends a
+        // single user message with the literal content below.
+        self::assertSame('gpt-4o', $payload['model']);
+        self::assertSame([['role' => 'user', 'content' => 'reply in json']], $payload['messages']);
+
+        // Default max token budget is 4096.
+        self::assertArrayHasKey('max_completion_tokens', $payload);
+        self::assertSame(4096, $payload['max_completion_tokens']);
+
+        // `gpt-4o` is not a reasoning model, so sampling params are spread in with the
+        // default temperature of 0.7.
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertSame(0.7, $payload['temperature']);
+    }
+
+    #[Test]
+    public function chatCompletionMergesAllSamplingParamsFlatIntoPayload(): void
+    {
+        // buildSamplingParams() returns temperature plus top_p; the spread must merge
+        // BOTH flat into the payload (not just the first entry, not nested).
+        $payload = $this->captureChatCompletionPayload(['top_p' => 0.9]);
+
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertSame(0.7, $payload['temperature']);
+        self::assertArrayHasKey('top_p', $payload);
+        self::assertSame(0.9, $payload['top_p']);
+    }
+
+    #[Test]
+    public function chatCompletionStripsSamplingParamsForReasoningModel(): void
+    {
+        // `gpt-5.2` is a reasoning model: buildSamplingParams() returns [] so no
+        // temperature key is emitted, while the model itself is still sent.
+        $payload = $this->captureChatCompletionPayload(['model' => 'gpt-5.2']);
+
+        self::assertSame('gpt-5.2', $payload['model']);
+        self::assertArrayNotHasKey('temperature', $payload);
+    }
+
+    // ===== Request payload shaping (chatCompletionWithTools) =====
+
+    #[Test]
+    public function chatCompletionWithToolsSendsModelToolsTokensAndTemperature(): void
+    {
+        $payload = $this->captureToolsPayload(
+            [['role' => 'user', 'content' => 'hi']],
+            [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_time', 'parameters' => []]])],
+            [],
+        );
+
+        self::assertSame('gpt-4o', $payload['model']);
+        self::assertSame([['role' => 'user', 'content' => 'hi']], $payload['messages']);
+
+        // ToolSpec::toArray() shape with defaulted description ('') and parameters ([]).
+        self::assertSame([
+            ['type' => 'function', 'function' => ['name' => 'get_time', 'description' => '', 'parameters' => []]],
+        ], $payload['tools']);
+
+        self::assertArrayHasKey('max_completion_tokens', $payload);
+        self::assertSame(4096, $payload['max_completion_tokens']);
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertSame(0.7, $payload['temperature']);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsMapsJsonResponseFormat(): void
+    {
+        $payload = $this->captureToolsPayload(
+            [['role' => 'user', 'content' => 'hi']],
+            [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_time', 'parameters' => []]])],
+            ['response_format' => 'json'],
+        );
+
+        self::assertArrayHasKey('response_format', $payload);
+        self::assertSame(['type' => 'json_object'], $payload['response_format']);
+    }
+
+    // ===== Request payload shaping (embeddings) =====
+
+    #[Test]
+    public function embeddingsSendsDefaultModelAndWrapsStringInputAsList(): void
+    {
+        $payload = $this->captureEmbeddingsPayload('hello', []);
+
+        // embeddings() falls back to DEFAULT_EMBEDDING_MODEL (not the configured chat model).
+        self::assertSame('text-embedding-3-small', $payload['model']);
+        // A scalar string input is wrapped into a single-element list.
+        self::assertSame(['hello'], $payload['input']);
+    }
+
+    #[Test]
+    public function embeddingsSendsArrayInputVerbatim(): void
+    {
+        $payload = $this->captureEmbeddingsPayload(['a', 'b'], []);
+
+        self::assertSame(['a', 'b'], $payload['input']);
+    }
+
+    #[Test]
+    public function embeddingsCastsEmbeddingValuesToFloatAndZeroesCompletionTokens(): void
+    {
+        $apiResponse = [
+            'object' => 'list',
+            'data' => [
+                ['embedding' => [0, 1, 0.5], 'index' => 0],
+            ],
+            'model' => 'text-embedding-3-small',
+            'usage' => ['prompt_tokens' => 7, 'total_tokens' => 7],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->embeddings('test');
+
+        // Integer JSON values (0, 1) must be coerced to float, not left as int.
+        self::assertSame([0.0, 1.0, 0.5], $result->embeddings[0]);
+        // completionTokens is hard-wired to 0 for embeddings; totalTokens == promptTokens.
+        self::assertSame(0, $result->usage->completionTokens);
+        self::assertSame(7, $result->usage->totalTokens);
+    }
+
+    // ===== Request payload shaping (analyzeImage) =====
+
+    #[Test]
+    public function analyzeImageSendsSingleUserMessageWithModelAndTokens(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/i.jpg']]),
+        ];
+
+        $payload = $this->captureVisionPayload($content, []);
+
+        $messages = $payload['messages'];
+        self::assertIsArray($messages);
+        self::assertCount(1, $messages);
+        $userMessage = $messages[0];
+        self::assertIsArray($userMessage);
+        self::assertSame('user', $userMessage['role']);
+
+        // analyzeImage() defaults the model to the literal 'gpt-5.2'.
+        self::assertSame('gpt-5.2', $payload['model']);
+        self::assertArrayHasKey('max_completion_tokens', $payload);
+        self::assertSame(4096, $payload['max_completion_tokens']);
+    }
+
+    #[Test]
+    public function analyzeImagePrependsSystemPromptMessage(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/i.jpg']]),
+        ];
+
+        $payload = $this->captureVisionPayload($content, ['system_prompt' => 'be brief']);
+
+        $messages = $payload['messages'];
+        self::assertIsArray($messages);
+        self::assertCount(2, $messages);
+        // System prompt is unshifted ahead of the user turn as a full role/content pair.
+        self::assertSame(['role' => 'system', 'content' => 'be brief'], $messages[0]);
+        $userMessage = $messages[1];
+        self::assertIsArray($userMessage);
+        self::assertSame('user', $userMessage['role']);
+    }
+
+    // ===== Request shaping (streamChatCompletion) =====
+
+    #[Test]
+    public function streamChatCompletionSendsExpectedUrlAndPayload(): void
+    {
+        $capturedUrl  = null;
+        $capturedBody = null;
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$capturedUrl): RequestInterface {
+                $capturedUrl = $uri;
+                $request = self::createStub(RequestInterface::class);
+                $request->method('withHeader')->willReturnCallback(fn(): RequestInterface => $request);
+                $request->method('withBody')->willReturnCallback(fn(): RequestInterface => $request);
+
+                return $request;
+            },
+        );
+
+        $subject = new OpenAiProvider(
+            $requestFactory,
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        // Trailing slash on the base URL makes the rtrim() + '/' concatenation observable.
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+            'baseUrl' => 'https://api.example.test/v1/',
+            'timeout' => 30,
+        ]);
+
+        $responseStream = self::createStub(StreamInterface::class);
+        $eofCallCount = 0;
+        $responseStream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
+            return ++$eofCallCount > 1;
+        });
+        $responseStream->method('read')->willReturn("data: [DONE]\n\n");
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($responseStream);
+
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturn($response);
+        $subject->setHttpClient($httpClient);
+
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => 'hi']]) as $ignored) {
+            // Drain the generator so the request is built and dispatched.
+            unset($ignored);
+        }
+
+        self::assertSame('https://api.example.test/v1/chat/completions', $capturedUrl);
+
+        self::assertIsString($capturedBody);
+        $payload = json_decode($capturedBody, true);
+        self::assertIsArray($payload);
+
+        self::assertSame('gpt-4o', $payload['model']);
+        self::assertSame([['role' => 'user', 'content' => 'hi']], $payload['messages']);
+        self::assertArrayHasKey('max_completion_tokens', $payload);
+        self::assertSame(4096, $payload['max_completion_tokens']);
+        self::assertArrayHasKey('stream', $payload);
+        self::assertTrue($payload['stream']);
+        self::assertArrayHasKey('temperature', $payload);
+        self::assertSame(0.7, $payload['temperature']);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeStreaming(): void
+    {
+        // No configure() call: the API key identifier stays empty, so
+        // validateConfiguration() must throw before any streaming begins.
+        $subject = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        // A benign response so that, if the validation guard were removed, the
+        // generator would complete silently and this test would fail instead.
+        $responseStream = self::createStub(StreamInterface::class);
+        $responseStream->method('eof')->willReturn(true);
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($responseStream);
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturn($response);
+        $subject->setHttpClient($httpClient);
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => 'hi']]) as $ignored) {
+            unset($ignored);
+        }
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnErrorStatus(): void
+    {
+        $errorBody = json_encode(['error' => ['message' => 'bad stream request']], JSON_THROW_ON_ERROR);
+
+        $responseStream = self::createStub(StreamInterface::class);
+        $responseStream->method('__toString')->willReturn($errorBody);
+        $responseStream->method('eof')->willReturn(true);
+        $responseStream->method('read')->willReturn('');
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(400);
+        $response->method('getBody')->willReturn($responseStream);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $this->expectException(ProviderResponseException::class);
+        $this->expectExceptionMessage('bad stream request');
+
+        foreach ($this->subject->streamChatCompletion([['role' => 'user', 'content' => 'hi']]) as $ignored) {
+            unset($ignored);
+        }
+    }
+
+    #[Test]
+    public function streamChatCompletionStopsAtDoneMarker(): void
+    {
+        // Content deliberately follows the [DONE] marker: it must NOT be yielded,
+        // proving the marker is detected (substr offset) and the loop returns.
+        $streamData = "data: {\"choices\":[{\"delta\":{\"content\":\"A\"}}]}\n\n"
+            . "data: [DONE]\n\n"
+            . "data: {\"choices\":[{\"delta\":{\"content\":\"B\"}}]}\n\n";
+
+        $stream = self::createStub(StreamInterface::class);
+        $eofCallCount = 0;
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
+            return ++$eofCallCount > 1;
+        });
+        $stream->method('read')->willReturn($streamData);
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($stream);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $chunks = [];
+        foreach ($this->subject->streamChatCompletion([['role' => 'user', 'content' => 'test']]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['A'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionReassemblesLinesSplitAcrossReads(): void
+    {
+        // A single SSE line arrives split across two reads; the buffer must
+        // accumulate (concatenate) across iterations to reassemble it.
+        $reads = [
+            'data: {"choices":[{"delta":{"content":"Hel',
+            "lo\"}}]}\n\ndata: [DONE]\n\n",
+        ];
+        $readIndex = 0;
+
+        $stream = self::createStub(StreamInterface::class);
+        $eofCallCount = 0;
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
+            return ++$eofCallCount > 2;
+        });
+        $stream->method('read')->willReturnCallback(function () use (&$readIndex, $reads): string {
+            return $reads[$readIndex++] ?? '';
+        });
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($stream);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $chunks = [];
+        foreach ($this->subject->streamChatCompletion([['role' => 'user', 'content' => 'test']]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['Hello'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        // A message carrying an invalid UTF-8 byte must be JSON-encoded with the
+        // substitute flag rather than aborting the stream setup.
+        $capturedBody = null;
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        $subject = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+
+        $responseStream = self::createStub(StreamInterface::class);
+        $responseStream->method('eof')->willReturn(true);
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($responseStream);
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturn($response);
+        $subject->setHttpClient($httpClient);
+
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => "bad \xB1 byte"]]) as $ignored) {
+            unset($ignored);
+        }
+
+        // Encoding succeeded (substitute flag), so a JSON body reached the factory.
+        self::assertIsString($capturedBody);
+        $payload = json_decode($capturedBody, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('messages', $payload);
+    }
+
+    /**
+     * Build a provider whose JSON request body is captured into $captured (by
+     * reference), with the HTTP client stubbed to return $apiResponse.
+     *
+     * @param array<string, mixed> $apiResponse
+     */
+    private function createCapturingSubject(?string &$captured, array $apiResponse): OpenAiProvider
+    {
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$captured): StreamInterface {
+                $captured = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        $subject = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+
+        $httpClientStub = $this->createHttpClientMock();
+        $httpClientStub->method('sendRequest')->willReturn($this->createJsonResponseMock($apiResponse));
+        $subject->setHttpClient($httpClientStub);
+
+        return $subject;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeCaptured(?string $captured): array
+    {
+        self::assertIsString($captured);
+        $decoded = json_decode($captured, true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Run chatCompletionWithTools and return the decoded JSON request body.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<ToolSpec>                         $tools
+     * @param array<string, mixed>                   $options
+     *
+     * @return array<string, mixed>
+     */
+    private function captureToolsPayload(array $messages, array $tools, array $options): array
+    {
+        $captured = null;
+        $subject  = $this->createCapturingSubject($captured, [
+            'id' => 'chatcmpl-test',
+            'choices' => [['message' => ['content' => '{}'], 'finish_reason' => 'stop']],
+            'model' => 'gpt-4o',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]);
+
+        $subject->chatCompletionWithTools($messages, $tools, $options);
+
+        return $this->decodeCaptured($captured);
+    }
+
+    /**
+     * Run embeddings and return the decoded JSON request body.
+     *
+     * @param string|array<int, string> $input
+     * @param array<string, mixed>      $options
+     *
+     * @return array<string, mixed>
+     */
+    private function captureEmbeddingsPayload(string|array $input, array $options): array
+    {
+        $captured = null;
+        $subject  = $this->createCapturingSubject($captured, [
+            'object' => 'list',
+            'data' => [['embedding' => [0.1], 'index' => 0]],
+            'model' => 'text-embedding-3-small',
+            'usage' => ['prompt_tokens' => 1, 'total_tokens' => 1],
+        ]);
+
+        $subject->embeddings($input, $options);
+
+        return $this->decodeCaptured($captured);
+    }
+
+    /**
+     * Run analyzeImage and return the decoded JSON request body.
+     *
+     * @param list<VisionContent>  $content
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function captureVisionPayload(array $content, array $options): array
+    {
+        $captured = null;
+        $subject  = $this->createCapturingSubject($captured, [
+            'id' => 'chatcmpl-test',
+            'model' => 'gpt-5.2',
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]);
+
+        $subject->analyzeImage($content, $options);
+
+        return $this->decodeCaptured($captured);
     }
 }

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 
+use Closure;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
@@ -1301,5 +1303,363 @@ class TranslationServiceTest extends AbstractUnitTestCase
             'en',
             (new TranslationOptions())->withBeUserUid(42),
         );
+    }
+
+    // ==================== request-transformation pinning tests ====================
+    // These strengthen the suite against mutations in the messages / ChatOptions
+    // that the service constructs and hands to LlmServiceManager::chat(), and in
+    // the prompt built by buildTranslationPrompt(). They capture the exact
+    // arguments rather than only asserting the happy-path return value.
+
+    /**
+     * Capture the messages + ChatOptions handed to LlmServiceManager::chat()
+     * for a single-turn feature call.
+     *
+     * @param Closure(TranslationService): mixed $call
+     *
+     * @return array{messages: array<array-key, mixed>, options: ChatOptions}
+     */
+    private function captureSingleChat(string $responseContent, Closure $call): array
+    {
+        $capturedMessages = [];
+        $capturedOptions = null;
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ChatOptions $chatOptions) use (
+                    &$capturedMessages,
+                    &$capturedOptions,
+                    $responseContent,
+                ): CompletionResponse {
+                    $capturedMessages = $messages;
+                    $capturedOptions = $chatOptions;
+
+                    return $this->createChatResponse($responseContent);
+                },
+            );
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+        );
+
+        $call($subject);
+
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+
+        return ['messages' => $capturedMessages, 'options' => $capturedOptions];
+    }
+
+    /**
+     * Invoke the private buildTranslationPrompt() with a fully-controlled raw
+     * options array and return the ['system', 'user'] strings.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array{system: string, user: string}
+     */
+    private function invokeBuildPrompt(string $text, string $source, string $target, array $options): array
+    {
+        $reflection = new ReflectionClass($this->subject);
+        $method = $reflection->getMethod('buildTranslationPrompt');
+        $prompt = $method->invoke($this->subject, $text, $source, $target, $options);
+
+        self::assertIsArray($prompt);
+        $system = $prompt['system'] ?? null;
+        $user = $prompt['user'] ?? null;
+        self::assertIsString($system);
+        self::assertIsString($user);
+
+        return ['system' => $system, 'user' => $user];
+    }
+
+    #[Test]
+    public function translateBuildsSystemAndUserMessagesWithDefaultChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            'Hallo Welt',
+            static fn(TranslationService $subject): object => $subject->translate('Hello World', 'de', 'en'),
+        );
+
+        $messages = $captured['messages'];
+        self::assertCount(2, $messages);
+
+        $system = $messages[0];
+        $user = $messages[1];
+        self::assertInstanceOf(ChatMessage::class, $system);
+        self::assertInstanceOf(ChatMessage::class, $user);
+        self::assertTrue($system->isSystem());
+        self::assertTrue($user->isUser());
+        self::assertStringContainsString('You are a professional', $system->content);
+        self::assertSame("Translate this text:\n\nHello World", $user->content);
+
+        // Default ChatOptions coalesce targets: temperature 0.3, maxTokens 2000,
+        // no provider (TranslationOptions defaults are all null there).
+        $options = $captured['options'];
+        self::assertSame(0.3, $options->getTemperature());
+        self::assertSame(2000, $options->getMaxTokens());
+        self::assertNull($options->getProvider());
+    }
+
+    #[Test]
+    public function translateForwardsCustomTemperatureAndMaxTokensOntoChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            'Translated',
+            static fn(TranslationService $subject): object => $subject->translate(
+                'Hello',
+                'de',
+                'en',
+                new TranslationOptions(temperature: 0.5, maxTokens: 1000),
+            ),
+        );
+
+        $options = $captured['options'];
+        self::assertSame(0.5, $options->getTemperature());
+        self::assertSame(1000, $options->getMaxTokens());
+    }
+
+    #[Test]
+    public function translateBatchPassesOptionsThroughToPerTextTranslateCall(): void
+    {
+        $captured = $this->captureSingleChat(
+            'Eins',
+            static fn(TranslationService $subject): array => $subject->translateBatch(
+                ['One'],
+                'de',
+                'en',
+                new TranslationOptions(formality: 'formal'),
+            ),
+        );
+
+        $system = $captured['messages'][0];
+        self::assertInstanceOf(ChatMessage::class, $system);
+        // If the batch discarded the passed options, formality would fall back to
+        // 'default' and the tone line would disappear.
+        self::assertStringContainsString('Maintain formal tone.', $system->content);
+    }
+
+    #[Test]
+    public function detectLanguagePinsMessagesAndChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            'fr',
+            static fn(TranslationService $subject): string => $subject->detectLanguage(
+                'Bonjour',
+                new TranslationOptions(provider: 'claude'),
+            ),
+        );
+
+        $messages = $captured['messages'];
+        self::assertCount(2, $messages);
+
+        $system = $messages[0];
+        $user = $messages[1];
+        self::assertInstanceOf(ChatMessage::class, $system);
+        self::assertInstanceOf(ChatMessage::class, $user);
+        self::assertSame(
+            'You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.',
+            $system->content,
+        );
+        self::assertSame("Detect the language of this text:\n\nBonjour", $user->content);
+
+        $options = $captured['options'];
+        self::assertSame(10, $options->getMaxTokens());
+        self::assertSame('claude', $options->getProvider());
+    }
+
+    #[Test]
+    public function scoreTranslationQualityPinsMessagesAndChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            '0.85',
+            static fn(TranslationService $subject): float => $subject->scoreTranslationQuality(
+                'Hello',
+                'Hallo',
+                'de',
+                new TranslationOptions(provider: 'claude'),
+            ),
+        );
+
+        $messages = $captured['messages'];
+        self::assertCount(2, $messages);
+
+        $system = $messages[0];
+        $user = $messages[1];
+        self::assertInstanceOf(ChatMessage::class, $system);
+        self::assertInstanceOf(ChatMessage::class, $user);
+        self::assertSame(
+            'You are a translation quality expert. Evaluate the translation quality based on accuracy, fluency, and consistency. Respond with ONLY a number between 0.0 and 1.0 (e.g., "0.85"). No explanation.',
+            $system->content,
+        );
+        self::assertSame(
+            "Source text:\nHello\n\nTranslation to de:\nHallo\n\nQuality score:",
+            $user->content,
+        );
+
+        $options = $captured['options'];
+        self::assertSame(10, $options->getMaxTokens());
+        self::assertSame('claude', $options->getProvider());
+    }
+
+    #[Test]
+    public function translateBatchWithTranslatorSkipsTranslatorResolutionForEmptyInput(): void
+    {
+        // The empty-input early return must short-circuit before any translator
+        // lookup — removing the `return []` would fall through to resolveTranslator().
+        $this->translatorRegistryMock
+            ->expects(self::never())
+            ->method('get');
+
+        $result = $this->subject->translateBatchWithTranslator([], 'de');
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function resolveTranslatorSkipsPresetLookupForEmptyPresetString(): void
+    {
+        // preset === '' must NOT trigger a configuration lookup: the guard is
+        // `is_string($preset) && $preset !== ''`. Swapping && for || would enter
+        // the branch and call getConfiguration('').
+        $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
+        $configServiceMock
+            ->expects(self::never())
+            ->method('getConfiguration');
+
+        $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
+        $translatorStub = self::createStub(TranslatorInterface::class);
+        $translatorRegistryMock
+            ->expects(self::once())
+            ->method('get')
+            ->with('llm')
+            ->willReturn($translatorStub);
+
+        $subject = new TranslationService(
+            $this->llmManagerStub,
+            $translatorRegistryMock,
+            $configServiceMock,
+        );
+
+        $reflection = new ReflectionClass($subject);
+        $method = $reflection->getMethod('resolveTranslator');
+        $result = $method->invoke($subject, ['preset' => '']);
+
+        self::assertSame($translatorStub, $result);
+    }
+
+    #[Test]
+    public function buildTranslationPromptRendersMinimalPrompt(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello World', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+            'glossary' => [],
+            'context' => '',
+            'preserve_formatting' => true,
+        ]);
+
+        $system = $prompt['system'];
+        // Domain + language-name resolution (en -> English, de -> German).
+        self::assertStringContainsString(
+            'You are a professional general translator. Translate the following text from English to German.',
+            $system,
+        );
+        // formality 'default' => no tone line.
+        self::assertStringNotContainsString('Maintain', $system);
+        // preserve_formatting true => formatting line present.
+        self::assertStringContainsString(
+            'Preserve all formatting, HTML tags, markdown, and special characters.',
+            $system,
+        );
+        // Empty glossary / context => their sections are absent.
+        self::assertStringNotContainsString('Use these exact term translations:', $system);
+        self::assertStringNotContainsString('Context (for reference only):', $system);
+        // Trailing instruction is appended, not replacing the prompt.
+        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
+
+        self::assertSame("Translate this text:\n\nHello World", $prompt['user']);
+    }
+
+    #[Test]
+    public function buildTranslationPromptDefaultsPreserveFormattingToTrueWhenKeyAbsent(): void
+    {
+        // No 'preserve_formatting' key => the `?? true` default applies.
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+        ]);
+
+        self::assertStringContainsString(
+            'Preserve all formatting, HTML tags, markdown, and special characters.',
+            $prompt['system'],
+        );
+    }
+
+    #[Test]
+    public function buildTranslationPromptOmitsFormattingLineWhenPreserveFormattingFalse(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+            'preserve_formatting' => false,
+        ]);
+
+        self::assertStringNotContainsString('Preserve all formatting', $prompt['system']);
+    }
+
+    #[Test]
+    public function buildTranslationPromptRendersAllSectionsWithFullOptions(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'formal',
+            'domain' => 'legal',
+            'glossary' => [
+                'Hello' => 'Hallo',   // string value
+                'count' => 5,         // int value
+                'ratio' => 1.5,       // float value
+                'bad' => ['x'],       // non-scalar => filtered out
+            ],
+            'context' => 'Software docs',
+            'preserve_formatting' => false,
+        ]);
+
+        $system = $prompt['system'];
+
+        // Intro must survive every section append (guards against `.=` -> `=`).
+        self::assertStringContainsString(
+            'You are a professional legal translator. Translate the following text from English to German.',
+            $system,
+        );
+        // formality 'formal' => tone line.
+        self::assertStringContainsString('Maintain formal tone.', $system);
+        // preserve false => no formatting line.
+        self::assertStringNotContainsString('Preserve all formatting', $system);
+        // Glossary header + one line per scalar term.
+        self::assertStringContainsString('Use these exact term translations:', $system);
+        self::assertStringContainsString('- Hello → Hallo', $system);
+        self::assertStringContainsString('- count → 5', $system);
+        self::assertStringContainsString('- ratio → 1.5', $system);
+        // Non-scalar glossary value is filtered out entirely.
+        self::assertStringNotContainsString('- bad', $system);
+        // Context section rendered.
+        self::assertStringContainsString("Context (for reference only):\nSoftware docs", $system);
+        // Closing instruction still appended.
+        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
+    }
+
+    #[Test]
+    public function buildTranslationPromptResolvesKnownLanguageNames(): void
+    {
+        // getLanguageName maps known codes; an unknown code falls back to itself.
+        $prompt = $this->invokeBuildPrompt('Hi', 'fr', 'zz', [
+            'formality' => 'default',
+            'domain' => 'general',
+        ]);
+
+        self::assertStringContainsString('from French to zz.', $prompt['system']);
     }
 }

--- a/Tests/Unit/Service/Task/TaskInputResolverTest.php
+++ b/Tests/Unit/Service/Task/TaskInputResolverTest.php
@@ -103,10 +103,134 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
 
         $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
 
-        self::assertStringContainsString('first', $output);
-        self::assertStringContainsString('second', $output);
-        // Two rows -> two lines.
-        self::assertCount(2, explode("\n", $output));
+        // Exact rendering pins the timestamp formatting, the type-label
+        // lookup (1 -> DB, 5 -> ERROR), the error marker threshold
+        // (error 0 -> no marker, error 1 -> [ERROR]) and the line glue.
+        // Timestamps are derived through the same date() call the
+        // production code uses, so the expectation is timezone-agnostic.
+        $line1 = '[' . date('Y-m-d H:i:s', 1714521600) . '] [DB]  first';
+        $line2 = '[' . date('Y-m-d H:i:s', 1714521660) . '] [ERROR] [ERROR] second';
+        self::assertSame($line1 . "\n" . $line2, $output);
+    }
+
+    #[Test]
+    public function syslogFormatsRowWithDefaultsForMissingFields(): void
+    {
+        // A row missing every optional key exercises the defensive
+        // fallbacks: tstamp -> 0, type -> 0 (OTHER), error -> 0 (no
+        // marker), details -> ''. Flipping any `isset() && …` guard to
+        // `||`/negation reads the undefined key (warning) or changes the
+        // rendered value; the `: 0`/`+1` default is pinned via the exact
+        // timestamp and OTHER label.
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->willReturn([[]]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+
+        self::assertSame('[' . date('Y-m-d H:i:s', 0) . '] [OTHER]  ', $output);
+    }
+
+    #[Test]
+    public function syslogCastsNumericStringRowFields(): void
+    {
+        // Untrusted sys_log values may arrive as numeric strings; the
+        // resolver casts tstamp/type to int before use. Dropping either
+        // cast passes a string into date() / translateSyslogType(int),
+        // which raises a TypeError under strict_types.
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->willReturn([
+                ['tstamp' => '1714521600', 'type' => '2', 'error' => '0', 'details' => 'x'],
+            ]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+
+        self::assertSame('[' . date('Y-m-d H:i:s', 1714521600) . '] [FILE]  x', $output);
+    }
+
+    #[Test]
+    public function syslogTranslatesEverySystemLogType(): void
+    {
+        // One row per known sys_log type value pins each arm of the
+        // type-label lookup (the arm that actually feeds the output — the
+        // English fallback, since LocalizationUtility::translate() returns
+        // null in the unit context). error 0 keeps the [ERROR] marker out,
+        // so each label's only source is the type translation.
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->willReturn([
+                ['tstamp' => 0, 'type' => 1, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 2, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 3, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 4, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 5, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 254, 'error' => 0, 'details' => ''],
+                ['tstamp' => 0, 'type' => 255, 'error' => 0, 'details' => ''],
+            ]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+
+        $time  = date('Y-m-d H:i:s', 0);
+        $lines = [
+            '[' . $time . '] [DB]  ',
+            '[' . $time . '] [FILE]  ',
+            '[' . $time . '] [CACHE]  ',
+            '[' . $time . '] [EXTENSION]  ',
+            '[' . $time . '] [ERROR]  ',
+            '[' . $time . '] [SETTING]  ',
+            '[' . $time . '] [LOGIN]  ',
+        ];
+        self::assertSame(implode("\n", $lines), $output);
+    }
+
+    #[Test]
+    public function syslogConfigLimitAndErrorOnlyAreParsedFromIntegers(): void
+    {
+        // A non-default numeric limit proves the parsed value (not the 50
+        // default) reaches the reader: negating the is_numeric() guard
+        // would fall back to 50.
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->with(25, false)
+            ->willReturn([]);
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_SYSLOG,
+            '{"limit":25,"error_only":false}',
+        ));
+
+        self::assertSame('', $output);
+    }
+
+    #[Test]
+    public function syslogConfigCoercesNumericStringLimitAndNonBoolErrorOnly(): void
+    {
+        // Untrusted config: limit as a numeric string, error_only as an
+        // int. The resolver casts them to (int)/(bool) before calling the
+        // typed reader (int $limit, bool $errorOnly). Dropping either cast
+        // passes the raw string/int, which TypeErrors under strict_types;
+        // resolveSyslog() catches it and returns the read-error string,
+        // so the '' expectation below fails on the mutant.
+        $this->systemLogReader
+            ->expects(self::once())
+            ->method('readRecent')
+            ->with(25, true)
+            ->willReturn([]);
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_SYSLOG,
+            '{"limit":"25","error_only":1}',
+        ));
+
+        self::assertSame('', $output);
     }
 
     /**
@@ -187,6 +311,57 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
         self::assertCount(2, $decoded);
     }
 
+    #[Test]
+    public function tableConfigCoercesNumericStringLimit(): void
+    {
+        // limit arriving as a numeric string is cast to int before the
+        // typed fetchAll(string, int) call. Dropping the cast passes the
+        // raw string, TypeErrors inside readTableRows() (caught as the
+        // broad Throwable arm), and yields the generic read-error string
+        // instead of the encoded rows.
+        $this->recordTableReader
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with('be_users', 7)
+            ->willReturn([['uid' => 1, 'username' => 'admin']]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_TABLE,
+            '{"table":"be_users","limit":"7"}',
+        ));
+
+        self::assertSame(
+            json_encode([['uid' => 1, 'username' => 'admin']], JSON_PRETTY_PRINT),
+            $output,
+        );
+    }
+
+    #[Test]
+    public function tableConfigCoercesNonStringTableName(): void
+    {
+        // A numeric table value from untrusted config is cast to string
+        // before the typed fetchAll(string, int) call. Dropping the cast
+        // passes the raw int, which TypeErrors inside readTableRows() and
+        // surfaces the generic read-error string.
+        $this->recordTableReader
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with('123', 5)
+            ->willReturn([['uid' => 1]]);
+        $this->logger->expects(self::never())->method(self::anything());
+
+        $output = $this->subject->resolve(self::makeTask(
+            Task::INPUT_TABLE,
+            '{"table":123,"limit":5}',
+        ));
+
+        self::assertSame(
+            json_encode([['uid' => 1]], JSON_PRETTY_PRINT),
+            $output,
+        );
+    }
+
     /**
      * REC #11b regression guard for the table branch — same contract as
      * the syslog version: warning logged with full context, generic
@@ -209,6 +384,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
                 self::stringContains('table read failed'),
                 self::callback(static function (array $context) use ($sensitive): bool {
                     self::assertArrayHasKey('exception', $context);
+                    self::assertArrayHasKey('taskUid', $context);
                     self::assertSame('be_users', $context['table'] ?? null);
                     self::assertSame(50, $context['limit'] ?? null);
                     $exception = $context['exception'];
@@ -251,6 +427,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->with(
                 self::stringContains('rejected by record-picker policy'),
                 self::callback(static function (array $context): bool {
+                    self::assertArrayHasKey('taskUid', $context);
                     self::assertSame('be_groups', $context['table'] ?? null);
                     self::assertInstanceOf(InvalidArgumentException::class, $context['exception']);
 

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -14,12 +14,15 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -258,21 +261,47 @@ final class ToolLoopServiceTest extends TestCase
     public function capHitSynthesisesFinalAnswerAndMarksTruncated(): void
     {
         $mgr = $this->createMock(LlmServiceManagerInterface::class);
-        // The model never stops requesting tools.
+        // The model never stops requesting tools; each tools round reports usage.
         $mgr->method('chatWithToolsForConfiguration')
-            ->willReturn($this->response('', [new ToolCall('call_x', 'loop_tool', [])]));
-        // Exactly one no-tools synthesis completion closes the loop.
+            ->willReturn($this->response('', [new ToolCall('call_x', 'loop_tool', [])], 10, 5));
+        // Exactly one no-tools synthesis completion closes the loop, with its
+        // own distinct usage split.
         $mgr->expects(self::once())
             ->method('chatWithConfiguration')
-            ->willReturn($this->response('SYNTHESISED'));
+            ->willReturn($this->response('SYNTHESISED', null, 3, 2));
 
-        $service = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
-        $result  = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), null, null, 2);
+        $runTrace = new RunTrace();
+        $service  = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
+        $result   = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), null, null, 2, $runTrace);
 
         self::assertSame(2, $result->iterations);
         self::assertTrue($result->truncated);
         self::assertSame('SYNTHESISED', $result->finalContent);
         self::assertCount(2, $result->trace);
+
+        // Usage is summed across both tools rounds (2 × 10/5) AND the synthesis
+        // completion (3/2): 23 prompt, 12 completion. Pins the two += accumulators
+        // on the cap-hit path (a `-=` or `=` mutant would yield 17/8 or 3/2).
+        self::assertSame(23, $result->usage->promptTokens);
+        self::assertSame(12, $result->usage->completionTokens);
+        self::assertSame(35, $result->usage->totalTokens);
+
+        // The synthesis is recorded as its OWN round after the last tool round:
+        // iterations (2) + 1 = round 3. It is the sole request step offering no
+        // tools, and the sole LLM step whose content is the synthesised answer.
+        $synthesisRequests = array_values(array_filter(
+            $runTrace->getSteps(),
+            static fn(RunStep $s): bool => $s->kind === RunStep::KIND_REQUEST && $s->toolSpecs === [],
+        ));
+        self::assertCount(1, $synthesisRequests);
+        self::assertSame(3, $synthesisRequests[0]->round);
+
+        $synthesisLlm = array_values(array_filter(
+            $runTrace->getSteps(),
+            static fn(RunStep $s): bool => $s->kind === RunStep::KIND_LLM && $s->content === 'SYNTHESISED',
+        ));
+        self::assertCount(1, $synthesisLlm);
+        self::assertSame(3, $synthesisLlm[0]->round);
     }
 
     #[Test]
@@ -366,8 +395,9 @@ final class ToolLoopServiceTest extends TestCase
     public function oversizedToolResultIsCappedToMaxBytes(): void
     {
         // A tool returning more than the byte cap must be truncated before it is
-        // fed back to the model, with a visible marker.
-        $big = str_repeat('x', 60000);
+        // fed back to the model, with a visible marker. A distinctive leading
+        // token pins the cut window's start offset.
+        $big = 'START' . str_repeat('x', 60000);
 
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
         $queue = [
@@ -381,8 +411,40 @@ final class ToolLoopServiceTest extends TestCase
 
         self::assertCount(1, $result->trace);
         $toolResult = $result->trace[0]->result;
-        self::assertLessThanOrEqual(50000, strlen($toolResult));
+        // Reserving the marker's bytes makes the capped output land on the cap
+        // exactly (content budget + marker = 50000).
+        self::assertSame(50000, strlen($toolResult));
         self::assertStringContainsString('tool result truncated', $toolResult);
+        // The cut keeps the head of the tool output (offset 0, not 1 or -1): the
+        // result still begins with the distinctive leading token.
+        self::assertStringStartsWith('START', $toolResult);
+        // The exact truncation marker (order + both operands of the concat) is
+        // appended verbatim, embedding the byte cap and the trailing " bytes]".
+        self::assertStringEndsWith("\n…[tool result truncated at 50000 bytes]", $toolResult);
+    }
+
+    #[Test]
+    public function resultAtExactlyMaxBytesIsReturnedUntruncated(): void
+    {
+        // Boundary: a tool result whose length equals the cap exactly must pass
+        // through unchanged (the guard is `<=`, not `<`) — no marker appended.
+        $exact = str_repeat('x', 50000);
+
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'edge_tool', [])]),
+            $this->response('done'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('edge_tool', $exact)]));
+        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+
+        self::assertCount(1, $result->trace);
+        $toolResult = $result->trace[0]->result;
+        self::assertSame(50000, strlen($toolResult));
+        self::assertStringNotContainsString('truncated', $toolResult);
+        self::assertSame($exact, $toolResult);
     }
 
     #[Test]
@@ -774,5 +836,122 @@ final class ToolLoopServiceTest extends TestCase
 
         self::assertSame(7, $meta[BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $meta);
+    }
+
+    #[Test]
+    public function defaultMaxIterationsIsFiveWhenNoCapGiven(): void
+    {
+        // No $maxIterations argument ⇒ the constructor default (5) governs the
+        // cap. The model never stops requesting tools, so the loop runs the full
+        // five rounds before synthesising — pinning the default to 5 (a 4 or 6
+        // default would end at 4 or 6 iterations / trace entries).
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_x', 'loop_tool', [])]));
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('SYNTHESISED'));
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
+        $result  = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), null);
+
+        self::assertSame(5, $result->iterations);
+        self::assertTrue($result->truncated);
+        self::assertCount(5, $result->trace);
+        self::assertSame('SYNTHESISED', $result->finalContent);
+    }
+
+    #[Test]
+    public function dryRunReturnsEmptyResultAndCallsNoProvider(): void
+    {
+        // A dry run assembles the prompt and returns immediately: no provider
+        // call, an empty answer, zero iterations, not truncated, zero usage.
+        // Passing NO RunTrace exercises the null-safe recordAssembledMessages
+        // (a non-null-safe mutant would fatal on the null trace).
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+        $mgr->expects(self::never())->method('chatWithConfiguration');
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
+        $result  = $service->runLoop(
+            [$this->userTurn('hi')],
+            new LlmConfiguration(),
+            null,
+            null,
+            null,
+            null,
+            new RunAugmentation([], [], true),
+        );
+
+        self::assertSame('', $result->finalContent);
+        self::assertSame([], $result->trace);
+        self::assertSame(0, $result->iterations);
+        self::assertFalse($result->truncated);
+        self::assertSame(0, $result->usage->promptTokens);
+        self::assertSame(0, $result->usage->completionTokens);
+        self::assertSame(0, $result->usage->totalTokens);
+    }
+
+    #[Test]
+    public function dryRunBakesSystemPromptOverrideAsLeadingSystemMessage(): void
+    {
+        // With an augmentation present and a per-run system-prompt override, the
+        // override (non-empty) wins over the configuration prompt and is baked as
+        // the FIRST assembled message. Recorded on the dry-run trace so it can be
+        // asserted without a provider call.
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+        $mgr->expects(self::never())->method('chatWithConfiguration');
+
+        $runTrace = new RunTrace();
+        $service  = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
+        $service->runLoop(
+            [$this->userTurn('hi')],
+            new LlmConfiguration(),
+            null,
+            new ToolOptions(systemPrompt: 'OVERRIDE_SYS'),
+            null,
+            $runTrace,
+            new RunAugmentation([], [], true),
+        );
+
+        $steps = $runTrace->getSteps();
+        self::assertNotSame([], $steps);
+        $assembled = $steps[0];
+        self::assertSame(RunStep::KIND_ASSEMBLED, $assembled->kind);
+
+        $messages = $assembled->messagesSent;
+        self::assertIsArray($messages);
+        $first = self::arr($messages[0] ?? null);
+        self::assertSame('system', $first['role'] ?? null);
+        self::assertSame('OVERRIDE_SYS', $first['content'] ?? null);
+    }
+
+    #[Test]
+    public function plainCompletionPathRecordsRequestAndLlmAtRoundOne(): void
+    {
+        // Empty allow-list ⇒ no tools offered ⇒ the single plain-completion
+        // branch. It records exactly one request step and one LLM step, both at
+        // round 1, with an empty tool-spec list — and a small, non-negative
+        // elapsed duration (pinning elapsedMs's subtraction and /1e6 scaling).
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->response('plain answer'));
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+
+        $runTrace = new RunTrace();
+        $service  = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
+        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), [], null, null, $runTrace);
+
+        $steps = $runTrace->getSteps();
+        self::assertCount(2, $steps);
+        self::assertSame(RunStep::KIND_REQUEST, $steps[0]->kind);
+        self::assertSame(1, $steps[0]->round);
+        self::assertSame([], $steps[0]->toolSpecs);
+        self::assertSame(RunStep::KIND_LLM, $steps[1]->kind);
+        self::assertSame(1, $steps[1]->round);
+        self::assertGreaterThanOrEqual(0.0, $steps[1]->durationMs);
+        self::assertLessThan(60000.0, $steps[1]->durationMs);
     }
 }

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -796,6 +796,354 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         self::assertEquals('abc', $result->sourceLanguage);
         self::assertEquals('xyz', $result->targetLanguage);
     }
+
+    // ==================== request-shape tests (messages + options) ====================
+
+    /**
+     * Stub the manager interface so every chat() call's messages AND options
+     * are captured; answers are served from a queue of fixed responses (one
+     * per expected chat() call).
+     *
+     * @param array<int, string> $responseContents
+     *
+     * @return array{0: LlmServiceManagerInterface&Stub, 1: object{messages: list<mixed>, options: array<int, ChatOptions>}}
+     */
+    private function createMessageCapturingManager(array $responseContents): array
+    {
+        $captured = new class {
+            /** @var list<mixed> */
+            public array $messages = [];
+            /** @var array<int, ChatOptions> */
+            public array $options = [];
+        };
+
+        $responses = [];
+        foreach ($responseContents as $content) {
+            $responses[] = new CompletionResponse(
+                content: $content,
+                model: 'gpt-5.2',
+                usage: new UsageStatistics(100, 50, 150),
+                finishReason: 'stop',
+                provider: 'openai',
+            );
+        }
+
+        $index = 0;
+        $llmManager = self::createStub(LlmServiceManagerInterface::class);
+        $llmManager
+            ->method('chat')
+            ->willReturnCallback(
+                static function (array $messages, ?ChatOptions $options = null) use ($captured, $responses, &$index): CompletionResponse {
+                    self::assertInstanceOf(ChatOptions::class, $options);
+                    $captured->messages[] = $messages;
+                    $captured->options[]  = $options;
+                    $response = $responses[$index] ?? $responses[count($responses) - 1];
+                    ++$index;
+
+                    return $response;
+                },
+            );
+
+        return [$llmManager, $captured];
+    }
+
+    /**
+     * @param array<mixed> $messages
+     */
+    private function assertMessageRole(array $messages, int $index, string $expectedRole): void
+    {
+        $message = $messages[$index];
+        self::assertIsArray($message);
+        self::assertSame($expectedRole, $message['role'] ?? null);
+    }
+
+    /**
+     * @param array<mixed> $messages
+     */
+    private function messageContentAt(array $messages, int $index): string
+    {
+        $message = $messages[$index];
+        self::assertIsArray($message);
+        $content = $message['content'] ?? null;
+        self::assertIsString($content);
+
+        return $content;
+    }
+
+    #[Test]
+    public function translateSendsSystemAndUserMessages(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Hallo Welt']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello World', 'de', 'en', ['provider' => 'openai']);
+
+        self::assertCount(1, $captured->messages);
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        self::assertCount(2, $messages);
+        $this->assertMessageRole($messages, 0, 'system');
+        $this->assertMessageRole($messages, 1, 'user');
+        self::assertSame(
+            "Translate this text:\n\n" . 'Hello World',
+            $this->messageContentAt($messages, 1),
+        );
+    }
+
+    #[Test]
+    public function translateBuildsDefaultSystemPrompt(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Hallo']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello World', 'de', 'en', ['provider' => 'openai']);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        // Language names resolved from the code map, domain default 'general'.
+        self::assertStringContainsString(
+            'You are a professional general translator. Translate the following text from English to German.',
+            $system,
+        );
+        // preserve_formatting defaults to true → the preserve line is present.
+        self::assertStringContainsString(
+            'Preserve all formatting, HTML tags, markdown, and special characters.',
+            $system,
+        );
+        // The trailing instruction is appended, not overwriting the prompt.
+        self::assertStringContainsString(
+            'Provide ONLY the translation, no explanations or notes.',
+            $system,
+        );
+        // formality defaults to 'default' → NO "Maintain … tone" line.
+        self::assertStringNotContainsString('Maintain', $system);
+    }
+
+    #[Test]
+    public function translateOmitsPreserveLineWhenPreserveFormattingFalse(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Plain']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('<p>Text</p>', 'de', 'en', ['provider' => 'openai', 'preserve_formatting' => false]);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringNotContainsString('Preserve all formatting', $system);
+    }
+
+    #[Test]
+    public function translateIncludesPreserveLineWhenPreserveFormattingExplicitlyTrue(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Kept']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'preserve_formatting' => true]);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringContainsString('You are a professional general translator', $system);
+        self::assertStringContainsString('Preserve all formatting, HTML tags, markdown, and special characters.', $system);
+    }
+
+    #[Test]
+    public function translateAddsFormalityLineToSystemPrompt(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Formell']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'formality' => 'formal']);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringContainsString('Maintain formal tone.', $system);
+        // The line is appended (.=), not overwriting the professional intro.
+        self::assertStringContainsString('You are a professional', $system);
+    }
+
+    #[Test]
+    public function translateUsesDomainInSystemPrompt(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Medizin']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'domain' => 'medical']);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringContainsString('You are a professional medical translator', $system);
+    }
+
+    #[Test]
+    public function translateRendersGlossaryTermsInSystemPrompt(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Glossar']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate(
+            'Hello',
+            'de',
+            'en',
+            ['provider' => 'openai', 'glossary' => ['term1' => 'Begriff1', 'term2' => 'Begriff2']],
+        );
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringContainsString('Use these exact term translations:', $system);
+        self::assertStringContainsString('- term1 → Begriff1', $system);
+        self::assertStringContainsString('- term2 → Begriff2', $system);
+        // Header + terms are appended (.=), not overwriting the professional intro.
+        self::assertStringContainsString('You are a professional', $system);
+    }
+
+    #[Test]
+    public function translateRendersContextInSystemPrompt(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Kontext']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'context' => 'Informal chat message']);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        $system = $this->messageContentAt($messages, 0);
+
+        self::assertStringContainsString('Context (for reference only):', $system);
+        self::assertStringContainsString('Informal chat message', $system);
+        self::assertStringContainsString('You are a professional', $system);
+    }
+
+    #[Test]
+    public function translateForwardsResolvedOptionsToChat(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Hallo']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'model' => 'gpt-5.2']);
+
+        self::assertCount(1, $captured->options);
+        $options = $captured->options[0];
+        self::assertSame(2000, $options->getMaxTokens());
+        self::assertSame(0.3, $options->getTemperature());
+        self::assertSame('openai', $options->getProvider());
+        self::assertSame('gpt-5.2', $options->getModel());
+    }
+
+    #[Test]
+    public function translateKeepsZeroBeUserUidOnChatOptions(): void
+    {
+        // uid 0 is the "anonymous / skip budget" sentinel and must survive
+        // (>= 0), not be coerced to null (> 0).
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['Hallo']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->translate('Hello', 'de', 'en', ['provider' => 'openai', 'beUserUid' => 0]);
+
+        self::assertSame(0, $captured->options[0]->getBeUserUid());
+    }
+
+    #[Test]
+    public function translateResultTranslatorPinsResolvedProvider(): void
+    {
+        $this->setResponse('Hallo Welt');
+
+        $result = $this->subject->translate('Hello World', 'de', 'en', ['provider' => 'openai']);
+
+        self::assertSame('llm:openai', $result->translator);
+    }
+
+    #[Test]
+    public function translateTracksUsageWithExactServiceAndMultibyteCharacterCount(): void
+    {
+        // 'Café!' is 5 characters but 6 bytes — mb_strlen (not strlen) must be
+        // recorded; the service string must carry the resolved provider.
+        $this->setResponse('Übersetzt');
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock
+            ->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                'translation',
+                'llm:openai',
+                ['characters' => 5],
+                null,
+                0,
+                'gpt-5.2',
+                0,
+                null,
+            );
+
+        $subject = new LlmTranslator($this->llmManager, $usageTrackerMock);
+        $subject->translate('Café!', 'de', 'en', ['provider' => 'openai']);
+    }
+
+    #[Test]
+    public function detectLanguageSendsExactDetectionMessages(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['de']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->detectLanguage('Hallo Welt');
+
+        self::assertCount(1, $captured->messages);
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        self::assertCount(2, $messages);
+        $this->assertMessageRole($messages, 0, 'system');
+        $this->assertMessageRole($messages, 1, 'user');
+        self::assertSame(
+            'You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.',
+            $this->messageContentAt($messages, 0),
+        );
+        self::assertSame(
+            "Detect the language of this text:\n\n" . 'Hallo Welt',
+            $this->messageContentAt($messages, 1),
+        );
+    }
+
+    #[Test]
+    public function detectLanguageTruncatesTextToFiveHundredCharacters(): void
+    {
+        $longText = str_repeat('A', 600);
+
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['de']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->detectLanguage($longText);
+
+        $messages = $captured->messages[0];
+        self::assertIsArray($messages);
+        self::assertSame(
+            "Detect the language of this text:\n\n" . substr($longText, 0, 500),
+            $this->messageContentAt($messages, 1),
+        );
+    }
+
+    #[Test]
+    public function detectLanguageUsesTenTokenBudget(): void
+    {
+        [$llmManager, $captured] = $this->createMessageCapturingManager(['de']);
+
+        $subject = new LlmTranslator($llmManager, $this->usageTrackerStub);
+        $subject->detectLanguage('Hallo Welt');
+
+        $options = $captured->options[0];
+        self::assertSame(10, $options->getMaxTokens());
+        self::assertSame(0.1, $options->getTemperature());
+    }
 }
 
 /**


### PR DESCRIPTION
Third batch of the mutation-MSI climb (batch 1 = #393 62.8→67%, batch 2 = #394 →70%).

Strengthens 7 more hotspots — OpenAI/Ollama/Mistral providers, TaskInputResolver,
ToolLoopService, LlmTranslator, TranslationService — by asserting the exact
request payload, endpoint construction, headers, parsed response fields,
tool-loop iteration, and translation prompt/parse. Batch 3 kills **+302** mutants
independently; combined with batches 1+2 (disjoint files) covered MSI is ~73.4%.

**AbstractProvider deferred**: its endpoint-gate test-double returns an anonymous
subclass whose test-only accessors aren't visible to PHPStan level 10 through the
declared return type — it needs a named fixture class, done separately so this
batch stays clean.

Verification: full unit suite green, cgl + PHPStan L10 clean. Bulk verification
caught and fixed a `{}`-vs-`[]` decode mismatch, a wrong `_raw`-capture premise
(dropped), and 11 level-10 issues before this landed.
