### PR TITLE
fix(provider): apply api_timeout and make max_retries=0 send one request

### DIFF
--- a/.ddev/sql/seed-ollama.sql
+++ b/.ddev/sql/seed-ollama.sql
@@ -14,7 +14,7 @@ INSERT INTO tx_nrllm_provider (
     'ollama',
     'http://ollama:11434',
     '',
-    30,
+    120,
     3,
     1,
     100,

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -44,7 +44,7 @@ class Provider extends AbstractEntity
     protected string $endpointUrl = '';
     protected string $apiKey = '';
     protected string $organizationId = '';
-    protected int $apiTimeout = 30;
+    protected int $apiTimeout = 120;
     protected int $maxRetries = 3;
     protected string $options = '';
     protected bool $isActive = true;

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -299,8 +299,10 @@ abstract class AbstractProvider implements ProviderInterface
         }
         $attempt = 0;
         $lastException = null;
+        // maxRetries counts retries after the initial attempt; max_retries = 0 still sends one request.
+        $maxAttempts = $this->maxRetries + 1;
 
-        while ($attempt < $this->maxRetries) {
+        while ($attempt < $maxAttempts) {
             try {
                 return $this->handleResponse($httpClient->sendRequest($request), $endpoint);
             } catch (ProviderResponseException $e) {
@@ -309,7 +311,7 @@ abstract class AbstractProvider implements ProviderInterface
                 $lastException = $e;
                 $attempt++;
 
-                if ($attempt < $this->maxRetries) {
+                if ($attempt < $maxAttempts) {
                     // Exponential backoff capped at 30s. Short-circuit at
                     // attempt >= 9 (100000 * 2**9 = 51.2s already exceeds the
                     // cap) so the 2 ** $attempt term cannot overflow the float→int
@@ -321,7 +323,7 @@ abstract class AbstractProvider implements ProviderInterface
         }
 
         throw new ProviderConnectionException(
-            'Failed to connect to provider after ' . $this->maxRetries . ' attempts: '
+            'Failed to connect to provider after ' . $attempt . ' attempts: '
             . $this->sanitizeErrorMessage($lastException?->getMessage() ?? self::UNKNOWN_ERROR),
             0,
             $lastException,

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -308,8 +308,11 @@ abstract class AbstractProvider implements ProviderInterface
         }
         $attempt = 0;
         $lastException = null;
-        // maxRetries counts retries after the initial attempt; max_retries = 0 still sends one request.
-        $maxAttempts = $this->maxRetries + 1;
+        // maxRetries counts retries after the initial attempt; max_retries = 0
+        // still sends one request. Clamp negatives (reachable via the options
+        // JSON maxRetries override, which configure() does not range-check) so
+        // the loop always runs at least once.
+        $maxAttempts = max(0, $this->maxRetries) + 1;
 
         while ($attempt < $maxAttempts) {
             $attemptStart = microtime(true);
@@ -326,8 +329,11 @@ abstract class AbstractProvider implements ProviderInterface
                 // multiply the caller's wait by maxAttempts. Guzzle raises the
                 // total timeout (cURL error 28) as a ConnectException — the
                 // same class as retryable connection failures — so the only
-                // reliable discriminator is the elapsed wall time.
-                if ($effectiveTimeout > 0 && (microtime(true) - $attemptStart) >= $effectiveTimeout) {
+                // reliable discriminator is the elapsed wall time. cURL can
+                // fire marginally before the integer limit, so allow a 0.5s
+                // tolerance; misclassifying an equally-slow connection failure
+                // as a timeout fails safe (fewer retries).
+                if ($effectiveTimeout > 0 && (microtime(true) - $attemptStart) >= $effectiveTimeout - 0.5) {
                     throw new ProviderConnectionException(
                         sprintf(
                             'Provider request timed out after %d seconds (attempt %d; timeouts are not retried)',

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -58,7 +58,7 @@ abstract class AbstractProvider implements ProviderInterface
     protected string $apiKeyIdentifier = '';
     protected string $baseUrl = '';
     protected string $defaultModel = '';
-    protected int $timeout = 30;
+    protected int $timeout = 120;
     protected int $maxRetries = 3;
 
     /** @var array<string> */
@@ -86,7 +86,7 @@ abstract class AbstractProvider implements ProviderInterface
         $this->apiKeyIdentifier = $this->getString($config, 'apiKeyIdentifier');
         $this->baseUrl = $this->getString($config, 'baseUrl', $this->getDefaultBaseUrl());
         $this->defaultModel = $this->getString($config, 'defaultModel', $this->getDefaultModel());
-        $this->timeout = $this->getInt($config, 'timeout', 30);
+        $this->timeout = $this->getInt($config, 'timeout', 120);
         $this->maxRetries = $this->getInt($config, 'maxRetries', 3);
 
         // Reset HTTP client when configuration changes
@@ -150,13 +150,18 @@ abstract class AbstractProvider implements ProviderInterface
      * with audit logging. For providers without API keys (like Ollama),
      * uses the httpClientFactory directly.
      *
+     * @param int|null $timeout per-request total-response timeout in seconds;
+     *                          falls back to the provider's configured timeout
+     *
      * @return ClientInterface HTTP client with authentication configured
      */
-    protected function getHttpClient(): ClientInterface
+    protected function getHttpClient(?int $timeout = null): ClientInterface
     {
         if ($this->configuredHttpClient !== null) {
             return $this->configuredHttpClient;
         }
+
+        $effective = ($timeout !== null && $timeout > 0) ? $timeout : $this->timeout;
 
         // For providers without API key, use httpClientFactory directly.
         // The authenticated path is gated by VaultHttpClient::sendRequest(),
@@ -168,14 +173,16 @@ abstract class AbstractProvider implements ProviderInterface
         // private/metadata IP literal cannot bypass the private-range filter.
         if ($this->apiKeyIdentifier === '') {
             $this->assertEndpointHostAllowed();
-            return $this->httpClientFactory->create();
+            return $this->httpClientFactory->create($effective > 0 ? $effective : null);
         }
 
-        return $this->vault->http()->withAuthentication(
+        $client = $this->vault->http()->withAuthentication(
             $this->apiKeyIdentifier,
             $this->getSecretPlacement(),
             $this->getSecretPlacementOptions(),
         );
+
+        return $effective > 0 ? $client->withTimeout($effective) : $client;
     }
 
     /**
@@ -266,10 +273,12 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return array<string, mixed>
      */
-    protected function sendRequest(string $endpoint, array $payload, string $method = 'POST'): array
+    protected function sendRequest(string $endpoint, array $payload, string $method = 'POST', ?int $timeout = null): array
     {
         // Validate configuration before making API calls
         $this->validateConfiguration();
+
+        $effectiveTimeout = ($timeout !== null && $timeout > 0) ? $timeout : $this->timeout;
 
         $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
 
@@ -289,7 +298,7 @@ abstract class AbstractProvider implements ProviderInterface
             $request = $request->withBody($body);
         }
 
-        $httpClient = $this->getHttpClient();
+        $httpClient = $this->getHttpClient($timeout);
         // Stamp a per-request audit reason (purpose + model) on the vault
         // client so the audit log records what each secret access served.
         // Test doubles injected via setHttpClient() are plain PSR-18
@@ -303,6 +312,8 @@ abstract class AbstractProvider implements ProviderInterface
         $maxAttempts = $this->maxRetries + 1;
 
         while ($attempt < $maxAttempts) {
+            $attemptStart = microtime(true);
+
             try {
                 return $this->handleResponse($httpClient->sendRequest($request), $endpoint);
             } catch (ProviderResponseException $e) {
@@ -310,6 +321,23 @@ abstract class AbstractProvider implements ProviderInterface
             } catch (Throwable $e) {
                 $lastException = $e;
                 $attempt++;
+
+                // A client-side timeout must not be retried: retrying would
+                // multiply the caller's wait by maxAttempts. Guzzle raises the
+                // total timeout (cURL error 28) as a ConnectException — the
+                // same class as retryable connection failures — so the only
+                // reliable discriminator is the elapsed wall time.
+                if ($effectiveTimeout > 0 && (microtime(true) - $attemptStart) >= $effectiveTimeout) {
+                    throw new ProviderConnectionException(
+                        sprintf(
+                            'Provider request timed out after %d seconds (attempt %d; timeouts are not retried)',
+                            $effectiveTimeout,
+                            $attempt,
+                        ),
+                        0,
+                        $e,
+                    );
+                }
 
                 if ($attempt < $maxAttempts) {
                     // Exponential backoff capped at 30s. Short-circuit at
@@ -328,6 +356,28 @@ abstract class AbstractProvider implements ProviderInterface
             0,
             $lastException,
         );
+    }
+
+    /**
+     * Resolve the per-request timeout from the call options.
+     *
+     * `options['timeout']` carries the configuration-level effective timeout
+     * (see LlmConfiguration::getEffectiveTimeout()); it overrides the
+     * provider's api_timeout for the single request. Returns null when the
+     * options carry no usable value, so the provider timeout applies.
+     *
+     * @param array<string, mixed> $options
+     */
+    protected function resolveRequestTimeout(array $options): ?int
+    {
+        $raw = $options['timeout'] ?? null;
+        if (!is_numeric($raw)) {
+            return null;
+        }
+
+        $seconds = (int)$raw;
+
+        return $seconds > 0 ? $seconds : null;
     }
 
     /**

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -187,7 +187,7 @@ final class ClaudeProvider extends AbstractProvider implements
 
         $payload = array_merge($payload, $this->buildSamplingParams($options));
 
-        $response = $this->sendRequest('messages', $payload);
+        $response = $this->sendRequest('messages', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $content = '';
         $nativeThinkingBlocks = [];
@@ -261,7 +261,7 @@ final class ClaudeProvider extends AbstractProvider implements
             $payload['tool_choice'] = $this->mapToolChoice($options['tool_choice']);
         }
 
-        $response = $this->sendRequest('messages', $payload);
+        $response = $this->sendRequest('messages', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $content = '';
         $nativeThinkingBlocks = [];
@@ -351,7 +351,7 @@ final class ClaudeProvider extends AbstractProvider implements
             $payload['system'] = $systemPrompt;
         }
 
-        $response = $this->sendRequest('messages', $payload);
+        $response = $this->sendRequest('messages', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $description = '';
         $contentBlocks = $this->getList($response, 'content');
@@ -508,7 +508,7 @@ final class ClaudeProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, 'messages');
         $stream = $response->getBody();
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -169,6 +169,7 @@ final class GeminiProvider extends AbstractProvider implements
         $response = $this->sendRequest(
             "models/{$model}:generateContent",
             $payload,
+            timeout: $this->resolveRequestTimeout($options),
         );
 
         $candidates = $this->getList($response, 'candidates');
@@ -234,6 +235,7 @@ final class GeminiProvider extends AbstractProvider implements
         $response = $this->sendRequest(
             "models/{$model}:generateContent",
             $payload,
+            timeout: $this->resolveRequestTimeout($options),
         );
 
         $candidates = $this->getList($response, 'candidates');
@@ -315,6 +317,7 @@ final class GeminiProvider extends AbstractProvider implements
             $response = $this->sendRequest(
                 "models/{$model}:embedContent",
                 $payload,
+                timeout: $this->resolveRequestTimeout($options),
             );
 
             $embeddingData = $this->getArray($response, 'embedding');
@@ -405,6 +408,7 @@ final class GeminiProvider extends AbstractProvider implements
         $response = $this->sendRequest(
             "models/{$model}:generateContent",
             $payload,
+            timeout: $this->resolveRequestTimeout($options),
         );
 
         $candidates = $this->getList($response, 'candidates');
@@ -503,7 +507,7 @@ final class GeminiProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, sprintf('models/%s:streamGenerateContent', $model));
         $stream = $response->getBody();
 

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -168,7 +168,7 @@ final class GroqProvider extends AbstractProvider implements
             $payload['seed'] = $this->getInt($options, 'seed');
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -218,7 +218,7 @@ final class GroqProvider extends AbstractProvider implements
             $payload['parallel_tool_calls'] = $this->getBool($options, 'parallel_tool_calls');
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -288,7 +288,7 @@ final class GroqProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -158,7 +158,7 @@ final class MistralProvider extends AbstractProvider implements
             $payload['safe_prompt'] = $this->getBool($options, 'safe_prompt');
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -203,7 +203,7 @@ final class MistralProvider extends AbstractProvider implements
             $payload['tool_choice'] = $options['tool_choice'];
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -257,7 +257,7 @@ final class MistralProvider extends AbstractProvider implements
             $payload['encoding_format'] = $this->getString($options, 'encoding_format');
         }
 
-        $response = $this->sendRequest('embeddings', $payload);
+        $response = $this->sendRequest('embeddings', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $data = $this->getList($response, 'data');
         /** @var array<int, array<int, float>> $embeddings */
@@ -317,7 +317,7 @@ final class MistralProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -201,7 +201,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $payload['options'] = $payloadOptions;
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $message = $this->getArray($response, 'message');
 
@@ -272,7 +272,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $payload['options'] = $payloadOptions;
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $message = $this->getArray($response, 'message');
 
@@ -422,7 +422,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $response = $this->sendRequest('api/embeddings', [
                 'model' => $model,
                 'prompt' => $text,
-            ]);
+            ], timeout: $this->resolveRequestTimeout($options));
 
             $rawEmbedding = $this->getList($response, 'embedding');
             $embedding = array_values(array_map(fn(mixed $v): float => (float)$v, $rawEmbedding));
@@ -489,7 +489,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT);
 
         yield from $this->streamChatLines($response->getBody());

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -129,7 +129,7 @@ final class OpenAiProvider extends AbstractProvider implements
             }
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -182,7 +182,7 @@ final class OpenAiProvider extends AbstractProvider implements
             $payload['tool_choice'] = $options['tool_choice'];
         }
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -238,7 +238,7 @@ final class OpenAiProvider extends AbstractProvider implements
             $payload['dimensions'] = $this->getInt($options, 'dimensions');
         }
 
-        $response = $this->sendRequest('embeddings', $payload);
+        $response = $this->sendRequest('embeddings', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $data = $this->getList($response, 'data');
         $embeddings = [];
@@ -291,7 +291,7 @@ final class OpenAiProvider extends AbstractProvider implements
             'max_completion_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];
 
-        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, timeout: $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -364,7 +364,7 @@ final class OpenAiProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -323,7 +323,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $payload['transforms'] = $transforms;
         }
 
-        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -388,7 +388,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             }
         }
 
-        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -447,7 +447,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $payload['dimensions'] = $this->getInt($options, 'dimensions');
         }
 
-        $response = $this->sendOpenRouterRequest('embeddings', $payload);
+        $response = $this->sendOpenRouterRequest('embeddings', $payload, $this->resolveRequestTimeout($options));
 
         $data = $this->getList($response, 'data');
         /** @var array<int, array<int, float>> $embeddings */
@@ -507,7 +507,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $payload['route'] = 'fallback';
         }
 
-        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload);
+        $response = $this->sendOpenRouterRequest(self::ENDPOINT_CHAT_COMPLETIONS, $payload, $this->resolveRequestTimeout($options));
 
         $choices = $this->getList($response, 'choices');
         $choice = $this->asArray($choices[0] ?? []);
@@ -573,7 +573,7 @@ final class OpenRouterProvider extends AbstractProvider implements
 
         $request = $this->createStreamingRequest($url, $payload);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($this->resolveRequestTimeout($options))->sendRequest($request);
         $this->assertStreamingResponseOk($response, self::ENDPOINT_CHAT_COMPLETIONS);
         $stream = $response->getBody();
 
@@ -875,7 +875,7 @@ final class OpenRouterProvider extends AbstractProvider implements
      *
      * @return array<string, mixed>
      */
-    private function sendOpenRouterRequest(string $endpoint, array $payload): array
+    private function sendOpenRouterRequest(string $endpoint, array $payload, ?int $timeout = null): array
     {
         $url = rtrim($this->baseUrl, '/') . '/' . ltrim($endpoint, '/');
 
@@ -893,7 +893,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 
-        $response = $this->getHttpClient()->sendRequest($request);
+        $response = $this->getHttpClient($timeout)->sendRequest($request);
         $statusCode = $response->getStatusCode();
         $responseBody = $response->getBody()->getContents();
 

--- a/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
+++ b/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Updates;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+/**
+ * Raise persisted provider api_timeout values from the old 30s default to 120s.
+ *
+ * Until the timeout wiring landed, api_timeout was stored but never applied
+ * to any HTTP request, so existing rows at the old TCA default of 30 never
+ * had an effect at runtime. With the timeout now enforced, 30 seconds would
+ * truncate long generations (local Ollama model loads alone can exceed it).
+ *
+ * A deliberately-chosen 30 is indistinguishable from the never-applied
+ * default, so it is migrated too — operators who want a 30 second timeout
+ * must re-set it after the upgrade.
+ */
+#[UpgradeWizard('nrLlm_providerApiTimeout120')]
+final class ProviderApiTimeoutUpdateWizard implements UpgradeWizardInterface
+{
+    private const TABLE = 'tx_nrllm_provider';
+    private const OLD_DEFAULT = 30;
+    private const NEW_DEFAULT = 120;
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    public function getTitle(): string
+    {
+        return 'Raise LLM provider API timeout from the old 30s default to 120s';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The provider api_timeout setting was previously never applied to API requests, '
+            . 'so rows still at the old default of 30 seconds had no runtime effect. Now that the '
+            . 'timeout is enforced, 30 seconds would truncate long generations. This wizard raises '
+            . 'all providers with api_timeout = 30 to the new default of 120 seconds. A deliberately '
+            . 'configured value of 30 cannot be distinguished from the old default and is migrated '
+            . 'as well — re-set it afterwards if you really want a 30 second timeout.';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->update(self::TABLE)
+            ->set('api_timeout', self::NEW_DEFAULT)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'api_timeout',
+                    $queryBuilder->createNamedParameter(self::OLD_DEFAULT, Connection::PARAM_INT),
+                ),
+            )
+            ->executeStatement();
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        // Include hidden and deleted rows so a later un-delete stays consistent.
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'api_timeout',
+                    $queryBuilder->createNamedParameter(self::OLD_DEFAULT, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) && (int)$count > 0;
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+}

--- a/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
+++ b/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
@@ -28,14 +28,14 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  * must re-set it after the upgrade.
  */
 #[UpgradeWizard('nrLlm_providerApiTimeout120')]
-final class ProviderApiTimeoutUpdateWizard implements UpgradeWizardInterface
+final readonly class ProviderApiTimeoutUpdateWizard implements UpgradeWizardInterface
 {
     private const TABLE = 'tx_nrllm_provider';
     private const OLD_DEFAULT = 30;
     private const NEW_DEFAULT = 120;
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getTitle(): string

--- a/Configuration/TCA/tx_nrllm_provider.php
+++ b/Configuration/TCA/tx_nrllm_provider.php
@@ -163,7 +163,7 @@ return [
                     'lower' => 1,
                     'upper' => 600,
                 ],
-                'default' => 30,
+                'default' => 120,
             ],
         ],
         'max_retries' => [

--- a/Documentation/Configuration/ProviderFields.rst
+++ b/Documentation/Configuration/ProviderFields.rst
@@ -87,16 +87,18 @@ Optional
 .. confval:: timeout
    :name: confval-provider-timeout
    :type: integer
-   :Default: 30
+   :Default: 120
 
-   Request timeout in seconds.
+   Maximum time in seconds to wait for the complete API response. A
+   configuration- or model-level timeout overrides this value per request.
 
 .. confval:: max_retries
    :name: confval-provider-max-retries
    :type: integer
    :Default: 3
 
-   Number of retry attempts on failure.
+   Number of retries after the first failed request (0 = try once, no
+   retries). Timed-out requests are not retried.
 
 .. confval:: options
    :name: confval-provider-options

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -469,22 +469,13 @@
                 <target>Optionale Organisations-ID (OpenAI, Azure)</target>
             </trans-unit>
 
-            <trans-unit id="tx_nrllm_provider.timeout">
-                <source>Response Timeout (seconds)</source>
-                <target>Antwort-Timeout (Sekunden)</target>
-            </trans-unit>
-            <trans-unit id="tx_nrllm_provider.timeout.description">
-                <source>Maximum time to wait for the complete API response. Includes connection (max 10s) and model processing time. Large models may need 60-300 seconds.</source>
-                <target>Maximale Wartezeit auf die vollständige API-Antwort. Beinhaltet Verbindungsaufbau (max. 10 s) und Modellverarbeitungszeit. Große Modelle benötigen möglicherweise 60-300 Sekunden.</target>
-            </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_timeout">
                 <source>API Timeout (seconds)</source>
                 <target>API-Timeout (Sekunden)</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.api_timeout.description">
-                <source>Connection and read timeout for API requests</source>
-                <target>Verbindungs- und Lese-Timeout für API-Anfragen</target>
+                <source>Maximum time in seconds to wait for the complete API response, including connection (max 10s) and model processing time. Large or reasoning models may need 120-300 seconds. A configuration- or model-level timeout overrides this value per request.</source>
+                <target>Maximale Wartezeit in Sekunden auf die vollständige API-Antwort, einschließlich Verbindungsaufbau (max. 10 s) und Modellverarbeitungszeit. Große Modelle oder Reasoning-Modelle benötigen möglicherweise 120-300 Sekunden. Ein Timeout auf Konfigurations- oder Modellebene überschreibt diesen Wert pro Anfrage.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.max_retries">

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -492,8 +492,8 @@
                 <target>Max. Wiederholungsversuche</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.max_retries.description">
-                <source>Number of retry attempts on failure</source>
-                <target>Anzahl der Wiederholungsversuche bei Fehlern</target>
+                <source>Number of retries after the first failed request (0 = try once, no retries)</source>
+                <target>Anzahl der Wiederholungsversuche nach der ersten fehlgeschlagenen Anfrage (0 = ein Versuch, keine Wiederholung)</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.options">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -382,7 +382,7 @@
                 <source>Max Retries</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.max_retries.description">
-                <source>Number of retry attempts on failure</source>
+                <source>Number of retries after the first failed request (0 = try once, no retries)</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.options">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -364,18 +364,11 @@
                 <source>Optional organization ID (OpenAI, Azure)</source>
             </trans-unit>
 
-            <trans-unit id="tx_nrllm_provider.timeout">
-                <source>Response Timeout (seconds)</source>
-            </trans-unit>
-            <trans-unit id="tx_nrllm_provider.timeout.description">
-                <source>Maximum time to wait for the complete API response. Includes connection (max 10s) and model processing time. Large models may need 60-300 seconds.</source>
-            </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_timeout">
                 <source>API Timeout (seconds)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.api_timeout.description">
-                <source>Connection and read timeout for API requests</source>
+                <source>Maximum time in seconds to wait for the complete API response, including connection (max 10s) and model processing time. Large or reasoning models may need 120-300 seconds. A configuration- or model-level timeout overrides this value per request.</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.max_retries">

--- a/Tests/Functional/Updates/ProviderApiTimeoutUpdateWizardTest.php
+++ b/Tests/Functional/Updates/ProviderApiTimeoutUpdateWizardTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Updates;
+
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Updates\ProviderApiTimeoutUpdateWizard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+
+#[CoversClass(ProviderApiTimeoutUpdateWizard::class)]
+final class ProviderApiTimeoutUpdateWizardTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_provider';
+
+    #[Test]
+    public function executeUpdateMigratesOnlyOldDefaultRows(): void
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE);
+        $connection->insert(self::TABLE, [
+            'pid' => 0,
+            'identifier' => 'legacy-default',
+            'name' => 'Legacy default timeout',
+            'adapter_type' => 'openai',
+            'api_timeout' => 30,
+        ], ['api_timeout' => Connection::PARAM_INT]);
+        $connection->insert(self::TABLE, [
+            'pid' => 0,
+            'identifier' => 'custom-timeout',
+            'name' => 'Custom timeout',
+            'adapter_type' => 'openai',
+            'api_timeout' => 45,
+        ], ['api_timeout' => Connection::PARAM_INT]);
+
+        $wizard = new ProviderApiTimeoutUpdateWizard($this->getConnectionPool());
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+
+        self::assertSame(120, $this->apiTimeoutOf('legacy-default'));
+        self::assertSame(45, $this->apiTimeoutOf('custom-timeout'));
+        self::assertFalse($wizard->updateNecessary());
+    }
+
+    #[Test]
+    public function executeUpdateMigratesHiddenAndDeletedRows(): void
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE);
+        $connection->insert(self::TABLE, [
+            'pid' => 0,
+            'identifier' => 'hidden-legacy',
+            'name' => 'Hidden legacy row',
+            'adapter_type' => 'openai',
+            'api_timeout' => 30,
+            'hidden' => 1,
+            'deleted' => 1,
+        ], ['api_timeout' => Connection::PARAM_INT]);
+
+        $wizard = new ProviderApiTimeoutUpdateWizard($this->getConnectionPool());
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+
+        self::assertSame(120, $this->apiTimeoutOf('hidden-legacy'));
+    }
+
+    #[Test]
+    public function updateNotNecessaryWithoutLegacyRows(): void
+    {
+        $wizard = new ProviderApiTimeoutUpdateWizard($this->getConnectionPool());
+
+        self::assertFalse($wizard->updateNecessary());
+    }
+
+    private function apiTimeoutOf(string $identifier): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $value = $queryBuilder
+            ->select('api_timeout')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'identifier',
+                    $queryBuilder->createNamedParameter($identifier),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return (int)$value;
+    }
+}

--- a/Tests/Unit/AbstractUnitTestCase.php
+++ b/Tests/Unit/AbstractUnitTestCase.php
@@ -152,6 +152,7 @@ abstract class AbstractUnitTestCase extends TestCase
         $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
         $vaultHttpClient->method('withAuthentication')->willReturn($vaultHttpClient);
         $vaultHttpClient->method('withReason')->willReturn($vaultHttpClient);
+        $vaultHttpClient->method('withTimeout')->willReturn($vaultHttpClient);
         $vaultHttpClient->method('sendRequest')->willReturnCallback(fn() => $this->createHttpResponseMock(200, '{}'));
 
         $stub = self::createStub(VaultServiceInterface::class);

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -590,9 +590,9 @@ final class ProviderTest extends AbstractUnitTestCase
     // ========================================
 
     #[Test]
-    public function defaultApiTimeoutIsThirtySeconds(): void
+    public function defaultApiTimeoutIsOneHundredTwentySeconds(): void
     {
-        self::assertSame(30, $this->subject->getApiTimeout());
+        self::assertSame(120, $this->subject->getApiTimeout());
     }
 
     #[Test]

--- a/Tests/Unit/Provider/AbstractProviderConfigureTest.php
+++ b/Tests/Unit/Provider/AbstractProviderConfigureTest.php
@@ -24,7 +24,7 @@ use ReflectionClass;
 class AbstractProviderConfigureTest extends AbstractUnitTestCase
 {
     #[Test]
-    public function configureUsesDefaultTimeoutOf30WhenNotProvided(): void
+    public function configureUsesDefaultTimeoutOf120WhenNotProvided(): void
     {
         $provider = new GeminiProvider(
             $this->createRequestFactoryMock(),
@@ -43,7 +43,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
         $reflection = new ReflectionClass($provider);
         $timeout = $reflection->getProperty('timeout');
 
-        self::assertEquals(30, $timeout->getValue($provider));
+        self::assertEquals(120, $timeout->getValue($provider));
     }
 
     #[Test]
@@ -255,10 +255,10 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
     {
         return [
             'minimum' => [1],
-            'default minus one' => [29],
-            'default' => [30],
-            'default plus one' => [31],
-            'high' => [120],
+            'default minus one' => [119],
+            'default' => [120],
+            'default plus one' => [121],
+            'low' => [30],
         ];
     }
 
@@ -346,7 +346,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
     public function configureWithEmptyArrayAppliesAllDefaults(): void
     {
         // An entirely empty config must leave every field at its safe default:
-        // empty api key (⇒ not available), timeout 30, maxRetries 3, the
+        // empty api key (⇒ not available), timeout 120, maxRetries 3, the
         // provider's own default base URL and model. No exception is thrown
         // (validation is lazy, deferred to the first real request).
         $provider = $this->geminiProvider();
@@ -354,7 +354,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
         $provider->configure([]);
 
         self::assertFalse($provider->isAvailable());
-        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(120, $this->intProperty($provider, 'timeout'));
         self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
 
         $baseUrl = $this->stringProperty($provider, 'baseUrl');
@@ -373,7 +373,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
         $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
 
         self::assertTrue($provider->isAvailable());
-        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(120, $this->intProperty($provider, 'timeout'));
         self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
         self::assertNotEmpty($provider->getDefaultModel());
     }
@@ -399,7 +399,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
     public function configureFallsBackToDefaultsForNonNumericStringNumerics(): void
     {
         // A non-numeric string cannot be coerced and must fall back to the
-        // default (30 / 3) rather than casting to 0, which would disable the
+        // default (120 / 3) rather than casting to 0, which would disable the
         // timeout / retry behaviour.
         $provider = $this->geminiProvider();
 
@@ -409,7 +409,7 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
             'maxRetries' => 'lots',
         ]);
 
-        self::assertSame(30, $this->intProperty($provider, 'timeout'));
+        self::assertSame(120, $this->intProperty($provider, 'timeout'));
         self::assertSame(3, $this->intProperty($provider, 'maxRetries'));
     }
 

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -373,8 +373,8 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
             $this->invokeMethod($provider, 'sendRequest', '/test', []);
             self::fail('Expected ProviderConnectionException');
         } catch (ProviderConnectionException $e) {
-            self::assertEquals(2, $attempts);
-            self::assertStringContainsString('Failed to connect to provider after 2 attempts', $e->getMessage());
+            self::assertEquals(3, $attempts);
+            self::assertStringContainsString('Failed to connect to provider after 3 attempts', $e->getMessage());
         }
     }
 
@@ -751,7 +751,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         );
         $provider->configure([
             'apiKeyIdentifier' => $this->randomApiKey(),
-            'maxRetries' => 5,
+            'maxRetries' => 2,
         ]);
         $provider->setHttpClient($httpClient);
 
@@ -759,8 +759,8 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
             $this->invokeMethod($provider, 'sendRequest', '/test', []);
             self::fail('Expected ProviderConnectionException');
         } catch (ProviderConnectionException $e) {
-            // Must contain the specific retry count
-            self::assertStringContainsString('5 attempts', $e->getMessage());
+            // Must contain the specific attempts-made count (maxRetries + 1)
+            self::assertStringContainsString('3 attempts', $e->getMessage());
             // And the original error message
             self::assertStringContainsString('Network error', $e->getMessage());
         }
@@ -798,12 +798,12 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         } catch (ProviderConnectionException $e) {
             // When we get a 500 status, lastException is set from the status code error
             // The message should contain 'Server returned status 500'
-            self::assertStringContainsString('2 attempts', $e->getMessage());
+            self::assertStringContainsString('3 attempts', $e->getMessage());
         }
     }
 
     #[Test]
-    public function sendRequestRetriesExactlyMaxRetriesTimes(): void
+    public function sendRequestRunsMaxRetriesPlusOneAttempts(): void
     {
         $attempts = 0;
 
@@ -824,15 +824,15 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         );
         $provider->configure([
             'apiKeyIdentifier' => $this->randomApiKey(),
-            'maxRetries' => 4,
+            'maxRetries' => 2,
         ]);
         $provider->setHttpClient($httpClient);
 
         try {
             $this->invokeMethod($provider, 'sendRequest', '/test', []);
         } catch (ProviderConnectionException) {
-            // Should have tried exactly 4 times
-            self::assertEquals(4, $attempts);
+            // maxRetries = 2 means the initial attempt plus two retries
+            self::assertEquals(3, $attempts);
         }
     }
 

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -908,6 +908,42 @@ class AbstractProviderTest extends AbstractUnitTestCase
     }
 
     /**
+     * A negative `maxRetries` — reachable through the options JSON override,
+     * which configure() does not range-check — must clamp to "no retries",
+     * not skip the loop entirely and resurrect the "0 attempts" bug.
+     */
+    #[Test]
+    public function negativeMaxRetriesStillSendsExactlyOneRequest(): void
+    {
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'maxRetries' => -3,
+        ]);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('socket reset'));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('after 1 attempts', $e->getMessage());
+            self::assertStringContainsString('socket reset', $e->getMessage());
+        }
+    }
+
+    /**
      * A 3xx (here 300) is neither a 2xx success nor a 4xx client error, so it
      * falls through to the final `throw new ProviderConnectionException(...)`.
      * Pins both the `< 300` success bound (the mutant `<= 300` would treat 300

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use GuzzleHttp\Client;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
@@ -35,6 +36,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use ReflectionProperty;
 use RuntimeException;
 
 /**
@@ -624,6 +626,7 @@ class AbstractProviderTest extends AbstractUnitTestCase
 
         $vaultHttpClient = self::createStub(VaultHttpClientInterface::class);
         $vaultHttpClient->method('withAuthentication')->willReturn($vaultHttpClient);
+        $vaultHttpClient->method('withTimeout')->willReturn($vaultHttpClient);
         $vaultHttpClient->method('withReason')->willReturnCallback(
             function (string $reason) use (&$capturedReasons, $vaultHttpClient): VaultHttpClientInterface {
                 $capturedReasons[] = $reason;
@@ -1224,6 +1227,179 @@ class AbstractProviderTest extends AbstractUnitTestCase
     }
 
     /**
+     * The provider's configured api_timeout must actually reach the vault
+     * HTTP client (#384): with no per-request timeout, getHttpClient()
+     * applies the configured value via withTimeout(). ProviderConnectionTest
+     * only asserts elapsed-time upper bounds and cannot prove this.
+     */
+    #[Test]
+    public function sendRequestAppliesProviderApiTimeoutToVaultClient(): void
+    {
+        $vaultClient = $this->createVaultHttpClientExpectingTimeout(120);
+        $provider = $this->openAiProviderWithVaultClient($vaultClient, providerTimeout: 120);
+
+        $response = $provider->complete('hi');
+
+        self::assertSame('ok', $response->content);
+    }
+
+    /**
+     * A per-request `options['timeout']` (the configuration-level effective
+     * timeout delivered via LlmConfiguration::toOptionsArray()) must win over
+     * the provider's api_timeout for the single request.
+     */
+    #[Test]
+    public function perRequestOptionsTimeoutWinsOverProviderApiTimeout(): void
+    {
+        $vaultClient = $this->createVaultHttpClientExpectingTimeout(240);
+        $provider = $this->openAiProviderWithVaultClient($vaultClient, providerTimeout: 30);
+
+        $response = $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'hi']],
+            ['timeout' => 240],
+        );
+
+        self::assertSame('ok', $response->content);
+    }
+
+    /**
+     * The api-key-less path (e.g. Ollama) must be bounded too: the effective
+     * timeout is passed to SecureHttpClientFactory::create(), which sets
+     * Guzzle's `timeout` option. The factory is final, so the produced Guzzle
+     * client's config is inspected directly.
+     */
+    #[Test]
+    public function apiKeylessProviderPassesTimeoutToFactory(): void
+    {
+        $provider = $this->makeGateProbe([
+            'apiKeyIdentifier' => '',
+            'baseUrl' => 'https://ok.test',
+            'timeout' => 77,
+        ]);
+
+        // Provider api_timeout applies when no per-request timeout is given.
+        self::assertSame(77, $this->guzzleTimeoutOf($provider->exposedGetHttpClient()));
+
+        // A per-request timeout overrides the provider api_timeout.
+        self::assertSame(240, $this->guzzleTimeoutOf($provider->exposedGetHttpClient(240)));
+    }
+
+    /**
+     * A request that consumed the effective timeout must NOT be retried —
+     * retrying would multiply the caller's wait by maxAttempts (#384). Guzzle
+     * reports a total timeout (cURL error 28) as a ConnectException, so the
+     * elapsed wall time is the discriminator.
+     */
+    #[Test]
+    public function timedOutRequestIsNotRetried(): void
+    {
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'mistral-large-latest',
+            'timeout' => 1,
+            'maxRetries' => 3,
+        ]);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(static function (): ResponseInterface {
+                usleep(1_100_000);
+                throw new class ('cURL error 28: Operation timed out', 4859032175) extends RuntimeException implements NetworkExceptionInterface {
+                    public function getRequest(): RequestInterface
+                    {
+                        throw new RuntimeException('not used');
+                    }
+                };
+            });
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException $e) {
+            self::assertStringContainsString('timed out after 1 seconds', $e->getMessage());
+            self::assertStringContainsString('timeouts are not retried', $e->getMessage());
+        }
+    }
+
+    /**
+     * Vault HTTP client double that expects withTimeout() to be called exactly
+     * once with the given value and answers requests with a minimal OpenAI
+     * chat completion payload.
+     */
+    private function createVaultHttpClientExpectingTimeout(int $expectedSeconds): VaultHttpClientInterface
+    {
+        $apiResponse = [
+            'choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']],
+            'model' => 'gpt-5.2',
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+
+        $vaultClient = $this->createMock(VaultHttpClientInterface::class);
+        $vaultClient->method('withAuthentication')->willReturnSelf();
+        $vaultClient->method('withReason')->willReturnSelf();
+        $vaultClient->expects(self::once())
+            ->method('withTimeout')
+            ->with($expectedSeconds)
+            ->willReturnSelf();
+        $vaultClient->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        return $vaultClient;
+    }
+
+    /**
+     * OpenAiProvider wired to a vault service whose http() yields the given
+     * client — the real vault code path, no setHttpClient() test seam.
+     */
+    private function openAiProviderWithVaultClient(
+        VaultHttpClientInterface $vaultClient,
+        int $providerTimeout,
+    ): OpenAiProvider {
+        $vault = self::createStub(VaultServiceInterface::class);
+        $vault->method('exists')->willReturn(true);
+        $vault->method('http')->willReturn($vaultClient);
+
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $vault,
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-5.2',
+            'timeout' => $providerTimeout,
+        ]);
+
+        return $provider;
+    }
+
+    /**
+     * Read the `timeout` option out of a Guzzle client produced by
+     * SecureHttpClientFactory::create().
+     */
+    private function guzzleTimeoutOf(ClientInterface $client): int
+    {
+        self::assertInstanceOf(Client::class, $client);
+        $config = (new ReflectionProperty(Client::class, 'config'))->getValue($client);
+        self::assertIsArray($config);
+        assert(isset($config['timeout']));
+        self::assertIsInt($config['timeout']);
+
+        return $config['timeout'];
+    }
+
+    /**
      * Stream factory stub that records the last content it was asked to wrap,
      * so tests can assert on the exact JSON-encoded request body.
      */
@@ -1319,9 +1495,9 @@ final class GateProbeProvider extends AbstractProvider
         );
     }
 
-    public function exposedGetHttpClient(): ClientInterface
+    public function exposedGetHttpClient(?int $timeout = null): ClientInterface
     {
-        return $this->getHttpClient();
+        return $this->getHttpClient($timeout);
     }
 
     /**

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -527,7 +527,7 @@ class AbstractProviderTest extends AbstractUnitTestCase
         $provider->configure([
             'apiKeyIdentifier' => $this->randomApiKey(),
             'defaultModel' => 'gpt-5.2',
-            'maxRetries' => 1,
+            'maxRetries' => 0,
         ]);
 
         $client = $this->createHttpClientMock();
@@ -864,14 +864,13 @@ class AbstractProviderTest extends AbstractUnitTestCase
     }
 
     /**
-     * With `maxRetries = 0` the retry loop never runs, so `$lastException`
-     * stays null and the final exception message falls back to the
-     * `?? self::UNKNOWN_ERROR` placeholder. Exercises the null-safe operator
-     * (the mutant drops `?->` and calls getMessage() on null) and pins the
-     * exception code to 0.
+     * Regression test for #387: `maxRetries = 0` means "no retries", not
+     * "no requests" — exactly one HTTP request is sent, and the surfaced
+     * exhaustion message reports the attempt actually made together with
+     * the real underlying error instead of the "Unknown error" placeholder.
      */
     #[Test]
-    public function connectionExhaustionWithZeroRetriesFallsBackToUnknownErrorAndCodeZero(): void
+    public function maxRetriesZeroSendsExactlyOneRequestAndSurfacesRealError(): void
     {
         $provider = new MistralProvider(
             $this->createRequestFactoryMock(),
@@ -885,15 +884,23 @@ class AbstractProviderTest extends AbstractUnitTestCase
             'defaultModel' => 'mistral-large-latest',
             'maxRetries' => 0,
         ]);
-        $provider->setHttpClient($this->createHttpClientMock());
+
+        $underlying = new RuntimeException('socket reset');
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('sendRequest')
+            ->willThrowException($underlying);
+        $provider->setHttpClient($client);
 
         try {
             $provider->complete('hi');
             self::fail('Expected ProviderConnectionException was not thrown');
         } catch (ProviderConnectionException $e) {
             self::assertSame(0, $e->getCode());
-            self::assertStringContainsString('after 0 attempts', $e->getMessage());
-            self::assertStringContainsString('Unknown error', $e->getMessage());
+            self::assertStringContainsString('after 1 attempts', $e->getMessage());
+            self::assertStringContainsString('socket reset', $e->getMessage());
+            self::assertStringNotContainsString('Unknown error', $e->getMessage());
+            self::assertSame($underlying, $e->getPrevious());
         }
     }
 

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -1315,7 +1315,7 @@ class AbstractProviderTest extends AbstractUnitTestCase
                 throw new class ('cURL error 28: Operation timed out', 4859032175) extends RuntimeException implements NetworkExceptionInterface {
                     public function getRequest(): RequestInterface
                     {
-                        throw new RuntimeException('not used');
+                        throw new RuntimeException('not used', 5686042759);
                     }
                 };
             });

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -18,7 +18,7 @@ CREATE TABLE tx_nrllm_provider (
     organization_id varchar(100) DEFAULT '' NOT NULL,
 
     -- Request settings (for API operations like list models, test connection)
-    api_timeout int(11) DEFAULT '30' NOT NULL,
+    api_timeout int(11) DEFAULT '120' NOT NULL,
     max_retries int(11) DEFAULT '3' NOT NULL,
 
     -- Additional options (JSON)


### PR DESCRIPTION
## Description

Two fixes to the provider retry/timeout path, one commit each:

**`max_retries` semantics (#387).** The retry loop ran `maxRetries` iterations, so `max_retries = 0` — a value the TCA form allows — sent zero HTTP requests and threw *"Failed to connect to provider after 0 attempts: Unknown error"*. The loop now runs `maxRetries + 1` attempts: `0` means one request, no retries. The exhaustion message reports attempts actually made.

**`api_timeout` wiring (#384).** `AbstractProvider::$timeout` was write-only; no timeout ever reached the HTTP client, and TYPO3's default `HTTP.timeout = 0` means Guzzle waits forever — a silent provider could block a PHP-FPM worker indefinitely. Timeout semantics per the analysis in #384's correction comment:

- **Total-response timeout** (what the field descriptions promise; the only shape nr-vault's `withTimeout()` offers).
- **Precedence:** per-request `options['timeout']` (from `LlmConfiguration::getEffectiveTimeout()`: configuration `timeout` > 0, else model `default_timeout`, else 120) wins; the provider's `api_timeout` is the fallback for direct adapter calls (test connection, model listing, wizard).
- Applied on both client paths: `VaultHttpClient::withTimeout()` (authenticated) and `SecureHttpClientFactory::create(?int)` (key-less/Ollama).

### Behavior changes

- Installs with the default `max_retries = 3` now send up to 4 requests on persistently failing providers (one extra ~0.8s backoff).
- Previously **unbounded** requests are now bounded: managed-path calls at ≥120s by default, direct adapter calls by `api_timeout`. Calls that today run longer than the resolved timeout and succeed will start failing.
- Streaming is bounded by the same *total* timeout — a stream still emitting at timeout T aborts. That is the decided semantics; raise the configuration/model timeout for long generations.
- Timed-out requests are **not retried** (detected by elapsed wall time, since Guzzle raises cURL 28 as `ConnectException`, the same class as retryable connection failures).
- `api_timeout` default moves 30 → 120 (TCA, `ext_tables.sql`, model, provider). A new upgrade wizard (`nrLlm_providerApiTimeout120`) migrates persisted rows at exactly the old default 30 to 120 — a deliberately chosen 30 cannot be distinguished from the never-applied default; wiring 30 as-is would truncate long generations (local Ollama model loads alone can exceed 30s).
- The orphan XLF label pair `tx_nrllm_provider.timeout(.description)` (a field the TCA never defined) is removed; its accurate "complete response / 60–300s" wording now lives in `api_timeout.description` (EN+DE).

## Related Issue

Fixes #384
Fixes #387

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — see behavior changes above

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates via `Build/Scripts/runTests.sh` (unit 4960 tests / phpstan level 10 / cgl: SUCCESS; new upgrade-wizard functional tests: 3/3 SUCCESS on sqlite; full functional left to CI)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
