### PR TITLE
feat(config): ConfigurationResolver::getActiveByIdentifier for user-less contexts

### DIFF
--- a/Classes/Exception/ConfigurationInactiveException.php
+++ b/Classes/Exception/ConfigurationInactiveException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when an LLM configuration exists but is deactivated.
+ */
+class ConfigurationInactiveException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Service/ConfigurationResolver.php
+++ b/Classes/Service/ConfigurationResolver.php
@@ -11,10 +11,14 @@ namespace Netresearch\NrLlm\Service;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Exception\AccessDeniedException;
+use Netresearch\NrLlm\Exception\ConfigurationInactiveException;
+use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 
 /**
  * Resolves the backend-module-managed default configuration for generic
- * (provider-agnostic) completion / chat / stream calls.
+ * (provider-agnostic) completion / chat / stream calls, and named
+ * configurations by identifier for user-less contexts (ADR-070).
  *
  * Extracted from {@see LlmServiceManager} so the "which configuration drives
  * this call" decision — and the guards around an access-restricted or
@@ -76,6 +80,56 @@ final readonly class ConfigurationResolver
             || $configuration->hasAccessRestrictions()
         ) {
             return null;
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * Resolve an active configuration by its identifier for user-less contexts
+     * (CLI, Symfony Messenger consumers, anonymous frontend requests).
+     *
+     * Counterpart of LlmConfigurationServiceInterface::getConfiguration(),
+     * which enforces a backend-user access check that user-less callers cannot
+     * satisfy. Applies the same refusal policy as
+     * {@see self::resolveDefaultConfiguration()}: an access-restricted
+     * configuration is not resolvable without a user to check the BE group
+     * membership against (ADR-070). Unlike the default path this does not
+     * require a directly assigned model — criteria-mode configurations resolve
+     * their model at call time via the *ForConfiguration() entry points
+     * (ADR-066).
+     *
+     * @throws ConfigurationNotFoundException when no configuration with the identifier exists (or no repository is wired)
+     * @throws ConfigurationInactiveException when the configuration exists but is deactivated
+     * @throws AccessDeniedException          when the configuration is restricted to BE groups (ADR-070)
+     */
+    public function getActiveByIdentifier(string $identifier): LlmConfiguration
+    {
+        $configuration = $this->configurationRepository?->findOneByIdentifier($identifier);
+
+        if ($configuration === null) {
+            throw new ConfigurationNotFoundException(
+                sprintf('LLM configuration "%s" not found', $identifier),
+                1784211001,
+            );
+        }
+
+        if (!$configuration->isActive()) {
+            throw new ConfigurationInactiveException(
+                sprintf('LLM configuration "%s" is not active', $identifier),
+                1784211002,
+            );
+        }
+
+        if ($configuration->hasAccessRestrictions()) {
+            throw new AccessDeniedException(
+                sprintf(
+                    'LLM configuration "%s" is restricted to backend groups'
+                    . ' and cannot be resolved without a user context',
+                    $identifier,
+                ),
+                1784211003,
+            );
         }
 
         return $configuration;

--- a/Documentation/Adr/Adr070UserlessConfigurationResolutionByIdentifier.rst
+++ b/Documentation/Adr/Adr070UserlessConfigurationResolutionByIdentifier.rst
@@ -1,0 +1,98 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-070:
+
+==================================================================
+ADR-070: User-less configuration resolution by identifier
+==================================================================
+
+:Status: Accepted
+:Date: 2026-07-16
+:Authors: Netresearch DTT GmbH
+
+.. _adr-070-context:
+
+Context
+=======
+
+Downstream extensions pin their LLM calls to a named
+:php:`LlmConfiguration` record and dispatch through the
+``*ForConfiguration()`` entry points. The documented lookup path,
+:php:`LlmConfigurationServiceInterface::getConfiguration()`, enforces a
+backend-user access check — unusable from user-less contexts such as CLI
+commands, Symfony Messenger consumers, or anonymous frontend requests.
+Consumers therefore resolved records through
+:php:`LlmConfigurationRepository::findOneByIdentifier()` directly (the
+pattern the Integration Guide documented in Step 5), which silently
+skipped two guards:
+
+- the ``isActive`` flag — a deactivated record kept serving traffic;
+- the ``beGroups`` access restriction — a record an admin restricted to
+  specific backend groups was resolvable by anyone.
+
+:php:`ConfigurationResolver` already existed as the access-check-free
+resolution collaborator for the *default*-configuration path, with a
+deliberate refusal policy: in a context without a backend user, an
+access-restricted default is not auto-applied, because there is no user
+to enforce the group membership against.
+
+.. _adr-070-decision:
+
+Decision
+========
+
+:php:`ConfigurationResolver` gains
+:php:`getActiveByIdentifier(string $identifier): LlmConfiguration` as the
+supported identifier lookup for user-less contexts. It throws typed
+exceptions instead of returning ``null``:
+
+- :php:`ConfigurationNotFoundException` — no record with the identifier
+  exists;
+- :php:`ConfigurationInactiveException` (new, implements
+  :php:`NrLlmExceptionInterface`) — the record exists but is deactivated;
+- :php:`AccessDeniedException` — the record is restricted to backend
+  groups.
+
+**Access-restricted records are refused in user-less contexts.** This
+extends the resolver's existing default-path policy to identifier
+lookup: ``beGroups`` restrictions express "only these backend groups may
+use this configuration", and a context without a user cannot prove
+membership — resolving the record anyway would turn the restriction into
+a no-op exactly where nobody is watching (unattended workers). A
+consumer that needs an access-restricted configuration in a worker
+context must attribute the call to a user via the options-carried
+``beUserUid`` (:ref:`ADR-052 <adr-052>`) and resolve through the
+user-aware :php:`LlmConfigurationServiceInterface`, or the admin removes
+the group restriction from the record.
+
+Unlike the default path, no directly assigned model is required:
+criteria-mode configurations carry no ``model_uid`` and resolve their
+model at call time (:ref:`ADR-066 <adr-066>`).
+
+No pinned-client facade is added. The per-capability
+``*ForConfiguration()`` methods are already the one-line pinned call;
+option building (attribution, detail levels, tool defaults) is consumer
+policy that a generic facade cannot guess.
+
+.. _adr-070-consequences:
+
+Consequences
+============
+
+- User-less consumers get one supported lookup with the ``isActive``
+  and access-restriction guards applied, instead of re-implementing them
+  (or forgetting to) around ``findOneByIdentifier()``.
+- Typed ``inactive`` vs. ``not found`` outcomes let consumers degrade
+  differently (e.g. log-and-skip vs. configuration error).
+- The Integration Guide's Step 5 now routes through the resolver; the
+  previous example also called a non-existent ``findByIdentifier()``
+  (actual method: ``findOneByIdentifier()``).
+- Access-restricted configurations are unavailable to user-less callers
+  by design — an intentional behaviour change against raw repository
+  lookup, which ignored the restriction.
+- One new exception class on the public surface
+  (:php:`ConfigurationInactiveException`).
+- :php:`ConfigurationResolver` stays a private, constructor-injected
+  service: no ``public: true`` entry is added, so the audited count in
+  :ref:`ADR-028 <adr-028>` / :ref:`ADR-065 <adr-065>` (as reduced by
+  :ref:`ADR-069 <adr-069>`) is unchanged.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -367,3 +367,4 @@ Tools
    Adr066CriteriaConfigurationResolution
    Adr067SolrPerLanguageCoreFilter
    Adr069RemovePromptTemplateStack
+   Adr070UserlessConfigurationResolutionByIdentifier

--- a/Documentation/Api/Exceptions.rst
+++ b/Documentation/Api/Exceptions.rst
@@ -74,6 +74,11 @@ Exceptions
 
    Thrown when a named configuration is not found.
 
+.. php:class:: ConfigurationInactiveException
+
+   Thrown when a named configuration exists but is
+   deactivated (:ref:`ADR-070 <adr-070>`).
+
 .. _api-events:
 
 Events

--- a/Documentation/Api/Exceptions.rst
+++ b/Documentation/Api/Exceptions.rst
@@ -79,6 +79,11 @@ Exceptions
    Thrown when a named configuration exists but is
    deactivated (:ref:`ADR-070 <adr-070>`).
 
+   Only ``ConfigurationResolver::getActiveByIdentifier()`` differentiates
+   inactive from not-found; the user-aware
+   ``LlmConfigurationServiceInterface::getConfiguration()`` signals the
+   inactive case as ``ConfigurationNotFoundException`` (code ``2690936773``).
+
 .. _api-events:
 
 Events

--- a/Documentation/Developer/IntegrationGuide.rst
+++ b/Documentation/Developer/IntegrationGuide.rst
@@ -198,18 +198,22 @@ Step 5: Use database configurations (optional)
 ================================================
 
 For advanced use cases, reference named configurations that admins create in the
-backend module:
+backend module. Resolve them through
+:php:`\Netresearch\NrLlm\Service\ConfigurationResolver::getActiveByIdentifier()`
+— it works in user-less contexts (CLI, Symfony Messenger consumers,
+anonymous frontend requests) and applies the guards a raw repository
+lookup skips (:ref:`ADR-070 <adr-070>`):
 
 .. code-block:: php
    :caption: Using named database configurations
 
-   use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+   use Netresearch\NrLlm\Service\ConfigurationResolver;
    use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 
    final readonly class BlogSummarizer
    {
        public function __construct(
-           private LlmConfigurationRepository $configRepo,
+           private ConfigurationResolver $configurationResolver,
            private LlmServiceManagerInterface $llm,
        ) {}
 
@@ -217,7 +221,7 @@ backend module:
        {
            // Uses the "blog-summarizer" configuration created by the admin
            // (specific model, temperature, system prompt, etc.)
-           $config = $this->configRepo->findByIdentifier('blog-summarizer');
+           $config = $this->configurationResolver->getActiveByIdentifier('blog-summarizer');
 
            $response = $this->llm->chat(
                [['role' => 'user', 'content' => "Summarize:\n\n" . $article]],
@@ -227,6 +231,22 @@ backend module:
            return $response->content;
        }
    }
+
+The method throws typed exceptions (all implementing
+:php:`NrLlmExceptionInterface`): :php:`ConfigurationNotFoundException`
+when no record with the identifier exists,
+:php:`ConfigurationInactiveException` when it exists but is deactivated,
+and :php:`AccessDeniedException` when it is restricted to backend groups
+(user-less callers cannot prove group membership; see
+:ref:`ADR-070 <adr-070>`).
+
+.. warning::
+
+   Do not resolve configurations via
+   ``LlmConfigurationRepository::findOneByIdentifier()`` directly: it
+   ignores the record's **isActive** flag and its backend-group access
+   restrictions, so a deactivated or restricted configuration would keep
+   serving your calls.
 
 .. _integration-guide-step6:
 

--- a/Tests/Unit/Service/ConfigurationResolverTest.php
+++ b/Tests/Unit/Service/ConfigurationResolverTest.php
@@ -12,6 +12,9 @@ namespace Netresearch\NrLlm\Tests\Unit\Service;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Exception\AccessDeniedException;
+use Netresearch\NrLlm\Exception\ConfigurationInactiveException;
+use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -120,5 +123,102 @@ class ConfigurationResolverTest extends AbstractUnitTestCase
         $subject = new ConfigurationResolver($repository);
 
         self::assertSame($default, $subject->resolveEffectiveConfiguration());
+    }
+
+    #[Test]
+    public function getActiveByIdentifierReturnsActiveUnrestrictedConfiguration(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('hasAccessRestrictions')->willReturn(false);
+
+        $repository = self::createMock(LlmConfigurationRepository::class);
+        $repository->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('blog-summarizer')
+            ->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertSame($configuration, $subject->getActiveByIdentifier('blog-summarizer'));
+    }
+
+    #[Test]
+    public function getActiveByIdentifierDoesNotRequireAnAssignedModel(): void
+    {
+        // Criteria-mode configurations carry no direct model relation; the
+        // model is resolved at call time (ADR-066), so the resolver must not
+        // refuse them the way the default path refuses a model-less default.
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getLlmModel')->willReturn(null);
+        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('hasAccessRestrictions')->willReturn(false);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        self::assertSame($configuration, $subject->getActiveByIdentifier('criteria-mode'));
+    }
+
+    #[Test]
+    public function getActiveByIdentifierThrowsWhenConfigurationIsMissing(): void
+    {
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn(null);
+
+        $subject = new ConfigurationResolver($repository);
+
+        $this->expectException(ConfigurationNotFoundException::class);
+        $this->expectExceptionCode(1784211001);
+
+        $subject->getActiveByIdentifier('missing');
+    }
+
+    #[Test]
+    public function getActiveByIdentifierThrowsWhenNoRepositoryWired(): void
+    {
+        $subject = new ConfigurationResolver();
+
+        $this->expectException(ConfigurationNotFoundException::class);
+        $this->expectExceptionCode(1784211001);
+
+        $subject->getActiveByIdentifier('anything');
+    }
+
+    #[Test]
+    public function getActiveByIdentifierThrowsWhenConfigurationIsInactive(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('isActive')->willReturn(false);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        $this->expectException(ConfigurationInactiveException::class);
+        $this->expectExceptionCode(1784211002);
+
+        $subject->getActiveByIdentifier('deactivated');
+    }
+
+    #[Test]
+    public function getActiveByIdentifierThrowsWhenConfigurationIsAccessRestricted(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('hasAccessRestrictions')->willReturn(true);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $subject = new ConfigurationResolver($repository);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211003);
+
+        $subject->getActiveByIdentifier('restricted');
     }
 }


### PR DESCRIPTION
## Problem

Consumers in user-less contexts (CLI, Symfony Messenger workers, anonymous frontend requests) cannot use `LlmConfigurationServiceInterface::getConfiguration()` (BE-user access gate) and fall back to raw `LlmConfigurationRepository::findOneByIdentifier()` — which ignores `isActive` and backend-group access restrictions. The IntegrationGuide Step 5 documented exactly that raw pattern, with a doc bug on top (`findByIdentifier` does not exist).

## Change

- `ConfigurationResolver::getActiveByIdentifier(string): LlmConfiguration` — resolves by identifier with the same refusal policy as the default-config path:
  - `ConfigurationNotFoundException` (1784211001) — no such identifier
  - `ConfigurationInactiveException` (1784211002, new, implements `NrLlmExceptionInterface`) — deactivated record
  - `AccessDeniedException` (1784211003) — group-restricted record in a user-less context
- ADR-070 records the user-less resolution policy (numbering skips 068, unused on main; 069 is taken).
- IntegrationGuide Step 5 now uses the resolver and warns against raw repository lookups.

## Notes

- `LlmConfigurationService::getConfiguration()` still throws `ConfigurationNotFoundException` for inactive records — changing that would be a BC break, out of scope here.
- Unit/phpstan/cgl/rector/fuzzy green locally; functional suite left to CI (local run exceeded the sandbox time budget).