### PR TITLE
test: strengthen assertions to raise mutation MSI, batch 4 (~75%, past target)

### DIFF
--- a/Tests/Unit/Fixture/RecordingLogger.php
+++ b/Tests/Unit/Fixture/RecordingLogger.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Fixture;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * In-memory PSR-3 logger for unit tests.
+ *
+ * Captures every log() call (level, rendered message, context) so assertions
+ * can verify a collaborator emitted the expected log line with the expected
+ * context — a NullLogger swallows all of that.
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array<array-key, mixed>}> */
+    public array $records = [];
+
+    /**
+     * @param array<array-key, mixed> $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level'   => $level,
+            'message' => (string)$message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * The first captured record whose level matches and whose message contains
+     * $messageNeedle, or null when none matched.
+     *
+     * @return array{level: mixed, message: string, context: array<array-key, mixed>}|null
+     */
+    public function firstMatching(string $level, string $messageNeedle): ?array
+    {
+        foreach ($this->records as $record) {
+            if ($record['level'] === $level && str_contains($record['message'], $messageNeedle)) {
+                return $record;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
@@ -21,14 +22,17 @@ use Netresearch\NrLlm\Provider\GroqProvider;
 use Netresearch\NrLlm\Provider\MistralProvider;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
@@ -729,5 +733,605 @@ class AbstractProviderTest extends AbstractUnitTestCase
             self::assertStringNotContainsString('sk-secret456', $e->getMessage());
             self::assertSame($networkException, $e->getPrevious());
         }
+    }
+
+    /**
+     * An empty `system_prompt` must NOT be surfaced as a leading system
+     * message: the guard is `is_string($p) && $p !== ''`, so the first
+     * message stays the user turn. Kills the `&&`->`||` mutant, which would
+     * add a `{role: system, content: ''}` message for the empty string.
+     */
+    #[Test]
+    public function completeDoesNotPrependEmptySystemPrompt(): void
+    {
+        $capturedBody = null;
+        $httpClientMock = $this->createHttpClientMock();
+        $httpClientMock->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'mistral-large-latest',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]));
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createCapturingStreamFactory($capturedBody),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($httpClientMock);
+
+        $provider->complete('Hello world', ['system_prompt' => '']);
+
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload['messages'] ?? null);
+        $first = $payload['messages'][0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame('user', $first['role'] ?? null);
+    }
+
+    /**
+     * The request URL is built as `rtrim(baseUrl,'/') . '/' . ltrim(endpoint,'/')`.
+     * Pin the full absolute URL so the mutant that drops the base-URL operand
+     * (leaving only `/endpoint`) is caught.
+     */
+    #[Test]
+    public function sendRequestBuildsAbsoluteUrlFromBaseUrlAndEndpoint(): void
+    {
+        $capturedUrl = null;
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturnCallback(
+            function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
+                $capturedUrl = (string)$request->getUri();
+                return $this->createJsonResponseMock([
+                    'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+                    'model' => 'mistral-large-latest',
+                    'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+                ]);
+            },
+        );
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'baseUrl' => 'https://mock.test/v1',
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($client);
+
+        $provider->complete('hi');
+
+        // MistralProvider posts to the 'chat/completions' endpoint.
+        self::assertSame('https://mock.test/v1/chat/completions', $capturedUrl);
+    }
+
+    /**
+     * A payload byte that is not valid UTF-8 must be json-encoded with
+     * `JSON_INVALID_UTF8_SUBSTITUTE` (replacement char U+FFFD), never dropped.
+     * The mutant that ANDs the two JSON flags yields flags == 0, so json_encode
+     * returns false on the invalid byte and stream creation fails — either way
+     * the substituted body assertion below no longer holds.
+     */
+    #[Test]
+    public function sendRequestSubstitutesInvalidUtf8InEncodedBody(): void
+    {
+        $capturedBody = null;
+        $httpClientMock = $this->createHttpClientMock();
+        $httpClientMock->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'mistral-large-latest',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ]));
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createCapturingStreamFactory($capturedBody),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($httpClientMock);
+
+        // 0xB1 is a lone continuation byte — invalid UTF-8 on its own.
+        $provider->complete("\xB1");
+
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload['messages'] ?? null);
+        $first = $payload['messages'][0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame("\u{FFFD}", $first['content'] ?? null);
+    }
+
+    /**
+     * With `maxRetries = 0` the retry loop never runs, so `$lastException`
+     * stays null and the final exception message falls back to the
+     * `?? self::UNKNOWN_ERROR` placeholder. Exercises the null-safe operator
+     * (the mutant drops `?->` and calls getMessage() on null) and pins the
+     * exception code to 0.
+     */
+    #[Test]
+    public function connectionExhaustionWithZeroRetriesFallsBackToUnknownErrorAndCodeZero(): void
+    {
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 0,
+        ]);
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertSame(0, $e->getCode());
+            self::assertStringContainsString('after 0 attempts', $e->getMessage());
+            self::assertStringContainsString('Unknown error', $e->getMessage());
+        }
+    }
+
+    /**
+     * A 3xx (here 300) is neither a 2xx success nor a 4xx client error, so it
+     * falls through to the final `throw new ProviderConnectionException(...)`.
+     * Pins both the `< 300` success bound (the mutant `<= 300` would treat 300
+     * as success) and the presence of the throw (the mutant drops it, so the
+     * method returns null → TypeError, and the "Server returned status 300"
+     * text never reaches the surfaced message).
+     */
+    #[Test]
+    public function threeHundredStatusSurfacesAsConnectionException(): void
+    {
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'mistral-large-latest',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ], 300));
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('Server returned status 300', $e->getMessage());
+        }
+    }
+
+    /**
+     * A 4xx body that is NOT valid JSON falls back to the
+     * `['error' => ['message' => self::UNKNOWN_ERROR]]` shape, so the surfaced
+     * message is exactly "Unknown error". The mutants that strip that array
+     * item degrade the message to "Unknown provider error" instead.
+     */
+    #[Test]
+    public function nonJsonFourxxBodyFallsBackToUnknownError(): void
+    {
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createHttpResponseMock(400, 'this is not json'));
+
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => 1,
+        ]);
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            self::assertSame('Unknown error', $e->getMessage());
+        }
+    }
+
+    /**
+     * A 300 streaming status is not a 2xx, so `assertStreamingResponseOk()`
+     * must throw. Pins the `< 300` bound: the mutant `<= 300` returns instead
+     * of throwing, silently yielding an empty stream.
+     */
+    #[Test]
+    public function streamingThreeHundredStatusThrowsConnectionException(): void
+    {
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+        ]);
+
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock([], 300));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->streamChatCompletion([['role' => 'user', 'content' => 'hello']])->current();
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertSame(300, $e->getCode());
+            self::assertStringContainsString('Server returned status 300', $e->getMessage());
+        }
+    }
+
+    /**
+     * A streaming status of EXACTLY 400 must map to ProviderResponseException
+     * (the 4xx branch). Pins the `>= 400` lower bound: the mutant `> 400`
+     * skips the 4xx branch for 400 and mis-maps it to a
+     * ProviderConnectionException.
+     */
+    #[Test]
+    public function streamingExactly400MapsToResponseException(): void
+    {
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+        ]);
+
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['error' => ['message' => 'bad request']], 400),
+        );
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->streamChatCompletion([['role' => 'user', 'content' => 'hello']])->current();
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            self::assertSame(400, $e->getCode());
+        }
+    }
+
+    /**
+     * `sendRequest()` calls `validateConfiguration()` first, which rejects a
+     * provider with no API-key identifier (code 1307337100). The mutant that
+     * drops that call would let the request proceed and succeed. Uses a named
+     * fixture so the protected `sendRequest()` is reachable.
+     */
+    #[Test]
+    public function sendRequestValidatesConfigurationBeforeDispatch(): void
+    {
+        // No apiKeyIdentifier configured -> validateConfiguration() must throw.
+        $provider = $this->makeGateProbe(['baseUrl' => 'https://ok.test/v1']);
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock(['data' => []]));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->exposedSendRequest('models', []);
+            self::fail('Expected ProviderConfigurationException was not thrown');
+        } catch (ProviderConfigurationException $e) {
+            self::assertSame(1307337100, $e->getCode());
+        }
+    }
+
+    /**
+     * `getSecretPlacementOptions()` supplies the vault audit `reason` passed to
+     * `withAuthentication()`. Pins the exact array so the mutant that returns
+     * `[]` is caught.
+     */
+    #[Test]
+    public function secretPlacementOptionsCarryAuditReason(): void
+    {
+        $capturedOptions = null;
+        $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
+        $vaultHttpClient->method('withAuthentication')->willReturnCallback(
+            function (string $secretIdentifier, SecretPlacement $placement, array $options) use (&$capturedOptions, $vaultHttpClient): VaultHttpClientInterface {
+                $capturedOptions = $options;
+                return $vaultHttpClient;
+            },
+        );
+
+        $vault = self::createStub(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('http')->willReturn($vaultHttpClient);
+
+        $provider = $this->makeGateProbe(['apiKeyIdentifier' => 'vault-id'], $vault);
+
+        $provider->exposedGetHttpClient();
+
+        self::assertSame(['reason' => 'LLM API call to Gate Probe'], $capturedOptions);
+    }
+
+    /**
+     * `buildAuditReason()` maps the endpoint shape to a purpose and appends a
+     * string model when present. Each assertion pins one match arm (embedding /
+     * the four chat spellings / the default) plus the string-model guard, so
+     * the arm-removal and `&&`->`||` mutants are all caught.
+     */
+    #[Test]
+    public function buildAuditReasonMapsEndpointPurposeAndModel(): void
+    {
+        $provider = $this->makeGateProbe([]);
+
+        self::assertSame('LLM embedding call to Gate Probe', $provider->exposedBuildAuditReason('v1/embeddings', []));
+        self::assertSame('LLM chat call to Gate Probe', $provider->exposedBuildAuditReason('v1/chat/completions', []));
+        self::assertSame('LLM chat call to Gate Probe', $provider->exposedBuildAuditReason('v1/messages', []));
+        self::assertSame('LLM chat call to Gate Probe', $provider->exposedBuildAuditReason('models/x:generateContent', []));
+        self::assertSame('LLM chat call to Gate Probe', $provider->exposedBuildAuditReason('api/generate', []));
+        self::assertSame('LLM API call to Gate Probe', $provider->exposedBuildAuditReason('v1/models', []));
+
+        // A string model is appended; a non-string model is ignored (the `&&`
+        // guard), so the `||` mutant that appends `(123)` is caught.
+        self::assertSame('LLM chat call to Gate Probe (m1)', $provider->exposedBuildAuditReason('v1/chat', ['model' => 'm1']));
+        self::assertSame('LLM chat call to Gate Probe', $provider->exposedBuildAuditReason('v1/chat', ['model' => 123]));
+    }
+
+    /**
+     * A whitespace-only base URL trims to empty, so the SSRF gate returns
+     * early (nothing to check) and hands back a client. The mutant that drops
+     * `trim()` treats "   " as a non-empty host and rejects it.
+     */
+    #[Test]
+    public function endpointGateTrimsBaseUrlAndReturnsEarlyForBlank(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => '   ']);
+
+        self::assertInstanceOf(ClientInterface::class, $provider->exposedGetHttpClient());
+    }
+
+    /**
+     * A schemeless private/link-local IP literal must be rejected by the SSRF
+     * gate with code 1751452800. The concat mutants that mangle the
+     * protocol-relative `'//' . $baseUrl` prefix produce an unparseable host
+     * (code 1751452801 instead), and the +/-1 code mutants change the code.
+     */
+    #[Test]
+    public function endpointGateRejectsSchemelessPrivateIpLiteral(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => '169.254.169.254']);
+
+        try {
+            $provider->exposedGetHttpClient();
+            self::fail('Expected ProviderConfigurationException was not thrown');
+        } catch (ProviderConfigurationException $e) {
+            self::assertSame(1751452800, $e->getCode());
+        }
+    }
+
+    /**
+     * An uppercase scheme must still be recognised (the `#i` regex flag) so the
+     * link-local host behind it is parsed and rejected (code 1751452800). The
+     * flag-removal mutant fails to match the scheme, mis-parses the host as
+     * "HTTPS" and lets it through.
+     */
+    #[Test]
+    public function endpointGateMatchesUppercaseSchemeCaseInsensitively(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => 'HTTPS://169.254.169.254']);
+
+        try {
+            $provider->exposedGetHttpClient();
+            self::fail('Expected ProviderConfigurationException was not thrown');
+        } catch (ProviderConfigurationException $e) {
+            self::assertSame(1751452800, $e->getCode());
+        }
+    }
+
+    /**
+     * The scheme regex is anchored (`^`): a `://` occurring later in a
+     * schemeless value must NOT be treated as a scheme. Here the anchored
+     * match fails, the value is parsed protocol-relative, the link-local host
+     * is found and rejected (code 1751452800). The caret-removal mutant matches
+     * the embedded `://`, mis-parses to a null host and yields code 1751452801.
+     */
+    #[Test]
+    public function endpointGateAnchorsSchemeRegexAtStart(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => '169.254.169.254/x://y']);
+
+        try {
+            $provider->exposedGetHttpClient();
+            self::fail('Expected ProviderConfigurationException was not thrown');
+        } catch (ProviderConfigurationException $e) {
+            self::assertSame(1751452800, $e->getCode());
+        }
+    }
+
+    /**
+     * A parseable, allowed host passes the SSRF gate and yields a client. This
+     * pins the `!is_string($host) || $host === ''` guard being FALSE for a real
+     * host: the negation/identity/or-negation mutants flip it true and throw.
+     */
+    #[Test]
+    public function endpointGateAcceptsAllowedHost(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => 'https://ok.test']);
+
+        self::assertInstanceOf(ClientInterface::class, $provider->exposedGetHttpClient());
+    }
+
+    /**
+     * A non-empty base URL with no derivable host (a bare path) fails closed
+     * with code 1751452801. Pins the guard being TRUE for a null host: the
+     * `||`->`&&` mutant makes it false and calls isHostAllowed(null) -> TypeError.
+     */
+    #[Test]
+    public function endpointGateRejectsUnparseableHost(): void
+    {
+        $provider = $this->makeGateProbe(['baseUrl' => '/onlypath']);
+
+        try {
+            $provider->exposedGetHttpClient();
+            self::fail('Expected ProviderConfigurationException was not thrown');
+        } catch (ProviderConfigurationException $e) {
+            self::assertSame(1751452801, $e->getCode());
+        }
+    }
+
+    /**
+     * Stream factory stub that records the last content it was asked to wrap,
+     * so tests can assert on the exact JSON-encoded request body.
+     */
+    private function createCapturingStreamFactory(?string &$captured): StreamFactoryInterface
+    {
+        $factory = self::createStub(StreamFactoryInterface::class);
+        $factory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$captured): StreamInterface {
+                $captured = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        return $factory;
+    }
+
+    /**
+     * Build a named AbstractProvider fixture that exposes the protected members
+     * under test (SSRF gate, buildAuditReason, sendRequest). A named class —
+     * not an anonymous subclass — is required so PHPStan can see the accessors
+     * through the declared return type.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function makeGateProbe(array $config, ?VaultServiceInterface $vault = null): GateProbeProvider
+    {
+        $provider = new GateProbeProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $vault ?? $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure($config);
+
+        return $provider;
+    }
+}
+
+/**
+ * Named AbstractProvider fixture exposing protected members for unit tests.
+ *
+ * PHPStan level 10 cannot resolve test-only accessors declared on an anonymous
+ * subclass returned through an `AbstractProvider` type, so this fixture is a
+ * top-level named class whose helper return type is itself.
+ */
+final class GateProbeProvider extends AbstractProvider
+{
+    public function getName(): string
+    {
+        return 'Gate Probe';
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'gate-probe';
+    }
+
+    protected function getDefaultBaseUrl(): string
+    {
+        return 'https://gate.example.invalid/v1';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvailableModels(): array
+    {
+        return ['model-a' => 'Model A'];
+    }
+
+    public function chatCompletion(array $messages, array $options = []): CompletionResponse
+    {
+        return new CompletionResponse(
+            content: '',
+            model: 'model-a',
+            usage: new UsageStatistics(0, 0, 0),
+            finishReason: 'stop',
+            provider: $this->getIdentifier(),
+        );
+    }
+
+    public function embeddings(string|array $input, array $options = []): EmbeddingResponse
+    {
+        return new EmbeddingResponse(
+            embeddings: [],
+            model: 'model-a',
+            usage: new UsageStatistics(0, 0, 0),
+            provider: $this->getIdentifier(),
+        );
+    }
+
+    public function exposedGetHttpClient(): ClientInterface
+    {
+        return $this->getHttpClient();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function exposedBuildAuditReason(string $endpoint, array $payload): string
+    {
+        return $this->buildAuditReason($endpoint, $payload);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function exposedSendRequest(string $endpoint, array $payload): array
+    {
+        return $this->sendRequest($endpoint, $payload);
     }
 }

--- a/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
+++ b/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
@@ -188,6 +188,8 @@ final class SolrSearchBackendTest extends TestCase
         self::assertCount(1, $uris);
         self::assertStringContainsString('fq=' . rawurlencode('type:pages'), $uris[0]);
         self::assertStringContainsString('fq=' . rawurlencode('uid:2'), $uris[0]);
+        // The match-all `q` must be present: fetchSource selects by fq only.
+        self::assertStringContainsString('q=' . rawurlencode('*:*'), $uris[0]);
         // The public-only access filter must guard the FETCH path exactly
         // like the search path — a guessable uid must never bypass it.
         self::assertStringContainsString('fq=' . rawurlencode('{!typo3access}0,-1'), $uris[0]);
@@ -209,6 +211,367 @@ final class SolrSearchBackendTest extends TestCase
         $unknownSite = SourceReference::parse('solr:ghost:pages:2:0');
         self::assertNotNull($unknownSite);
         self::assertNull($backend->fetchSource($unknownSite, AccessContext::publicOnly()));
+    }
+
+    #[Test]
+    public function continuesToTheNextSiteWhenOneHasNoEndpoint(): void
+    {
+        // The first site is disabled (no endpoint); the loop must CONTINUE to
+        // the enabled site — a break would abort the cascade after the first.
+        $disabled = new Site('secondary', 2, [
+            'base' => 'https://secondary.example/',
+            'solr_enabled_read' => false,
+            'solr_scheme_read' => 'https',
+            'solr_host_read' => 'solr.example',
+            'solr_port_read' => 8983,
+            'solr_path_read' => '',
+            'solr_core_read' => 'core_en',
+            'languages' => [['languageId' => 0, 'title' => 'EN', 'locale' => 'en_US.UTF-8', 'base' => '/']],
+        ]);
+        $requestFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$disabled, $this->site()]), $requestFactory);
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:8983/solr/core_en/select?', $uris[0]);
+        self::assertFalse($result->isEmpty());
+    }
+
+    #[Test]
+    public function stopsCollectingWhenMaxSourcesCapIsReached(): void
+    {
+        // Two mappable documents, but the query caps at one source: the `>=`
+        // cap must return AT the limit, never one past it.
+        $requestFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), $requestFactory);
+
+        $result = $backend->search(RetrievalQuery::create('aikido', 1), AccessContext::publicOnly());
+
+        self::assertCount(1, $result->sources);
+        self::assertSame('solr:main:pages:2:0', $result->sources[0]->sourceId);
+    }
+
+    #[Test]
+    public function nonOkStatusWithParseableBodyStillYieldsEmptyResult(): void
+    {
+        // A 5xx carrying a well-formed body must be discarded on the status
+        // check alone — the parser must never run on a failed response.
+        $backend = new SolrSearchBackend(
+            new FakeSiteFinder([$this->site()]),
+            FakeSolrHttpClient::withJson(self::DOCS_JSON, 500),
+        );
+
+        self::assertTrue($backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly())->isEmpty());
+    }
+
+    #[Test]
+    public function scalarJsonBodyYieldsEmptyResult(): void
+    {
+        // A non-array decoded body (a bare JSON string) is rejected by the
+        // is_array guard before any ['response'] access.
+        $backend = new SolrSearchBackend(
+            new FakeSiteFinder([$this->site()]),
+            FakeSolrHttpClient::withJson('"a bare string, not an object"'),
+        );
+
+        self::assertTrue($backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly())->isEmpty());
+    }
+
+    #[Test]
+    public function fetchSourceRejectsTypeWithLeadingOrTrailingJunk(): void
+    {
+        $doc = '{"response":{"docs":[{"title":"T","content":"C","url":"https://example.org/x"}]}}';
+
+        $trailing = SourceReference::parse('solr:main:pages.:2:0');
+        self::assertNotNull($trailing);
+        $backendTrailing = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($doc));
+        self::assertNull(
+            $backendTrailing->fetchSource($trailing, AccessContext::publicOnly()),
+            'a type with a trailing non-word char must fail the anchored ($) regex',
+        );
+
+        $leading = SourceReference::parse('solr:main:.pages:2:0');
+        self::assertNotNull($leading);
+        $backendLeading = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($doc));
+        self::assertNull(
+            $backendLeading->fetchSource($leading, AccessContext::publicOnly()),
+            'a type with a leading non-word char must fail the anchored (^) regex',
+        );
+    }
+
+    #[Test]
+    public function dropsDocumentsWithoutAPositiveUid(): void
+    {
+        // Missing uid → default 0 → below the `>= 1` floor → dropped. A default
+        // of 1, or a weakened OR chain, would wrongly keep it.
+        $json = '{"response":{"docs":[
+            {"type":"pages","title":"No uid","content":"c","url":"https://example.org/x","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        self::assertTrue(
+            $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly())->isEmpty(),
+        );
+    }
+
+    #[Test]
+    public function keepsDocumentWithUidEqualToOne(): void
+    {
+        // uid === 1 is valid: the floor is `< 1`, not `<= 1`.
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":1,"title":"One","content":"c","url":"https://example.org/one","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame('solr:main:pages:1:0', $result->sources[0]->sourceId);
+    }
+
+    #[Test]
+    public function usesTheDocumentLanguageIdForTheSource(): void
+    {
+        // The source language comes from the document's own `language` field,
+        // not the query language (coalesce order matters).
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":3,"title":"L","content":"c","url":"https://example.org/l","language":5}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame(5, $result->sources[0]->languageId);
+        self::assertSame('solr:main:pages:3:5', $result->sources[0]->sourceId);
+    }
+
+    #[Test]
+    public function mapsNumericStringScoreAndRejectsNonNumericScore(): void
+    {
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":10,"title":"A","content":"a","url":"https://example.org/a","language":0,"score":"2.5"},
+            {"type":"pages","uid":11,"title":"B","content":"b","url":"https://example.org/b","language":0,"score":"nope"}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(2, $result->sources);
+        // Numeric string → float via the explicit (float) cast.
+        self::assertSame(2.5, $result->sources[0]->score);
+        // Non-numeric score → null (the is_numeric guard is an AND, not an OR).
+        self::assertNull($result->sources[1]->score);
+    }
+
+    #[Test]
+    public function keepsAbsoluteUrlWhenItHasNoParseableHost(): void
+    {
+        // baseHost is set but the document URL has an empty host: the host
+        // comparison is guarded by `$host !== ''` (an AND), so the URL is kept.
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":4,"title":"H","content":"c","url":"https:///aikido","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame('https:///aikido', $result->sources[0]->url);
+    }
+
+    #[Test]
+    public function absolutizesRelativeUrlIncludingTheSitePort(): void
+    {
+        // A relative URL is absolutized against scheme://host:port — the port
+        // segment and its ':' separator must both survive.
+        $site = $this->site(['base' => 'https://example.org:8443/']);
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":6,"title":"N","content":"c","url":"/news","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$site]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame('https://example.org:8443/news', $result->sources[0]->url);
+    }
+
+    #[Test]
+    public function firstMatchingLanguageConfigWins(): void
+    {
+        // Two entries for language 0: the loop BREAKS on the first match, so
+        // the first core is used (a continue would let the last one win).
+        $site = $this->site(languages: [
+            ['languageId' => 0, 'title' => 'EN', 'locale' => 'en_US.UTF-8', 'base' => '/', 'solr_core_read' => 'core_first'],
+            ['languageId' => 0, 'title' => 'EN2', 'locale' => 'en_US.UTF-8', 'base' => '/', 'solr_core_read' => 'core_second'],
+        ]);
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$site]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:8983/solr/core_first/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function solrReadEnabledDefaultsToTrueWhenUnset(): void
+    {
+        // No solr_enabled_read key → the default (true) applies → a request is
+        // made. A default of false would silently disable read.
+        $site = new Site('main', 1, [
+            'base' => 'https://example.org/',
+            'solr_scheme_read' => 'https',
+            'solr_host_read' => 'solr.example',
+            'solr_port_read' => 8983,
+            'solr_path_read' => '',
+            'solr_core_read' => 'core_en',
+            'languages' => [['languageId' => 0, 'title' => 'EN', 'locale' => 'en_US.UTF-8', 'base' => '/']],
+        ]);
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$site]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        self::assertCount(1, $requestFactory->requestedUris());
+    }
+
+    #[Test]
+    public function rejectsCoreWithLeadingOrTrailingUnsafeCharacters(): void
+    {
+        // The core name is validated by an anchored ^...$ regex; junk on either
+        // end must produce no request at all.
+        $trailingFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        (new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_core_read' => 'core_en.'])]), $trailingFactory))
+            ->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertSame([], $trailingFactory->requestedUris(), 'trailing junk in the core must be rejected ($ anchor)');
+
+        $leadingFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        (new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_core_read' => '.core_en'])]), $leadingFactory))
+            ->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertSame([], $leadingFactory->requestedUris(), 'leading junk in the core must be rejected (^ anchor)');
+    }
+
+    #[Test]
+    public function acceptsPortAtLowerBoundaryOne(): void
+    {
+        // port 1 is inside the accepted range: the floor is `< 1`, not `<= 1`.
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_port_read' => 1])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:1/solr/core_en/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function acceptsPortAtUpperBoundary65535(): void
+    {
+        // port 65535 is inside the accepted range: the ceiling is `> 65535`.
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_port_read' => 65535])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:65535/solr/core_en/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function rejectsPortBelowOne(): void
+    {
+        // port 0 is out of range → no request. Guards the `$port < 1` term.
+        $requestFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_port_read' => 0])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        self::assertSame([], $requestFactory->requestedUris());
+    }
+
+    #[Test]
+    public function rejectsNonHttpScheme(): void
+    {
+        // A scheme outside {http,https} → no request. Guards the in_array term.
+        $requestFactory = FakeSolrHttpClient::withJson(self::DOCS_JSON);
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_scheme_read' => 'ftp'])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        self::assertSame([], $requestFactory->requestedUris());
+    }
+
+    #[Test]
+    public function stripsSurroundingSlashesFromConfiguredPath(): void
+    {
+        // '/custom/' → 'custom' → '/custom/solr/{core}/select'. Pins the outer
+        // slash-trim, the '/solr' guard (must NOT fire for a non-solr path),
+        // and the leading-slash join.
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_path_read' => '/custom/'])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:8983/custom/solr/core_en/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function stripsTrailingSolrSegmentFromALongerPath(): void
+    {
+        // 'foo/solr' → the trailing '/solr' is peeled to 'foo'. Pins the
+        // substr offsets and the rtrim in the '/solr' handling.
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_path_read' => '/foo/solr'])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('https://solr.example:8983/foo/solr/core_en/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function whitespaceOnlyConfigValueFallsBackToDefault(): void
+    {
+        // A whitespace-only scheme is treated as unset → default 'http'. The
+        // trim inside the emptiness check makes this a fallback, not an empty
+        // (invalid) scheme that would suppress the request.
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site(['solr_scheme_read' => '   '])]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('http://solr.example:8983/solr/core_en/select?', $uris[0]);
+    }
+
+    #[Test]
+    public function missingConfigValueFallsBackToDefault(): void
+    {
+        // No solr_scheme_read key → default 'http'. If the null fallback were
+        // skipped the scheme would be '' and no request made.
+        $site = new Site('main', 1, [
+            'base' => 'https://example.org/',
+            'solr_enabled_read' => true,
+            'solr_host_read' => 'solr.example',
+            'solr_port_read' => 8983,
+            'solr_path_read' => '',
+            'solr_core_read' => 'core_en',
+            'languages' => [['languageId' => 0, 'title' => 'EN', 'locale' => 'en_US.UTF-8', 'base' => '/']],
+        ]);
+        $requestFactory = FakeSolrHttpClient::withJson('{"response":{"docs":[]}}');
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$site]), $requestFactory);
+
+        $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+
+        $uris = $requestFactory->requestedUris();
+        self::assertCount(1, $uris);
+        self::assertStringStartsWith('http://solr.example:8983/solr/core_en/select?', $uris[0]);
     }
 
     /**

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -25,11 +25,11 @@ use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingLogger;
 use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingUsageTracker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\AspectInterface;
@@ -42,11 +42,14 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
 
     private InMemoryTelemetryRepository $telemetry;
 
+    private RecordingLogger $logger;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->usage     = new RecordingUsageTracker();
         $this->telemetry = new InMemoryTelemetryRepository();
+        $this->logger    = new RecordingLogger();
     }
 
     #[Test]
@@ -115,20 +118,34 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertSame(6, $call['metrics']['tokens']);
         self::assertSame(0.25, $call['metrics']['cost']);
         self::assertSame(9, $call['configurationUid']);
+        // The served model's uid (getUid() => 3) is attributed, not the 0/null fallback.
+        self::assertSame(3, $call['modelUid']);
         self::assertSame('gpt-4o', $call['modelId']);
         self::assertSame(42, $call['beUserUid']);
+        // No task metadata was supplied, so readInt() yields its 0 default.
+        self::assertSame(0, $call['taskUid']);
 
         self::assertCount(1, $this->telemetry->records);
         $record = $this->telemetry->records[0];
         self::assertSame('stream', $record->operation);
         self::assertSame('corr-1', $record->correlationId);
         self::assertSame('primary', $record->configurationIdentifier);
+        // beUser is resolved from the caller-supplied metadata (42), not the
+        // ambient backend.user aspect (0).
+        self::assertSame(42, $record->beUser);
         self::assertTrue($record->success);
         self::assertSame('', $record->errorClass);
         self::assertFalse($record->cacheHit);
         self::assertSame(0, $record->fallbackAttempts);
         self::assertNotNull($record->timeToFirstTokenMs);
         self::assertGreaterThanOrEqual(0, $record->timeToFirstTokenMs);
+        // latencyMs is a small elapsed duration (endNs - startNs); the additive
+        // mutant would make it an astronomically large hrtime sum.
+        self::assertGreaterThanOrEqual(0, $record->latencyMs);
+        self::assertLessThan(60000, $record->latencyMs);
+        self::assertLessThan(60000, $record->timeToFirstTokenMs);
+        // A completed stream is never the "aborted before completion" path.
+        self::assertNull($this->logger->firstMatching('info', 'aborted before completion'));
     }
 
     #[Test]
@@ -162,6 +179,9 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         ));
 
         self::assertSame('groq', $this->usage->calls[0]['provider']);
+        // "x" is one byte => ceil(1/4) = 1 completion token; a -1 seed for the
+        // byte counter (0 tokens) or round() instead of ceil() (0 tokens) both fail this.
+        self::assertSame(1, $this->usage->calls[0]['metrics']['completionTokens']);
     }
 
     #[Test]
@@ -187,11 +207,21 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertCount(1, $this->usage->calls, 'Partial usage must be recorded on early break.');
         // Only the first 4-char chunk was drained => 1 completion token.
         self::assertSame(1, $this->usage->calls[0]['metrics']['completionTokens']);
+        // 0 prompt chars => estimateTokens(0) = 0 (the <= 0 guard returns 0).
+        self::assertSame(0, $this->usage->calls[0]['metrics']['promptTokens']);
+        // The served config carries no model, so modelUid falls back to 0.
+        self::assertSame(0, $this->usage->calls[0]['modelUid']);
 
         self::assertCount(1, $this->telemetry->records);
         $record = $this->telemetry->records[0];
         self::assertFalse($record->success, 'An abandoned stream did not complete.');
         self::assertSame('', $record->errorClass, 'An early break is not an exception.');
+
+        // The abort branch (no success, no exception) logs the partial length.
+        $abort = $this->requireLog('info', 'aborted before completion');
+        self::assertSame(4, $abort['context']['completionChars']);
+        self::assertSame('corr-1', $abort['context']['correlationId']);
+        self::assertSame('stream', $abort['context']['operation']);
     }
 
     #[Test]
@@ -341,18 +371,25 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             throw new ProviderConnectionException($config->getIdentifier() . ' down', 1495872191);
         };
 
-        $caught = false;
+        $surfaced = null;
         try {
             iterator_to_array($dispatcher->stream(
                 $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
                 $primary,
                 $open,
             ));
-        } catch (ProviderConnectionException) {
-            $caught = true;
+        } catch (ProviderConnectionException $e) {
+            $surfaced = $e;
         }
 
-        self::assertTrue($caught, 'An exhausted streaming fallback chain must surface the last error.');
+        if ($surfaced === null) {
+            self::fail('An exhausted streaming fallback chain must surface the last error.');
+        }
+        // The LAST retryable exception is surfaced (the ?? fallback default is
+        // never reached because $lastRetryable is set) — code/message prove the
+        // actual candidate error propagated, not a freshly built default.
+        self::assertSame(1495872191, $surfaced->getCode());
+        self::assertSame('fb2 down', $surfaced->getMessage());
         self::assertSame([], $this->usage->calls, 'A stream that produced nothing bills no usage.');
         self::assertSame(2, $this->telemetry->records[0]->fallbackAttempts);
         self::assertFalse($this->telemetry->records[0]->success);
@@ -444,9 +481,205 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertSame([], $this->telemetry->records, 'Telemetry must honour the disabled setting.');
     }
 
+    #[Test]
+    public function propagatesANonRetryablePrimingFailureWithoutDispatchingTheFallback(): void
+    {
+        $fallback = $this->configuration('fallback', providerType: 'claude', modelId: 'claude', uid: 5);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($fallback);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            modelId: 'gpt-4o',
+            fallbackChain: new FallbackChain(['primary', 'fallback']),
+        );
+
+        // 400 on priming => non-retryable: it must throw immediately, never
+        // reaching the fallback candidate.
+        $open = static function (LlmConfiguration $config): Generator {
+            if ($config->getIdentifier() === 'primary') {
+                yield from [];
+
+                throw new ProviderResponseException('bad request', 400);
+            }
+
+            yield 'must-not-be-served';
+        };
+
+        $caught = false;
+        try {
+            iterator_to_array($dispatcher->stream(
+                $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+                $primary,
+                $open,
+            ));
+        } catch (ProviderResponseException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught, 'A non-retryable priming failure must propagate.');
+        self::assertSame([], $this->usage->calls, 'No candidate served, so nothing is billed.');
+        self::assertCount(1, $this->telemetry->records);
+        self::assertFalse($this->telemetry->records[0]->success);
+        self::assertSame(0, $this->telemetry->records[0]->fallbackAttempts, 'The fallback must not be dispatched.');
+        self::assertSame(ProviderResponseException::class, $this->telemetry->records[0]->errorClass);
+    }
+
+    #[Test]
+    public function treatsARateLimitedPrimingFailureAsRetryableAndSwapsToTheFallback(): void
+    {
+        $fallback = $this->configuration('fallback', providerType: 'claude', modelId: 'claude', uid: 5);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($fallback);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            modelId: 'gpt-4o',
+            fallbackChain: new FallbackChain(['primary', 'fallback']),
+        );
+
+        // HTTP 429 on priming: a sibling provider might not be throttled, so a
+        // ProviderResponseException with code 429 is the one that IS retryable.
+        $open = static function (LlmConfiguration $config): Generator {
+            if ($config->getIdentifier() === 'primary') {
+                yield from [];
+
+                throw new ProviderResponseException('rate limited', 429);
+            }
+
+            yield 'served-by-fallback';
+        };
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            $primary,
+            $open,
+        ));
+
+        self::assertSame(['served-by-fallback'], $chunks, 'A 429 primary must fall back, not surface.');
+        self::assertCount(1, $this->telemetry->records);
+        self::assertTrue($this->telemetry->records[0]->success);
+        self::assertSame(1, $this->telemetry->records[0]->fallbackAttempts);
+        self::assertSame('claude', $this->usage->calls[0]['provider']);
+
+        // The retry decision is logged with the failing configuration named.
+        $warning = $this->requireLog('warning', 'attempt failed before first chunk');
+        self::assertSame('primary', $warning['context']['configuration']);
+        self::assertSame('corr-1', $warning['context']['correlationId']);
+        self::assertSame('stream', $warning['context']['operation']);
+    }
+
+    #[Test]
+    public function skipsAnInactiveFallbackConfiguration(): void
+    {
+        // Present but inactive: candidates() must drop it, like FallbackMiddleware.
+        $inactive = $this->configuration('fb1', providerType: 'claude', active: false);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($inactive);
+
+        $dispatcher = $this->dispatcher(repository: $repository);
+
+        $primary = $this->configuration(
+            'primary',
+            providerType: 'openai',
+            fallbackChain: new FallbackChain(['primary', 'fb1']),
+        );
+
+        // Primary fails priming retryably; fb1 would serve IF it were considered.
+        $open = static function (LlmConfiguration $config): Generator {
+            if ($config->getIdentifier() === 'primary') {
+                yield from [];
+
+                throw new ProviderConnectionException('primary down', 1495872199);
+            }
+
+            yield 'must-not-be-served';
+        };
+
+        $caught = false;
+        try {
+            iterator_to_array($dispatcher->stream(
+                $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+                $primary,
+                $open,
+            ));
+        } catch (ProviderConnectionException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught, 'With the only fallback inactive, the chain is exhausted and surfaces.');
+        self::assertSame([], $this->usage->calls, 'The inactive fallback never served, so nothing is billed.');
+        self::assertCount(1, $this->telemetry->records);
+        self::assertFalse($this->telemetry->records[0]->success);
+        self::assertSame(0, $this->telemetry->records[0]->fallbackAttempts, 'An inactive fallback is not dispatched.');
+    }
+
+    #[Test]
+    public function attributesNoConfigurationUidWhenTheServedConfigurationIsUnpersisted(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 4]),
+            // A transient / unpersisted configuration reports uid 0.
+            $this->configuration('primary', providerType: 'openai', uid: 0),
+            $this->staticStream(['ok']),
+        ));
+
+        self::assertCount(1, $this->usage->calls);
+        self::assertNull(
+            $this->usage->calls[0]['configurationUid'],
+            'A uid of 0 (unpersisted) must map to a null configuration attribution.',
+        );
+    }
+
+    #[Test]
+    public function fallsBackToUnknownProviderWhenNeitherConfigNorMetadataNamesOne(): void
+    {
+        $dispatcher = $this->dispatcher();
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([
+                StreamingDispatcher::METADATA_PROMPT_CHARS => 4,
+                // Present but empty: a blank string names no provider.
+                StreamingDispatcher::METADATA_PROVIDER     => '',
+            ]),
+            $this->configuration('ad-hoc:stream', providerType: ''),
+            $this->staticStream(['x']),
+        ));
+
+        self::assertSame('unknown', $this->usage->calls[0]['provider']);
+    }
+
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
+
+    /**
+     * The first captured log record of the given level whose message contains
+     * $needle. Fails the test (never-returning) when none matched, so the
+     * caller can use the returned array without a null check.
+     *
+     * @return array{level: mixed, message: string, context: array<array-key, mixed>}
+     */
+    private function requireLog(string $level, string $needle): array
+    {
+        $record = $this->logger->firstMatching($level, $needle);
+        if ($record === null) {
+            self::fail(sprintf('Expected a "%s" log containing "%s".', $level, $needle));
+        }
+
+        return $record;
+    }
 
     private function dispatcher(
         ?BudgetServiceInterface $budget = null,
@@ -458,7 +691,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->usage,
             $this->telemetry,
             $repository ?? self::createStub(LlmConfigurationRepository::class),
-            new NullLogger(),
+            $this->logger,
             $this->contextWithAmbientUser(0),
             $extensionConfiguration ?? $this->extensionConfiguration(true),
         );
@@ -499,6 +732,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         ?Model $model = null,
         ?int $uid = null,
         ?FallbackChain $fallbackChain = null,
+        bool $active = true,
     ): LlmConfiguration&MockObject {
         $configuration = $this->createMock(LlmConfiguration::class);
         $configuration->method('getIdentifier')->willReturn($identifier);
@@ -506,7 +740,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         $configuration->method('getModelId')->willReturn($modelId);
         $configuration->method('getLlmModel')->willReturn($model);
         $configuration->method('getUid')->willReturn($uid);
-        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('isActive')->willReturn($active);
         $configuration->method('getFallbackChainDTO')->willReturn($fallbackChain ?? new FallbackChain());
 
         return $configuration;

--- a/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
@@ -47,7 +47,38 @@ final class SearchCodeToolTest extends TestCase
         $spec = $this->tool->getSpec();
 
         self::assertSame('search_code', $spec->name);
-        self::assertSame(['pattern'], $spec->parameters['required'] ?? null);
+        self::assertSame(
+            'Search the project source files for a literal substring (or a regular expression with '
+            . 'regex=true). Returns path:line hits. Vendor, var and dot directories are skipped.',
+            $spec->description,
+        );
+        // Pin the whole JSON-Schema parameter block so any dropped item/type is caught.
+        self::assertSame(
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'pattern' => [
+                        'type'        => 'string',
+                        'description' => 'Literal substring to find (case-sensitive). With regex=true: a PCRE pattern body without delimiters.',
+                    ],
+                    'regex' => [
+                        'type'        => 'boolean',
+                        'description' => 'Treat pattern as a regular expression (default false = literal substring).',
+                    ],
+                    'path' => [
+                        'type'        => 'string',
+                        'description' => 'Optional subdirectory (relative to the project root) to restrict the search to.',
+                    ],
+                    'max_results' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum hits to return (default 30, cap 100).',
+                    ],
+                ],
+                'required' => ['pattern'],
+            ],
+            $spec->parameters,
+        );
+        self::assertSame(['pattern'], $spec->parameters['required']);
         self::assertTrue($this->tool->requiresAdmin());
         self::assertSame('code', $this->tool->getGroup());
     }
@@ -58,7 +89,12 @@ final class SearchCodeToolTest extends TestCase
         $output = $this->tool->execute(['pattern' => 'findMeHere']);
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
+        // Relative path is root-stripped with no leading slash and not the full/offset pathname:
+        // each hit line begins right after a newline with "Classes/…".
+        self::assertStringContainsString("\nClasses/Alpha.php:2:", $output);
         self::assertStringContainsString('Resources/notes.md:1:', $output);
+        // Short hit lines are never length-truncated, so no ellipsis appears.
+        self::assertStringNotContainsString('…', $output);
         // Skipped: vendor/, dot dirs, var/, non-source extensions.
         self::assertStringNotContainsString('vendor/acme', $output);
         self::assertStringNotContainsString('.git', $output);
@@ -94,8 +130,10 @@ final class SearchCodeToolTest extends TestCase
     #[Test]
     public function deniesEscapingSearchPath(): void
     {
-        self::assertStringContainsString(
-            'Denied or not found',
+        // The reported subPath is trimmed of surrounding slashes ("../" -> ".."),
+        // so pin the exact denial message.
+        self::assertSame(
+            'Denied or not found: search path "..".',
             $this->tool->execute(['pattern' => 'x', 'path' => '../']),
         );
     }
@@ -104,6 +142,118 @@ final class SearchCodeToolTest extends TestCase
     public function reportsNoMatches(): void
     {
         self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'zzz-not-there']));
+    }
+
+    #[Test]
+    public function defaultsToLiteralNotRegexWhenFlagAbsent(): void
+    {
+        // "findMe." is absent as a literal but, as a regex, matches "findMeH".
+        // Without regex=true the tool must treat it literally -> no match.
+        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'findMe.']));
+    }
+
+    #[Test]
+    public function regexEscapesTildeDelimiterInPattern(): void
+    {
+        file_put_contents($this->root . '/Classes/Tilde.php', "<?php\n// a~b marker\n");
+
+        // "~" is the delimiter; it must be escaped in the pattern body, otherwise
+        // "~a~b~" reads "b" as a modifier and the pattern is rejected as invalid.
+        $output = $this->tool->execute(['pattern' => 'a~b', 'regex' => true]);
+
+        self::assertStringContainsString('Classes/Tilde.php:2:', $output);
+        self::assertStringNotContainsString('invalid regular expression', $output);
+    }
+
+    #[Test]
+    public function regexScanDoesNotSkipFilesContainingThePatternLiterally(): void
+    {
+        // In regex mode the literal str_contains() pre-filter must NOT run;
+        // a file whose bytes contain the raw pattern still has to be scanned.
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'regex' => true]);
+
+        self::assertStringContainsString('Classes/Alpha.php:2:', $output);
+    }
+
+    #[Test]
+    public function searchesWithinValidSubPath(): void
+    {
+        // A valid subdirectory resolves under the root and scopes the walk to it.
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes']);
+
+        self::assertStringContainsString('Classes/Alpha.php:2:', $output);
+        self::assertStringNotContainsString('Denied', $output);
+        self::assertStringNotContainsString('Resources/notes.md', $output);
+    }
+
+    #[Test]
+    public function searchesWholeRootWithDotPath(): void
+    {
+        // path="." resolves to the root itself; containment must accept root == candidate.
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => '.']);
+
+        self::assertStringContainsString('Classes/Alpha.php:2:', $output);
+        self::assertStringContainsString('Resources/notes.md:1:', $output);
+    }
+
+    #[Test]
+    public function deniesSubPathPointingAtAFile(): void
+    {
+        // A file (not a directory) must be rejected by the is_dir() guard.
+        self::assertStringContainsString(
+            'Denied or not found',
+            $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes/Alpha.php']),
+        );
+    }
+
+    #[Test]
+    public function deniesSiblingDirectorySharingRootPrefix(): void
+    {
+        // A sibling whose name is the root name plus a suffix shares the root's
+        // string prefix; the trailing "/" in the containment needle must reject it.
+        $sibling = $this->root . 'x';
+        mkdir($sibling . '/Classes', 0o777, true);
+        file_put_contents($sibling . '/Classes/Sib.php', "<?php // findMeHere\n");
+
+        try {
+            $output = $this->tool->execute([
+                'pattern' => 'findMeHere',
+                'path'    => '../' . basename($this->root) . 'x',
+            ]);
+
+            self::assertStringContainsString('Denied or not found', $output);
+            self::assertStringNotContainsString('Sib.php', $output);
+        } finally {
+            GeneralUtility::rmdir($sibling, true);
+        }
+    }
+
+    #[Test]
+    public function trimsSurroundingWhitespaceFromMatchedLine(): void
+    {
+        file_put_contents($this->root . '/Classes/Indent.php', "<?php\n    findMeHere indented\n");
+
+        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+
+        // The leading indentation is trimmed: exactly ": findMeHere indented" follows the line number.
+        self::assertStringContainsString('Classes/Indent.php:2: findMeHere indented', $output);
+    }
+
+    #[Test]
+    public function respectsMultibyteAwareLineLengthBoundary(): void
+    {
+        // Exactly MAX_LINE_LENGTH (200) chars: kept verbatim, no ellipsis (> not >=, not <=).
+        $exact = 'findMeHere' . str_repeat('a', 190);
+        // 160 characters but 310 bytes: mb_strlen (not strlen) keeps it below the cap.
+        $multibyte = 'findMeHere' . str_repeat('é', 150);
+        file_put_contents($this->root . '/Classes/Exact.php', $exact . "\n");
+        file_put_contents($this->root . '/Classes/Multibyte.php', $multibyte . "\n");
+
+        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+
+        self::assertStringContainsString('Classes/Exact.php:1: ' . $exact, $output);
+        self::assertStringNotContainsString($exact . '…', $output);
+        self::assertStringNotContainsString($multibyte . '…', $output);
     }
 
     protected function tearDown(): void

--- a/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
@@ -168,9 +168,12 @@ final class SearchCodeToolTest extends TestCase
     #[Test]
     public function regexScanDoesNotSkipFilesContainingThePatternLiterally(): void
     {
-        // In regex mode the literal str_contains() pre-filter must NOT run;
-        // a file whose bytes contain the raw pattern still has to be scanned.
-        $output = $this->tool->execute(['pattern' => 'findMeHere', 'regex' => true]);
+        // In regex mode the literal str_contains() pre-filter must NOT run.
+        // The pattern matches `findMeHere` only AS A REGEX — the raw bytes
+        // `find.{2}Here` appear nowhere in the fixture, so if the pre-filter
+        // were (wrongly) applied in regex mode it would skip the file and this
+        // assertion would fail.
+        $output = $this->tool->execute(['pattern' => 'find.{2}Here', 'regex' => true]);
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
     }

--- a/Tests/Unit/Service/UsageTrackerServiceTest.php
+++ b/Tests/Unit/Service/UsageTrackerServiceTest.php
@@ -170,6 +170,12 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->with(
                 self::stringContains('UPDATE tx_nrllm_service_usage SET'),
                 self::callback(fn(array $params) => $params['tokens'] === 500
+                        && $params['promptTokens'] === 25
+                        && $params['completionTokens'] === 75
+                        && $params['characters'] === 300
+                        && $params['audioSeconds'] === 12
+                        && $params['images'] === 3
+                        && $params['cost'] === 0.05
                         && $params['uid'] === 123),
             );
 
@@ -179,7 +185,15 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->willReturn($connectionMock);
 
         $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
-        $subject->trackUsage('chat', 'openai', ['tokens' => 500]);
+        $subject->trackUsage('chat', 'openai', [
+            'tokens' => 500,
+            'promptTokens' => 25,
+            'completionTokens' => 75,
+            'characters' => 300,
+            'audioSeconds' => 12,
+            'images' => 3,
+            'cost' => 0.05,
+        ]);
     }
 
     #[Test]
@@ -235,6 +249,8 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
 
         $metrics = [
             'tokens' => 100,
+            'promptTokens' => 25,
+            'completionTokens' => 75,
             'characters' => 500,
             'audioSeconds' => 30,
             'images' => 2,
@@ -249,6 +265,8 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->with(
                 'tx_nrllm_service_usage',
                 self::callback(fn(array $data) => $data['tokens_used'] === $metrics['tokens']
+                        && $data['prompt_tokens'] === $metrics['promptTokens']
+                        && $data['completion_tokens'] === $metrics['completionTokens']
                         && $data['characters_used'] === $metrics['characters']
                         && $data['audio_seconds_used'] === $metrics['audioSeconds']
                         && $data['images_generated'] === $metrics['images']
@@ -338,7 +356,21 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['be_user'] === 0),
+                self::callback(fn(array $data) => $data['be_user'] === 0
+                        && array_key_exists('pid', $data)
+                        && $data['pid'] === 0
+                        && $data['configuration_uid'] === 0
+                        && $data['task_uid'] === 0
+                        && $data['model_uid'] === 0
+                        && $data['model_id'] === ''
+                        && $data['request_count'] === 1
+                        && $data['tokens_used'] === 0
+                        && $data['prompt_tokens'] === 0
+                        && $data['completion_tokens'] === 0
+                        && $data['characters_used'] === 0
+                        && $data['audio_seconds_used'] === 0
+                        && $data['images_generated'] === 0
+                        && $data['estimated_cost'] === 0.0),
             );
 
         $connectionPoolStub = self::createStub(ConnectionPool::class);
@@ -348,6 +380,146 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
 
         $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
         $subject->trackUsage('translation', 'deepl', []);
+    }
+
+    #[Test]
+    public function trackUsageUpdateUsesZeroDefaultsForEmptyMetrics(): void
+    {
+        // On the UPDATE path every increment falls back to a neutral 0 / 0.0
+        // when the corresponding metric is absent, so the running totals do not
+        // move for the missing dimensions.
+        $this->setupBackendUser(5);
+
+        $resultStub = self::createStub(Result::class);
+        $resultStub->method('fetchOne')->willReturn(456);
+
+        $queryBuilderStub = self::createStub(QueryBuilder::class);
+        $queryBuilderStub->method('select')->willReturnSelf();
+        $queryBuilderStub->method('from')->willReturnSelf();
+        $queryBuilderStub->method('where')->willReturnSelf();
+        $queryBuilderStub->method('expr')->willReturn($this->exprStub);
+        $queryBuilderStub->method('createNamedParameter')->willReturnCallback(fn(string|int|float $v): string => "'$v'");
+        $queryBuilderStub->method('executeQuery')->willReturn($resultStub);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->method('createQueryBuilder')->willReturn($queryBuilderStub);
+        $connectionMock
+            ->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                self::stringContains('UPDATE tx_nrllm_service_usage SET'),
+                self::callback(fn(array $params) => $params['tokens'] === 0
+                        && $params['promptTokens'] === 0
+                        && $params['completionTokens'] === 0
+                        && $params['characters'] === 0
+                        && $params['audioSeconds'] === 0
+                        && $params['images'] === 0
+                        && $params['cost'] === 0.0
+                        && $params['uid'] === 456),
+            );
+
+        $connectionPoolStub = self::createStub(ConnectionPool::class);
+        $connectionPoolStub
+            ->method('getConnectionForTable')
+            ->willReturn($connectionMock);
+
+        $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
+        $subject->trackUsage('chat', 'openai', []);
+    }
+
+    #[Test]
+    public function trackUsageLookupUsesConfigurationUidInWhereClause(): void
+    {
+        // The daily-aggregation lookup keys on configuration_uid: null collapses
+        // to 0, an explicit value is used verbatim. Capture the expr()->eq()
+        // arguments to pin the exact value that enters the WHERE clause.
+        $this->setupBackendUser(5);
+
+        /** @var list<array{0: string, 1: mixed}> $eqCalls */
+        $eqCalls = [];
+        $exprStub = self::createStub(ExpressionBuilder::class);
+        $exprStub->method('eq')->willReturnCallback(
+            function (string $fieldName, mixed $value) use (&$eqCalls): string {
+                $eqCalls[] = [$fieldName, $value];
+
+                return 'eq_expr';
+            },
+        );
+
+        $resultStub = self::createStub(Result::class);
+        $resultStub->method('fetchOne')->willReturn(false);
+
+        $queryBuilderStub = self::createStub(QueryBuilder::class);
+        $queryBuilderStub->method('select')->willReturnSelf();
+        $queryBuilderStub->method('from')->willReturnSelf();
+        $queryBuilderStub->method('where')->willReturnSelf();
+        $queryBuilderStub->method('expr')->willReturn($exprStub);
+        $queryBuilderStub->method('createNamedParameter')->willReturnCallback(fn(string|int|float $v): string => "'$v'");
+        $queryBuilderStub->method('executeQuery')->willReturn($resultStub);
+
+        $connectionStub = self::createStub(Connection::class);
+        $connectionStub->method('createQueryBuilder')->willReturn($queryBuilderStub);
+
+        $connectionPoolStub = self::createStub(ConnectionPool::class);
+        $connectionPoolStub->method('getConnectionForTable')->willReturn($connectionStub);
+
+        $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
+        // No configuration → default 0 in the lookup key.
+        $subject->trackUsage('chat', 'openai', []);
+        // Explicit configuration → its own value in the lookup key.
+        $subject->trackUsage('chat', 'openai', [], 42);
+
+        self::assertContains(['configuration_uid', 0], $eqCalls);
+        self::assertContains(['configuration_uid', 42], $eqCalls);
+        self::assertContains(['task_uid', 0], $eqCalls);
+        self::assertContains(['model_uid', 0], $eqCalls);
+        self::assertContains(['be_user', 5], $eqCalls);
+    }
+
+    #[Test]
+    public function trackUsageAttributesUsageToExplicitBackendUser(): void
+    {
+        // An explicit beUserUid must win over the ambient backend.user context
+        // (the ?? coalesces beUserUid FIRST, only falling back to the context).
+        $aspectStub = new class implements AspectInterface {
+            public function get(string $name): mixed
+            {
+                return match ($name) {
+                    'id' => 5,
+                    default => null,
+                };
+            }
+        };
+        $this->contextMock->method('getAspect')->willReturn($aspectStub);
+
+        $resultStub = self::createStub(Result::class);
+        $resultStub->method('fetchOne')->willReturn(false);
+
+        $queryBuilderStub = self::createStub(QueryBuilder::class);
+        $queryBuilderStub->method('select')->willReturnSelf();
+        $queryBuilderStub->method('from')->willReturnSelf();
+        $queryBuilderStub->method('where')->willReturnSelf();
+        $queryBuilderStub->method('expr')->willReturn($this->exprStub);
+        $queryBuilderStub->method('createNamedParameter')->willReturnCallback(fn(string|int|float $v): string => "'$v'");
+        $queryBuilderStub->method('executeQuery')->willReturn($resultStub);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->method('createQueryBuilder')->willReturn($queryBuilderStub);
+        $connectionMock
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrllm_service_usage',
+                self::callback(fn(array $data) => $data['be_user'] === 99),
+            );
+
+        $connectionPoolStub = self::createStub(ConnectionPool::class);
+        $connectionPoolStub
+            ->method('getConnectionForTable')
+            ->willReturn($connectionMock);
+
+        $subject = new UsageTrackerService($connectionPoolStub, $this->contextMock);
+        $subject->trackUsage('chat', 'openai', [], beUserUid: 99);
     }
 
     // ==================== getUsageReport tests ====================


### PR DESCRIPTION
Final batch of the mutation-MSI climb (batch 1 #393 62.8→67%, batch 2 #394 →70%,
batch 3 #395 →~73.4%).

Strengthens the last hotspots with unit tests: **AbstractProvider** (the SSRF
endpoint gate, retry/backoff, audit-reason, streaming status — via a named
`GateProbeProvider` fixture so protected accessors stay visible to PHPStan L10),
**SearchCodeTool** (path-escape guard, schema, line-length), **StreamingDispatcher**
(retry classification, usage attribution, abort logging — via a `RecordingLogger`
fixture), **SolrSearchBackend** (language-core selection, query construction),
**UsageTrackerService**.

Batch 4 kills +198 independently; combined with batches 1–3 (disjoint files) the
covered MSI reaches **~75%**, past the 74% target. `ReadRecordsTool` (57 escaped)
was skipped — it has no unit test, and Infection runs only the unit suite, so its
mutants aren't killable this way.

Equivalent/unobservable mutants left unkilled and documented: timing-only backoff
`usleep` arithmetic, unreachable file/time budgets, `JsonSerializable` array_map
no-ops, and a language-without-`languageId` case that TYPO3's own `Site`
constructor normalises.

Verification: full unit suite green, cgl + PHPStan L10 clean (bulk-verified — this
round caught a stale test premise and a level-10 dead-coalesce before landing).
