### PR TITLE
fix(provider): send OpenAI-Organization and options customHeaders on requests

### DIFF
--- a/Classes/Domain/DTO/ProviderOptions.php
+++ b/Classes/Domain/DTO/ProviderOptions.php
@@ -20,8 +20,9 @@ use JsonSerializable;
  * adapter-extras that go BEYOND the typed entity columns
  * (`api_key`, `endpoint_url`, `api_timeout`, `max_retries`,
  * `organization_id`). The placeholder shipped in TCA is
- * `{"custom_header": "value"}` and real test fixtures use `proxy`,
- * `custom_param`, etc., so the field is genuinely open-ended.
+ * `{"customHeaders": {"X-Custom-Header": "value"}}` and real test
+ * fixtures use `proxy`, `custom_param`, etc., so the field is genuinely
+ * open-ended.
  *
  * That open-endedness is why slices 16e/16f initially stopped at the
  * `array<string, mixed>` surface. This slice walks the rest of the way:
@@ -29,6 +30,14 @@ use JsonSerializable;
  * `customHeaders`) and everything else flows through `$extra` as
  * `array<string, mixed>` — same permissive shape callers already see
  * via `Provider::getOptionsArray()`, just behind a typed accessor.
+ *
+ * Wiring status: `customHeaders` is consumed by
+ * `AbstractProvider::configure()` and sent on every outgoing API request
+ * (including streaming). `proxy` is NOT applied per provider — proxy
+ * routing is controlled globally via
+ * `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']` or the HTTP(S)_PROXY
+ * environment variables (nr-vault's SecureHttpClientFactory); the key is
+ * preserved here for round-trip only.
  *
  * The DTO is the typed application-level surface; the entity still
  * persists JSON to keep Extbase property mapping working unchanged
@@ -47,8 +56,10 @@ final readonly class ProviderOptions implements JsonSerializable
 {
     /**
      * @param string|null           $proxy         HTTP proxy URL (e.g. `http://proxy.example.com:3128`).
-     *                                             Null means "no proxy override" — the adapter uses its
-     *                                             process-default routing.
+     *                                             Currently not applied to outgoing provider requests
+     *                                             (per-provider proxy is not supported by the vault HTTP
+     *                                             client); configure a proxy globally via TYPO3's HTTP
+     *                                             settings. Preserved for round-trip only.
      * @param array<string, string> $customHeaders Extra HTTP headers to send on every API call.
      *                                             Keys are header names, values are header values.
      *                                             Both must be strings; non-string values are dropped

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -473,7 +473,11 @@ abstract class AbstractProvider implements ProviderInterface
 
         $headers = [];
         foreach ($raw as $name => $value) {
-            if (!is_string($name) || preg_match('/^[A-Za-z0-9!#$%&\'*+.^_`|~-]+$/', $name) !== 1) {
+            // PHP casts numeric-string array keys ("123") to int on decode;
+            // cast back so such names reach the token check instead of being
+            // dropped for not being strings.
+            $name = (string)$name;
+            if (preg_match('/^[A-Za-z0-9!#$%&\'*+.^_`|~-]+$/', $name) !== 1) {
                 continue;
             }
 

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -60,6 +60,10 @@ abstract class AbstractProvider implements ProviderInterface
     protected string $defaultModel = '';
     protected int $timeout = 120;
     protected int $maxRetries = 3;
+    protected string $organizationId = '';
+
+    /** @var array<string, string> */
+    protected array $customHeaders = [];
 
     /** @var array<string> */
     protected array $supportedFeatures = [];
@@ -88,6 +92,8 @@ abstract class AbstractProvider implements ProviderInterface
         $this->defaultModel = $this->getString($config, 'defaultModel', $this->getDefaultModel());
         $this->timeout = $this->getInt($config, 'timeout', 120);
         $this->maxRetries = $this->getInt($config, 'maxRetries', 3);
+        $this->organizationId = $this->getString($config, 'organizationId');
+        $this->customHeaders = $this->extractCustomHeaders($config);
 
         // Reset HTTP client when configuration changes
         $this->configuredHttpClient = null;
@@ -286,6 +292,7 @@ abstract class AbstractProvider implements ProviderInterface
             ->withHeader('Content-Type', 'application/json');
 
         $request = $this->addProviderSpecificHeaders($request);
+        $request = $this->applyCustomHeaders($request);
 
         if ($method === 'POST' && $payload !== []) {
             // JSON_INVALID_UTF8_SUBSTITUTE: a request payload carrying an invalid
@@ -426,6 +433,58 @@ abstract class AbstractProvider implements ProviderInterface
     protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
     {
         return $request;
+    }
+
+    /**
+     * Apply operator-configured custom headers (options JSON `customHeaders`)
+     * to an outgoing request. Applied after addProviderSpecificHeaders(), so
+     * on a name collision the operator's value wins (withHeader replaces).
+     * Authentication cannot be overridden on authenticated providers: the
+     * vault HTTP client injects the Authorization/api-key header at send
+     * time, after these headers are set.
+     */
+    protected function applyCustomHeaders(RequestInterface $request): RequestInterface
+    {
+        foreach ($this->customHeaders as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
+    }
+
+    /**
+     * Extract and sanitize the `customHeaders` map from the provider config.
+     * Entries with a non-string value, a name that is not a valid RFC 7230
+     * token, or a value containing CR/LF are dropped: a malformed entry from
+     * a hand-edited options row must not throw from PSR-7 withHeader() and
+     * break every request, and the CR/LF guard blocks header injection from
+     * the DB field.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, string>
+     */
+    private function extractCustomHeaders(array $config): array
+    {
+        $raw = $config['customHeaders'] ?? null;
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $headers = [];
+        foreach ($raw as $name => $value) {
+            if (!is_string($name) || preg_match('/^[A-Za-z0-9!#$%&\'*+.^_`|~-]+$/', $name) !== 1) {
+                continue;
+            }
+
+            if (!is_string($value) || str_contains($value, "\r") || str_contains($value, "\n")) {
+                continue;
+            }
+
+            $headers[$name] = $value;
+        }
+
+        return $headers;
     }
 
     /**

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -505,6 +505,10 @@ final class ClaudeProvider extends AbstractProvider implements
             ->withHeader('anthropic-version', self::API_VERSION)
             ->withHeader('Accept', 'text/event-stream');
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -504,6 +504,10 @@ final class GeminiProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -285,6 +285,10 @@ final class GroqProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -314,6 +314,10 @@ final class MistralProvider extends AbstractProvider implements
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -486,6 +486,10 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json');
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Psr\Http\Message\RequestInterface;
 
 #[AsLlmProvider(priority: 100)]
 final class OpenAiProvider extends AbstractProvider implements
@@ -63,6 +64,22 @@ final class OpenAiProvider extends AbstractProvider implements
     public function getDefaultModel(): string
     {
         return $this->defaultModel !== '' ? $this->defaultModel : self::DEFAULT_CHAT_MODEL;
+    }
+
+    /**
+     * Send the configured organization ID as the `OpenAI-Organization`
+     * request header. This also serves the azure_openai, together,
+     * fireworks, perplexity and custom adapter types, which all map to
+     * this provider class — OpenAI-compatible APIs ignore the header
+     * when it does not apply.
+     */
+    protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
+    {
+        if ($this->organizationId !== '') {
+            $request = $request->withHeader('OpenAI-Organization', $this->organizationId);
+        }
+
+        return $request;
     }
 
     /**
@@ -360,6 +377,10 @@ final class OpenAiProvider extends AbstractProvider implements
         $request = $this->requestFactory->createRequest('POST', $url)
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'text/event-stream');
+
+        // Streaming bypasses sendRequest(), so both the organization header
+        // and operator-configured custom headers must be applied here.
+        $request = $this->applyCustomHeaders($this->addProviderSpecificHeaders($request));
 
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -651,6 +651,10 @@ final class OpenRouterProvider extends AbstractProvider implements
             $request = $request->withHeader('X-Title', $this->appName);
         }
 
+        // Streaming bypasses sendRequest(), so operator-configured custom
+        // headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
 
         return $request->withBody($body);
@@ -889,6 +893,10 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($this->appName !== '') {
             $request = $request->withHeader('X-Title', $this->appName);
         }
+
+        // This non-streaming path bypasses AbstractProvider::sendRequest(),
+        // so operator-configured custom headers must be applied here.
+        $request = $this->applyCustomHeaders($request);
 
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);

--- a/Configuration/TCA/tx_nrllm_provider.php
+++ b/Configuration/TCA/tx_nrllm_provider.php
@@ -187,7 +187,7 @@ return [
                 'cols' => 60,
                 'rows' => 5,
                 'trim' => true,
-                'placeholder' => '{"custom_header": "value"}',
+                'placeholder' => '{"customHeaders": {"X-Custom-Header": "value"}}',
             ],
         ],
         'is_active' => [

--- a/Documentation/Configuration/ProviderFields.rst
+++ b/Documentation/Configuration/ProviderFields.rst
@@ -82,7 +82,9 @@ Optional
    :type: string
    :Default: (empty)
 
-   Organization ID (OpenAI, Azure).
+   Organization ID (OpenAI, Azure). Sent as the `OpenAI-Organization`
+   request header by the OpenAI-compatible adapters (`openai`,
+   `azure_openai`, `together`, `fireworks`, `perplexity`, `custom`).
 
 .. confval:: timeout
    :name: confval-provider-timeout
@@ -105,4 +107,22 @@ Optional
    :type: JSON
    :Default: {}
 
-   Additional adapter-specific options.
+   Additional adapter-specific options. Supported key:
+
+   `customHeaders`
+      Object mapping header names to values, sent on every API request
+      (including streaming), for example:
+
+      .. code-block:: json
+
+         {"customHeaders": {"X-Custom-Header": "value"}}
+
+      Custom headers are applied after the adapter's own headers, so a
+      colliding name overrides the adapter value — a mistyped
+      `Content-Type` breaks that provider's calls.
+
+   .. note::
+
+      A per-provider `proxy` is not supported; TYPO3's global HTTP proxy
+      configuration (`$GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']`)
+      applies to all outgoing provider requests.

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -492,8 +492,8 @@
                 <target>Zusätzliche Optionen</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.options.description">
-                <source>Additional provider-specific options as JSON</source>
-                <target>Zusätzliche anbieterspezifische Optionen als JSON</target>
+                <source>Additional provider-specific options as JSON. Supported: {"customHeaders": {"X-Custom-Header": "value"}} to send extra HTTP headers.</source>
+                <target>Zusätzliche anbieterspezifische Optionen als JSON. Unterstützt: {"customHeaders": {"X-Custom-Header": "value"}} für zusätzliche HTTP-Header.</target>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.is_active">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -382,7 +382,7 @@
                 <source>Additional Options</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.options.description">
-                <source>Additional provider-specific options as JSON</source>
+                <source>Additional provider-specific options as JSON. Supported: {"customHeaders": {"X-Custom-Header": "value"}} to send extra HTTP headers.</source>
             </trans-unit>
 
             <trans-unit id="tx_nrllm_provider.is_active">

--- a/Tests/Unit/Provider/AbstractProviderConfigureTest.php
+++ b/Tests/Unit/Provider/AbstractProviderConfigureTest.php
@@ -134,6 +134,152 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function configureReadsOrganizationId(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'organizationId' => 'org-abc123',
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $organizationId = $reflection->getProperty('organizationId');
+
+        self::assertEquals('org-abc123', $organizationId->getValue($provider));
+    }
+
+    #[Test]
+    public function configureDefaultsOrganizationIdToEmptyString(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $organizationId = $reflection->getProperty('organizationId');
+
+        self::assertEquals('', $organizationId->getValue($provider));
+    }
+
+    #[Test]
+    public function configureReadsCustomHeadersMap(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'customHeaders' => ['X-A' => '1', 'X-B' => '2'],
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $customHeaders = $reflection->getProperty('customHeaders');
+
+        self::assertEquals(['X-A' => '1', 'X-B' => '2'], $customHeaders->getValue($provider));
+    }
+
+    #[Test]
+    public function configureDefaultsCustomHeadersToEmptyArray(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $customHeaders = $reflection->getProperty('customHeaders');
+
+        self::assertSame([], $customHeaders->getValue($provider));
+    }
+
+    #[Test]
+    public function configureDropsInvalidCustomHeaderEntries(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'customHeaders' => [
+                'X-Valid'           => 'ok',
+                'X-Int-Value'       => 42,
+                'X Space Name'      => 'dropped',
+                'X-Invalid-(Name)'  => 'dropped',
+                'X-Crlf-Value'      => "evil\r\nInjected: yes",
+                'X-Also-Valid'      => 'kept',
+            ],
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $customHeaders = $reflection->getProperty('customHeaders');
+
+        self::assertSame(
+            ['X-Valid' => 'ok', 'X-Also-Valid' => 'kept'],
+            $customHeaders->getValue($provider),
+        );
+    }
+
+    #[Test]
+    public function configureIgnoresNonArrayCustomHeaders(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'customHeaders' => 'not-an-array',
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        $customHeaders = $reflection->getProperty('customHeaders');
+
+        self::assertSame([], $customHeaders->getValue($provider));
+    }
+
+    #[Test]
     public function configureUsesProvidedBaseUrl(): void
     {
         $provider = new GeminiProvider(

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -735,6 +735,42 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function sendRequestAppliesConfiguredCustomHeaders(): void
+    {
+        $capturedRequest = null;
+        $httpFactory = new HttpFactory();
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest) {
+                $capturedRequest = $request;
+
+                return $this->createJsonResponseMock(['ok' => true]);
+            });
+
+        $provider = new GeminiProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'customHeaders' => ['X-Custom-Header' => 'custom-value'],
+        ]);
+        $provider->setHttpClient($httpClient);
+
+        $reflection = new ReflectionClass($provider);
+        $method = $reflection->getMethod('sendRequest');
+        $method->invoke($provider, '/test', ['key' => 'value']);
+
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertSame('custom-value', $capturedRequest->getHeaderLine('X-Custom-Header'));
+    }
+
+    #[Test]
     public function sendRequestErrorMessageContainsRetryCount(): void
     {
         $httpClient = self::createStub(ClientInterface::class);

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
@@ -148,6 +149,51 @@ class ClaudeProviderTest extends AbstractUnitTestCase
         self::assertEquals('Claude response content', $result->content);
         self::assertEquals('claude-sonnet-4-20250514', $result->model);
         self::assertEquals('stop', $result->finishReason);
+    }
+
+    #[Test]
+    public function sendRequestKeepsProviderHeadersAlongsideCustomHeaders(): void
+    {
+        $capturedRequest = null;
+        $httpFactory = new HttpFactory();
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest): ResponseInterface {
+                $capturedRequest = $request;
+
+                return $this->createJsonResponseMock([
+                    'id' => 'msg_test',
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [['type' => 'text', 'text' => 'ok']],
+                    'model' => 'claude-sonnet-4-20250514',
+                    'stop_reason' => 'end_turn',
+                    'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+                ]);
+            });
+
+        $subject = new ClaudeProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'customHeaders' => ['X-Custom-Header' => 'custom-value'],
+        ]);
+        $subject->setHttpClient($httpClient);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'hi']]);
+
+        // Custom headers must not clobber provider-specific headers with
+        // different names: both must be present on the outgoing request.
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertNotSame('', $capturedRequest->getHeaderLine('anthropic-version'));
+        self::assertSame('custom-value', $capturedRequest->getHeaderLine('X-Custom-Header'));
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
@@ -1716,6 +1717,133 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         self::assertTrue($payload['stream']);
         self::assertArrayHasKey('temperature', $payload);
         self::assertSame(0.7, $payload['temperature']);
+    }
+
+    // ===== Organization ID and custom headers =====
+
+    /**
+     * Build a provider with real PSR-7 factories and a client stub that
+     * captures the outgoing request, so headers are inspectable.
+     *
+     * @param array<string, mixed> $config Extra configure() keys
+     */
+    private function createHeaderCapturingProvider(array $config, ?RequestInterface &$capturedRequest): OpenAiProvider
+    {
+        $httpFactory = new HttpFactory();
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest): ResponseInterface {
+                $capturedRequest = $request;
+
+                return $this->createJsonResponseMock([
+                    'id' => 'chatcmpl-test',
+                    'object' => 'chat.completion',
+                    'created' => time(),
+                    'model' => 'gpt-4o',
+                    'choices' => [
+                        [
+                            'index' => 0,
+                            'message' => ['role' => 'assistant', 'content' => 'ok'],
+                            'finish_reason' => 'stop',
+                        ],
+                    ],
+                    'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+                ]);
+            });
+
+        $subject = new OpenAiProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure(array_merge([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+        ], $config));
+        $subject->setHttpClient($httpClient);
+
+        return $subject;
+    }
+
+    #[Test]
+    public function chatCompletionSendsOpenAiOrganizationHeaderWhenConfigured(): void
+    {
+        $capturedRequest = null;
+        $subject = $this->createHeaderCapturingProvider(['organizationId' => 'org-abc123'], $capturedRequest);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'hi']]);
+
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertSame('org-abc123', $capturedRequest->getHeaderLine('OpenAI-Organization'));
+    }
+
+    #[Test]
+    public function chatCompletionOmitsOrganizationHeaderWhenUnset(): void
+    {
+        $capturedRequest = null;
+        $subject = $this->createHeaderCapturingProvider([], $capturedRequest);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'hi']]);
+
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertFalse($capturedRequest->hasHeader('OpenAI-Organization'));
+    }
+
+    #[Test]
+    public function streamChatCompletionSendsOrganizationAndCustomHeaders(): void
+    {
+        $capturedRequest = null;
+        $httpFactory = new HttpFactory();
+
+        $subject = new OpenAiProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'gpt-4o',
+            'organizationId' => 'org-abc123',
+            'customHeaders' => ['X-Custom-Header' => 'v1'],
+        ]);
+
+        $responseStream = self::createStub(StreamInterface::class);
+        $eofCallCount = 0;
+        $responseStream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
+            return ++$eofCallCount > 1;
+        });
+        $responseStream->method('read')->willReturn("data: [DONE]\n\n");
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($responseStream);
+
+        $httpClient = $this->createHttpClientMock();
+        $httpClient->method('sendRequest')->willReturnCallback(
+            function (RequestInterface $request) use (&$capturedRequest, $response): ResponseInterface {
+                $capturedRequest = $request;
+
+                return $response;
+            },
+        );
+        $subject->setHttpClient($httpClient);
+
+        foreach ($subject->streamChatCompletion([['role' => 'user', 'content' => 'hi']]) as $ignored) {
+            // Drain the generator so the request is built and dispatched.
+            unset($ignored);
+        }
+
+        // The streaming path bypasses sendRequest(), so this proves the
+        // streaming request builder applies both header sources itself.
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertSame('org-abc123', $capturedRequest->getHeaderLine('OpenAI-Organization'));
+        self::assertSame('v1', $capturedRequest->getHeaderLine('X-Custom-Header'));
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
@@ -218,6 +219,59 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertEquals('OpenRouter response', $result->content);
         self::assertEquals('anthropic/claude-3.5-sonnet', $result->model);
+    }
+
+    #[Test]
+    public function chatCompletionSendsCustomHeaders(): void
+    {
+        $capturedRequest = null;
+        $httpFactory = new HttpFactory();
+
+        $httpClient = self::createStub(ClientInterface::class);
+        $httpClient
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest): ResponseInterface {
+                $capturedRequest = $request;
+
+                return $this->createJsonResponseMock([
+                    'id' => 'gen-test',
+                    'model' => 'anthropic/claude-3.5-sonnet',
+                    'choices' => [
+                        [
+                            'index' => 0,
+                            'message' => ['role' => 'assistant', 'content' => 'ok'],
+                            'finish_reason' => 'stop',
+                        ],
+                    ],
+                    'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+                ]);
+            });
+
+        $subject = new OpenRouterProvider(
+            $httpFactory,
+            $httpFactory,
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel' => 'anthropic/claude-3.5-sonnet',
+            'siteUrl' => 'https://example.com',
+            'appName' => 'Test App',
+            'customHeaders' => ['X-Custom-Header' => 'custom-value'],
+        ]);
+        $subject->setHttpClient($httpClient);
+
+        $subject->chatCompletion([['role' => 'user', 'content' => 'hi']]);
+
+        // OpenRouter chat goes through the private sendOpenRouterRequest(),
+        // which bypasses AbstractProvider::sendRequest() — the custom header
+        // must be applied there, and the attribution headers must survive.
+        self::assertInstanceOf(RequestInterface::class, $capturedRequest);
+        self::assertSame('custom-value', $capturedRequest->getHeaderLine('X-Custom-Header'));
+        self::assertSame('https://example.com', $capturedRequest->getHeaderLine('HTTP-Referer'));
+        self::assertSame('Test App', $capturedRequest->getHeaderLine('X-Title'));
     }
 
     #[Test]


### PR DESCRIPTION
> **Stacked on #400** (`fix/provider-timeout-and-retries`) — both change `AbstractProvider` and the 7 provider subclasses. Merge #400 first; this PR retargets to `main` automatically when #400's branch is deleted.

## Description

`AbstractProvider::configure()` consumed a fixed 5-key whitelist and silently dropped everything else. Two operator-facing controls never reached any request:

- **Organization ID** (`tx_nrllm_provider.organization_id`): now stored by `configure()` and emitted as the `OpenAI-Organization` header via `OpenAiProvider::addProviderSpecificHeaders()`. `OpenAiProvider` also serves the `azure_openai`, `together`, `fireworks`, `perplexity` and `custom` adapter types, so a filled field sends the header there too — OpenAI-compatible APIs ignore it (documented in the RST).
- **`options.customHeaders`**: applied on all request paths — `sendRequest()`, the 7 per-provider streaming builders, and OpenRouter's non-streaming helper. Applied *after* provider-specific headers, so an operator can deliberately override e.g. `anthropic-version` (RST warns that a mistyped `Content-Type` breaks that provider). `Authorization` cannot be hijacked on authenticated providers — the vault client injects it at send time, after these headers. Malformed entries (non-token name, non-string value, CR/LF) are dropped at `configure()` time — the CR/LF guard also blocks header injection from the DB field.
- **`options.proxy` is NOT implemented** — nr-vault's `SecureHttpClientFactory` exposes no per-client proxy option. The `ProviderOptions` docblock now states the key is round-trip-only and the global TYPO3 HTTP proxy applies.
- The shipped TCA placeholder changed from the never-working `{"custom_header": "value"}` to `{"customHeaders": {"X-Custom-Header": "value"}}` (EN/DE XLF + RST updated).

## Related Issue

Fixes #388

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates via `Build/Scripts/runTests.sh` (unit 4972 tests / phpstan / cgl: SUCCESS; no functional surface touched — CI authoritative)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
