### PR TITLE
feat(retrieval): public keyword-search facade over the site-search cascade (ADR-071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Public keyword-search facade** (ADR-070). New public contract
+  `Service\Retrieval\KeywordSearchInterface` — `search(string $query, int $limit,
+  ?int $languageId = null): list<KeywordHit>` plus `isAvailable()` — over the ADR-049
+  site-search cascade, so downstream extensions no longer bind to private retrieval
+  internals. Input is clamped (never throws), results are always public-only, and any
+  backend failure degrades to an empty list. A second registration,
+  `nr_llm.keyword_search.index_backed`, excludes the priority-0 database LIKE fallback
+  for consumers that must treat "index unavailable" as empty (e.g. hybrid dense+sparse
+  fusion). Documented in `Documentation/Api/KeywordSearch.rst`; audited public-service
+  count 26 → 28.
+
 ## [0.20.0] - 2026-07-16
 
 Closes out the operator-config audit: every backend-visible provider/model/configuration

--- a/Classes/Service/Retrieval/KeywordHit.php
+++ b/Classes/Service/Retrieval/KeywordHit.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Retrieval;
+
+/**
+ * One keyword-search hit returned by {@see KeywordSearchInterface}
+ * (ADR-071).
+ *
+ * The public counterpart of the internal {@see EvidenceSource}: the same
+ * fields minus the backend label, so the facade can evolve the cascade
+ * internals without changing this contract. `score` is backend-native
+ * relevance (not comparable across backends); `pageUid` is set when the
+ * answering backend can resolve the hit to a page, null otherwise.
+ */
+final readonly class KeywordHit
+{
+    public function __construct(
+        public string $sourceId,
+        public string $title,
+        public string $url,
+        public string $excerpt,
+        public int $languageId,
+        public ?float $score = null,
+        public ?int $pageUid = null,
+    ) {}
+}

--- a/Classes/Service/Retrieval/KeywordSearchInterface.php
+++ b/Classes/Service/Retrieval/KeywordSearchInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Retrieval;
+
+/**
+ * Public keyword-search contract over the site-search cascade (ADR-071).
+ *
+ * The narrow facade downstream extensions wire against instead of the
+ * private retrieval internals. Semantics:
+ *
+ * - Input is never rejected: the query is trimmed and truncated to
+ *   {@see RetrievalQuery::MAX_QUERY_LENGTH}, the limit clamped to
+ *   1..{@see RetrievalQuery::MAX_SOURCES}, a negative language id
+ *   clamped to 0. A query shorter than
+ *   {@see RetrievalQuery::MIN_QUERY_LENGTH} yields an empty list.
+ * - Results are always filtered public-only
+ *   ({@see AccessContext::publicOnly()}): hits are what the anonymous
+ *   visitor could read.
+ * - Any backend failure degrades to an empty list — the facade never
+ *   throws.
+ *
+ * Two container registrations exist (ADR-071): this interface alias
+ * resolves the full cascade including the database LIKE fallback, and
+ * the named service `nr_llm.keyword_search.index_backed` resolves an
+ * index-backed-only variant that excludes the fallback — for consumers
+ * (e.g. hybrid dense+sparse fusion) that must see "index unavailable"
+ * as empty rather than receive LIKE hits.
+ */
+interface KeywordSearchInterface
+{
+    /**
+     * Run a public-only keyword search and return the hits of the first
+     * available backend, deduplicated by URL and capped at `$limit`.
+     *
+     * @param string   $query      free-text query; trimmed and truncated, never rejected
+     * @param int      $limit      maximum hits, clamped to 1..RetrievalQuery::MAX_SOURCES
+     * @param int|null $languageId sys_language uid to search in; null means default (0)
+     *
+     * @return list<KeywordHit> empty when nothing matched, the query is
+     *                          too short, or no backend is available
+     */
+    public function search(string $query, int $limit, ?int $languageId = null): array;
+
+    /**
+     * Whether at least one search backend of this variant can answer
+     * right now. Never throws.
+     */
+    public function isAvailable(): bool;
+}

--- a/Classes/Service/Retrieval/KeywordSearchService.php
+++ b/Classes/Service/Retrieval/KeywordSearchService.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Retrieval;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Throwable;
+
+/**
+ * Default implementation of {@see KeywordSearchInterface} (ADR-071): a
+ * clamping, degrade-to-empty facade over the retrieval cascade.
+ *
+ * Composes a {@see RetrievalService} over the tagged backends rather
+ * than duplicating the cascade. With `$indexBackedOnly` the priority-0
+ * fallback tier (the database LIKE backend, see
+ * {@see SearchBackendInterface::getPriority()}) is excluded, so an
+ * unavailable index yields an empty result instead of LIKE hits.
+ */
+final class KeywordSearchService implements KeywordSearchInterface
+{
+    private ?RetrievalService $cascade = null;
+
+    /** @var list<SearchBackendInterface>|null */
+    private ?array $selectedBackends = null;
+
+    /**
+     * @param iterable<SearchBackendInterface> $backends
+     */
+    public function __construct(
+        #[AutowireIterator(SearchBackendInterface::TAG_NAME)]
+        private readonly iterable $backends,
+        private readonly bool $indexBackedOnly = false,
+    ) {}
+
+    public function search(string $query, int $limit, ?int $languageId = null): array
+    {
+        $query = trim($query);
+        if (mb_strlen($query) > RetrievalQuery::MAX_QUERY_LENGTH) {
+            $query = trim(mb_substr($query, 0, RetrievalQuery::MAX_QUERY_LENGTH));
+        }
+        if (mb_strlen($query) < RetrievalQuery::MIN_QUERY_LENGTH) {
+            return [];
+        }
+
+        $limit = max(1, min($limit, RetrievalQuery::MAX_SOURCES));
+
+        try {
+            $result = $this->cascade()->search(
+                RetrievalQuery::create($query, $limit, null, max(0, $languageId ?? 0)),
+                AccessContext::publicOnly(),
+            );
+        } catch (Throwable) {
+            return [];
+        }
+
+        return array_map(
+            static fn(EvidenceSource $source): KeywordHit => new KeywordHit(
+                sourceId: $source->sourceId,
+                title: $source->title,
+                url: $source->url,
+                excerpt: $source->excerpt,
+                languageId: $source->languageId,
+                score: $source->score,
+                pageUid: $source->pageUid,
+            ),
+            $result->sources,
+        );
+    }
+
+    public function isAvailable(): bool
+    {
+        foreach ($this->selectedBackends() as $backend) {
+            try {
+                if ($backend->isAvailable()) {
+                    return true;
+                }
+            } catch (Throwable) {
+                // An erroring backend counts as unavailable.
+            }
+        }
+
+        return false;
+    }
+
+    private function cascade(): RetrievalService
+    {
+        return $this->cascade ??= new RetrievalService($this->selectedBackends());
+    }
+
+    /**
+     * @return list<SearchBackendInterface>
+     */
+    private function selectedBackends(): array
+    {
+        if ($this->selectedBackends === null) {
+            $selected = [];
+            foreach ($this->backends as $backend) {
+                if ($this->indexBackedOnly && $backend->getPriority() <= 0) {
+                    continue;
+                }
+                $selected[] = $backend;
+            }
+            $this->selectedBackends = $selected;
+        }
+
+        return $this->selectedBackends;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -54,6 +54,20 @@ services:
   Netresearch\NrLlm\Service\Retrieval\SolrHttpClientInterface:
     alias: Netresearch\NrLlm\Service\Retrieval\SolrHttpClient
 
+  # Public keyword-search facade (ADR-071). The interface alias resolves
+  # the full cascade (concrete class stays private); the named variant
+  # excludes the priority-0 database LIKE fallback for consumers that
+  # need "index unavailable -> empty" (e.g. hybrid dense+sparse fusion).
+  Netresearch\NrLlm\Service\Retrieval\KeywordSearchInterface:
+    alias: Netresearch\NrLlm\Service\Retrieval\KeywordSearchService
+    public: true
+
+  nr_llm.keyword_search.index_backed:
+    class: Netresearch\NrLlm\Service\Retrieval\KeywordSearchService
+    arguments:
+      $indexBackedOnly: true
+    public: true
+
   Netresearch\NrLlm\Specialized\Translation\TranslatorRegistryInterface:
     alias: Netresearch\NrLlm\Specialized\Translation\TranslatorRegistry
     public: true

--- a/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
+++ b/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
@@ -99,6 +99,14 @@ aliases = 14:
 * ``Service\Feature\TranslationService`` (+ Interface)
 * ``Service\Feature\ToolCallingService`` (+ Interface, ADR-051)
 
+Added to Category A after this ADR (count superseded by
+:ref:`adr-071`):
+
+* ``Service\Retrieval\KeywordSearchInterface`` (alias; the concrete
+  ``KeywordSearchService`` stays private, ADR-071)
+* ``nr_llm.keyword_search.index_backed`` (named index-backed-only
+  variant, ADR-071)
+
 **B. Supporting-service interface aliases** (concrete classes now
 private) — 6:
 

--- a/Documentation/Adr/Adr071PublicKeywordSearchFacade.rst
+++ b/Documentation/Adr/Adr071PublicKeywordSearchFacade.rst
@@ -1,0 +1,160 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-071:
+
+==================================================================
+ADR-071: Public keyword-search facade over the retrieval cascade
+==================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-071-context:
+
+Context
+=======
+
+ADR-049 built the site-search retrieval cascade
+(:php:`Service\Retrieval\RetrievalService` over the tagged
+``nr_llm.retrieval_backend`` implementations: Solr, ke_search,
+indexed_search, database LIKE fallback). Every class in that namespace
+is private — the only public faces of the capability are the LLM tools
+``site_rag_query`` / ``site_fetch_source``. Yet ADR-050 explicitly
+promises keyword content-finding to downstream extensions ("a consumer
+that only needs keyword content-finding uses nr_llm alone"), and
+ADR-028 / ADR-065 require cross-extension consumption to go through the
+documented, audited public surface.
+
+That gap has a demonstrated cost: nr_ai_search's hybrid retrieval binds
+its sparse arm to the **private concrete** service
+:php:`Service\Retrieval\SolrSearchBackend` via an ``@``-reference in
+its own :file:`Services.yaml` and imports four non-contract classes
+(:php:`RetrievalQuery` including its bounds constants,
+:php:`AccessContext`, :php:`SearchBackendInterface`,
+:php:`EvidenceSource`). A private service id carries no semver signal:
+any rename or restructuring inside nr_llm breaks the consumer's
+container compile silently, across the consumer's whole version
+constraint.
+
+.. _adr-071-decision:
+
+Decision
+========
+
+Close the gap with a deliberately **narrow** public facade instead of
+exposing the retrieval internals.
+
+The contract
+------------
+
+:php:`Netresearch\NrLlm\Service\Retrieval\KeywordSearchInterface` with
+exactly two methods:
+
+.. code-block:: php
+
+   public function search(string $query, int $limit, ?int $languageId = null): array; // list<KeywordHit>
+   public function isAvailable(): bool;
+
+:php:`KeywordHit` is a final readonly DTO carrying ``sourceId``,
+``title``, ``url``, ``excerpt``, ``languageId`` (int), ``score``
+(?float, backend-native, not comparable across backends) and
+``pageUid`` (?int) — the fields of the internal :php:`EvidenceSource`
+minus the backend label, so cascade internals can evolve without
+touching the contract.
+
+Semantics
+---------
+
+- **Clamp, never throw.** The query is trimmed and truncated to
+  :php:`RetrievalQuery::MAX_QUERY_LENGTH`; a query shorter than
+  :php:`RetrievalQuery::MIN_QUERY_LENGTH` returns an empty list; the
+  limit is clamped to 1..\ :php:`RetrievalQuery::MAX_SOURCES`; a
+  negative language id is clamped to 0. Out-of-range input is a normal
+  call, not an exception.
+- **Public-only.** The facade always searches with
+  :php:`AccessContext::publicOnly()` — hits are what the anonymous
+  visitor could read.
+- **Degrade to empty.** Any backend failure yields an empty list; the
+  facade never throws. Cascade order, first-available-wins, URL
+  deduplication and the result cap are ADR-049 semantics, reused
+  unchanged (the implementation composes :php:`RetrievalService`).
+
+The pinning question: index-backed-only mode
+--------------------------------------------
+
+A hybrid dense+sparse consumer (nr_ai_search's RRF fusion) pins an
+index-backed engine and must treat "index unavailable" as an **empty
+sparse arm** — fusing hits from the priority-0 database LIKE fallback
+would silently mix engines of incomparable relevance into the fusion.
+The facade therefore ships in two container registrations of the same
+implementation class:
+
+- The :php:`KeywordSearchInterface` **alias** resolves the full cascade
+  including the database fallback — the right default for "find the
+  page about X" consumers.
+- The **named service** ``nr_llm.keyword_search.index_backed`` resolves
+  a variant constructed with ``$indexBackedOnly: true`` that excludes
+  the priority-0 tier, per the :php:`SearchBackendInterface::getPriority()`
+  contract ("the always-available database fallback uses 0,
+  index-backed engines use higher values"). Its :php:`isAvailable()`
+  answers for index-backed engines only.
+
+A named service variant was chosen over a second interface method so
+the contract stays at two methods and each variant gives a coherent
+:php:`isAvailable()` answer for its own mode. Consumers wire it as a
+named argument, e.g.:
+
+.. code-block:: yaml
+
+   Vendor\Ext\Search\SparseArm:
+     arguments:
+       $keywordSearch: '@nr_llm.keyword_search.index_backed'
+
+Both registrations are ``public: true`` and part of the audited,
+semver-guarded surface.
+
+.. _adr-071-consequences:
+
+Consequences
+============
+
+- **Public-service count: 26 → 28.** The interface alias and the named
+  index-backed variant join ADR-065's Category A (documented downstream
+  contract). This ADR is the new count authority, superseding ADR-069's
+  count exactly as ADR-069 superseded ADR-065's. The breakdown is now
+  16 + 5 + 1 + 4 + 2 = **28**. The
+  :php:`Tests\Unit\Configuration\PublicServicesPolicyTest`
+  ``EXPECTED_PUBLIC_TRUE_COUNT`` constant and this ADR are the audit
+  trail; ADR-065's Category A list is amended in place.
+- **The facade constrains Retrieval refactors.** The clamping,
+  public-only and degrade-to-empty semantics plus the
+  ``getPriority() > 0`` index-backed distinction are now contract;
+  cascade internals (backends, :php:`RetrievalService`,
+  :php:`EvidenceSource`) remain private and free to change as long as
+  the facade is preserved.
+- **Consumers drop private references.** nr_ai_search can replace its
+  ``@Netresearch\NrLlm\Service\Retrieval\SolrSearchBackend`` binding
+  and its :php:`RetrievalQuery` / :php:`AccessContext` /
+  :php:`EvidenceSource` imports with the interface (or the named
+  variant) and :php:`KeywordHit`, guarded by a normal version
+  constraint bump.
+- **Documentation.** The facade is documented in
+  :file:`Documentation/Api/KeywordSearch.rst`.
+
+.. _adr-071-alternatives:
+
+Alternatives considered
+=======================
+
+- **Publish the internals** (:php:`SearchBackendInterface`,
+  :php:`RetrievalService`, :php:`RetrievalQuery`, ...). Rejected: far
+  wider surface, freezes the cascade's internal shape pre-1.0, and
+  repeats the coupling this ADR removes one level down.
+- **A second interface method** (``searchIndexBacked()``). Rejected:
+  the mode would double every future method and leave
+  :php:`isAvailable()` ambiguous about which mode it answers for.
+- **Constructor flag without a named registration.** Rejected: a
+  consumer could only reach the index-backed variant by redefining the
+  service in its own container configuration — reintroducing exactly
+  the unversioned wiring knowledge this facade exists to remove.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -368,4 +368,5 @@ Tools
    Adr067SolrPerLanguageCoreFilter
    Adr069RemovePromptTemplateStack
    Adr070UserlessConfigurationResolutionByIdentifier
+   Adr071PublicKeywordSearchFacade
    Adr073FirstPartyTestingFixtures

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -17,6 +17,7 @@ Complete API reference for the TYPO3 LLM extension.
    VisionService
    TranslationService
    ToolCallingService
+   KeywordSearch
    ResponseObjects
    OptionClasses
    ProviderInterface

--- a/Documentation/Api/KeywordSearch.rst
+++ b/Documentation/Api/KeywordSearch.rst
@@ -1,0 +1,118 @@
+.. include:: /Includes.rst.txt
+
+.. _api-keyword-search:
+
+=============
+KeywordSearch
+=============
+
+.. php:namespace:: Netresearch\NrLlm\Service\Retrieval
+
+.. php:interface:: KeywordSearchInterface
+
+   Public keyword-search facade over the site-search retrieval cascade
+   (:ref:`adr-071`). Searches the first available backend (Solr,
+   ke_search, indexed_search, database fallback), always filtered
+   public-only — hits are what the anonymous visitor could read.
+
+   Input is clamped, never rejected, and any backend failure degrades
+   to an empty result: the facade never throws.
+
+   .. php:method:: search(string $query, int $limit, ?int $languageId = null): array
+
+      Run a public-only keyword search. The query is trimmed and
+      truncated to 200 characters; a query shorter than 2 characters
+      returns an empty list. The limit is clamped to 1–20; a negative
+      language id is clamped to 0. Hits are deduplicated by URL and
+      capped at the limit.
+
+      :param string $query: Free-text query
+      :param int $limit: Maximum number of hits (clamped to 1–20)
+      :param ?int $languageId: sys_language uid; null means default (0)
+      :returns: list<KeywordHit> — empty when nothing matched, the
+         query is too short, or no backend is available
+
+   .. php:method:: isAvailable(): bool
+
+      Whether at least one search backend of this variant can answer
+      right now. Never throws.
+
+.. php:class:: KeywordHit
+
+   One keyword-search hit. Final readonly DTO.
+
+   .. php:attr:: sourceId
+
+      string — Stable source id; format is backend-internal.
+
+   .. php:attr:: title
+
+      string — Result title.
+
+   .. php:attr:: url
+
+      string — Public URL of the hit (may be empty when the backend
+      cannot resolve one).
+
+   .. php:attr:: excerpt
+
+      string — Short indexed-content excerpt.
+
+   .. php:attr:: languageId
+
+      int — sys_language uid the hit belongs to.
+
+   .. php:attr:: score
+
+      ?float — Backend-native relevance score; not comparable across
+      backends; null when the backend reports none.
+
+   .. php:attr:: pageUid
+
+      ?int — Page uid when the answering backend can resolve the hit
+      to a page, null otherwise.
+
+Service variants
+================
+
+Two container registrations exist (:ref:`adr-071`):
+
+- :php:`KeywordSearchInterface` — the full cascade including the
+  database LIKE fallback. Wire it via constructor type hint or resolve
+  it from the container.
+- ``nr_llm.keyword_search.index_backed`` — a named variant that
+  excludes the fallback tier. Use it when "index unavailable" must
+  yield an empty result instead of LIKE hits (e.g. hybrid dense+sparse
+  fusion). Its :php:`isAvailable()` answers for index-backed engines
+  only.
+
+Usage
+=====
+
+.. code-block:: php
+
+   use Netresearch\NrLlm\Service\Retrieval\KeywordSearchInterface;
+
+   final class PageFinder
+   {
+       public function __construct(
+           private readonly KeywordSearchInterface $keywordSearch,
+       ) {}
+
+       public function findCandidates(string $topic): array
+       {
+           if (!$this->keywordSearch->isAvailable()) {
+               return [];
+           }
+
+           return $this->keywordSearch->search($topic, 10);
+       }
+   }
+
+Wiring the index-backed-only variant:
+
+.. code-block:: yaml
+
+   Vendor\Ext\Search\SparseArm:
+     arguments:
+       $keywordSearch: '@nr_llm.keyword_search.index_backed'

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -43,9 +43,12 @@ final class PublicServicesPolicyTest extends TestCase
      * overrides were never load-bearing. Categories per ADR-065:
      *
      * - Category A (Documented downstream LLM-API contract): 7 concrete
-     *   services + 7 interface aliases = 14 — LlmServiceManager,
-     *   ProviderAdapterRegistry, and the Completion/Vision/Embedding/
-     *   Translation/ToolCalling (ADR-051) feature pairs.
+     *   services + 7 interface aliases + 2 keyword-search facade entries
+     *   (ADR-071: KeywordSearchInterface alias and the named
+     *   `nr_llm.keyword_search.index_backed` variant) = 16 —
+     *   LlmServiceManager, ProviderAdapterRegistry, and the
+     *   Completion/Vision/Embedding/Translation/ToolCalling (ADR-051)
+     *   feature pairs.
      * - Category B (Supporting-service interface aliases; the concrete
      *   classes are now private): 5 — CacheManagerInterface,
      *   UsageTrackerServiceInterface, TranslatorRegistryInterface,
@@ -58,15 +61,15 @@ final class PublicServicesPolicyTest extends TestCase
      *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 14 + 5 + 1 + 4 + 2 = **26**.
+     * Total: 16 + 5 + 1 + 4 + 2 = **28**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr069RemovePromptTemplateStack.rst` (the current
-     * count authority, superseding ADR-065's count) in the same PR — the
+     * `Documentation/Adr/Adr071PublicKeywordSearchFacade.rst` (the current
+     * count authority, superseding ADR-069's count) in the same PR — the
      * diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 26;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 28;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Service/Retrieval/Fixtures/FakeSearchBackend.php
+++ b/Tests/Unit/Service/Retrieval/Fixtures/FakeSearchBackend.php
@@ -25,6 +25,8 @@ final class FakeSearchBackend implements SearchBackendInterface
 {
     public int $searchCalls = 0;
 
+    public ?RetrievalQuery $lastQuery = null;
+
     /**
      * @param list<EvidenceSource> $sources
      */
@@ -35,6 +37,7 @@ final class FakeSearchBackend implements SearchBackendInterface
         private readonly array $sources = [],
         private readonly bool $throwsOnSearch = false,
         private readonly ?string $fetchResult = null,
+        private readonly bool $throwsOnAvailability = false,
     ) {}
 
     public function getIdentifier(): string
@@ -49,12 +52,17 @@ final class FakeSearchBackend implements SearchBackendInterface
 
     public function isAvailable(): bool
     {
+        if ($this->throwsOnAvailability) {
+            throw new RuntimeException('availability boom', 1751000001);
+        }
+
         return $this->available;
     }
 
     public function search(RetrievalQuery $query, AccessContext $context): EvidenceList
     {
         ++$this->searchCalls;
+        $this->lastQuery = $query;
         if ($this->throwsOnSearch) {
             throw new RuntimeException('boom', 1751000000);
         }

--- a/Tests/Unit/Service/Retrieval/KeywordSearchServiceTest.php
+++ b/Tests/Unit/Service/Retrieval/KeywordSearchServiceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Retrieval;
+
+use Netresearch\NrLlm\Service\Retrieval\EvidenceSource;
+use Netresearch\NrLlm\Service\Retrieval\KeywordHit;
+use Netresearch\NrLlm\Service\Retrieval\KeywordSearchService;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
+use Netresearch\NrLlm\Tests\Unit\Service\Retrieval\Fixtures\FakeSearchBackend;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KeywordSearchService::class)]
+#[CoversClass(KeywordHit::class)]
+final class KeywordSearchServiceTest extends TestCase
+{
+    #[Test]
+    public function queryIsTrimmedAndTruncatedToMaxLength(): void
+    {
+        $backend = new FakeSearchBackend('solr', 30, sources: [FakeSearchBackend::source('solr:1')]);
+        $service = new KeywordSearchService([$backend]);
+
+        $service->search('  ' . str_repeat('a', RetrievalQuery::MAX_QUERY_LENGTH + 50) . '  ', 5);
+
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(str_repeat('a', RetrievalQuery::MAX_QUERY_LENGTH), $backend->lastQuery->query);
+    }
+
+    #[Test]
+    public function tooShortQueryReturnsEmptyWithoutQueryingBackends(): void
+    {
+        $backend = new FakeSearchBackend('solr', 30, sources: [FakeSearchBackend::source('solr:1')]);
+        $service = new KeywordSearchService([$backend]);
+
+        self::assertSame([], $service->search('  a  ', 5));
+        self::assertSame(0, $backend->searchCalls);
+    }
+
+    #[Test]
+    public function limitIsClampedToRetrievalQueryBounds(): void
+    {
+        $backend = new FakeSearchBackend('solr', 30, sources: [FakeSearchBackend::source('solr:1')]);
+        $service = new KeywordSearchService([$backend]);
+
+        $service->search('term', 0);
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(1, $backend->lastQuery->maxSources);
+
+        $service->search('term', 999);
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(RetrievalQuery::MAX_SOURCES, $backend->lastQuery->maxSources);
+    }
+
+    #[Test]
+    public function negativeAndNullLanguageIdsResolveToDefaultLanguage(): void
+    {
+        $backend = new FakeSearchBackend('solr', 30, sources: [FakeSearchBackend::source('solr:1')]);
+        $service = new KeywordSearchService([$backend]);
+
+        $service->search('term', 5, -3);
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(0, $backend->lastQuery->languageId);
+
+        $service->search('term', 5);
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(0, $backend->lastQuery->languageId);
+
+        $service->search('term', 5, 2);
+        self::assertNotNull($backend->lastQuery);
+        self::assertSame(2, $backend->lastQuery->languageId);
+    }
+
+    #[Test]
+    public function throwingBackendDegradesToEmptyList(): void
+    {
+        $service = new KeywordSearchService([new FakeSearchBackend('solr', 30, throwsOnSearch: true)]);
+
+        self::assertSame([], $service->search('term', 5));
+    }
+
+    #[Test]
+    public function noAvailableBackendYieldsEmptyListAndUnavailability(): void
+    {
+        $service = new KeywordSearchService([new FakeSearchBackend('solr', 30, available: false)]);
+
+        self::assertSame([], $service->search('term', 5));
+        self::assertFalse($service->isAvailable());
+    }
+
+    #[Test]
+    public function availabilityProbeSurvivesThrowingBackend(): void
+    {
+        $service = new KeywordSearchService([
+            new FakeSearchBackend('broken', 30, throwsOnAvailability: true),
+            new FakeSearchBackend('database', 0),
+        ]);
+
+        self::assertTrue($service->isAvailable());
+    }
+
+    #[Test]
+    public function fullCascadeIncludesDatabaseFallback(): void
+    {
+        $solr = new FakeSearchBackend('solr', 30, available: false);
+        $database = new FakeSearchBackend('database', 0, sources: [FakeSearchBackend::source('database:1:0')]);
+        $service = new KeywordSearchService([$solr, $database]);
+
+        $hits = $service->search('term', 5);
+
+        self::assertCount(1, $hits);
+        self::assertSame('database:1:0', $hits[0]->sourceId);
+        self::assertTrue($service->isAvailable());
+    }
+
+    #[Test]
+    public function indexBackedOnlyModeExcludesPriorityZeroFallback(): void
+    {
+        $solr = new FakeSearchBackend('solr', 30, available: false);
+        $database = new FakeSearchBackend('database', 0, sources: [FakeSearchBackend::source('database:1:0')]);
+        $service = new KeywordSearchService([$solr, $database], indexBackedOnly: true);
+
+        self::assertSame([], $service->search('term', 5));
+        self::assertSame(0, $database->searchCalls);
+        self::assertFalse($service->isAvailable());
+    }
+
+    #[Test]
+    public function indexBackedOnlyModeStillAnswersFromIndexBackedBackend(): void
+    {
+        $solr = new FakeSearchBackend('solr', 30, sources: [FakeSearchBackend::source('solr:1')]);
+        $database = new FakeSearchBackend('database', 0, sources: [FakeSearchBackend::source('database:1:0')]);
+        $service = new KeywordSearchService([$solr, $database], indexBackedOnly: true);
+
+        $hits = $service->search('term', 5);
+
+        self::assertCount(1, $hits);
+        self::assertSame('solr:1', $hits[0]->sourceId);
+        self::assertTrue($service->isAvailable());
+    }
+
+    #[Test]
+    public function hitsCarryAllEvidenceSourceFields(): void
+    {
+        $source = new EvidenceSource(
+            sourceId: 'solr:site:42:1',
+            title: 'A page',
+            url: 'https://example.org/a-page',
+            excerpt: 'Excerpt text',
+            backend: 'solr',
+            languageId: 1,
+            pageUid: 42,
+            score: 0.87,
+        );
+        $service = new KeywordSearchService([new FakeSearchBackend('solr', 30, sources: [$source])]);
+
+        $hits = $service->search('term', 5, 1);
+
+        self::assertCount(1, $hits);
+        $hit = $hits[0];
+        self::assertSame('solr:site:42:1', $hit->sourceId);
+        self::assertSame('A page', $hit->title);
+        self::assertSame('https://example.org/a-page', $hit->url);
+        self::assertSame('Excerpt text', $hit->excerpt);
+        self::assertSame(1, $hit->languageId);
+        self::assertSame(0.87, $hit->score);
+        self::assertSame(42, $hit->pageUid);
+    }
+
+    #[Test]
+    public function hitsAreDeduplicatedByUrlAndCappedAtLimit(): void
+    {
+        $sources = [
+            FakeSearchBackend::source('a:1', 'https://example.org/one'),
+            FakeSearchBackend::source('a:2', 'https://example.org/one'),
+            FakeSearchBackend::source('a:3', 'https://example.org/three'),
+            FakeSearchBackend::source('a:4', 'https://example.org/four'),
+        ];
+        $service = new KeywordSearchService([new FakeSearchBackend('solr', 30, sources: $sources)]);
+
+        $hits = $service->search('term', 2);
+
+        self::assertCount(2, $hits);
+        self::assertSame(['a:1', 'a:3'], array_map(static fn(KeywordHit $hit): string => $hit->sourceId, $hits));
+    }
+}


### PR DESCRIPTION
## Problem

Extensions consuming keyword site-search from PHP (e.g. nr-ai-search's sparse hybrid arm) have no public contract — they bind the **private** `SolrSearchBackend` service by id in their own `Services.yaml`. That coupling is unversioned: any internal rename breaks their container compile with no semver signal. nr-llm ADR-050 already promises this capability to "a consumer that only needs keyword content-finding", but only as LLM tools, not as a PHP API.

## Change (ADR-071)

- `KeywordSearchInterface` — `search(string $query, int $limit, ?int $languageId = null): list<KeywordHit>` + `isAvailable(): bool`
  - clamping semantics: input never rejected (trim/truncate/clamp to `RetrievalQuery` bounds)
  - `AccessContext::publicOnly()` internally — hits are what the anonymous visitor could read
  - degrade-to-empty on any backend failure — the facade never throws
- `KeywordHit` DTO: sourceId, title, url, excerpt, languageId (int), score, pageUid
- **Index-backed-only variant** `nr_llm.keyword_search.index_backed` (excludes the priority-0 database LIKE fallback, defined via the documented `getPriority() > 0` contract) — hybrid consumers need "index unavailable → empty", never LIKE-hit fusion
- ADR-065 audited surface list + `PublicServicesPolicyTest` updated, API docs page added

ADR is numbered **071** (070 is taken by #408; renumbered before push).

## Consumer follow-up

nr-ai-search's `SolrKeywordArm` shrinks to a thin DTO-mapping adapter and drops the private-service reference once its composer floor includes this release (tracked there; its ADR-028 amendment already references this interface).

## Gates

unit (4934 incl. 12 new), phpstan L10, cgl, rector, fuzzy green locally; functional left to CI.