### PR TITLE
docs: state the six-suite pre-push gate parity in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,15 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 2. Use `make` shortcuts (`make test-unit`, `make phpstan`, `make cgl`) — they delegate to `runTests.sh`.
 3. Pre-commit hooks via `Build/captainhook.json` (auto-installed by composer plugin) run cgl + phpstan + commit-msg checks.
 4. Sign commits with `git commit -S --signoff` (DCO required).
-5. Pre-push gate parity with CI is SIX suites: `unit`, `functional -d sqlite`, `phpstan`, `cgl`, `rector -n`, `fuzzy` — CI runs all six, and `rector`/`fuzzy` are the two habitually forgotten ones. Contract changes (setter clamps, validation ranges) have assertion twins in `Tests/Fuzzy/` — grep there before pushing.
+5. Pre-push gate parity with CI is these six suites — CI runs all six, and `rector`/`fuzzy` are the two habitually forgotten ones:
+   - `unit`
+   - `functional -d sqlite`
+   - `phpstan`
+   - `cgl`
+   - `rector -n`
+   - `fuzzy`
+
+   Contract changes (setter clamps, validation ranges) have assertion twins in `Tests/Fuzzy/` — grep there before pushing.
 6. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 13.4 / 14.0; merged via `--merge` strategy (preserves signatures).
 <!-- AGENTS-GENERATED:END development -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 2. Use `make` shortcuts (`make test-unit`, `make phpstan`, `make cgl`) — they delegate to `runTests.sh`.
 3. Pre-commit hooks via `Build/captainhook.json` (auto-installed by composer plugin) run cgl + phpstan + commit-msg checks.
 4. Sign commits with `git commit -S --signoff` (DCO required).
-5. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 13.4 / 14.0; merged via `--merge` strategy (preserves signatures).
+5. Pre-push gate parity with CI is SIX suites: `unit`, `functional -d sqlite`, `phpstan`, `cgl`, `rector -n`, `fuzzy` — CI runs all six, and `rector`/`fuzzy` are the two habitually forgotten ones. Contract changes (setter clamps, validation ranges) have assertion twins in `Tests/Fuzzy/` — grep there before pushing.
+6. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 13.4 / 14.0; merged via `--merge` strategy (preserves signatures).
 <!-- AGENTS-GENERATED:END development -->
 
 <!-- AGENTS-GENERATED:START filemap -->


### PR DESCRIPTION
## Description

Adds the pre-push gate-parity list to the Development Workflow section: `unit`, `functional -d sqlite`, `phpstan`, `cgl`, `rector -n`, `fuzzy`. Both CI failures in the 2026-07-16 issue sweep (#400/#403 Rector, #402 fuzzy) came from the two suites missing from the habitual local list; contract-change edits also get a pointer to the assertion twins in `Tests/Fuzzy/`.

## Related Issue

None — retro follow-up from the #400–#404 sweep.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass (docs-only)
- [ ] I have added tests that prove my fix/feature works (n/a)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings