### PR TITLE
feat(evaluation): retrieval-quality evaluation via golden question sets (ADR-072)

### DIFF
--- a/Classes/Command/RetrievalEvalRunCommand.php
+++ b/Classes/Command/RetrievalEvalRunCommand.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverRegistry;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetRegistry;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalEvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalSetEvaluationResult;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Runs a golden question set against a retriever, prints the per-question
+ * hits and the top-1/top-3 hit rates with their by-form and by-hard-class
+ * breakdowns, then compares the run against the previous one for the same
+ * (set, retriever) and reports any regression (ADR-072) — the retrieval
+ * sibling of {@see EvalRunCommand}.
+ *
+ * Explicitly invoked — nothing here runs in the request pipeline, and no
+ * LLM is involved: the run costs one retrieval call per question.
+ */
+#[AsCommand(
+    name: 'nrllm:eval:retrieval',
+    description: 'Run a golden question set against a retriever and report hit rates and regression.',
+)]
+final class RetrievalEvalRunCommand extends Command
+{
+    public function __construct(
+        private readonly GoldenQuestionSetRegistry $setRegistry,
+        private readonly EvaluatableRetrieverRegistry $retrieverRegistry,
+        private readonly RetrievalEvaluationService $evaluationService,
+        private readonly EvaluationResultRepositoryInterface $repository,
+        private readonly RegressionDetector $regressionDetector,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('set', InputArgument::REQUIRED, 'Golden question set identifier (e.g. nr_ai_search.bmdv)')
+            ->addArgument('retriever', InputArgument::REQUIRED, 'Retriever identifier (e.g. nr_llm.lexical)')
+            ->addOption('max-top1-drop', null, InputOption::VALUE_REQUIRED, 'Top-1 hit-rate drop (0..1) that counts as a regression', '0.1')
+            ->addOption('max-top3-drop', null, InputOption::VALUE_REQUIRED, 'Top-3 hit-rate drop (0..1) that counts as a regression', '0.1')
+            ->addOption('fail-on-regression', null, InputOption::VALUE_NONE, 'Exit with a non-zero status when a regression is detected');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $setArgument = $input->getArgument('set');
+        $setIdentifier = is_string($setArgument) ? $setArgument : '';
+        $set = $this->setRegistry->findByIdentifier($setIdentifier);
+        if ($set === null) {
+            $io->error(sprintf('Unknown golden question set "%s".', $setIdentifier));
+            $available = $this->setRegistry->identifiers();
+            if ($available !== []) {
+                $io->writeln('Available sets: ' . implode(', ', $available));
+            }
+
+            return Command::FAILURE;
+        }
+
+        $retrieverArgument = $input->getArgument('retriever');
+        $retrieverIdentifier = is_string($retrieverArgument) ? $retrieverArgument : '';
+        $retriever = $this->retrieverRegistry->findByIdentifier($retrieverIdentifier);
+        if ($retriever === null) {
+            $io->error(sprintf('Unknown retriever "%s".', $retrieverIdentifier));
+            $available = $this->retrieverRegistry->identifiers();
+            if ($available !== []) {
+                $io->writeln('Available retrievers: ' . implode(', ', $available));
+            }
+
+            return Command::FAILURE;
+        }
+
+        $result = $this->evaluationService->run($set, $retriever);
+
+        $io->title(sprintf('Retrieval evaluation: %s vs %s', $set->identifier, $retriever->getIdentifier()));
+        $this->renderEvaluations($io, $result);
+
+        $persistable = $result->toSetEvaluationResult();
+        $previous = $this->repository->findLatest($persistable->setIdentifier, $persistable->model, $persistable->grader);
+        $this->repository->save($persistable);
+
+        $report = $this->regressionDetector->compare(
+            $persistable->toSummary(),
+            $previous,
+            new RegressionThresholds(
+                $this->floatOption($input, 'max-top1-drop', 0.1),
+                $this->floatOption($input, 'max-top3-drop', 0.1),
+            ),
+        );
+
+        $io->section('Regression check (pass rate = top-1 hit rate, mean score = top-3 hit rate)');
+        $io->writeln($report->summary);
+
+        if ($report->isRegression) {
+            $io->warning('Retrieval regression detected against the previous run.');
+            if ($input->getOption('fail-on-regression') === true) {
+                return Command::FAILURE;
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderEvaluations(SymfonyStyle $io, RetrievalSetEvaluationResult $result): void
+    {
+        $rows = [];
+        foreach ($result->evaluations as $evaluation) {
+            $rows[] = [
+                $evaluation->questionId,
+                $evaluation->form->value,
+                $evaluation->hardClass ?? '-',
+                $evaluation->top1Hit ? 'hit' : 'MISS',
+                $evaluation->top3Hit ? 'hit' : 'MISS',
+                (string)$evaluation->latencyMs,
+            ];
+        }
+        $io->table(['Question', 'Form', 'Hard class', 'Top-1', 'Top-3', 'Latency (ms)'], $rows);
+
+        $io->writeln(sprintf('Retriever:      %s', $result->retriever));
+        $io->writeln(sprintf(
+            'Top-1 hit rate: %.1f%% (%d/%d)',
+            $result->top1HitRate() * 100,
+            $result->top1HitCount(),
+            $result->questionCount(),
+        ));
+        $io->writeln(sprintf(
+            'Top-3 hit rate: %.1f%% (%d/%d)',
+            $result->top3HitRate() * 100,
+            $result->top3HitCount(),
+            $result->questionCount(),
+        ));
+
+        $this->renderBreakdown($io, 'By form', $result->hitRatesByForm());
+        $this->renderBreakdown($io, 'By hard class', $result->hitRatesByHardClass());
+    }
+
+    /**
+     * @param array<string, array{questions: int, top1HitRate: float, top3HitRate: float}> $breakdown
+     */
+    private function renderBreakdown(SymfonyStyle $io, string $title, array $breakdown): void
+    {
+        if ($breakdown === []) {
+            return;
+        }
+
+        $io->section($title);
+        $rows = [];
+        foreach ($breakdown as $key => $rates) {
+            $rows[] = [
+                $key,
+                (string)$rates['questions'],
+                sprintf('%.1f%%', $rates['top1HitRate'] * 100),
+                sprintf('%.1f%%', $rates['top3HitRate'] * 100),
+            ];
+        }
+        $io->table(['Class', 'Questions', 'Top-1', 'Top-3'], $rows);
+    }
+
+    private function floatOption(InputInterface $input, string $name, float $default): float
+    {
+        $value = $input->getOption($name);
+
+        return is_numeric($value) ? (float)$value : $default;
+    }
+}

--- a/Classes/Domain/Enum/QuestionForm.php
+++ b/Classes/Domain/Enum/QuestionForm.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * The question forms a golden retrieval question can declare (ADR-072).
+ *
+ * The form classifies how the question relates to the vocabulary of its
+ * target documents and is the primary split for hit-rate reporting:
+ *
+ * - MATCH the question's vocabulary overlaps the target document, so
+ *         lexical and vector retrieval both have a fair chance
+ * - GAP   an everyday rewording with little vocabulary overlap — the
+ *         class retrieval quality problems live in, and the one a
+ *         retrieval change is usually meant to improve
+ */
+enum QuestionForm: string
+{
+    case MATCH = 'match';
+    case GAP = 'gap';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn(self $case): string => $case->value,
+            self::cases(),
+        );
+    }
+}

--- a/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
+++ b/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A retriever that can be measured against a golden question set
+ * (ADR-072).
+ *
+ * The contract is deliberately minimal — a question string in, ranked
+ * document ids out — so ANY retrieval pipeline can be evaluated: nr_llm's
+ * own lexical cascade (see {@see LexicalSearchRetriever}), a consumer
+ * extension's vector retrieval, a reranked pipeline, or an A/B variant of
+ * one. The adapter owns the mapping from its native results to document
+ * ids; those ids must use the same identity scheme as the golden set's
+ * `expectedDocumentIds` (e.g. chunk-id prefixes for chunked vector
+ * stores), otherwise no hit can ever match.
+ *
+ * Implementations are discovered via the `nr_llm.evaluatable_retriever`
+ * DI tag (auto-applied by AutoconfigureTag) and collected by
+ * EvaluatableRetrieverRegistry, so `nrllm:eval:retrieval` can address them
+ * by identifier.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface EvaluatableRetrieverInterface
+{
+    public const TAG_NAME = 'nr_llm.evaluatable_retriever';
+
+    /**
+     * Namespaced identifier the CLI addresses this retriever by,
+     * e.g. `nr_llm.lexical` or `nr_ai_search.vector`.
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * Retrieve the ranked document ids for a question, best match first.
+     *
+     * @param int $limit Maximum number of documents the evaluation will look at
+     *
+     * @return list<string> Ranked document ids, best first
+     */
+    public function retrieve(string $question, int $limit): array;
+}

--- a/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
+++ b/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
@@ -22,7 +22,10 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * one. The adapter owns the mapping from its native results to document
  * ids; those ids must use the same identity scheme as the golden set's
  * `expectedDocumentIds` (e.g. chunk-id prefixes for chunked vector
- * stores), otherwise no hit can ever match.
+ * stores), otherwise no hit can ever match. The returned ranking MAY be
+ * chunk-grained — the same document id may appear once per chunk — the
+ * evaluator collapses duplicates to the first occurrence, so adapters
+ * need not dedup themselves.
  *
  * Implementations are discovered via the `nr_llm.evaluatable_retriever`
  * DI tag (auto-applied by AutoconfigureTag) and collected by
@@ -43,9 +46,13 @@ interface EvaluatableRetrieverInterface
     /**
      * Retrieve the ranked document ids for a question, best match first.
      *
-     * @param int $limit Maximum number of documents the evaluation will look at
+     * Duplicate ids are allowed (one entry per chunk); the evaluator dedups
+     * them in ranking order. The limit is therefore an overfetched raw
+     * ranking depth, larger than the metric depth the evaluation scores.
      *
-     * @return list<string> Ranked document ids, best first
+     * @param int $limit Maximum number of raw results to return
+     *
+     * @return list<string> Ranked document ids, best first, MAY contain duplicates
      */
     public function retrieve(string $question, int $limit): array;
 }

--- a/Classes/Service/Evaluation/EvaluatableRetrieverRegistry.php
+++ b/Classes/Service/Evaluation/EvaluatableRetrieverRegistry.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Collects every DI-tagged EvaluatableRetrieverInterface and exposes them
+ * by identifier (ADR-072), mirroring GoldenQuestionSetRegistry.
+ *
+ * A duplicate identifier across retrievers is a developer error and fails
+ * fast with a LogicException at construction time.
+ */
+final class EvaluatableRetrieverRegistry
+{
+    /** @var array<string, EvaluatableRetrieverInterface> */
+    private array $byIdentifier = [];
+
+    /**
+     * @param iterable<EvaluatableRetrieverInterface> $retrievers
+     */
+    public function __construct(
+        #[AutowireIterator(EvaluatableRetrieverInterface::TAG_NAME)]
+        iterable $retrievers,
+    ) {
+        foreach ($retrievers as $retriever) {
+            $identifier = $retriever->getIdentifier();
+            if (isset($this->byIdentifier[$identifier])) {
+                throw new LogicException(
+                    sprintf('Duplicate evaluatable retriever identifier "%s".', $identifier),
+                    1794000060,
+                );
+            }
+            $this->byIdentifier[$identifier] = $retriever;
+        }
+    }
+
+    /**
+     * @return list<EvaluatableRetrieverInterface>
+     */
+    public function all(): array
+    {
+        return array_values($this->byIdentifier);
+    }
+
+    public function findByIdentifier(string $identifier): ?EvaluatableRetrieverInterface
+    {
+        return $this->byIdentifier[$identifier] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function identifiers(): array
+    {
+        return array_keys($this->byIdentifier);
+    }
+}

--- a/Classes/Service/Evaluation/GoldenQuestion.php
+++ b/Classes/Service/Evaluation/GoldenQuestion.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * A single labeled question inside a golden question set (ADR-072), the
+ * retrieval counterpart of {@see GoldenPrompt}.
+ *
+ * `expectedDocumentIds` are ALL document ids that answer the question
+ * (multi-target labels are intentional); a retrieved document counts as a
+ * hit when it is any of them. An EMPTY list declares a question no indexed
+ * document answers — such a question scores as a hit only when the
+ * retriever correctly returns nothing.
+ *
+ * `hardClass` optionally marks a known-difficult retrieval class the set
+ * wants broken out in reporting. The BMDV methodology uses
+ * `near-duplicate`, `specific-vs-general`, `prose-free`, `boilerplate` and
+ * `normal`; the value is free-form so consumer sets can extend the
+ * taxonomy. `answerGist` is label documentation for humans re-verifying
+ * the labels — the scoring never reads it.
+ */
+final readonly class GoldenQuestion
+{
+    /**
+     * @param list<string> $expectedDocumentIds All document ids that answer the question; empty = expects no result
+     */
+    public function __construct(
+        public string $id,
+        public string $question,
+        public QuestionForm $form,
+        public array $expectedDocumentIds,
+        public ?string $hardClass = null,
+        public ?string $answerGist = null,
+    ) {
+        if ($id === '') {
+            throw new InvalidArgumentException('Golden question id must not be empty.', 1794000050);
+        }
+        if ($question === '') {
+            throw new InvalidArgumentException(
+                sprintf('Golden question "%s" must declare a non-empty question.', $id),
+                1794000051,
+            );
+        }
+        $seen = [];
+        foreach ($expectedDocumentIds as $documentId) {
+            if ($documentId === '') {
+                throw new InvalidArgumentException(
+                    sprintf('Golden question "%s" declares an empty expected document id.', $id),
+                    1794000052,
+                );
+            }
+            if (isset($seen[$documentId])) {
+                throw new InvalidArgumentException(
+                    sprintf('Golden question "%s" declares duplicate expected document id "%s".', $id, $documentId),
+                    1794000053,
+                );
+            }
+            $seen[$documentId] = true;
+        }
+        if ($hardClass === '') {
+            throw new InvalidArgumentException(
+                sprintf('Golden question "%s" must declare a non-empty hard class or none.', $id),
+                1794000054,
+            );
+        }
+    }
+
+    /**
+     * Whether the correct retrieval outcome for this question is an empty
+     * result (no indexed document answers it).
+     */
+    public function expectsNoResult(): bool
+    {
+        return $this->expectedDocumentIds === [];
+    }
+}

--- a/Classes/Service/Evaluation/GoldenQuestionSet.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSet.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+
+/**
+ * A named collection of golden questions a consuming extension declares for
+ * retrieval-quality evaluation (ADR-072), mirroring {@see GoldenPromptSet}.
+ *
+ * The identifier is namespaced (e.g. `nr_ai_search.bmdv`) so sets from
+ * different extensions cannot collide, following the ConfigurationPreset
+ * identifier convention (ADR-056). nr_llm ships no golden questions — the
+ * labels only mean something against a concrete corpus, so every set lives
+ * in the extension that owns the indexed content.
+ */
+final readonly class GoldenQuestionSet
+{
+    /**
+     * Lowercase dot-namespaced identifier: segments of `[a-z0-9_]`
+     * separated by single dots, e.g. `nr_ai_search.bmdv`.
+     */
+    private const IDENTIFIER_PATTERN = '/^[a-z0-9_]+(?:\.[a-z0-9_]+)*$/';
+
+    /**
+     * @param list<GoldenQuestion> $questions
+     */
+    public function __construct(
+        public string $identifier,
+        public string $name,
+        public string $description,
+        public array $questions,
+    ) {
+        if ($identifier === '' || preg_match(self::IDENTIFIER_PATTERN, $identifier) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid golden question set identifier "%s": expected lowercase segments of [a-z0-9_] separated by dots, e.g. "nr_ai_search.bmdv".',
+                    $identifier,
+                ),
+                1794000055,
+            );
+        }
+        if ($name === '') {
+            throw new InvalidArgumentException(
+                sprintf('Golden question set "%s" must declare a non-empty name.', $identifier),
+                1794000056,
+            );
+        }
+        if ($questions === []) {
+            throw new InvalidArgumentException(
+                sprintf('Golden question set "%s" must declare at least one question.', $identifier),
+                1794000057,
+            );
+        }
+        $seen = [];
+        foreach ($questions as $question) {
+            if (isset($seen[$question->id])) {
+                throw new InvalidArgumentException(
+                    sprintf('Golden question set "%s" declares duplicate question id "%s".', $identifier, $question->id),
+                    1794000058,
+                );
+            }
+            $seen[$question->id] = true;
+        }
+    }
+}

--- a/Classes/Service/Evaluation/GoldenQuestionSetProviderInterface.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSetProviderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A provider of golden question sets a consuming extension contributes for
+ * retrieval-quality evaluation (ADR-072), mirroring
+ * {@see GoldenPromptSetProviderInterface}.
+ *
+ * Implementations are discovered via the `nr_llm.golden_question_set` DI
+ * tag (auto-applied by AutoconfigureTag) and collected by
+ * GoldenQuestionSetRegistry through a tagged iterator. A consuming
+ * extension only needs to implement this interface and register its class
+ * as a service — no further wiring.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface GoldenQuestionSetProviderInterface
+{
+    public const TAG_NAME = 'nr_llm.golden_question_set';
+
+    /**
+     * The golden question sets this extension declares.
+     *
+     * @return list<GoldenQuestionSet>
+     */
+    public function getGoldenQuestionSets(): array;
+}

--- a/Classes/Service/Evaluation/GoldenQuestionSetRegistry.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSetRegistry.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Collects every DI-tagged GoldenQuestionSetProviderInterface and exposes
+ * the declared golden question sets (ADR-072).
+ *
+ * Providers are injected through the `nr_llm.golden_question_set` tagged
+ * iterator (mirroring GoldenPromptSetRegistry) and their sets indexed by
+ * identifier; a duplicate identifier across providers is a developer error
+ * and fails fast with a LogicException at construction time.
+ */
+final class GoldenQuestionSetRegistry
+{
+    /** @var array<string, GoldenQuestionSet> */
+    private array $byIdentifier = [];
+
+    /**
+     * @param iterable<GoldenQuestionSetProviderInterface> $providers
+     */
+    public function __construct(
+        #[AutowireIterator(GoldenQuestionSetProviderInterface::TAG_NAME)]
+        iterable $providers,
+    ) {
+        foreach ($providers as $provider) {
+            foreach ($provider->getGoldenQuestionSets() as $set) {
+                if (isset($this->byIdentifier[$set->identifier])) {
+                    throw new LogicException(
+                        sprintf('Duplicate golden question set identifier "%s".', $set->identifier),
+                        1794000059,
+                    );
+                }
+                $this->byIdentifier[$set->identifier] = $set;
+            }
+        }
+    }
+
+    /**
+     * @return list<GoldenQuestionSet>
+     */
+    public function all(): array
+    {
+        return array_values($this->byIdentifier);
+    }
+
+    public function findByIdentifier(string $identifier): ?GoldenQuestionSet
+    {
+        return $this->byIdentifier[$identifier] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function identifiers(): array
+    {
+        return array_keys($this->byIdentifier);
+    }
+}

--- a/Classes/Service/Evaluation/LexicalSearchRetriever.php
+++ b/Classes/Service/Evaluation/LexicalSearchRetriever.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Retrieval\AccessContext;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalService;
+
+/**
+ * The evaluatable adapter over nr_llm's own lexical retrieval cascade
+ * (ADR-049), so `nrllm:eval:retrieval` has a built-in target and consumer
+ * extensions have a concrete adapter pattern to copy (ADR-072).
+ *
+ * Document identity is the evidence `sourceId` — golden sets measuring
+ * this retriever must label their `expectedDocumentIds` with those ids.
+ * Retrieval runs public-only, matching what RAG evidence exposes to an
+ * anonymous visitor. Questions are clamped to the RetrievalQuery length
+ * bounds: over-long ones are truncated, under-short ones (below two
+ * characters) cannot be searched and yield an empty result.
+ */
+final readonly class LexicalSearchRetriever implements EvaluatableRetrieverInterface
+{
+    public const IDENTIFIER = 'nr_llm.lexical';
+
+    public function __construct(
+        private RetrievalService $retrievalService,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function retrieve(string $question, int $limit): array
+    {
+        $question = trim($question);
+        if (mb_strlen($question) > RetrievalQuery::MAX_QUERY_LENGTH) {
+            // Truncation can expose interior whitespace at the cut — trim again.
+            $question = trim(mb_substr($question, 0, RetrievalQuery::MAX_QUERY_LENGTH));
+        }
+        if (mb_strlen($question) < RetrievalQuery::MIN_QUERY_LENGTH) {
+            return [];
+        }
+
+        $query = RetrievalQuery::create(
+            $question,
+            max(1, min($limit, RetrievalQuery::MAX_SOURCES)),
+        );
+        $evidence = $this->retrievalService->search($query, AccessContext::publicOnly());
+
+        $documentIds = [];
+        foreach ($evidence->sources as $source) {
+            $documentIds[] = $source->sourceId;
+        }
+
+        return $documentIds;
+    }
+}

--- a/Classes/Service/Evaluation/QuestionEvaluation.php
+++ b/Classes/Service/Evaluation/QuestionEvaluation.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+
+/**
+ * The evaluation of one golden question within a retrieval run (ADR-072):
+ * the top-1/top-3 hit verdicts, the documents the retriever actually
+ * returned, and the wall-clock latency of the retrieval call — the
+ * retrieval counterpart of {@see PromptEvaluation}.
+ *
+ * `form` and `hardClass` are copied from the question so the result can
+ * compute its by-form and by-hard-class breakdowns without re-resolving
+ * the set.
+ */
+final readonly class QuestionEvaluation
+{
+    /**
+     * @param list<string> $retrievedDocumentIds Distinct document ids the retriever returned, best first
+     */
+    public function __construct(
+        public string $questionId,
+        public QuestionForm $form,
+        public ?string $hardClass,
+        public bool $top1Hit,
+        public bool $top3Hit,
+        public array $retrievedDocumentIds,
+        public int $latencyMs,
+    ) {}
+
+    /**
+     * @return array{questionId: string, form: string, hardClass: string|null, top1Hit: bool, top3Hit: bool, retrievedDocumentIds: list<string>, latencyMs: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'questionId' => $this->questionId,
+            'form' => $this->form->value,
+            'hardClass' => $this->hardClass,
+            'top1Hit' => $this->top1Hit,
+            'top3Hit' => $this->top3Hit,
+            'retrievedDocumentIds' => $this->retrievedDocumentIds,
+            'latencyMs' => $this->latencyMs,
+        ];
+    }
+}

--- a/Classes/Service/Evaluation/RetrievalEvaluationService.php
+++ b/Classes/Service/Evaluation/RetrievalEvaluationService.php
@@ -19,7 +19,10 @@ namespace Netresearch\NrLlm\Service\Evaluation;
  * question's expected documents. Duplicate ids in the retriever's ranking
  * (e.g. several chunks of the same document mapped to one document id) are
  * collapsed to the first occurrence before ranks are counted, so top-3
- * always means the three best distinct documents. A question that expects
+ * always means the three best distinct documents. To survive that dedup,
+ * the retriever is asked for an overfetched raw ranking
+ * (TOP_K * OVERFETCH_MULTIPLIER results) — a chunk-grained ranking would
+ * otherwise collapse to fewer than TOP_K documents. A question that expects
  * no result (empty `expectedDocumentIds`) is a hit — on both metrics —
  * only when the retriever returns nothing.
  *
@@ -31,9 +34,20 @@ final readonly class RetrievalEvaluationService
 {
     /**
      * The retrieval depth the evaluation looks at — the deepest metric is
-     * the top-3 hit rate, so retrievers are asked for three documents.
+     * the top-3 hit rate, so hits are scored over the three best distinct
+     * documents.
      */
     public const TOP_K = 3;
+
+    /**
+     * How many times TOP_K raw results are requested from the retriever.
+     * Retrievers may rank chunk-grained ids (several chunks of the same
+     * document mapped to one document id), so asking for exactly TOP_K
+     * results could collapse to fewer than TOP_K distinct documents after
+     * dedup — deflating the hit rates. Overfetching leaves the dedup enough
+     * raw results to fill all TOP_K distinct ranks.
+     */
+    public const OVERFETCH_MULTIPLIER = 4;
 
     /**
      * Execute the set against the retriever and return the scored result.
@@ -44,7 +58,7 @@ final readonly class RetrievalEvaluationService
 
         foreach ($set->questions as $question) {
             $startedAt = microtime(true);
-            $ranked = $retriever->retrieve($question->question, self::TOP_K);
+            $ranked = $retriever->retrieve($question->question, self::TOP_K * self::OVERFETCH_MULTIPLIER);
             $latencyMs = (int)round((microtime(true) - $startedAt) * 1000);
 
             $documents = $this->distinctTopDocuments($ranked);

--- a/Classes/Service/Evaluation/RetrievalEvaluationService.php
+++ b/Classes/Service/Evaluation/RetrievalEvaluationService.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * Runs a golden question set against a retriever and scores every question
+ * by document-level top-1/top-3 hit (ADR-072) — the retrieval counterpart
+ * of {@see EvaluationService}.
+ *
+ * Scoring follows the methodology the BMDV set established: a top-k hit
+ * means any of the k best-ranked DISTINCT documents is one of the
+ * question's expected documents. Duplicate ids in the retriever's ranking
+ * (e.g. several chunks of the same document mapped to one document id) are
+ * collapsed to the first occurrence before ranks are counted, so top-3
+ * always means the three best distinct documents. A question that expects
+ * no result (empty `expectedDocumentIds`) is a hit — on both metrics —
+ * only when the retriever returns nothing.
+ *
+ * Like EvaluationService, this is an explicitly invoked, out-of-request
+ * operation that neither persists nor compares — the retrieval eval
+ * command wires persistence and regression detection around it.
+ */
+final readonly class RetrievalEvaluationService
+{
+    /**
+     * The retrieval depth the evaluation looks at — the deepest metric is
+     * the top-3 hit rate, so retrievers are asked for three documents.
+     */
+    public const TOP_K = 3;
+
+    /**
+     * Execute the set against the retriever and return the scored result.
+     */
+    public function run(GoldenQuestionSet $set, EvaluatableRetrieverInterface $retriever): RetrievalSetEvaluationResult
+    {
+        $evaluations = [];
+
+        foreach ($set->questions as $question) {
+            $startedAt = microtime(true);
+            $ranked = $retriever->retrieve($question->question, self::TOP_K);
+            $latencyMs = (int)round((microtime(true) - $startedAt) * 1000);
+
+            $documents = $this->distinctTopDocuments($ranked);
+
+            if ($question->expectsNoResult()) {
+                $top1Hit = $top3Hit = $documents === [];
+            } else {
+                $top1Hit = $documents !== [] && in_array($documents[0], $question->expectedDocumentIds, true);
+                $top3Hit = array_intersect($documents, $question->expectedDocumentIds) !== [];
+            }
+
+            $evaluations[] = new QuestionEvaluation(
+                $question->id,
+                $question->form,
+                $question->hardClass,
+                $top1Hit,
+                $top3Hit,
+                $documents,
+                $latencyMs,
+            );
+        }
+
+        return new RetrievalSetEvaluationResult($set->identifier, $retriever->getIdentifier(), $evaluations, time());
+    }
+
+    /**
+     * The first TOP_K distinct non-empty document ids in ranking order.
+     * Collapsing duplicates before slicing keeps the document-level rank
+     * semantics even when a retriever hands back one id per chunk.
+     *
+     * @param list<string> $ranked
+     *
+     * @return list<string>
+     */
+    private function distinctTopDocuments(array $ranked): array
+    {
+        $documents = [];
+        foreach ($ranked as $documentId) {
+            if ($documentId === '' || in_array($documentId, $documents, true)) {
+                continue;
+            }
+            $documents[] = $documentId;
+            if (count($documents) === self::TOP_K) {
+                break;
+            }
+        }
+
+        return $documents;
+    }
+}

--- a/Classes/Service/Evaluation/RetrievalSetEvaluationResult.php
+++ b/Classes/Service/Evaluation/RetrievalSetEvaluationResult.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Evaluation;
+
+/**
+ * The rich result of running a golden question set against one retriever
+ * (ADR-072): every per-question evaluation plus the aggregate top-1/top-3
+ * hit rates and their by-form and by-hard-class breakdowns — the retrieval
+ * counterpart of {@see SetEvaluationResult}.
+ *
+ * `toSetEvaluationResult()` maps the run onto the existing persistence and
+ * regression machinery (ADR-060): the retriever identifier takes the model
+ * column, the top-1 hit verdict becomes the per-question pass, and the
+ * top-3 hit becomes the per-question score — so the stored `passRate` is
+ * the top-1 hit rate and the stored `meanScore` is the top-3 hit rate.
+ */
+final readonly class RetrievalSetEvaluationResult
+{
+    /**
+     * The grader identifier retrieval runs are stored under. It scopes the
+     * (set, model, grader) persistence key so retrieval hit rates are never
+     * compared against prompt-grading scores.
+     */
+    public const GRADER_IDENTIFIER = 'retrieval_hit_rate';
+
+    /**
+     * @param list<QuestionEvaluation> $evaluations
+     */
+    public function __construct(
+        public string $setIdentifier,
+        public string $retriever,
+        public array $evaluations,
+        public int $runTimestamp,
+    ) {}
+
+    public function questionCount(): int
+    {
+        return count($this->evaluations);
+    }
+
+    public function top1HitCount(): int
+    {
+        return $this->countHits($this->evaluations, static fn(QuestionEvaluation $evaluation): bool => $evaluation->top1Hit);
+    }
+
+    public function top3HitCount(): int
+    {
+        return $this->countHits($this->evaluations, static fn(QuestionEvaluation $evaluation): bool => $evaluation->top3Hit);
+    }
+
+    /**
+     * Fraction of questions whose top-ranked document is a target
+     * (0.0-1.0); 0.0 for an empty set.
+     */
+    public function top1HitRate(): float
+    {
+        return $this->rate($this->top1HitCount());
+    }
+
+    /**
+     * Fraction of questions with any target in the top three documents
+     * (0.0-1.0); 0.0 for an empty set.
+     */
+    public function top3HitRate(): float
+    {
+        return $this->rate($this->top3HitCount());
+    }
+
+    /**
+     * Hit rates split by question form (`match` / `gap`), the primary
+     * reporting split of the methodology. Only forms that occur in the set
+     * appear.
+     *
+     * @return array<string, array{questions: int, top1HitRate: float, top3HitRate: float}>
+     */
+    public function hitRatesByForm(): array
+    {
+        return $this->breakdown(static fn(QuestionEvaluation $evaluation): string => $evaluation->form->value);
+    }
+
+    /**
+     * Hit rates split by hard class, the secondary reporting split.
+     * Questions without a hard class are not part of the breakdown.
+     *
+     * @return array<string, array{questions: int, top1HitRate: float, top3HitRate: float}>
+     */
+    public function hitRatesByHardClass(): array
+    {
+        return $this->breakdown(static fn(QuestionEvaluation $evaluation): ?string => $evaluation->hardClass);
+    }
+
+    /**
+     * Map the run onto the ADR-060 result model so the existing repository
+     * and RegressionDetector can persist and compare it: passed = top-1
+     * hit, score = 1.0 for a top-3 hit else 0.0, model = retriever
+     * identifier, grader = {@see self::GRADER_IDENTIFIER}.
+     */
+    public function toSetEvaluationResult(): SetEvaluationResult
+    {
+        $evaluations = [];
+        foreach ($this->evaluations as $evaluation) {
+            $evaluations[] = new PromptEvaluation(
+                $evaluation->questionId,
+                new GradingResult(
+                    $evaluation->top1Hit,
+                    $evaluation->top3Hit ? 1.0 : 0.0,
+                    self::GRADER_IDENTIFIER,
+                    sprintf(
+                        'top-1 %s, top-3 %s',
+                        $evaluation->top1Hit ? 'hit' : 'miss',
+                        $evaluation->top3Hit ? 'hit' : 'miss',
+                    ),
+                ),
+                $evaluation->latencyMs,
+            );
+        }
+
+        return new SetEvaluationResult(
+            $this->setIdentifier,
+            $this->retriever,
+            self::GRADER_IDENTIFIER,
+            $evaluations,
+            $this->runTimestamp,
+        );
+    }
+
+    /**
+     * @param list<QuestionEvaluation>           $evaluations
+     * @param callable(QuestionEvaluation): bool $isHit
+     */
+    private function countHits(array $evaluations, callable $isHit): int
+    {
+        $hits = 0;
+        foreach ($evaluations as $evaluation) {
+            if ($isHit($evaluation)) {
+                ++$hits;
+            }
+        }
+
+        return $hits;
+    }
+
+    private function rate(int $hits): float
+    {
+        if ($this->evaluations === []) {
+            return 0.0;
+        }
+
+        return (float)$hits / $this->questionCount();
+    }
+
+    /**
+     * @param callable(QuestionEvaluation): (string|null) $group Returns the group key, or null to exclude the question
+     *
+     * @return array<string, array{questions: int, top1HitRate: float, top3HitRate: float}>
+     */
+    private function breakdown(callable $group): array
+    {
+        /** @var array<string, list<QuestionEvaluation>> $grouped */
+        $grouped = [];
+        foreach ($this->evaluations as $evaluation) {
+            $key = $group($evaluation);
+            if ($key === null) {
+                continue;
+            }
+            $grouped[$key][] = $evaluation;
+        }
+
+        $result = [];
+        foreach ($grouped as $key => $evaluations) {
+            $count = count($evaluations);
+            $result[$key] = [
+                'questions' => $count,
+                'top1HitRate' => (float)$this->countHits($evaluations, static fn(QuestionEvaluation $evaluation): bool => $evaluation->top1Hit) / $count,
+                'top3HitRate' => (float)$this->countHits($evaluations, static fn(QuestionEvaluation $evaluation): bool => $evaluation->top3Hit) / $count,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -366,3 +366,10 @@ services:
         description: 'Run a golden prompt set against a model and report grading and regression.'
         schedulable: false
 
+  Netresearch\NrLlm\Command\RetrievalEvalRunCommand:
+    tags:
+      - name: 'console.command'
+        command: 'nrllm:eval:retrieval'
+        description: 'Run a golden question set against a retriever and report hit rates and regression.'
+        schedulable: false
+

--- a/Documentation/Adr/Adr072RetrievalQualityEvaluation.rst
+++ b/Documentation/Adr/Adr072RetrievalQualityEvaluation.rst
@@ -82,11 +82,14 @@ unchanged.** nr_llm ships the methodology, not the questions.
    both a runnable target and the pattern to copy.
 
 3. **Hit-rate scoring.** ``RetrievalEvaluationService`` asks the retriever
-   for the top three documents per question, collapses duplicate ids to the
-   first occurrence (so top-3 always means the three best DISTINCT
-   documents, even when a retriever hands back one id per chunk), and scores
-   top-1/top-3 hits. ``RetrievalSetEvaluationResult`` aggregates the rates
-   overall, by form, and by hard class. Like ``EvaluationService`` it
+   for an overfetched raw ranking per question
+   (``TOP_K * OVERFETCH_MULTIPLIER`` results), collapses duplicate ids to
+   the first occurrence (so top-3 always means the three best DISTINCT
+   documents, even when a retriever hands back one id per chunk — the
+   overfetch keeps a chunk-grained ranking from collapsing to fewer than
+   three documents), and scores top-1/top-3 hits over the three best
+   distinct documents. ``RetrievalSetEvaluationResult`` aggregates the
+   rates overall, by form, and by hard class. Like ``EvaluationService`` it
    neither persists nor compares.
 
 4. **Persistence and regression via ADR-060, by mapping.**

--- a/Documentation/Adr/Adr072RetrievalQualityEvaluation.rst
+++ b/Documentation/Adr/Adr072RetrievalQualityEvaluation.rst
@@ -1,0 +1,173 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-072:
+
+==============================================================================
+ADR-072: Retrieval-quality evaluation — golden questions and top-k hit rates
+==============================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-072-context:
+
+Context
+=======
+
+:ref:`ADR-060 <adr-060>` gave nr_llm a quality-evaluation layer for
+**generated answers**: golden prompt sets, graders, result persistence, and
+regression detection. It measures the model, not the retrieval in front of
+it — yet in a RAG pipeline the retrieval step decides which evidence the
+model ever sees, and retrieval changes (an embedding swap, a reranker, a
+chunking retune, a new lexical backend) can silently degrade what gets found
+with nothing to catch it.
+
+A working methodology for exactly this already exists downstream: the
+nr_ai_search extension built a 48-question labeled retrieval-eval set over
+its BMDV corpus. Its method is corpus-agnostic and proven:
+
+* **Question forms.** ``MATCH`` questions share vocabulary with the target
+  document; ``GAP`` questions are everyday rewordings with little vocabulary
+  overlap — the class retrieval quality problems live in and the primary
+  split for reporting.
+* **Hard classes.** Questions can be tagged with a known-difficult retrieval
+  class (``near-duplicate``, ``specific-vs-general``, ``prose-free``,
+  ``boilerplate``, ``normal``) for a secondary per-class breakdown.
+* **Multi-target labels.** A question lists ALL document ids that answer it;
+  any of them counts as a hit.
+* **Top-k document-level hit rate.** The primary metric is the top-1 and
+  top-3 hit rate — a hit means any of the k best-ranked distinct documents
+  is a target — reported overall, split by form, and broken down by hard
+  class.
+
+The methodology (schema and scoring protocol) belongs in nr_llm so every
+consumer can measure a retrieval change; the questions themselves do not —
+labels only mean something against a concrete corpus, so the BMDV set stays
+in nr_ai_search.
+
+The building blocks again already existed: the DI-tag provider/registry
+pattern and the persistence + regression machinery from ADR-060.
+
+.. _adr-072-decision:
+
+Decision
+========
+
+**Add the retrieval counterpart of ADR-060 — golden question sets, a
+pluggable retriever contract, document-level top-1/top-3 hit-rate scoring,
+and a CLI — reusing the ADR-060 persistence and regression machinery
+unchanged.** nr_llm ships the methodology, not the questions.
+
+1. **Golden question sets via DI tag.** ``GoldenQuestion`` carries the
+   question text, its ``QuestionForm`` (``MATCH``/``GAP``), the expected
+   document ids (multi-target), an optional free-form hard class, and an
+   optional answer gist (label documentation, never scored). A question
+   with an EMPTY expected-document list declares that no indexed document
+   answers it; it scores as a hit only when the retriever correctly returns
+   nothing. ``GoldenQuestionSetProviderInterface`` (tag
+   ``nr_llm.golden_question_set``) and ``GoldenQuestionSetRegistry`` mirror
+   the ADR-060 provider/registry pair. No built-in set ships — unlike golden
+   prompts, golden questions are meaningless without the consumer's corpus.
+
+2. **Pluggable retrievers.** ``EvaluatableRetrieverInterface`` (tag
+   ``nr_llm.evaluatable_retriever``) is deliberately minimal — a question
+   string and a limit in, ranked document ids out — so ANY retrieval
+   pipeline can be measured: nr_llm's own lexical cascade, a consumer's
+   vector retrieval, a reranked variant. The adapter owns the mapping from
+   its native results to document ids, which must use the same identity
+   scheme as the golden set's labels (e.g. chunk-id prefixes for chunked
+   vector stores). nr_llm ships one adapter, ``LexicalSearchRetriever``
+   (identifier ``nr_llm.lexical``), over the ADR-049 retrieval cascade —
+   both a runnable target and the pattern to copy.
+
+3. **Hit-rate scoring.** ``RetrievalEvaluationService`` asks the retriever
+   for the top three documents per question, collapses duplicate ids to the
+   first occurrence (so top-3 always means the three best DISTINCT
+   documents, even when a retriever hands back one id per chunk), and scores
+   top-1/top-3 hits. ``RetrievalSetEvaluationResult`` aggregates the rates
+   overall, by form, and by hard class. Like ``EvaluationService`` it
+   neither persists nor compares.
+
+4. **Persistence and regression via ADR-060, by mapping.**
+   ``RetrievalSetEvaluationResult::toSetEvaluationResult()`` maps a run onto
+   the existing result model: the retriever identifier takes the model
+   column, top-1 hit becomes the per-question pass, top-3 hit becomes the
+   per-question score — so the stored ``passRate`` is the top-1 hit rate and
+   the stored ``meanScore`` is the top-3 hit rate. The grader column is
+   fixed to ``retrieval_hit_rate``, which scopes the (set, model, grader)
+   key so retrieval rates are never compared against prompt-grading scores.
+   ``EvaluationResultRepositoryInterface``, ``tx_nrllm_eval_result``,
+   ``RegressionDetector`` and ``RegressionThresholds`` are reused without
+   change.
+
+5. **CLI, not request path.** ``nrllm:eval:retrieval <set> <retriever>``
+   runs a set against a retriever, prints per-question hits, the aggregate
+   hit rates and both breakdowns, saves the run, and reports the regression
+   verdict (``--max-top1-drop`` / ``--max-top3-drop`` map onto the ADR-060
+   thresholds; ``--fail-on-regression`` makes a regression a non-zero exit
+   for CI). No LLM is involved — a run costs one retrieval call per
+   question.
+
+6. **No public-surface growth.** Everything is private; the command is made
+   public by the ``console.command`` tag as in ADR-060, and the two provider
+   interfaces are discovered via their DI tags. The audited ADR-028 count is
+   unchanged.
+
+.. _adr-072-consequences:
+
+Consequences
+============
+
+Positive
+--------
+
+* Retrieval quality becomes measurable with the same accept/reject
+  discipline ADR-060 gave answer quality: a consumer labels a question set
+  once, then every embedding swap, reranker trial or chunking retune is a
+  before/after hit-rate comparison with regression detection in CI.
+* One retriever contract lets the same golden set measure competing
+  pipelines (lexical vs. vector vs. reranked) side by side — the stored
+  (set, retriever) history keeps their baselines separate.
+* The persistence and regression machinery is reused, not duplicated.
+
+Negative / limitations
+-----------------------
+
+* The metric mapping overloads the stored columns' names: for retrieval runs
+  ``passRate`` means top-1 hit rate and ``meanScore`` means top-3 hit rate.
+  The dedicated ``retrieval_hit_rate`` grader value makes the reinterpretation
+  explicit and keeps the histories separate.
+* The retrieval depth is fixed at top-3 (the methodology's deepest metric);
+  configurable k is a follow-up if a consumer needs top-5/top-10.
+* Latency is recorded per question but not part of regression detection.
+* The by-form and by-hard-class breakdowns are reported by the CLI but not
+  persisted individually — only the aggregate rates are stored, so
+  regressions inside one class that cancel out across classes are not
+  auto-detected.
+
+.. _adr-072-alternatives:
+
+Alternatives considered
+=======================
+
+**Shipping golden questions with nr_llm.** Rejected: relevance labels are
+statements about one concrete corpus. The BMDV set stays in nr_ai_search;
+nr_llm ships the schema, the scoring protocol, and test fixtures only.
+
+**A separate retrieval-result table and regression detector.** Rejected:
+the ADR-060 summary (two 0.0–1.0 rates per run, keyed by set/model/grader)
+fits retrieval runs exactly; a parallel subsystem would duplicate
+persistence, retention (ADR-064) and regression logic for no expressiveness
+gain.
+
+**Scoring at chunk level.** Rejected: the methodology deliberately scores at
+document level (a document is identified by its chunk-id prefix) because
+"did the right document surface" is the question a retrieval change must
+answer; chunk-level ranks are an implementation detail of the store.
+
+**Reranking-aware metrics (MRR, nDCG).** Rejected for this slice: top-1/
+top-3 hit rates are what the established acceptance criteria use, are
+robust with multi-target labels, and stay interpretable for small sets.
+Graded-relevance metrics need graded labels the methodology does not
+collect.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -369,4 +369,5 @@ Tools
    Adr069RemovePromptTemplateStack
    Adr070UserlessConfigurationResolutionByIdentifier
    Adr071PublicKeywordSearchFacade
+   Adr072RetrievalQualityEvaluation
    Adr073FirstPartyTestingFixtures

--- a/Documentation/Developer/QualityEvaluation.rst
+++ b/Documentation/Developer/QualityEvaluation.rst
@@ -174,3 +174,82 @@ per set, averaged). Candidates without evaluation data keep their base order
 behind the scored ones; with ``minQuality`` set, candidates below it (or
 without data) are excluded. Making quality a first-class sort key inside
 :php:`ModelSelectionService` is a planned follow-up (see :ref:`ADR-060 <adr-060>`).
+
+.. _developer-quality-evaluation-retrieval:
+
+Retrieval evaluation
+====================
+
+The retrieval counterpart measures the retrieval step of a RAG pipeline —
+which documents surface for a question — with **golden question sets** and
+document-level top-1/top-3 hit rates. See :ref:`ADR-072 <adr-072>` for the
+design and the methodology it adopts.
+
+A golden question carries the question text, its form (``MATCH`` = the
+vocabulary overlaps the target document, ``GAP`` = an everyday rewording —
+the class retrieval problems live in), ALL document ids that answer it
+(any of them counts as a hit), an optional hard class for a per-class
+breakdown, and an optional answer gist documenting the label. A question
+with an empty expected-document list declares that nothing in the index
+answers it and scores as a hit only when the retriever returns nothing.
+nr_llm ships no golden questions — labels only mean something against a
+concrete corpus, so every set lives in the extension owning the content.
+
+Declare a set by implementing :php:`GoldenQuestionSetProviderInterface`
+(tag ``nr_llm.golden_question_set``, applied automatically):
+
+.. code-block:: php
+
+    use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
+    use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetProviderInterface;
+
+    final class BmdvGoldenQuestionSetProvider implements GoldenQuestionSetProviderInterface
+    {
+        public function getGoldenQuestionSets(): array
+        {
+            return [
+                new GoldenQuestionSet(
+                    identifier: 'nr_ai_search.bmdv',
+                    name: 'BMDV retrieval eval',
+                    description: 'Labeled questions over the BMDV corpus.',
+                    questions: [
+                        new GoldenQuestion(
+                            id: 'dialogforum-termin',
+                            question: 'Wann findet das Dialogforum statt?',
+                            form: QuestionForm::MATCH,
+                            expectedDocumentIds: ['234_0', '309_0'],
+                            hardClass: 'near-duplicate',
+                        ),
+                    ],
+                ),
+            ];
+        }
+    }
+
+The retriever under test implements :php:`EvaluatableRetrieverInterface`
+(tag ``nr_llm.evaluatable_retriever``): a question string and a limit in,
+ranked document ids out. The adapter owns the mapping from its native
+results to document ids, which must use the same identity scheme as the
+set's labels. nr_llm ships :php:`LexicalSearchRetriever`
+(``nr_llm.lexical``) over its own search cascade as the pattern to copy;
+a consumer wraps its vector retrieval the same way.
+
+Run with the ``nrllm:eval:retrieval`` command:
+
+.. code-block:: bash
+
+    # Measure the built-in lexical cascade against a labeled set
+    vendor/bin/typo3 nrllm:eval:retrieval nr_ai_search.bmdv nr_llm.lexical
+
+    # Fail (non-zero exit) if hit rates regressed — for CI
+    vendor/bin/typo3 nrllm:eval:retrieval nr_ai_search.bmdv nr_ai_search.vector \
+        --fail-on-regression --max-top1-drop 0.05 --max-top3-drop 0.05
+
+The command prints the per-question hits, the top-1/top-3 hit rates with
+by-form and by-hard-class breakdowns, stores the run in
+``tx_nrllm_eval_result`` (grader ``retrieval_hit_rate``; the stored pass
+rate is the top-1 hit rate and the stored mean score the top-3 hit rate),
+and reports whether the run regressed against the previous one for the
+same set and retriever.

--- a/Tests/Unit/Command/RetrievalEvalRunCommandTest.php
+++ b/Tests/Unit/Command/RetrievalEvalRunCommandTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\RetrievalEvalRunCommand;
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverRegistry;
+use Netresearch\NrLlm\Service\Evaluation\EvaluationResultSummary;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetProviderInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetRegistry;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalEvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalSetEvaluationResult;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryEvaluationResultRepository;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticRetriever;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(RetrievalEvalRunCommand::class)]
+final class RetrievalEvalRunCommandTest extends TestCase
+{
+    private const SET_IDENTIFIER = 'nr_llm.test';
+
+    private const RETRIEVER_IDENTIFIER = 'test.retriever';
+
+    private function registry(): GoldenQuestionSetRegistry
+    {
+        $set = new GoldenQuestionSet(self::SET_IDENTIFIER, 'Test set', 'desc', [
+            new GoldenQuestion('office', 'Where is the office?', QuestionForm::MATCH, ['doc-a'], 'normal'),
+            new GoldenQuestion('hours', 'When are you open?', QuestionForm::GAP, ['doc-b']),
+        ]);
+        $provider = new class ([$set]) implements GoldenQuestionSetProviderInterface {
+            /**
+             * @param list<GoldenQuestionSet> $sets
+             */
+            public function __construct(private readonly array $sets) {}
+
+            public function getGoldenQuestionSets(): array
+            {
+                return $this->sets;
+            }
+        };
+
+        return new GoldenQuestionSetRegistry([$provider]);
+    }
+
+    private function command(StaticRetriever $retriever, InMemoryEvaluationResultRepository $repository): RetrievalEvalRunCommand
+    {
+        return new RetrievalEvalRunCommand(
+            $this->registry(),
+            new EvaluatableRetrieverRegistry([$retriever]),
+            new RetrievalEvaluationService(),
+            $repository,
+            new RegressionDetector(),
+        );
+    }
+
+    private function perfectRetriever(): StaticRetriever
+    {
+        return new StaticRetriever([
+            'Where is the office?' => ['doc-a'],
+            'When are you open?' => ['doc-b'],
+        ]);
+    }
+
+    private function perfectBaseline(): EvaluationResultSummary
+    {
+        return new EvaluationResultSummary(
+            self::SET_IDENTIFIER,
+            self::RETRIEVER_IDENTIFIER,
+            RetrievalSetEvaluationResult::GRADER_IDENTIFIER,
+            2,
+            2,
+            1.0,
+            1.0,
+            1_700_000_000,
+        );
+    }
+
+    #[Test]
+    public function unknownSetFailsWithHint(): void
+    {
+        $tester = new CommandTester($this->command($this->perfectRetriever(), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => 'does.not.exist', 'retriever' => self::RETRIEVER_IDENTIFIER]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Unknown golden question set', $tester->getDisplay());
+        self::assertStringContainsString(self::SET_IDENTIFIER, $tester->getDisplay());
+    }
+
+    #[Test]
+    public function unknownRetrieverFailsWithHint(): void
+    {
+        $tester = new CommandTester($this->command($this->perfectRetriever(), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, 'retriever' => 'does.not.exist']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Unknown retriever', $tester->getDisplay());
+        self::assertStringContainsString(self::RETRIEVER_IDENTIFIER, $tester->getDisplay());
+    }
+
+    #[Test]
+    public function perfectRunReportsHitRatesAndPersists(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $tester = new CommandTester($this->command($this->perfectRetriever(), $repository));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, 'retriever' => self::RETRIEVER_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Top-1 hit rate: 100.0% (2/2)', $tester->getDisplay());
+        self::assertStringContainsString('Top-3 hit rate: 100.0% (2/2)', $tester->getDisplay());
+        self::assertStringContainsString('By form', $tester->getDisplay());
+        self::assertStringContainsString('By hard class', $tester->getDisplay());
+        self::assertCount(1, $repository->saved);
+        self::assertSame(RetrievalSetEvaluationResult::GRADER_IDENTIFIER, $repository->saved[0]->grader);
+        self::assertSame(self::RETRIEVER_IDENTIFIER, $repository->saved[0]->model);
+    }
+
+    #[Test]
+    public function firstRunHasNoBaselineAndSucceeds(): void
+    {
+        $tester = new CommandTester($this->command(new StaticRetriever(), new InMemoryEvaluationResultRepository()));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, 'retriever' => self::RETRIEVER_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('baseline', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function regressionWarnsButSucceedsWithoutFailFlag(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $repository->seed($this->perfectBaseline());
+        $tester = new CommandTester($this->command(new StaticRetriever(), $repository));
+
+        $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, 'retriever' => self::RETRIEVER_IDENTIFIER]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Retrieval regression detected', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function regressionFailsWithFailFlag(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $repository->seed($this->perfectBaseline());
+        $tester = new CommandTester($this->command(new StaticRetriever(), $repository));
+
+        $exitCode = $tester->execute([
+            'set' => self::SET_IDENTIFIER,
+            'retriever' => self::RETRIEVER_IDENTIFIER,
+            '--fail-on-regression' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+    }
+
+    #[Test]
+    public function dropWithinTolerancesIsNoRegression(): void
+    {
+        $repository = new InMemoryEvaluationResultRepository();
+        $repository->seed($this->perfectBaseline());
+        // doc-a is found top-1; the second question misses entirely: both
+        // rates drop 50 pp, tolerated by loosened thresholds.
+        $retriever = new StaticRetriever(['Where is the office?' => ['doc-a']]);
+        $tester = new CommandTester($this->command($retriever, $repository));
+
+        $exitCode = $tester->execute([
+            'set' => self::SET_IDENTIFIER,
+            'retriever' => self::RETRIEVER_IDENTIFIER,
+            '--max-top1-drop' => '0.5',
+            '--max-top3-drop' => '0.5',
+            '--fail-on-regression' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No regression', $tester->getDisplay());
+    }
+}

--- a/Tests/Unit/Service/Evaluation/EvaluatableRetrieverRegistryTest.php
+++ b/Tests/Unit/Service/Evaluation/EvaluatableRetrieverRegistryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use LogicException;
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticRetriever;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EvaluatableRetrieverRegistry::class)]
+final class EvaluatableRetrieverRegistryTest extends TestCase
+{
+    #[Test]
+    public function collectsRetrieversByIdentifier(): void
+    {
+        $registry = new EvaluatableRetrieverRegistry([
+            new StaticRetriever(identifier: 'a.one'),
+            new StaticRetriever(identifier: 'b.two'),
+        ]);
+
+        self::assertCount(2, $registry->all());
+        self::assertSame(['a.one', 'b.two'], $registry->identifiers());
+        self::assertNotNull($registry->findByIdentifier('a.one'));
+        self::assertNull($registry->findByIdentifier('missing'));
+    }
+
+    #[Test]
+    public function duplicateIdentifierFailsFast(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(1794000060);
+        self::assertInstanceOf(EvaluatableRetrieverRegistry::class, new EvaluatableRetrieverRegistry([
+            new StaticRetriever(identifier: 'a.one'),
+            new StaticRetriever(identifier: 'a.one'),
+        ]));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/Fixture/RecordingSearchBackend.php
+++ b/Tests/Unit/Service/Evaluation/Fixture/RecordingSearchBackend.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture;
+
+use Netresearch\NrLlm\Service\Retrieval\AccessContext;
+use Netresearch\NrLlm\Service\Retrieval\EvidenceList;
+use Netresearch\NrLlm\Service\Retrieval\EvidenceSource;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
+use Netresearch\NrLlm\Service\Retrieval\SearchBackendInterface;
+use Netresearch\NrLlm\Service\Retrieval\SourceReference;
+
+/**
+ * A recording lexical backend for LexicalSearchRetriever tests:
+ * RetrievalService is final and cannot be mocked, so the adapter is tested
+ * through a real cascade over this single backend, which returns canned
+ * source ids and records the query it received.
+ */
+final class RecordingSearchBackend implements SearchBackendInterface
+{
+    public ?RetrievalQuery $receivedQuery = null;
+
+    /**
+     * @param list<string> $sourceIds
+     */
+    public function __construct(
+        private readonly array $sourceIds = [],
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return 'test';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function search(RetrievalQuery $query, AccessContext $context): EvidenceList
+    {
+        $this->receivedQuery = $query;
+        $sources = [];
+        foreach ($this->sourceIds as $sourceId) {
+            // Unique URL per source — the cascade deduplicates same-URL hits.
+            $sources[] = new EvidenceSource($sourceId, 'Title', 'https://example.org/' . rawurlencode($sourceId), 'Excerpt', 'test', 0);
+        }
+
+        return new EvidenceList('test', $sources);
+    }
+
+    public function fetchSource(SourceReference $reference, AccessContext $context): ?string
+    {
+        return null;
+    }
+}

--- a/Tests/Unit/Service/Evaluation/Fixture/StaticRetriever.php
+++ b/Tests/Unit/Service/Evaluation/Fixture/StaticRetriever.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture;
+
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverInterface;
+
+/**
+ * An EvaluatableRetriever test double that returns a canned ranking per
+ * question and records what it was asked — so hit-rate scoring and the
+ * retrieval eval command can be exercised without a search backend.
+ */
+final class StaticRetriever implements EvaluatableRetrieverInterface
+{
+    /** @var list<array{question: string, limit: int}> */
+    public array $receivedCalls = [];
+
+    /**
+     * @param array<string, list<string>> $rankingsByQuestion Ranked document ids keyed by question text
+     * @param list<string>                $defaultRanking     Ranking for questions without a canned entry
+     */
+    public function __construct(
+        private readonly array $rankingsByQuestion = [],
+        private readonly array $defaultRanking = [],
+        private readonly string $identifier = 'test.retriever',
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function retrieve(string $question, int $limit): array
+    {
+        $this->receivedCalls[] = ['question' => $question, 'limit' => $limit];
+
+        return $this->rankingsByQuestion[$question] ?? $this->defaultRanking;
+    }
+}

--- a/Tests/Unit/Service/Evaluation/GoldenQuestionSetRegistryTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenQuestionSetRegistryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetProviderInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GoldenQuestionSetRegistry::class)]
+final class GoldenQuestionSetRegistryTest extends TestCase
+{
+    private function set(string $identifier): GoldenQuestionSet
+    {
+        return new GoldenQuestionSet(
+            $identifier,
+            'Name',
+            'Description',
+            [new GoldenQuestion('q1', 'Where is the office?', QuestionForm::MATCH, ['doc-1'])],
+        );
+    }
+
+    private function provider(GoldenQuestionSet ...$sets): GoldenQuestionSetProviderInterface
+    {
+        return new class (array_values($sets)) implements GoldenQuestionSetProviderInterface {
+            /**
+             * @param list<GoldenQuestionSet> $sets
+             */
+            public function __construct(private readonly array $sets) {}
+
+            public function getGoldenQuestionSets(): array
+            {
+                return $this->sets;
+            }
+        };
+    }
+
+    #[Test]
+    public function collectsSetsFromAllProviders(): void
+    {
+        $registry = new GoldenQuestionSetRegistry([
+            $this->provider($this->set('a.one')),
+            $this->provider($this->set('b.two')),
+        ]);
+
+        self::assertCount(2, $registry->all());
+        self::assertSame(['a.one', 'b.two'], $registry->identifiers());
+        self::assertNotNull($registry->findByIdentifier('a.one'));
+        self::assertNull($registry->findByIdentifier('missing'));
+    }
+
+    #[Test]
+    public function duplicateIdentifierFailsFast(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(1794000059);
+        self::assertInstanceOf(GoldenQuestionSetRegistry::class, new GoldenQuestionSetRegistry([
+            $this->provider($this->set('a.one')),
+            $this->provider($this->set('a.one')),
+        ]));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/GoldenQuestionSetTest.php
+++ b/Tests/Unit/Service/Evaluation/GoldenQuestionSetTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GoldenQuestionSet::class)]
+#[CoversClass(GoldenQuestion::class)]
+final class GoldenQuestionSetTest extends TestCase
+{
+    private function question(string $id = 'q1'): GoldenQuestion
+    {
+        return new GoldenQuestion($id, 'Where is the office?', QuestionForm::MATCH, ['doc-1']);
+    }
+
+    #[Test]
+    public function validSetIsConstructed(): void
+    {
+        $set = new GoldenQuestionSet('nr_ai_search.bmdv', 'BMDV', 'A set', [$this->question()]);
+
+        self::assertSame('nr_ai_search.bmdv', $set->identifier);
+        self::assertCount(1, $set->questions);
+    }
+
+    #[Test]
+    public function validQuestionCarriesItsLabels(): void
+    {
+        $question = new GoldenQuestion(
+            'q1',
+            'Wo wird der Ausbildungsstand erfasst?',
+            QuestionForm::GAP,
+            ['247_0_0', '250_0_0'],
+            'specific-vs-general',
+            'BASt und DEGES ermitteln den Stand im BIM-Radar.',
+        );
+
+        self::assertSame(QuestionForm::GAP, $question->form);
+        self::assertSame(['247_0_0', '250_0_0'], $question->expectedDocumentIds);
+        self::assertSame('specific-vs-general', $question->hardClass);
+        self::assertFalse($question->expectsNoResult());
+    }
+
+    #[Test]
+    public function emptyExpectedDocumentsDeclareANoResultQuestion(): void
+    {
+        $question = new GoldenQuestion('q1', 'Is there a moon base?', QuestionForm::GAP, []);
+
+        self::assertTrue($question->expectsNoResult());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidIdentifierProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'uppercase' => ['NrAiSearch.bmdv'],
+            'leading dot' => ['.bmdv'],
+            'trailing dot' => ['bmdv.'],
+            'spaces' => ['nr ai search'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidIdentifierProvider')]
+    public function invalidIdentifierIsRejected(string $identifier): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000055);
+        self::assertInstanceOf(GoldenQuestionSet::class, new GoldenQuestionSet($identifier, 'BMDV', 'A set', [$this->question()]));
+    }
+
+    #[Test]
+    public function emptyNameIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000056);
+        self::assertInstanceOf(GoldenQuestionSet::class, new GoldenQuestionSet('a.set', '', 'A set', [$this->question()]));
+    }
+
+    #[Test]
+    public function emptyQuestionListIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000057);
+        self::assertInstanceOf(GoldenQuestionSet::class, new GoldenQuestionSet('a.set', 'BMDV', 'A set', []));
+    }
+
+    #[Test]
+    public function duplicateQuestionIdIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000058);
+        self::assertInstanceOf(GoldenQuestionSet::class, new GoldenQuestionSet('a.set', 'BMDV', 'A set', [
+            $this->question('q1'),
+            $this->question('q1'),
+        ]));
+    }
+
+    #[Test]
+    public function emptyQuestionIdIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000050);
+        self::assertInstanceOf(GoldenQuestion::class, new GoldenQuestion('', 'Where?', QuestionForm::MATCH, ['doc-1']));
+    }
+
+    #[Test]
+    public function emptyQuestionTextIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000051);
+        self::assertInstanceOf(GoldenQuestion::class, new GoldenQuestion('q1', '', QuestionForm::MATCH, ['doc-1']));
+    }
+
+    #[Test]
+    public function emptyExpectedDocumentIdIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000052);
+        self::assertInstanceOf(GoldenQuestion::class, new GoldenQuestion('q1', 'Where?', QuestionForm::MATCH, ['']));
+    }
+
+    #[Test]
+    public function duplicateExpectedDocumentIdIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000053);
+        self::assertInstanceOf(GoldenQuestion::class, new GoldenQuestion('q1', 'Where?', QuestionForm::MATCH, ['doc-1', 'doc-1']));
+    }
+
+    #[Test]
+    public function emptyHardClassIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1794000054);
+        self::assertInstanceOf(GoldenQuestion::class, new GoldenQuestion('q1', 'Where?', QuestionForm::MATCH, ['doc-1'], ''));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/LexicalSearchRetrieverTest.php
+++ b/Tests/Unit/Service/Evaluation/LexicalSearchRetrieverTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Service\Evaluation\LexicalSearchRetriever;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
+use Netresearch\NrLlm\Service\Retrieval\RetrievalService;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\RecordingSearchBackend;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LexicalSearchRetriever::class)]
+final class LexicalSearchRetrieverTest extends TestCase
+{
+    private function retriever(RecordingSearchBackend $backend): LexicalSearchRetriever
+    {
+        return new LexicalSearchRetriever(new RetrievalService([$backend]));
+    }
+
+    #[Test]
+    public function identifierIsStable(): void
+    {
+        $retriever = $this->retriever(new RecordingSearchBackend());
+
+        self::assertSame('nr_llm.lexical', $retriever->getIdentifier());
+    }
+
+    #[Test]
+    public function returnsTheEvidenceSourceIdsInRankOrder(): void
+    {
+        $retriever = $this->retriever(new RecordingSearchBackend(['test:page:1', 'test:page:2']));
+
+        self::assertSame(['test:page:1', 'test:page:2'], $retriever->retrieve('Where is the office?', 3));
+    }
+
+    #[Test]
+    public function passesTheLimitAsMaxSources(): void
+    {
+        $backend = new RecordingSearchBackend(['test:page:1']);
+        $retriever = $this->retriever($backend);
+
+        $retriever->retrieve('Where is the office?', 3);
+
+        self::assertNotNull($backend->receivedQuery);
+        self::assertSame(3, $backend->receivedQuery->maxSources);
+    }
+
+    #[Test]
+    public function tooShortQuestionYieldsEmptyResultWithoutSearching(): void
+    {
+        $backend = new RecordingSearchBackend(['test:page:1']);
+        $retriever = $this->retriever($backend);
+
+        self::assertSame([], $retriever->retrieve(' a ', 3));
+        self::assertNull($backend->receivedQuery);
+    }
+
+    #[Test]
+    public function overlongQuestionIsTruncatedToTheQueryBound(): void
+    {
+        $backend = new RecordingSearchBackend(['test:page:1']);
+        $retriever = $this->retriever($backend);
+
+        $retriever->retrieve(str_repeat('a', RetrievalQuery::MAX_QUERY_LENGTH + 50), 3);
+
+        self::assertNotNull($backend->receivedQuery);
+        self::assertSame(RetrievalQuery::MAX_QUERY_LENGTH, mb_strlen($backend->receivedQuery->query));
+    }
+}

--- a/Tests/Unit/Service/Evaluation/RetrievalEvaluationServiceTest.php
+++ b/Tests/Unit/Service/Evaluation/RetrievalEvaluationServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalEvaluationService;
+use Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture\StaticRetriever;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RetrievalEvaluationService::class)]
+final class RetrievalEvaluationServiceTest extends TestCase
+{
+    private function set(GoldenQuestion ...$questions): GoldenQuestionSet
+    {
+        return new GoldenQuestionSet('a.set', 'Set', 'Description', array_values($questions));
+    }
+
+    #[Test]
+    public function topRankedTargetIsATop1AndTop3Hit(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-a'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-b', 'doc-c']),
+        );
+
+        self::assertTrue($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function thirdRankedTargetIsOnlyATop3Hit(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-c'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-b', 'doc-c']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function fourthRankedTargetIsAMissOnBothMetrics(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-d'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-b', 'doc-c', 'doc-d']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertFalse($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function anyOfSeveralTargetDocumentsCountsAsAHit(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-x', 'doc-b'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-b', 'doc-c']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function duplicateDocumentIdsCollapseToDistinctRanks(): void
+    {
+        // Four chunks mapping to two documents: top-3 must still reach doc-b.
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-b'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-a', 'doc-a', 'doc-b']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
+        self::assertSame(['doc-a', 'doc-b'], $result->evaluations[0]->retrievedDocumentIds);
+    }
+
+    #[Test]
+    public function emptyDocumentIdsInTheRankingAreIgnored(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-a'])),
+            new StaticRetriever(defaultRanking: ['', 'doc-a']),
+        );
+
+        self::assertTrue($result->evaluations[0]->top1Hit);
+        self::assertSame(['doc-a'], $result->evaluations[0]->retrievedDocumentIds);
+    }
+
+    #[Test]
+    public function retrievedDocumentsAreCappedAtTopK(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-a'])),
+            new StaticRetriever(defaultRanking: ['doc-a', 'doc-b', 'doc-c', 'doc-d', 'doc-e']),
+        );
+
+        self::assertCount(RetrievalEvaluationService::TOP_K, $result->evaluations[0]->retrievedDocumentIds);
+    }
+
+    #[Test]
+    public function emptyRetrievalOnAQuestionWithTargetsMissesBothMetrics(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::GAP, ['doc-a'])),
+            new StaticRetriever(),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertFalse($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function noResultQuestionScoresAsHitOnCorrectEmptyResult(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Is there a moon base?', QuestionForm::GAP, [])),
+            new StaticRetriever(),
+        );
+
+        self::assertTrue($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function noResultQuestionScoresAsMissWhenAnythingIsRetrieved(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Is there a moon base?', QuestionForm::GAP, [])),
+            new StaticRetriever(defaultRanking: ['doc-a']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertFalse($result->evaluations[0]->top3Hit);
+    }
+
+    #[Test]
+    public function retrieverIsAskedEachQuestionWithTopKLimit(): void
+    {
+        $retriever = new StaticRetriever();
+        $service = new RetrievalEvaluationService();
+        $service->run(
+            $this->set(
+                new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-a']),
+                new GoldenQuestion('q2', 'Question two?', QuestionForm::GAP, ['doc-b']),
+            ),
+            $retriever,
+        );
+
+        self::assertSame([
+            ['question' => 'Question one?', 'limit' => RetrievalEvaluationService::TOP_K],
+            ['question' => 'Question two?', 'limit' => RetrievalEvaluationService::TOP_K],
+        ], $retriever->receivedCalls);
+    }
+
+    #[Test]
+    public function resultCarriesSetRetrieverAndQuestionLabels(): void
+    {
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::GAP, ['doc-a'], 'near-duplicate')),
+            new StaticRetriever(identifier: 'nr_ai_search.vector'),
+        );
+
+        self::assertSame('a.set', $result->setIdentifier);
+        self::assertSame('nr_ai_search.vector', $result->retriever);
+        self::assertSame('q1', $result->evaluations[0]->questionId);
+        self::assertSame(QuestionForm::GAP, $result->evaluations[0]->form);
+        self::assertSame('near-duplicate', $result->evaluations[0]->hardClass);
+        self::assertGreaterThanOrEqual(0, $result->evaluations[0]->latencyMs);
+        self::assertGreaterThan(0, $result->runTimestamp);
+    }
+}

--- a/Tests/Unit/Service/Evaluation/RetrievalEvaluationServiceTest.php
+++ b/Tests/Unit/Service/Evaluation/RetrievalEvaluationServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
 
 use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverInterface;
 use Netresearch\NrLlm\Service\Evaluation\GoldenQuestion;
 use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
 use Netresearch\NrLlm\Service\Evaluation\RetrievalEvaluationService;
@@ -24,6 +25,33 @@ final class RetrievalEvaluationServiceTest extends TestCase
     private function set(GoldenQuestion ...$questions): GoldenQuestionSet
     {
         return new GoldenQuestionSet('a.set', 'Set', 'Description', array_values($questions));
+    }
+
+    /**
+     * A retriever that, unlike StaticRetriever, truncates its ranking to
+     * the requested limit — mirroring a real backend, where only the
+     * overfetch makes raw results beyond the metric depth reachable.
+     *
+     * @param list<string> $ranking
+     */
+    private function limitRespectingRetriever(array $ranking): EvaluatableRetrieverInterface
+    {
+        return new class ($ranking) implements EvaluatableRetrieverInterface {
+            /**
+             * @param list<string> $ranking
+             */
+            public function __construct(private readonly array $ranking) {}
+
+            public function getIdentifier(): string
+            {
+                return 'test.limit_respecting';
+            }
+
+            public function retrieve(string $question, int $limit): array
+            {
+                return array_slice($this->ranking, 0, $limit);
+            }
+        };
     }
 
     #[Test]
@@ -158,7 +186,7 @@ final class RetrievalEvaluationServiceTest extends TestCase
     }
 
     #[Test]
-    public function retrieverIsAskedEachQuestionWithTopKLimit(): void
+    public function retrieverIsAskedEachQuestionWithOverfetchedLimit(): void
     {
         $retriever = new StaticRetriever();
         $service = new RetrievalEvaluationService();
@@ -170,10 +198,40 @@ final class RetrievalEvaluationServiceTest extends TestCase
             $retriever,
         );
 
+        $limit = RetrievalEvaluationService::TOP_K * RetrievalEvaluationService::OVERFETCH_MULTIPLIER;
         self::assertSame([
-            ['question' => 'Question one?', 'limit' => RetrievalEvaluationService::TOP_K],
-            ['question' => 'Question two?', 'limit' => RetrievalEvaluationService::TOP_K],
+            ['question' => 'Question one?', 'limit' => $limit],
+            ['question' => 'Question two?', 'limit' => $limit],
         ], $retriever->receivedCalls);
+    }
+
+    #[Test]
+    public function chunkGrainedRankingStillFillsAllDistinctRanksOnALimitRespectingRetriever(): void
+    {
+        // Two chunks of doc-a rank first: without overfetching, a retriever
+        // that honours the limit would return only [doc-a, doc-a, doc-b] —
+        // two distinct documents — and never surface doc-c.
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-x'])),
+            $this->limitRespectingRetriever(['doc-a', 'doc-a', 'doc-b', 'doc-c', 'doc-d']),
+        );
+
+        self::assertSame(['doc-a', 'doc-b', 'doc-c'], $result->evaluations[0]->retrievedDocumentIds);
+    }
+
+    #[Test]
+    public function targetAtRawRankFourButDistinctRankThreeIsATop3Hit(): void
+    {
+        // doc-c is the fourth raw result but the third distinct document.
+        $service = new RetrievalEvaluationService();
+        $result = $service->run(
+            $this->set(new GoldenQuestion('q1', 'Question one?', QuestionForm::MATCH, ['doc-c'])),
+            $this->limitRespectingRetriever(['doc-a', 'doc-a', 'doc-b', 'doc-c']),
+        );
+
+        self::assertFalse($result->evaluations[0]->top1Hit);
+        self::assertTrue($result->evaluations[0]->top3Hit);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Evaluation/RetrievalSetEvaluationResultTest.php
+++ b/Tests/Unit/Service/Evaluation/RetrievalSetEvaluationResultTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation;
+
+use Netresearch\NrLlm\Domain\Enum\QuestionForm;
+use Netresearch\NrLlm\Service\Evaluation\QuestionEvaluation;
+use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
+use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
+use Netresearch\NrLlm\Service\Evaluation\RetrievalSetEvaluationResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RetrievalSetEvaluationResult::class)]
+#[CoversClass(QuestionEvaluation::class)]
+final class RetrievalSetEvaluationResultTest extends TestCase
+{
+    private function evaluation(
+        string $id,
+        bool $top1,
+        bool $top3,
+        QuestionForm $form = QuestionForm::MATCH,
+        ?string $hardClass = null,
+    ): QuestionEvaluation {
+        return new QuestionEvaluation($id, $form, $hardClass, $top1, $top3, ['doc-a'], 5);
+    }
+
+    private function retrievalResult(QuestionEvaluation ...$evaluations): RetrievalSetEvaluationResult
+    {
+        return new RetrievalSetEvaluationResult('a.set', 'test.retriever', array_values($evaluations), 1_700_000_000);
+    }
+
+    #[Test]
+    public function emptyResultHasZeroRates(): void
+    {
+        $result = $this->retrievalResult();
+
+        self::assertSame(0, $result->questionCount());
+        self::assertSame(0.0, $result->top1HitRate());
+        self::assertSame(0.0, $result->top3HitRate());
+        self::assertSame([], $result->hitRatesByForm());
+        self::assertSame([], $result->hitRatesByHardClass());
+    }
+
+    #[Test]
+    public function hitRatesAreTheHitFractions(): void
+    {
+        $result = $this->retrievalResult(
+            $this->evaluation('q1', true, true),
+            $this->evaluation('q2', false, true),
+            $this->evaluation('q3', false, false),
+            $this->evaluation('q4', true, true),
+        );
+
+        self::assertSame(4, $result->questionCount());
+        self::assertSame(2, $result->top1HitCount());
+        self::assertSame(3, $result->top3HitCount());
+        self::assertSame(0.5, $result->top1HitRate());
+        self::assertSame(0.75, $result->top3HitRate());
+    }
+
+    #[Test]
+    public function hitRatesByFormSplitMatchAndGap(): void
+    {
+        $result = $this->retrievalResult(
+            $this->evaluation('q1', true, true, QuestionForm::MATCH),
+            $this->evaluation('q2', false, true, QuestionForm::MATCH),
+            $this->evaluation('q3', false, false, QuestionForm::GAP),
+        );
+
+        self::assertSame([
+            'match' => ['questions' => 2, 'top1HitRate' => 0.5, 'top3HitRate' => 1.0],
+            'gap' => ['questions' => 1, 'top1HitRate' => 0.0, 'top3HitRate' => 0.0],
+        ], $result->hitRatesByForm());
+    }
+
+    #[Test]
+    public function hitRatesByHardClassSkipUnclassifiedQuestions(): void
+    {
+        $result = $this->retrievalResult(
+            $this->evaluation('q1', true, true, QuestionForm::MATCH, 'near-duplicate'),
+            $this->evaluation('q2', false, false, QuestionForm::GAP, 'near-duplicate'),
+            $this->evaluation('q3', true, true, QuestionForm::MATCH),
+        );
+
+        self::assertSame([
+            'near-duplicate' => ['questions' => 2, 'top1HitRate' => 0.5, 'top3HitRate' => 0.5],
+        ], $result->hitRatesByHardClass());
+    }
+
+    #[Test]
+    public function conversionMapsTop1ToPassAndTop3ToScore(): void
+    {
+        $converted = $this->retrievalResult(
+            $this->evaluation('q1', true, true),
+            $this->evaluation('q2', false, true),
+            $this->evaluation('q3', false, false),
+        )->toSetEvaluationResult();
+
+        self::assertSame('a.set', $converted->setIdentifier);
+        self::assertSame('test.retriever', $converted->model);
+        self::assertSame(RetrievalSetEvaluationResult::GRADER_IDENTIFIER, $converted->grader);
+        self::assertSame(1_700_000_000, $converted->runTimestamp);
+
+        self::assertTrue($converted->evaluations[0]->result->passed);
+        self::assertSame(1.0, $converted->evaluations[0]->result->score);
+        self::assertFalse($converted->evaluations[1]->result->passed);
+        self::assertSame(1.0, $converted->evaluations[1]->result->score);
+        self::assertFalse($converted->evaluations[2]->result->passed);
+        self::assertSame(0.0, $converted->evaluations[2]->result->score);
+
+        // The persisted aggregates are the hit rates: passRate = top-1, meanScore = top-3.
+        $summary = $converted->toSummary();
+        self::assertEqualsWithDelta(1 / 3, $summary->passRate, 1e-9);
+        self::assertEqualsWithDelta(2 / 3, $summary->meanScore, 1e-9);
+    }
+
+    #[Test]
+    public function regressionDetectorFlagsATop1HitRateDrop(): void
+    {
+        $baseline = $this->retrievalResult(
+            $this->evaluation('q1', true, true),
+            $this->evaluation('q2', true, true),
+        )->toSetEvaluationResult()->toSummary();
+
+        $current = $this->retrievalResult(
+            $this->evaluation('q1', false, true),
+            $this->evaluation('q2', true, true),
+        )->toSetEvaluationResult()->toSummary();
+
+        $report = (new RegressionDetector())->compare($current, $baseline, new RegressionThresholds(0.1, 0.1));
+
+        self::assertTrue($report->isRegression);
+        self::assertEqualsWithDelta(-0.5, $report->passRateDelta, 1e-9);
+        self::assertSame(0.0, $report->meanScoreDelta);
+    }
+}


### PR DESCRIPTION
## Gap

The ADR-060 evaluation framework grades **model output** against golden prompts; nothing measures **retrieval quality** — whether a retriever surfaces the right documents top-k before an embedding swap, reranker change, or chunking retune ships.

## Change (ADR-072)

Mirrors the ADR-060 machinery one-to-one:

- `GoldenQuestion`/`GoldenQuestionSet` — MATCH/GAP question forms, hard-class taxonomy (near-duplicate, specific-vs-general, prose-free, boilerplate), multi-target relevance labels
- `RetrievalEvaluationService` — top-1/top-3 document-level hit rates; questions with an empty expected-document list score by correct-empty
- `GoldenQuestionSetProviderInterface` + registry (mirrors `GoldenPromptSetProviderInterface`)
- `EvaluatableRetrieverInterface` + registry — pluggable, so the builtin lexical cascade (shipped `LexicalSearchRetriever`) and external retrievers (a consumer's vector/hybrid retrieval) are measured with the same protocol
- `RetrievalEvalRunCommand` CLI runner
- Regression persistence reuses `tx_nrllm_eval_result` + `RegressionDetector` unchanged (top-1 → passRate, top-3 → meanScore under grader `retrieval_hit_rate`; reinterpretation documented in the ADR's limitations)

No golden questions ship with nr-llm — sets are provider-supplied (the labeled BMDV set stays in nr-ai-search). Methodology follows the retrieval-eval protocol proven there (`Build/eval`).

ADR is numbered **072** (070 taken by #408, 071 by #412; renumbered before push).

Note for review: this branch and #412 both extend the ADR index / changelog — trivial conflicts expected with whichever merges second.

## Gates

unit (4972), phpstan L10 incl. phpat, cgl, rector, fuzzy, integration, docs render green locally; functional was at 976/1191 zero-failures when the local time budget expired — left to CI.