### PR TITLE
fix(retrieval): default scheme-relative site base to https in Solr URL scoping

### DIFF
--- a/Classes/Service/Retrieval/SolrSearchBackend.php
+++ b/Classes/Service/Retrieval/SolrSearchBackend.php
@@ -273,6 +273,21 @@ final class SolrSearchBackend implements SearchBackendInterface
     {
         $base = $site->getBase();
         $baseHost = $base->getHost();
+        // A scheme-relative site base ('base: //host/') carries no scheme;
+        // default to https so emitted URLs stay absolute (not '://host/…').
+        $scheme = $base->getScheme() !== '' ? $base->getScheme() : 'https';
+
+        if (str_starts_with($url, '//')) {
+            // Scheme-relative document URL: host-scope like an absolute one,
+            // then prefix only the scheme — the leading-'/' branch below
+            // would prepend the whole origin a second time.
+            $host = self::toStr(parse_url($url, PHP_URL_HOST));
+            if ($baseHost !== '' && $host !== '' && strcasecmp($host, $baseHost) !== 0) {
+                return null;
+            }
+
+            return $scheme . ':' . $url;
+        }
 
         if (str_starts_with($url, 'https://') || str_starts_with($url, 'http://')) {
             $host = self::toStr(parse_url($url, PHP_URL_HOST));
@@ -287,7 +302,7 @@ final class SolrSearchBackend implements SearchBackendInterface
             if ($baseHost === '') {
                 return $url;
             }
-            $origin = $base->getScheme() . '://' . $baseHost
+            $origin = $scheme . '://' . $baseHost
                 . ($base->getPort() !== null ? ':' . $base->getPort() : '');
 
             return $origin . $url;

--- a/Classes/Service/Retrieval/SolrSearchBackend.php
+++ b/Classes/Service/Retrieval/SolrSearchBackend.php
@@ -281,8 +281,10 @@ final class SolrSearchBackend implements SearchBackendInterface
             // Scheme-relative document URL: host-scope like an absolute one,
             // then prefix only the scheme — the leading-'/' branch below
             // would prepend the whole origin a second time.
+            // An empty/unparseable host ('///evil.example/x') is dropped
+            // too: browsers resolve such URLs to a foreign host.
             $host = self::toStr(parse_url($url, PHP_URL_HOST));
-            if ($baseHost !== '' && $host !== '' && strcasecmp($host, $baseHost) !== 0) {
+            if ($baseHost !== '' && ($host === '' || strcasecmp($host, $baseHost) !== 0)) {
                 return null;
             }
 
@@ -291,7 +293,7 @@ final class SolrSearchBackend implements SearchBackendInterface
 
         if (str_starts_with($url, 'https://') || str_starts_with($url, 'http://')) {
             $host = self::toStr(parse_url($url, PHP_URL_HOST));
-            if ($baseHost !== '' && $host !== '' && strcasecmp($host, $baseHost) !== 0) {
+            if ($baseHost !== '' && ($host === '' || strcasecmp($host, $baseHost) !== 0)) {
                 return null;
             }
 

--- a/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
+++ b/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
@@ -364,18 +364,19 @@ final class SolrSearchBackendTest extends TestCase
     }
 
     #[Test]
-    public function keepsAbsoluteUrlWhenItHasNoParseableHost(): void
+    public function dropsAbsoluteUrlWhenItHasNoParseableHost(): void
     {
-        // baseHost is set but the document URL has an empty host: the host
-        // comparison is guarded by `$host !== ''` (an AND), so the URL is kept.
+        // baseHost is set but the document URL has an empty host:
+        // parse_url('https:///evil.example/x', PHP_URL_HOST) is false -> ''.
+        // The host comparison must drop it, not skip it — browsers resolve
+        // such URLs to the foreign host.
         $json = '{"response":{"docs":[
-            {"type":"pages","uid":4,"title":"H","content":"c","url":"https:///aikido","language":0}
+            {"type":"pages","uid":4,"title":"H","content":"c","url":"https:///evil.example/x","language":0}
         ]}}';
         $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
 
         $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
-        self::assertCount(1, $result->sources);
-        self::assertSame('https:///aikido', $result->sources[0]->url);
+        self::assertTrue($result->isEmpty(), 'empty-host absolute document leaked');
     }
 
     #[Test]
@@ -438,6 +439,21 @@ final class SolrSearchBackendTest extends TestCase
 
         $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
         self::assertTrue($result->isEmpty(), 'foreign-host scheme-relative document leaked');
+    }
+
+    #[Test]
+    public function emptyHostSchemeRelativeDocumentUrlIsDropped(): void
+    {
+        // parse_url('///evil.example/x', PHP_URL_HOST) is false -> '' — the
+        // guard must drop it, not skip the comparison: browsers resolve
+        // 'https:///evil.example/x' to the foreign host.
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":9,"title":"F","content":"c","url":"///evil.example/x","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertTrue($result->isEmpty(), 'empty-host scheme-relative document leaked');
     }
 
     #[Test]

--- a/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
+++ b/Tests/Unit/Service/Retrieval/SolrSearchBackendTest.php
@@ -395,6 +395,52 @@ final class SolrSearchBackendTest extends TestCase
     }
 
     #[Test]
+    public function absolutizesRelativeUrlAgainstSchemeRelativeSiteBase(): void
+    {
+        // A scheme-relative site base ('base: //host/') has no scheme; the
+        // https default must apply — not the degenerate '://example.org/news'.
+        $site = $this->site(['base' => '//example.org/']);
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":6,"title":"N","content":"c","url":"/news","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$site]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame('https://example.org/news', $result->sources[0]->url);
+    }
+
+    #[Test]
+    public function schemeRelativeDocumentUrlGetsSchemeOnlyNotADoubleOrigin(): void
+    {
+        // '//example.org/news' starts with '/', so the plain relative branch
+        // would prepend the full origin a second time
+        // ('https://example.org//example.org/news'); only the scheme may be added.
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":6,"title":"N","content":"c","url":"//example.org/news","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertCount(1, $result->sources);
+        self::assertSame('https://example.org/news', $result->sources[0]->url);
+    }
+
+    #[Test]
+    public function crossHostSchemeRelativeDocumentUrlIsDropped(): void
+    {
+        // The shared-core host guard applies to scheme-relative document
+        // URLs just as it does to absolute ones.
+        $json = '{"response":{"docs":[
+            {"type":"pages","uid":9,"title":"F","content":"c","url":"//other.example/aikido","language":0}
+        ]}}';
+        $backend = new SolrSearchBackend(new FakeSiteFinder([$this->site()]), FakeSolrHttpClient::withJson($json));
+
+        $result = $backend->search(RetrievalQuery::create('aikido'), AccessContext::publicOnly());
+        self::assertTrue($result->isEmpty(), 'foreign-host scheme-relative document leaked');
+    }
+
+    #[Test]
     public function firstMatchingLanguageConfigWins(): void
     {
         // Two entries for language 0: the loop BREAKS on the first match, so


### PR DESCRIPTION
## Problem

A scheme-relative TYPO3 site base (`base: //host/`) has an empty scheme, so `SolrSearchBackend::siteScopedUrl()` emitted degenerate `://host/path` URLs — visible in every `site_rag_query` citation on such sites.

A second edge shares the root cause: scheme-relative **document** URLs (`//host/path`) fell into the leading-`/` branch and were double-prefixed with the full origin.

## Fix

- Default the empty base scheme to `https` before building the origin.
- Handle `//host/path` document URLs in their own branch: scheme prefix only, with the same cross-host guard as absolute URLs (previously `//other.example/…` was absolutized into the site origin instead of dropped).

## Tests

- relative doc URL against `base: //example.org/` → `https://example.org/news`
- scheme-relative doc URL → no double origin
- cross-host scheme-relative doc URL → dropped

Downstream note: nr-ai-search's `UrlNormalizer` carries a consumer-side workaround for the `://` form; it can be removed once its composer floor is raised past the release containing this fix.