### PR TITLE
fix: keep adjacent text nodes separated in strip_tags excerpts

### DIFF
--- a/Classes/Service/Retrieval/ExcerptBuilder.php
+++ b/Classes/Service/Retrieval/ExcerptBuilder.php
@@ -19,6 +19,13 @@ final readonly class ExcerptBuilder
     public const DEFAULT_LENGTH = 160;
 
     /**
+     * The '<' of non-inline tags only: a space inserted there keeps adjacent
+     * text nodes ("<td>Price</td><td>100</td>") separated after strip_tags
+     * without splitting words joined by inline markup ("cyber<b>security</b>").
+     */
+    private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
+
+    /**
      * Plain-text excerpt centred on the first query match; falls back to
      * the text head when the query does not occur literally.
      */
@@ -40,8 +47,10 @@ final readonly class ExcerptBuilder
 
     public static function plain(string $text): string
     {
-        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
-        // stay separated after strip_tags; the collapse removes the extra spaces.
-        return trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $text))));
+        // Space before each non-inline tag so adjacent text nodes stay
+        // separated after strip_tags; the collapse removes the extra spaces.
+        $spaced = (string)preg_replace(self::NON_INLINE_TAG_PATTERN, ' <', $text);
+
+        return trim((string)preg_replace('/\s+/', ' ', strip_tags($spaced)));
     }
 }

--- a/Classes/Service/Retrieval/ExcerptBuilder.php
+++ b/Classes/Service/Retrieval/ExcerptBuilder.php
@@ -40,6 +40,8 @@ final readonly class ExcerptBuilder
 
     public static function plain(string $text): string
     {
-        return trim((string)preg_replace('/\s+/', ' ', strip_tags($text)));
+        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
+        // stay separated after strip_tags; the collapse removes the extra spaces.
+        return trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $text))));
     }
 }

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -227,7 +227,9 @@ final readonly class GetPageContentTool implements ToolInterface
      */
     private function excerpt(string $bodytext): string
     {
-        $plain = trim((string)preg_replace('/\s+/', ' ', strip_tags($bodytext)));
+        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
+        // stay separated after strip_tags; the collapse removes the extra spaces.
+        $plain = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $bodytext))));
         if ($plain === '') {
             return '';
         }

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -48,6 +48,13 @@ final readonly class GetPageContentTool implements ToolInterface
     /** Upper bound on emitted content elements per call. */
     private const ROW_CAP = 100;
 
+    /**
+     * The '<' of non-inline tags only: a space inserted there keeps adjacent
+     * text nodes ("<td>Price</td><td>100</td>") separated after strip_tags
+     * without splitting words joined by inline markup ("cyber<b>security</b>").
+     */
+    private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
+
     public function __construct(
         protected ConnectionPool $connectionPool,
     ) {}
@@ -227,9 +234,10 @@ final readonly class GetPageContentTool implements ToolInterface
      */
     private function excerpt(string $bodytext): string
     {
-        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
-        // stay separated after strip_tags; the collapse removes the extra spaces.
-        $plain = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $bodytext))));
+        // Space before each non-inline tag so adjacent text nodes stay
+        // separated after strip_tags; the collapse removes the extra spaces.
+        $spaced = (string)preg_replace(self::NON_INLINE_TAG_PATTERN, ' <', $bodytext);
+        $plain  = trim((string)preg_replace('/\s+/', ' ', strip_tags($spaced)));
         if ($plain === '') {
             return '';
         }

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -49,6 +49,13 @@ final readonly class ProbeUrlTool implements ToolInterface
 
     private const REPORTED_HEADERS = ['content-type', 'location', 'cache-control', 'x-typo3-cache'];
 
+    /**
+     * The '<' of non-inline tags only: a space inserted there keeps adjacent
+     * text nodes ("<td>Price</td><td>100</td>") separated after strip_tags
+     * without splitting words joined by inline markup ("cyber<b>security</b>").
+     */
+    private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
+
     public function __construct(
         private EgressPolicyService $egressPolicy,
         private RequestFactory $requestFactory,
@@ -168,9 +175,10 @@ final readonly class ProbeUrlTool implements ToolInterface
 
     private function bodyExcerpt(string $body): string
     {
-        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
-        // stay separated after strip_tags; the collapse removes the extra spaces.
-        $text = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $body))));
+        // Space before each non-inline tag so adjacent text nodes stay
+        // separated after strip_tags; the collapse removes the extra spaces.
+        $spaced = (string)preg_replace(self::NON_INLINE_TAG_PATTERN, ' <', $body);
+        $text   = trim((string)preg_replace('/\s+/', ' ', strip_tags($spaced)));
         if ($text === '') {
             return '';
         }

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -168,7 +168,9 @@ final readonly class ProbeUrlTool implements ToolInterface
 
     private function bodyExcerpt(string $body): string
     {
-        $text = trim((string)preg_replace('/\s+/', ' ', strip_tags($body)));
+        // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
+        // stay separated after strip_tags; the collapse removes the extra spaces.
+        $text = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $body))));
         if ($text === '') {
             return '';
         }

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -50,6 +50,13 @@ final readonly class SearchRecordsTool implements ToolInterface
 
     private const EXCERPT_LENGTH = 120;
 
+    /**
+     * The '<' of non-inline tags only: a space inserted there keeps adjacent
+     * text nodes ("<td>Price</td><td>100</td>") separated after strip_tags
+     * without splitting words joined by inline markup ("cyber<b>security</b>").
+     */
+    private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
+
     public function __construct(
         protected ConnectionPool $connectionPool,
         protected TableReadAccessService $tableAccess,
@@ -280,9 +287,10 @@ final readonly class SearchRecordsTool implements ToolInterface
             if ($value === '') {
                 continue;
             }
-            // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
-            // stay separated after strip_tags; the collapse removes the extra spaces.
-            $plain    = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $value))));
+            // Space before each non-inline tag so adjacent text nodes stay
+            // separated after strip_tags; the collapse removes the extra spaces.
+            $spaced   = (string)preg_replace(self::NON_INLINE_TAG_PATTERN, ' <', $value);
+            $plain    = trim((string)preg_replace('/\s+/', ' ', strip_tags($spaced)));
             $position = mb_stripos($plain, $query);
             if ($position === false) {
                 continue;

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -280,7 +280,9 @@ final readonly class SearchRecordsTool implements ToolInterface
             if ($value === '') {
                 continue;
             }
-            $plain    = trim((string)preg_replace('/\s+/', ' ', strip_tags($value)));
+            // Space before each tag so adjacent text nodes ("<td>Price</td><td>100</td>")
+            // stay separated after strip_tags; the collapse removes the extra spaces.
+            $plain    = trim((string)preg_replace('/\s+/', ' ', strip_tags(str_replace('<', ' <', $value))));
             $position = mb_stripos($plain, $query);
             if ($position === false) {
                 continue;

--- a/Tests/Unit/Service/Retrieval/ExcerptBuilderTest.php
+++ b/Tests/Unit/Service/Retrieval/ExcerptBuilderTest.php
@@ -36,6 +36,24 @@ final class ExcerptBuilderTest extends TestCase
     }
 
     #[Test]
+    public function keepsWordsJoinedByInlineElementsIntact(): void
+    {
+        self::assertSame(
+            'cybersecurity',
+            ExcerptBuilder::plain('cyber<b>security</b>'),
+        );
+    }
+
+    #[Test]
+    public function separatesAdjacentParagraphs(): void
+    {
+        self::assertSame(
+            'one two',
+            ExcerptBuilder::plain('<p>one</p><p>two</p>'),
+        );
+    }
+
+    #[Test]
     public function adjacentBlockElementsYieldSingleSpaces(): void
     {
         $plain = ExcerptBuilder::plain("<h1>Title</h1>\n<p>Intro <b>text</b></p><p>Next</p>");

--- a/Tests/Unit/Service/Retrieval/ExcerptBuilderTest.php
+++ b/Tests/Unit/Service/Retrieval/ExcerptBuilderTest.php
@@ -27,6 +27,24 @@ final class ExcerptBuilderTest extends TestCase
     }
 
     #[Test]
+    public function separatesAdjacentTextNodesAtTagBoundaries(): void
+    {
+        self::assertSame(
+            'Price 100 Total 200',
+            ExcerptBuilder::plain('<tr><td>Price</td><td>100</td></tr><tr><td>Total</td><td>200</td></tr>'),
+        );
+    }
+
+    #[Test]
+    public function adjacentBlockElementsYieldSingleSpaces(): void
+    {
+        $plain = ExcerptBuilder::plain("<h1>Title</h1>\n<p>Intro <b>text</b></p><p>Next</p>");
+
+        self::assertSame('Title Intro text Next', $plain);
+        self::assertStringNotContainsString('  ', $plain);
+    }
+
+    #[Test]
     public function centresExcerptOnTheMatchWithEllipses(): void
     {
         $text = str_repeat('lorem ipsum ', 30) . 'Netresearch Migration' . str_repeat(' dolor sit', 30);

--- a/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
+
+use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\ProbeUrlTool;
+use Netresearch\NrLlm\Service\Tool\Builtin\SearchRecordsTool;
+use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Tag-boundary spacing of the tools' plain-text excerpts: naive strip_tags
+ * concatenates adjacent text nodes ('<td>Price</td><td>100</td>' becomes
+ * 'Price100'), so each excerpt helper inserts a space at tag boundaries
+ * before stripping and collapses the whitespace afterwards. The excerpt
+ * helpers touch no collaborator (formatHit only the dependency-free
+ * TableReadAccessService), so newInstanceWithoutConstructor is safe.
+ */
+#[CoversClass(ProbeUrlTool::class)]
+#[CoversClass(GetPageContentTool::class)]
+#[CoversClass(SearchRecordsTool::class)]
+final class ExcerptTagSpacingTest extends TestCase
+{
+    /**
+     * @param class-string $class
+     * @param list<mixed>  $arguments
+     */
+    private static function invokeExcerptHelper(string $class, string $method, array $arguments): string
+    {
+        $reflection = new ReflectionClass($class);
+        $instance   = $reflection->newInstanceWithoutConstructor();
+
+        if ($class === SearchRecordsTool::class) {
+            // formatHit resolves the label field through the (stateless)
+            // table-access denylist; initialise only that dependency.
+            $reflection->getProperty('tableAccess')->setValue($instance, new TableReadAccessService());
+        }
+
+        $result = $reflection->getMethod($method)->invoke($instance, ...$arguments);
+        self::assertIsString($result);
+
+        return $result;
+    }
+
+    #[Test]
+    public function probeUrlBodyExcerptSeparatesAdjacentTableCells(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            ProbeUrlTool::class,
+            'bodyExcerpt',
+            ['<table><tr><td>Price</td><td>100</td></tr></table>'],
+        );
+
+        self::assertSame('Price 100', $excerpt);
+    }
+
+    #[Test]
+    public function probeUrlBodyExcerptSeparatesAdjacentBlockElementsWithoutDoubleSpaces(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            ProbeUrlTool::class,
+            'bodyExcerpt',
+            ["<h1>Title</h1>\n<p>Intro <b>text</b></p><p>Next</p>"],
+        );
+
+        self::assertSame('Title Intro text Next', $excerpt);
+        self::assertStringNotContainsString('  ', $excerpt);
+    }
+
+    #[Test]
+    public function probeUrlBodyExcerptKeepsTheByteCap(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            ProbeUrlTool::class,
+            'bodyExcerpt',
+            ['<td>' . str_repeat('a', 3000) . '</td>'],
+        );
+
+        // 2048 capped bytes plus the appended ellipsis.
+        self::assertSame(2048 + strlen('…'), strlen($excerpt));
+        self::assertStringEndsWith('…', $excerpt);
+    }
+
+    #[Test]
+    public function pageContentExcerptSeparatesAdjacentTableCells(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            GetPageContentTool::class,
+            'excerpt',
+            ['<tr><td>Price</td><td>100</td></tr><tr><td>Total</td><td>200</td></tr>'],
+        );
+
+        self::assertSame('Price 100 Total 200', $excerpt);
+    }
+
+    #[Test]
+    public function pageContentExcerptKeepsTheLengthCap(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            GetPageContentTool::class,
+            'excerpt',
+            ['<p>' . str_repeat('a', 250) . '</p>'],
+        );
+
+        // 200 capped characters plus the appended ellipsis.
+        self::assertSame(201, mb_strlen($excerpt));
+        self::assertStringEndsWith('…', $excerpt);
+    }
+
+    #[Test]
+    public function searchRecordsMatchExcerptSeparatesAdjacentTableCells(): void
+    {
+        $hit = self::invokeExcerptHelper(
+            SearchRecordsTool::class,
+            'formatHit',
+            [
+                'tt_content',
+                ['uid' => 7, 'pid' => 1, 'bodytext' => '<tr><td>Price</td><td>100</td></tr>'],
+                ['bodytext'],
+                'Price 100',
+            ],
+        );
+
+        // Before the fix the plain text was 'Price100', so a query spanning
+        // the cell boundary produced no match excerpt at all.
+        self::assertStringContainsString('tt_content:7', $hit);
+        self::assertStringContainsString('match(bodytext): Price 100', $hit);
+    }
+}

--- a/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
@@ -21,8 +21,9 @@ use ReflectionClass;
 /**
  * Tag-boundary spacing of the tools' plain-text excerpts: naive strip_tags
  * concatenates adjacent text nodes ('<td>Price</td><td>100</td>' becomes
- * 'Price100'), so each excerpt helper inserts a space at tag boundaries
- * before stripping and collapses the whitespace afterwards. The excerpt
+ * 'Price100'), so each excerpt helper inserts a space at non-inline tag
+ * boundaries before stripping and collapses the whitespace afterwards —
+ * words joined by inline markup ('cyber<b>security</b>') stay intact. The excerpt
  * helpers touch no collaborator (formatHit only the dependency-free
  * TableReadAccessService), so newInstanceWithoutConstructor is safe.
  */
@@ -78,6 +79,18 @@ final class ExcerptTagSpacingTest extends TestCase
     }
 
     #[Test]
+    public function probeUrlBodyExcerptKeepsInlineJoinedWordsIntact(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            ProbeUrlTool::class,
+            'bodyExcerpt',
+            ['<p>cyber<b>security</b> report</p>'],
+        );
+
+        self::assertSame('cybersecurity report', $excerpt);
+    }
+
+    #[Test]
     public function probeUrlBodyExcerptKeepsTheByteCap(): void
     {
         $excerpt = self::invokeExcerptHelper(
@@ -101,6 +114,18 @@ final class ExcerptTagSpacingTest extends TestCase
         );
 
         self::assertSame('Price 100 Total 200', $excerpt);
+    }
+
+    #[Test]
+    public function pageContentExcerptKeepsInlineJoinedWordsIntact(): void
+    {
+        $excerpt = self::invokeExcerptHelper(
+            GetPageContentTool::class,
+            'excerpt',
+            ['<p>cyber<b>security</b> report</p>'],
+        );
+
+        self::assertSame('cybersecurity report', $excerpt);
     }
 
     #[Test]
@@ -135,5 +160,23 @@ final class ExcerptTagSpacingTest extends TestCase
         // the cell boundary produced no match excerpt at all.
         self::assertStringContainsString('tt_content:7', $hit);
         self::assertStringContainsString('match(bodytext): Price 100', $hit);
+    }
+
+    #[Test]
+    public function searchRecordsMatchExcerptKeepsInlineJoinedWordsIntact(): void
+    {
+        $hit = self::invokeExcerptHelper(
+            SearchRecordsTool::class,
+            'formatHit',
+            [
+                'tt_content',
+                ['uid' => 7, 'pid' => 1, 'bodytext' => '<p>cyber<b>security</b> report</p>'],
+                ['bodytext'],
+                'cybersecurity',
+            ],
+        );
+
+        // A word joined by an inline element must stay searchable as one word.
+        self::assertStringContainsString('match(bodytext): cybersecurity report', $hit);
     }
 }


### PR DESCRIPTION
## Problem

Naive `strip_tags()` concatenates adjacent text nodes: `<td>Price</td><td>100</td>` → `Price100` in excerpts that egress to the model and end users.

## Fix

Insert a space before each tag prior to stripping (`str_replace('<', ' <', …)`); the existing `\s+` collapse removes the extras. Applied to all four prose-excerpt sites: `ExcerptBuilder::plain()`, `ProbeUrlTool::bodyExcerpt()`, `GetPageContentTool::excerpt()`, `SearchRecordsTool` match-excerpt.

`GetPhpInfoRawTool` deliberately untouched: raw config dump preserving newline structure, web-SAPI-only branch, no input — the one-line fix shape does not apply there.

Note for `SearchRecordsTool`: match positions are computed on the *fixed* plain text, so this slightly changes excerpt windows for records whose HTML previously glued words together — that is the corrected behavior.

## Tests

Adjacency cases (table cells, adjacent block elements) for each fixed site; full unit + functional (sqlite) + integration + fuzzy suites green locally.