### PR TITLE
feat(testing): first-party test doubles for tool-calling and embedding interfaces (ADR-073)

### DIFF
--- a/Classes/Testing/FakeEmbeddingService.php
+++ b/Classes/Testing/FakeEmbeddingService.php
@@ -79,7 +79,8 @@ final class FakeEmbeddingService implements EmbeddingServiceInterface
 
     /**
      * When set, the next provider-backed call throws this instead of returning
-     * a canned value.
+     * a canned value. Cleared before throwing, so subsequent calls return
+     * canned values again.
      */
     public ?Throwable $throwable = null;
 
@@ -165,7 +166,10 @@ final class FakeEmbeddingService implements EmbeddingServiceInterface
     private function guardThrow(): void
     {
         if ($this->throwable instanceof Throwable) {
-            throw $this->throwable;
+            $throwable = $this->throwable;
+            $this->throwable = null;
+
+            throw $throwable;
         }
     }
 }

--- a/Classes/Testing/FakeEmbeddingService.php
+++ b/Classes/Testing/FakeEmbeddingService.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Testing;
+
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\EmbeddingServiceInterface;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
+use Throwable;
+
+/**
+ * Consumer-facing test double for {@see EmbeddingServiceInterface}.
+ *
+ * Ships in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace so
+ * downstream extensions (search/RAG indexers, controllers) can fake the
+ * embedding surface in their unit tests instead of hand-rolling a double that
+ * breaks whenever the interface grows. Implementing the real interface means
+ * PHPStan keeps this double in sync with the production contract.
+ *
+ * The five provider-backed methods (`embed*`) return the canned values in the
+ * public result properties and record every call in the matching `*Calls`
+ * array; set {@see $throwable} to make the next provider-backed call throw.
+ * The four pure vector helpers (`cosineSimilarity`, `findMostSimilar`,
+ * `pairwiseSimilarities`, `normalize`) return canned values only — a fake has
+ * no reason to reimplement deterministic math; use the real `EmbeddingService`
+ * when the actual arithmetic is under test.
+ *
+ * Not a DI service: excluded from container autoconfiguration in
+ * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
+ * never wire it into production.
+ */
+final class FakeEmbeddingService implements EmbeddingServiceInterface
+{
+    /**
+     * Canned vector returned by {@see self::embed()} and
+     * {@see self::embedForConfiguration()}.
+     *
+     * @var array<int, float>
+     */
+    public array $embedResult = [0.1, 0.2, 0.3];
+
+    /**
+     * Canned vectors returned by {@see self::embedBatch()} and
+     * {@see self::embedBatchForConfiguration()}.
+     *
+     * @var array<int, array<int, float>>
+     */
+    public array $embedBatchResult = [[0.1, 0.2, 0.3]];
+
+    /**
+     * Canned response for {@see self::embedFull()}; a default wrapping
+     * {@see self::$embedResult} is built when left null.
+     */
+    public ?EmbeddingResponse $embedFullResult = null;
+
+    public float $cosineSimilarityResult = 1.0;
+
+    /** @var array<int, array{index: int, similarity: float}> */
+    public array $findMostSimilarResult = [];
+
+    /** @var array<int, array<int, float>> */
+    public array $pairwiseSimilaritiesResult = [];
+
+    /**
+     * Canned result for {@see self::normalize()}; the input vector is returned
+     * unchanged when left null.
+     *
+     * @var array<int, float>|null
+     */
+    public ?array $normalizeResult = null;
+
+    /**
+     * When set, the next provider-backed call throws this instead of returning
+     * a canned value.
+     */
+    public ?Throwable $throwable = null;
+
+    /** @var list<array{text: string, options: ?EmbeddingOptions}> */
+    public array $embedCalls = [];
+
+    /** @var list<array{text: string, options: ?EmbeddingOptions}> */
+    public array $embedFullCalls = [];
+
+    /** @var list<array{texts: array<int, string>, options: ?EmbeddingOptions}> */
+    public array $embedBatchCalls = [];
+
+    /** @var list<array{text: string, configuration: LlmConfiguration, options: ?EmbeddingOptions}> */
+    public array $embedForConfigurationCalls = [];
+
+    /** @var list<array{texts: array<int, string>, configuration: LlmConfiguration, options: ?EmbeddingOptions}> */
+    public array $embedBatchForConfigurationCalls = [];
+
+    public function embed(string $text, ?EmbeddingOptions $options = null): array
+    {
+        $this->embedCalls[] = ['text' => $text, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->embedResult;
+    }
+
+    public function embedFull(string $text, ?EmbeddingOptions $options = null): EmbeddingResponse
+    {
+        $this->embedFullCalls[] = ['text' => $text, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->embedFullResult ?? new EmbeddingResponse(
+            embeddings: [$this->embedResult],
+            model: 'fake-embedding-model',
+            usage: new UsageStatistics(0, 0, 0),
+        );
+    }
+
+    public function embedBatch(array $texts, ?EmbeddingOptions $options = null): array
+    {
+        $this->embedBatchCalls[] = ['texts' => $texts, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->embedBatchResult;
+    }
+
+    public function embedForConfiguration(string $text, LlmConfiguration $configuration, ?EmbeddingOptions $options = null): array
+    {
+        $this->embedForConfigurationCalls[] = ['text' => $text, 'configuration' => $configuration, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->embedResult;
+    }
+
+    public function embedBatchForConfiguration(array $texts, LlmConfiguration $configuration, ?EmbeddingOptions $options = null): array
+    {
+        $this->embedBatchForConfigurationCalls[] = ['texts' => $texts, 'configuration' => $configuration, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->embedBatchResult;
+    }
+
+    public function cosineSimilarity(array $vectorA, array $vectorB): float
+    {
+        return $this->cosineSimilarityResult;
+    }
+
+    public function findMostSimilar(array $queryVector, array $candidateVectors, int $topK = 5): array
+    {
+        return $this->findMostSimilarResult;
+    }
+
+    public function pairwiseSimilarities(array $vectors): array
+    {
+        return $this->pairwiseSimilaritiesResult;
+    }
+
+    public function normalize(array $vector): array
+    {
+        return $this->normalizeResult ?? $vector;
+    }
+
+    private function guardThrow(): void
+    {
+        if ($this->throwable instanceof Throwable) {
+            throw $this->throwable;
+        }
+    }
+}

--- a/Classes/Testing/FakeToolCallingService.php
+++ b/Classes/Testing/FakeToolCallingService.php
@@ -77,7 +77,7 @@ final class FakeToolCallingService implements ToolCallingServiceInterface
 
         $response = array_shift($this->responses);
         if (!$response instanceof CompletionResponse) {
-            throw new LogicException(sprintf('%s::%s() was called but no response was queued in $responses.', self::class, $method));
+            throw new LogicException(sprintf('%s::%s() was called but no response was queued in $responses.', self::class, $method), 4235799970);
         }
 
         return $response;

--- a/Classes/Testing/FakeToolCallingService.php
+++ b/Classes/Testing/FakeToolCallingService.php
@@ -52,7 +52,10 @@ final class FakeToolCallingService implements ToolCallingServiceInterface
     /** @var list<array{messages: list<ChatMessage|array<string, mixed>>, tools: list<ToolSpec|array<string, mixed>>, configuration: LlmConfiguration, options: ?ToolOptions}> */
     public array $chatWithToolsForConfigurationCalls = [];
 
-    /** When set, the next call throws this instead of returning a response. */
+    /**
+     * When set, the next call throws this instead of returning a response.
+     * Cleared before throwing, so subsequent calls return queued responses again.
+     */
     public ?Throwable $throwable = null;
 
     public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
@@ -72,7 +75,10 @@ final class FakeToolCallingService implements ToolCallingServiceInterface
     private function next(string $method): CompletionResponse
     {
         if ($this->throwable instanceof Throwable) {
-            throw $this->throwable;
+            $throwable = $this->throwable;
+            $this->throwable = null;
+
+            throw $throwable;
         }
 
         $response = array_shift($this->responses);

--- a/Classes/Testing/FakeToolCallingService.php
+++ b/Classes/Testing/FakeToolCallingService.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Testing;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Feature\ToolCallingServiceInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Throwable;
+
+/**
+ * Consumer-facing test double for {@see ToolCallingServiceInterface}.
+ *
+ * Ships in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace so
+ * downstream extensions can type-hint their unit tests against a maintained
+ * fake instead of hand-rolling one that fatals whenever the interface grows —
+ * the failure mode ADR-051 records for nr_ai_search. Implementing the real
+ * interface means PHPStan keeps this double in sync with the production
+ * contract.
+ *
+ * Queue one {@see CompletionResponse} per expected call in {@see $responses};
+ * they are returned in FIFO order across both methods. Every call is captured
+ * in the matching `*Calls` array for assertions. Set {@see $throwable} to make
+ * the next call throw instead of returning a queued response.
+ *
+ * Not a DI service: excluded from container autoconfiguration in
+ * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
+ * never wire it into production.
+ */
+final class FakeToolCallingService implements ToolCallingServiceInterface
+{
+    /**
+     * Responses returned in FIFO order, one per call across both methods.
+     *
+     * @var list<CompletionResponse>
+     */
+    public array $responses = [];
+
+    /** @var list<array{messages: list<ChatMessage|array<string, mixed>>, tools: list<ToolSpec|array<string, mixed>>, options: ?ToolOptions}> */
+    public array $chatWithToolsCalls = [];
+
+    /** @var list<array{messages: list<ChatMessage|array<string, mixed>>, tools: list<ToolSpec|array<string, mixed>>, configuration: LlmConfiguration, options: ?ToolOptions}> */
+    public array $chatWithToolsForConfigurationCalls = [];
+
+    /** When set, the next call throws this instead of returning a response. */
+    public ?Throwable $throwable = null;
+
+    public function chatWithTools(array $messages, array $tools, ?ToolOptions $options = null): CompletionResponse
+    {
+        $this->chatWithToolsCalls[] = ['messages' => $messages, 'tools' => $tools, 'options' => $options];
+
+        return $this->next(__FUNCTION__);
+    }
+
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null): CompletionResponse
+    {
+        $this->chatWithToolsForConfigurationCalls[] = ['messages' => $messages, 'tools' => $tools, 'configuration' => $configuration, 'options' => $options];
+
+        return $this->next(__FUNCTION__);
+    }
+
+    private function next(string $method): CompletionResponse
+    {
+        if ($this->throwable instanceof Throwable) {
+            throw $this->throwable;
+        }
+
+        $response = array_shift($this->responses);
+        if (!$response instanceof CompletionResponse) {
+            throw new LogicException(sprintf('%s::%s() was called but no response was queued in $responses.', self::class, $method));
+        }
+
+        return $response;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -23,6 +23,7 @@ services:
       - '../Classes/Service/SetupWizard/Exception/*'
       - '../Classes/Service/Skill/Exception/*'
       - '../Classes/Specialized/Exception/*'
+      - '../Classes/Testing/*'
       - '../Classes/Widgets/*'
 
   # ========================================

--- a/Documentation/Adr/Adr073FirstPartyTestingFixtures.rst
+++ b/Documentation/Adr/Adr073FirstPartyTestingFixtures.rst
@@ -1,0 +1,76 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-073:
+
+====================================================================
+ADR-073: First-party test doubles for consumer-facing interfaces
+====================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-073-context:
+
+Context
+=======
+
+The feature-service interfaces are documented as the consumer entry
+points (ADR-051): a downstream extension depends on
+``ToolCallingServiceInterface`` or ``EmbeddingServiceInterface`` and, in
+its own unit tests, substitutes a fake. Every consumer currently
+hand-rolls that fake. ``nr_ai_search`` carries a
+``FakeToolCallingService`` and a ``FakeEmbeddingService`` under its own
+test namespace, re-deriving the canned-response and call-recording
+behaviour that any consumer of the same interface needs.
+
+A hand-rolled fake also re-introduces the maintenance trap ADR-051 set
+out to remove: it drifts from the interface it imitates. When the
+interface grows a method the fake does not implement, the consumer's
+suite fatals — the same breakage that blocked ``nr_ai_search``'s
+0.13 → 0.16 update.
+
+.. _adr-073-decision:
+
+Decision
+========
+
+Ship maintained test doubles from nr_llm itself, in a new
+runtime-autoloaded namespace ``Netresearch\NrLlm\Testing\``
+(``Classes/Testing/``, mapped by the production ``autoload`` block, not
+``autoload-dev``) so consumers autoload them without nr_llm's dev
+dependencies:
+
+- ``FakeToolCallingService`` implements ``ToolCallingServiceInterface``:
+  a FIFO queue of ``CompletionResponse`` values, per-call recording for
+  both methods, and a settable throwable.
+- ``FakeEmbeddingService`` implements ``EmbeddingServiceInterface``: canned
+  vectors plus per-call recording for the five provider-backed ``embed*``
+  methods (so a test can assert the ``LlmConfiguration`` was passed
+  through) and canned returns for the four pure vector helpers, which a
+  fake has no reason to reimplement.
+
+Both implement the real interface, so PHPStan fails the build if a fake
+drifts from the contract — the drift ADR-051 could not prevent for a
+consumer's own copy is now caught here.
+
+The fakes are excluded from container autoconfiguration
+(``Classes/Testing/*`` in the ``Configuration/Services.yaml`` exclude
+list) and add no ``public: true`` override, so the audited public-service
+count (ADR-028 / ADR-065 / ADR-069) is unchanged. Their docblocks mark
+them as consumer test fixtures, not for production wiring.
+
+.. _adr-073-consequences:
+
+Consequences
+============
+
+- A consumer deletes its hand-rolled fake and type-hints
+  ``Netresearch\NrLlm\Testing\Fake*`` instead; the double tracks the
+  interface automatically.
+- The ``Testing\`` namespace is a supported public surface. Renaming a
+  fake's properties or methods is a breaking change for consumers and
+  belongs in a release note.
+- The fakes cover the tool-calling and embedding interfaces named in
+  ADR-051. Other feature interfaces (completion, vision, translation)
+  gain a first-party fake only when a consumer needs one.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -368,3 +368,4 @@ Tools
    Adr067SolrPerLanguageCoreFilter
    Adr069RemovePromptTemplateStack
    Adr070UserlessConfigurationResolutionByIdentifier
+   Adr073FirstPartyTestingFixtures

--- a/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
+++ b/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
@@ -113,6 +113,24 @@ final class FakeEmbeddingServiceTest extends TestCase
     }
 
     #[Test]
+    public function throwableIsOneShotAndNextCallReturnsTheCannedValueAgain(): void
+    {
+        $subject = new FakeEmbeddingService();
+        $subject->embedResult = [0.5, 0.6];
+        $subject->throwable   = new RuntimeException('embed failed');
+
+        try {
+            $subject->embed('text');
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // one-shot: cleared before throwing
+        }
+
+        self::assertNull($subject->throwable);
+        self::assertSame([0.5, 0.6], $subject->embed('text'));
+    }
+
+    #[Test]
     public function vectorHelpersReturnTheirCannedValues(): void
     {
         $subject = new FakeEmbeddingService();

--- a/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
+++ b/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Testing;
+
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\EmbeddingServiceInterface;
+use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
+use Netresearch\NrLlm\Testing\FakeEmbeddingService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(FakeEmbeddingService::class)]
+final class FakeEmbeddingServiceTest extends TestCase
+{
+    #[Test]
+    public function implementsTheRealInterface(): void
+    {
+        self::assertInstanceOf(EmbeddingServiceInterface::class, new FakeEmbeddingService());
+    }
+
+    #[Test]
+    public function embedReturnsCannedVectorAndRecordsTheCall(): void
+    {
+        $options = new EmbeddingOptions();
+
+        $subject = new FakeEmbeddingService();
+        $subject->embedResult = [0.5, 0.6];
+
+        self::assertSame([0.5, 0.6], $subject->embed('hello', $options));
+        self::assertCount(1, $subject->embedCalls);
+        self::assertSame('hello', $subject->embedCalls[0]['text']);
+        self::assertSame($options, $subject->embedCalls[0]['options']);
+    }
+
+    #[Test]
+    public function embedBatchReturnsCannedVectorsAndRecordsTheCall(): void
+    {
+        $subject = new FakeEmbeddingService();
+        $subject->embedBatchResult = [[1.0], [2.0]];
+
+        self::assertSame([[1.0], [2.0]], $subject->embedBatch(['a', 'b']));
+        self::assertSame(['a', 'b'], $subject->embedBatchCalls[0]['texts']);
+    }
+
+    #[Test]
+    public function embedForConfigurationRecordsTheConfiguration(): void
+    {
+        $configuration = new LlmConfiguration();
+
+        $subject = new FakeEmbeddingService();
+        $subject->embedResult = [0.7];
+
+        self::assertSame([0.7], $subject->embedForConfiguration('text', $configuration));
+        self::assertSame($configuration, $subject->embedForConfigurationCalls[0]['configuration']);
+    }
+
+    #[Test]
+    public function embedBatchForConfigurationRecordsTheConfiguration(): void
+    {
+        $configuration = new LlmConfiguration();
+
+        $subject = new FakeEmbeddingService();
+        $subject->embedBatchResult = [[0.8]];
+
+        self::assertSame([[0.8]], $subject->embedBatchForConfiguration(['text'], $configuration));
+        self::assertSame($configuration, $subject->embedBatchForConfigurationCalls[0]['configuration']);
+    }
+
+    #[Test]
+    public function embedFullBuildsADefaultResponseWrappingTheCannedVector(): void
+    {
+        $subject = new FakeEmbeddingService();
+        $subject->embedResult = [0.1, 0.9];
+
+        $response = $subject->embedFull('text');
+
+        self::assertSame([[0.1, 0.9]], $response->embeddings);
+        self::assertCount(1, $subject->embedFullCalls);
+    }
+
+    #[Test]
+    public function embedFullReturnsTheConfiguredResponseWhenSet(): void
+    {
+        $canned = new EmbeddingResponse([[0.3]], 'custom-model', new UsageStatistics(1, 0, 1));
+
+        $subject = new FakeEmbeddingService();
+        $subject->embedFullResult = $canned;
+
+        self::assertSame($canned, $subject->embedFull('text'));
+    }
+
+    #[Test]
+    public function throwsConfiguredThrowableFromProviderBackedCalls(): void
+    {
+        $subject = new FakeEmbeddingService();
+        $subject->throwable = new RuntimeException('embed failed');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('embed failed');
+
+        $subject->embed('text');
+    }
+
+    #[Test]
+    public function vectorHelpersReturnTheirCannedValues(): void
+    {
+        $subject = new FakeEmbeddingService();
+        $subject->cosineSimilarityResult    = 0.42;
+        $subject->findMostSimilarResult     = [['index' => 0, 'similarity' => 0.42]];
+        $subject->pairwiseSimilaritiesResult = [[1.0]];
+
+        self::assertSame(0.42, $subject->cosineSimilarity([1.0], [1.0]));
+        self::assertSame([['index' => 0, 'similarity' => 0.42]], $subject->findMostSimilar([1.0], [[1.0]]));
+        self::assertSame([[1.0]], $subject->pairwiseSimilarities([[1.0]]));
+    }
+
+    #[Test]
+    public function normalizeReturnsTheInputVectorUnlessOverridden(): void
+    {
+        $subject = new FakeEmbeddingService();
+        self::assertSame([1.0, 2.0], $subject->normalize([1.0, 2.0]));
+
+        $subject->normalizeResult = [0.0, 1.0];
+        self::assertSame([0.0, 1.0], $subject->normalize([1.0, 2.0]));
+    }
+}

--- a/Tests/Unit/Testing/FakeToolCallingServiceTest.php
+++ b/Tests/Unit/Testing/FakeToolCallingServiceTest.php
@@ -90,6 +90,26 @@ final class FakeToolCallingServiceTest extends TestCase
     }
 
     #[Test]
+    public function throwableIsOneShotAndNextCallReturnsAQueuedResponseAgain(): void
+    {
+        $queued = self::response('after');
+
+        $subject = new FakeToolCallingService();
+        $subject->responses = [$queued];
+        $subject->throwable = new RuntimeException('boom');
+
+        try {
+            $subject->chatWithTools([], []);
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // one-shot: cleared before throwing
+        }
+
+        self::assertNull($subject->throwable);
+        self::assertSame($queued, $subject->chatWithTools([], []));
+    }
+
+    #[Test]
     public function throwsWhenCalledWithoutAQueuedResponse(): void
     {
         $subject = new FakeToolCallingService();

--- a/Tests/Unit/Testing/FakeToolCallingServiceTest.php
+++ b/Tests/Unit/Testing/FakeToolCallingServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Testing;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\ToolCallingServiceInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Testing\FakeToolCallingService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(FakeToolCallingService::class)]
+final class FakeToolCallingServiceTest extends TestCase
+{
+    #[Test]
+    public function implementsTheRealInterface(): void
+    {
+        self::assertInstanceOf(ToolCallingServiceInterface::class, new FakeToolCallingService());
+    }
+
+    #[Test]
+    public function returnsQueuedResponsesInFifoOrderAcrossBothMethods(): void
+    {
+        $first = self::response('first');
+        $second = self::response('second');
+
+        $subject = new FakeToolCallingService();
+        $subject->responses = [$first, $second];
+
+        self::assertSame($first, $subject->chatWithTools([], []));
+        self::assertSame($second, $subject->chatWithToolsForConfiguration([], [], new LlmConfiguration()));
+    }
+
+    #[Test]
+    public function recordsChatWithToolsArguments(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'hi']];
+        $tools    = [['name' => 'search']];
+        $options  = new ToolOptions();
+
+        $subject = new FakeToolCallingService();
+        $subject->responses = [self::response('ok')];
+
+        $subject->chatWithTools($messages, $tools, $options);
+
+        self::assertCount(1, $subject->chatWithToolsCalls);
+        self::assertSame($messages, $subject->chatWithToolsCalls[0]['messages']);
+        self::assertSame($tools, $subject->chatWithToolsCalls[0]['tools']);
+        self::assertSame($options, $subject->chatWithToolsCalls[0]['options']);
+        self::assertSame([], $subject->chatWithToolsForConfigurationCalls);
+    }
+
+    #[Test]
+    public function recordsConfigurationPassedToPerConfigurationCall(): void
+    {
+        $configuration = new LlmConfiguration();
+
+        $subject = new FakeToolCallingService();
+        $subject->responses = [self::response('ok')];
+
+        $subject->chatWithToolsForConfiguration([], [], $configuration);
+
+        self::assertCount(1, $subject->chatWithToolsForConfigurationCalls);
+        self::assertSame($configuration, $subject->chatWithToolsForConfigurationCalls[0]['configuration']);
+    }
+
+    #[Test]
+    public function throwsConfiguredThrowableInsteadOfReturning(): void
+    {
+        $subject = new FakeToolCallingService();
+        $subject->responses = [self::response('unused')];
+        $subject->throwable = new RuntimeException('boom');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $subject->chatWithTools([], []);
+    }
+
+    #[Test]
+    public function throwsWhenCalledWithoutAQueuedResponse(): void
+    {
+        $subject = new FakeToolCallingService();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('no response was queued');
+
+        $subject->chatWithTools([], []);
+    }
+
+    private static function response(string $content): CompletionResponse
+    {
+        return new CompletionResponse($content, 'fake-model', new UsageStatistics(0, 0, 0));
+    }
+}


### PR DESCRIPTION
## Problem

Consumers of nr_llm's feature interfaces (tool calling, embedding) each hand-roll a fake in their own test suite. Those fakes drift: when the interface grows a method, the consumer's suite fatals — the exact failure ADR-051 documents for nr_ai_search's 0.13 → 0.16 update.

## Change (ADR-073)

Maintained doubles shipped by nr_llm itself, in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace (production `autoload`, so consumers get them without nr_llm's dev deps):

- `FakeToolCallingService` — FIFO queue of `CompletionResponse`s, per-call recording for both methods, settable throwable
- `FakeEmbeddingService` — canned vectors + per-call recording for the five provider-backed `embed*` methods (records the passed `LlmConfiguration`); canned returns for the four pure vector helpers (documented: no math reimplementation)

Both implement the real interface, so PHPStan fails the build if a double drifts. Excluded from container autoconfiguration (`Configuration/Services.yaml` exclude entry — the ADR-065 audited `public: true` count is unchanged); never wire into production.

## Tests

16 unit tests (canned-response selection, call recording, throwable, configuration passthrough); full suite, phpstan L10 incl. phpat, cgl green locally.