### PR TITLE
docs(developer): consumer recipes for endpoint protection and safe markdown rendering

### DIFF
--- a/Documentation/Developer/EndpointProtection.rst
+++ b/Documentation/Developer/EndpointProtection.rst
@@ -50,8 +50,14 @@ implementation:
 .. code-block:: yaml
    :caption: Configuration/Services.yaml
 
-   Symfony\Component\RateLimiter\Storage\StorageInterface:
-       alias: TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage
+   services:
+       _defaults:
+           autowire: true
+           autoconfigure: true
+           public: false
+
+       Symfony\Component\RateLimiter\Storage\StorageInterface:
+           alias: TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage
 
 .. note::
 
@@ -62,10 +68,14 @@ implementation:
    limiter service as a named ``$storage`` argument referencing
    ``@TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage``.
 
-The limiter itself keys on the client IP resolved through
-:php:`NormalizedParams`, which honors TYPO3's reverse-proxy configuration
+The limiter itself keys on the client IP resolved through the
+``normalizedParams`` request attribute — a :php:`NormalizedParams`
+instance TYPO3 sets on every frontend and backend request — which honors
+TYPO3's reverse-proxy configuration
 (:php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']`) instead of
-trusting ``REMOTE_ADDR`` blindly:
+trusting ``REMOTE_ADDR`` blindly. The raw ``REMOTE_ADDR`` fallback only
+covers requests that never passed through TYPO3's request handling, such
+as unit tests:
 
 .. code-block:: php
    :caption: Classes/Infrastructure/RequestRateLimiter.php
@@ -105,12 +115,9 @@ trusting ``REMOTE_ADDR`` blindly:
        {
            $normalizedParams = $request->getAttribute('normalizedParams');
 
-           if (!$normalizedParams instanceof NormalizedParams) {
-               $normalizedParams =
-                   NormalizedParams::createFromRequest($request);
-           }
-
-           $remoteIp = $normalizedParams->getRemoteAddress();
+           $remoteIp = $normalizedParams instanceof NormalizedParams
+               ? $normalizedParams->getRemoteAddress()
+               : (string)($request->getServerParams()['REMOTE_ADDR'] ?? '');
 
            return !$this->rateLimiterFactory
                ->create($remoteIp)
@@ -131,12 +138,25 @@ Design choices worth keeping:
 .. code-block:: yaml
    :caption: Configuration/Services.yaml — one limiter per endpoint
 
-   MyVendor\MyExtension\Infrastructure\RequestRateLimiter: ~
+   services:
+       _defaults:
+           autowire: true
+           autoconfigure: true
+           public: false
 
-   myext.rate_limiter.chat:
-       class: MyVendor\MyExtension\Infrastructure\RequestRateLimiter
-       arguments:
-           $limiterId: 'myext_chat'
+       MyVendor\MyExtension\Infrastructure\RequestRateLimiter: ~
+
+       myext.rate_limiter.chat:
+           class: MyVendor\MyExtension\Infrastructure\RequestRateLimiter
+           arguments:
+               $limiterId: 'myext_chat'
+
+The ``~`` (null) definition inherits everything from ``_defaults``:
+with ``autowire: true`` the :php:`StorageInterface` constructor
+argument resolves through the alias above, and the two scalar
+parameters keep their declared defaults. Without the ``_defaults``
+block (or an explicit ``autowire: true`` on the definition) the
+container would fail to instantiate the service.
 
 *   Where the limit value comes from — extension configuration, a site
     setting, or a constructor default — is your choice. If you read it
@@ -197,6 +217,12 @@ detail in server-side logs only:
 
 .. code-block:: php
    :caption: Controller action combining all three patterns
+
+   use InvalidArgumentException;
+   use Netresearch\NrLlm\Provider\Exception\ProviderException;
+   use Psr\Http\Message\ResponseInterface;
+
+   // … inside the controller class:
 
    public function searchAction(string $query = ''): ResponseInterface
    {

--- a/Documentation/Developer/EndpointProtection.rst
+++ b/Documentation/Developer/EndpointProtection.rst
@@ -1,0 +1,254 @@
+.. include:: /Includes.rst.txt
+
+.. _developer-endpoint-protection:
+
+===============================================
+Protecting anonymous LLM-cost-bearing endpoints
+===============================================
+
+Every request that reaches an anonymous frontend endpoint backed by nr-llm
+(a search box, a chat widget, a content assistant) triggers a paid provider
+call. A single scripted attacker — or one careless crawler — can turn such
+an endpoint into an open cost faucet.
+
+nr-llm's :ref:`per-user budgets <administration-user-budgets>` cap the
+*aggregate* spend attributed to a backend user, so a runaway endpoint
+cannot exceed its monthly ceiling. Budgets do not, however, limit the
+*request rate* of an individual attacker: one IP can still burn the whole
+budget and deny the feature to everyone else. Per-request protection is the
+consuming extension's responsibility, at its own HTTP surface.
+
+This page shows the three patterns to apply. They are small, build only on
+TYPO3 core and Symfony primitives, and need no extra infrastructure.
+
+.. contents::
+   :local:
+   :depth: 2
+
+.. _developer-endpoint-protection-rate-limiter:
+
+Per-IP rate limiting
+====================
+
+TYPO3 core already depends on ``symfony/rate-limiter`` (core's own login
+rate limiting uses it) and ships a storage adapter that persists limiter
+state in the caching framework:
+:php:`TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage`. The
+whole recipe is one service alias plus a ~25-line class.
+
+Require the component explicitly, since your code uses its classes
+directly:
+
+.. code-block:: bash
+   :caption: Add the dependency
+
+   composer require symfony/rate-limiter
+
+Alias the Symfony storage interface to TYPO3's caching-framework-backed
+implementation:
+
+.. code-block:: yaml
+   :caption: Configuration/Services.yaml
+
+   Symfony\Component\RateLimiter\Storage\StorageInterface:
+       alias: TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage
+
+.. note::
+
+   Service aliases are container-wide, not per-extension. If another
+   extension in the same installation aliases
+   :php:`StorageInterface` to a different storage, the definitions
+   collide. In that case, drop the alias and pass the storage to your
+   limiter service as a named ``$storage`` argument referencing
+   ``@TYPO3\CMS\Core\RateLimiter\Storage\CachingFrameworkStorage``.
+
+The limiter itself keys on the client IP resolved through
+:php:`NormalizedParams`, which honors TYPO3's reverse-proxy configuration
+(:php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']`) instead of
+trusting ``REMOTE_ADDR`` blindly:
+
+.. code-block:: php
+   :caption: Classes/Infrastructure/RequestRateLimiter.php
+
+   <?php
+
+   declare(strict_types=1);
+
+   namespace MyVendor\MyExtension\Infrastructure;
+
+   use Psr\Http\Message\ServerRequestInterface;
+   use Symfony\Component\RateLimiter\RateLimiterFactory;
+   use Symfony\Component\RateLimiter\Storage\StorageInterface;
+   use TYPO3\CMS\Core\Http\NormalizedParams;
+
+   final readonly class RequestRateLimiter
+   {
+       private RateLimiterFactory $rateLimiterFactory;
+
+       public function __construct(
+           StorageInterface $storage,
+           int $limitPerMinute = 30,
+           string $limiterId = 'myext_frontend',
+       ) {
+           $this->rateLimiterFactory = new RateLimiterFactory(
+               [
+                   'id' => $limiterId,
+                   'policy' => 'sliding_window',
+                   'limit' => $limitPerMinute,
+                   'interval' => '1 minute',
+               ],
+               $storage,
+           );
+       }
+
+       public function tooManyRequests(ServerRequestInterface $request): bool
+       {
+           $normalizedParams = $request->getAttribute('normalizedParams');
+
+           if (!$normalizedParams instanceof NormalizedParams) {
+               $normalizedParams =
+                   NormalizedParams::createFromRequest($request);
+           }
+
+           $remoteIp = $normalizedParams->getRemoteAddress();
+
+           return !$this->rateLimiterFactory
+               ->create($remoteIp)
+               ->consume()
+               ->isAccepted();
+       }
+   }
+
+Design choices worth keeping:
+
+*   ``sliding_window`` avoids the burst-at-window-boundary problem of the
+    ``fixed_window`` policy: an attacker cannot double the effective rate
+    by straddling two windows.
+*   The limiter ``id`` partitions the counters. Give each cost-bearing
+    endpoint its own id (and, if the costs differ, its own limit) by
+    registering separately configured instances:
+
+.. code-block:: yaml
+   :caption: Configuration/Services.yaml — one limiter per endpoint
+
+   MyVendor\MyExtension\Infrastructure\RequestRateLimiter: ~
+
+   myext.rate_limiter.chat:
+       class: MyVendor\MyExtension\Infrastructure\RequestRateLimiter
+       arguments:
+           $limiterId: 'myext_chat'
+
+*   Where the limit value comes from — extension configuration, a site
+    setting, or a constructor default — is your choice. If you read it
+    from configuration, validate it at construction time and fail hard on
+    a missing or non-positive value rather than silently running
+    unlimited.
+
+.. _developer-endpoint-protection-cross-site:
+
+Rejecting cross-site requests
+=============================
+
+Browsers implementing the Fetch Metadata spec send a ``Sec-Fetch-Site``
+header with every request. Rejecting the value ``cross-site`` stops other
+origins from firing forged POSTs at your endpoint through visitors'
+browsers — a cost-exhaustion vector that per-IP limiting alone spreads
+across many victim IPs instead of stopping:
+
+.. code-block:: php
+   :caption: Classes/Infrastructure/FrontendRequestInspector.php
+
+   <?php
+
+   declare(strict_types=1);
+
+   namespace MyVendor\MyExtension\Infrastructure;
+
+   use Psr\Http\Message\ServerRequestInterface;
+
+   final readonly class FrontendRequestInspector
+   {
+       public function isCrossSiteRequest(
+           ServerRequestInterface $request,
+       ): bool {
+           return $request->getHeaderLine('Sec-Fetch-Site') === 'cross-site';
+       }
+   }
+
+**The check fails open by design.** A request *without* the header (an
+older browser, or a non-browser client such as curl) is not blocked. This
+is deliberate, not an oversight: all current browsers send the header
+automatically, so the check reliably covers the browser-mediated
+cross-site attack it targets, while non-browser clients — which never
+send Fetch Metadata — are exactly what the rate limiter above handles.
+Treat this check as defense in depth on top of the rate limiter, never as
+the sole protection.
+
+.. _developer-endpoint-protection-error-shaping:
+
+Never-leak error shaping
+========================
+
+An anonymous endpoint must not reveal *why* a request was refused or what
+failed internally. Provider names, exception messages, configuration
+paths, and budget states are reconnaissance material. Shape every failure
+path to the same generic, translated message, and keep the diagnostic
+detail in server-side logs only:
+
+.. code-block:: php
+   :caption: Controller action combining all three patterns
+
+   public function searchAction(string $query = ''): ResponseInterface
+   {
+       if ($this->requestInspector->isCrossSiteRequest($this->request)
+           || $this->rateLimiter->tooManyRequests($this->request)
+       ) {
+           $this->view->assign('message', $this->translator->translate(
+               'search.rateLimited',
+               'Too many requests - please wait a moment and try again.',
+           ));
+
+           return $this->htmlResponse();
+       }
+
+       try {
+           $answer = $this->queryFlow->answer(trim($query));
+       } catch (ProviderException | InvalidArgumentException) {
+           // The exception carries its diagnostic context for server-side
+           // logging; none of it is forwarded to the response.
+           $this->view->assign('message', $this->translator->translate(
+               'search.error',
+               'Something went wrong. Please try again later.',
+           ));
+
+           return $this->htmlResponse();
+       }
+
+       $this->view->assign('answer', $answer);
+
+       return $this->htmlResponse();
+   }
+
+Two details matter:
+
+*   Catch :php:`InvalidArgumentException` (or your own input-validation
+    exception) alongside the provider exceptions. Value-object
+    constructors that enforce structural invariants (query length caps,
+    range checks) throw it for attacker-controlled input; uncaught, that
+    surfaces as an HTTP 500 with a stack trace instead of the generic
+    message.
+*   Use the same response *shape* for the rate-limited and the failed
+    path. Distinguishable responses let an attacker probe which control
+    they tripped.
+
+.. _developer-endpoint-protection-reference:
+
+Reference implementation
+========================
+
+The ``nr_ai_search`` extension (Netresearch) applies all three patterns to
+its anonymous search and chat plugins: its
+:php:`RequestRateLimiter` and :php:`FrontendRequestInspector` classes in
+:file:`Classes/Infrastructure/` match the recipes above, with the limit
+read from extension configuration and a separately configured limiter id
+per controller.

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -240,4 +240,6 @@ Best practices
    ConfigurationPresets
    QualityEvaluation
    IntegrationGuide
+   EndpointProtection
+   SafeMarkdownRendering
    FeatureServices/Index

--- a/Documentation/Developer/SafeMarkdownRendering.rst
+++ b/Documentation/Developer/SafeMarkdownRendering.rst
@@ -1,0 +1,165 @@
+.. include:: /Includes.rst.txt
+
+.. _developer-safe-markdown-rendering:
+
+=========================================
+Rendering LLM Markdown server-side safely
+=========================================
+
+LLM responses are untrusted output (see
+:ref:`best practices <developer-best-practices>`): the model can echo raw
+HTML, ``javascript:`` links, or attacker-supplied fragments straight from
+its prompt context back into its answer. If your extension converts that
+Markdown to HTML on the server and injects it into a page, the converter
+configuration is a security boundary.
+
+This page shows the hardened server-side recipe, and when to prefer the
+alternative that nr-llm itself uses — client-side escaping plus sandboxed
+iframes.
+
+.. contents::
+   :local:
+   :depth: 2
+
+.. _developer-safe-markdown-hardened-commonmark:
+
+Hardened league/commonmark configuration
+========================================
+
+``league/commonmark`` is *not* a dependency of nr-llm; add it to your
+extension:
+
+.. code-block:: bash
+   :caption: Add the dependency
+
+   composer require "league/commonmark:^2.4"
+
+The library's own defaults are unsafe for LLM output: ``html_input``
+defaults to ``allow`` (raw HTML in the Markdown passes through verbatim)
+and ``allow_unsafe_links`` defaults to ``true`` (``javascript:`` and
+``data:`` link destinations are kept). Both must be overridden explicitly:
+
+.. code-block:: yaml
+   :caption: Configuration/Services.yaml
+
+   League\CommonMark\CommonMarkConverter:
+       arguments:
+           $config:
+               html_input: 'strip'
+               allow_unsafe_links: false
+
+   League\CommonMark\ConverterInterface:
+       alias: League\CommonMark\CommonMarkConverter
+
+``html_input: strip`` removes any raw HTML the model emitted;
+``allow_unsafe_links: false`` suppresses link and image destinations with
+unsafe schemes such as ``javascript:``.
+
+.. _developer-safe-markdown-fallback:
+
+Escaping fallback on converter failure
+======================================
+
+The converter can throw — on malformed input or on a configuration error.
+Neither case may end in an uncaught exception (denial of service via
+crafted output) or in emitting the raw text unescaped. Fall back to
+:php:`htmlspecialchars()`, which yields correctly escaped, if unformatted,
+output:
+
+.. code-block:: php
+   :caption: Classes/Presentation/SafeMarkdownRenderer.php
+
+   <?php
+
+   declare(strict_types=1);
+
+   namespace MyVendor\MyExtension\Presentation;
+
+   use League\CommonMark\ConverterInterface;
+   use League\CommonMark\Exception\CommonMarkException;
+   use League\Config\Exception\ConfigurationExceptionInterface;
+
+   final readonly class SafeMarkdownRenderer
+   {
+       public function __construct(
+           private ConverterInterface $markdownConverter,
+       ) {}
+
+       public function render(string $llmMarkdown): string
+       {
+           try {
+               return $this->markdownConverter
+                   ->convert($llmMarkdown)
+                   ->getContent();
+           } catch (CommonMarkException | ConfigurationExceptionInterface) {
+               return htmlspecialchars(
+                   $llmMarkdown,
+                   \ENT_QUOTES | \ENT_HTML5,
+               );
+           }
+       }
+   }
+
+In a Fluid template, output the result raw — it is already HTML — and
+never pass it through another escaping layer that would double-encode it:
+
+.. code-block:: html
+   :caption: Resources/Private/Templates/Show.html
+
+   <div class="llm-answer">{answerHtml -> f:format.raw()}</div>
+
+.. warning::
+
+   The hardened converter only guards content that goes *through* it.
+   Hyperlink targets your template builds outside the converter — for
+   example source URLs taken from index metadata and placed into ``href``
+   attributes — are a separate trust boundary: Fluid's default
+   htmlspecialchars-based escaping does not neutralize a ``javascript:``
+   URI inside an ``href``. Validate such URIs server-side (allow absolute
+   ``http(s)://`` URLs and single-slash site-relative paths; reject
+   everything else, including protocol-relative ``//host`` forms).
+
+.. _developer-safe-markdown-client-side:
+
+Alternative: client-side escaping and sandboxed iframes
+=======================================================
+
+nr-llm's own backend module deliberately does *not* render LLM output
+server-side. Its task-execution view
+(:file:`Resources/Public/JavaScript/Backend/TaskExecute.js`) escapes
+plain, Markdown, and JSON output client-side before insertion, and shows
+LLM-*generated HTML* only inside an iframe with ``sandbox=""`` — the
+fully restrictive sandbox, which blocks script execution, form
+submission, and same-origin access entirely.
+
+Which strategy fits depends on where and how the output is displayed:
+
+Server-side hardened rendering (this page)
+    Choose it for anonymous frontend pages: the output is complete
+    HTML that works without JavaScript, can be cached with the page,
+    and is identical for every client. The
+    :ref:`endpoint-protection recipes <developer-endpoint-protection>`
+    pair with it on the same controller.
+
+Client-side escaping + sandboxed iframes (nr-llm's approach)
+    Choose it for interactive views — backend modules,
+    single-page-style widgets — where output arrives incrementally
+    (streaming) and is inserted into a live DOM, or where the feature is
+    previewing LLM-generated *HTML itself*, which no Markdown converter
+    setting can make safe to inline. The sandbox attribute confines the
+    document instead of sanitizing it.
+
+The two are not exclusive: an extension with a frontend plugin and a
+backend preview module uses both, each at its own surface.
+
+.. _developer-safe-markdown-reference:
+
+Reference implementation
+========================
+
+The ``nr_ai_search`` extension (Netresearch) implements the server-side
+recipe for its anonymous search and chat plugins: the hardened converter
+configuration lives in its :file:`Configuration/Services.yaml`, and its
+:php:`MarkdownAnswerPresenter` (:file:`Classes/Provider/`) combines the
+converter with the :php:`htmlspecialchars()` fallback and server-side
+``href`` validation for source links.

--- a/Documentation/Developer/SafeMarkdownRendering.rst
+++ b/Documentation/Developer/SafeMarkdownRendering.rst
@@ -42,14 +42,20 @@ and ``allow_unsafe_links`` defaults to ``true`` (``javascript:`` and
 .. code-block:: yaml
    :caption: Configuration/Services.yaml
 
-   League\CommonMark\CommonMarkConverter:
-       arguments:
-           $config:
-               html_input: 'strip'
-               allow_unsafe_links: false
+   services:
+       _defaults:
+           autowire: true
+           autoconfigure: true
+           public: false
 
-   League\CommonMark\ConverterInterface:
-       alias: League\CommonMark\CommonMarkConverter
+       League\CommonMark\CommonMarkConverter:
+           arguments:
+               $config:
+                   html_input: 'strip'
+                   allow_unsafe_links: false
+
+       League\CommonMark\ConverterInterface:
+           alias: League\CommonMark\CommonMarkConverter
 
 ``html_input: strip`` removes any raw HTML the model emitted;
 ``allow_unsafe_links: false`` suppresses link and image destinations with


### PR DESCRIPTION
Adds two consumer-facing how-to pages under Documentation/Developer/:

- **Protecting anonymous LLM-cost-bearing endpoints** — per-IP rate limiting (`symfony/rate-limiter` + TYPO3 `CachingFrameworkStorage` alias + `NormalizedParams` keying), the `Sec-Fetch-Site` cross-site check with its fail-open rationale, and never-leak error shaping. Clarifies the split vs. nr-llm's per-user budgets (aggregate spend cap ≠ per-attacker rate limit).
- **Rendering LLM markdown server-side safely** — hardened `league/commonmark` config (`html_input: strip`, `allow_unsafe_links: false`, `htmlspecialchars` fallback), plus guidance on when to prefer the client-side strategy (escaping + sandboxed iframes) that nr-llm's own backend uses.

Docs-only; rendered with the same `render-guides` image the docs CI uses. Facts verified against the cited nr-ai-search reference implementation.

Follows up on the keep-in-consumer decisions for the rate-limiter / request-inspector / markdown-rendering extraction candidates: the recipe is the shared artifact, not a library class.