### PR TITLE
chore: release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-16
+
+Closes out the operator-config audit: every backend-visible provider/model/configuration
+setting now either works or is gone. Three breaking changes — see below.
+
+> Note: version 0.19.1 was prepared but never tagged; its two fixes first ship in this
+> release.
+
+### Added
+
+- **Per-configuration daily limits are now enforced** (#389). The Configuration record's
+  *Max requests / tokens / cost per day* fields were stored but never consulted;
+  `BudgetService` now aggregates the dispatched configuration's current-day usage from
+  `tx_nrllm_service_usage` and denies requests once a cap is exhausted, in addition to
+  the existing per-user budget — most restrictive wins. Callers without a backend user
+  (CLI, scheduler, frontend) are gated by configuration caps too, where they previously
+  bypassed budgeting entirely.
+- **Model limits act as call defaults** (#390). A model's *Max output tokens* becomes the
+  effective `max_tokens` when neither the call options nor the configuration set one
+  (precedence: per-call option > configuration > model > provider default), and an
+  embedding model's *Dimensions* fills `EmbeddingOptions` when the caller left it unset.
+- **Organization ID and custom headers are now sent** (#388). The provider's
+  *Organization ID* is emitted as the `OpenAI-Organization` header (OpenAI-compatible
+  adapter types included), and `options.customHeaders` is applied on every request path
+  — streaming builders included — with header names/values sanitized (CR/LF-injection
+  guarded). The `options.proxy` key is documented as not implemented; the global TYPO3
+  HTTP proxy applies.
+- **Upgrade wizard `nrLlm_providerApiTimeout120`** migrates provider rows persisted at
+  the old `api_timeout` default of 30 to the new default 120 (part of #384).
+
+### Changed
+
+- **BREAKING: `api_timeout` is applied as a total-response timeout** (#384). The field
+  was write-only, so every provider request ran unbounded (TYPO3's default HTTP timeout
+  of 0) and a silent provider could pin a PHP-FPM worker indefinitely. Requests are now
+  bounded by the per-request `timeout` option (from the configuration's effective
+  timeout, ≥ 120s by default) with the provider's `api_timeout` as fallback; the default
+  moves 30 → 120; timed-out requests are not retried; streaming aborts at the same total
+  timeout. Calls that legitimately run longer need a raised configuration/model timeout.
+- **BREAKING: `max_retries` counts retries after the initial attempt** (#387). `0` now
+  sends exactly one request (previously: zero requests failing with *"after 0 attempts:
+  Unknown error"*); the default of 3 now sends up to 4 requests on persistently failing
+  providers. Negative values clamp to "no retries".
+- **BREAKING: `BudgetServiceInterface::check()` gained an optional `?LlmConfiguration`
+  parameter** (#389) — third-party implementations of the interface must update their
+  signature.
+- `LlmConfiguration::setMaxTokens()` accepts 0 as "no explicit limit" (clamp floor moved
+  from 1); existing records are unaffected since the old floor made 0 unstorable (#390).
+
+### Removed
+
+- **BREAKING: the PromptTemplate stack** — entity, repository, service + interface,
+  exception, DI alias and the `tx_nrllm_prompttemplate` table declaration (#399,
+  ADR-069). It was never usable at runtime (the table had no TCA) and had no consumers;
+  prompt snippets (ADR-031) and tasks superseded the concept. The orphaned table can be
+  dropped via the database analyzer; the audited public-service count moves 27 → 26.
+
+### Fixed
+
+- Criteria-mode configurations no longer share embedding cache entries under an empty
+  model id — the cache key resolves the concrete model when the configuration has no
+  direct model relation (#390 follow-up).
+- `max_retries = 0` no longer disables a provider with a misleading connection error
+  (#387, see Changed).
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/Documentation/Changelog.rst
+++ b/Documentation/Changelog.rst
@@ -11,6 +11,75 @@ All notable changes to the TYPO3 LLM Extension are documented here.
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_ and
 the project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+.. _version-0-20-0:
+
+Version 0.20.0 (2026-07-16)
+===========================
+
+Closes out the operator-config audit: every backend-visible provider, model
+and configuration setting now either works or is gone. Three breaking
+changes; full details in the repository ``CHANGELOG.md``.
+
+*  **Breaking:** the provider *API timeout* is now applied as a
+   total-response timeout (previously write-only — requests ran unbounded).
+   Default moves 30 → 120 seconds; the ``nrLlm_providerApiTimeout120``
+   upgrade wizard migrates rows persisted at the old default; timed-out
+   requests are not retried (#384).
+*  **Breaking:** *Max retries* counts retries after the initial attempt —
+   ``0`` sends exactly one request instead of none (#387).
+*  **Breaking:** the never-functional PromptTemplate stack is removed
+   (ADR-069); drop the orphaned ``tx_nrllm_prompttemplate`` table via the
+   database analyzer (#399). ``BudgetServiceInterface::check()`` gained an
+   optional ``?LlmConfiguration`` parameter (#389).
+*  Per-configuration daily limits (requests / tokens / cost) are enforced
+   alongside per-user budgets — most restrictive wins (#389).
+*  Model *Max output tokens* and *Dimensions* act as call defaults when the
+   caller and configuration leave them unset (#390).
+*  Provider *Organization ID* is sent as ``OpenAI-Organization``;
+   ``options.customHeaders`` is applied on all request paths (#388).
+
+.. _version-0-19-1:
+
+Version 0.19.1 (2026-07-15, first shipped with 0.20.0)
+======================================================
+
+Prepared but never tagged; its fixes first ship in 0.20.0.
+
+*  Criteria-mode configurations work with every ``*ForConfiguration()``
+   call — the model is resolved through ``ModelSelectionService`` instead of
+   the (null) direct relation (#372).
+*  Embedding cache tags built from dotted preset identifiers are sanitized
+   (#372).
+
+.. _version-0-19-0:
+
+Version 0.19.0 (2026-07-14)
+===========================
+
+*  Per-user usage attribution for the specialized speech and image services
+   (ADR-057): transcription, synthesis and image generation record the
+   calling backend user instead of the ambient bucket (#362).
+*  Configuration identifiers with dots no longer crash cached calls — cache
+   keys and tags are sanitized (#365); ``LlmTranslator`` chat rows carry the
+   per-user attribution (#361); backend model-test button fixed (#363).
+
+.. _version-0-18-0:
+
+Version 0.18.0 (2026-07-14)
+===========================
+
+*  Configuration presets module UI (ADR-056 follow-up): the Configurations
+   backend module surfaces pending presets with one-click apply/update.
+
+.. _version-0-17-0:
+
+Version 0.17.0 (2026-07-13)
+===========================
+
+*  Configuration presets: consuming extensions declare the
+   ``LlmConfiguration`` records they need via the
+   ``nr_llm.configuration_preset`` registration (ADR-056).
+
 .. _version-0-16-1:
 
 Version 0.16.1 (2026-07-10)

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.19.1"
-        release="0.19.1"
+        version="0.20.0"
+        release="0.20.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.19.1",
+            "version": "0.20.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.19.1',
+    'version' => '0.20.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
## Description

Release 0.20.0 — version bump across all surfaces (`ext_emconf.php`, `composer.json`, `Documentation/guides.xml`), `CHANGELOG.md` section for 0.20.0, and `Documentation/Changelog.rst` brought back in sync (it had drifted at 0.16.1; compact entries backfilled for 0.17.0–0.19.1).

Version 0.19.1 was prepared earlier but never tagged — its fixes first ship in this release (noted in both changelogs).

Breaking changes in 0.20.0: `api_timeout` applied as total-response timeout (default 30 → 120 + upgrade wizard), `max_retries` = retries-after-first-attempt, `BudgetServiceInterface::check()` signature, PromptTemplate stack removal (ADR-069).

## Related Issue

Release chore — no issue.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass (version/changelog-only change; CI validates)
- [ ] I have added tests that prove my fix/feature works (n/a)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
