### PR TITLE
feat(retrieval): host ReciprocalRankFusion as newable utility (ADR-074)

### DIFF
--- a/Classes/Service/Retrieval/ReciprocalRankFusion.php
+++ b/Classes/Service/Retrieval/ReciprocalRankFusion.php
@@ -29,13 +29,15 @@ final readonly class ReciprocalRankFusion
      *                                           duplicates within a list are ignored past their first rank
      * @param list<float>        $weights        per-list weight (same index); missing/extra default to 1.0
      *
-     * @return list<string> fused keys, highest RRF score first; ties keep first-seen order
+     * @return list<int|string> fused keys, highest RRF score first; ties keep first-seen
+     *                          order. PHP array-key coercion applies: numeric-string keys
+     *                          (e.g. '42') come back as ints.
      */
     public function fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array
     {
         $k = max(1, $k);
 
-        /** @var array<string, float> $scores insertion order = list order, then per-list new keys */
+        /** @var array<int|string, float> $scores insertion order = list order, then per-list new keys */
         $scores = [];
 
         foreach ($rankedKeyLists as $listIndex => $keys) {

--- a/Classes/Service/Retrieval/ReciprocalRankFusion.php
+++ b/Classes/Service/Retrieval/ReciprocalRankFusion.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Retrieval;
+
+/**
+ * Reciprocal Rank Fusion (Cormack et al., 2009) for hybrid retrieval (ADR-074).
+ *
+ * Fuses several ranked key lists using only per-list RANK, never score
+ * magnitude — so it combines dense cosine and sparse BM25 rankings, which live
+ * on incomparable scales, without any score normalization. For each key the
+ * fused score is Σ_i weight_i / (k + rank_i), where rank_i is the key's 1-based
+ * position in list i (absent = no contribution).
+ *
+ * Newable utility, deliberately not a DI service (excluded from container
+ * autoconfiguration): consumers construct it with `new`. nr_llm's own
+ * retrieval cascade stays first-available-wins (ADR-049) and does not call it.
+ */
+final readonly class ReciprocalRankFusion
+{
+    /**
+     * @param list<list<string>> $rankedKeyLists each inner list is keys best-first;
+     *                                           duplicates within a list are ignored past their first rank
+     * @param list<float>        $weights        per-list weight (same index); missing/extra default to 1.0
+     *
+     * @return list<string> fused keys, highest RRF score first; ties keep first-seen order
+     */
+    public function fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array
+    {
+        $k = max(1, $k);
+
+        /** @var array<string, float> $scores insertion order = list order, then per-list new keys */
+        $scores = [];
+
+        foreach ($rankedKeyLists as $listIndex => $keys) {
+            $weight = $weights[$listIndex] ?? 1.0;
+            $rank = 0;
+            $seenInList = [];
+
+            foreach ($keys as $key) {
+                if (isset($seenInList[$key])) {
+                    continue;
+                }
+
+                $seenInList[$key] = true;
+                ++$rank;
+                $scores[$key] = ($scores[$key] ?? 0.0) + $weight / ($k + $rank);
+            }
+        }
+
+        // arsort is stable in PHP 8: equal scores keep insertion order (list 0
+        // before list 1's new keys), giving deterministic tie-breaking.
+        arsort($scores);
+
+        return array_keys($scores);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,6 +20,8 @@ services:
       - '../Classes/Attribute/*'
       - '../Classes/Domain/Model/*'
       - '../Classes/Provider/Exception/*'
+      # Newable rank-fusion math (ADR-074): consumers construct it, no DI.
+      - '../Classes/Service/Retrieval/ReciprocalRankFusion.php'
       - '../Classes/Service/SetupWizard/Exception/*'
       - '../Classes/Service/Skill/Exception/*'
       - '../Classes/Specialized/Exception/*'

--- a/Documentation/Adr/Adr074ReciprocalRankFusionUtility.rst
+++ b/Documentation/Adr/Adr074ReciprocalRankFusionUtility.rst
@@ -1,0 +1,74 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-074:
+
+====================================================
+ADR-074: Reciprocal Rank Fusion as a hosted utility
+====================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-074-context:
+
+Context
+=======
+
+``nr_ai_search`` fuses its dense (embedding) and sparse (keyword) retrieval
+arms with Reciprocal Rank Fusion (Cormack et al., 2009): rank-only fusion
+combines rankings whose scores live on incomparable scales — dense cosine
+similarity versus BM25 — without any score normalization. Its implementation
+is 55 lines, pure and dependency-free, and the sparse arm it fuses is
+nr_llm's own keyword-search facade (ADR-071).
+
+The 2026-07 downstream-extraction analysis flagged the class as genuinely
+portable but deferred hosting it here: ADR-049 decided the retrieval
+cascade is first-available-wins with no cross-backend merging, so RRF would
+have been public API with zero callers inside nr_llm. The revisit trigger
+was a second consumer of rank fusion, or a fan-out-and-merge retrieval
+mode superseding ADR-049.
+
+Every hybrid consumer that pairs its own dense arm with the ADR-071 sparse
+facade needs this same fusion step, and each copy re-derives the identical
+math. The maintainer pulled the second-consumer trigger forward: host the
+utility now so hybrid consumers share one implementation instead of each
+carrying a private copy.
+
+.. _adr-074-decision:
+
+Decision
+========
+
+Host the class as ``Netresearch\NrLlm\Service\Retrieval\ReciprocalRankFusion``
+with the signature identical to the ``nr_ai_search`` original —
+``fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array`` —
+so a consumer migrates by swapping the namespace import, nothing else.
+
+- **Pure final class, no interface.** The math has exactly one correct
+  implementation; an interface would add an abstraction with nothing to
+  substitute.
+- **Newable, not a DI service.** The class is stateless with a no-argument
+  constructor; consumers instantiate it with ``new``. It is excluded from
+  container autoconfiguration in ``Configuration/Services.yaml`` and adds
+  no ``public: true`` override, so the audited public-service count
+  (ADR-028 / ADR-065 / ADR-071) is unchanged.
+- **ADR-049 is unchanged.** nr_llm's own retrieval cascade remains
+  first-available-wins: ``RetrievalService`` does not fan out across
+  backends and does not merge their results. ``ReciprocalRankFusion`` is a
+  consumer-facing utility; no nr_llm code path calls it.
+
+.. _adr-074-consequences:
+
+Consequences
+============
+
+- ``nr_ai_search`` (and any later hybrid consumer) deletes its own copy and
+  imports ``Netresearch\NrLlm\Service\Retrieval\ReciprocalRankFusion``;
+  behaviour is bit-identical.
+- The class is supported public API surface: changing ``fuse()``'s
+  signature or tie-breaking semantics is a breaking change for consumers
+  and belongs in a release note.
+- Should ADR-049's cascade ever gain a fan-out-and-merge mode, the fusion
+  math is already in place; adopting it there would be a new ADR
+  superseding ADR-049, not a change to this one.

--- a/Documentation/Adr/Adr074ReciprocalRankFusionUtility.rst
+++ b/Documentation/Adr/Adr074ReciprocalRankFusionUtility.rst
@@ -44,6 +44,8 @@ Host the class as ``Netresearch\NrLlm\Service\Retrieval\ReciprocalRankFusion``
 with the signature identical to the ``nr_ai_search`` original —
 ``fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array`` —
 so a consumer migrates by swapping the namespace import, nothing else.
+As in the original, PHP array-key coercion applies to the fused result:
+numeric-string keys (e.g. ``'42'``) come back as ``int``.
 
 - **Pure final class, no interface.** The math has exactly one correct
   implementation; an interface would add an abstraction with nothing to

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -371,3 +371,4 @@ Tools
    Adr071PublicKeywordSearchFacade
    Adr072RetrievalQualityEvaluation
    Adr073FirstPartyTestingFixtures
+   Adr074ReciprocalRankFusionUtility

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -18,6 +18,7 @@ Complete API reference for the TYPO3 LLM extension.
    TranslationService
    ToolCallingService
    KeywordSearch
+   ReciprocalRankFusion
    ResponseObjects
    OptionClasses
    ProviderInterface

--- a/Documentation/Api/ReciprocalRankFusion.rst
+++ b/Documentation/Api/ReciprocalRankFusion.rst
@@ -38,7 +38,10 @@ ReciprocalRankFusion
          ranks dominate
       :param array $weights: list<float> — per-list weight (same index);
          missing or extra entries default to 1.0
-      :returns: list<string> — fused keys, highest RRF score first
+      :returns: list<int|string> — fused keys, highest RRF score first.
+         PHP array-key coercion applies: numeric-string keys (e.g.
+         ``'42'``) come back as ``int``, so compare fused keys loosely or
+         cast before a strict comparison.
 
 Usage
 =====

--- a/Documentation/Api/ReciprocalRankFusion.rst
+++ b/Documentation/Api/ReciprocalRankFusion.rst
@@ -1,0 +1,58 @@
+.. include:: /Includes.rst.txt
+
+.. _api-reciprocal-rank-fusion:
+
+====================
+ReciprocalRankFusion
+====================
+
+.. php:namespace:: Netresearch\NrLlm\Service\Retrieval
+
+.. php:class:: ReciprocalRankFusion
+
+   Reciprocal Rank Fusion (Cormack et al., 2009) for hybrid retrieval
+   (:ref:`adr-074`). Fuses several ranked key lists using only per-list
+   rank, never score magnitude — so it combines rankings on incomparable
+   score scales (dense cosine similarity, sparse BM25) without any
+   normalization.
+
+   Final readonly class, newable: construct it with ``new``, it is not a
+   DI service. nr_llm's own retrieval cascade (:ref:`adr-049`) does not
+   call it — it exists for hybrid consumers that fan out to several
+   retrieval arms themselves.
+
+   .. php:method:: fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array
+
+      Fuse ranked key lists into one list ordered by descending RRF
+      score. For each key the fused score is
+      Σ\ :sub:`i` weight\ :sub:`i` / (k + rank\ :sub:`i`), where
+      rank\ :sub:`i` is the key's 1-based position in list *i*; a key
+      absent from a list contributes nothing there. Duplicates within a
+      list are ignored past their first rank. Equal scores keep
+      first-seen order (list 0 before list 1's new keys). A ``$k``
+      below 1 is clamped to 1.
+
+      :param array $rankedKeyLists: list<list<string>> — each inner list
+         is keys best-first
+      :param int $k: rank-smoothing constant; smaller values let top
+         ranks dominate
+      :param array $weights: list<float> — per-list weight (same index);
+         missing or extra entries default to 1.0
+      :returns: list<string> — fused keys, highest RRF score first
+
+Usage
+=====
+
+.. code-block:: php
+
+   use Netresearch\NrLlm\Service\Retrieval\ReciprocalRankFusion;
+
+   $denseKeys = ['page:12', 'page:7', 'page:3'];   // embedding arm, best-first
+   $sparseKeys = ['page:7', 'page:9'];             // keyword arm, best-first
+
+   $fused = (new ReciprocalRankFusion())->fuse(
+       [$denseKeys, $sparseKeys],
+       60,
+       [1.0, 0.5],  // trust the dense arm twice as much
+   );
+   // ['page:7', ...] — ranked in both arms, so it wins

--- a/Tests/Unit/Service/Retrieval/ReciprocalRankFusionTest.php
+++ b/Tests/Unit/Service/Retrieval/ReciprocalRankFusionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Retrieval;
+
+use Netresearch\NrLlm\Service\Retrieval\ReciprocalRankFusion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ReciprocalRankFusion::class)]
+final class ReciprocalRankFusionTest extends TestCase
+{
+    #[Test]
+    public function singleListPreservesOrder(): void
+    {
+        self::assertSame(['a', 'b', 'c'], (new ReciprocalRankFusion())->fuse([['a', 'b', 'c']], 60));
+    }
+
+    #[Test]
+    public function disjointListsInterleaveByRank(): void
+    {
+        // rank-1 of each arm ties (1/61) and keeps list order (a before x); then rank-2 (b before y).
+        self::assertSame(['a', 'x', 'b', 'y'], (new ReciprocalRankFusion())->fuse([['a', 'b'], ['x', 'y']], 60));
+    }
+
+    #[Test]
+    public function sharedKeySumsBothContributions(): void
+    {
+        // b: dense rank2 (1/62) + sparse rank1 (1/61) = 0.0325 beats a (1/61) and c (1/62).
+        self::assertSame(['b', 'a', 'c'], (new ReciprocalRankFusion())->fuse([['a', 'b'], ['b', 'c']], 60));
+    }
+
+    #[Test]
+    public function smallerKLetsTopRankDominate(): void
+    {
+        self::assertSame('b', (new ReciprocalRankFusion())->fuse([['a', 'b'], ['b', 'c']], 1)[0]);
+    }
+
+    #[Test]
+    public function weightBiasesOneArm(): void
+    {
+        // Both rank-1, but the dense arm's weight (5) outranks the sparse arm's (1).
+        self::assertSame(['a', 'x'], (new ReciprocalRankFusion())->fuse([['a'], ['x']], 60, [5.0, 1.0]));
+    }
+
+    #[Test]
+    public function missingWeightDefaultsToOne(): void
+    {
+        // Only the first arm has an explicit weight; the second falls back to 1.0
+        // and its rank-1 key ties with an explicit-1.0 arm's rank-1 key.
+        self::assertSame(['a', 'x'], (new ReciprocalRankFusion())->fuse([['a'], ['x']], 60, [1.0]));
+    }
+
+    #[Test]
+    public function extraWeightsAreIgnored(): void
+    {
+        self::assertSame(['a', 'x'], (new ReciprocalRankFusion())->fuse([['a'], ['x']], 60, [5.0, 1.0, 9.0]));
+    }
+
+    #[Test]
+    public function deduplicatesWithinList(): void
+    {
+        self::assertSame(['a', 'b'], (new ReciprocalRankFusion())->fuse([['a', 'a', 'b']], 60));
+    }
+
+    #[Test]
+    public function duplicateKeepsFirstRankWithinList(): void
+    {
+        // The duplicate 'b' at position 3 is skipped without consuming a rank,
+        // so c is rank 3 and d rank 4 — not demoted to 4 and 5.
+        self::assertSame(
+            ['a', 'b', 'c', 'd'],
+            (new ReciprocalRankFusion())->fuse([['a', 'b', 'b', 'c', 'd']], 60),
+        );
+    }
+
+    #[Test]
+    public function emptyListsYieldEmpty(): void
+    {
+        self::assertSame([], (new ReciprocalRankFusion())->fuse([[], []]));
+    }
+
+    #[Test]
+    public function noListsYieldEmpty(): void
+    {
+        self::assertSame([], (new ReciprocalRankFusion())->fuse([]));
+    }
+
+    #[Test]
+    public function nonPositiveKIsClamped(): void
+    {
+        // k=0 would divide by rank alone; clamped to 1, so this must not error and stays ordered.
+        self::assertSame(['a', 'b'], (new ReciprocalRankFusion())->fuse([['a', 'b']], 0));
+    }
+
+    #[Test]
+    public function negativeKIsClamped(): void
+    {
+        // k=-1 would make (k + rank) zero at rank 1; clamped to 1 avoids division by zero.
+        self::assertSame(['a', 'b'], (new ReciprocalRankFusion())->fuse([['a', 'b']], -1));
+    }
+}

--- a/Tests/Unit/Service/Retrieval/ReciprocalRankFusionTest.php
+++ b/Tests/Unit/Service/Retrieval/ReciprocalRankFusionTest.php
@@ -94,6 +94,13 @@ final class ReciprocalRankFusionTest extends TestCase
     }
 
     #[Test]
+    public function numericStringKeysComeBackAsInts(): void
+    {
+        // PHP array-key coercion in the score accumulator: '42' becomes int 42.
+        self::assertSame([42], (new ReciprocalRankFusion())->fuse([['42']]));
+    }
+
+    #[Test]
     public function nonPositiveKIsClamped(): void
     {
         // k=0 would divide by rank alone; clamped to 1, so this must not error and stays ordered.


### PR DESCRIPTION
Resolves #415 — pulls the "second consumer" revisit trigger forward per maintainer decision.

## What

- `Classes/Service/Retrieval/ReciprocalRankFusion.php` — ported verbatim from nr-ai-search (`Classes/Provider/ReciprocalRankFusion.php`) with the identical `fuse(array $rankedKeyLists, int $k = 60, array $weights = []): array` signature and semantics; only the namespace, file header, and ADR reference changed. Final readonly, no interface, newable.
- `Configuration/Services.yaml` — single-file exclude from namespace autoregistration; no `public: true` added, so the ADR-028/065/071 audited count (28) and `PublicServicesPolicyTest` are untouched.
- `Tests/Unit/Service/Retrieval/ReciprocalRankFusionTest.php` — the 8 upstream cases ported to this repo's attribute conventions, plus 5 new cases: missing-weight default, extra weights ignored, duplicate not consuming a rank, no lists, negative `k` clamp.
- `Documentation/Adr/Adr074ReciprocalRankFusionUtility.rst` (+ `Adr/Index.rst`) — records why fusion math is hosted although ADR-049's first-wins cascade does not call it, and that ADR-049's semantics are unchanged: nr_llm still does not fan out or merge.
- `Documentation/Api/ReciprocalRankFusion.rst` (+ `Api/Index.rst`) — API page in the style of the KeywordSearch page (the comparable ADR-071 consumer surface).

## Gates (final tree)

- unit: 5049 tests / 13432 assertions OK (new file alone: 13/13)
- phpstan (level 10): SUCCESS
- cgl dry-run: SUCCESS
- rector dry-run: SUCCESS