### PR TITLE
feat: use model max output tokens and dimensions as call defaults

### DIFF
--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -521,9 +521,13 @@ class LlmConfiguration extends AbstractEntity
         $this->temperature = round(max(0.0, min(2.0, $temperature)), 2);
     }
 
+    /**
+     * 0 = no explicit limit — the resolved model's max_output_tokens
+     * (or the provider default) applies (#390).
+     */
     public function setMaxTokens(int $maxTokens): void
     {
-        $this->maxTokens = max(1, $maxTokens);
+        $this->maxTokens = max(0, $maxTokens);
     }
 
     public function setTopP(float $topP): void
@@ -688,7 +692,9 @@ class LlmConfiguration extends AbstractEntity
 
         return new ChatOptions(
             temperature: $this->temperature,
-            maxTokens: $this->maxTokens,
+            // 0 = unset — ChatOptions::validate() rejects non-positive
+            // max_tokens, so the unset state maps to null (#390).
+            maxTokens: $this->maxTokens > 0 ? $this->maxTokens : null,
             topP: $this->topP,
             frequencyPenalty: $this->frequencyPenalty,
             presencePenalty: $this->presencePenalty,
@@ -707,11 +713,16 @@ class LlmConfiguration extends AbstractEntity
     {
         $options = [
             'temperature' => $this->temperature,
-            'max_tokens' => $this->maxTokens,
             'top_p' => $this->topP,
             'frequency_penalty' => $this->frequencyPenalty,
             'presence_penalty' => $this->presencePenalty,
         ];
+
+        // 0 = unset — omit the key so the resolved model's
+        // max_output_tokens (or the provider default) applies (#390).
+        if ($this->maxTokens > 0) {
+            $options['max_tokens'] = $this->maxTokens;
+        }
 
         if ($this->systemPrompt !== '') {
             $options['system_prompt'] = $this->systemPrompt;

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -437,7 +437,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $configuration,
             ProviderOperation::Tools,
             function (LlmConfiguration $config) use ($normalisedMessages, $normalisedTools, $optionOverrides): CompletionResponse {
-                $adapter = $this->getAdapterFromConfiguration($config);
+                $llmModel = $this->resolveModelForConfiguration($config);
+                $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter instanceof ToolCapableInterface) {
                     throw new UnsupportedFeatureException(
                         sprintf('Provider "%s" does not support tool calling', $adapter->getIdentifier()),
@@ -445,8 +446,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                     );
                 }
 
-                $callOptions = array_merge($config->toOptionsArray(), $optionOverrides);
-                unset($callOptions['provider']);
+                $callOptions = $this->buildCallOptions($config, $llmModel, $optionOverrides);
 
                 return $adapter->chatCompletionWithTools(
                     $this->messageShaper->applySystemPrompt($normalisedMessages, $callOptions),
@@ -519,7 +519,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             ProviderCallContext::for(ProviderOperation::Embedding, $metadata),
             $configuration,
             function (LlmConfiguration $config) use ($input, $optionOverrides): array {
-                $adapter = $this->getAdapterFromConfiguration($config);
+                $llmModel = $this->resolveModelForConfiguration($config);
+                $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter->supportsFeature('embeddings')) {
                     throw new UnsupportedFeatureException(
                         sprintf('Provider "%s" does not support embeddings', $adapter->getIdentifier()),
@@ -527,8 +528,13 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                     );
                 }
 
-                $callOptions = array_merge($config->toOptionsArray(), $optionOverrides);
-                unset($callOptions['provider']);
+                $callOptions = $this->buildCallOptions($config, $llmModel, $optionOverrides);
+
+                // Embedding-only default: fill the vector size from the model
+                // when the caller's EmbeddingOptions left it unset (#390).
+                if (!isset($callOptions['dimensions']) && $llmModel->getDimensions() > 0) {
+                    $callOptions['dimensions'] = $llmModel->getDimensions();
+                }
 
                 return $adapter->embeddings($input, $callOptions)->toArray();
             },
@@ -591,6 +597,14 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     public function getAdapterFromConfiguration(LlmConfiguration $configuration): ProviderInterface
     {
+        return $this->adapterRegistry->createAdapterFromModel($this->resolveModelForConfiguration($configuration));
+    }
+
+    /**
+     * Resolve the concrete Model entity an LlmConfiguration call runs against.
+     */
+    private function resolveModelForConfiguration(LlmConfiguration $configuration): Model
+    {
         // Criteria-mode configurations carry no direct model relation (model_uid = 0);
         // their model is selected at call time from the stored criteria. Resolve
         // through ModelSelectionService — which returns the directly configured model
@@ -614,7 +628,32 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // one. Per-model cost analytics for criteria configs (UsageMiddleware
         // reads getLlmModel() directly) remain a separate, non-destructive
         // follow-up.
-        return $this->adapterRegistry->createAdapterFromModel($llmModel);
+        return $llmModel;
+    }
+
+    /**
+     * Merge a configuration's stored option defaults with per-call overrides
+     * and fill `max_tokens` from the resolved model when neither set it (#390).
+     *
+     * Precedence: explicit per-call option > configuration max_tokens (> 0)
+     * > model max_output_tokens (> 0) > provider default (4096 for
+     * OpenAI/Claude-shaped payloads; Ollama omits num_predict so the server
+     * default applies).
+     *
+     * @param array<string, mixed> $optionOverrides
+     *
+     * @return array<string, mixed>
+     */
+    private function buildCallOptions(LlmConfiguration $config, Model $model, array $optionOverrides): array
+    {
+        $options = array_merge($config->toOptionsArray(), $optionOverrides);
+        unset($options['provider']);
+
+        if (!isset($options['max_tokens']) && $model->getMaxOutputTokens() > 0) {
+            $options['max_tokens'] = $model->getMaxOutputTokens();
+        }
+
+        return $options;
     }
 
     /**
@@ -639,9 +678,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $configuration,
             ProviderOperation::Chat,
             function (LlmConfiguration $config) use ($normalisedMessages, $optionOverrides): CompletionResponse {
-                $adapter = $this->getAdapterFromConfiguration($config);
-                $options = array_merge($config->toOptionsArray(), $optionOverrides);
-                unset($options['provider']);
+                $llmModel = $this->resolveModelForConfiguration($config);
+                $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
+                $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
                 return $adapter->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $options), $options);
             },
             $metadata,
@@ -662,9 +701,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $configuration,
             ProviderOperation::Completion,
             function (LlmConfiguration $config) use ($prompt, $optionOverrides): CompletionResponse {
-                $adapter = $this->getAdapterFromConfiguration($config);
-                $options = array_merge($config->toOptionsArray(), $optionOverrides);
-                unset($options['provider']);
+                $llmModel = $this->resolveModelForConfiguration($config);
+                $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
+                $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
                 return $adapter->complete($prompt, $options);
             },
             $metadata,
@@ -887,11 +926,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = [], array $metadata = []): Generator
     {
         $open = function (LlmConfiguration $config) use ($messages, $optionOverrides): Generator {
-            $adapter = $this->getAdapterFromConfiguration($config);
-            $options = array_merge($config->toOptionsArray(), $optionOverrides);
-
-            // Remove provider key as we already have the adapter
-            unset($options['provider']);
+            $llmModel = $this->resolveModelForConfiguration($config);
+            $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
+            $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
 
             $this->assertStreamingCapable($adapter, 1735300101);
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -498,9 +498,16 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // different models never share entries. EmbedCacheKeyBuilder returns an
         // empty array for cache_ttl <= 0 (EmbeddingOptions::noCache()).
         $cacheTtl = is_int($optionOverrides['cache_ttl'] ?? null) ? $optionOverrides['cache_ttl'] : 0;
+        // Criteria-mode configurations have no direct model relation, so their
+        // getModelId() is '' — resolve the concrete model for the key in that
+        // case, or entries keyed under the empty id would be shared across
+        // whatever model the criteria select over time. Fixed-mode configs
+        // keep the relation's id without the extra resolution.
         $effectiveModel = is_string($optionOverrides['model'] ?? null)
             ? $optionOverrides['model']
-            : $configuration->getModelId();
+            : ($configuration->getModelId() !== ''
+                ? $configuration->getModelId()
+                : $this->resolveModelForConfiguration($configuration)->getModelId());
         // EmbedCacheKeyBuilder sanitizes the scope tag: configuration
         // identifiers use the dotted preset scheme (nr_ai_search.embeddings),
         // and the cache frontend rejects a tag containing a dot with an
@@ -649,8 +656,14 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $options = array_merge($config->toOptionsArray(), $optionOverrides);
         unset($options['provider']);
 
-        if (!isset($options['max_tokens']) && $model->getMaxOutputTokens() > 0) {
-            $options['max_tokens'] = $model->getMaxOutputTokens();
+        // An explicit non-positive max_tokens override means "unset" too —
+        // passing 0 through would fail provider-side validation.
+        if (!isset($options['max_tokens']) || (is_int($options['max_tokens']) && $options['max_tokens'] <= 0)) {
+            if ($model->getMaxOutputTokens() > 0) {
+                $options['max_tokens'] = $model->getMaxOutputTokens();
+            } else {
+                unset($options['max_tokens']);
+            }
         }
 
         return $options;

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -233,7 +233,9 @@ return [
                 'type' => 'number',
                 'size' => 10,
                 'range' => [
-                    'lower' => 1,
+                    // 0 = unset: fall back to the model's max output tokens
+                    // (or the provider default) — see #390.
+                    'lower' => 0,
                     'upper' => 128000,
                 ],
                 'default' => 1000,

--- a/Documentation/Configuration/ConfigFields.rst
+++ b/Documentation/Configuration/ConfigFields.rst
@@ -65,9 +65,14 @@ Optional
 .. confval:: max_tokens (config)
    :name: confval-config-max-tokens
    :type: integer
-   :Default: (model default)
+   :Default: 1000
 
-   Maximum response length in tokens.
+   Maximum response length in tokens. Set ``0``
+   to inherit the model's
+   :ref:`max_output_tokens <confval-model-max-output-tokens>`.
+   Precedence: per-call option > configuration
+   value (> 0) > model ``max_output_tokens``
+   (> 0) > provider default.
 
 .. confval:: top_p
    :name: confval-config-top-p

--- a/Documentation/Configuration/ModelFields.rst
+++ b/Documentation/Configuration/ModelFields.rst
@@ -67,9 +67,22 @@ Optional
 .. confval:: max_output_tokens
    :name: confval-model-max-output-tokens
    :type: integer
-   :Default: (model default)
+   :Default: 0 (unknown)
 
-   Maximum output tokens.
+   Maximum output tokens. Acts as the default
+   output cap for requests whose configuration
+   sets :ref:`max_tokens <confval-config-max-tokens>`
+   to ``0`` and whose caller sent no per-call
+   ``max_tokens`` option.
+
+.. confval:: dimensions
+   :name: confval-model-dimensions
+   :type: integer
+   :Default: 0 (unknown)
+
+   Embedding vector dimensionality. Acts as the
+   default vector size for embedding requests
+   whose options left ``dimensions`` unset.
 
 .. confval:: capabilities
    :name: confval-model-capabilities

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -175,7 +175,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_tokens.description">
                 <source>Maximum number of tokens in the response</source>
-                <target>Maximale Anzahl der Token in der Antwort</target>
+                <target>Maximale Anzahl der Token in der Antwort. 0 = die im Modell hinterlegten maximalen Ausgabe-Token (oder der Anbieter-Standard) gelten.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.top_p">
@@ -614,7 +614,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_model.max_output_tokens.description">
                 <source>Maximum output tokens per request (0 = unknown)</source>
-                <target>Maximale Ausgabe-Token pro Anfrage (0 = unbekannt)</target>
+                <target>Maximale Ausgabe-Token pro Anfrage (0 = unbekannt). Dient als Standard-Obergrenze für Anfragen, die selbst keine maximalen Token setzen.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.dimensions">
@@ -623,7 +623,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_model.dimensions.description">
                 <source>Embedding vector dimensionality of the model (0 = unknown)</source>
-                <target>Dimensionalität des Embedding-Vektors des Modells (0 = unbekannt)</target>
+                <target>Dimensionalität des Embedding-Vektors des Modells (0 = unbekannt). Dient als Standard-Vektorgröße für Embedding-Anfragen, die selbst keine Dimensionen setzen.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.capabilities">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -136,7 +136,7 @@
                 <source>Max Tokens</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_tokens.description">
-                <source>Limits how long the response can be. One token is roughly ¾ of a word in English — so 100 tokens ≈ 75 words, 1000 tokens ≈ 750 words, 4000 tokens ≈ a 3-page article. Set this to match your use case: 256 for short answers, 1000–2000 for summaries, 4000–8000 for full articles or translations. Higher values cost more — the model stops generating when it reaches this limit. The upper bound depends on the model (check the model's max output tokens).</source>
+                <source>Limits how long the response can be. One token is roughly ¾ of a word in English — so 100 tokens ≈ 75 words, 1000 tokens ≈ 750 words, 4000 tokens ≈ a 3-page article. Set this to match your use case: 256 for short answers, 1000–2000 for summaries, 4000–8000 for full articles or translations. Higher values cost more — the model stops generating when it reaches this limit. The upper bound depends on the model (check the model's max output tokens). Set 0 to use the model's configured max output tokens (or the provider default).</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.top_p">
@@ -477,14 +477,14 @@
                 <source>Max Output Tokens</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.max_output_tokens.description">
-                <source>Maximum output tokens per request (0 = unknown)</source>
+                <source>Maximum output tokens per request (0 = unknown). Used as the default output cap for requests that do not set max tokens themselves.</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.dimensions">
                 <source>Embedding Dimensions</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.dimensions.description">
-                <source>Embedding vector dimensionality of the model (0 = unknown)</source>
+                <source>Embedding vector dimensionality of the model (0 = unknown). Used as the default vector size for embedding requests that do not set dimensions themselves.</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_model.capabilities">

--- a/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
+++ b/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
@@ -341,14 +341,16 @@ class LlmConfigurationRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function maxTokensIsAtLeastOne(): void
+    public function maxTokensIsAtLeastZero(): void
     {
         $configuration = new LlmConfiguration();
 
+        // 0 = unset — the model's max_output_tokens (or the provider
+        // default) applies (#390).
         $configuration->setMaxTokens(0);
-        self::assertEquals(1, $configuration->getMaxTokens());
+        self::assertEquals(0, $configuration->getMaxTokens());
 
         $configuration->setMaxTokens(-100);
-        self::assertEquals(1, $configuration->getMaxTokens());
+        self::assertEquals(0, $configuration->getMaxTokens());
     }
 }

--- a/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
+++ b/Tests/Fuzzy/Domain/LlmConfigurationFuzzyTest.php
@@ -92,7 +92,7 @@ class LlmConfigurationFuzzyTest extends AbstractFuzzyTestCase
     }
 
     #[Test]
-    public function maxTokensIsAtLeastOne(): void
+    public function maxTokensIsAtLeastZero(): void
     {
         $this
             ->forAll(Generator\int()) // @phpstan-ignore function.notFound
@@ -102,8 +102,8 @@ class LlmConfigurationFuzzyTest extends AbstractFuzzyTestCase
 
                 $result = $config->getMaxTokens();
 
-                // Max tokens should be at least 1
-                $this->assertGreaterThanOrEqual(1, $result);
+                // Max tokens should be at least 0 (0 = no explicit limit)
+                $this->assertGreaterThanOrEqual(0, $result);
             });
     }
 

--- a/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
+++ b/Tests/Fuzzy/Security/InputSanitizationFuzzyTest.php
@@ -275,10 +275,11 @@ class InputSanitizationFuzzyTest extends AbstractFuzzyTestCase
                 $config->setMaxTokens($value);
 
                 $result = $config->getMaxTokens();
-                // setMaxTokens() clamps to a lower bound of 1 (no upper cap).
-                // Assert the exact contract for every boundary rather than a
-                // tautological >= 1 (which max(1, …) can never fail).
-                self::assertSame(max(1, $value), $result);
+                // setMaxTokens() clamps to a lower bound of 0 (0 = no explicit
+                // limit, no upper cap). Assert the exact contract for every
+                // boundary rather than a tautological >= 0 (which max(0, …)
+                // can never fail).
+                self::assertSame(max(0, $value), $result);
             });
     }
 

--- a/Tests/Unit/Domain/Model/LlmConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/LlmConfigurationTest.php
@@ -141,7 +141,7 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
     }
 
     // ========================================
-    // MaxTokens clamping (minimum 1)
+    // MaxTokens clamping (minimum 0; 0 = unset, #390)
     // ========================================
 
     #[Test]
@@ -152,17 +152,17 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function setMaxTokensClampsToOneForZero(): void
+    public function setMaxTokensStoresZeroAsUnset(): void
     {
         $this->subject->setMaxTokens(0);
-        self::assertSame(1, $this->subject->getMaxTokens());
+        self::assertSame(0, $this->subject->getMaxTokens());
     }
 
     #[Test]
-    public function setMaxTokensClampsToOneForNegative(): void
+    public function setMaxTokensClampsToZeroForNegative(): void
     {
         $this->subject->setMaxTokens(-100);
-        self::assertSame(1, $this->subject->getMaxTokens());
+        self::assertSame(0, $this->subject->getMaxTokens());
     }
 
     // ========================================
@@ -596,6 +596,15 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
         self::assertNull($options->getModel());
     }
 
+    #[Test]
+    public function toChatOptionsMapsZeroMaxTokensToNull(): void
+    {
+        $this->subject->setMaxTokens(0);
+        $options = $this->subject->toChatOptions();
+
+        self::assertNull($options->getMaxTokens());
+    }
+
     // ========================================
     // toOptionsArray
     // ========================================
@@ -611,6 +620,25 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
         self::assertArrayHasKey('frequency_penalty', $options);
         self::assertArrayHasKey('presence_penalty', $options);
         self::assertArrayHasKey('timeout', $options);
+    }
+
+    #[Test]
+    public function toOptionsArrayOmitsMaxTokensWhenZero(): void
+    {
+        $this->subject->setMaxTokens(0);
+        $options = $this->subject->toOptionsArray();
+
+        self::assertArrayNotHasKey('max_tokens', $options);
+    }
+
+    #[Test]
+    public function toOptionsArrayIncludesMaxTokensWhenPositive(): void
+    {
+        $this->subject->setMaxTokens(2000);
+        $options = $this->subject->toOptionsArray();
+
+        self::assertArrayHasKey('max_tokens', $options);
+        self::assertSame(2000, $options['max_tokens']);
     }
 
     #[Test]

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -885,6 +885,46 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     /**
+     * An explicit per-call max_tokens of 0 means "unset" like everywhere
+     * else in the #390 contract — it must fall through to the model default
+     * instead of sending a 0 the provider API would reject.
+     */
+    #[Test]
+    public function chatWithConfigurationZeroOverrideFallsBackToModelDefault(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['max_tokens' => 2000]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
+                ['max_tokens' => 8192],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config, [], ['max_tokens' => 0]);
+    }
+
+    /**
      * Neither configuration nor model define a cap → no max_tokens key is
      * sent, so the provider's own hardcoded default applies (#390 tier 4).
      */

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -767,6 +767,190 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         );
     }
 
+    /**
+     * When the configuration emits no max_tokens (stored value 0 = unset),
+     * the resolved model's max_output_tokens fills the gap (#390).
+     */
+    #[Test]
+    public function chatWithConfigurationUsesModelMaxOutputTokensWhenConfigurationUnset(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['temperature' => 0.7]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
+                ['temperature' => 0.7, 'max_tokens' => 8192],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config);
+    }
+
+    /**
+     * A configuration's stored max_tokens (> 0) wins over the model's
+     * max_output_tokens (#390 precedence, tier 2 over tier 3).
+     */
+    #[Test]
+    public function chatWithConfigurationConfigurationMaxTokensWinsOverModelDefault(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['max_tokens' => 2000]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
+                ['max_tokens' => 2000],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config);
+    }
+
+    /**
+     * An explicit per-call max_tokens override wins over both the
+     * configuration and the model (#390 precedence, tier 1).
+     */
+    #[Test]
+    public function chatWithConfigurationExplicitOverrideWinsOverConfigurationAndModel(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['max_tokens' => 2000]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
+                ['max_tokens' => 500],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config, [], ['max_tokens' => 500]);
+    }
+
+    /**
+     * Neither configuration nor model define a cap → no max_tokens key is
+     * sent, so the provider's own hardcoded default applies (#390 tier 4).
+     */
+    #[Test]
+    public function chatWithConfigurationSendsNoMaxTokensWhenNothingConfigured(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(0);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['temperature' => 0.7]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'ok',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                [ChatMessage::fromArray(['role' => 'user', 'content' => 'Hello'])],
+                ['temperature' => 0.7],
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config);
+    }
+
+    /**
+     * The tool-calling closure applies the same model default (#390).
+     */
+    #[Test]
+    public function chatWithToolsForConfigurationUsesModelMaxOutputTokensWhenConfigurationUnset(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['temperature' => 0.7]);
+
+        $toolProvider = new TestableToolProvider();
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($toolProvider);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->chatWithToolsForConfiguration(
+            [['role' => 'user', 'content' => 'Hello']],
+            [new ToolSpec(name: 'echo', description: 'echoes input', parameters: [])],
+            $config,
+        );
+
+        self::assertSame(8192, $toolProvider->getLastOptions()['max_tokens']);
+    }
+
     #[Test]
     public function completeWithConfigurationUsesAdapter(): void
     {
@@ -885,6 +1069,131 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         // Per-call options win over the configuration's stored model id.
         self::assertSame('override-model', $capturedOptions['model']);
+    }
+
+    /**
+     * When the caller's EmbeddingOptions leave dimensions unset, the resolved
+     * model's dimensions fill the gap (#390).
+     */
+    #[Test]
+    public function embedForConfigurationUsesModelDimensionsWhenOptionsUnset(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getDimensions')->willReturn(1024);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('embed-config');
+        $config->method('getModelId')->willReturn('text-embedding-3-small');
+        $config->method('toOptionsArray')->willReturn(['model' => 'text-embedding-3-small']);
+
+        $capturedOptions = [];
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('supportsFeature')->willReturnCallback(
+            static fn(string $feature): bool => $feature === 'embeddings',
+        );
+        $mockAdapter->method('embeddings')->willReturnCallback(
+            function (string|array $input, array $options) use (&$capturedOptions): EmbeddingResponse {
+                $capturedOptions = $options;
+                return new EmbeddingResponse(
+                    embeddings: [[0.1]],
+                    model: 'text-embedding-3-small',
+                    usage: new UsageStatistics(1, 0, 1),
+                    provider: 'openai',
+                );
+            },
+        );
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->embedForConfiguration('text', $config);
+
+        self::assertSame(1024, $capturedOptions['dimensions']);
+    }
+
+    /**
+     * Explicit per-call dimensions win over the model's dimensions (#390).
+     */
+    #[Test]
+    public function embedForConfigurationExplicitDimensionsWinOverModel(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getDimensions')->willReturn(1024);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('embed-config');
+        $config->method('getModelId')->willReturn('text-embedding-3-small');
+        $config->method('toOptionsArray')->willReturn(['model' => 'text-embedding-3-small']);
+
+        $capturedOptions = [];
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('supportsFeature')->willReturnCallback(
+            static fn(string $feature): bool => $feature === 'embeddings',
+        );
+        $mockAdapter->method('embeddings')->willReturnCallback(
+            function (string|array $input, array $options) use (&$capturedOptions): EmbeddingResponse {
+                $capturedOptions = $options;
+                return new EmbeddingResponse(
+                    embeddings: [[0.1]],
+                    model: 'text-embedding-3-small',
+                    usage: new UsageStatistics(1, 0, 1),
+                    provider: 'openai',
+                );
+            },
+        );
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->embedForConfiguration('text', $config, new EmbeddingOptions(dimensions: 256));
+
+        self::assertSame(256, $capturedOptions['dimensions']);
+    }
+
+    /**
+     * No per-call dimensions and no model dimensions (0 = unknown) → the key
+     * stays absent so the provider/model native default applies (#390).
+     */
+    #[Test]
+    public function embedForConfigurationOmitsDimensionsWhenModelUnset(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getDimensions')->willReturn(0);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('embed-config');
+        $config->method('getModelId')->willReturn('text-embedding-3-small');
+        $config->method('toOptionsArray')->willReturn(['model' => 'text-embedding-3-small']);
+
+        $capturedOptions = [];
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('supportsFeature')->willReturnCallback(
+            static fn(string $feature): bool => $feature === 'embeddings',
+        );
+        $mockAdapter->method('embeddings')->willReturnCallback(
+            function (string|array $input, array $options) use (&$capturedOptions): EmbeddingResponse {
+                $capturedOptions = $options;
+                return new EmbeddingResponse(
+                    embeddings: [[0.1]],
+                    model: 'text-embedding-3-small',
+                    usage: new UsageStatistics(1, 0, 1),
+                    provider: 'openai',
+                );
+            },
+        );
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $manager->embedForConfiguration('text', $config);
+
+        self::assertArrayNotHasKey('dimensions', $capturedOptions);
     }
 
     #[Test]
@@ -1359,6 +1668,30 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             ],
             $adapter->capturedMessages,
         );
+    }
+
+    /**
+     * The streaming opener applies the same model max_tokens default (#390).
+     */
+    #[Test]
+    public function streamChatWithConfigurationUsesModelMaxOutputTokensWhenConfigurationUnset(): void
+    {
+        $model = self::createStub(Model::class);
+        $model->method('getMaxOutputTokens')->willReturn(8192);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn(['temperature' => 0.5]);
+
+        $adapter = new StubStreamingProvider();
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($adapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        iterator_to_array($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config));
+
+        self::assertSame(8192, $adapter->capturedOptions['max_tokens']);
     }
 
     #[Test]


### PR DESCRIPTION
## Description

`Model::getMaxOutputTokens()` and `Model::getDimensions()` — both operator-settable on the Model record — had zero production callers. Setting them changed nothing.

They are now wired as **defaults-when-unset** at the point where the resolved model and the call options meet (`LlmServiceManager`): a new `resolveModelForConfiguration()` (criteria-mode aware) + `buildCallOptions()` used by the five `*WithConfiguration` paths.

- **`max_tokens` precedence:** per-call option > configuration `max_tokens` (> 0) > model `max_output_tokens` (> 0) > provider default.
- **`dimensions`:** `embedForConfiguration()` fills `dimensions` from the model when the caller left it unset (explicit options still win); embedding path only.
- To make "unset" expressible, `LlmConfiguration::setMaxTokens()`'s clamp floor moved from 1 to 0 and the TCA range lower is now 0 — `0` means "no explicit limit". Existing data is unaffected: every stored record has `max_tokens >= 1` (old clamp + old TCA lower bound) and new records keep the default 1000. The model default engages only after an operator explicitly sets the field to 0.

Flagged, deliberately not touched: `ConfigurationController::testAction()` bypasses `buildCallOptions()` (backend test button uses the provider default for `max_tokens = 0`); the setup/task wizards still clamp written `maxTokens` to ≥ 1.

## Related Issue

Fixes #390

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates via `Build/Scripts/runTests.sh` (unit 4968 tests / phpstan / cgl: SUCCESS; full functional suite on sqlite: 1140 tests SUCCESS)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
