### PR TITLE
fix: enforce per-configuration daily limits in budget gate

### DIFF
--- a/Classes/Domain/DTO/BudgetCheckResult.php
+++ b/Classes/Domain/DTO/BudgetCheckResult.php
@@ -25,6 +25,9 @@ final readonly class BudgetCheckResult
     public const LIMIT_MONTHLY_REQUESTS = 'monthly_requests';
     public const LIMIT_MONTHLY_TOKENS = 'monthly_tokens';
     public const LIMIT_MONTHLY_COST = 'monthly_cost';
+    public const LIMIT_CONFIGURATION_DAILY_REQUESTS = 'configuration_daily_requests';
+    public const LIMIT_CONFIGURATION_DAILY_TOKENS = 'configuration_daily_tokens';
+    public const LIMIT_CONFIGURATION_DAILY_COST = 'configuration_daily_cost';
 
     /**
      * Human-friendly labels, keyed by LIMIT_* value. Kept here as a
@@ -42,6 +45,9 @@ final readonly class BudgetCheckResult
         self::LIMIT_MONTHLY_REQUESTS => 'monthly request count',
         self::LIMIT_MONTHLY_TOKENS => 'monthly token usage',
         self::LIMIT_MONTHLY_COST => 'monthly cost',
+        self::LIMIT_CONFIGURATION_DAILY_REQUESTS => 'configuration daily request count',
+        self::LIMIT_CONFIGURATION_DAILY_TOKENS => 'configuration daily token usage',
+        self::LIMIT_CONFIGURATION_DAILY_COST => 'configuration daily cost',
     ];
 
     public function __construct(

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -26,7 +26,10 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Metadata keys consumed (callers put them on the context):
  *  - `BudgetMiddleware::METADATA_BE_USER_UID` : int, the backend user
  *    whose budget is checked. 0 / absent / non-int means "skip the
- *    check" (CLI, scheduler, unauthenticated callers; see ADR-025 rule 1).
+ *    PER-USER check" (CLI, scheduler, unauthenticated callers; see
+ *    ADR-025 rule 1). The dispatched configuration's own per-day caps
+ *    are still evaluated whenever the configuration is persisted and
+ *    has limits — they are configuration-scoped, not user-scoped.
  *  - `BudgetMiddleware::METADATA_PLANNED_COST` : float, the expected
  *    cost of the call in the configured currency. 0.0 / absent means
  *    "I do not know the cost yet — evaluate only the non-cost limits
@@ -47,6 +50,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * that want to charge each retry separately should register a custom
  * pipeline order; the default ordering is defined by ADR-026 (the
  * middleware pipeline itself), with the rule set documented there.
+ * Because of that ordering, the per-configuration caps checked here are
+ * the PRIMARY configuration's — a fallback swap is not re-checked
+ * pre-flight (same single-pre-flight semantics as the per-user scope);
+ * usage IS recorded against the served configuration, so its cap
+ * catches up on the next request.
  *
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.
@@ -78,7 +86,7 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
         $beUserUid   = $this->readInt($context, self::METADATA_BE_USER_UID);
         $plannedCost = $this->readFloat($context, self::METADATA_PLANNED_COST);
 
-        $result = $this->budgetService->check($beUserUid, $plannedCost);
+        $result = $this->budgetService->check($beUserUid, $plannedCost, $configuration);
 
         if (!$result->allowed) {
             throw new BudgetExceededException($result);

--- a/Classes/Service/Budget/BudgetUsageWindowsInterface.php
+++ b/Classes/Service/Budget/BudgetUsageWindowsInterface.php
@@ -39,4 +39,20 @@ interface BudgetUsageWindowsInterface
         ?int $monthlyFromTimestamp,
         int $toTimestamp,
     ): array;
+
+    /**
+     * Aggregate usage attributed to one configuration within a single
+     * window, across ALL backend users.
+     *
+     * Serves the per-configuration daily cap (issue #389): the totals are
+     * compared against the configuration's own maxRequestsPerDay /
+     * maxTokensPerDay / maxCostPerDay ceilings.
+     *
+     * @return array{requests: int, tokens: int, cost: float}
+     */
+    public function aggregateForConfiguration(
+        int $configurationUid,
+        int $fromTimestamp,
+        int $toTimestamp,
+    ): array;
 }

--- a/Classes/Service/Budget/UserBudgetUsageWindows.php
+++ b/Classes/Service/Budget/UserBudgetUsageWindows.php
@@ -79,4 +79,38 @@ final readonly class UserBudgetUsageWindows implements BudgetUsageWindowsInterfa
             ],
         ];
     }
+
+    public function aggregateForConfiguration(
+        int $configurationUid,
+        int $fromTimestamp,
+        int $toTimestamp,
+    ): array {
+        // One roundtrip on the config_lookup(configuration_uid, request_date)
+        // index; sums span every backend user because the cap is scoped to
+        // the configuration, not to a user.
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::USAGE_TABLE);
+
+        $row = $queryBuilder
+            ->addSelectLiteral('SUM(request_count) AS requests')
+            ->addSelectLiteral('SUM(tokens_used) AS tokens')
+            ->addSelectLiteral('SUM(estimated_cost) AS cost')
+            ->from(self::USAGE_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('configuration_uid', $queryBuilder->createNamedParameter($configurationUid)),
+                $queryBuilder->expr()->gte('request_date', $queryBuilder->createNamedParameter($fromTimestamp)),
+                $queryBuilder->expr()->lte('request_date', $queryBuilder->createNamedParameter($toTimestamp)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($row)) {
+            return ['requests' => 0, 'tokens' => 0, 'cost' => 0.0];
+        }
+
+        return [
+            'requests' => is_numeric($row['requests'] ?? null) ? (int)$row['requests'] : 0,
+            'tokens' => is_numeric($row['tokens'] ?? null) ? (int)$row['tokens'] : 0,
+            'cost' => is_numeric($row['cost'] ?? null) ? (float)$row['cost'] : 0.0,
+        ];
+    }
 }

--- a/Classes/Service/BudgetService.php
+++ b/Classes/Service/BudgetService.php
@@ -11,13 +11,25 @@ namespace Netresearch\NrLlm\Service;
 
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 
 /**
- * Enforces per-backend-user daily and monthly AI spending ceilings.
+ * Enforces per-backend-user daily/monthly AI spending ceilings AND the
+ * active configuration's per-day usage caps.
  *
- * The budget record on tx_nrllm_user_budget is a ceiling, not a counter.
+ * Two scopes, checked in order — the most restrictive wins:
+ *  1. Per-user: the budget record on tx_nrllm_user_budget is a ceiling,
+ *     not a counter. Skipped for beUserUid <= 0 (ADR-025 rule 1).
+ *  2. Per-configuration: the dispatched LlmConfiguration's own
+ *     maxRequestsPerDay / maxTokensPerDay / maxCostPerDay caps, compared
+ *     against the configuration's current-day usage across ALL users.
+ *     Applies even when beUserUid is 0 (CLI/scheduler) because the cap
+ *     is configuration-scoped, not user-scoped. Transient configurations
+ *     (no persisted uid) and configurations without limits are skipped —
+ *     the common no-limits case costs zero extra DB queries.
+ *
  * Actual usage is aggregated on demand from tx_nrllm_service_usage — the
  * same table the UsageTracker already writes to — so we never drift from
  * the source of truth and we don't pay a second-write cost per request.
@@ -42,12 +54,23 @@ final readonly class BudgetService implements BudgetServiceInterface
         private BudgetUsageWindowsInterface $usageWindows,
     ) {}
 
-    public function check(int $beUserUid, float $plannedCost = 0.0): BudgetCheckResult
+    public function check(int $beUserUid, float $plannedCost = 0.0, ?LlmConfiguration $configuration = null): BudgetCheckResult
     {
         // Negative planned cost would artificially reduce the projected
         // total and let callers bypass cost limits. Clamp defensively.
         $plannedCost = max(0.0, $plannedCost);
 
+        $result = $this->checkUserBudget($beUserUid, $plannedCost);
+
+        if ($result->allowed && $configuration !== null) {
+            $result = $this->checkConfigurationLimits($configuration, $plannedCost);
+        }
+
+        return $result;
+    }
+
+    private function checkUserBudget(int $beUserUid, float $plannedCost): BudgetCheckResult
+    {
         $budget = $beUserUid > 0 ? $this->repository->findOneByBeUser($beUserUid) : null;
         if ($budget === null || !$budget->isActive() || !$budget->hasAnyLimit()) {
             return BudgetCheckResult::allowed();
@@ -104,6 +127,40 @@ final readonly class BudgetService implements BudgetServiceInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Compare the configuration's current-day usage (all users) against
+     * its own per-day caps. Transient configurations (no persisted uid)
+     * and configurations without limits are allowed without touching the
+     * database.
+     */
+    private function checkConfigurationLimits(LlmConfiguration $configuration, float $plannedCost): BudgetCheckResult
+    {
+        $configurationUid = $configuration->getUid() ?? 0;
+        if ($configurationUid <= 0 || !$configuration->hasUsageLimits()) {
+            return BudgetCheckResult::allowed();
+        }
+
+        $now = new DateTimeImmutable();
+        $usage = $this->usageWindows->aggregateForConfiguration(
+            $configurationUid,
+            $now->setTime(0, 0, 0)->getTimestamp(),
+            $now->getTimestamp(),
+        );
+
+        return $this->compare(
+            usage: $usage,
+            plannedCost: $plannedCost,
+            requestLimit: $configuration->getMaxRequestsPerDay(),
+            tokenLimit: $configuration->getMaxTokensPerDay(),
+            costLimit: $configuration->getMaxCostPerDay(),
+            limitIds: [
+                'request' => BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_REQUESTS,
+                'token' => BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_TOKENS,
+                'cost' => BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST,
+            ],
+        );
     }
 
     /**

--- a/Classes/Service/BudgetServiceInterface.php
+++ b/Classes/Service/BudgetServiceInterface.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service;
 
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 
 /**
- * Public surface of the per-backend-user AI budget gate.
+ * Public surface of the AI budget gate (per-backend-user and
+ * per-configuration scopes).
  *
  * Consumers (middleware, feature services, tests) should depend on this
  * interface rather than the concrete `BudgetService` so the
@@ -21,14 +23,23 @@ use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 interface BudgetServiceInterface
 {
     /**
-     * Pre-flight check: is the user allowed to make a request whose
-     * expected cost is `$plannedCost`?
+     * Pre-flight check: is this request, whose expected cost is
+     * `$plannedCost`, allowed?
      *
-     * Returns `BudgetCheckResult::allowed()` when there is no budget
-     * record, the budget is inactive, no limits are set, or every
-     * configured limit (current-day and current-month) is still under
-     * its cap. Otherwise returns `BudgetCheckResult::denied(...)`
-     * naming the first bucket that would overflow.
+     * Per-user scope: returns `BudgetCheckResult::allowed()` when there
+     * is no budget record, the budget is inactive, no limits are set, or
+     * every configured limit (current-day and current-month) is still
+     * under its cap.
+     *
+     * Per-configuration scope: when a persisted `$configuration` with
+     * usage limits is supplied, its per-day request/token/cost caps are
+     * checked AFTER the per-user budget passes. The most restrictive
+     * scope wins — the first scope that denies short-circuits.
+     * Configuration caps apply regardless of `$beUserUid` (they gate
+     * CLI/scheduler traffic too).
+     *
+     * Otherwise returns `BudgetCheckResult::denied(...)` naming the
+     * first bucket that would overflow.
      */
-    public function check(int $beUserUid, float $plannedCost = 0.0): BudgetCheckResult;
+    public function check(int $beUserUid, float $plannedCost = 0.0, ?LlmConfiguration $configuration = null): BudgetCheckResult;
 }

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -118,7 +118,7 @@ final readonly class StreamingDispatcher
         LlmConfiguration $configuration,
         callable $open,
     ): Generator {
-        $this->assertWithinBudget($context);
+        $this->assertWithinBudget($context, $configuration);
 
         return $this->drain($context, $configuration, $open);
     }
@@ -285,11 +285,12 @@ final readonly class StreamingDispatcher
     /**
      * @throws BudgetExceededException when the pre-flight check denies the call
      */
-    private function assertWithinBudget(ProviderCallContext $context): void
+    private function assertWithinBudget(ProviderCallContext $context, LlmConfiguration $configuration): void
     {
         $result = $this->budgetService->check(
             $this->readInt($context, BudgetMiddleware::METADATA_BE_USER_UID),
             $this->readFloat($context, BudgetMiddleware::METADATA_PLANNED_COST),
+            $configuration,
         );
 
         if (!$result->allowed) {

--- a/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
@@ -131,6 +131,77 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
         self::assertTrue($terminalRan, 'A user with no budget record is unconstrained and proceeds.');
     }
 
+    #[Test]
+    public function overConfigurationCostCapRequestIsBlocked(): void
+    {
+        // Reproduces the reported gap (issue #389) exactly: NO user budget
+        // row at all — only the configuration's own daily cost cap protects.
+        // 2.0 already spent today on configuration 5, whose cap is 1.0.
+        $this->insertUsageRow(estimatedCost: 2.0, configurationUid: 5);
+
+        $terminalRan = false;
+
+        try {
+            $this->pipeline()->run(
+                context: $this->contextFor(plannedCost: 0.5),
+                configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+                terminal: static function () use (&$terminalRan): string {
+                    $terminalRan = true;
+
+                    return 'should-never-run';
+                },
+            );
+            self::fail('Expected BudgetExceededException for an over-cap configuration.');
+        } catch (BudgetExceededException $e) {
+            self::assertFalse($terminalRan, 'An over-cap request must NOT reach the terminal call.');
+            self::assertFalse($e->result->allowed);
+            self::assertSame(BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST, $e->result->exceededLimit);
+            self::assertEqualsWithDelta(2.0, $e->result->currentUsage, 0.0001);
+            self::assertEqualsWithDelta(1.0, $e->result->limit, 0.0001);
+        }
+    }
+
+    #[Test]
+    public function withinConfigurationCostCapRequestProceeds(): void
+    {
+        // 0.4 spent today + 0.5 planned = 0.9 <= 1.0 cap -> allowed.
+        $this->insertUsageRow(estimatedCost: 0.4, configurationUid: 5);
+
+        $terminalRan = false;
+        $this->pipeline()->run(
+            context: $this->contextFor(plannedCost: 0.5),
+            configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+            terminal: static function () use (&$terminalRan): string {
+                $terminalRan = true;
+
+                return 'ok';
+            },
+        );
+
+        self::assertTrue($terminalRan, 'A within-cap request must reach the terminal provider call.');
+    }
+
+    #[Test]
+    public function configurationCapIgnoresOtherConfigurationsUsage(): void
+    {
+        // Heavy spend on a DIFFERENT configuration must not count against
+        // configuration 5's cap: the aggregate is scoped by configuration_uid.
+        $this->insertUsageRow(estimatedCost: 50.0, configurationUid: 99);
+
+        $terminalRan = false;
+        $this->pipeline()->run(
+            context: $this->contextFor(plannedCost: 0.5),
+            configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+            terminal: static function () use (&$terminalRan): string {
+                $terminalRan = true;
+
+                return 'ok';
+            },
+        );
+
+        self::assertTrue($terminalRan, 'Another configuration\'s usage must not trip this configuration\'s cap.');
+    }
+
     /**
      * Build a real pipeline containing ONLY the container-resolved
      * BudgetMiddleware (which itself wraps the real BudgetService + DB-backed
@@ -161,10 +232,14 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
         );
     }
 
-    private function configuration(): LlmConfiguration
+    private function configuration(?int $uid = null, float $maxCostPerDay = 0.0): LlmConfiguration
     {
         $config = new LlmConfiguration();
         $config->setIdentifier('primary');
+        if ($uid !== null) {
+            $config->_setProperty('uid', $uid);
+        }
+        $config->setMaxCostPerDay($maxCostPerDay);
 
         return $config;
     }
@@ -193,14 +268,14 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
      * Insert a usage row dated to "now" so it falls inside the current monthly
      * window the BudgetService aggregates over.
      */
-    private function insertUsageRow(float $estimatedCost): void
+    private function insertUsageRow(float $estimatedCost, int $configurationUid = 0): void
     {
         $now = (new DateTimeImmutable('now'))->getTimestamp();
         $this->connectionPool->getConnectionForTable(self::TABLE_USAGE)->insert(self::TABLE_USAGE, [
             'pid'                => 0,
             'service_type'       => 'chat',
             'service_provider'   => 'openai',
-            'configuration_uid'  => 0,
+            'configuration_uid'  => $configurationUid,
             'model_uid'          => 1,
             'model_id'           => 'gpt-4o',
             'be_user'            => self::BE_USER_UID,

--- a/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
+++ b/Tests/Unit/Domain/DTO/BudgetCheckResultTest.php
@@ -101,6 +101,21 @@ class BudgetCheckResultTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function deniedReasonUsesConfigurationScopeLabel(): void
+    {
+        // Pins the LIMIT_LABELS entries for the configuration scope
+        // (issue #389): the reason must carry the human label, not the key.
+        $result = BudgetCheckResult::denied(
+            BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST,
+            currentUsage: 1.5,
+            limit: 1.0,
+        );
+
+        self::assertStringContainsString('configuration daily cost', $result->reason);
+        self::assertStringNotContainsString('configuration_daily_cost', $result->reason);
+    }
+
+    #[Test]
     public function allLimitConstantsAreDistinctAndNonEmpty(): void
     {
         $limits = [
@@ -110,9 +125,12 @@ class BudgetCheckResultTest extends AbstractUnitTestCase
             BudgetCheckResult::LIMIT_MONTHLY_REQUESTS,
             BudgetCheckResult::LIMIT_MONTHLY_TOKENS,
             BudgetCheckResult::LIMIT_MONTHLY_COST,
+            BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_REQUESTS,
+            BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_TOKENS,
+            BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST,
         ];
 
-        self::assertCount(6, array_unique($limits));
+        self::assertCount(9, array_unique($limits));
         foreach ($limits as $limit) {
             self::assertNotSame('', $limit);
         }

--- a/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
@@ -91,14 +91,15 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
     #[Test]
     public function passesUidZeroWhenMetadataAbsent(): void
     {
+        $configuration = $this->configuration();
         $this->budgetService->expects(self::once())
             ->method('check')
-            ->with(0, 0.0)
+            ->with(0, 0.0, self::identicalTo($configuration))
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
             context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
+            configuration: $configuration,
             terminal: static fn(LlmConfiguration $c): string => 'ok',
         );
     }
@@ -106,14 +107,15 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
     #[Test]
     public function coercesIntegerPlannedCostToFloat(): void
     {
+        $configuration = $this->configuration();
         $this->budgetService->expects(self::once())
             ->method('check')
-            ->with(7, 3.0)
+            ->with(7, 3.0, self::identicalTo($configuration))
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
             context: $this->contextFor(beUserUid: 7, plannedCost: 3), // int, not float
-            configuration: $this->configuration(),
+            configuration: $configuration,
             terminal: static fn(LlmConfiguration $c): string => 'ok',
         );
     }
@@ -123,9 +125,10 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
     {
         // Non-int for uid and non-numeric for cost must fall back to
         // 0 / 0.0 rather than cast surprisingly.
+        $configuration = $this->configuration();
         $this->budgetService->expects(self::once())
             ->method('check')
-            ->with(0, 0.0)
+            ->with(0, 0.0, self::identicalTo($configuration))
             ->willReturn(BudgetCheckResult::allowed());
 
         $context = new ProviderCallContext(
@@ -139,7 +142,7 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
 
         $this->pipeline()->run(
             context: $context,
-            configuration: $this->configuration(),
+            configuration: $configuration,
             terminal: static fn(LlmConfiguration $c): string => 'ok',
         );
     }
@@ -151,14 +154,15 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
         // "allowed / unauthenticated". The middleware does not pre-filter;
         // it forwards whatever was on the metadata so the service keeps
         // ownership of that policy.
+        $configuration = $this->configuration();
         $this->budgetService->expects(self::once())
             ->method('check')
-            ->with(-1, 0.0)
+            ->with(-1, 0.0, self::identicalTo($configuration))
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
             context: $this->contextFor(beUserUid: -1, plannedCost: 0.0),
-            configuration: $this->configuration(),
+            configuration: $configuration,
             terminal: static fn(LlmConfiguration $c): string => 'ok',
         );
     }

--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service;
 
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
@@ -286,19 +287,157 @@ class BudgetServiceTest extends AbstractUnitTestCase
         self::assertFalse($service->check(42, plannedCost: 3.0)->allowed);
     }
 
+    #[Test]
+    public function deniesWhenConfigurationDailyCostCapExceeded(): void
+    {
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+        $service = $this->makeService(configUsage: ['requests' => 1, 'tokens' => 10, 'cost' => 0.9]);
+        $config = $this->makeConfiguration(uid: 7, dailyCost: 1.0);
+
+        // 0.9 used + 0.5 planned = 1.4 > 1.0 cap
+        $result = $service->check(42, 0.5, $config);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST, $result->exceededLimit);
+        self::assertSame(0.9, $result->currentUsage);
+        self::assertSame(1.0, $result->limit);
+    }
+
+    #[Test]
+    public function deniesOnConfigurationDailyRequestLimit(): void
+    {
+        // Usage already at the limit -> +1 incoming > limit (compare() semantics)
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+        $service = $this->makeService(configUsage: ['requests' => 10, 'tokens' => 0, 'cost' => 0.0]);
+        $config = $this->makeConfiguration(uid: 7, dailyRequests: 10);
+
+        $result = $service->check(42, 0.0, $config);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_REQUESTS, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function deniesOnConfigurationDailyTokenLimit(): void
+    {
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+        $service = $this->makeService(configUsage: ['requests' => 0, 'tokens' => 1500, 'cost' => 0.0]);
+        $config = $this->makeConfiguration(uid: 7, dailyTokens: 1000);
+
+        $result = $service->check(42, 0.0, $config);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_TOKENS, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function configurationCapAppliesEvenForZeroBeUserUid(): void
+    {
+        // CLI/scheduler traffic (beUserUid 0) skips only the per-user
+        // check; the configuration-scoped cap still gates the call.
+        $service = $this->makeService(configUsage: ['requests' => 1, 'tokens' => 10, 'cost' => 0.9]);
+        $config = $this->makeConfiguration(uid: 7, dailyCost: 1.0);
+
+        $result = $service->check(0, 0.5, $config);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_CONFIGURATION_DAILY_COST, $result->exceededLimit);
+    }
+
+    #[Test]
+    public function skipsConfigurationWithoutPersistedUid(): void
+    {
+        // A transient configuration (uid null) cannot carry operator-set
+        // caps; it must be allowed without any aggregation query.
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+
+        /** @var BudgetUsageWindowsInterface&MockObject $usageWindows */
+        $usageWindows = $this->createMock(BudgetUsageWindowsInterface::class);
+        $usageWindows->expects(self::never())->method('aggregateForConfiguration');
+
+        $service = new BudgetService($this->repositoryStub, $usageWindows);
+        $config = $this->makeConfiguration(uid: null, dailyCost: 1.0);
+
+        self::assertTrue($service->check(42, 5.0, $config)->allowed);
+    }
+
+    #[Test]
+    public function skipsConfigurationWithoutLimits(): void
+    {
+        // Persisted configuration without any limit set: the common case
+        // must not cost an extra DB query.
+        $this->repositoryStub->method('findOneByBeUser')->willReturn(null);
+
+        /** @var BudgetUsageWindowsInterface&MockObject $usageWindows */
+        $usageWindows = $this->createMock(BudgetUsageWindowsInterface::class);
+        $usageWindows->expects(self::never())->method('aggregateForConfiguration');
+
+        $service = new BudgetService($this->repositoryStub, $usageWindows);
+        $config = $this->makeConfiguration(uid: 7);
+
+        self::assertTrue($service->check(42, 5.0, $config)->allowed);
+    }
+
+    #[Test]
+    public function userDenialTakesPrecedenceOverConfiguration(): void
+    {
+        // Both scopes would deny; the user scope is checked first and
+        // short-circuits, so the config aggregate is never queried.
+        $budget = $this->makeBudget(dailyCost: 1.0);
+        $this->repositoryStub->method('findOneByBeUser')->willReturn($budget);
+
+        /** @var BudgetUsageWindowsInterface&MockObject $usageWindows */
+        $usageWindows = $this->createMock(BudgetUsageWindowsInterface::class);
+        $usageWindows->method('aggregate')->willReturn([
+            'daily' => ['requests' => 0, 'tokens' => 0, 'cost' => 0.9],
+            'monthly' => ['requests' => 0, 'tokens' => 0, 'cost' => 0.9],
+        ]);
+        $usageWindows->expects(self::never())->method('aggregateForConfiguration');
+
+        $service = new BudgetService($this->repositoryStub, $usageWindows);
+        $config = $this->makeConfiguration(uid: 7, dailyCost: 1.0);
+
+        $result = $service->check(42, 0.5, $config);
+
+        self::assertFalse($result->allowed);
+        self::assertSame(BudgetCheckResult::LIMIT_DAILY_COST, $result->exceededLimit);
+    }
+
     /**
      * @param array{requests: int, tokens: int, cost: float}|null $daily
      * @param array{requests: int, tokens: int, cost: float}|null $monthly
+     * @param array{requests: int, tokens: int, cost: float}|null $configUsage
      */
-    private function makeService(array $daily = null, array $monthly = null): BudgetService
+    private function makeService(array $daily = null, array $monthly = null, array $configUsage = null): BudgetService
     {
         $usageWindows = self::createStub(BudgetUsageWindowsInterface::class);
         $usageWindows->method('aggregate')->willReturn([
             'daily' => $daily ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
             'monthly' => $monthly ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
         ]);
+        $usageWindows->method('aggregateForConfiguration')->willReturn(
+            $configUsage ?? ['requests' => 0, 'tokens' => 0, 'cost' => 0.0],
+        );
 
         return new BudgetService($this->repositoryStub, $usageWindows);
+    }
+
+    private function makeConfiguration(
+        ?int $uid,
+        int $dailyRequests = 0,
+        int $dailyTokens = 0,
+        float $dailyCost = 0.0,
+    ): LlmConfiguration {
+        $config = new LlmConfiguration();
+        if ($uid !== null) {
+            $config->_setProperty('uid', $uid);
+        }
+        $config->setIdentifier('capped');
+        $config->setMaxRequestsPerDay($dailyRequests);
+        $config->setMaxTokensPerDay($dailyTokens);
+        $config->setMaxCostPerDay($dailyCost);
+
+        return $config;
     }
 
     private function makeBudget(


### PR DESCRIPTION
## Description

The Configuration record's **Limits** tab (*Max requests / tokens / cost per day*) persisted values that nothing enforced — budget checking ran only against the per-backend-user `UserBudget` record. An operator setting a per-configuration daily cost cap had no cap in effect.

`BudgetService::check()` now enforces **both scopes** — after the per-user check, it aggregates the dispatched configuration's current-day usage from `tx_nrllm_service_usage` (which already records `configuration_uid` on every row, covered by the `config_lookup` index) and compares it against the configuration's own caps. Most restrictive wins; an exhausted configuration cap denies the request with a scope-labelled reason.

### Behavior changes

- **`beUserUid = 0` callers** (CLI, scheduler, frontend plugins without `withBeUserUid()`) were previously never budget-blocked; a configuration with per-day caps now gates them too. That is the point of a configuration-scoped cap, but scheduled jobs can newly fail on the day the cap is reached.
- **`BudgetServiceInterface::check()`** gained an optional `?LlmConfiguration` parameter — a signature change for third-party implementations of the interface (in-tree there is exactly one).
- Known, pre-existing and unchanged: the budget gate (middleware priority 75) runs outside the fallback middleware (50), so a fallback swap's caps are not pre-flight-checked — usage is recorded against the served configuration, so its cap engages on the next request. Cache hits bypass both scopes, as before. The gate remains best-effort under concurrency (no locking), same as the existing per-user scope.
- Perf: one additional SUM query per call, only when the dispatched configuration is persisted *and* has limits.

## Related Issue

Fixes #389

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — interface signature + newly enforced caps

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates via `Build/Scripts/runTests.sh` (unit 4964 tests / phpstan / cgl: SUCCESS; full functional suite on sqlite: 1143 tests SUCCESS)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
