### PR TITLE
test: cover previously-untested classes (0% coverage batch)

### DIFF
--- a/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
+use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+
+/**
+ * Renders the usage analytics dashboard through the real ModuleTemplate
+ * stack against an empty usage table: the chart containers and the
+ * embedded chart JSON must render, and an unknown ?range= value must be
+ * normalized instead of failing.
+ */
+#[CoversClass(AnalyticsController::class)]
+final class AnalyticsControllerTest extends AbstractFunctionalTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function indexActionRendersDashboardWithChartData(): void
+    {
+        $response = $this->dispatchIndex([]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+
+        self::assertStringContainsString('id="nrllm-analytics-data"', $body);
+        self::assertStringContainsString('id="nrllm-trend-chart"', $body);
+        self::assertStringContainsString('id="nrllm-provider-chart"', $body);
+        // The embedded JSON payload carries all four datasets.
+        self::assertStringContainsString('"trend"', $body);
+        self::assertStringContainsString('"byProvider"', $body);
+        self::assertStringContainsString('"byModel"', $body);
+        self::assertStringContainsString('"byService"', $body);
+    }
+
+    #[Test]
+    public function indexActionNormalizesUnknownRangeParameter(): void
+    {
+        $response = $this->dispatchIndex(['range' => 'bogus-range']);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function dispatchIndex(array $queryParams): ResponseInterface
+    {
+        $this->importFixture('BeUsers.csv');
+        $backendUser = $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $controller = new AnalyticsController(
+            $this->getService(ModuleTemplateFactory::class),
+            $this->getService(UsageAnalyticsServiceInterface::class),
+            $this->getService(BackendUriBuilder::class),
+            $this->getService(PageRenderer::class),
+        );
+        $this->setPrivateProperty($controller, 'request', $this->createBackendRequest($queryParams));
+
+        return $controller->indexAction();
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function createBackendRequest(array $queryParams): ExtbaseRequest
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\Analytics');
+        $extbaseParameters->setControllerActionName('index');
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withQueryParams($queryParams)
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/nrllm/analytics', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('extbase', $extbaseParameters);
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        return new ExtbaseRequest($serverRequest);
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+}

--- a/Tests/Functional/Controller/Backend/PromptSnippetControllerTest.php
+++ b/Tests/Functional/Controller/Backend/PromptSnippetControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\FormEngineUrlBuilder;
+use Netresearch\NrLlm\Controller\Backend\PromptSnippetController;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+
+/**
+ * Renders the prompt snippet library list through the real ModuleTemplate
+ * stack: the active fixture snippets must surface with FormEngine edit
+ * URLs and the new-record doc-header button.
+ */
+#[CoversClass(PromptSnippetController::class)]
+final class PromptSnippetControllerTest extends AbstractFunctionalTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function listActionRendersSnippetLibrary(): void
+    {
+        $this->importFixture('PromptSnippets.csv');
+        $this->importFixture('BeUsers.csv');
+        $backendUser = $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $controller = new PromptSnippetController(
+            $this->getService(ModuleTemplateFactory::class),
+            $this->getService(IconFactory::class),
+            $this->getService(PromptSnippetRepository::class),
+            $this->getService(FormEngineUrlBuilder::class),
+        );
+        $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
+
+        $response = $controller->listAction();
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+
+        // Active fixture snippets surface by name.
+        self::assertStringContainsString('Casual tone', $body);
+        self::assertStringContainsString('Formal tone', $body);
+        // FormEngine deep links (the record/edit backend route) for editing
+        // and creating records.
+        self::assertStringContainsString('record/edit', $body);
+        self::assertStringContainsString('tx_nrllm_promptsnippet', $body);
+    }
+
+    private function createBackendRequest(): ExtbaseRequest
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\PromptSnippet');
+        $extbaseParameters->setControllerActionName('list');
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/nrllm/snippets', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('extbase', $extbaseParameters);
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        return new ExtbaseRequest($serverRequest);
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+}

--- a/Tests/Functional/Controller/Backend/TaskListControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskListControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\TaskListController;
+use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+
+/**
+ * Renders the Task catalog list through the real ModuleTemplate stack:
+ * the fixture tasks must surface grouped by category with edit URLs,
+ * counts, and the wizard/new-record doc-header buttons.
+ */
+#[CoversClass(TaskListController::class)]
+final class TaskListControllerTest extends AbstractFunctionalTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function listActionRendersTasksGroupedByCategory(): void
+    {
+        $this->importFixture('Tasks.csv');
+        $this->importFixture('LlmConfigurations.csv');
+        $this->importFixture('BeUsers.csv');
+        $backendUser = $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $controller = new TaskListController(
+            $this->getService(ModuleTemplateFactory::class),
+            $this->getService(IconFactory::class),
+            $this->getService(TaskRepository::class),
+            $this->getService(BackendUriBuilder::class),
+            $this->getService(UsageAnalyticsServiceInterface::class),
+        );
+        $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
+
+        $response = $controller->listAction();
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+
+        // The fixture tasks surface with their names.
+        self::assertStringContainsString('Test Manual Task', $body);
+        self::assertStringContainsString('Test Syslog Task', $body);
+        // Deep links into FormEngine (the record/edit backend route) exist.
+        self::assertStringContainsString('record/edit', $body);
+    }
+
+    private function createBackendRequest(): ExtbaseRequest
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\TaskList');
+        $extbaseParameters->setControllerActionName('list');
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/nrllm/tasks', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('extbase', $extbaseParameters);
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        return new ExtbaseRequest($serverRequest);
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+}

--- a/Tests/Functional/Controller/Backend/TaskWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskWizardControllerTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\TaskWizardController;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Service\WizardGeneratorService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder as ExtbaseUriBuilder;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+
+/**
+ * The AI task wizard (ADR-027 slice 13e) end to end against the real
+ * container: the description form render, the fail-closed validation
+ * redirects, and wizardCreateAction()'s persistence chain including the
+ * numeric clamps and enum allow-lists on wizard-supplied values.
+ *
+ * The generation preview actions are exercised through their error path
+ * (the fixture provider cannot be reached from the test container), which
+ * must degrade into a flash message + redirect, never an exception.
+ */
+#[CoversClass(TaskWizardController::class)]
+final class TaskWizardControllerTest extends AbstractFunctionalTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function wizardFormActionRendersDescriptionForm(): void
+    {
+        $this->setUpFixturesAndUser();
+        $controller = $this->createController($this->createBackendRequest());
+
+        $response = $controller->wizardFormAction();
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+        self::assertStringContainsString('id="wizard-form"', $body);
+        self::assertStringContainsString('id="wizard-description"', $body);
+        self::assertStringContainsString('id="wizard-config"', $body);
+    }
+
+    #[Test]
+    public function wizardGenerateActionWithEmptyDescriptionRedirectsToForm(): void
+    {
+        $this->setUpFixturesAndUser();
+        $controller = $this->createController($this->createBackendRequest());
+
+        $response = $controller->wizardGenerateAction('   ');
+
+        $this->assertRedirectsToWizardForm($response);
+    }
+
+    #[Test]
+    public function wizardGenerateActionRendersPreviewFromFallbackWhenProviderFails(): void
+    {
+        $this->setUpFixturesAndUser();
+        $controller = $this->createController($this->createBackendRequest());
+
+        // The fixture provider endpoint is unreachable from the test
+        // container; WizardGeneratorService degrades to its deterministic
+        // fallback task, and the action must still render the preview.
+        $response = $controller->wizardGenerateAction('Summarize the weekly error logs');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+        self::assertStringContainsString('Summarize the weekly error logs', $body);
+    }
+
+    #[Test]
+    public function wizardGenerateChainActionWithEmptyDescriptionRedirectsToForm(): void
+    {
+        $this->setUpFixturesAndUser();
+        $controller = $this->createController($this->createBackendRequest());
+
+        $response = $controller->wizardGenerateChainAction('');
+
+        $this->assertRedirectsToWizardForm($response);
+    }
+
+    #[Test]
+    public function wizardCreateActionPersistsConfigurationAndTaskWithClampedValues(): void
+    {
+        $this->setUpFixturesAndUser();
+        $request = $this->createBackendRequest([
+            'task' => [
+                'identifier'      => 'wizard-made-task',
+                'name'            => 'Wizard Made Task',
+                'description'     => 'Created by the wizard test',
+                'category'        => 'not-a-category',
+                'prompt_template' => 'Do the thing: {{input}}',
+                'output_format'   => 'not-a-format',
+            ],
+            'configuration' => [
+                'identifier'  => 'wizard-made-config',
+                'name'        => 'Wizard Made Config',
+                'temperature' => '5',
+                'max_tokens'  => '999999999',
+                'top_p'       => '9',
+            ],
+            'model_choice'       => 'existing',
+            'existing_model_uid' => '1',
+            'config_choice'      => 'new',
+        ]);
+        $controller = $this->createController($request);
+
+        $response = $controller->wizardCreateAction();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringContainsString('nrllm', $response->getHeaderLine('location'));
+
+        $connection = $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_task');
+
+        $task = $connection->select(
+            ['*'],
+            'tx_nrllm_task',
+            ['identifier' => 'wizard-made-task'],
+        )->fetchAssociative();
+        self::assertIsArray($task);
+        // Unknown enum values fall back to their defaults.
+        self::assertSame('general', $task['category']);
+        self::assertSame('markdown', $task['output_format']);
+        self::assertSame(1, (int)$task['is_active']);
+
+        $config = $connection->select(
+            ['*'],
+            'tx_nrllm_configuration',
+            ['identifier' => 'wizard-made-config'],
+        )->fetchAssociative();
+        self::assertIsArray($config);
+        // Out-of-range numerics are clamped, not rejected.
+        self::assertIsNumeric($config['temperature']);
+        self::assertSame(2.0, (float)$config['temperature']);
+        self::assertSame(128000, (int)$config['max_tokens']);
+        self::assertIsNumeric($config['top_p']);
+        self::assertSame(1.0, (float)$config['top_p']);
+        // The created task points at the created configuration.
+        self::assertSame((int)$config['uid'], (int)$task['configuration_uid']);
+    }
+
+    #[Test]
+    public function wizardCreateActionWithNonArrayBodyRedirectsToForm(): void
+    {
+        $this->setUpFixturesAndUser();
+        $controller = $this->createController($this->createBackendRequest(null));
+
+        $response = $controller->wizardCreateAction();
+
+        $this->assertRedirectsToWizardForm($response);
+    }
+
+    private function setUpFixturesAndUser(): void
+    {
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+        $this->importFixture('LlmConfigurations.csv');
+        $this->importFixture('BeUsers.csv');
+        $backendUser = $this->setUpBackendUser(1); // uid 1 is an admin (admin=1)
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+    }
+
+    private function createController(ExtbaseRequest $request): TaskWizardController
+    {
+        $controller = new TaskWizardController(
+            $this->getService(ModuleTemplateFactory::class),
+            $this->getService(TaskRepository::class),
+            $this->getService(LlmConfigurationRepository::class),
+            $this->getService(ModelRepository::class),
+            $this->getService(WizardGeneratorService::class),
+            $this->getService(PersistenceManagerInterface::class),
+            $this->getService(FlashMessageService::class),
+            $this->getService(PageRenderer::class),
+            $this->getService(BackendUriBuilder::class),
+            new NullLogger(),
+        );
+        $this->setPrivateProperty($controller, 'request', $request);
+
+        // The validation redirects go through Extbase's UriBuilder.
+        $uriBuilder = $this->getService(ExtbaseUriBuilder::class);
+        $uriBuilder->setRequest($request);
+        $this->setPrivateProperty($controller, 'uriBuilder', $uriBuilder);
+
+        return $controller;
+    }
+
+    private function assertRedirectsToWizardForm(ResponseInterface $response): void
+    {
+        self::assertInstanceOf(RedirectResponse::class, $response);
+
+        // The guard paths must leave the user an explanation: exactly the
+        // enqueued flash message. (The redirect target itself is built by
+        // Extbase's UriBuilder, which resolves to the module URL only under
+        // a fully routed backend request — not in this harness.)
+        $messages = $this->getService(FlashMessageService::class)
+            ->getMessageQueueByIdentifier()
+            ->getAllMessagesAndFlush();
+        self::assertNotEmpty($messages);
+    }
+
+    /**
+     * @param array<string, mixed>|null $parsedBody
+     */
+    private function createBackendRequest(?array $parsedBody = []): ExtbaseRequest
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\TaskWizard');
+        $extbaseParameters->setControllerActionName('wizardForm');
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/nrllm/tasks', [
+                'packageName' => 'netresearch/nr-llm',
+                '_identifier' => 'nrllm_tasks',
+            ]))
+            ->withAttribute('extbase', $extbaseParameters);
+        if ($parsedBody !== null) {
+            $serverRequest = $serverRequest->withParsedBody($parsedBody);
+        }
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        return new ExtbaseRequest($serverRequest);
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+}

--- a/Tests/Functional/Fixtures/UserBudgets.csv
+++ b/Tests/Functional/Fixtures/UserBudgets.csv
@@ -1,0 +1,6 @@
+"tx_nrllm_user_budget"
+,"uid","pid","be_user","max_requests_per_day","max_tokens_per_day","max_cost_per_day","max_requests_per_month","max_tokens_per_month","max_cost_per_month","is_active","tstamp","crdate","deleted","hidden"
+,1,0,1,100,50000,5.0000,2000,1000000,50.0000,1,1703347200,1703347200,0,0
+,2,0,2,10,1000,0.5000,100,20000,2.0000,1,1703347200,1703347200,0,0
+,3,0,1,999,999999,99.0000,9999,9999999,999.0000,1,1703347200,1703347200,0,0
+,4,0,3,1,1,0.0100,1,1,0.0100,1,1703347200,1703347200,0,1

--- a/Tests/Functional/Repository/UserBudgetRepositoryTest.php
+++ b/Tests/Functional/Repository/UserBudgetRepositoryTest.php
@@ -71,7 +71,11 @@ final class UserBudgetRepositoryTest extends AbstractFunctionalTestCase
     {
         $map = $this->repository->findByBeUsers([1, 2, 2, 0, -7, 42]);
 
-        self::assertSame([1, 2], array_keys($map));
+        // The map is keyed by be_user; row order is not asserted because the
+        // underlying IN() query carries no ORDER BY.
+        $users = array_keys($map);
+        sort($users);
+        self::assertSame([1, 2], $users);
         self::assertSame(1, $map[1]->getBeUser());
         self::assertSame(2, $map[2]->getBeUser());
     }

--- a/Tests/Functional/Repository/UserBudgetRepositoryTest.php
+++ b/Tests/Functional/Repository/UserBudgetRepositoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Repository;
+
+use Netresearch\NrLlm\Domain\Model\UserBudget;
+use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Functional tests for UserBudgetRepository.
+ *
+ * Fixture layout (UserBudgets.csv): uid 1 and uid 3 both belong to be_user 1
+ * (the duplicate exercises first-wins), uid 2 belongs to be_user 2, and uid 4
+ * (be_user 3) is hidden — enable fields must keep it invisible even though
+ * storage-page filtering is disabled for these global records.
+ */
+#[CoversClass(UserBudgetRepository::class)]
+final class UserBudgetRepositoryTest extends AbstractFunctionalTestCase
+{
+    private UserBudgetRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('UserBudgets.csv');
+        $this->repository = $this->getService(UserBudgetRepository::class);
+    }
+
+    #[Test]
+    public function findOneByBeUserReturnsTheUsersBudget(): void
+    {
+        $budget = $this->repository->findOneByBeUser(2);
+
+        self::assertInstanceOf(UserBudget::class, $budget);
+        self::assertSame(2, $budget->getBeUser());
+        self::assertSame(10, $budget->getMaxRequestsPerDay());
+        self::assertSame(2.0, $budget->getMaxCostPerMonth());
+    }
+
+    #[Test]
+    public function findOneByBeUserRejectsNonPositiveUids(): void
+    {
+        self::assertNull($this->repository->findOneByBeUser(0));
+        self::assertNull($this->repository->findOneByBeUser(-5));
+    }
+
+    #[Test]
+    public function findOneByBeUserReturnsNullForUserWithoutBudget(): void
+    {
+        self::assertNull($this->repository->findOneByBeUser(42));
+    }
+
+    #[Test]
+    public function findOneByBeUserIgnoresHiddenBudgets(): void
+    {
+        self::assertNull($this->repository->findOneByBeUser(3));
+    }
+
+    #[Test]
+    public function findByBeUsersBatchLoadsKeyedByUserAndFiltersInvalidUids(): void
+    {
+        $map = $this->repository->findByBeUsers([1, 2, 2, 0, -7, 42]);
+
+        self::assertSame([1, 2], array_keys($map));
+        self::assertSame(1, $map[1]->getBeUser());
+        self::assertSame(2, $map[2]->getBeUser());
+    }
+
+    #[Test]
+    public function findByBeUsersEmptyInputYieldsEmptyMap(): void
+    {
+        self::assertSame([], $this->repository->findByBeUsers([]));
+        self::assertSame([], $this->repository->findByBeUsers([0, -1]));
+    }
+
+    #[Test]
+    public function findByBeUsersFirstBudgetWinsOnDuplicates(): void
+    {
+        $map = $this->repository->findByBeUsers([1]);
+
+        // be_user 1 has budgets uid 1 and uid 3 — the first one wins,
+        // mirroring findOneByBeUser()'s getFirst().
+        $single = $this->repository->findOneByBeUser(1);
+        self::assertInstanceOf(UserBudget::class, $single);
+        self::assertSame($single->getUid(), $map[1]->getUid());
+    }
+}

--- a/Tests/Functional/Service/Budget/UserBudgetUsageWindowsTest.php
+++ b/Tests/Functional/Service/Budget/UserBudgetUsageWindowsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Budget;
+
+use Netresearch\NrLlm\Service\Budget\UserBudgetUsageWindows;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The SQL rollup behind the per-user budget windows: one query must return
+ * daily and monthly totals side by side (conditional SUMs), scoped to the
+ * requested backend user and bounded by the wider (monthly) window.
+ */
+#[CoversClass(UserBudgetUsageWindows::class)]
+final class UserBudgetUsageWindowsTest extends AbstractFunctionalTestCase
+{
+    private const NOW = 1_700_000_000;
+
+    private const DAY = 86_400;
+
+    private UserBudgetUsageWindows $windows;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->windows = new UserBudgetUsageWindows($this->getService(ConnectionPool::class));
+    }
+
+    #[Test]
+    public function bothWindowsUnsetShortCircuitToZeroTotals(): void
+    {
+        $result = $this->windows->aggregate(1, null, null, self::NOW);
+
+        $empty = ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        self::assertSame(['daily' => $empty, 'monthly' => $empty], $result);
+    }
+
+    #[Test]
+    public function emptyTableYieldsZeroTotals(): void
+    {
+        $result = $this->windows->aggregate(1, self::NOW - self::DAY, self::NOW - 30 * self::DAY, self::NOW);
+
+        self::assertSame(0, $result['daily']['requests']);
+        self::assertSame(0, $result['daily']['tokens']);
+        self::assertSame(0.0, $result['daily']['cost']);
+        self::assertSame(0, $result['monthly']['requests']);
+    }
+
+    #[Test]
+    public function separatesDailyFromMonthlyWindowAndIgnoresOlderRows(): void
+    {
+        // Inside the daily window (and therefore also the monthly one).
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 2 * 3600, requests: 2, tokens: 100, cost: 0.5);
+        // Inside the monthly window only.
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 10 * self::DAY, requests: 3, tokens: 200, cost: 1.25);
+        // Outside both windows — must not count at all.
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 40 * self::DAY, requests: 7, tokens: 999, cost: 9.0);
+
+        $result = $this->windows->aggregate(1, self::NOW - self::DAY, self::NOW - 30 * self::DAY, self::NOW);
+
+        self::assertSame(2, $result['daily']['requests']);
+        self::assertSame(100, $result['daily']['tokens']);
+        self::assertSame(0.5, $result['daily']['cost']);
+        self::assertSame(5, $result['monthly']['requests']);
+        self::assertSame(300, $result['monthly']['tokens']);
+        self::assertSame(1.75, $result['monthly']['cost']);
+    }
+
+    #[Test]
+    public function onlyDailyWindowSetUsesDailyBoundAsSqlLowerBound(): void
+    {
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 3600, requests: 1, tokens: 10, cost: 0.25);
+        // Before the daily bound — with no monthly window this row is out of scope.
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 5 * self::DAY, requests: 4, tokens: 40, cost: 1.0);
+
+        $result = $this->windows->aggregate(1, self::NOW - self::DAY, null, self::NOW);
+
+        self::assertSame(1, $result['daily']['requests']);
+        // The monthly window is unset (PHP_INT_MAX sentinel): nothing qualifies.
+        self::assertSame(0, $result['monthly']['requests']);
+    }
+
+    #[Test]
+    public function scopesToTheRequestedBackendUser(): void
+    {
+        $this->insertUsage(beUser: 1, requestDate: self::NOW - 3600, requests: 2, tokens: 20, cost: 0.5);
+        $this->insertUsage(beUser: 2, requestDate: self::NOW - 3600, requests: 9, tokens: 90, cost: 9.0);
+
+        $result = $this->windows->aggregate(1, self::NOW - self::DAY, self::NOW - 30 * self::DAY, self::NOW);
+
+        self::assertSame(2, $result['daily']['requests']);
+        self::assertSame(2, $result['monthly']['requests']);
+    }
+
+    private function insertUsage(int $beUser, int $requestDate, int $requests, int $tokens, float $cost): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_service_usage')
+            ->insert('tx_nrllm_service_usage', [
+                'pid'            => 0,
+                'service_type'   => 'completion',
+                'be_user'        => $beUser,
+                'request_count'  => $requests,
+                'tokens_used'    => $tokens,
+                'estimated_cost' => $cost,
+                'request_date'   => $requestDate,
+            ]);
+    }
+}

--- a/Tests/Functional/Service/Overview/ProviderReachabilityServiceTest.php
+++ b/Tests/Functional/Service/Overview/ProviderReachabilityServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Overview;
+
+use Netresearch\NrLlm\Service\Overview\ProviderReachabilityService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+
+/**
+ * The token-free reachability probe behind the overview's provider dots.
+ *
+ * Uses only providers whose adapter fails fast without any network I/O
+ * (an api-key adapter whose vault key cannot be resolved reports
+ * "API key may be missing" from isAvailable()), so the "down" verdict is
+ * deterministic and the test never leaves the machine. The 60s result
+ * cache must short-circuit the second call.
+ */
+#[CoversClass(ProviderReachabilityService::class)]
+final class ProviderReachabilityServiceTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The 60s result cache may outlive a sibling test's run depending on
+        // the configured backend — start every test from a cold cache.
+        $this->getService(CacheManager::class)->getCache('nrllm_reachability')->flush();
+    }
+
+    #[Test]
+    public function noConfiguredProvidersYieldsEmptyListAndCachesIt(): void
+    {
+        $service = $this->getService(ProviderReachabilityService::class);
+
+        self::assertSame(['providers' => []], $service->check());
+
+        // Second call is served from the nrllm_reachability cache.
+        $cached = $this->getService(CacheManager::class)
+            ->getCache('nrllm_reachability')
+            ->get('status');
+        self::assertSame(['providers' => []], $cached);
+        self::assertSame(['providers' => []], $service->check());
+    }
+
+    #[Test]
+    public function unresolvableApiKeyProviderReportsDownWithoutNetworkIo(): void
+    {
+        // openai-test carries a vault UUID that no vault record backs, so the
+        // adapter's isAvailable() fails fast — no HTTP request is attempted.
+        $this->importFixture('Providers.csv');
+        $this->markProviderInactive('ollama-local');
+
+        $service = $this->getService(ProviderReachabilityService::class);
+        $result = $service->check();
+
+        self::assertNotSame([], $result['providers']);
+        foreach ($result['providers'] as $provider) {
+            self::assertSame('down', $provider['status'], $provider['identifier']);
+            self::assertNotSame('', $provider['name']);
+        }
+    }
+
+    /**
+     * Deactivate a fixture provider whose adapter would attempt real
+     * network I/O (the Ollama adapter needs no API key).
+     */
+    private function markProviderInactive(string $identifier): void
+    {
+        $this->getConnection()->update(
+            'tx_nrllm_provider',
+            ['is_active' => 0],
+            ['identifier' => $identifier],
+        );
+    }
+}

--- a/Tests/Functional/Service/Task/DeprecationLogReaderTest.php
+++ b/Tests/Functional/Service/Task/DeprecationLogReaderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Task;
+
+use Netresearch\NrLlm\Service\Task\DeprecationLogReader;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Best-effort tail read of TYPO3's deprecation log for the Task input
+ * source: a missing file yields the localized placeholder (never an
+ * exception), an existing file yields its tail capped at the requested
+ * line count.
+ */
+#[CoversClass(DeprecationLogReader::class)]
+final class DeprecationLogReaderTest extends AbstractFunctionalTestCase
+{
+    private const LOG_PATH = 'var/log/typo3_deprecations.log';
+
+    private DeprecationLogReader $reader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reader = new DeprecationLogReader();
+        $this->removeLog();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeLog();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function missingLogYieldsPlaceholderMessageInsteadOfFailing(): void
+    {
+        $message = $this->reader->readTail();
+
+        self::assertNotSame('', $message);
+        self::assertStringNotContainsString('deprecation entry', $message);
+    }
+
+    #[Test]
+    public function existingLogIsReturnedVerbatimWhenShorterThanTheCap(): void
+    {
+        $this->writeLog("first deprecation entry\nsecond deprecation entry");
+
+        $content = $this->reader->readTail();
+
+        self::assertSame("first deprecation entry\nsecond deprecation entry", $content);
+    }
+
+    #[Test]
+    public function longLogIsCappedToTheRequestedTail(): void
+    {
+        $lines = [];
+        for ($i = 1; $i <= 10; ++$i) {
+            $lines[] = 'deprecation entry ' . $i;
+        }
+        $this->writeLog(implode("\n", $lines));
+
+        $tail = $this->reader->readTail(3);
+
+        self::assertSame(
+            "deprecation entry 8\ndeprecation entry 9\ndeprecation entry 10",
+            $tail,
+        );
+    }
+
+    private function logFile(): string
+    {
+        return GeneralUtility::getFileAbsFileName(self::LOG_PATH);
+    }
+
+    private function writeLog(string $content): void
+    {
+        $file = $this->logFile();
+        self::assertNotSame('', $file, 'test instance must resolve the log path');
+        GeneralUtility::mkdir_deep(dirname($file));
+        file_put_contents($file, $content);
+    }
+
+    private function removeLog(): void
+    {
+        $file = $this->logFile();
+        if ($file !== '' && file_exists($file)) {
+            unlink($file);
+        }
+    }
+}

--- a/Tests/Functional/Service/Task/RecordTableReaderTest.php
+++ b/Tests/Functional/Service/Task/RecordTableReaderTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Task;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Task\RecordTableReader;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+
+/**
+ * The record-picker read path (schema introspection + fetches) against the
+ * real test database: allow-listing, label detection via TCA and column
+ * fallback, the sample/by-uid/all fetches, and the fail-closed exclusion
+ * guard on user-supplied table names.
+ */
+#[CoversClass(RecordTableReader::class)]
+final class RecordTableReaderTest extends AbstractFunctionalTestCase
+{
+    private RecordTableReader $reader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reader = new RecordTableReader(
+            $this->getService(ConnectionPool::class),
+            $this->getService(TcaSchemaFactory::class),
+        );
+    }
+
+    #[Test]
+    public function listAllowedTablesContainsRealTablesButNotExcludedOnes(): void
+    {
+        $tables = $this->reader->listAllowedTables();
+        $names = array_column($tables, 'name');
+
+        self::assertContains('be_users', $names);
+        self::assertContains('tx_nrllm_task', $names);
+        // Exact-name exclusions.
+        self::assertNotContains('sys_refindex', $names);
+        self::assertNotContains('sys_registry', $names);
+        // Prefix exclusions.
+        foreach ($names as $name) {
+            self::assertStringStartsNotWith('cache_', $name);
+        }
+
+        // Sorted by label, and every entry carries a non-empty label.
+        $labels = array_column($tables, 'label');
+        $sorted = $labels;
+        usort($sorted, strcasecmp(...));
+        self::assertSame($sorted, $labels);
+    }
+
+    #[Test]
+    public function formatTableLabelHumanizesKnownPrefixes(): void
+    {
+        self::assertSame('Nrllm Task', $this->reader->formatTableLabel('tx_nrllm_task'));
+        self::assertSame('System: Log', $this->reader->formatTableLabel('sys_log'));
+        self::assertSame('Backend: Users', $this->reader->formatTableLabel('be_users'));
+        self::assertSame('Frontend: Users', $this->reader->formatTableLabel('fe_users'));
+        self::assertSame('Pages', $this->reader->formatTableLabel('pages'));
+    }
+
+    #[Test]
+    public function detectLabelFieldUsesTcaLabelCapability(): void
+    {
+        // be_users TCA declares username as its label field.
+        self::assertSame('username', $this->reader->detectLabelField('be_users'));
+    }
+
+    #[Test]
+    public function detectLabelFieldFallsBackToCommonColumnNames(): void
+    {
+        // tx_nrllm_service_usage has no TCA; its columns include none of the
+        // fallback names, so detection yields '' — while sys_registry-like
+        // tables with a 'name'-ish column resolve via the fallback list.
+        self::assertSame('', $this->reader->detectLabelField('tx_nrllm_service_usage'));
+    }
+
+    #[Test]
+    public function tableHasUidColumnDistinguishesTables(): void
+    {
+        self::assertTrue($this->reader->tableHasUidColumn('be_users'));
+        // be_sessions is keyed by ses_id and has no uid column.
+        self::assertFalse($this->reader->tableHasUidColumn('be_sessions'));
+    }
+
+    #[Test]
+    public function fetchSampleRecordsReturnsUidAndLabel(): void
+    {
+        $this->importFixture('BeUsers.csv');
+
+        $records = $this->reader->fetchSampleRecords('be_users', '', 10);
+
+        self::assertNotSame([], $records);
+        $byUid = array_column($records, 'label', 'uid');
+        self::assertSame('admin', $byUid[1]);
+        self::assertSame('editor', $byUid[2]);
+    }
+
+    #[Test]
+    public function fetchSampleRecordsHonorsLimitAndOrdersByUidDescForUidLabel(): void
+    {
+        $this->importFixture('BeUsers.csv');
+
+        // Passing 'uid' selects only uid, orders uid DESC and uses the uid
+        // value itself as the label.
+        $records = $this->reader->fetchSampleRecords('be_users', 'uid', 1);
+
+        self::assertSame([['uid' => 2, 'label' => '2']], $records);
+    }
+
+    #[Test]
+    public function fetchSampleRecordsFallsBackToUidPlaceholderWithoutLabelField(): void
+    {
+        // tx_nrllm_service_usage has no TCA and none of the fallback label
+        // columns, so no label field resolves and the placeholder is used.
+        $connection = $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_service_usage');
+        $connection->insert('tx_nrllm_service_usage', [
+            'pid'          => 0,
+            'service_type' => 'completion',
+            'request_date' => 1700000000,
+        ]);
+        $uid = (int)$connection->lastInsertId();
+
+        $records = $this->reader->fetchSampleRecords('tx_nrllm_service_usage', '', 5);
+
+        self::assertSame([['uid' => $uid, 'label' => '[UID ' . $uid . ']']], $records);
+    }
+
+    #[Test]
+    public function fetchSampleRecordsRejectsExcludedTable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1745430001);
+
+        $this->reader->fetchSampleRecords('sys_refindex', '', 5);
+    }
+
+    #[Test]
+    public function loadRecordsByUidsReturnsFullRowsInAnyOrder(): void
+    {
+        $this->importFixture('BeUsers.csv');
+
+        $records = $this->reader->loadRecordsByUids('be_users', [2, 1]);
+
+        self::assertCount(2, $records);
+        $usernames = array_column($records, 'username');
+        sort($usernames);
+        self::assertSame(['admin', 'editor'], $usernames);
+    }
+
+    #[Test]
+    public function loadRecordsByUidsWithEmptyListShortCircuits(): void
+    {
+        self::assertSame([], $this->reader->loadRecordsByUids('be_users', []));
+    }
+
+    #[Test]
+    public function loadRecordsByUidsRejectsExcludedTable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->reader->loadRecordsByUids('sys_registry', [1]);
+    }
+
+    #[Test]
+    public function fetchAllReturnsRowsUpToLimit(): void
+    {
+        $this->importFixture('BeUsers.csv');
+
+        self::assertCount(1, $this->reader->fetchAll('be_users', 1));
+        self::assertCount(2, $this->reader->fetchAll('be_users', 10));
+    }
+
+    #[Test]
+    public function fetchAllRejectsExcludedTablePrefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->reader->fetchAll('index_words', 100);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolGroupStateRepositoryTest.php
+++ b/Tests/Functional/Service/Tool/ToolGroupStateRepositoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for ToolGroupStateRepository against the
+ * tx_nrllm_tool_group_state table — the per-GROUP sibling of
+ * {@see ToolStateRepositoryTest} with the same upsert semantics:
+ * no row means "enabled", the first setEnabled() inserts, repeats
+ * update in place, and overrides() reflects the persisted booleans.
+ */
+#[CoversClass(ToolGroupStateRepository::class)]
+final class ToolGroupStateRepositoryTest extends AbstractFunctionalTestCase
+{
+    private ToolGroupStateRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new ToolGroupStateRepository($this->getService(ConnectionPool::class));
+    }
+
+    #[Test]
+    public function freshStoreHasNoOverrides(): void
+    {
+        self::assertSame([], $this->repository->overrides());
+    }
+
+    #[Test]
+    public function setEnabledInsertsThenReflectsInOverrides(): void
+    {
+        $this->repository->setEnabled('diagnostics', true);
+        $this->repository->setEnabled('rag', false);
+
+        $overrides = $this->repository->overrides();
+
+        self::assertTrue($overrides['diagnostics'] ?? null);
+        self::assertFalse($overrides['rag'] ?? null);
+    }
+
+    #[Test]
+    public function repeatedSetEnabledUpdatesInPlaceWithoutDuplicateRow(): void
+    {
+        $this->repository->setEnabled('fal', true);
+        // Same value again — must not create a second row.
+        $this->repository->setEnabled('fal', true);
+        // Then flip it.
+        $this->repository->setEnabled('fal', false);
+
+        $overrides = $this->repository->overrides();
+        self::assertArrayHasKey('fal', $overrides);
+        self::assertFalse($overrides['fal']);
+
+        $rowCount = $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_tool_group_state')
+            ->count('uid', 'tx_nrllm_tool_group_state', ['group_name' => 'fal']);
+        self::assertSame(1, $rowCount);
+    }
+
+    #[Test]
+    public function overridesSkipRowsWithEmptyGroupName(): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_tool_group_state')
+            ->insert('tx_nrllm_tool_group_state', [
+                'pid'        => 0,
+                'group_name' => '',
+                'enabled'    => 1,
+            ]);
+        $this->repository->setEnabled('rag', true);
+
+        self::assertSame(['rag' => true], $this->repository->overrides());
+    }
+}

--- a/Tests/Unit/Controller/Backend/Response/PlaygroundRunResponseTest.php
+++ b/Tests/Unit/Controller/Backend/Response/PlaygroundRunResponseTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend\Response;
+
+use Netresearch\NrLlm\Controller\Backend\Response\PlaygroundRunResponse;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The playground run payload must expose the final answer, the ordered
+ * inspector steps (each serialised via RunStep::toArray()) and the summed
+ * usage block exactly as Playground.js consumes them.
+ */
+#[CoversClass(PlaygroundRunResponse::class)]
+final class PlaygroundRunResponseTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function toArrayExposesAnswerStepsAndUsage(): void
+    {
+        $llmStep  = new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 12.345, content: 'thinking done');
+        $toolStep = new RunStep(kind: RunStep::KIND_TOOL, round: 1, durationMs: 3.0, toolName: 'fetch_logs');
+
+        $response = new PlaygroundRunResponse(
+            finalContent: 'The answer.',
+            iterations: 2,
+            truncated: false,
+            dryRun: false,
+            steps: [$llmStep, $toolStep],
+            promptTokens: 10,
+            completionTokens: 20,
+            totalTokens: 30,
+            estimatedCost: 0.0042,
+        );
+
+        $payload = $response->toArray();
+
+        self::assertTrue($payload['success']);
+        self::assertSame('The answer.', $payload['finalContent']);
+        self::assertSame(2, $payload['iterations']);
+        self::assertFalse($payload['truncated']);
+        self::assertFalse($payload['dryRun']);
+        self::assertSame(
+            [$llmStep->toArray(), $toolStep->toArray()],
+            $payload['steps'],
+        );
+        self::assertSame(
+            [
+                'promptTokens'     => 10,
+                'completionTokens' => 20,
+                'totalTokens'      => 30,
+                'estimatedCost'    => 0.0042,
+            ],
+            $payload['usage'],
+        );
+    }
+
+    #[Test]
+    public function toArrayKeepsDryRunFlagAndNullCost(): void
+    {
+        $response = new PlaygroundRunResponse(
+            finalContent: '',
+            iterations: 0,
+            truncated: true,
+            dryRun: true,
+            steps: [],
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: null,
+        );
+
+        $payload = $response->toArray();
+
+        self::assertTrue($payload['dryRun']);
+        self::assertTrue($payload['truncated']);
+        self::assertSame([], $payload['steps']);
+        self::assertIsArray($payload['usage']);
+        self::assertNull($payload['usage']['estimatedCost']);
+    }
+}

--- a/Tests/Unit/Form/Tca/ToolGroupItemsTest.php
+++ b/Tests/Unit/Form/Tca/ToolGroupItemsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Form\Tca;
+
+use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The itemsProcFunc must list the registered tools' groups (sorted,
+ * de-duplicated) and keep groups already stored on the record selectable
+ * even when no installed tool claims them any more.
+ */
+#[CoversClass(ToolGroupItems::class)]
+final class ToolGroupItemsTest extends AbstractUnitTestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function addsRegistryGroupsSortedAndDeduplicated(): void
+    {
+        $this->registerRegistryWithGroups(['rag', 'diagnostics', 'rag', 'fal']);
+
+        $params = ['items' => []];
+        (new ToolGroupItems())->addItems($params);
+
+        self::assertSame(
+            [
+                ['label' => 'diagnostics', 'value' => 'diagnostics'],
+                ['label' => 'fal', 'value' => 'fal'],
+                ['label' => 'rag', 'value' => 'rag'],
+            ],
+            $params['items'],
+        );
+    }
+
+    #[Test]
+    public function keepsStoredButUnknownGroupsSelectable(): void
+    {
+        $this->registerRegistryWithGroups(['diagnostics']);
+
+        $params = [
+            'items' => [],
+            'row'   => ['allowed_tool_groups' => 'diagnostics,orphaned_group'],
+        ];
+        (new ToolGroupItems())->addItems($params);
+
+        self::assertSame(
+            [
+                ['label' => 'diagnostics', 'value' => 'diagnostics'],
+                ['label' => 'orphaned_group', 'value' => 'orphaned_group'],
+            ],
+            $params['items'],
+        );
+    }
+
+    #[Test]
+    public function acceptsStoredValueAsArrayFromFormEngine(): void
+    {
+        $this->registerRegistryWithGroups([]);
+
+        $params = [
+            'items' => [],
+            'row'   => ['allowed_tool_groups' => ['legacy_a', 'legacy_b']],
+        ];
+        (new ToolGroupItems())->addItems($params);
+
+        self::assertSame(
+            [
+                ['label' => 'legacy_a', 'value' => 'legacy_a'],
+                ['label' => 'legacy_b', 'value' => 'legacy_b'],
+            ],
+            $params['items'],
+        );
+    }
+
+    #[Test]
+    public function ignoresNonScalarStoredValue(): void
+    {
+        $this->registerRegistryWithGroups([]);
+
+        $params = [
+            'items' => [],
+            'row'   => ['allowed_tool_groups' => null],
+        ];
+        (new ToolGroupItems())->addItems($params);
+
+        self::assertSame([], $params['items']);
+    }
+
+    /**
+     * @param list<string> $groups
+     */
+    private function registerRegistryWithGroups(array $groups): void
+    {
+        $tools = [];
+        foreach ($groups as $i => $group) {
+            $tools[] = new FakeTool('tool_' . $i . '_' . $group, group: $group);
+        }
+        GeneralUtility::addInstance(ToolRegistry::class, new ToolRegistry($tools));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/SetEvaluationResultTest.php
+++ b/Tests/Unit/Service/Evaluation/SetEvaluationResultTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+use Netresearch\NrLlm\Service\Evaluation\PromptEvaluation;
+use Netresearch\NrLlm\Service\Evaluation\SetEvaluationResult;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Aggregation semantics of the golden-set run result (ADR-060): counts,
+ * pass rate and mean score derived from the per-prompt evaluations, the
+ * empty-set guards, and the collapse to the persistable summary.
+ */
+#[CoversClass(SetEvaluationResult::class)]
+final class SetEvaluationResultTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function aggregatesCountsPassRateAndMeanScore(): void
+    {
+        $result = $this->resultWith([
+            $this->evaluation('p1', passed: true, score: 1.0),
+            $this->evaluation('p2', passed: false, score: 0.25),
+            $this->evaluation('p3', passed: true, score: 0.5),
+            $this->evaluation('p4', passed: false, score: 0.25),
+        ]);
+
+        self::assertSame(4, $result->promptCount());
+        self::assertSame(2, $result->passedCount());
+        self::assertSame(0.5, $result->passRate());
+        self::assertSame(0.5, $result->meanScore());
+    }
+
+    #[Test]
+    public function emptySetYieldsZeroRatesInsteadOfDivisionByZero(): void
+    {
+        $result = $this->resultWith([]);
+
+        self::assertSame(0, $result->promptCount());
+        self::assertSame(0, $result->passedCount());
+        self::assertSame(0.0, $result->passRate());
+        self::assertSame(0.0, $result->meanScore());
+    }
+
+    #[Test]
+    public function toSummaryCollapsesAggregatesAndCarriesUid(): void
+    {
+        $result = $this->resultWith([
+            $this->evaluation('p1', passed: true, score: 0.75),
+            $this->evaluation('p2', passed: false, score: 0.25),
+        ]);
+
+        $summary = $result->toSummary(42);
+
+        self::assertSame('golden-de', $summary->setIdentifier);
+        self::assertSame('test-model', $summary->model);
+        self::assertSame('exact', $summary->grader);
+        self::assertSame(2, $summary->promptCount);
+        self::assertSame(1, $summary->passedCount);
+        self::assertSame(0.5, $summary->passRate);
+        self::assertSame(0.5, $summary->meanScore);
+        self::assertSame(1700000000, $summary->runTimestamp);
+        self::assertSame(42, $summary->uid);
+    }
+
+    #[Test]
+    public function toSummaryDefaultsUidToZero(): void
+    {
+        self::assertSame(0, $this->resultWith([])->toSummary()->uid);
+    }
+
+    /**
+     * @param list<PromptEvaluation> $evaluations
+     */
+    private function resultWith(array $evaluations): SetEvaluationResult
+    {
+        return new SetEvaluationResult(
+            setIdentifier: 'golden-de',
+            model: 'test-model',
+            grader: 'exact',
+            evaluations: $evaluations,
+            runTimestamp: 1700000000,
+        );
+    }
+
+    private function evaluation(string $promptId, bool $passed, float $score): PromptEvaluation
+    {
+        return new PromptEvaluation(
+            promptId: $promptId,
+            result: new GradingResult($passed, $score, 'exact'),
+            latencyMs: 5,
+        );
+    }
+}

--- a/Tests/Unit/Service/Tool/FalStorageGateTest.php
+++ b/Tests/Unit/Service/Tool/FalStorageGateTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+
+/**
+ * The shared FAL storage gate (ADR-047) must stay fail-closed: no user
+ * means no storages, admins get the configured allow-list verbatim, and
+ * non-admins only the intersection with their file-mount storages —
+ * in allow-list order.
+ */
+#[CoversClass(FalStorageGate::class)]
+final class FalStorageGateTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function missingUserYieldsNoStorages(): void
+    {
+        $gate = new FalStorageGate([1, 2]);
+
+        self::assertSame([], $gate->effectiveStorages(null));
+        self::assertFalse($gate->isAllowed(null, 1));
+    }
+
+    #[Test]
+    public function adminGetsConfiguredAllowListVerbatim(): void
+    {
+        $admin = $this->userWith(isAdmin: true, storageUids: []);
+
+        $gate = new FalStorageGate([3, 1]);
+
+        self::assertSame([3, 1], $gate->effectiveStorages($admin));
+        self::assertTrue($gate->isAllowed($admin, 3));
+        self::assertFalse($gate->isAllowed($admin, 2));
+    }
+
+    #[Test]
+    public function nonAdminGetsIntersectionInAllowListOrder(): void
+    {
+        // File mounts reach storages 2 and 3; the allow-list permits 3, 1, 2.
+        $editor = $this->userWith(isAdmin: false, storageUids: [2, 3]);
+
+        $gate = new FalStorageGate([3, 1, 2]);
+
+        self::assertSame([3, 2], $gate->effectiveStorages($editor));
+        self::assertTrue($gate->isAllowed($editor, 2));
+        self::assertFalse($gate->isAllowed($editor, 1));
+    }
+
+    #[Test]
+    public function nonAdminWithoutReachableStoragesIsDenied(): void
+    {
+        $editor = $this->userWith(isAdmin: false, storageUids: [7]);
+
+        $gate = new FalStorageGate([1]);
+
+        self::assertSame([], $gate->effectiveStorages($editor));
+        self::assertFalse($gate->isAllowed($editor, 1));
+        self::assertFalse($gate->isAllowed($editor, 7));
+    }
+
+    /**
+     * @param list<int> $storageUids
+     */
+    private function userWith(bool $isAdmin, array $storageUids): BackendUserAuthentication
+    {
+        $storages = [];
+        foreach ($storageUids as $uid) {
+            $storage = self::createStub(ResourceStorage::class);
+            $storage->method('getUid')->willReturn($uid);
+            $storages[] = $storage;
+        }
+
+        $user = self::createStub(BackendUserAuthentication::class);
+        $user->method('isAdmin')->willReturn($isAdmin);
+        $user->method('getFileStorages')->willReturn($storages);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## What

First tests for **14 production classes with 0% coverage from any suite** (unit + functional union, measured via codecov's merged report at 2ca9894b), ~640 previously-uncovered lines. Full-suite line coverage was 86.23%; every class here had literally no test exercising it.

### Unit (4 files, 14 tests)
- `PlaygroundRunResponse` — payload shape incl. dry-run and null-cost
- `SetEvaluationResult` — aggregate counts/rates, empty-set guards, `toSummary()`
- `FalStorageGate` — fail-closed storage intersection (ADR-047): no user → nothing, admin → allow-list verbatim, non-admin → file-mount intersection in allow-list order
- `ToolGroupItems` — TCA itemsProcFunc: sorted registry groups + stored-but-orphaned groups stay selectable, FormEngine array/scalar/null stored values

### Functional (10 files, 45 tests, new `UserBudgets.csv` fixture)
- `UserBudgetUsageWindows` — conditional-SUM daily/monthly rollup: window separation, PHP_INT_MAX sentinel for unset windows, per-user scoping
- `ToolGroupStateRepository` — upsert semantics incl. no-duplicate-row and empty-group-name skip
- `UserBudgetRepository` — enable-field filtering despite `setRespectStoragePage(false)`, batch map keyed by be_user, first-wins duplicates
- `RecordTableReader` — picker allow-list, TCA label capability vs. column fallback, sample/by-uid/all fetches, fail-closed exclusion guard on user-supplied table names (uid-placeholder labels covered via a TCA-less table)
- `DeprecationLogReader` — placeholder on missing log, tail capping
- `ProviderReachabilityService` — empty-list caching; deterministic no-network 'down' verdict (unresolvable vault key fails `isAvailable()` before any HTTP)
- `TaskListController` / `AnalyticsController` / `PromptSnippetController` — render actions through the real ModuleTemplate stack (fixture records surface, FormEngine `record/edit` deep links, chart JSON datasets)
- `TaskWizardController` — form render, empty-description/invalid-body redirects with flash messages, `wizardCreateAction()` persistence incl. numeric clamps (temperature 5→2.0, max_tokens→128000, top_p 9→1.0) and enum fallbacks, provider-failure fallback preview

## Deliberately not covered

`PromptTemplateRepository` (37 lines, 0%): **`tx_nrllm_prompttemplate` has no TCA**, so Extbase cannot map the table at runtime — the repository (and `PromptTemplateService`'s persistence path) appears unusable outside unit tests with mocked repos. Needs a decision: add TCA or remove the dormant code. Happy to file a follow-up issue.

## Verification

Local via `Build/Scripts/runTests.sh -p 8.4`: unit 4970 tests / functional (sqlite) 1185 tests — both suites green with the pre-existing notice/deprecation baseline; PHPStan level 10, cgl and Rector dry-runs clean.
