### PR TITLE
feat: seed dimensions metadata for well-known embedding models

### DIFF
--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\EmbeddingModelDimensions;
 use Netresearch\NrLlm\Service\SetupWizard\ConfigurationGenerator;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
@@ -422,6 +423,9 @@ final class SetupWizardController extends ActionController
             $model->setProvider($provider);
             $model->setContextLength($contextLength);
             $model->setMaxOutputTokens($maxOutputTokens);
+            // Seed the vector dimensionality for well-known embedding models
+            // (ADR-055: 0 = unknown, consumers probe live otherwise).
+            $model->setDimensions(EmbeddingModelDimensions::forModelId($modelId));
             $model->setCapabilities(implode(',', array_filter($modelCapabilities, is_string(...))));
             $model->setIsActive(true);
             $model->setIsDefault((bool)($modelData['recommended'] ?? false));

--- a/Classes/Service/EmbeddingModelDimensions.php
+++ b/Classes/Service/EmbeddingModelDimensions.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+/**
+ * Static catalog of vector dimensionality for well-known embedding models.
+ *
+ * ADR-055 made `tx_nrllm_model.dimensions` descriptive metadata
+ * (0 = unknown), but nothing seeded it: every record started at 0, so
+ * consumers validating a persisted vector index against the configured
+ * model fell back to a paid live calibration probe. This catalog seeds
+ * the column for the embedding models this extension already references
+ * (provider default-model constants, setup wizard discovery) — on record
+ * creation via the setup wizard and on existing rows via
+ * EmbeddingModelDimensionsUpdateWizard.
+ *
+ * Maintenance contract mirrors OpenAiPriceCatalog:
+ *  - every entry documents its source and verification date;
+ *  - unknown model ids return 0 ("unknown") — callers keep the column
+ *    default rather than guessing.
+ */
+final class EmbeddingModelDimensions
+{
+    /**
+     * Default output dimensionality per provider model id.
+     *
+     * Sources (verified 2026-07-16):
+     *  - text-embedding-3-small 1536, text-embedding-3-large 3072:
+     *    https://platform.openai.com/docs/guides/embeddings
+     *    (`openai/…` is the OpenRouter route to the same model,
+     *    OpenRouterProvider::DEFAULT_EMBEDDING_MODEL)
+     *  - mistral-embed 1024: https://docs.mistral.ai/capabilities/embeddings/
+     *  - nomic-embed-text 768: https://ollama.com/library/nomic-embed-text
+     *  - gemini-embedding-2 3072 (Matryoshka default):
+     *    https://deepmind.google/models/gemini/embedding/
+     *
+     * text-embedding-ada-002 (1536) is deliberately absent:
+     * LlmServiceManager forwards a non-zero record value as the
+     * `dimensions` request parameter, which the OpenAI API rejects for
+     * ada-002 (only the v3 models accept it).
+     *
+     * @var array<string, int>
+     */
+    private const DIMENSIONS = [
+        'text-embedding-3-small' => 1536,
+        'text-embedding-3-large' => 3072,
+        'openai/text-embedding-3-small' => 1536,
+        'mistral-embed' => 1024,
+        'nomic-embed-text' => 768,
+        'gemini-embedding-2' => 3072,
+    ];
+
+    /**
+     * Static catalog — not meant to be instantiated.
+     */
+    private function __construct() {}
+
+    /**
+     * Dimensionality for the given provider model id, 0 when unknown.
+     *
+     * Ollama model ids carry a tag suffix (`nomic-embed-text:latest`);
+     * the lookup falls back to the bare name before the first colon.
+     */
+    public static function forModelId(string $modelId): int
+    {
+        $dimensions = self::DIMENSIONS[$modelId] ?? null;
+        if ($dimensions !== null) {
+            return $dimensions;
+        }
+
+        $colonPosition = strpos($modelId, ':');
+        if ($colonPosition === false) {
+            return 0;
+        }
+
+        return self::DIMENSIONS[substr($modelId, 0, $colonPosition)] ?? 0;
+    }
+}

--- a/Classes/Updates/EmbeddingModelDimensionsUpdateWizard.php
+++ b/Classes/Updates/EmbeddingModelDimensionsUpdateWizard.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Updates;
+
+use Netresearch\NrLlm\Service\EmbeddingModelDimensions;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+/**
+ * Seed the ADR-055 `dimensions` column for well-known embedding models.
+ *
+ * The column shipped with 0 ("unknown") on every existing row and nothing
+ * populated it, so consumers validating a persisted vector index against
+ * the configured model kept falling back to a paid live calibration probe.
+ * This wizard fills `dimensions` from the EmbeddingModelDimensions catalog
+ * for rows whose model_id is a known embedding model and whose value is
+ * still 0 — an explicitly configured value is never touched.
+ */
+#[UpgradeWizard('nrLlm_embeddingModelDimensions')]
+final readonly class EmbeddingModelDimensionsUpdateWizard implements UpgradeWizardInterface
+{
+    private const TABLE = 'tx_nrllm_model';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function getTitle(): string
+    {
+        return 'Seed vector dimensions for well-known LLM embedding models';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The tx_nrllm_model.dimensions column (ADR-055) defaults to 0 ("unknown"), which makes '
+            . 'embedding consumers fall back to a live calibration call against the provider. This wizard '
+            . 'fills the column with the published vector dimensionality for well-known embedding models '
+            . '(e.g. text-embedding-3-small, mistral-embed, nomic-embed-text) where it is still 0. '
+            . 'Rows with an explicitly configured value are not touched.';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        foreach ($this->seedableRows() as $uid => $dimensions) {
+            $connection->update(
+                self::TABLE,
+                ['dimensions' => $dimensions],
+                ['uid' => $uid],
+                ['dimensions' => Connection::PARAM_INT],
+            );
+        }
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->seedableRows() !== [];
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    /**
+     * Rows still at dimensions = 0 whose model_id is a known embedding
+     * model, as uid => catalog dimensionality.
+     *
+     * @return array<int, int>
+     */
+    private function seedableRows(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        // Include hidden and deleted rows so a later un-delete stays consistent.
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('uid', 'model_id')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'dimensions',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $seedable = [];
+        foreach ($rows as $row) {
+            $uid = is_numeric($row['uid'] ?? null) ? (int)$row['uid'] : 0;
+            $modelId = is_string($row['model_id'] ?? null) ? $row['model_id'] : '';
+            $dimensions = EmbeddingModelDimensions::forModelId($modelId);
+            if ($uid > 0 && $dimensions > 0) {
+                $seedable[$uid] = $dimensions;
+            }
+        }
+
+        return $seedable;
+    }
+}

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -501,6 +501,66 @@ final class SetupWizardControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function saveActionSeedsDimensionsForKnownEmbeddingModels(): void
+    {
+        $request = new ServerRequest('POST', self::AJAX_NRLLM_WIZARD_SAVE);
+        $request = $request->withHeader('Content-Type', self::APPLICATION_JSON);
+        $request = $request->withBody(Utils::streamFor(json_encode([
+            'provider' => [
+                'suggestedName' => 'OpenAI Embeddings',
+                'adapterType' => 'openai',
+                'endpoint' => self::HTTPS_API_OPENAI_COM_V1,
+                'apiKey' => 'sk-test-key-12345',
+            ],
+            'models' => [
+                [
+                    'modelId' => 'text-embedding-3-small',
+                    'name' => 'Text Embedding 3 Small',
+                    'capabilities' => ['embeddings'],
+                    'selected' => true,
+                ],
+                [
+                    'modelId' => 'gpt-5',
+                    'name' => 'GPT-5',
+                    'capabilities' => ['chat'],
+                    'selected' => true,
+                ],
+            ],
+            'configurations' => [],
+            'pid' => 0,
+        ])));
+
+        // Act
+        $response = $this->controller->saveAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        // Known embedding models get the published dimensionality (ADR-055),
+        // everything else keeps the column default 0 ("unknown").
+        self::assertSame(1536, $this->dimensionsOfModelId('text-embedding-3-small'));
+        self::assertSame(0, $this->dimensionsOfModelId('gpt-5'));
+    }
+
+    private function dimensionsOfModelId(string $modelId): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('tx_nrllm_model');
+        $queryBuilder->getRestrictions()->removeAll();
+        $value = $queryBuilder
+            ->select('dimensions')
+            ->from('tx_nrllm_model')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'model_id',
+                    $queryBuilder->createNamedParameter($modelId),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return (int)$value;
+    }
+
+    #[Test]
     public function saveActionNormalizesBareOpenAiEndpointToIncludeV1(): void
     {
         // #98: a bare OpenAI host entered in the wizard must be stored WITH the /v1

--- a/Tests/Functional/Updates/EmbeddingModelDimensionsUpdateWizardTest.php
+++ b/Tests/Functional/Updates/EmbeddingModelDimensionsUpdateWizardTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Updates;
+
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Updates\EmbeddingModelDimensionsUpdateWizard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+
+#[CoversClass(EmbeddingModelDimensionsUpdateWizard::class)]
+final class EmbeddingModelDimensionsUpdateWizardTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_model';
+
+    #[Test]
+    public function executeUpdateSeedsOnlyKnownModelsStillAtZero(): void
+    {
+        $this->insertModel('openai-small', 'text-embedding-3-small', 0);
+        $this->insertModel('mistral', 'mistral-embed', 0);
+        $this->insertModel('custom-dims', 'text-embedding-3-small', 256);
+        $this->insertModel('chat-model', 'gpt-5.2', 0);
+
+        $wizard = new EmbeddingModelDimensionsUpdateWizard($this->getConnectionPool());
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+
+        self::assertSame(1536, $this->dimensionsOf('openai-small'));
+        self::assertSame(1024, $this->dimensionsOf('mistral'));
+        // An explicitly configured value is never touched.
+        self::assertSame(256, $this->dimensionsOf('custom-dims'));
+        // Unknown models stay at 0 ("unknown").
+        self::assertSame(0, $this->dimensionsOf('chat-model'));
+        self::assertFalse($wizard->updateNecessary());
+    }
+
+    #[Test]
+    public function executeUpdateResolvesOllamaTagSuffixes(): void
+    {
+        $this->insertModel('ollama-nomic', 'nomic-embed-text:latest', 0);
+
+        $wizard = new EmbeddingModelDimensionsUpdateWizard($this->getConnectionPool());
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+
+        self::assertSame(768, $this->dimensionsOf('ollama-nomic'));
+    }
+
+    #[Test]
+    public function executeUpdateSeedsHiddenAndDeletedRows(): void
+    {
+        $this->insertModel('hidden-embed', 'text-embedding-3-large', 0, hidden: 1, deleted: 1);
+
+        $wizard = new EmbeddingModelDimensionsUpdateWizard($this->getConnectionPool());
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+
+        self::assertSame(3072, $this->dimensionsOf('hidden-embed'));
+    }
+
+    #[Test]
+    public function updateNotNecessaryWithoutSeedableRows(): void
+    {
+        $this->insertModel('chat-only', 'gpt-5.2', 0);
+
+        $wizard = new EmbeddingModelDimensionsUpdateWizard($this->getConnectionPool());
+
+        self::assertFalse($wizard->updateNecessary());
+    }
+
+    private function insertModel(
+        string $identifier,
+        string $modelId,
+        int $dimensions,
+        int $hidden = 0,
+        int $deleted = 0,
+    ): void {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE);
+        $connection->insert(self::TABLE, [
+            'pid' => 0,
+            'identifier' => $identifier,
+            'name' => $identifier,
+            'model_id' => $modelId,
+            'dimensions' => $dimensions,
+            'hidden' => $hidden,
+            'deleted' => $deleted,
+        ], ['dimensions' => Connection::PARAM_INT]);
+    }
+
+    private function dimensionsOf(string $identifier): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $value = $queryBuilder
+            ->select('dimensions')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'identifier',
+                    $queryBuilder->createNamedParameter($identifier),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return (int)$value;
+    }
+}

--- a/Tests/Unit/Service/EmbeddingModelDimensionsTest.php
+++ b/Tests/Unit/Service/EmbeddingModelDimensionsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Service\EmbeddingModelDimensions;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(EmbeddingModelDimensions::class)]
+class EmbeddingModelDimensionsTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function knownModelProvider(): array
+    {
+        return [
+            'openai small' => ['text-embedding-3-small', 1536],
+            'openai large' => ['text-embedding-3-large', 3072],
+            'openrouter route to openai small' => ['openai/text-embedding-3-small', 1536],
+            'mistral' => ['mistral-embed', 1024],
+            'ollama nomic' => ['nomic-embed-text', 768],
+            'gemini' => ['gemini-embedding-2', 3072],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('knownModelProvider')]
+    public function forModelIdReturnsPublishedDimensionality(string $modelId, int $expected): void
+    {
+        self::assertSame($expected, EmbeddingModelDimensions::forModelId($modelId));
+    }
+
+    #[Test]
+    public function forModelIdStripsOllamaTagSuffix(): void
+    {
+        self::assertSame(768, EmbeddingModelDimensions::forModelId('nomic-embed-text:latest'));
+        self::assertSame(768, EmbeddingModelDimensions::forModelId('nomic-embed-text:v1.5'));
+    }
+
+    #[Test]
+    public function forModelIdReturnsZeroForUnknownModels(): void
+    {
+        self::assertSame(0, EmbeddingModelDimensions::forModelId('gpt-5.2'));
+        self::assertSame(0, EmbeddingModelDimensions::forModelId('unknown-embed:latest'));
+        self::assertSame(0, EmbeddingModelDimensions::forModelId(''));
+    }
+
+    #[Test]
+    public function forModelIdDoesNotSeedAda002(): void
+    {
+        // ada-002 rejects the `dimensions` request parameter which
+        // LlmServiceManager fills from the record — must stay unknown.
+        self::assertSame(0, EmbeddingModelDimensions::forModelId('text-embedding-ada-002'));
+    }
+}


### PR DESCRIPTION
## Problem

ADR-055 added the `tx_nrllm_model.dimensions` column (0 = unknown), but no preset or wizard seeds it — every record starts at 0, so embedding consumers (e.g. nr-ai-search's index-drift check) fall back to a paid live calibration probe.

## Change

- `EmbeddingModelDimensions` catalog: published dimensionality for embedding models the repo already references (OpenAI v3 small/large, OpenRouter route, mistral-embed, nomic-embed-text incl. Ollama tag-suffix fallback, gemini-embedding-2). Each entry documents its source and verification date, mirroring the `OpenAiPriceCatalog` maintenance contract. Unknown ids return 0.
- Setup wizard seeds the column on model creation.
- `EmbeddingModelDimensionsUpdateWizard` back-fills existing rows where the value is still 0; explicitly configured values are never touched.

`text-embedding-ada-002` is deliberately absent: `LlmServiceManager` forwards a non-zero record value as the `dimensions` request parameter (Classes/Service/LlmServiceManager.php:542), which the OpenAI API rejects for ada-002 (only v3 models accept it).

Data only — no interface changes.