### PR TITLE
test: second-pass strengthening + ReadRecordsTool test — 81% covered MSI (batch 5)

### DIFF
--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\ClaudeProvider;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -1832,5 +1835,490 @@ class ClaudeProviderTest extends AbstractUnitTestCase
                 ],
             ],
         ], $payload['messages']);
+    }
+
+    // ===== Streaming request/parse tests =====
+
+    /**
+     * Drive streamChatCompletion() against a stubbed SSE response while
+     * capturing the request URL, the encoded JSON request payload, the
+     * yielded chunks and the byte counts requested from the response stream.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
+     * @param list<string>                           $sseChunks raw SSE data served one element per read() call
+     *
+     * @return array{url: string, payload: array<string, mixed>, chunks: list<string>, readLengths: list<int>}
+     */
+    private function runStreamingCapture(
+        array $messages,
+        array $options = [],
+        array $sseChunks = ["data: {\"type\":\"message_stop\"}\n"],
+        string $baseUrl = '',
+        int $statusCode = 200,
+    ): array {
+        $capturedUrl = null;
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$capturedUrl): RequestInterface {
+                $capturedUrl = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            },
+        );
+
+        $capturedBody = null;
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+                return $stream;
+            },
+        );
+
+        $subject = new ClaudeProvider(
+            $requestFactory,
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'claude-sonnet-4-20250514',
+            'baseUrl' => $baseUrl,
+            'timeout' => 30,
+        ]);
+
+        $remainingChunks = $sseChunks;
+        /** @var list<int> $readLengths */
+        $readLengths = [];
+        $responseStream = self::createStub(StreamInterface::class);
+        $responseStream->method('eof')->willReturnCallback(
+            static function () use (&$remainingChunks): bool {
+                return $remainingChunks === [];
+            },
+        );
+        $responseStream->method('read')->willReturnCallback(
+            static function (int $length) use (&$remainingChunks, &$readLengths): string {
+                $readLengths[] = $length;
+
+                return array_shift($remainingChunks) ?? '';
+            },
+        );
+        $responseStream->method('__toString')->willReturn(implode('', $sseChunks));
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($responseStream);
+
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturn($response);
+        $subject->setHttpClient($httpClient);
+
+        $chunks = [];
+        foreach ($subject->streamChatCompletion($messages, $options) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertIsString($capturedUrl);
+        self::assertIsString($capturedBody);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode($capturedBody, true, 512, JSON_THROW_ON_ERROR);
+
+        return ['url' => $capturedUrl, 'payload' => $payload, 'chunks' => $chunks, 'readLengths' => $readLengths];
+    }
+
+    /**
+     * The streaming endpoint URL is the trimmed base URL plus '/messages';
+     * a trailing slash on the configured base URL must not double up.
+     */
+    #[Test]
+    public function streamChatCompletionBuildsMessagesEndpointUrlFromBaseUrl(): void
+    {
+        $result = $this->runStreamingCapture(
+            [['role' => 'user', 'content' => 'Hi']],
+            [],
+            ["data: {\"type\":\"message_stop\"}\n"],
+            'https://claude.example/v1/',
+        );
+
+        self::assertSame('https://claude.example/v1/messages', $result['url']);
+    }
+
+    /**
+     * Pin down the exact streaming request payload: model, converted
+     * ChatMessage objects, default max_tokens, the stream flag, the top-level
+     * system field and the merged (clamped) sampling params.
+     */
+    #[Test]
+    public function streamChatCompletionRequestPayloadHasExactShape(): void
+    {
+        $result = $this->runStreamingCapture(
+            [
+                ['role' => 'system', 'content' => 'Be helpful'],
+                ChatMessage::user('Hello'),
+            ],
+            ['temperature' => 1.8],
+        );
+
+        $payload = $result['payload'];
+        self::assertSame('claude-sonnet-4-20250514', $payload['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Hello']], $payload['messages']);
+        self::assertSame(4096, $payload['max_tokens']);
+        self::assertTrue($payload['stream']);
+        self::assertSame('Be helpful', $payload['system']);
+        $this->assertPayloadTemperature($payload, 1.0);
+    }
+
+    /**
+     * JSON_INVALID_UTF8_SUBSTITUTE must be in effect: a non-UTF-8 byte in the
+     * message content is replaced with U+FFFD instead of failing the encode.
+     */
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $result = $this->runStreamingCapture([['role' => 'user', 'content' => "caf\xE9"]]);
+
+        self::assertSame([['role' => 'user', 'content' => "caf\u{FFFD}"]], $result['payload']['messages']);
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnHttpErrorStatus(): void
+    {
+        $this->expectException(ProviderResponseException::class);
+
+        $this->runStreamingCapture(
+            [['role' => 'user', 'content' => 'Hi']],
+            [],
+            ['{"error":{"message":"bad request"}}'],
+            '',
+            400,
+        );
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeRequest(): void
+    {
+        $subject = new ClaudeProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'claude-sonnet-4-20250514',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        $subject->setHttpClient($this->createHttpClientMock());
+
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionCode(1307337100);
+
+        $subject->streamChatCompletion([['role' => 'user', 'content' => 'test']])->current();
+    }
+
+    /**
+     * A data line split across two read() calls must be re-assembled from the
+     * buffer (append, not replace) before parsing. Also pins the 1024-byte
+     * chunk size requested per read.
+     */
+    #[Test]
+    public function streamChatCompletionAccumulatesPartialLinesAcrossChunkReads(): void
+    {
+        $result = $this->runStreamingCapture(
+            [['role' => 'user', 'content' => 'Hi']],
+            [],
+            [
+                'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hel',
+                "lo\"}}\ndata: {\"type\":\"message_stop\"}\n",
+            ],
+        );
+
+        self::assertSame(['Hello'], $result['chunks']);
+        self::assertSame([1024, 1024], $result['readLengths']);
+    }
+
+    /**
+     * SSE events separated by a single newline (no blank line) must all be
+     * consumed — the buffer advances exactly one byte past each newline.
+     */
+    #[Test]
+    public function streamChatCompletionParsesSingleNewlineSeparatedEvents(): void
+    {
+        $streamData = "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"A\"}}\n"
+            . "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"B\"}}\n"
+            . "data: {\"type\":\"message_stop\"}\n";
+
+        $result = $this->runStreamingCapture([['role' => 'user', 'content' => 'Hi']], [], [$streamData]);
+
+        self::assertSame(['A', 'B'], $result['chunks']);
+    }
+
+    /**
+     * Lines without the exact 'data: ' prefix are skipped entirely (even when
+     * their tail happens to be valid delta JSON), and unknown event types
+     * (e.g. ping) neither yield text nor terminate the stream.
+     */
+    #[Test]
+    public function streamChatCompletionIgnoresNonDataPrefixedAndUnknownEventLines(): void
+    {
+        $streamData = "data: {\"type\":\"ping\"}\n"
+            . "ddata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"EVIL\"}}\n"
+            . "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n"
+            . "data: {\"type\":\"message_stop\"}\n";
+
+        $result = $this->runStreamingCapture([['role' => 'user', 'content' => 'Hi']], [], [$streamData]);
+
+        self::assertSame(['Hi'], $result['chunks']);
+    }
+
+    #[Test]
+    public function streamChatCompletionStopsAtMessageStopAndIgnoresLaterDeltas(): void
+    {
+        $streamData = "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"A\"}}\n"
+            . "data: {\"type\":\"message_stop\"}\n"
+            . "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"B\"}}\n";
+
+        $result = $this->runStreamingCapture([['role' => 'user', 'content' => 'Hi']], [], [$streamData]);
+
+        self::assertSame(['A'], $result['chunks']);
+    }
+
+    // ===== Message-conversion payload tests =====
+
+    /**
+     * Pin the exact conversation transformation for a full tool round-trip:
+     * assistant text + tool_use blocks (JSON-string arguments decoded), tool
+     * results accumulated into a user message and flushed before the next
+     * non-tool message, later messages preserved, and a trailing tool result
+     * flushed as a final user message.
+     */
+    #[Test]
+    public function chatCompletionWithToolsConversationPayloadHasExactShape(): void
+    {
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => ['type' => 'object']]])];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($tools): void {
+                $s->chatCompletionWithTools(
+                    [
+                        ['role' => 'user', 'content' => 'What is the weather?'],
+                        [
+                            'role' => 'assistant',
+                            'content' => 'Let me check.',
+                            'tool_calls' => [
+                                [
+                                    'id' => 'call_123',
+                                    'type' => 'function',
+                                    'function' => ['name' => 'get_weather', 'arguments' => '{"location":"Berlin"}'],
+                                ],
+                            ],
+                        ],
+                        ['role' => 'tool', 'tool_call_id' => 'call_123', 'content' => '{"temp":20}'],
+                        ['role' => 'user', 'content' => 'And tomorrow?'],
+                        ['role' => 'tool', 'tool_call_id' => 'call_999', 'content' => 'late result'],
+                    ],
+                    $tools,
+                );
+            },
+        );
+
+        self::assertSame([
+            ['role' => 'user', 'content' => 'What is the weather?'],
+            [
+                'role' => 'assistant',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Let me check.'],
+                    ['type' => 'tool_use', 'id' => 'call_123', 'name' => 'get_weather', 'input' => ['location' => 'Berlin']],
+                ],
+            ],
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'tool_result', 'tool_use_id' => 'call_123', 'content' => '{"temp":20}'],
+                ],
+            ],
+            ['role' => 'user', 'content' => 'And tomorrow?'],
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'tool_result', 'tool_use_id' => 'call_999', 'content' => 'late result'],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    /**
+     * A plain assistant text message (no tool_calls key) passes through
+     * unchanged — and must not probe the absent tool_calls key (that would
+     * raise an undefined-array-key warning under failOnWarning).
+     */
+    #[Test]
+    public function chatCompletionPassesPlainAssistantMessageThrough(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion([
+                    ['role' => 'user', 'content' => 'Hi'],
+                    ['role' => 'assistant', 'content' => 'Hello there.'],
+                    ['role' => 'user', 'content' => 'Thanks'],
+                ]);
+            },
+        );
+
+        self::assertSame([
+            ['role' => 'user', 'content' => 'Hi'],
+            ['role' => 'assistant', 'content' => 'Hello there.'],
+            ['role' => 'user', 'content' => 'Thanks'],
+        ], $payload['messages']);
+    }
+
+    /**
+     * Pin the exact multimodal conversion: text pass-through, base64 data URL
+     * split into media_type + data, plain URL as url source, and Claude-native
+     * document blocks forwarded unchanged.
+     */
+    #[Test]
+    public function chatCompletionMultimodalRequestPayloadHasExactShape(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion([
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            ['type' => 'text', 'text' => 'Look at these'],
+                            ['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,iVBORw0KGgo=']],
+                            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/pic.jpg']],
+                            ['type' => 'document', 'source' => ['type' => 'base64', 'media_type' => 'application/pdf', 'data' => 'JVBERi0=']],
+                        ],
+                    ],
+                ]);
+            },
+        );
+
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Look at these'],
+                    [
+                        'type' => 'image',
+                        'source' => ['type' => 'base64', 'media_type' => 'image/png', 'data' => 'iVBORw0KGgo='],
+                    ],
+                    [
+                        'type' => 'image',
+                        'source' => ['type' => 'url', 'url' => 'https://example.com/pic.jpg'],
+                    ],
+                    ['type' => 'document', 'source' => ['type' => 'base64', 'media_type' => 'application/pdf', 'data' => 'JVBERi0=']],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    /**
+     * MIME-style wrapped base64 contains raw newlines; `.` does not match
+     * them, so the end-anchored regex must reject the URL instead of
+     * forwarding a silently truncated image payload.
+     */
+    #[Test]
+    public function chatCompletionDropsBase64DataUrlWithEmbeddedNewline(): void
+    {
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s): void {
+                $s->chatCompletion([
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            ['type' => 'text', 'text' => 'Broken image'],
+                            ['type' => 'image_url', 'image_url' => ['url' => "data:image/png;base64,iVBOR\nw0KGgo="]],
+                        ],
+                    ],
+                ]);
+            },
+        );
+
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Broken image'],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    /**
+     * Same newline-in-data-URL rejection on the vision path: the anchored
+     * regex must fail the match, so the image block is skipped entirely.
+     */
+    #[Test]
+    public function analyzeImageSkipsDataUrlWithEmbeddedNewline(): void
+    {
+        $content = [
+            VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => "data:image/png;base64,iVBOR\nw0KGgo="]]),
+        ];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($content): void {
+                $s->analyzeImage($content);
+            },
+        );
+
+        self::assertSame([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'What is this?'],
+                ],
+            ],
+        ], $payload['messages']);
+    }
+
+    /**
+     * Pin the exact Claude tool_choice mapping for every supported input
+     * shape (string shortcuts, named tool, array pass-through).
+     *
+     * @param array<string, string> $expected
+     */
+    #[Test]
+    #[DataProvider('toolChoicePayloadProvider')]
+    public function chatCompletionWithToolsMapsToolChoicePayload(mixed $toolChoice, array $expected): void
+    {
+        $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'get_weather', 'description' => 'Get weather', 'parameters' => ['type' => 'object']]])];
+
+        $payload = $this->captureRequestPayload(
+            static function (ClaudeProvider $s) use ($tools, $toolChoice): void {
+                $s->chatCompletionWithTools(
+                    [['role' => 'user', 'content' => 'Weather?']],
+                    $tools,
+                    ['tool_choice' => $toolChoice],
+                );
+            },
+        );
+
+        self::assertSame($expected, $payload['tool_choice']);
+    }
+
+    /**
+     * @return array<string, array{0: mixed, 1: array<string, string>}>
+     */
+    public static function toolChoicePayloadProvider(): array
+    {
+        return [
+            'auto maps to type auto' => ['auto', ['type' => 'auto']],
+            'none maps to type none' => ['none', ['type' => 'none']],
+            'required maps to type any' => ['required', ['type' => 'any']],
+            'tool name maps to named tool' => ['get_weather', ['type' => 'tool', 'name' => 'get_weather']],
+            'array passes through unchanged' => [['type' => 'tool', 'name' => 'lookup'], ['type' => 'tool', 'name' => 'lookup']],
+        ];
     }
 }

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -1574,32 +1574,9 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ?string &$capturedUri,
         ?string &$capturedBody,
     ): GeminiProvider {
-        $requestFactory = self::createStub(RequestFactoryInterface::class);
-        $requestFactory->method('createRequest')
-            ->willReturnCallback(function (string $method, string $uri) use (
-                &$capturedMethod,
-                &$capturedUri,
-            ): RequestInterface {
-                $capturedMethod = $method;
-                $capturedUri    = $uri;
-
-                return $this->createRequestMock($method, $uri);
-            });
-
-        $streamFactory = self::createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $content) use (&$capturedBody): StreamInterface {
-                $capturedBody = $content;
-                $stream       = self::createStub(StreamInterface::class);
-                $stream->method('__toString')->willReturn($content);
-                $stream->method('getContents')->willReturn($content);
-
-                return $stream;
-            });
-
         $subject = new GeminiProvider(
-            $requestFactory,
-            $streamFactory,
+            $this->createCapturingRequestFactory($capturedMethod, $capturedUri),
+            $this->createCapturingStreamFactory($capturedBody),
             $this->createLoggerMock(),
             $this->createVaultServiceMock(),
             $this->createSecureHttpClientFactoryMock(),
@@ -1613,6 +1590,122 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $subject->setHttpClient($this->createJsonHttpClient($apiResponse));
 
         return $subject;
+    }
+
+    /**
+     * Request factory stub that records the method and URI of every
+     * created request.
+     */
+    private function createCapturingRequestFactory(
+        ?string &$capturedMethod,
+        ?string &$capturedUri,
+    ): RequestFactoryInterface {
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')
+            ->willReturnCallback(function (string $method, string $uri) use (
+                &$capturedMethod,
+                &$capturedUri,
+            ): RequestInterface {
+                $capturedMethod = $method;
+                $capturedUri    = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            });
+
+        return $requestFactory;
+    }
+
+    /**
+     * Stream factory stub that records the JSON body of every created stream.
+     */
+    private function createCapturingStreamFactory(?string &$capturedBody): StreamFactoryInterface
+    {
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')
+            ->willReturnCallback(function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+                $stream       = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            });
+
+        return $streamFactory;
+    }
+
+    /**
+     * Build an SSE streaming response stub: read() replays $sseData once,
+     * eof() flips to true afterwards.
+     */
+    private function createSseResponse(string $sseData, int $statusCode = 200): ResponseInterface
+    {
+        $streamStub = self::createStub(StreamInterface::class);
+        $readCount = 0;
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+            return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
+        });
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+            $readCount++;
+            return $sseData;
+        });
+        $streamStub->method('__toString')->willReturn($sseData);
+        $streamStub->method('getContents')->willReturn($sseData);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn($statusCode);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        return $responseStub;
+    }
+
+    /**
+     * Build a subject for streaming tests whose request-factory /
+     * stream-factory capture the outgoing method, URI and JSON body, and
+     * whose HTTP client replays the given SSE response.
+     */
+    private function createStreamingCapturingSubject(
+        ResponseInterface $sseResponse,
+        ?string &$capturedMethod,
+        ?string &$capturedUri,
+        ?string &$capturedBody,
+        string $baseUrl = '',
+    ): GeminiProvider {
+        $subject = new GeminiProvider(
+            $this->createCapturingRequestFactory($capturedMethod, $capturedUri),
+            $this->createCapturingStreamFactory($capturedBody),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gemini-3-flash-preview',
+            'baseUrl' => $baseUrl,
+            'timeout' => 30,
+        ]);
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($sseResponse);
+        $subject->setHttpClient($httpClient);
+
+        return $subject;
+    }
+
+    /**
+     * Minimal one-candidate generateContent response for capture tests.
+     *
+     * @return array<string, mixed>
+     */
+    private static function okCandidateResponse(): array
+    {
+        return [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'ok']], 'role' => 'model'],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1],
+        ];
     }
 
     /**
@@ -1998,5 +2091,528 @@ class GeminiProviderTest extends AbstractUnitTestCase
         ];
 
         $this->subject->analyzeImage($content, ['model' => '../../secret']);
+    }
+
+    // ===== Second-pass outgoing-request assertions (mutation coverage) =====
+
+    #[Test]
+    public function analyzeImageSkipsNonImageDataUri(): void
+    {
+        // analyzeImage() is image-only: a `data:application/pdf` URI matches
+        // the base64 regex but fails the `image/` MIME check and must be
+        // dropped from the outgoing parts.
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->analyzeImage([
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'data:application/pdf;base64,JVBERi0=']]),
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Describe']]]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function analyzeImageSkipsImageDataUriWithEmbeddedNewline(): void
+    {
+        // Wrapped base64 (MIME line folding) carries a raw newline; the
+        // `$`-anchored regex must reject it instead of silently truncating
+        // the payload to its first line.
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->analyzeImage([
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => "data:image/png;base64,iVBORw0K\nGgo="]]),
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Describe']]]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function analyzeImageSendsFileDataForRemoteImageUrl(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->analyzeImage([
+            VisionContent::fromArray(['type' => 'text', 'text' => 'Describe this']),
+            VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']]),
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [[
+                'role' => 'user',
+                'parts' => [
+                    ['text' => 'Describe this'],
+                    ['fileData' => ['mimeType' => 'image/jpeg', 'fileUri' => 'https://example.com/image.jpg']],
+                ],
+            ]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function analyzeImageSendsSystemInstructionFromOption(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->analyzeImage(
+            [VisionContent::fromArray(['type' => 'text', 'text' => 'What is this?'])],
+            ['system_prompt' => 'You are a technical analyst.'],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertArrayHasKey('systemInstruction', $body);
+        self::assertSame(
+            ['parts' => [['text' => 'You are a technical analyst.']]],
+            $body['systemInstruction'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionSendsSystemInstructionAndRemainingMessages(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([
+            ['role' => 'system', 'content' => 'You are helpful.'],
+            ['role' => 'user', 'content' => 'Hello'],
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        // The system message maps to systemInstruction; the user turn must
+        // still be converted (`continue`, not `break`).
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Hello']]]],
+            $body['contents'],
+        );
+        self::assertArrayHasKey('systemInstruction', $body);
+        self::assertSame(
+            ['parts' => [['text' => 'You are helpful.']]],
+            $body['systemInstruction'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsExactConversationPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'get_weather', 'description' => 'x', 'parameters' => ['type' => 'object']],
+            ]),
+        ];
+
+        $messages = [
+            ['role' => 'user', 'content' => 'Check weather'],
+            [
+                'role' => 'assistant',
+                'content' => 'Checking now.',
+                'tool_calls' => [
+                    [
+                        'id' => 'call_1',
+                        'type' => 'function',
+                        'function' => ['name' => 'get_weather', 'arguments' => '{"city":"Hamburg"}'],
+                    ],
+                    [
+                        'id' => 'call_2',
+                        'type' => 'function',
+                        'function' => ['name' => 'get_time', 'arguments' => '{"zone":"Europe/Berlin"}'],
+                    ],
+                ],
+            ],
+            // NO 'name' keys: both must resolve via the tool_call_id mapping.
+            ['role' => 'tool', 'tool_call_id' => 'call_1', 'content' => '{"temp":12}'],
+            // Non-JSON tool output must be wrapped as {result: ...}.
+            ['role' => 'tool', 'tool_call_id' => 'call_2', 'content' => 'half past nine'],
+        ];
+
+        $subject->chatCompletionWithTools($messages, $tools);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [
+                ['role' => 'user', 'parts' => [['text' => 'Check weather']]],
+                ['role' => 'model', 'parts' => [
+                    ['text' => 'Checking now.'],
+                    ['functionCall' => ['name' => 'get_weather', 'args' => ['city' => 'Hamburg']]],
+                    ['functionCall' => ['name' => 'get_time', 'args' => ['zone' => 'Europe/Berlin']]],
+                ]],
+                ['role' => 'user', 'parts' => [[
+                    'functionResponse' => ['name' => 'get_weather', 'response' => ['temp' => 12]],
+                ]]],
+                ['role' => 'user', 'parts' => [[
+                    'functionResponse' => ['name' => 'get_time', 'response' => ['result' => 'half past nine']],
+                ]]],
+            ],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionSendsExactMultimodalImagePayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Describe this image'],
+                    ['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,iVBORw0KGgo=']],
+                ],
+            ],
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [[
+                'role' => 'user',
+                'parts' => [
+                    ['text' => 'Describe this image'],
+                    ['inlineData' => ['mimeType' => 'image/png', 'data' => 'iVBORw0KGgo=']],
+                ],
+            ]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionSendsExactDocumentPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Summarize this PDF'],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'base64',
+                            'media_type' => 'application/pdf',
+                            'data' => 'JVBERi0xLjQ=',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [[
+                'role' => 'user',
+                'parts' => [
+                    ['text' => 'Summarize this PDF'],
+                    ['inlineData' => ['mimeType' => 'application/pdf', 'data' => 'JVBERi0xLjQ=']],
+                ],
+            ]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function chatCompletionSkipsMultimodalDataUriWithEmbeddedNewline(): void
+    {
+        // Same anchored-regex guard as on the vision path: wrapped base64
+        // with a raw newline must not be truncated to its first line.
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            self::okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion([
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Describe'],
+                    ['type' => 'image_url', 'image_url' => ['url' => "data:image/png;base64,iVBORw0K\nGgo="]],
+                ],
+            ],
+        ]);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Describe']]]],
+            $body['contents'],
+        );
+    }
+
+    // ===== Second-pass streaming assertions (mutation coverage) =====
+
+    #[Test]
+    public function streamChatCompletionSendsExactRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createStreamingCapturingSubject(
+            $this->createSseResponse("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hi!\"}]}}]}\n"),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+            'https://gemini.example/v1beta/',
+        );
+
+        $chunks = [];
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => 'Hi']]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['Hi!'], $chunks);
+        self::assertSame('POST', $capturedMethod);
+        // rtrim() must deduplicate the trailing slash of the configured base URL.
+        self::assertSame(
+            'https://gemini.example/v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse',
+            $capturedUri,
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Hi']]]],
+            $body['contents'],
+        );
+        self::assertIsArray($body['generationConfig']);
+        self::assertArrayHasKey('temperature', $body['generationConfig']);
+        self::assertSame(0.7, $body['generationConfig']['temperature']);
+        self::assertArrayHasKey('maxOutputTokens', $body['generationConfig']);
+        self::assertSame(4096, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    #[Test]
+    public function streamChatCompletionConvertsChatMessageObjectsToArrays(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createStreamingCapturingSubject(
+            $this->createSseResponse("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n"),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $chunks = [];
+        foreach ($subject->streamChatCompletion([new ChatMessage('user', 'Hello from VO')]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['ok'], $chunks);
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(
+            [['role' => 'user', 'parts' => [['text' => 'Hello from VO']]]],
+            $body['contents'],
+        );
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        // A message carrying a non-UTF-8 byte (e.g. ISO-8859-1 log output
+        // echoed into the conversation) must degrade to U+FFFD via
+        // JSON_INVALID_UTF8_SUBSTITUTE; without the flag json_encode()
+        // returns false and the request cannot be built.
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createStreamingCapturingSubject(
+            $this->createSseResponse("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n"),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $chunks = [];
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => "Caf\xE9"]]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['ok'], $chunks);
+        self::assertIsString($capturedBody);
+        // json_encode() (no JSON_UNESCAPED_UNICODE) escapes the substituted
+        // U+FFFD replacement character as the literal `\ufffd` sequence.
+        self::assertStringContainsString('Caf\ufffd', $capturedBody);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeRequest(): void
+    {
+        $subject = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'gemini-3-flash-preview',
+            'baseUrl' => '',
+            'timeout' => 30,
+        ]);
+        // A pre-wired SSE client that would complete without error: the typed
+        // configuration failure must fire BEFORE any request is attempted.
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn(
+            $this->createSseResponse("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"never\"}]}}]}\n"),
+        );
+        $subject->setHttpClient($httpClient);
+
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionCode(1307337100);
+
+        $subject->streamChatCompletion([['role' => 'user', 'content' => 'Hi']])->current();
+    }
+
+    #[Test]
+    public function streamChatCompletionRejectsInvalidModelIdWithTypedException(): void
+    {
+        $this->expectException(ProviderConfigurationException::class);
+        $this->expectExceptionCode(1751280000);
+
+        $this->subject->streamChatCompletion(
+            [['role' => 'user', 'content' => 'hi']],
+            ['model' => '../../secret'],
+        )->current();
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsProviderResponseExceptionOnHttpError(): void
+    {
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse('{"error":{"message":"API key not valid"}}', 401));
+
+        $this->expectException(ProviderResponseException::class);
+
+        $this->subject->streamChatCompletion([['role' => 'user', 'content' => 'Hi']])->current();
+    }
+
+    #[Test]
+    public function streamChatCompletionAccumulatesBufferAcrossChunkReads(): void
+    {
+        // One SSE line split across two read() chunks: the buffer must
+        // ACCUMULATE (`.=`) — a plain assignment would drop the first half
+        // and lose the line.
+        $chunkOne = 'data: {"candidates":[{"content":{"parts":[{"text":"Hel';
+        $chunkTwo = "lo\"}]}}]}\n";
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $readCount = 0;
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+            return $readCount >= 2; // @phpstan-ignore greaterOrEqual.alwaysFalse
+        });
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $chunkOne, $chunkTwo) {
+            $readCount++;
+            return $readCount === 1 ? $chunkOne : $chunkTwo;
+        });
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+
+        $chunks = [];
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => 'Hi']]) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertSame(['Hello'], $chunks);
     }
 }

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Provider\GroqProvider;
@@ -20,7 +21,10 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(GroqProvider::class)]
@@ -282,6 +286,8 @@ class GroqProviderTest extends AbstractUnitTestCase
     {
         $this->expectException(UnsupportedFeatureException::class);
         $this->expectExceptionMessage('Groq does not support embeddings');
+        // Pin the exception code against Increment/DecrementInteger mutants.
+        $this->expectExceptionCode(4840547720);
 
         $this->subject->embeddings('Test text');
     }
@@ -902,5 +908,594 @@ class GroqProviderTest extends AbstractUnitTestCase
         $this->expectException(ProviderResponseException::class);
 
         $this->subject->testConnection();
+    }
+
+    // ==================== Request-shape (payload / URL) assertions ====================
+
+    /**
+     * Build a GroqProvider whose request/stream factories capture the
+     * outgoing HTTP method, URL and JSON body so a test can assert the exact
+     * transformation the provider performs.
+     *
+     * The captured variables MUST be initialised (to null) at the call site.
+     *
+     * @param string|null $capturedMethod receives the last createRequest() method
+     * @param string|null $capturedUrl    receives the last createRequest() URL
+     * @param string|null $capturedBody   receives the last createStream() JSON body
+     *
+     * @return array{subject: GroqProvider, httpClient: ClientInterface&MockObject}
+     */
+    private function createCapturingSubject(
+        ?string &$capturedMethod,
+        ?string &$capturedUrl,
+        ?string &$capturedBody,
+        string $baseUrl = '',
+    ): array {
+        $requestFactory = self::createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturnCallback(
+            function (string $method, string $uri) use (&$capturedMethod, &$capturedUrl): RequestInterface {
+                $capturedMethod = $method;
+                $capturedUrl    = $uri;
+
+                return $this->createRequestMock($method, $uri);
+            },
+        );
+
+        $streamFactory = self::createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturnCallback(
+            function (string $content) use (&$capturedBody): StreamInterface {
+                $capturedBody = $content;
+
+                $stream = self::createStub(StreamInterface::class);
+                $stream->method('__toString')->willReturn($content);
+                $stream->method('getContents')->willReturn($content);
+
+                return $stream;
+            },
+        );
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+
+        $subject = new GroqProvider(
+            $requestFactory,
+            $streamFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => $baseUrl,
+            'timeout' => 30,
+        ]);
+
+        $subject->setHttpClient($httpClientMock);
+
+        return ['subject' => $subject, 'httpClient' => $httpClientMock];
+    }
+
+    /**
+     * Decode a captured JSON request body into an associative array.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCapturedBody(?string $body): array
+    {
+        self::assertIsString($body, 'expected a JSON request body to have been captured');
+
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Build a chat completion API response fixture with a single choice.
+     *
+     * @return array<string, mixed>
+     */
+    private function chatApiResponseFixture(): array
+    {
+        return [
+            'model' => 'llama-3.3-70b-versatile',
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+    }
+
+    /**
+     * Build a stream response stub that emits the given SSE payload as a
+     * single read.
+     */
+    private function createStreamResponseStub(string $streamContent, int $statusCode = 200): ResponseInterface
+    {
+        $streamStub = self::createStub(StreamInterface::class);
+        $streamStub->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $streamStub->method('read')->willReturn($streamContent);
+        $streamStub->method('__toString')->willReturn($streamContent);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn($statusCode);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        return $responseStub;
+    }
+
+    #[Test]
+    public function chatCompletionSendsExpectedRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($this->chatApiResponseFixture()));
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'Ping']]);
+
+        self::assertSame('POST', $capturedMethod);
+        // Empty base URL in the fixture configuration produces a RELATIVE URI.
+        self::assertSame('/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        // ArrayItemRemoval on 'model' / ArrayItem `=>`→`>` on temperature+max_tokens.
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('llama-3.3-70b-versatile', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Ping']], $body['messages']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+        // Without stop/stop_sequences options no `stop` key may appear: pins
+        // the `is_array(...)` guard against its `||` mutant (null would leak).
+        self::assertArrayNotHasKey('stop', $body);
+    }
+
+    #[Test]
+    public function chatCompletionMapsStopSequencesToStop(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($this->chatApiResponseFixture()));
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Ping']],
+            ['stop_sequences' => ['STOP1', 'STOP2']],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        // A non-empty stop_sequences array is copied verbatim to the `stop` key.
+        self::assertArrayHasKey('stop', $body);
+        self::assertSame(['STOP1', 'STOP2'], $body['stop']);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsStopForEmptyStopSequences(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($this->chatApiResponseFixture()));
+
+        // An empty stop_sequences array must NOT produce a `stop` key: this pins
+        // the `&& $stopSequences !== []` guard against the `||` mutant, which
+        // would emit `stop => []`.
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Ping']],
+            ['stop_sequences' => []],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayNotHasKey('stop', $body);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSendsExpectedRequestPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $spec = ToolSpec::fromArray([
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_weather',
+                'description' => 'Get current weather',
+                'parameters' => ['type' => 'object', 'properties' => []],
+            ],
+        ]);
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($this->chatApiResponseFixture()));
+
+        $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'Ping']], [$spec]);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('llama-3.3-70b-versatile', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Ping']], $body['messages']);
+        // Normalise the expected through the same JSON round-trip the body went
+        // through (decodeCapturedBody uses assoc=true), so an empty `properties`
+        // object ({}) compares equal on both sides rather than stdClass vs [].
+        self::assertSame(json_decode((string)json_encode([$spec->toArray()]), true), $body['tools']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+    }
+
+    // ==================== Streaming request-shape assertions ====================
+
+    #[Test]
+    public function streamChatCompletionSendsExpectedRequestAndUrl(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        // Trailing slash on the base URL makes the rtrim() observable: without
+        // it the URL would contain a double slash.
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+            'https://api.groq.com/openai/v1/',
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+                . "data: [DONE]\n",
+            ));
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Hi'], $chunks);
+
+        self::assertSame('POST', $capturedMethod);
+        self::assertSame('https://api.groq.com/openai/v1/chat/completions', $capturedUrl);
+
+        $body = $this->decodeCapturedBody($capturedBody);
+
+        self::assertArrayHasKey('model', $body);
+        self::assertSame('llama-3.3-70b-versatile', $body['model']);
+        self::assertSame([['role' => 'user', 'content' => 'Test']], $body['messages']);
+        self::assertArrayHasKey('temperature', $body);
+        self::assertSame(0.7, $body['temperature']);
+        self::assertArrayHasKey('max_tokens', $body);
+        self::assertSame(4096, $body['max_tokens']);
+        self::assertArrayHasKey('stream', $body);
+        self::assertTrue($body['stream']);
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+            'https://api.groq.com/openai/v1',
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+                . "data: [DONE]\n",
+            ));
+
+        // An invalid UTF-8 byte must be substituted (JSON_INVALID_UTF8_SUBSTITUTE),
+        // never abort the encode: the `|` flag combination is what enables this,
+        // so the `&` mutant makes json_encode() return false and breaks the call.
+        $chunks = iterator_to_array($subject->streamChatCompletion(
+            [['role' => 'user', 'content' => "Bad \xB1 byte"]],
+        ));
+
+        self::assertSame(['Hi'], $chunks);
+
+        self::assertIsString($capturedBody);
+        // json_encode() (no JSON_UNESCAPED_UNICODE) escapes U+FFFD as the
+        // literal six-character ASCII sequence backslash-u-f-f-f-d.
+        self::assertStringContainsString('\\ufffd', $capturedBody);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeStreaming(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        // Empty API key identifier: validateConfiguration() must throw before
+        // any request is built.
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->method('sendRequest')->willReturn($this->createStreamResponseStub(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+            . "data: [DONE]\n",
+        ));
+        $subject->setHttpClient($httpClientMock);
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnHttpErrorStatus(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        // A 4xx streaming response must surface a typed exception: this pins the
+        // assertStreamingResponseOk() call against its MethodCallRemoval mutant.
+        $errorStream = self::createStub(StreamInterface::class);
+        $errorStream->method('eof')->willReturn(true);
+        $errorStream->method('read')->willReturn('');
+        $errorStream->method('__toString')->willReturn('{"error":{"message":"Unauthorized"}}');
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(401);
+        $responseStub->method('getBody')->willReturn($errorStream);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $this->expectException(ProviderResponseException::class);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+    }
+
+    #[Test]
+    public function streamChatCompletionAccumulatesBufferAcrossReads(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        // A single SSE line split across two reads: the first chunk carries no
+        // newline, so it is only usable once appended to the second chunk. This
+        // pins `$buffer .= $chunk` against the `$buffer = $chunk` mutant, which
+        // would discard the first chunk and yield nothing.
+        $chunk1 = 'data: {"choices":[{"delta":{"content":"Hello"';
+        $chunk2 = "}}]}\n\ndata: [DONE]\n";
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $streamStub->method('eof')->willReturnOnConsecutiveCalls(false, false, true);
+        $streamStub->method('read')->willReturnOnConsecutiveCalls($chunk1, $chunk2);
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Hello'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionReadsInKilobyteChunks(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        // Pin the SSE read granularity: the stream is consumed in 1024-byte
+        // chunks (Increment/DecrementInteger mutants shift it to 1023/1025).
+        $streamMock = $this->createMock(StreamInterface::class);
+        $streamMock->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $streamMock->expects(self::once())
+            ->method('read')
+            ->with(1024)
+            ->willReturn(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Chunk\"}}]}\n\n"
+                . "data: [DONE]\n",
+            );
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($streamMock);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Chunk'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionStopsAtDoneMarker(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        // Content AFTER the [DONE] marker must never be yielded: this pins the
+        // `return` at the marker (ReturnRemoval) and the exact `substr($line, 6)`
+        // offset — the off-by-one mutant turns the marker into ` [DONE]`, misses
+        // the comparison and keeps streaming.
+        $streamContent = "data: {\"choices\":[{\"delta\":{\"content\":\"Before\"}}]}\n\n"
+                         . "data: [DONE]\n"
+                         . "data: {\"choices\":[{\"delta\":{\"content\":\"After\"}}]}\n\n";
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub($streamContent));
+        $subject->setHttpClient($httpClientMock);
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['Before'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionSkipsChunksBeyondJsonDepthLimit(): void
+    {
+        $subject = new GroqProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'llama-3.3-70b-versatile',
+            'baseUrl' => 'https://api.groq.com/openai/v1',
+            'timeout' => 30,
+        ]);
+
+        // Pin the json_decode() depth limit of 512 from BOTH sides:
+        // - a chunk with 510 nested arrays inside the object (total depth 511)
+        //   decodes at depth 512 but fails at 511 → kills the DecrementInteger
+        //   mutant (which would drop "at-limit");
+        // - a chunk with 511 nested arrays (total depth 512+1) throws at 512
+        //   but decodes at 513 → kills the IncrementInteger mutant (which
+        //   would additionally yield "beyond-limit").
+        $atLimit = '{"choices":[{"delta":{"content":"at-limit"}}],"pad":'
+                   . str_repeat('[', 510) . '1' . str_repeat(']', 510) . '}';
+        $beyondLimit = '{"choices":[{"delta":{"content":"beyond-limit"}}],"pad":'
+                       . str_repeat('[', 511) . '1' . str_repeat(']', 511) . '}';
+
+        $streamContent = 'data: ' . $atLimit . "\n\n"
+                         . 'data: ' . $beyondLimit . "\n\n"
+                         . "data: [DONE]\n";
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createStreamResponseStub($streamContent));
+        $subject->setHttpClient($httpClientMock);
+
+        $chunks = iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
+
+        self::assertSame(['at-limit'], $chunks);
     }
 }

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -1386,17 +1388,13 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     // ---------------------------------------------------------------------
 
     /**
-     * Build a provider whose request factory records every outgoing request
+     * Build a request factory that records every outgoing request
      * (method, URI, headers, JSON body) into $captured.
      *
-     * @param array<string, mixed>                                                                   $config
      * @param list<array{method: string, uri: string, headers: array<string, string>, body: string}> $captured
      */
-    private function createCapturingProvider(
-        array $config,
-        ResponseInterface $response,
-        array &$captured,
-    ): OpenRouterProvider {
+    private function createCapturingRequestFactory(array &$captured): RequestFactoryInterface
+    {
         $requestFactory = self::createStub(RequestFactoryInterface::class);
         $requestFactory->method('createRequest')->willReturnCallback(
             function (string $method, string $uri) use (&$captured): RequestInterface {
@@ -1429,11 +1427,20 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             },
         );
 
-        $httpClient = self::createStub(ClientInterface::class);
-        $httpClient->method('sendRequest')->willReturn($response);
+        return $requestFactory;
+    }
 
+    /**
+     * @param array<string, mixed>                                                                   $config
+     * @param list<array{method: string, uri: string, headers: array<string, string>, body: string}> $captured
+     */
+    private function createCapturingProviderWithClient(
+        array $config,
+        ClientInterface $httpClient,
+        array &$captured,
+    ): OpenRouterProvider {
         $provider = new OpenRouterProvider(
-            $requestFactory,
+            $this->createCapturingRequestFactory($captured),
             $this->createStreamFactoryMock(),
             $this->createLoggerMock(),
             $this->createVaultServiceMock(),
@@ -1450,6 +1457,149 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $provider->setHttpClient($httpClient);
 
         return $provider;
+    }
+
+    /**
+     * Build a provider whose request factory records every outgoing request
+     * (method, URI, headers, JSON body) into $captured.
+     *
+     * @param array<string, mixed>                                                                   $config
+     * @param list<array{method: string, uri: string, headers: array<string, string>, body: string}> $captured
+     */
+    private function createCapturingProvider(
+        array $config,
+        ResponseInterface $response,
+        array &$captured,
+    ): OpenRouterProvider {
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($response);
+
+        return $this->createCapturingProviderWithClient($config, $httpClient, $captured);
+    }
+
+    /**
+     * Capturing provider whose HTTP client answers the /models endpoint with
+     * $modelsResponse and every other endpoint with $chatResponse.
+     *
+     * @param array<string, mixed>                                                                   $config
+     * @param array<string, mixed>                                                                   $modelsResponse
+     * @param list<array{method: string, uri: string, headers: array<string, string>, body: string}> $captured
+     */
+    private function createCapturingRoutingProvider(
+        array $config,
+        array $modelsResponse,
+        ResponseInterface $chatResponse,
+        array &$captured,
+    ): OpenRouterProvider {
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturnCallback(
+            fn(RequestInterface $request): ResponseInterface => str_contains((string)$request->getUri(), '/models')
+                    ? $this->createJsonResponseMock($modelsResponse)
+                    : $chatResponse,
+        );
+
+        return $this->createCapturingProviderWithClient($config, $httpClient, $captured);
+    }
+
+    /**
+     * Build a streaming (SSE) response stub that serves the given reads in
+     * order and reports EOF once they are exhausted.
+     *
+     * @param list<string> $reads
+     */
+    private function createSseResponse(array $reads, int $statusCode = 200): ResponseInterface
+    {
+        $readCount = 0;
+
+        $stream = self::createStub(StreamInterface::class);
+        $stream->method('eof')->willReturnCallback(
+            static function () use (&$readCount, $reads): bool {
+                return $readCount >= count($reads);
+            },
+        );
+        $stream->method('read')->willReturnCallback(
+            static function () use (&$readCount, $reads): string {
+                return $reads[$readCount++] ?? '';
+            },
+        );
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
+    }
+
+    /**
+     * Live-model-list entry fixture for the /models endpoint.
+     *
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<string, mixed>
+     */
+    private static function modelEntry(string $id, float $prompt, float $completion, array $overrides = []): array
+    {
+        return $overrides + [
+            'id' => $id,
+            'name' => $id,
+            'context_length' => 8000,
+            'architecture' => ['modality' => 'text'],
+            'pricing' => ['prompt' => $prompt, 'completion' => $completion],
+            'supports_function_calling' => false,
+        ];
+    }
+
+    /**
+     * Run a chat completion through a capturing routing provider and return
+     * the model id the provider actually put into the request payload.
+     *
+     * @param array<string, mixed>       $config
+     * @param list<array<string, mixed>> $modelEntries
+     * @param array<string, mixed>       $chatOptions
+     */
+    private function capturedRoutedModel(array $config, array $modelEntries, array $chatOptions = []): string
+    {
+        $captured = [];
+        $provider = $this->createCapturingRoutingProvider(
+            $config,
+            ['data' => $modelEntries],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion([['role' => 'user', 'content' => 'Hi']], $chatOptions);
+
+        self::assertArrayHasKey(1, $captured);
+        $body = $this->decodeCapturedBody($captured[1]['body']);
+        self::assertIsString($body['model']);
+
+        return $body['model'];
+    }
+
+    /**
+     * Run analyzeImage through a capturing routing provider and return the
+     * model id the provider actually put into the request payload.
+     *
+     * @param array<string, mixed>       $config
+     * @param list<array<string, mixed>> $modelEntries
+     */
+    private function capturedVisionModel(array $config, array $modelEntries): string
+    {
+        $captured = [];
+        $provider = $this->createCapturingRoutingProvider(
+            $config,
+            ['data' => $modelEntries],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->analyzeImage([VisionContent::fromArray(['type' => 'text', 'text' => 'Hi'])]);
+
+        self::assertArrayHasKey(1, $captured);
+        $body = $this->decodeCapturedBody($captured[1]['body']);
+        self::assertIsString($body['model']);
+
+        return $body['model'];
     }
 
     /**
@@ -1938,5 +2088,582 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         self::assertSame(0.0, $result['usage']);
         self::assertTrue($result['is_free_tier']);
         self::assertSame(['requests' => 200, 'interval' => '10s'], $result['rate_limit']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Streaming request/parsing pins
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function streamChatCompletionBuildsExactRequestAndPayload(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [
+                'siteUrl' => 'https://example.com',
+                'appName' => 'Test App',
+                'fallbackModels' => 'openai/gpt-4o, anthropic/claude-3-opus',
+            ],
+            $this->createSseResponse(["data: [DONE]\n"]),
+            $captured,
+        );
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame([], $chunks);
+        self::assertCount(1, $captured);
+
+        self::assertSame('POST', $captured[0]['method']);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions', $captured[0]['uri']);
+        self::assertSame('application/json', $captured[0]['headers']['Content-Type'] ?? null);
+        self::assertSame('text/event-stream', $captured[0]['headers']['Accept'] ?? null);
+        self::assertSame('https://example.com', $captured[0]['headers']['HTTP-Referer'] ?? null);
+        self::assertSame('Test App', $captured[0]['headers']['X-Title'] ?? null);
+
+        self::assertSame(
+            [
+                'model' => 'primary/model',
+                'messages' => [['role' => 'user', 'content' => 'Hi']],
+                'temperature' => 0.7,
+                'max_tokens' => 4096,
+                'stream' => true,
+                'route' => 'fallback',
+                'models' => ['primary/model', 'openai/gpt-4o', 'anthropic/claude-3-opus'],
+            ],
+            $this->decodeCapturedBody($captured[0]['body']),
+        );
+    }
+
+    #[Test]
+    public function streamChatCompletionTrimsTrailingSlashFromBaseUrl(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            ['baseUrl' => 'https://openrouter.ai/api/v1/'],
+            $this->createSseResponse(["data: [DONE]\n"]),
+            $captured,
+        );
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame([], $chunks);
+        self::assertCount(1, $captured);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions', $captured[0]['uri']);
+    }
+
+    #[Test]
+    public function chatCompletionTrimsTrailingSlashFromBaseUrl(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            ['baseUrl' => 'https://openrouter.ai/api/v1/'],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        );
+
+        self::assertCount(1, $captured);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions', $captured[0]['uri']);
+    }
+
+    #[Test]
+    public function streamChatCompletionValidatesConfigurationBeforeStreaming(): void
+    {
+        $provider = $this->createProviderWithConfig(['apiKeyIdentifier' => '']);
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse(["data: [DONE]\n"]));
+
+        $this->expectException(ProviderConfigurationException::class);
+
+        $provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        )->current();
+    }
+
+    #[Test]
+    public function streamChatCompletionThrowsOnHttpErrorStatus(): void
+    {
+        $provider = $this->createProviderWithConfig([]);
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse([], 500));
+
+        $this->expectException(ProviderConnectionException::class);
+        $this->expectExceptionMessage('Server returned status 500');
+
+        $provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        )->current();
+    }
+
+    #[Test]
+    public function streamChatCompletionIgnoresDataAfterDoneMarker(): void
+    {
+        $provider = $this->createProviderWithConfig([]);
+
+        $streamData = "data: {\"choices\":[{\"delta\":{\"content\":\"before\"}}]}\n"
+            . "data: [DONE]\n"
+            . "data: {\"choices\":[{\"delta\":{\"content\":\"after\"}}]}\n";
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse([$streamData]));
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame(['before'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionConcatenatesPartialReads(): void
+    {
+        $provider = $this->createProviderWithConfig([]);
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse([
+                'data: {"choices":[{"delta":{"content":"Hel',
+                "lo\"}}]}\ndata: [DONE]\n",
+            ]));
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame(['Hello'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionParsesSingleNewlineSeparatedEvents(): void
+    {
+        $provider = $this->createProviderWithConfig([]);
+
+        $streamData = "data: {\"choices\":[{\"delta\":{\"content\":\"A\"}}]}\n"
+            . "data: {\"choices\":[{\"delta\":{\"content\":\"B\"}}]}\n"
+            . "data: [DONE]\n";
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createSseResponse([$streamData]));
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame(['A', 'B'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            [],
+            $this->createSseResponse(["data: [DONE]\n"]),
+            $captured,
+        );
+
+        $chunks = iterator_to_array($provider->streamChatCompletion(
+            [['role' => 'user', 'content' => "Caf\xE9!"]],
+            ['model' => 'primary/model'],
+        ));
+
+        self::assertSame([], $chunks);
+        self::assertCount(1, $captured);
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+        self::assertSame([['role' => 'user', 'content' => "Caf\u{FFFD}!"]], $body['messages']);
+    }
+
+    #[Test]
+    public function chatCompletionSubstitutesInvalidUtf8InPayload(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => "Caf\xE9!"]],
+            ['model' => 'primary/model'],
+        );
+
+        self::assertCount(1, $captured);
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+        self::assertSame([['role' => 'user', 'content' => "Caf\u{FFFD}!"]], $body['messages']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Embeddings / vision transformation pins
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function embeddingsCastsValuesToFloatAndReportsZeroCompletionTokens(): void
+    {
+        $apiResponse = [
+            'model' => 'openai/text-embedding-3-small',
+            'data' => [['index' => 0, 'embedding' => [1, '0.5', 0.25]]],
+            'usage' => ['prompt_tokens' => 7, 'total_tokens' => 7],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->embeddings('test');
+
+        self::assertSame([[1.0, 0.5, 0.25]], $result->embeddings);
+        self::assertSame(7, $result->usage->promptTokens);
+        self::assertSame(0, $result->usage->completionTokens);
+        self::assertSame(7, $result->usage->totalTokens);
+    }
+
+    #[Test]
+    public function analyzeImageBuildsExactRequest(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->analyzeImage(
+            [
+                VisionContent::fromArray(['type' => 'text', 'text' => 'Describe']),
+                VisionContent::fromArray(['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/i.png']]),
+            ],
+            ['model' => 'vision/model'],
+        );
+
+        // Request 0 is the vision-model discovery (models list), request 1 the completion.
+        self::assertCount(2, $captured);
+        self::assertArrayHasKey(1, $captured);
+        self::assertSame('POST', $captured[1]['method']);
+
+        self::assertSame(
+            [
+                'model' => 'vision/model',
+                'messages' => [
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            ['type' => 'text', 'text' => 'Describe'],
+                            ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/i.png']],
+                        ],
+                    ],
+                ],
+                'max_tokens' => 4096,
+                'route' => 'fallback',
+            ],
+            $this->decodeCapturedBody($captured[1]['body']),
+        );
+    }
+
+    #[Test]
+    public function analyzeImagePrependsSystemPromptMessage(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->analyzeImage(
+            [VisionContent::fromArray(['type' => 'text', 'text' => 'Hi'])],
+            ['model' => 'vision/model', 'system_prompt' => 'Be nice'],
+        );
+
+        self::assertArrayHasKey(1, $captured);
+        $body = $this->decodeCapturedBody($captured[1]['body']);
+
+        self::assertSame(
+            [
+                ['role' => 'system', 'content' => 'Be nice'],
+                ['role' => 'user', 'content' => [['type' => 'text', 'text' => 'Hi']]],
+            ],
+            $body['messages'],
+        );
+    }
+
+    #[Test]
+    public function analyzeImageMetadataIncludesActualProviderAndCost(): void
+    {
+        $apiResponse = [
+            'id' => 'gen-test',
+            'model' => 'vision/model',
+            'provider' => 'anthropic',
+            'total_cost' => 0.5,
+            'choices' => [['message' => ['content' => 'a cat'], 'finish_reason' => 'stop']],
+            'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15],
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->analyzeImage(
+            [VisionContent::fromArray(['type' => 'text', 'text' => 'Hi'])],
+            ['model' => 'vision/model'],
+        );
+
+        self::assertSame(
+            ['actual_provider' => 'anthropic', 'cost' => 0.5],
+            $result->metadata,
+        );
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsIncludesFallbackModelsInPayload(): void
+    {
+        $spec = ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'f']]);
+
+        $captured = [];
+        $provider = $this->createCapturingProvider(
+            ['fallbackModels' => 'openai/gpt-4o, anthropic/claude-3-opus'],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletionWithTools(
+            [['role' => 'user', 'content' => 'Hi']],
+            [$spec],
+            ['model' => 'primary/model'],
+        );
+
+        self::assertCount(1, $captured);
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+
+        self::assertSame('fallback', $body['route']);
+        self::assertSame(
+            ['primary/model', 'openai/gpt-4o', 'anthropic/claude-3-opus'],
+            $body['models'],
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Routing pins: assert the model id the provider actually REQUESTS,
+    // not the model id the mocked response echoes back.
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function costOptimizedRoutingRequestsCheapestModelByAverage(): void
+    {
+        // Averages: 0.0255 / 0.0205 / 0.02 — mid/model is cheapest only when
+        // BOTH pricing components enter the (prompt + completion) / 2 average.
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('prompt-heavy/model', 0.05, 0.001),
+                self::modelEntry('completion-heavy/model', 0.001, 0.04),
+                self::modelEntry('mid/model', 0.02, 0.02),
+            ],
+        );
+
+        self::assertSame('mid/model', $model);
+    }
+
+    #[Test]
+    public function costOptimizedRoutingPrefersFirstModelOnPriceTie(): void
+    {
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('first/model', 0.01, 0.01),
+                self::modelEntry('second/model', 0.01, 0.01),
+            ],
+        );
+
+        self::assertSame('first/model', $model);
+    }
+
+    #[Test]
+    public function performanceRoutingRequestsFastKeywordModel(): void
+    {
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'performance'],
+            [
+                self::modelEntry('slow/opus', 0.01, 0.03),
+                self::modelEntry('quick/flash', 0.001, 0.002),
+            ],
+        );
+
+        self::assertSame('quick/flash', $model);
+    }
+
+    #[Test]
+    public function balancedRoutingRequestsBalancedKeywordModel(): void
+    {
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'balanced'],
+            [
+                self::modelEntry('fast/haiku', 0.0001, 0.0001),
+                self::modelEntry('steady/sonnet', 0.003, 0.015),
+            ],
+        );
+
+        self::assertSame('steady/sonnet', $model);
+    }
+
+    #[Test]
+    public function explicitRoutingSkipsModelDiscovery(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingRoutingProvider(
+            ['routingStrategy' => 'explicit'],
+            ['data' => [self::modelEntry('steady/sonnet', 0.003, 0.015)]],
+            $this->chatResponse(),
+            $captured,
+        );
+
+        $provider->chatCompletion([['role' => 'user', 'content' => 'Hi']]);
+
+        // Explicit routing must not fetch the live model list at all.
+        self::assertCount(1, $captured);
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+        self::assertSame('anthropic/claude-3.5-sonnet', $body['model']);
+    }
+
+    #[Test]
+    public function minContextFilterKeepsBoundaryModel(): void
+    {
+        // A model whose context length EQUALS min_context must survive the
+        // filter (>=), while smaller ones are dropped.
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('tiny/context', 0.00001, 0.00001, ['context_length' => 4000]),
+                self::modelEntry('exact/context', 0.0001, 0.0001, ['context_length' => 100000]),
+                self::modelEntry('huge/context', 0.01, 0.01, ['context_length' => 128000]),
+            ],
+            ['min_context' => 100000],
+        );
+
+        self::assertSame('exact/context', $model);
+    }
+
+    #[Test]
+    public function routingWithoutFilterOptionsKeepsIncapableModels(): void
+    {
+        // Without vision_required / function_calling options the capability
+        // filters must NOT run: the cheap incapable model stays eligible.
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('plain/cheap', 0.0001, 0.0001),
+                self::modelEntry('able/model', 0.01, 0.01, [
+                    'architecture' => ['modality' => 'multimodal'],
+                    'supports_function_calling' => true,
+                ]),
+            ],
+        );
+
+        self::assertSame('plain/cheap', $model);
+    }
+
+    #[Test]
+    public function visionRequiredFilterRoutesToVisionCapableModel(): void
+    {
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('text/cheap', 0.0001, 0.0001),
+                self::modelEntry('vision/pricier', 0.01, 0.01, [
+                    'architecture' => ['modality' => 'multimodal'],
+                ]),
+            ],
+            ['vision_required' => true],
+        );
+
+        self::assertSame('vision/pricier', $model);
+    }
+
+    #[Test]
+    public function functionCallingFilterRoutesToToolCapableModel(): void
+    {
+        $model = $this->capturedRoutedModel(
+            ['routingStrategy' => 'cost_optimized'],
+            [
+                self::modelEntry('plain/cheap', 0.0001, 0.0001),
+                self::modelEntry('tools/pricier', 0.01, 0.01, [
+                    'supports_function_calling' => true,
+                ]),
+            ],
+            ['function_calling' => true],
+        );
+
+        self::assertSame('tools/pricier', $model);
+    }
+
+    // ---------------------------------------------------------------------
+    // Vision-model selection pins
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function analyzeImageUsesVisionCapableDefaultModel(): void
+    {
+        $model = $this->capturedVisionModel(
+            [],
+            [self::modelEntry('anthropic/claude-3.5-sonnet', 0.003, 0.015, [
+                'architecture' => ['modality' => 'multimodal'],
+            ])],
+        );
+
+        self::assertSame('anthropic/claude-3.5-sonnet', $model);
+    }
+
+    #[Test]
+    public function analyzeImageFallsBackToFirstListedVisionModel(): void
+    {
+        // The default model is absent from the live list; the FIRST entry of
+        // the curated vision-model list that is available must be selected.
+        $model = $this->capturedVisionModel(
+            [],
+            [self::modelEntry('anthropic/claude-sonnet-4-5', 0.003, 0.015)],
+        );
+
+        self::assertSame('anthropic/claude-sonnet-4-5', $model);
+    }
+
+    #[Test]
+    public function analyzeImageSelectsListedVisionModelFromAvailableModels(): void
+    {
+        // Only a later curated entry is available: it must be picked over the
+        // hardcoded 'openai/gpt-5.2' fallback and over unavailable entries.
+        $model = $this->capturedVisionModel(
+            [],
+            [self::modelEntry('google/gemini-3-flash', 0.001, 0.002)],
+        );
+
+        self::assertSame('google/gemini-3-flash', $model);
+    }
+
+    #[Test]
+    public function handleOpenRouterErrorIncludesApiErrorMessage(): void
+    {
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(
+                ['error' => ['message' => 'upstream exploded']],
+                500,
+            ));
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('OpenRouter API error (500): upstream exploded');
+
+        $this->subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Hi']],
+            ['model' => 'primary/model'],
+        );
     }
 }

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -1684,6 +1684,12 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $text = $contents[0]['parts'][0]['text'] ?? null;
         self::assertIsString($text);
         self::assertStringStartsWith('You are an expert at configuring LLM integrations.', $text);
+        // SYSTEM_PROMPT (ending "…code/technical assistance.") and the model
+        // prompt are joined by exactly one blank line ("\n\n").
+        self::assertStringContainsString(
+            "and code/technical assistance.\n\nAvailable models:",
+            $text,
+        );
         self::assertStringContainsString(
             "Available models:\n- Gemini 3 Flash (gemini-3-flash): Fast model",
             $text,
@@ -1916,5 +1922,413 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         self::assertNotEmpty($result);
         self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
+    }
+
+    // ==================== second-pass mutation kills ====================
+
+    /**
+     * Stub the full HTTP round trip: request factory, stream factory and
+     * HTTP client return canned objects so generate() sees $body as the
+     * API response.
+     */
+    private function stubHttpRoundTrip(int $statusCode, string $body): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub
+            ->method('createStream')
+            ->willReturn($streamStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForGenerator($statusCode, $body));
+    }
+
+    /**
+     * Wrap an LLM "content" string in the OpenAI chat-completions
+     * response envelope.
+     */
+    private function openAiResponseWithContent(string $content): string
+    {
+        return (string)json_encode(['choices' => [['message' => ['content' => $content]]]]);
+    }
+
+    /**
+     * Build a subject wired to the shared stubs but with a caller-supplied
+     * logger (mock), including the HTTP-client test seam.
+     */
+    private function createSubjectWithLogger(LoggerInterface $logger): ConfigurationGenerator
+    {
+        $subject = new ConfigurationGenerator(
+            $this->vaultStub,
+            $this->createSecureHttpClientFactoryMock(),
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $logger,
+        );
+        $subject->setHttpClient($this->httpClientStub);
+
+        return $subject;
+    }
+
+    #[Test]
+    public function generateWithoutModelsReturnsFallbackWithoutLoggingAWarning(): void
+    {
+        // With no models the guard returns the fallback BEFORE the try
+        // block: no LLM call is attempted, so no warning may be logged.
+        // (Removing the guard's return would TypeError on callLLM(model:
+        // null) inside the try and log a warning.)
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects(self::never())->method('warning');
+
+        $subject = $this->createSubjectWithLogger($loggerMock);
+
+        $result = $subject->generate($this->createOpenAiProvider(), 'test-key', []);
+
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
+    }
+
+    #[Test]
+    public function generateSubstitutesInvalidUtf8InRequestBodyInsteadOfFailing(): void
+    {
+        // The model description carries a non-UTF-8 byte. With
+        // JSON_INVALID_UTF8_SUBSTITUTE the request body encodes (U+FFFD
+        // substitution) and the call proceeds to the parsed result. With
+        // the flags AND-ed (= 0) json_encode returns false and the run
+        // falls back to the static presets.
+        $provider = $this->createOpenAiProvider();
+        $models   = [
+            new DiscoveredModel(
+                modelId: 'utf8-model',
+                name: 'UTF-8 Model',
+                description: "Latin-1 byte: \xB1 end",
+                capabilities: ['chat'],
+                contextLength: 100000,
+                recommended: true,
+            ),
+        ];
+
+        $content = (string)json_encode([
+            ['identifier' => 'utf8-config', 'name' => 'UTF-8 Config', 'systemPrompt' => 'Help.'],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($provider, 'test-key', $models);
+
+        self::assertCount(1, $result);
+        self::assertSame('utf8-config', $result[0]->identifier);
+    }
+
+    #[Test]
+    public function generateLogsExactApiErrorMessageOnNon200Response(): void
+    {
+        // The thrown ProviderResponseException message surfaces verbatim in
+        // the warning context ('LLM API error: ' . status; the sanitizer
+        // only redacts credential query params). Pins concat order and both
+        // operands.
+        $this->stubHttpRoundTrip(503, '{}');
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM setup-wizard configuration generation failed; using fallback presets',
+                self::callback(static function (mixed $context): bool {
+                    self::assertIsArray($context);
+                    self::assertArrayHasKey('exception', $context);
+                    self::assertSame('LLM API error: 503', $context['exception']);
+                    return true;
+                }),
+            );
+
+        $subject = $this->createSubjectWithLogger($loggerMock);
+
+        $result = $subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
+    }
+
+    #[Test]
+    public function generateDoesNotParseBodyOfNon200Response(): void
+    {
+        // A parseable body on an error status must NOT be used: the throw
+        // aborts callLLM and the fallback presets are returned.
+        $content = (string)json_encode([
+            ['identifier' => 'should-not-appear', 'name' => 'Nope', 'systemPrompt' => 'Nope.'],
+        ]);
+        $this->stubHttpRoundTrip(500, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        $identifiers = array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result);
+        self::assertContains('content-assistant', $identifiers);
+        self::assertNotContains('should-not-appear', $identifiers);
+    }
+
+    #[Test]
+    public function generateHandlesNonArrayApiBodyWithoutLoggingAWarning(): void
+    {
+        // Body decodes to a string, not an array: callLLM returns ''
+        // cleanly (no exception, no warning). Removing that return would
+        // TypeError in extractContentFromResponse and log a warning.
+        $this->stubHttpRoundTrip(200, '"just a string"');
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects(self::never())->method('warning');
+
+        $subject = $this->createSubjectWithLogger($loggerMock);
+
+        $result = $subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
+    }
+
+    #[Test]
+    public function generateHandlesUnparseableContentWithoutLoggingAWarning(): void
+    {
+        // extractJson() yields null → parseResponse returns [] cleanly.
+        // Removing that return would TypeError in array_is_list(null) and
+        // log a warning.
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent('No JSON here at all'));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects(self::never())->method('warning');
+
+        $subject = $this->createSubjectWithLogger($loggerMock);
+
+        $result = $subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertContains('content-assistant', array_map(static fn(SuggestedConfiguration $c): string => $c->identifier, $result));
+    }
+
+    #[Test]
+    public function generatePrefersConfigurationsKeyOverConfigsKey(): void
+    {
+        $content = (string)json_encode([
+            'configurations' => [
+                ['identifier' => 'from-configurations', 'name' => 'A', 'systemPrompt' => 'A.'],
+            ],
+            'configs' => [
+                ['identifier' => 'from-configs', 'name' => 'B', 'systemPrompt' => 'B.'],
+            ],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('from-configurations', $result[0]->identifier);
+    }
+
+    #[Test]
+    public function generateReturnsAllParsedConfigurationsInOrder(): void
+    {
+        $content = (string)json_encode([
+            ['identifier' => 'first-config', 'name' => 'First', 'systemPrompt' => 'One.'],
+            ['identifier' => 'second-config', 'name' => 'Second', 'systemPrompt' => 'Two.'],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(2, $result);
+        self::assertSame('first-config', $result[0]->identifier);
+        self::assertSame('second-config', $result[1]->identifier);
+    }
+
+    #[Test]
+    public function generateReadsSnakeCaseFallbackKeys(): void
+    {
+        // Only snake_case keys present: the ?? chains must reach the
+        // second operand ($item['system_prompt'], $item['max_tokens']).
+        $content = (string)json_encode([
+            [
+                'identifier'    => 'snake-item',
+                'name'          => 'Snake Item',
+                'system_prompt' => 'Snake prompt.',
+                'max_tokens'    => 1234,
+            ],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('snake-item', $result[0]->identifier);
+        self::assertSame('Snake prompt.', $result[0]->systemPrompt);
+        self::assertSame(1234, $result[0]->maxTokens);
+        self::assertSame(0.7, $result[0]->temperature);
+    }
+
+    #[Test]
+    public function generatePrefersCamelCaseKeysOverSnakeCase(): void
+    {
+        $content = (string)json_encode([
+            [
+                'identifier'    => 'camel-item',
+                'name'          => 'Camel Item',
+                'systemPrompt'  => 'Camel wins.',
+                'system_prompt' => 'Snake loses.',
+                'maxTokens'     => 2222,
+                'max_tokens'    => 3333,
+            ],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('Camel wins.', $result[0]->systemPrompt);
+        self::assertSame(2222, $result[0]->maxTokens);
+    }
+
+    #[Test]
+    public function generateAppliesDefaultsForOmittedItemFields(): void
+    {
+        $content = (string)json_encode([
+            ['identifier' => 'defaults-item', 'name' => 'Defaults'],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('', $result[0]->description);
+        self::assertSame('', $result[0]->systemPrompt);
+        self::assertSame(0.7, $result[0]->temperature);
+        self::assertSame(4096, $result[0]->maxTokens);
+    }
+
+    #[Test]
+    public function generateCoercesNumericStringTemperatureAndMaxTokens(): void
+    {
+        // Numeric strings must be cast — without (float)/(int) casts the
+        // strict-typed DTO constructor would TypeError and force fallback.
+        $content = (string)json_encode([
+            [
+                'identifier'  => 'stringy-item',
+                'name'        => 'Stringy',
+                'temperature' => '0.4',
+                'maxTokens'   => '1234',
+            ],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('stringy-item', $result[0]->identifier);
+        self::assertSame(0.4, $result[0]->temperature);
+        self::assertSame(1234, $result[0]->maxTokens);
+    }
+
+    #[Test]
+    public function generateFallsBackToDefaultsForNonNumericValues(): void
+    {
+        $content = (string)json_encode([
+            [
+                'identifier'  => 'nonnumeric-item',
+                'name'        => 'Non Numeric',
+                'temperature' => 'hot',
+                'maxTokens'   => 'lots',
+            ],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame(0.7, $result[0]->temperature);
+        self::assertSame(4096, $result[0]->maxTokens);
+    }
+
+    #[Test]
+    public function generateExtractsJsonOnlyReachableViaMarkdownFence(): void
+    {
+        // A stray "]" after the fence poisons both the raw candidate and
+        // the bracket-regex candidate (greedy match runs to the LAST "]"),
+        // so ONLY the markdown-fence capture ($matches[1]) decodes.
+        $jsonContent = (string)json_encode([
+            ['identifier' => 'md-only-config', 'name' => 'MD Only', 'systemPrompt' => 'Fence.'],
+        ]);
+        $content = "```json\n" . $jsonContent . "\n```\nStray ] bracket.";
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('md-only-config', $result[0]->identifier);
+    }
+
+    #[Test]
+    public function generateTrimsHyphensFromSanitizedIdentifier(): void
+    {
+        // '_trimmed_' → '-trimmed-' after the underscore replacement; the
+        // final trim($identifier, '-') must strip the edge hyphens.
+        $content = (string)json_encode([
+            ['identifier' => '_trimmed_', 'name' => 'Trimmed', 'systemPrompt' => 'Trim.'],
+        ]);
+        $this->stubHttpRoundTrip(200, $this->openAiResponseWithContent($content));
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $this->createTestModels());
+
+        self::assertCount(1, $result);
+        self::assertSame('trimmed', $result[0]->identifier);
+    }
+
+    #[Test]
+    public function fallbackUsesFirstRecommendedModelWhenSeveralAreRecommended(): void
+    {
+        // getFallbackConfigurations breaks on the FIRST recommended model
+        // (list order), not the last.
+        $models = [
+            new DiscoveredModel(
+                modelId: 'rec-a',
+                name: 'Rec A',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 100000,
+                recommended: true,
+            ),
+            new DiscoveredModel(
+                modelId: 'rec-b',
+                name: 'Rec B',
+                description: 'Test',
+                capabilities: ['chat'],
+                contextLength: 200000,
+                recommended: true,
+            ),
+        ];
+        $this->stubHttpRoundTrip(500, '{}');
+
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', $models);
+
+        self::assertNotEmpty($result);
+        self::assertSame('rec-a', $result[0]->recommendedModelId);
+    }
+
+    #[Test]
+    public function fallbackConfigurationsHaveExpectedMaxTokens(): void
+    {
+        $result = $this->subject->generate($this->createOpenAiProvider(), 'test-key', []);
+
+        $maxTokensByIdentifier = [];
+        foreach ($result as $config) {
+            $maxTokensByIdentifier[$config->identifier] = $config->maxTokens;
+        }
+
+        self::assertSame(
+            [
+                'content-assistant'  => 4096,
+                'content-summarizer' => 2048,
+                'translator'         => 8192,
+                'seo-optimizer'      => 4096,
+                'code-assistant'     => 8192,
+            ],
+            $maxTokensByIdentifier,
+        );
     }
 }

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -1300,6 +1300,10 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
+        // The valid entry after the bad ones must still be processed LIVE —
+        // if the loop had stopped early, the result would be the fallback
+        // catalog (which contains the same id), so pin the fallback flag.
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
         $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
@@ -2510,6 +2514,9 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $models = $this->subject->discover($provider, 'test-key');
 
+        // The invalid ids must be SKIPPED (not break the loop, not blow up
+        // with a TypeError that degrades to the fallback catalog).
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
         $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
         // None of the invalid entries should appear
@@ -3342,7 +3349,9 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             ->with(
                 'LLM model discovery received a malformed JSON response',
                 self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'openai'
-                    && ($ctx['sample'] ?? null) === substr($body, 0, 200)),
+                    && ($ctx['sample'] ?? null) === substr($body, 0, 200)
+                    && is_string($ctx['message'] ?? null)
+                    && ($ctx['message'] ?? '') !== ''),
             );
 
         $subject = $this->makeSubjectWithLogger($logger);
@@ -3350,6 +3359,418 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             adapterType: 'openai',
             endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+        );
+
+        $subject->discover($provider, 'test-key');
+    }
+
+    // ==================== decodeModelListBody JSON depth boundary ====================
+
+    #[Test]
+    public function discoverOpenAiDecodesBodyNestedExactlyAtJsonDepthLimit(): void
+    {
+        // decodeModelListBody() decodes with the PHP-default maximum depth of
+        // 512. This body needs exactly depth 512 (object wrapper + 510 nested
+        // arrays around a scalar — boundary verified against json_decode): it
+        // must decode and yield a LIVE result. A lower limit would reject it
+        // as malformed and silently degrade to the fallback catalog, which
+        // contains no gpt-4.1 entry.
+        $pad = str_repeat('[', 510) . '1' . str_repeat(']', 510);
+        $body = '{"data":[{"id":"gpt-4.1"}],"pad":' . $pad . '}';
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, $body));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-4.1', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiFallsBackWhenBodyExceedsJsonDepthLimit(): void
+    {
+        // One nesting level beyond the depth limit (511 nested arrays inside
+        // the object wrapper → depth 513) must be rejected as malformed JSON
+        // and degrade to the fallback catalog. A higher limit would decode the
+        // body and surface the live gpt-4.1 entry instead.
+        $pad = str_repeat('[', 511) . '1' . str_repeat(']', 511);
+        $body = '{"data":[{"id":"gpt-4.1"}],"pad":' . $pad . '}';
+
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, $body));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertNotContains('gpt-4.1', $modelIds);
+        self::assertContains('gpt-5.5', $modelIds);
+    }
+
+    // ==================== discoverOpenAI data-shape edge cases ====================
+
+    #[Test]
+    public function discoverOpenAiReturnsFallbackWhenDataKeyMissing(): void
+    {
+        // An array body WITHOUT a 'data' key must yield an empty data list
+        // (→ fallback) without touching the missing key — accessing
+        // $data['data'] unguarded would raise an undefined-array-key warning
+        // (failOnWarning turns that into a failure).
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{"object":"list"}'));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-5.5', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiSkipsNonStringModelIdWithoutFailing(): void
+    {
+        // A non-string id must be skipped BEFORE the relevance check — passing
+        // the int into isRelevantOpenAIModel() would raise a TypeError that
+        // degrades the whole discovery to the fallback catalog (which contains
+        // no gpt-4.1).
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [['id' => 123], ['id' => 'gpt-4.1']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('gpt-4.1', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiExcludesRealtimeModels(): void
+    {
+        // 'gpt-realtime' matches none of the include patterns and carries the
+        // 'realtime' exclusion marker on its own (no '-search'), so it must be
+        // filtered — the realtime arm must exclude independently of the
+        // '-search' arm.
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [['id' => 'gpt-realtime'], ['id' => 'gpt-4.1']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertNotContains('gpt-realtime', $modelIds);
+        self::assertContains('gpt-4.1', $modelIds);
+    }
+
+    #[Test]
+    public function discoverOpenAiDerivesTextToSpeechCapabilityForDatedTtsVariant(): void
+    {
+        // 'tts-1-1106' (dated TTS release) has no spec entry and does NOT end
+        // in '-tts', so its capability must come from the 'tts-' PREFIX arm of
+        // defaultOpenAICapabilities().
+        $provider = new DetectedProvider(
+            adapterType: 'openai',
+            endpoint: 'https://api.openai.com',
+            suggestedName: 'OpenAI',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [['id' => 'tts-1-1106']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertCount(1, $models);
+        self::assertSame(['text_to_speech'], $models[0]->capabilities);
+    }
+
+    // ==================== discoverAnthropic transformation pinning ====================
+
+    #[Test]
+    public function discoverAnthropicBuildsModelsUrlWithAuthHeaders(): void
+    {
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $captured = [];
+        $this->configureCapturingRequestFactory($captured);
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{"data": []}'));
+
+        $this->subject->discover($provider, 'test-api-key');
+
+        self::assertSame('GET', $captured['method']);
+        self::assertSame('https://api.anthropic.com/v1/models', $captured['uri']);
+        self::assertSame('test-api-key', $captured['headers']['x-api-key'] ?? null);
+        self::assertSame('2023-06-01', $captured['headers']['anthropic-version'] ?? null);
+        // Anthropic must NOT get a Bearer Authorization header.
+        self::assertArrayNotHasKey('Authorization', $captured['headers']);
+    }
+
+    #[Test]
+    public function discoverAnthropicReturnsFallbackOnNonOkStatusEvenWithParseableBody(): void
+    {
+        // A non-200 status must short-circuit to the fallback catalog and NOT
+        // parse the (otherwise valid) body — proven by a body whose model id
+        // is absent from the fallback list.
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                401,
+                (string)json_encode(['data' => [['id' => 'claude-3-haiku-20240307']]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'bad-key');
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertNotContains('claude-3-haiku-20240307', $modelIds);
+        self::assertContains('claude-opus-4-5-20251101', $modelIds);
+    }
+
+    #[Test]
+    public function discoverAnthropicReturnsFallbackWhenDataKeyMissing(): void
+    {
+        // An array body WITHOUT a 'data' key must yield an empty model list
+        // (→ fallback) without touching the missing key (see the matching
+        // OpenAI test for the warning rationale).
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(200, '{"object":"list"}'));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertTrue($this->subject->wasLastDiscoveryFromFallback());
+        $modelIds = array_map(static fn(DiscoveredModel $m): string => $m->modelId, $models);
+        self::assertContains('claude-opus-4-5-20251101', $modelIds);
+    }
+
+    #[Test]
+    public function discoverAnthropicSortsRecommendedModelsFirst(): void
+    {
+        // Insertion order is [non-recommended, recommended]; the usort must
+        // move the recommended model to the front. Kills both the removed-sort
+        // and the flipped-comparison mutants.
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => [
+                    ['id' => 'claude-sonnet-4-20250514'],
+                    ['id' => 'claude-opus-4-5-20251101'],
+                ]]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertCount(2, $models);
+        self::assertSame('claude-opus-4-5-20251101', $models[0]->modelId);
+        self::assertTrue($models[0]->recommended);
+        self::assertSame('claude-sonnet-4-20250514', $models[1]->modelId);
+    }
+
+    #[Test]
+    public function discoverAnthropicEnrichesEverySpecWithExactValues(): void
+    {
+        // Pin every field of the Anthropic spec table (enrichAnthropicModel)
+        // via the dated model ids the API actually returns — each resolves its
+        // spec through the prefix match, and without a display_name the name
+        // must come from the spec. Values mirror ModelDiscovery's spec table.
+        // [name, description, costInput, costOutput, recommended]
+        $expected = [
+            'claude-opus-4-5-20251101' => ['Claude Opus 4.5', 'Most intelligent, best for coding, agents, and computer use', 500, 2500, true],
+            'claude-sonnet-4-5-20250929' => ['Claude Sonnet 4.5', 'Balanced performance and cost', 300, 1500, true],
+            'claude-haiku-4-5-20251001' => ['Claude Haiku 4.5', 'Fast and cost-effective for simple tasks', 100, 500, true],
+            'claude-opus-4-20250514' => ['Claude Opus 4', 'Previous generation Opus', 1500, 7500, false],
+            'claude-sonnet-4-20250514' => ['Claude Sonnet 4', 'Previous generation Sonnet', 300, 1500, false],
+        ];
+
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+
+        $data = array_map(static fn(string $id): array => ['id' => $id], array_keys($expected));
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(
+                200,
+                (string)json_encode(['data' => $data]),
+            ));
+
+        $models = $this->subject->discover($provider, 'test-key');
+
+        self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
+        $byId = [];
+        foreach ($models as $model) {
+            $byId[$model->modelId] = $model;
+        }
+
+        foreach ($expected as $id => $spec) {
+            self::assertArrayHasKey($id, $byId, sprintf('Model %s missing from discovery result', $id));
+            $model = $byId[$id];
+            self::assertSame($spec[0], $model->name, $id . ' name');
+            self::assertSame($spec[1], $model->description, $id . ' description');
+            self::assertSame(['chat', 'vision', 'tools', 'streaming'], $model->capabilities, $id . ' capabilities');
+            self::assertSame(200000, $model->contextLength, $id . ' contextLength');
+            self::assertSame(32000, $model->maxOutputTokens, $id . ' maxOutputTokens');
+            self::assertSame($spec[2], $model->costInput, $id . ' costInput');
+            self::assertSame($spec[3], $model->costOutput, $id . ' costOutput');
+            self::assertSame($spec[4], $model->recommended, $id . ' recommended');
+        }
+    }
+
+    #[Test]
+    public function discoverAnthropicLogsHttpErrorWithProviderAndStatus(): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseStubForDiscovery(503, '{}'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM model discovery returned an unexpected HTTP status',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'anthropic' && ($ctx['status'] ?? null) === 503),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
+        );
+
+        $subject->discover($provider, 'test-key');
+    }
+
+    #[Test]
+    public function discoverAnthropicLogsRequestFailureWithExceptionClass(): void
+    {
+        $this->requestFactoryStub
+            ->method('createRequest')
+            ->willReturn($this->createRequestMock());
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('anthropic down'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'LLM model discovery request failed',
+                self::callback(static fn(array $ctx): bool => ($ctx['provider'] ?? null) === 'anthropic'
+                    && ($ctx['exception'] ?? null) === RuntimeException::class
+                    && ($ctx['message'] ?? null) === 'anthropic down'),
+            );
+
+        $subject = $this->makeSubjectWithLogger($logger);
+        $provider = new DetectedProvider(
+            adapterType: 'anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
+            suggestedName: 'Anthropic',
         );
 
         $subject->discover($provider, 'test-key');

--- a/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Result;
+use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Unit tests for {@see ReadRecordsTool}: spec shape, field resolution
+ * (explicit list vs. TCA label/label_alt defaults), filter validation and
+ * binding, and the row output format. The query builder chain is stubbed
+ * with call-capturing closures so the exact select list, filter columns and
+ * bound parameters can be asserted positionally.
+ */
+#[CoversClass(ReadRecordsTool::class)]
+final class ReadRecordsToolTest extends TestCase
+{
+    private mixed $tcaBackup = null;
+
+    private mixed $beUserBackup = null;
+
+    /** @var list<string> Tables passed to ConnectionPool::getQueryBuilderForTable(). */
+    private array $requestedTables = [];
+
+    /** @var list<list<string>> Positional argument lists of every select() call. */
+    private array $selectCalls = [];
+
+    /** @var list<array{string, mixed}> [field, placeholder] of every expr()->eq() call. */
+    private array $eqCalls = [];
+
+    /** @var list<array{mixed, mixed}> [value, type] of every createNamedParameter() call. */
+    private array $paramCalls = [];
+
+    private int $andWhereCalls = 0;
+
+    /** @var list<int|null> */
+    private array $maxResults = [];
+
+    /** @var list<int> */
+    private array $firstResults = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tcaBackup    = $GLOBALS['TCA'] ?? null;
+        $this->beUserBackup = $GLOBALS['BE_USER'] ?? null;
+        unset($GLOBALS['BE_USER']);
+
+        // label_alt: one valid column (needs trimming), one unknown column,
+        // one credential-ish column that exists — each discriminates a
+        // different guard in the default-field resolution.
+        $GLOBALS['TCA'] = [
+            'tt_content' => [
+                'ctrl' => [
+                    'label'     => 'header',
+                    'label_alt' => ' bodytext , no_such_col, password_field ',
+                ],
+                'columns' => [
+                    'header'         => [],
+                    'bodytext'       => [],
+                    'CType'          => [],
+                    'colPos'         => [],
+                    'sorting'        => [],
+                    'layout'         => [],
+                    'password_field' => [],
+                ],
+            ],
+        ];
+
+        $this->requestedTables = [];
+        $this->selectCalls     = [];
+        $this->eqCalls         = [];
+        $this->paramCalls      = [];
+        $this->andWhereCalls   = 0;
+        $this->maxResults      = [];
+        $this->firstResults    = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TCA'] = $this->tcaBackup;
+        if ($this->beUserBackup !== null) {
+            $GLOBALS['BE_USER'] = $this->beUserBackup;
+        } else {
+            unset($GLOBALS['BE_USER']);
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function specPinsDescriptionAndParameterSchema(): void
+    {
+        $spec = $this->tool([])->getSpec();
+
+        self::assertSame('read_records', $spec->name);
+        self::assertSame(
+            'Read records of one TYPO3 table with equality filters (no SQL). Returns uid, pid and the '
+            . 'label field by default; pass "fields" for specific columns. Deleted and hidden records '
+            . 'are excluded; credential-like columns are never returned.',
+            $spec->description,
+        );
+        // Pin the whole JSON-Schema parameter block so any dropped item/type is caught.
+        self::assertSame(
+            [
+                'type'       => 'object',
+                'properties' => [
+                    'table' => [
+                        'type'        => 'string',
+                        'description' => 'The TCA table to read (e.g. "pages", "tt_content").',
+                    ],
+                    'uid' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: a single record uid.',
+                    ],
+                    'pid' => [
+                        'type'        => 'integer',
+                        'description' => 'Optional: only records on this page uid.',
+                    ],
+                    'where_equals' => [
+                        'type'        => 'object',
+                        'description' => 'Optional: field => value equality filters (max 5, TCA columns only).',
+                        'additionalProperties' => true,
+                    ],
+                    'fields' => [
+                        'type'        => 'array',
+                        'items'       => ['type' => 'string'],
+                        'description' => 'Optional: columns to return (validated against the TCA).',
+                    ],
+                    'limit' => [
+                        'type'        => 'integer',
+                        'description' => 'Maximum rows (default 20, hard cap 50).',
+                    ],
+                    'offset' => [
+                        'type'        => 'integer',
+                        'description' => 'Rows to skip for pagination (default 0).',
+                    ],
+                ],
+                'required' => ['table'],
+            ],
+            $spec->parameters,
+        );
+    }
+
+    #[Test]
+    public function trimsTableNameAndReturnsFormattedRowsForExplicitFields(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $tool               = $this->tool([
+            ['uid' => 1, 'pid' => 2, 'header' => 'Hello'],
+            ['uid' => 3, 'pid' => 2, 'header' => null],
+        ]);
+
+        // "uid" is requested explicitly: the merged uid/pid prefix must be
+        // deduplicated, keeping the ['uid', 'pid', 'header'] order.
+        $output = $tool->execute([
+            'table'  => '  tt_content  ',
+            'fields' => ['uid', 'header'],
+        ]);
+
+        self::assertSame(['tt_content'], $this->requestedTables);
+        self::assertSame([['uid', 'pid', 'header']], $this->selectCalls);
+        // No uid/pid/where_equals argument -> not a single filter is bound.
+        self::assertSame(0, $this->andWhereCalls);
+        self::assertSame([], $this->paramCalls);
+        self::assertSame(
+            "Records in tt_content (2, offset 0):\n"
+            . "- tt_content:1\n"
+            . "  pid: 2\n"
+            . "  header: Hello\n"
+            . "- tt_content:3\n"
+            . "  pid: 2\n"
+            . '  header: null',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function defaultFieldsComeFromTrimmedNonSensitiveTcaLabels(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $tool               = $this->tool([
+            ['uid' => 7, 'pid' => 1, 'header' => 'A', 'bodytext' => 'B'],
+        ]);
+
+        $output = $tool->execute(['table' => 'tt_content']);
+
+        // label "header" plus label_alt "bodytext" (trimmed); "no_such_col"
+        // (not a TCA column) and "password_field" (credential-ish) are dropped.
+        self::assertSame([['uid', 'pid', 'header', 'bodytext']], $this->selectCalls);
+        self::assertSame(0, $this->andWhereCalls);
+        self::assertSame(
+            "Records in tt_content (1, offset 0):\n"
+            . "- tt_content:7\n"
+            . "  pid: 1\n"
+            . "  header: A\n"
+            . '  bodytext: B',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function skipsCtrlLabelThatIsNotATcaColumn(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $GLOBALS['TCA']     = [
+            'tt_content' => [
+                'ctrl'    => ['label' => 'ghost_col', 'label_alt' => 'header'],
+                'columns' => ['header' => []],
+            ],
+        ];
+        $tool = $this->tool([['uid' => 9, 'pid' => 4, 'header' => 'H']]);
+
+        $output = $tool->execute(['table' => 'tt_content']);
+
+        // "ghost_col" is a ctrl label without a column definition: it must
+        // not be selected; only the label_alt column survives.
+        self::assertSame([['uid', 'pid', 'header']], $this->selectCalls);
+        self::assertStringContainsString('- tt_content:9', $output);
+    }
+
+    #[Test]
+    public function bindsUidPidAndWhereEqualsFiltersPositionally(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $tool               = $this->tool([['uid' => 5, 'pid' => 0, 'header' => 'News']]);
+
+        $output = $tool->execute([
+            'table'        => 'tt_content',
+            'fields'       => ['uid', 'header'],
+            'uid'          => 42,
+            'pid'          => 0,
+            'offset'       => 7,
+            'where_equals' => [
+                ' header ' => 'News',
+                'colPos'   => 7,
+                'CType'    => 'text',
+                'sorting'  => 3,
+                'layout'   => 1,
+            ],
+        ]);
+
+        // uid first, then pid (0 is valid: the root page), then the five
+        // where_equals columns in argument order with the key trimmed.
+        self::assertSame(7, $this->andWhereCalls);
+        self::assertSame(
+            [
+                ['uid', ':p1'],
+                ['pid', ':p2'],
+                ['header', ':p3'],
+                ['colPos', ':p4'],
+                ['CType', ':p5'],
+                ['sorting', ':p6'],
+                ['layout', ':p7'],
+            ],
+            $this->eqCalls,
+        );
+        self::assertSame(
+            [
+                [42, Connection::PARAM_INT],
+                [0, Connection::PARAM_INT],
+                ['News', ParameterType::STRING],
+                [7, Connection::PARAM_INT],
+                ['text', ParameterType::STRING],
+                [3, Connection::PARAM_INT],
+                [1, Connection::PARAM_INT],
+            ],
+            $this->paramCalls,
+        );
+        self::assertSame([20], $this->maxResults);
+        self::assertSame([7], $this->firstResults);
+        self::assertSame(
+            "Records in tt_content (1, offset 7):\n"
+            . "- tt_content:5\n"
+            . "  pid: 0\n"
+            . '  header: News',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function rejectsMoreThanFiveWhereEqualsFiltersBeforeTouchingTheDatabase(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $tool               = $this->tool([]);
+
+        $output = $tool->execute([
+            'table'        => 'tt_content',
+            'where_equals' => [
+                'header'   => 'a',
+                'bodytext' => 'b',
+                'CType'    => 'c',
+                'colPos'   => 1,
+                'sorting'  => 2,
+                'layout'   => 3,
+            ],
+        ]);
+
+        self::assertSame(
+            'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.',
+            $output,
+        );
+        self::assertSame([], $this->requestedTables);
+    }
+
+    #[Test]
+    public function ignoresNegativePidAndZeroUidArguments(): void
+    {
+        $GLOBALS['BE_USER'] = $this->adminUser();
+        $tool               = $this->tool([['uid' => 11, 'pid' => 3, 'header' => 'X']]);
+
+        $output = $tool->execute([
+            'table'  => 'tt_content',
+            'fields' => ['header'],
+            'uid'    => 0,
+            'pid'    => -3,
+        ]);
+
+        // A present-but-negative pid and a zero uid are no filters at all.
+        self::assertSame(0, $this->andWhereCalls);
+        self::assertSame([], $this->paramCalls);
+        self::assertStringContainsString('- tt_content:11', $output);
+    }
+
+    private function adminUser(): BackendUserAuthentication
+    {
+        $user = $this->createMock(BackendUserAuthentication::class);
+        $user->method('isAdmin')->willReturn(true);
+
+        return $user;
+    }
+
+    /**
+     * A ReadRecordsTool whose query-builder chain records every select(),
+     * expr()->eq(), createNamedParameter(), andWhere(), setMaxResults() and
+     * setFirstResult() call into the test-case capture properties and yields
+     * the given rows.
+     *
+     * @param list<array<string, int|string|null>> $rows
+     */
+    private function tool(array $rows): ReadRecordsTool
+    {
+        $result = self::createStub(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($rows);
+
+        $expressionBuilder = self::createStub(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturnCallback(
+            function (string $fieldName, mixed $value): string {
+                $this->eqCalls[] = [$fieldName, $value];
+
+                return sprintf('eq(%s)', $fieldName);
+            },
+        );
+
+        $queryBuilder = self::createStub(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnCallback(
+            function (string ...$selects) use ($queryBuilder): QueryBuilder {
+                $this->selectCalls[] = array_values($selects);
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('from')->willReturn($queryBuilder);
+        $queryBuilder->method('orderBy')->willReturn($queryBuilder);
+        $queryBuilder->method('setMaxResults')->willReturnCallback(
+            function (?int $maxResults = null) use ($queryBuilder): QueryBuilder {
+                $this->maxResults[] = $maxResults;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('setFirstResult')->willReturnCallback(
+            function (int $firstResult) use ($queryBuilder): QueryBuilder {
+                $this->firstResults[] = $firstResult;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturnCallback(
+            function (mixed $value, mixed $type = ParameterType::STRING): string {
+                $this->paramCalls[] = [$value, $type];
+
+                return ':p' . count($this->paramCalls);
+            },
+        );
+        $queryBuilder->method('andWhere')->willReturnCallback(
+            function (mixed ...$predicates) use ($queryBuilder): QueryBuilder {
+                ++$this->andWhereCalls;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = self::createStub(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturnCallback(
+            function (string $table) use ($queryBuilder): QueryBuilder {
+                $this->requestedTables[] = $table;
+
+                return $queryBuilder;
+            },
+        );
+
+        return new ReadRecordsTool($connectionPool, new TableReadAccessService());
+    }
+}

--- a/Tests/Unit/Service/WizardGeneratorServiceTest.php
+++ b/Tests/Unit/Service/WizardGeneratorServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service;
 
 use ArrayIterator;
+use JsonException;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
@@ -2087,5 +2088,698 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
         $result = $this->subject->generateConfiguration('inactive only');
 
         self::assertFalse($result['generated']);
+    }
+
+    // ==================== No-config guard returns immediately (ReturnRemoval) ====================
+
+    /**
+     * Build a subject whose logger is a mock that must never receive warning().
+     *
+     * Without the early `return $this->fallback…()` the code proceeds into the
+     * LLM call with a null config, which always ends in a logged warning
+     * (either the caught Throwable or the unparseable stub response).
+     */
+    private function createSubjectExpectingNoWarning(): WizardGeneratorService
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        return new WizardGeneratorService(
+            $this->llmServiceManager,
+            $this->configurationRepository,
+            $this->modelRepository,
+            $logger,
+        );
+    }
+
+    #[Test]
+    public function testGenerateConfigurationWithoutConfigReturnsBeforeBuildingContext(): void
+    {
+        $this->stubNoDefaultConfig();
+        $this->modelRepository->expects(self::never())->method('findActive');
+
+        $result = $this->createSubjectExpectingNoWarning()->generateConfiguration('no config path');
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testGenerateTaskWithoutConfigReturnsBeforeBuildingContext(): void
+    {
+        $this->stubNoDefaultConfig();
+
+        $result = $this->createSubjectExpectingNoWarning()->generateTask('no config path');
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testGenerateTaskWithChainWithoutConfigReturnsBeforeBuildingContext(): void
+    {
+        $this->stubNoDefaultConfig();
+        $this->modelRepository->expects(self::never())->method('findActive');
+
+        $result = $this->createSubjectExpectingNoWarning()->generateTaskWithChain('no config path');
+
+        self::assertFalse($result['generated']);
+    }
+
+    // ==================== parseJsonResponse: depth limit and strategy boundaries ====================
+
+    /**
+     * Run generateConfiguration with a fixed LLM response content and return the result.
+     *
+     * @return array<string, mixed>
+     */
+    private function generateConfigurationFromContent(string $content): array
+    {
+        $config = $this->createConfigurationWithModel();
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse($content));
+
+        return $this->subject->generateConfiguration('depth probe request', $config);
+    }
+
+    #[Test]
+    public function testParseJsonDirectParseAcceptsNestingWithinDepthLimit(): void
+    {
+        // 511 nested arrays decode fine at depth 512 but fail at 511 (the
+        // DecrementInteger mutant). No braces/fences: no other strategy can rescue.
+        $content = str_repeat('[', 511) . str_repeat(']', 511);
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonDirectParseRejectsNestingBeyondDepthLimit(): void
+    {
+        // 512 nested arrays exceed depth 512 (need 513) — must fall back. The
+        // IncrementInteger mutant (depth 513) would accept them.
+        $content = str_repeat('[', 512) . str_repeat(']', 512);
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonDirectParseAcceptsTopLevelJsonArray(): void
+    {
+        // A JSON list has no braces and no fences: only the direct-parse is_array
+        // branch can accept it. The negated-if mutant loses the result entirely.
+        $result = $this->generateConfigurationFromContent('["a","b"]');
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonMarkdownBlockAcceptsJsonArray(): void
+    {
+        // Fenced JSON list: direct parse fails (fences), brace strategy cannot
+        // match (no braces) — only the markdown branch's is_array assignment works.
+        $result = $this->generateConfigurationFromContent("note\n```json\n[1, 2]\n```");
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonMarkdownBlockUsesTrimmedCaptureGroup(): void
+    {
+        // Direct parse fails (fences + prefix). The stray '{' in the prefix makes the
+        // greedy brace strategy capture invalid JSON, so ONLY the markdown branch can
+        // succeed — and only via trim(): the trailing \x0B (vertical tab) is inside
+        // the capture group, is NOT valid JSON whitespace, but IS removed by trim().
+        // Kills: skipped-strategy mutants, $matches[0] (includes fences), UnwrapTrim.
+        $content = "junk { noise\n```json\n{\"a\":1}\x0B```";
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonMarkdownBlockAcceptsNestingWithinDepthLimit(): void
+    {
+        $content = "Note:\n```json\n" . str_repeat('[', 511) . str_repeat(']', 511) . "\n```";
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonMarkdownBlockRejectsNestingBeyondDepthLimit(): void
+    {
+        $content = "Note:\n```json\n" . str_repeat('[', 512) . str_repeat(']', 512) . "\n```";
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonEmbeddedObjectAcceptsNestingWithinDepthLimit(): void
+    {
+        // 511 nested objects: the "Result: " prefix breaks the direct parse, there
+        // are no fences, so only the brace-extraction strategy (depth 512) succeeds.
+        $content = 'Result: ' . str_repeat('{"a":', 511) . '1' . str_repeat('}', 511);
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertTrue($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonEmbeddedObjectRejectsNestingBeyondDepthLimit(): void
+    {
+        $content = 'Result: ' . str_repeat('{"a":', 512) . '1' . str_repeat('}', 512);
+
+        $result = $this->generateConfigurationFromContent($content);
+
+        self::assertFalse($result['generated']);
+    }
+
+    // ==================== parseJsonResponse: warning is logged exactly when parsing fails ====================
+
+    #[Test]
+    public function testParseJsonSuccessViaMarkdownBlockDoesNotLogParseWarning(): void
+    {
+        // Direct parse fails (lastError set) but the markdown block succeeds:
+        // the parse warning fires only for `result === null` — the flipped
+        // comparison mutant would log despite the successful parse.
+        $config = $this->createConfigurationWithModel();
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse("Here:\n```json\n{\"name\":\"Wrapped Name\"}\n```"));
+
+        $subject = $this->createSubjectExpectingNoWarning();
+        $result = $subject->generateConfiguration('markdown no warning', $config);
+
+        self::assertTrue($result['generated']);
+        self::assertSame('Wrapped Name', $result['name']);
+    }
+
+    #[Test]
+    public function testParseJsonScalarResponseWithoutParseErrorDoesNotLog(): void
+    {
+        // '42' is valid JSON but not an array: every strategy yields null WITHOUT
+        // a JsonException, so lastError stays null and nothing may be logged.
+        // The `lastError === null` / `||` mutants would dereference null here.
+        $config = $this->createConfigurationWithModel();
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse('42'));
+
+        $subject = $this->createSubjectExpectingNoWarning();
+        $result = $subject->generateConfiguration('scalar response', $config);
+
+        self::assertFalse($result['generated']);
+    }
+
+    #[Test]
+    public function testParseJsonFailureLogsExceptionMessageAndContentSample(): void
+    {
+        // Content > 201 chars so every substr mutation (offset ±1, length 199/201,
+        // unwrap) produces a different sample. Expected values are derived from the
+        // same json_decode call and substr window the source uses.
+        $content = 'unparseable ' . str_repeat('y', 250);
+
+        $expectedError = '';
+        try {
+            json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $expectedError = $e->getMessage();
+        }
+        self::assertNotSame('', $expectedError);
+
+        $config = $this->createConfigurationWithModel();
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse($content));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Wizard could not parse LLM JSON response',
+                [
+                    'exception' => $expectedError,
+                    'sample' => substr($content, 0, 200),
+                ],
+            );
+
+        $subject = new WizardGeneratorService(
+            $this->llmServiceManager,
+            $this->configurationRepository,
+            $this->modelRepository,
+            $logger,
+        );
+
+        $result = $subject->generateConfiguration('log parse failure', $config);
+
+        self::assertFalse($result['generated']);
+    }
+
+    // ==================== Normalization: snake_case wins over camelCase when both present ====================
+
+    #[Test]
+    public function testNormalizeConfigurationPrefersSnakeCaseOverCamelCase(): void
+    {
+        $llmJson = json_encode([
+            'identifier' => 'prec-config',
+            'name' => 'Precedence Config',
+            'description' => 'Polished config description.',
+            'system_prompt' => 'Snake sys.',
+            'systemPrompt' => 'Camel sys.',
+            'max_tokens' => 2048,
+            'maxTokens' => 512,
+            'top_p' => 0.25,
+            'topP' => 0.75,
+            'frequency_penalty' => 0.5,
+            'frequencyPenalty' => 1.5,
+            'presence_penalty' => 0.75,
+            'presencePenalty' => 1.75,
+            'recommended_model' => 'snake-model',
+            'recommendedModel' => 'camel-model',
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->generateConfigurationFromContent($llmJson);
+
+        self::assertTrue($result['generated']);
+        // The LLM's polished description wins over the raw user request.
+        self::assertSame('Polished config description.', $result['description']);
+        self::assertSame('Snake sys.', $result['system_prompt']);
+        self::assertSame(2048, $result['max_tokens']);
+        self::assertSame(0.25, $result['top_p']);
+        self::assertSame(0.5, $result['frequency_penalty']);
+        self::assertSame(0.75, $result['presence_penalty']);
+        self::assertSame('snake-model', $result['recommended_model']);
+    }
+
+    #[Test]
+    public function testNormalizeTaskPrefersSnakeCaseOverCamelCase(): void
+    {
+        $config = $this->createConfigurationWithModel();
+        $this->configurationRepository->method('findAll')->willReturn([]);
+
+        $llmJson = json_encode([
+            'identifier' => 'prec-task',
+            'name' => 'Precedence Task',
+            'description' => 'Polished task description.',
+            'category' => 'content',
+            'prompt_template' => 'Snake template {{input}}',
+            'promptTemplate' => 'Camel template {{input}}',
+            'output_format' => 'json',
+            'outputFormat' => 'html',
+        ], JSON_THROW_ON_ERROR);
+
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse($llmJson));
+
+        $result = $this->subject->generateTask('raw task request', $config);
+
+        self::assertTrue($result['generated']);
+        self::assertSame('Polished task description.', $result['description']);
+        self::assertSame('Snake template {{input}}', $result['prompt_template']);
+        self::assertSame('json', $result['output_format']);
+    }
+
+    /**
+     * Run generateTaskWithChain with a fixed LLM response payload.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function generateTaskWithChainFromPayload(array $payload): array
+    {
+        $config = $this->createConfigurationWithModel();
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub([]));
+        $this->configurationRepository->method('findAll')->willReturn([]);
+
+        $this->llmServiceManager
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createCompletionResponse(json_encode($payload, JSON_THROW_ON_ERROR)));
+
+        return $this->subject->generateTaskWithChain('raw chain request', $config);
+    }
+
+    #[Test]
+    public function testNormalizeFullChainPrefersSnakeCaseOverCamelCase(): void
+    {
+        $result = $this->generateTaskWithChainFromPayload([
+            'task' => [
+                'identifier' => 'prec-chain',
+                'name' => 'Precedence Chain',
+                'description' => 'Polished chain description.',
+                'category' => 'content',
+                'prompt_template' => 'Snake {{input}}',
+                'promptTemplate' => 'Camel {{input}}',
+                'output_format' => 'json',
+                'outputFormat' => 'html',
+            ],
+            'configuration' => [
+                'identifier' => 'prec-chain-config',
+                'name' => 'Chain Custom Name',
+                'description' => 'Chain config description.',
+                'system_prompt' => 'Snake sys.',
+                'systemPrompt' => 'Camel sys.',
+                'temperature' => 0.5,
+                'max_tokens' => 999999,
+                'maxTokens' => 500,
+                'top_p' => 0.25,
+                'topP' => 0.75,
+                'frequency_penalty' => 0.5,
+                'frequencyPenalty' => 1.5,
+                'presence_penalty' => 0.75,
+                'presencePenalty' => 1.75,
+            ],
+            'recommended_model_id' => 'snake-rec',
+            'recommendedModelId' => 'camel-rec',
+            'suggested_model' => [
+                'name' => 'Suggested',
+                'model_id' => 'snake-mid',
+                'modelId' => 'camel-mid',
+                'description' => 'Suggested desc.',
+                'capabilities' => 'chat',
+            ],
+        ]);
+
+        self::assertTrue($result['generated']);
+
+        self::assertIsArray($result['task']);
+        $task = $result['task'];
+        self::assertSame('Polished chain description.', $task['description']);
+        self::assertSame('Snake {{input}}', $task['prompt_template']);
+        self::assertSame('json', $task['output_format']);
+
+        self::assertIsArray($result['configuration']);
+        $configuration = $result['configuration'];
+        self::assertSame('Chain Custom Name', $configuration['name']);
+        self::assertSame('Chain config description.', $configuration['description']);
+        self::assertSame('Snake sys.', $configuration['system_prompt']);
+        // 999999 is clamped to exactly 128000 — the upper-bound ±1 mutants differ.
+        self::assertSame(128000, $configuration['max_tokens']);
+        self::assertSame(0.25, $configuration['top_p']);
+        self::assertSame(0.5, $configuration['frequency_penalty']);
+        self::assertSame(0.75, $configuration['presence_penalty']);
+
+        self::assertSame('snake-rec', $result['recommended_model_id']);
+
+        self::assertIsArray($result['suggested_model']);
+        $suggestedModel = $result['suggested_model'];
+        self::assertSame('snake-mid', $suggestedModel['model_id']);
+        self::assertSame('Suggested desc.', $suggestedModel['description']);
+    }
+
+    #[Test]
+    public function testNormalizeFullChainHonorsCamelCaseOnlyKeys(): void
+    {
+        $result = $this->generateTaskWithChainFromPayload([
+            'task' => [
+                'identifier' => 'camel-chain',
+                'name' => 'Camel Chain',
+                'description' => 'Camel chain description.',
+                'category' => 'developer',
+                'promptTemplate' => 'Camel template {{input}}',
+                'outputFormat' => 'html',
+            ],
+            'configuration' => [
+                'identifier' => 'camel-chain-config',
+                'name' => 'Camel Config',
+                'description' => 'Camel config description.',
+                'systemPrompt' => 'Camel sys.',
+                'maxTokens' => 512,
+                'topP' => 0.25,
+                'frequencyPenalty' => 0.5,
+                'presencePenalty' => 0.75,
+            ],
+            'recommendedModelId' => 'camel-rec',
+            'suggested_model' => [
+                'name' => 'Suggested',
+                'modelId' => 'camel-mid',
+                'description' => 'Camel suggested.',
+                'capabilities' => 'chat',
+            ],
+        ]);
+
+        self::assertTrue($result['generated']);
+
+        self::assertIsArray($result['task']);
+        $task = $result['task'];
+        self::assertSame('Camel template {{input}}', $task['prompt_template']);
+        self::assertSame('html', $task['output_format']);
+
+        self::assertIsArray($result['configuration']);
+        $configuration = $result['configuration'];
+        self::assertSame('Camel sys.', $configuration['system_prompt']);
+        self::assertSame(512, $configuration['max_tokens']);
+        self::assertSame(0.25, $configuration['top_p']);
+        self::assertSame(0.5, $configuration['frequency_penalty']);
+        self::assertSame(0.75, $configuration['presence_penalty']);
+
+        self::assertSame('camel-rec', $result['recommended_model_id']);
+
+        self::assertIsArray($result['suggested_model']);
+        $suggestedModel = $result['suggested_model'];
+        self::assertSame('camel-mid', $suggestedModel['model_id']);
+    }
+
+    #[Test]
+    public function testNormalizeFullChainAppliesDefaultsWhenConfigValuesMissing(): void
+    {
+        $result = $this->generateTaskWithChainFromPayload([
+            'task' => [
+                'identifier' => 'defaults-chain',
+                'name' => 'Defaults Chain',
+                'description' => 'Defaults chain description.',
+                'category' => 'general',
+                'prompt_template' => '{{input}}',
+                'output_format' => 'markdown',
+            ],
+            'configuration' => [
+                'identifier' => 'defaults-config',
+                'name' => 'Defaults Config',
+                'description' => 'd',
+                'system_prompt' => 's',
+            ],
+            'recommended_model_id' => '',
+            'suggested_model' => [
+                'name' => 'S',
+                'model_id' => 'mid',
+                'description' => 'sd',
+                'capabilities' => 'chat',
+            ],
+        ]);
+
+        self::assertTrue($result['generated']);
+        self::assertIsArray($result['configuration']);
+        $configuration = $result['configuration'];
+        self::assertSame(0.7, $configuration['temperature']);
+        self::assertSame(4096, $configuration['max_tokens']);
+        self::assertSame(1.0, $configuration['top_p']);
+        self::assertSame(0.0, $configuration['frequency_penalty']);
+        self::assertSame(0.0, $configuration['presence_penalty']);
+    }
+
+    // ==================== Fallback results: exact full shape ====================
+
+    /**
+     * 45-char description: the substr(…, 0, 40) window is observable — every
+     * offset/length mutation and the unwrap produce a different identifier.
+     */
+    private function longFallbackDescription(): string
+    {
+        return 'b' . str_repeat('a', 44);
+    }
+
+    private function expectedTruncatedIdentifier(): string
+    {
+        return 'b' . str_repeat('a', 39);
+    }
+
+    #[Test]
+    public function testFallbackConfigurationFullShape(): void
+    {
+        $this->stubNoDefaultConfig();
+        $description = $this->longFallbackDescription();
+
+        $result = $this->subject->generateConfiguration($description);
+
+        self::assertSame([
+            'identifier' => $this->expectedTruncatedIdentifier(),
+            'name' => 'New Configuration',
+            'description' => $description,
+            'system_prompt' => 'You are a helpful assistant. ' . $description,
+            'temperature' => 0.7,
+            'max_tokens' => 4096,
+            'top_p' => 1.0,
+            'frequency_penalty' => 0.0,
+            'presence_penalty' => 0.0,
+            'recommended_model' => '',
+            'generated' => false,
+        ], $result);
+    }
+
+    #[Test]
+    public function testFallbackTaskFullShape(): void
+    {
+        $this->stubNoDefaultConfig();
+        $description = $this->longFallbackDescription();
+
+        $result = $this->subject->generateTask($description);
+
+        self::assertSame([
+            'identifier' => $this->expectedTruncatedIdentifier(),
+            'name' => 'New Task',
+            'description' => $description,
+            'category' => 'general',
+            'prompt_template' => $description . "\n\n{{input}}",
+            'output_format' => 'markdown',
+            'generated' => false,
+        ], $result);
+    }
+
+    #[Test]
+    public function testFallbackTaskChainFullShape(): void
+    {
+        $this->stubNoDefaultConfig();
+        $description = $this->longFallbackDescription();
+        $identifier = $this->expectedTruncatedIdentifier();
+
+        $result = $this->subject->generateTaskWithChain($description);
+
+        self::assertSame([
+            'task' => [
+                'identifier' => $identifier,
+                'name' => 'New Task',
+                'description' => $description,
+                'category' => 'general',
+                'prompt_template' => $description . "\n\n{{input}}",
+                'output_format' => 'markdown',
+            ],
+            'configuration' => [
+                'identifier' => $identifier . '-config',
+                'name' => 'New Task Configuration',
+                'description' => 'Configuration for: ' . $description,
+                'system_prompt' => 'You are a helpful assistant. ' . $description,
+                'temperature' => 0.7,
+                'max_tokens' => 4096,
+                'top_p' => 1.0,
+                'frequency_penalty' => 0.0,
+                'presence_penalty' => 0.0,
+            ],
+            'recommended_model_id' => '',
+            'suggested_model' => [
+                'name' => '',
+                'model_id' => '',
+                'description' => '',
+                'capabilities' => 'chat',
+            ],
+            'generated' => false,
+        ], $result);
+    }
+
+    // ==================== Full-chain context: slice window and label placement ====================
+
+    #[Test]
+    public function testGenerateTaskWithChainContextLimitsModelsToTenAndKeepsLabelOrder(): void
+    {
+        $config = $this->createConfigurationWithModel();
+
+        $models = [];
+        for ($i = 1; $i <= 11; ++$i) {
+            $m = $this->createActiveModel('model-' . $i, 'Model ' . $i);
+            $m->setDescription('Desc ' . $i);
+            $models[] = $m;
+        }
+        $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub($models));
+
+        $existingConfig = new LlmConfiguration();
+        $existingConfig->setName('Chain Ref');
+        $existingConfig->setIdentifier('chain-ref');
+        $existingConfig->setDescription('Ref desc');
+        $this->configurationRepository->method('findAll')->willReturn([$existingConfig]);
+
+        $llmJson = json_encode([
+            'task' => [
+                'identifier' => 'ctx-chain',
+                'name' => 'Ctx Chain',
+                'description' => 'Ctx.',
+                'category' => 'general',
+                'prompt_template' => '{{input}}',
+                'output_format' => 'markdown',
+            ],
+            'configuration' => [
+                'identifier' => 'ctx-chain-config',
+                'name' => 'Ctx Config',
+                'description' => 'Ctx.',
+                'system_prompt' => 'Ctx.',
+            ],
+            'recommended_model_id' => 'model-1',
+            'suggested_model' => [
+                'name' => 'M',
+                'model_id' => 'model-1',
+                'description' => 'd',
+                'capabilities' => 'chat',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $captured = null;
+        $this->stubChatCapturing($this->createCompletionResponse($llmJson), $captured);
+
+        $result = $this->subject->generateTaskWithChain('chain context capture', $config);
+
+        self::assertTrue($result['generated']);
+
+        $userContent = $this->messageContent($captured, 1, 'user');
+
+        // Label directly precedes the first model line (Concat order) and the
+        // slice window is [0, 10): model 1 and 10 in, model 11 out. The needles
+        // include the ':' so '(model-1)' cannot false-match inside '(model-11)'.
+        self::assertStringContainsString(
+            "Available models (prefer these):\n- Model 1 (model-1): Desc 1",
+            $userContent,
+        );
+        self::assertStringContainsString('(model-10):', $userContent);
+        self::assertStringNotContainsString('(model-11)', $userContent);
+
+        // Configs label directly precedes the config line (Concat order).
+        self::assertStringContainsString(
+            "Existing configurations (for reference, avoid duplicate names):\n- Chain Ref (identifier: chain-ref): Ref desc",
+            $userContent,
+        );
+    }
+
+    // ==================== sanitizeIdentifier trims leading/trailing hyphens ====================
+
+    #[Test]
+    public function testGenerateConfigurationTrimsHyphensFromIdentifier(): void
+    {
+        $llmJson = json_encode([
+            'identifier' => '--wrapped--',
+            'name' => 'Wrapped',
+            'description' => 'Wrapped identifier.',
+            'system_prompt' => 'Help.',
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->generateConfigurationFromContent($llmJson);
+
+        self::assertTrue($result['generated']);
+        self::assertSame('wrapped', $result['identifier']);
     }
 }

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\FalImageService;
@@ -36,6 +37,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
+use ReflectionProperty;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -1832,5 +1834,408 @@ class FalImageServiceTest extends AbstractUnitTestCase
         ]);
 
         self::assertSame(1, $this->readProperty($subject, 'pollInterval'));
+    }
+
+    // ==================== second pass: audit context ====================
+
+    /**
+     * Read the private audit context off the abstract base. With the injected
+     * test client, getSecureClient() returns early and never consumes the
+     * context via getAuditReason(), so the value set by the public method
+     * under test is still stored afterwards.
+     */
+    private function readAuditContext(FalImageService $subject): mixed
+    {
+        return (new ReflectionProperty(AbstractSpecializedService::class, 'auditContext'))->getValue($subject);
+    }
+
+    #[Test]
+    public function generateSetsModelAndPurposeAuditContext(): void
+    {
+        // generate() records `<model>, generate` (sprintf('%s, generate', $model))
+        // for the vault audit log before dispatching.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset');
+
+        self::assertSame('flux-schnell, generate', $this->readAuditContext($subject));
+    }
+
+    #[Test]
+    public function generateMultipleSetsModelAndPurposeAuditContext(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generateMultiple('A sunset', 2);
+
+        self::assertSame('flux-schnell, generate', $this->readAuditContext($subject));
+    }
+
+    // ==================== second pass: configuration guard ====================
+
+    #[Test]
+    public function loadConfigurationLeavesBaseUrlUntouchedWhenFalConfigIsNotAnArray(): void
+    {
+        // The abstract initializes $baseUrl = '' and loadServiceConfiguration()
+        // returns at the fal-branch guard, so the FAL default URL must NOT be
+        // adopted when the fal config entry is present but not an array.
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['image' => ['fal' => 'not-an-array']]);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+        );
+
+        self::assertFalse($subject->isAvailable());
+        self::assertSame('', $this->readProperty($subject, 'baseUrl'));
+    }
+
+    // ==================== second pass: image_size resolution (payload) ====================
+
+    #[Test]
+    public function generateSendsExplicitImageSizeVerbatimInPayload(): void
+    {
+        // An explicit image_size option is returned as-is by resolveImageSize()
+        // and must not fall through to the 'square_hd' default.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', ['image_size' => 'landscape_16_9']);
+
+        self::assertSame('landscape_16_9', $this->decodedBody()['image_size']);
+    }
+
+    #[Test]
+    public function generateDerivesImageSizeFromNumericStringWidthAndHeight(): void
+    {
+        // Numeric strings are cast to int ((int)'1920' / (int)'1080'), and the
+        // derived array carries BOTH keys in width-then-height order.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', ['width' => '1920', 'height' => '1080']);
+
+        self::assertSame(['width' => 1920, 'height' => 1080], $this->decodedBody()['image_size']);
+    }
+
+    #[Test]
+    public function generateDefaultsNonNumericWidthOrHeightTo1024(): void
+    {
+        // Each non-numeric dimension falls back to exactly 1024 while the
+        // numeric partner is kept (source: `is_numeric(...) ? (int)... : 1024`).
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', ['width' => 'wide', 'height' => 768]);
+        $subject->generate('A sunset', 'flux-schnell', ['width' => 768, 'height' => 'tall']);
+
+        self::assertSame(['width' => 1024, 'height' => 768], $this->decodedBody(0)['image_size']);
+        self::assertSame(['width' => 768, 'height' => 1024], $this->decodedBody(1)['image_size']);
+    }
+
+    #[Test]
+    public function generateUsesDefaultImageSizeWhenOnlyWidthGiven(): void
+    {
+        // The width/height branch requires BOTH keys (isset && isset); a lone
+        // width must yield the 'square_hd' default, not a derived pair.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', ['width' => 800]);
+
+        self::assertSame('square_hd', $this->decodedBody()['image_size']);
+    }
+
+    // ==================== second pass: numeric option casting (payload) ====================
+
+    #[Test]
+    public function generateCastsNumericOptionValuesInPayload(): void
+    {
+        // Numeric strings are cast per applyNumericOptions()/buildGeneratePayload():
+        // guidance_scale (float), num_inference_steps (int), seed (int),
+        // enable_safety_checker (bool), and num_images is clamped to <= 4.
+        // JSON round-trip makes the cast observable: '3.5' would serialize as
+        // a string, 1 would stay an int instead of true.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', [
+            'num_images' => 10,
+            'guidance_scale' => '3.5',
+            'num_inference_steps' => '25',
+            'seed' => '42',
+            'enable_safety_checker' => 1,
+        ]);
+
+        $payload = $this->decodedBody();
+        self::assertSame(4, $payload['num_images']);
+        self::assertSame(3.5, $payload['guidance_scale']);
+        self::assertSame(25, $payload['num_inference_steps']);
+        self::assertSame(42, $payload['seed']);
+        self::assertTrue($payload['enable_safety_checker']);
+    }
+
+    #[Test]
+    public function generateDefaultsNonNumericOptionValuesInPayload(): void
+    {
+        // Non-numeric values hit the ternary fallbacks: num_images 1,
+        // num_inference_steps 20, seed 0 (source defaults in applyNumericOptions()).
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithJson(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-schnell', [
+            'num_images' => 'many',
+            'num_inference_steps' => 'fast',
+            'seed' => 'random',
+        ]);
+
+        $payload = $this->decodedBody();
+        self::assertSame(1, $payload['num_images']);
+        self::assertSame(20, $payload['num_inference_steps']);
+        self::assertSame(0, $payload['seed']);
+    }
+
+    #[Test]
+    public function imageToImageCastsNumericStringStrengthInPayload(): void
+    {
+        // A numeric-string strength must arrive as a JSON float (0.5), not the
+        // raw string ('0.5') — applyImageToImageOptions() casts via (float).
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/transformed.png']]]);
+
+        $subject->imageToImage(
+            'https://example.com/source.png',
+            'Make it darker',
+            'flux-dev',
+            ['strength' => '0.5'],
+        );
+
+        self::assertSame(0.5, $this->decodedBody()['strength']);
+    }
+
+    // ==================== second pass: extractSize guards ====================
+
+    #[Test]
+    public function generateSizeFallsBackWhenWidthIsNotScalar(): void
+    {
+        // is_scalar($width) && is_scalar($height): an array width must fall to
+        // the '1024x1024' default instead of being string-concatenated.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://example.com/image.png', 'width' => [800], 'height' => 600]],
+        ]);
+
+        $result = $subject->generate('A sunset');
+
+        self::assertSame('1024x1024', $result->size);
+    }
+
+    #[Test]
+    public function generateSizeFallsBackWhenHeightMissing(): void
+    {
+        // isset($image['width']) && isset($image['height']): with only width
+        // present the guard must short-circuit to the default size without
+        // touching the missing height key.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://example.com/image.png', 'width' => 800]],
+        ]);
+
+        $result = $subject->generate('A sunset');
+
+        self::assertSame('1024x1024', $result->size);
+    }
+
+    #[Test]
+    public function generateHandlesEmptyImagesList(): void
+    {
+        // images = [] must short-circuit at isset($images[0]) and yield the
+        // empty image (no URL, default size) without touching offset 0.
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest(['images' => []]);
+
+        $result = $subject->generate('A sunset');
+
+        self::assertSame('', $result->url);
+        self::assertSame('1024x1024', $result->size);
+    }
+
+    // ==================== second pass: queue URL construction ====================
+
+    #[Test]
+    public function generateBuildsStatusAndResultUrlsFromEndpointAndRequestId(): void
+    {
+        // Full queue round-trip URL pinning: submit POST to the endpoint,
+        // status GET at <queue>/<endpoint>/requests/<id>/status, result GET at
+        // <queue>/<endpoint>/requests/<id>. Endpoint = MODELS['flux-pro'],
+        // request id = respondWithQueue()'s 'test-request-123'.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate('A sunset', 'flux-pro');
+
+        self::assertSame(
+            [
+                ['method' => 'POST', 'uri' => 'https://queue.fal.run/fal-ai/flux-pro'],
+                ['method' => 'GET', 'uri' => 'https://queue.fal.run/fal-ai/flux-pro/requests/test-request-123/status'],
+                ['method' => 'GET', 'uri' => 'https://queue.fal.run/fal-ai/flux-pro/requests/test-request-123'],
+            ],
+            $this->capturedRequests,
+        );
+    }
+
+    // ==================== second pass: poll attempt budget ====================
+
+    #[Test]
+    public function pollForResultAllowsCeilOfTimeoutOverIntervalAttempts(): void
+    {
+        // timeout 1s, pollInterval 999ms → maxAttempts = ceil(1000/999) = 2.
+        // A first non-terminal poll followed by COMPLETED must succeed; any
+        // shrinking of the budget (floor/round rounding, 1000→999 in the
+        // milliseconds factor) would allow only one attempt and time out.
+        $config = [
+            'image' => [
+                'fal' => [
+                    'apiKeyIdentifier' => 'test-api-key',
+                    'timeout' => 1,
+                    'pollInterval' => 999,
+                ],
+            ],
+        ];
+        $subject = $this->createSubject($config);
+
+        $this->setupQueueResponses(
+            ['IN_PROGRESS', 'COMPLETED'],
+            ['images' => [['url' => 'https://example.com/image.png']]],
+        );
+
+        $result = $subject->generate('A sunset', 'sdxl');
+
+        self::assertSame('sdxl', $result->model);
+    }
+
+    // ==================== second pass: queue payload encoding ====================
+
+    #[Test]
+    public function queueRequestSubstitutesInvalidUtf8InPayload(): void
+    {
+        // json_encode(..., JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE):
+        // a prompt with a lone 0xE9 byte (invalid UTF-8, the real input class
+        // behind PR #315/#316) must be substituted with U+FFFD rather than
+        // making the encode fail.
+        $subject = $this->createSubject();
+        $this->installCapturingFactories();
+        $this->respondWithQueue(['images' => [['url' => 'https://example.com/image.png']]]);
+
+        $subject->generate("A caf\xE9 sunset", 'sdxl');
+
+        self::assertSame("A caf\u{FFFD} sunset", $this->decodedBody()['prompt']);
+    }
+
+    // ==================== second pass: queue error context / messages ====================
+
+    #[Test]
+    public function queueSubmissionWithoutRequestIdCarriesProviderContext(): void
+    {
+        $subject = $this->createSubject();
+        // Submit response lacks request_id (only a status field).
+        $this->setupSuccessfulRequest(['status' => 'queued']);
+
+        try {
+            $subject->generate('A sunset', 'sdxl');
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame('FAL queue submission failed: no request_id', $e->getMessage());
+            self::assertSame(['provider' => 'fal'], $e->context);
+        }
+    }
+
+    #[Test]
+    public function queueFailureSurfacesErrorTextAndRequestContext(): void
+    {
+        // FAILED status: message = 'FAL generation failed: ' . the response's
+        // error string (coalesce + is_string guard keep it verbatim); context
+        // carries provider AND the polled request id.
+        $subject = $this->createSubject();
+
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturn($streamStub);
+
+        $submitBody = self::createStub(StreamInterface::class);
+        $submitBody->method('__toString')->willReturn((string)json_encode(['request_id' => 'req-77']));
+        $submitResponse = self::createStub(ResponseInterface::class);
+        $submitResponse->method('getStatusCode')->willReturn(200);
+        $submitResponse->method('getBody')->willReturn($submitBody);
+
+        $statusBody = self::createStub(StreamInterface::class);
+        $statusBody->method('__toString')->willReturn((string)json_encode([
+            'status' => 'FAILED',
+            'error' => 'Content policy violation',
+        ]));
+        $statusResponse = self::createStub(ResponseInterface::class);
+        $statusResponse->method('getStatusCode')->willReturn(200);
+        $statusResponse->method('getBody')->willReturn($statusBody);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls($submitResponse, $statusResponse);
+
+        try {
+            $subject->generate('A sunset', 'sdxl');
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame('FAL generation failed: Content policy violation', $e->getMessage());
+            self::assertSame(['provider' => 'fal', 'request_id' => 'req-77'], $e->context);
+        }
+    }
+
+    #[Test]
+    public function queueTimeoutCarriesRequestContext(): void
+    {
+        // timeout 1s / pollInterval 1000ms → one exhausted poll; the timeout
+        // exception context carries provider AND the request id
+        // ('test-request-123' from setupQueueResponses()).
+        $config = [
+            'image' => [
+                'fal' => [
+                    'apiKeyIdentifier' => 'test-api-key',
+                    'timeout' => 1,
+                    'pollInterval' => 1000,
+                ],
+            ],
+        ];
+        $subject = $this->createSubject($config);
+
+        $this->setupQueueResponses(['IN_PROGRESS'], null);
+
+        try {
+            $subject->generate('A sunset', 'sdxl');
+            self::fail('Expected ServiceUnavailableException');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame('FAL generation timed out', $e->getMessage());
+            self::assertSame(['provider' => 'fal', 'request_id' => 'test-request-123'], $e->context);
+        }
     }
 }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -752,9 +752,16 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
         $this->setupSuccessfulRequest();
 
-        $this->expectException(ServiceUnavailableException::class);
-
-        $subject->synthesizeToFile('Hello world', '/non/existent/path/file.mp3');
+        try {
+            $subject->synthesizeToFile('Hello world', '/non/existent/path/file.mp3');
+            self::fail('Expected ServiceUnavailableException was not thrown');
+        } catch (ServiceUnavailableException $e) {
+            // The exception names the failed path and carries the provider
+            // context used by upstream error reporting.
+            self::assertStringContainsString('/non/existent/path/file.mp3', $e->getMessage());
+            self::assertSame('speech', $e->service);
+            self::assertSame(['provider' => 'tts'], $e->context);
+        }
     }
 
     // ==================== synthesizeLong tests ====================
@@ -1141,6 +1148,9 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         self::assertEquals('nova', $result->voice);
         self::assertEquals('tts-1-hd', $result->model);
         self::assertEquals('opus', $result->format);
+        // The effective speed is echoed into the result metadata — the only
+        // place a caller can read back what rate was actually requested.
+        self::assertSame(['speed' => 1.5], $result->metadata);
     }
 
     #[Test]
@@ -1560,5 +1570,411 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
 
         self::assertIsArray($chunks);
         self::assertCount(1, $chunks);
+    }
+
+    // ==================== second-pass mutation pins ====================
+
+    #[Test]
+    public function synthesizeLongSendsExactMaxLengthMultibyteTextVerbatim(): void
+    {
+        $subject = $this->createSubject();
+
+        $captured = ['method' => '', 'url' => '', 'body' => '', 'headers' => []];
+        $this->setupCapturingRequest($captured);
+
+        // Codepoint length exactly 4096 (2001 + 2 + 2093) but BYTE length
+        // 8188: the short-text branch must measure by codepoint and take
+        // the text as-is. Any mutant that falls into the split path re-joins
+        // the two sentences with a SINGLE space, so the double space between
+        // them is the discriminator visible in the outgoing payload.
+        $text = str_repeat('ü', 2000) . '.' . '  ' . str_repeat('ü', 2092) . '.';
+
+        $results = $subject->synthesizeLong($text);
+
+        self::assertCount(1, $results);
+        $decoded = json_decode($captured['body'], true);
+        self::assertIsArray($decoded);
+        self::assertSame($text, $decoded['input']);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksKeepsExactLimitSentenceVerbatim(): void
+    {
+        $subject = $this->createSubject();
+
+        // The second sentence is exactly 4096 characters and ends in ', '.
+        // At exactly the limit it is NOT long-split — the whole sentence
+        // becomes one chunk, trailing separator intact. A `>=` boundary
+        // mutant routes it through splitLongSentence(), whose flush rtrims
+        // the trailing ', ' away.
+        $sentence = str_repeat('x', 4094) . ', ';
+        $text = 'Intro. ' . $sentence;
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(['Intro.', $sentence], $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksStripsTrailingSeparatorFromFinalCommaChunk(): void
+    {
+        $subject = $this->createSubject();
+
+        // Over-limit sentence ending in ', ': explode() yields a trailing
+        // empty part, so the final running chunk still carries its ', '
+        // separator — the flush in splitLongSentence() must rtrim it.
+        $text = str_repeat('a', 4000) . ', ' . str_repeat('b', 1000) . ', ';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame([str_repeat('a', 4000), str_repeat('b', 1000)], $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksMergesCommaPartsUpToExactLimit(): void
+    {
+        $subject = $this->createSubject();
+
+        // Second chunk is 1202 + 2894 = exactly 4096 characters: the last
+        // part merges only because its separator is '' (it IS the last part)
+        // and the comparison is `<=`. Mutants that give the last part a ', '
+        // separator (lastIndex off-by-one, `<`→`<=`, swapped ternary) or use
+        // strict `<` push it to 4098 / fail at 4096 and emit three chunks;
+        // concat-order mutants corrupt the merged chunk's content.
+        $text = str_repeat('a', 3000) . ', ' . str_repeat('b', 1200) . ', ' . str_repeat('c', 2893) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('a', 3000),
+                str_repeat('b', 1200) . ', ' . str_repeat('c', 2893) . '.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksPreservesSeparatorBetweenLeadingMergedParts(): void
+    {
+        $subject = $this->createSubject();
+
+        // The first two parts merge into one chunk; the ', ' between them is
+        // part of the chunk content (only TRAILING separators are trimmed).
+        $text = str_repeat('a', 2000) . ', ' . str_repeat('b', 2000) . ', ' . str_repeat('c', 3000) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('a', 2000) . ', ' . str_repeat('b', 2000),
+                str_repeat('c', 3000) . '.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksPreservesSeparatorBeforeFinalMergedPart(): void
+    {
+        $subject = $this->createSubject();
+
+        // Four parts; the last three merge into the second chunk. The ', '
+        // between the second-to-last and last part must survive — an
+        // off-by-one lastIndex hands the second-to-last part an empty
+        // separator and glues 'c…' and 'd…' together.
+        $text = str_repeat('a', 3000) . ', ' . str_repeat('b', 1200)
+            . ', ' . str_repeat('c', 100) . ', ' . str_repeat('d', 100) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('a', 3000),
+                str_repeat('b', 1200) . ', ' . str_repeat('c', 100) . ', ' . str_repeat('d', 100) . '.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksAccountsForSeparatorWhenMergingCommaParts(): void
+    {
+        $subject = $this->createSubject();
+
+        // Merging part two INCLUDING its ', ' separator would hit 4098 > 4096,
+        // so the chunk is flushed as part one only. A mutant that measures the
+        // test chunk WITHOUT the separator sees 4096 <= 4096, merges, and
+        // produces ['a…, b…', 'c….'] instead.
+        $text = str_repeat('a', 2000) . ', ' . str_repeat('b', 2094) . ', ' . str_repeat('c', 500) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('a', 2000),
+                str_repeat('b', 2094) . ', ' . str_repeat('c', 500) . '.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksMeasuresMergedCommaChunksByCodepoint(): void
+    {
+        $subject = $this->createSubject();
+
+        // First two multibyte parts: 4004 codepoints (merge) but 8004 bytes
+        // (would flush). A byte-wise running-chunk measure splits them apart
+        // and yields three chunks instead of two.
+        $text = str_repeat('ü', 2000) . ', ' . str_repeat('ü', 2000) . ', ' . str_repeat('ü', 1500) . '.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('ü', 2000) . ', ' . str_repeat('ü', 2000),
+                str_repeat('ü', 1500) . '.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksMeasuresCommaPartOverflowByCodepoint(): void
+    {
+        $subject = $this->createSubject();
+
+        // The 'ü' part is 2502 codepoints (fits after the flush, merges with
+        // the tail) but 5002 bytes. A byte-wise part-length check would
+        // hard-split it into its own chunk and orphan the tail.
+        $text = str_repeat('a', 4000) . ', ' . str_repeat('ü', 2500) . ', tail.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame(
+            [
+                str_repeat('a', 4000),
+                str_repeat('ü', 2500) . ', tail.',
+            ],
+            $chunks,
+        );
+    }
+
+    #[Test]
+    public function splitTextIntoChunksHardSplitsCommalessSentenceAtCodepointBoundaries(): void
+    {
+        $subject = $this->createSubject();
+
+        // 5000 two-byte characters, no commas: hard-split at 4096 CODEPOINTS
+        // gives chunks of 4096 + 904. A byte-wise split cuts every 4096 BYTES
+        // (= 2048 'ü') and yields three shorter chunks.
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, str_repeat('ü', 5000));
+
+        self::assertSame([str_repeat('ü', 4096), str_repeat('ü', 904)], $chunks);
+    }
+
+    #[Test]
+    public function splitTextIntoChunksHardSplitsOverLimitCommaPartAtCodepointBoundaries(): void
+    {
+        $subject = $this->createSubject();
+
+        // The first comma part alone exceeds the limit and is hard-split at
+        // codepoint boundaries into 4096 + 904; the short tail part follows
+        // as its own chunk. A byte-wise split of the 10000-byte part yields
+        // 2048 + 2048 + 904; dropping the hard-split loop loses the part
+        // entirely.
+        $text = str_repeat('ü', 5000) . ', x.';
+
+        $reflection = new ReflectionClass($subject);
+        $chunks = $reflection->getMethod('splitTextIntoChunks')->invoke($subject, $text);
+
+        self::assertSame([str_repeat('ü', 4096), str_repeat('ü', 904), 'x.'], $chunks);
+    }
+
+    #[Test]
+    public function synthesizeRecordsModelAndVoiceAsPendingAuditContext(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest();
+
+        $subject->synthesize('Hello world');
+
+        // The test seam bypasses the vault secure client, so the audit
+        // context set right before dispatch is still pending; folding it
+        // into the audit reason is exactly what the secure-client build
+        // would record with the secret access.
+        $reflection = new ReflectionClass($subject);
+        $reason = $reflection->getMethod('getAuditReason')->invoke($subject);
+
+        self::assertSame('OpenAI TTS API call (tts-1, voice alloy)', $reason);
+    }
+
+    #[Test]
+    public function synthesizeEmptyTextExceptionCarriesProviderContext(): void
+    {
+        $subject = $this->createSubject();
+
+        try {
+            $subject->synthesize('   ');
+            self::fail('Expected ServiceUnavailableException was not thrown');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame('Input text cannot be empty', $e->getMessage());
+            self::assertSame('speech', $e->service);
+            self::assertSame(['provider' => 'tts'], $e->context);
+        }
+    }
+
+    #[Test]
+    public function synthesizeOverLengthExceptionReportsCodepointLengthInContext(): void
+    {
+        $subject = $this->createSubject();
+
+        // 4097 two-byte characters: the context must report the CODEPOINT
+        // length 4097, not the byte length 8194, alongside the provider key.
+        try {
+            $subject->synthesize(str_repeat('ü', 4097));
+            self::fail('Expected ServiceUnavailableException was not thrown');
+        } catch (ServiceUnavailableException $e) {
+            self::assertStringContainsString('Input text exceeds maximum length', $e->getMessage());
+            self::assertSame(['provider' => 'tts', 'length' => 4097], $e->context);
+        }
+    }
+
+    #[Test]
+    public function synthesizeSubstitutesInvalidUtf8InPayload(): void
+    {
+        $subject = $this->createSubject();
+
+        $captured = ['method' => '', 'url' => '', 'body' => '', 'headers' => []];
+        $this->setupCapturingRequest($captured);
+
+        // "\xE9" is an invalid UTF-8 byte. JSON_INVALID_UTF8_SUBSTITUTE
+        // replaces it with U+FFFD so the request still encodes; without the
+        // flag combination json_encode() returns false and the stream
+        // factory would reject it.
+        $result = $subject->synthesize("Caf\xE9 test");
+
+        self::assertSame('audio-binary-content', $result->audioContent);
+        $decoded = json_decode($captured['body'], true);
+        self::assertIsArray($decoded);
+        self::assertSame("Caf\u{FFFD} test", $decoded['input']);
+    }
+
+    #[Test]
+    public function synthesizeTreatsStatus300AsError(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupFailedRequest(300, 'Multiple choices');
+
+        // The success window is [200, 300): a 300 response is an error and
+        // maps through the default branch of mapErrorStatus().
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('OpenAI TTS API error: Multiple choices');
+
+        $subject->synthesize('Hello world');
+    }
+
+    #[Test]
+    public function sendBinaryRequestLogsApiErrorWithStatusCode(): void
+    {
+        $this->setupFailedRequest(500, 'Server error');
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock
+            ->expects(self::once())
+            ->method('error')
+            ->with('TTS API error', ['status_code' => 500, 'error' => 'Server error']);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $loggerMock,
+        );
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->synthesize('Test text');
+    }
+
+    #[Test]
+    public function sendBinaryRequestLogsAndWrapsConnectionException(): void
+    {
+        $connectionError = new RuntimeException('Connection refused');
+
+        $requestStub = self::createStub(RequestInterface::class);
+        $requestStub->method('withHeader')->willReturnSelf();
+        $requestStub->method('withBody')->willReturnSelf();
+        $this->requestFactoryStub->method('createRequest')->willReturn($requestStub);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $this->streamFactoryStub->method('createStream')->willReturn($streamStub);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willThrowException($connectionError);
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock
+            ->expects(self::once())
+            ->method('error')
+            ->with('TTS API connection error', ['exception' => $connectionError]);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $loggerMock,
+        );
+
+        try {
+            $subject->synthesize('Test text');
+            self::fail('Expected ServiceUnavailableException was not thrown');
+        } catch (ServiceUnavailableException $e) {
+            self::assertSame('Failed to connect to TTS API', $e->getMessage());
+            self::assertSame('speech', $e->service);
+            self::assertSame(['provider' => 'tts'], $e->context);
+            self::assertSame(0, $e->getCode());
+            self::assertSame($connectionError, $e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function synthesizeLongChecksAvailabilityBeforeParsingOptions(): void
+    {
+        $subject = $this->createSubjectWithoutApiKey();
+
+        // ensureAvailable() must fire BEFORE the options array is parsed:
+        // an invalid voice would otherwise surface as an
+        // InvalidArgumentException from the options validation instead of
+        // the not-configured error.
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Tts service is not configured');
+
+        $subject->synthesizeLong('Hello world', ['voice' => 'not-a-real-voice']);
     }
 }


### PR DESCRIPTION
Fifth batch of the mutation-MSI climb (batches 1–4: 62.8% → 75%, #393–#396).

**Measured on this tree: 81% Covered Code MSI** (8371 killed / 1923 escaped) —
up from 75%, and 7 points above the 74% `infection.json.dist` floor.

## What this batch does

- **Second pass** over the largest remaining escaped pools with fresh
  post-batch-4 mutant lists: `ModelDiscovery`, `WizardGeneratorService`,
  `OpenRouterProvider`, `GeminiProvider`, `ClaudeProvider`, `GroqProvider`,
  `FalImageService`, `TextToSpeechService`, `ConfigurationGenerator`.
- **Fixes a round-1 blind spot**: routing/fallback tests now assert the model id
  the provider *requests* (captured outgoing payload), not the id the mocked
  response echoes back — which is why routing mutants previously survived.
- **New `ReadRecordsToolTest`** — the tool had no unit test at all, so its 57
  escaped mutants were structurally unkillable before.

Equivalent mutants triaged and documented per file (unreachable regex arms,
exclusion arms shadowed by later returns, PCRE-error casts, json_decode depth
boundaries verified empirically) rather than chased with contorted assertions.

## Verification

Full unit suite green (780 tests / 2718 assertions across the touched files),
cgl + PHPStan L10 clean — all on the first bulk-verification pass. MSI measured
by a full Infection run on this branch.
