### PR TITLE
feat(document): document analysis via native PDF ingestion with rasterize fallback (ADR-076)

### DIFF
--- a/Classes/Specialized/Document/DocumentAnalysisResult.php
+++ b/Classes/Specialized/Document/DocumentAnalysisResult.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Document;
+
+/**
+ * Result of a document analysis (ADR-076).
+ */
+final readonly class DocumentAnalysisResult
+{
+    /**
+     * @param string $text                   The model's answer. On the native path this is
+     *                                       whole-document reasoning from a single call; on
+     *                                       the rasterization fallback it is the per-page
+     *                                       answers concatenated with `[Page N]` markers.
+     * @param string $model                  Model that produced the answer
+     * @param string $provider               Provider identifier that produced the answer
+     * @param bool   $usedNativeDocumentPath true when the PDF was ingested natively by a
+     *                                       document-capable provider; false when it was
+     *                                       rasterized and read page-by-page by a vision model
+     * @param int    $rasterizedPageCount    Number of pages rasterized on the fallback path;
+     *                                       0 on the native path
+     */
+    public function __construct(
+        public string $text,
+        public string $model,
+        public string $provider,
+        public bool $usedNativeDocumentPath,
+        public int $rasterizedPageCount = 0,
+    ) {}
+}

--- a/Classes/Specialized/Document/DocumentAnalysisService.php
+++ b/Classes/Specialized/Document/DocumentAnalysisService.php
@@ -214,6 +214,8 @@ final readonly class DocumentAnalysisService
             return $this->rasterizer->renderDocument($path);
         } finally {
             if (is_file($path)) {
+                // Path comes from tempnam() above, not user input.
+                // nosemgrep: php.lang.security.unlink-use.unlink-use
                 unlink($path);
             }
         }

--- a/Classes/Specialized/Document/DocumentAnalysisService.php
+++ b/Classes/Specialized/Document/DocumentAnalysisService.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Document;
+
+use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
+use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Specialized\Exception\PdfRasterizationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
+
+/**
+ * Stateless "understand this document" primitive (ADR-076).
+ *
+ * Analyzes a PDF against a caller-supplied prompt. When the resolved
+ * provider implements {@see DocumentCapableInterface} the PDF is ingested
+ * natively as a Base64 document block in ONE chat call — whole-document
+ * reasoning. Otherwise the document is rasterized page-by-page (poppler via
+ * {@see PdfRasterizerInterface}) and each page is read by the vision model;
+ * the per-page answers are concatenated with `[Page N]` markers.
+ *
+ * Ingestion orchestration stays with the consumer: chunking, per-page
+ * degradation policy (a failed page on the fallback path fails the call —
+ * catch and retry on the consumer side), enable/disable flags, and cost
+ * capping. Budget attribution mirrors the feature services: `beUserUid`
+ * is auto-populated from the backend user context when the caller did not
+ * set it (REC #4).
+ */
+final readonly class DocumentAnalysisService
+{
+    use AutoPopulatesBeUserUidTrait;
+
+    public function __construct(
+        private LlmServiceManagerInterface $llmManager,
+        private VisionServiceInterface $visionService,
+        private PdfRasterizerInterface $rasterizer,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
+    ) {}
+
+    /**
+     * Analyze a PDF with a custom prompt.
+     *
+     * @param string $pdf    Raw PDF bytes (must start with the %PDF- header)
+     * @param string $prompt Analysis prompt, applied to the whole document on
+     *                       the native path and to each page on the fallback
+     *
+     * @throws UnsupportedFormatException  when the bytes are not a PDF
+     * @throws ServiceUnavailableException when neither the native path nor the
+     *                                     rasterization fallback is possible
+     *                                     (provider lacks document support and
+     *                                     poppler is not installed)
+     * @throws PdfRasterizationException   when rasterization itself fails
+     */
+    public function analyzeDocument(string $pdf, string $prompt, ?ChatOptions $options = null): DocumentAnalysisResult
+    {
+        if (!str_starts_with($pdf, '%PDF-')) {
+            throw UnsupportedFormatException::documentFormat();
+        }
+
+        $options = $this->autoPopulateBeUserUid($options ?? new ChatOptions());
+
+        $provider = $this->llmManager->getProvider($this->resolveProviderKey($options));
+
+        if (
+            $provider instanceof DocumentCapableInterface
+            && $provider->supportsDocuments()
+            && in_array('pdf', $provider->getSupportedDocumentFormats(), true)
+        ) {
+            return $this->analyzeNatively($pdf, $prompt, $options->withProvider($provider->getIdentifier()));
+        }
+
+        return $this->analyzeViaRasterization($pdf, $prompt, $options, $provider->getIdentifier());
+    }
+
+    /**
+     * Provider key to probe for document capability. An explicit per-call
+     * provider wins; otherwise the backend-managed default configuration's
+     * provider type — the same record `LlmServiceManager::chat()` would
+     * route to — so the capability probe and the dispatch cannot diverge.
+     * Null falls through to the registry default provider.
+     */
+    private function resolveProviderKey(ChatOptions $options): ?string
+    {
+        $providerKey = $options->getProvider();
+        if ($providerKey !== null && $providerKey !== '') {
+            return $providerKey;
+        }
+
+        $configuration = $this->llmManager->resolveEffectiveConfiguration();
+        if ($configuration !== null && $configuration->getProviderType() !== '') {
+            return $configuration->getProviderType();
+        }
+
+        return null;
+    }
+
+    /**
+     * Native path: one chat call carrying the whole PDF as a Base64 document
+     * block. The document-capable providers (Gemini, Claude) convert the
+     * block to their inline-document wire format.
+     */
+    private function analyzeNatively(string $pdf, string $prompt, ChatOptions $options): DocumentAnalysisResult
+    {
+        $messages = [
+            [
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => $prompt,
+                    ],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'base64',
+                            'media_type' => 'application/pdf',
+                            'data' => base64_encode($pdf),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $this->llmManager->chat($messages, $options);
+
+        return new DocumentAnalysisResult(
+            text: $response->getText(),
+            model: $response->model,
+            provider: $response->provider,
+            usedNativeDocumentPath: true,
+        );
+    }
+
+    /**
+     * Fallback path: rasterize every page and put each one through the
+     * vision model with the caller's prompt. Requires the poppler binaries;
+     * a per-page vision failure fails the call (no silent partial result —
+     * degradation policy is the consumer's).
+     */
+    private function analyzeViaRasterization(
+        string $pdf,
+        string $prompt,
+        ChatOptions $options,
+        string $providerIdentifier,
+    ): DocumentAnalysisResult {
+        if (!$this->rasterizer->isAvailable()) {
+            throw ServiceUnavailableException::rasterizerUnavailable($providerIdentifier);
+        }
+
+        $pages = $this->rasterize($pdf);
+        $visionOptions = $this->buildVisionOptions($options);
+
+        $sections = [];
+        $model = '';
+        $provider = '';
+        foreach ($pages as $pageNumber => $png) {
+            $dataUri = 'data:image/png;base64,' . base64_encode($png);
+            $response = $this->visionService->analyzeImageFull($dataUri, $prompt, $visionOptions);
+            $model = $response->model;
+            $provider = $response->provider;
+            $text = trim($response->getText());
+            if ($text !== '') {
+                $sections[] = sprintf("[Page %d]\n%s", $pageNumber, $text);
+            }
+        }
+
+        return new DocumentAnalysisResult(
+            text: implode("\n\n", $sections),
+            model: $model,
+            provider: $provider,
+            usedNativeDocumentPath: false,
+            rasterizedPageCount: count($pages),
+        );
+    }
+
+    /**
+     * Materialise the PDF bytes to a temporary file for the rasterizer
+     * (poppler reads files, not stdin) and clean it up afterwards.
+     *
+     * @throws PdfRasterizationException
+     *
+     * @return array<int, string> PNG bytes per 1-based page number
+     */
+    private function rasterize(string $pdf): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nrllm_doc_');
+        if ($path === false) {
+            throw new PdfRasterizationException('Unable to allocate a temporary file for document analysis.', 1784211011);
+        }
+
+        try {
+            if (file_put_contents($path, $pdf) === false) {
+                throw new PdfRasterizationException('Unable to write the document to a temporary file.', 1784211012);
+            }
+
+            return $this->rasterizer->renderDocument($path);
+        } finally {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    /**
+     * Carry the chat options' passthrough fields over to the vision fallback.
+     * Every typed field must be copied across — a missing field looks like
+     * "use the default" (same class of bug as VisionService's options
+     * rebuild, PR #177).
+     */
+    private function buildVisionOptions(ChatOptions $options): VisionOptions
+    {
+        return new VisionOptions(
+            maxTokens: $options->getMaxTokens(),
+            temperature: $options->getTemperature(),
+            provider: $options->getProvider(),
+            model: $options->getModel(),
+            beUserUid: $options->getBeUserUid(),
+            plannedCost: $options->getPlannedCost(),
+        );
+    }
+}

--- a/Classes/Specialized/Document/DocumentAnalysisService.php
+++ b/Classes/Specialized/Document/DocumentAnalysisService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Document;
 
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
@@ -56,6 +57,10 @@ final readonly class DocumentAnalysisService
      *                       the native path and to each page on the fallback
      *
      * @throws UnsupportedFormatException  when the bytes are not a PDF
+     * @throws ProviderException           when no provider is resolvable (the
+     *                                     caller pinned none and no active
+     *                                     default configuration exists) — the
+     *                                     same error a plain chat() call raises
      * @throws ServiceUnavailableException when neither the native path nor the
      *                                     rasterization fallback is possible
      *                                     (provider lacks document support and
@@ -77,7 +82,7 @@ final readonly class DocumentAnalysisService
             && $provider->supportsDocuments()
             && in_array('pdf', $provider->getSupportedDocumentFormats(), true)
         ) {
-            return $this->analyzeNatively($pdf, $prompt, $options->withProvider($provider->getIdentifier()));
+            return $this->analyzeNatively($pdf, $prompt, $options);
         }
 
         return $this->analyzeViaRasterization($pdf, $prompt, $options, $provider->getIdentifier());
@@ -87,8 +92,10 @@ final readonly class DocumentAnalysisService
      * Provider key to probe for document capability. An explicit per-call
      * provider wins; otherwise the backend-managed default configuration's
      * provider type — the same record `LlmServiceManager::chat()` would
-     * route to — so the capability probe and the dispatch cannot diverge.
-     * Null falls through to the registry default provider.
+     * route to. The key is used for the probe ONLY; dispatch passes the
+     * caller's options through unchanged so `chat()` resolves the same
+     * default record itself. Null makes `getProvider()` throw the "no
+     * default provider configured" {@see ProviderException}.
      */
     private function resolveProviderKey(ChatOptions $options): ?string
     {

--- a/Classes/Specialized/Document/PdfRasterizerInterface.php
+++ b/Classes/Specialized/Document/PdfRasterizerInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Document;
+
+use Netresearch\NrLlm\Specialized\Exception\PdfRasterizationException;
+
+/**
+ * Rasterizes PDF pages to image blobs so a vision model can read pages of a
+ * document whose provider has no native PDF ingestion (ADR-076). Kept behind
+ * an interface so the concrete poppler-backed implementation (which shells
+ * out to system binaries) can be substituted by a fake in unit tests, and so
+ * consumers can detect a missing binary before committing to the fallback.
+ *
+ * All methods take an absolute local filesystem path (the caller materialises
+ * in-memory PDF bytes to a temporary file first).
+ */
+interface PdfRasterizerInterface
+{
+    /**
+     * @throws PdfRasterizationException if the image inventory cannot be produced
+     *
+     * @return list<int> 1-based page numbers that carry at least one embedded
+     *                   raster image
+     */
+    public function imagePages(string $absolutePath): array;
+
+    /**
+     * @throws PdfRasterizationException if the page cannot be rendered
+     *
+     * @return string PNG bytes of the rasterized page
+     */
+    public function renderPage(string $absolutePath, int $page): string;
+
+    /**
+     * @throws PdfRasterizationException if the document cannot be rendered
+     *
+     * @return array<int, string> PNG bytes per 1-based page number, ascending,
+     *                            covering every page of the document
+     */
+    public function renderDocument(string $absolutePath): array;
+
+    /**
+     * Whether the rasterizer's system dependencies are present. A false result
+     * means rasterization-based processing is impossible on this host.
+     */
+    public function isAvailable(): bool;
+}

--- a/Classes/Specialized/Document/PopplerPdfRenderer.php
+++ b/Classes/Specialized/Document/PopplerPdfRenderer.php
@@ -100,6 +100,8 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
         }
 
         // pdftoppm writes "<stub>-<page>.png"; the stub itself must not collide.
+        // Path comes from tempnam() above, not user input.
+        // nosemgrep: php.lang.security.unlink-use.unlink-use
         unlink($stub);
 
         try {
@@ -142,6 +144,8 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
             $leftovers = glob($stub . '*.png');
             foreach ($leftovers === false ? [] : $leftovers as $leftover) {
                 if (is_file($leftover)) {
+                    // Path comes from glob() over the tempnam() stub, not user input.
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use
                     unlink($leftover);
                 }
             }

--- a/Classes/Specialized/Document/PopplerPdfRenderer.php
+++ b/Classes/Specialized/Document/PopplerPdfRenderer.php
@@ -99,11 +99,10 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
             throw new PdfRasterizationException('Unable to allocate a temporary file for PDF rendering.', 1784211004);
         }
 
-        // pdftoppm writes "<stub>-<page>.png"; the stub itself must not collide.
-        // Path comes from tempnam() above, not user input.
-        // nosemgrep: php.lang.security.unlink-use.unlink-use
-        unlink($stub);
-
+        // The stub file stays on disk while pdftoppm runs: it keeps the
+        // tempnam() name reservation (no concurrent re-issue of the same
+        // prefix), and pdftoppm only ever writes "<stub>-<page>.png", which
+        // never collides with the suffix-less stub itself. Removed in finally.
         try {
             $this->run([
                 'pdftoppm',
@@ -141,6 +140,11 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
 
             return $pages;
         } finally {
+            if (is_file($stub)) {
+                // Path comes from tempnam() above, not user input.
+                // nosemgrep: php.lang.security.unlink-use.unlink-use
+                unlink($stub);
+            }
             $leftovers = glob($stub . '*.png');
             foreach ($leftovers === false ? [] : $leftovers as $leftover) {
                 if (is_file($leftover)) {
@@ -171,7 +175,35 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
             throw new PdfRasterizationException(sprintf('Could not start "%s" - is poppler installed?', $command[0]), 1784211015);
         }
 
-        $stdout = (string)stream_get_contents($pipes[1]);
+        // Drain BOTH pipes concurrently: a child blocked on a full stderr pipe
+        // buffer would never finish writing stdout (classic proc_open
+        // deadlock) — poppler spams per-object syntax warnings to stderr on
+        // corrupt PDFs, easily exceeding the pipe buffer.
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+        $output = [1 => '', 2 => ''];
+        $open = $pipes;
+        while ($open !== []) {
+            $read = array_values($open);
+            $write = null;
+            $except = null;
+            if (stream_select($read, $write, $except, null) === false) {
+                break;
+            }
+            foreach ($open as $fd => $pipe) {
+                if (!\in_array($pipe, $read, true)) {
+                    continue;
+                }
+                $chunk = fread($pipe, 65536);
+                if ($chunk === false || ($chunk === '' && feof($pipe))) {
+                    unset($open[$fd]);
+                    continue;
+                }
+                $output[$fd] .= $chunk;
+            }
+        }
+        $stdout = $output[1];
+        $stderr = $output[2];
         fclose($pipes[1]);
         fclose($pipes[2]);
         $exitCode = proc_close($process);
@@ -179,7 +211,8 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
         // `-v` prints its banner to stderr and exits 0; a missing sub-binary or a
         // real failure returns non-zero. poppler's -v exits 0, so this is a clean gate.
         if ($exitCode !== 0) {
-            throw new PdfRasterizationException(sprintf('"%s" exited with code %d.', $command[0], $exitCode), 1784211008);
+            $detail = trim($stderr) === '' ? '' : sprintf(' Stderr: %s', mb_substr(trim($stderr), 0, 500));
+            throw new PdfRasterizationException(sprintf('"%s" exited with code %d.%s', $command[0], $exitCode, $detail), 1784211008);
         }
 
         return $stdout;

--- a/Classes/Specialized/Document/PopplerPdfRenderer.php
+++ b/Classes/Specialized/Document/PopplerPdfRenderer.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Document;
+
+use Netresearch\NrLlm\Specialized\Exception\PdfRasterizationException;
+use Throwable;
+
+/**
+ * poppler-backed PDF rasterizer: `pdfimages -list` to find image-bearing
+ * pages, `pdftoppm` to rasterize a single page or the whole document to PNG.
+ * Invoked via proc_open with an ARRAY argv so no shell parses the path (no
+ * command-injection surface).
+ *
+ * Ported from nr_ai_search's PopplerPdfRenderer (its ADR-034 renderer) with
+ * the whole-document `renderDocument()` added for the ADR-076 rasterization
+ * fallback. The poppler binaries are an OPTIONAL system dependency (see
+ * composer.json `suggest`); a missing binary or a non-zero exit raises
+ * PdfRasterizationException.
+ */
+final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
+{
+    private const RENDER_DPI = 150;
+
+    public function imagePages(string $absolutePath): array
+    {
+        $listing = $this->run(['pdfimages', '-list', $absolutePath]);
+        $pages = [];
+        foreach (explode("\n", $listing) as $index => $line) {
+            if ($index < 2) {
+                // First two lines are the column header and its underline rule.
+                continue;
+            }
+
+            if (preg_match('/^\s*(\d+)\s/', $line, $matches) === 1) {
+                $pages[(int)$matches[1]] = true;
+            }
+        }
+
+        $pages = array_keys($pages);
+        sort($pages);
+
+        return $pages;
+    }
+
+    public function renderPage(string $absolutePath, int $page): string
+    {
+        $rendered = $this->rasterize(
+            $absolutePath,
+            ['-f', (string)$page, '-l', (string)$page],
+            sprintf('pdftoppm produced no output for page %d.', $page),
+        );
+
+        $png = reset($rendered);
+        if ($png === false) {
+            throw new PdfRasterizationException(sprintf('pdftoppm produced no output for page %d.', $page), 1784211005);
+        }
+
+        return $png;
+    }
+
+    public function renderDocument(string $absolutePath): array
+    {
+        return $this->rasterize($absolutePath, [], 'pdftoppm produced no output for the document.');
+    }
+
+    public function isAvailable(): bool
+    {
+        try {
+            $this->run(['pdftoppm', '-v']);
+            $this->run(['pdfimages', '-v']);
+
+            return true;
+        } catch (PdfRasterizationException) {
+            return false;
+        }
+    }
+
+    /**
+     * Run pdftoppm over the document (optionally restricted via `-f`/`-l`
+     * arguments) and collect the produced PNGs keyed by 1-based page number.
+     *
+     * @param list<string> $rangeArguments
+     *
+     * @throws PdfRasterizationException
+     *
+     * @return array<int, string> PNG bytes per page, ascending
+     */
+    private function rasterize(string $absolutePath, array $rangeArguments, string $emptyOutputMessage): array
+    {
+        $stub = tempnam(sys_get_temp_dir(), 'nrllm_pdf_');
+        if ($stub === false) {
+            throw new PdfRasterizationException('Unable to allocate a temporary file for PDF rendering.', 1784211004);
+        }
+
+        // pdftoppm writes "<stub>-<page>.png"; the stub itself must not collide.
+        unlink($stub);
+
+        try {
+            $this->run([
+                'pdftoppm',
+                '-png',
+                '-r',
+                (string)self::RENDER_DPI,
+                ...$rangeArguments,
+                $absolutePath,
+                $stub,
+            ]);
+            $rendered = glob($stub . '*.png');
+            if ($rendered === false || $rendered === []) {
+                throw new PdfRasterizationException($emptyOutputMessage, 1784211005);
+            }
+
+            $pages = [];
+            foreach ($rendered as $file) {
+                if (preg_match('/-(\d+)\.png$/', $file, $matches) !== 1) {
+                    continue;
+                }
+
+                $png = file_get_contents($file);
+                if ($png === false || $png === '') {
+                    throw new PdfRasterizationException(sprintf('Rendered page %d could not be read.', (int)$matches[1]), 1784211006);
+                }
+
+                $pages[(int)$matches[1]] = $png;
+            }
+
+            if ($pages === []) {
+                throw new PdfRasterizationException($emptyOutputMessage, 1784211005);
+            }
+
+            ksort($pages);
+
+            return $pages;
+        } finally {
+            $leftovers = glob($stub . '*.png');
+            foreach ($leftovers === false ? [] : $leftovers as $leftover) {
+                if (is_file($leftover)) {
+                    unlink($leftover);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws PdfRasterizationException on spawn failure or non-zero exit
+     */
+    private function run(array $command): string
+    {
+        try {
+            $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        } catch (Throwable $e) {
+            // TYPO3's error handler can turn proc_open()'s "binary not found" warning
+            // into an exception; treat that the same as a false return.
+            throw new PdfRasterizationException(sprintf('Could not start "%s" - is poppler installed?', $command[0]), 1784211007, $e);
+        }
+
+        if (!is_resource($process)) {
+            throw new PdfRasterizationException(sprintf('Could not start "%s" - is poppler installed?', $command[0]), 1784211007);
+        }
+
+        $stdout = (string)stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        // `-v` prints its banner to stderr and exits 0; a missing sub-binary or a
+        // real failure returns non-zero. poppler's -v exits 0, so this is a clean gate.
+        if ($exitCode !== 0) {
+            throw new PdfRasterizationException(sprintf('"%s" exited with code %d.', $command[0], $exitCode), 1784211008);
+        }
+
+        return $stdout;
+    }
+}

--- a/Classes/Specialized/Document/PopplerPdfRenderer.php
+++ b/Classes/Specialized/Document/PopplerPdfRenderer.php
@@ -59,7 +59,7 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
 
         $png = reset($rendered);
         if ($png === false) {
-            throw new PdfRasterizationException(sprintf('pdftoppm produced no output for page %d.', $page), 1784211005);
+            throw new PdfRasterizationException(sprintf('pdftoppm produced no output for page %d.', $page), 1784211013);
         }
 
         return $png;
@@ -132,7 +132,7 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
             }
 
             if ($pages === []) {
-                throw new PdfRasterizationException($emptyOutputMessage, 1784211005);
+                throw new PdfRasterizationException($emptyOutputMessage, 1784211014);
             }
 
             ksort($pages);
@@ -164,7 +164,7 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
         }
 
         if (!is_resource($process)) {
-            throw new PdfRasterizationException(sprintf('Could not start "%s" - is poppler installed?', $command[0]), 1784211007);
+            throw new PdfRasterizationException(sprintf('Could not start "%s" - is poppler installed?', $command[0]), 1784211015);
         }
 
         $stdout = (string)stream_get_contents($pipes[1]);

--- a/Classes/Specialized/Exception/PdfRasterizationException.php
+++ b/Classes/Specialized/Exception/PdfRasterizationException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Exception;
+
+use Throwable;
+
+/**
+ * Thrown by a PdfRasterizerInterface implementation when a page cannot be
+ * rasterized or the image-page list cannot be produced — typically because
+ * the required system binary (poppler's pdftoppm/pdfimages) is missing or a
+ * PDF is malformed. The service domain is fixed to 'document' so the
+ * constructor keeps the (message, code, previous) shape of the ported
+ * renderer's throw sites.
+ */
+final class PdfRasterizationException extends SpecializedServiceException
+{
+    public function __construct(string $message, int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 'document', null, $code, $previous);
+    }
+}

--- a/Classes/Specialized/Exception/ServiceUnavailableException.php
+++ b/Classes/Specialized/Exception/ServiceUnavailableException.php
@@ -68,6 +68,28 @@ final class ServiceUnavailableException extends SpecializedServiceException
     }
 
     /**
+     * Create exception for a provider without native PDF support on a host
+     * without the poppler binaries: neither analysis path is possible.
+     *
+     * @param string $provider The resolved LLM provider identifier
+     */
+    public static function rasterizerUnavailable(string $provider): self
+    {
+        return new self(
+            sprintf(
+                'Provider "%s" has no native PDF support and the poppler binaries (pdftoppm, pdfimages) are not installed. Install poppler-utils to enable the rasterization fallback, or configure a document-capable provider.',
+                $provider,
+            ),
+            'document',
+            [
+                'reason' => 'rasterizer_unavailable',
+                'provider' => $provider,
+            ],
+            1784211009,
+        );
+    }
+
+    /**
      * Create exception for translator not found in registry.
      *
      * @param string $identifier The translator identifier that was not found

--- a/Classes/Specialized/Exception/UnsupportedFormatException.php
+++ b/Classes/Specialized/Exception/UnsupportedFormatException.php
@@ -12,7 +12,8 @@ namespace Netresearch\NrLlm\Specialized\Exception;
 /**
  * Exception thrown when a file format is not supported.
  *
- * Used for audio formats (speech services) and image formats (generation).
+ * Used for audio formats (speech services), image formats (generation)
+ * and document formats (analysis).
  */
 final class UnsupportedFormatException extends SpecializedServiceException
 {
@@ -58,6 +59,22 @@ final class UnsupportedFormatException extends SpecializedServiceException
                 'format' => $format,
                 'type' => 'audio',
             ],
+        );
+    }
+
+    /**
+     * Create exception for document bytes that are not a supported format.
+     */
+    public static function documentFormat(): self
+    {
+        return new self(
+            'Document is not a PDF (missing %PDF- header). Supported: pdf',
+            'document',
+            [
+                'format' => 'unknown',
+                'type' => 'document',
+            ],
+            1784211010,
         );
     }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -336,6 +336,19 @@ services:
     public: true
 
   # ========================================
+  # Document Analysis Services
+  # ========================================
+  # DocumentAnalysisService is Category D consumer API (ADR-076). The
+  # rasterizer alias stays private: consumers autowire the interface, and
+  # a substitute rasterizer is wired by aliasing it to another class.
+
+  Netresearch\NrLlm\Specialized\Document\DocumentAnalysisService:
+    public: true
+
+  Netresearch\NrLlm\Specialized\Document\PdfRasterizerInterface:
+    alias: Netresearch\NrLlm\Specialized\Document\PopplerPdfRenderer
+
+  # ========================================
   # Setup Wizard Services
   # ========================================
   # ProviderDetector stays PUBLIC: it is resolved via

--- a/Documentation/Adr/Adr076DocumentUnderstanding.rst
+++ b/Documentation/Adr/Adr076DocumentUnderstanding.rst
@@ -1,0 +1,131 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-076:
+
+====================================================================
+ADR-076: Document understanding — native-first, rasterize fallback
+====================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-076-context:
+
+Context
+=======
+
+Two providers already implement ``DocumentCapableInterface`` (Gemini,
+Claude): they accept a whole PDF as a Base64 ``document`` content block
+in a single chat call and reason over it natively. Meanwhile
+``nr_ai_search`` built a PDF *ingestion* enrichment (its ADR-034) that
+never uses that capability: it shells out to poppler (``pdfimages`` /
+``pdftoppm``), rasterizes image-bearing pages, and sends each page
+through ``VisionServiceInterface``. The renderer trio it wrote for that
+— ``PdfRendererInterface``, ``PopplerPdfRenderer``,
+``PdfRenderingException`` — is consumer-agnostic: nothing in it knows
+about ingestion, chunking, or degradation policy.
+
+The 2026-07 downstream-extraction analysis (issue #416) decided the
+ingestion pipeline stays in the consumer, but that when nr_llm grows
+document understanding it must be designed around the *existing* native
+capability, with rasterization only as the compatibility fallback.
+
+.. _adr-076-decision:
+
+Decision
+========
+
+``Netresearch\NrLlm\Specialized\Document\DocumentAnalysisService`` is
+the stateless "understand this document" primitive:
+``analyzeDocument(string $pdf, string $prompt, ?ChatOptions $options)``.
+
+**Native path first.** The service resolves the effective provider the
+same way ``LlmServiceManager::chat()`` would (explicit per-call
+provider, else the default configuration's provider type, else the
+registry default). When that provider implements
+``DocumentCapableInterface`` and supports PDF, the whole document goes
+into ONE chat call as a Base64 ``document`` block. Native ingestion is
+preferred because the model reasons over the *whole* document — layout,
+cross-page references, figures in context — at one call's latency and
+attribution, instead of N per-page approximations stitched together.
+
+**Rasterization as fallback only.** For providers without document
+support, the PDF is rasterized page-by-page and each page is read by
+``VisionServiceInterface`` with the caller's prompt; the answers are
+concatenated with ``[Page N]`` markers. The rasterizer is the ported
+``nr_ai_search`` renderer behind a new seam:
+
+- ``PdfRasterizerInterface`` — image-page inventory, single-page and
+  whole-document rasterization to PNG blobs, availability probe.
+- ``PopplerPdfRenderer`` — the poppler-backed implementation, ported
+  essentially unchanged (array-argv ``proc_open``, no shell parsing,
+  temp-stub cleanup in ``finally``), extended by the whole-document
+  ``renderDocument()`` the fallback needs.
+- ``PdfRasterizationException`` — the typed rasterization failure.
+
+**poppler is an optional system dependency.** Declared in
+``composer.json`` ``suggest`` (``poppler-utils``); it is only needed
+when the fallback runs. When rasterization is needed but the binaries
+are absent, the service throws the typed, actionable
+``ServiceUnavailableException::rasterizerUnavailable()`` (install
+poppler-utils, or configure a document-capable provider). When the
+native path is taken, poppler is never touched.
+
+**What stays consumer-side, permanently:** ingestion orchestration,
+enable/disable and cost-cap configuration flags, per-page degradation
+contracts ("a failed page keeps the plain-text extraction"), chunking
+and indexing. On the fallback path a failed page therefore fails the
+call — consumers own retry/degrade policy.
+
+.. _adr-076-public-services:
+
+Public-service accounting (count authority)
+===========================================
+
+``DocumentAnalysisService`` joins Category D (Specialized standalone
+consumer API) as a concrete ``public: true`` service; the
+``PdfRasterizerInterface`` alias stays private (DI autowiring only).
+This supersedes ADR-071's count as the audited breakdown
+(:ref:`ADR-028 <adr-028>` / :ref:`ADR-065 <adr-065>` process):
+
+- Category A (documented downstream LLM-API contract): 16
+- Category B (supporting-service interface aliases): 5
+- Category C (concrete-only documented surface): 1
+- Category D (Specialized standalone consumer API): **5** — Whisper,
+  TextToSpeech, DallE, Fal, **DocumentAnalysis**
+- Category E (resolved outside DI via ``makeInstance()``): 2
+
+Total ``public: true`` overrides: **29**.
+
+.. _adr-076-boundary:
+
+Relation to ADR-050 and nr_ai_search
+====================================
+
+:ref:`ADR-050 <adr-050>` drew the retrieval boundary ("no consumer
+pipeline in nr_llm"), and its reading so far kept *all* PDF-vision
+processing consumer-side. This ADR supersedes that reading for the
+stateless primitive only: "understand this document" is a capability on
+the same footing as ``EmbeddingService::embed()`` — no persistent
+state, no pipeline, no configuration flags. Everything pipeline-shaped
+remains in ``nr_ai_search`` per ADR-050's stopping rule.
+
+``nr_ai_search`` will adopt ``PdfRasterizerInterface`` /
+``PopplerPdfRenderer`` (replacing its own copy) and amend its ADR-028
+consumer-side in a follow-up change set — nothing in nr_llm depends on
+that migration.
+
+.. _adr-076-consequences:
+
+Consequences
+============
+
+- Consumers get whole-document reasoning in one call on Gemini/Claude
+  without writing provider-specific ``document`` blocks themselves.
+- The fallback keeps the feature working on every vision-capable
+  provider, at per-page cost/latency and without cross-page reasoning.
+- One more audited public service (29); the policy test locks the
+  count against this ADR.
+- nr_llm gains an optional system-binary dependency surface (poppler),
+  but only on the fallback path and typed-failing when absent.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -372,3 +372,4 @@ Tools
    Adr072RetrievalQualityEvaluation
    Adr073FirstPartyTestingFixtures
    Adr074ReciprocalRankFusionUtility
+   Adr076DocumentUnderstanding

--- a/Documentation/Api/DocumentAnalysisService.rst
+++ b/Documentation/Api/DocumentAnalysisService.rst
@@ -1,0 +1,116 @@
+.. include:: /Includes.rst.txt
+
+.. _api-document-analysis-service:
+
+=======================
+DocumentAnalysisService
+=======================
+
+.. php:namespace:: Netresearch\NrLlm\Specialized\Document
+
+.. php:class:: DocumentAnalysisService
+
+   Stateless "understand this document" primitive (:ref:`ADR-076
+   <adr-076>`).
+
+   When the resolved provider implements
+   :php:`DocumentCapableInterface` (Gemini, Claude), the PDF is
+   ingested natively as a Base64 document block in a single chat
+   call — whole-document reasoning. Otherwise the document is
+   rasterized page-by-page with poppler and each page is read by
+   the vision model; the per-page answers are concatenated with
+   ``[Page N]`` markers.
+
+   .. php:method:: analyzeDocument(string $pdf, string $prompt, ?ChatOptions $options = null): DocumentAnalysisResult
+
+      Analyze a PDF with a custom prompt.
+
+      :param string $pdf: Raw PDF bytes (must start with the
+         ``%PDF-`` header)
+      :param string $prompt: Analysis prompt, applied to the whole
+         document on the native path and to each page on the
+         fallback
+      :param ChatOptions|null $options: Chat options; ``provider``,
+         ``model``, ``maxTokens``, ``temperature`` and the budget
+         attribution fields (``beUserUid``, ``plannedCost``) are
+         passed through to whichever path runs
+      :returns: :php:`DocumentAnalysisResult` with the answer text,
+         the model/provider that produced it, whether the native
+         document path was used, and the rasterized page count
+      :throws: :php:`UnsupportedFormatException` when the bytes are
+         not a PDF
+      :throws: :php:`ServiceUnavailableException` when the provider
+         lacks native PDF support and poppler is not installed
+      :throws: :php:`PdfRasterizationException` when rasterization
+         itself fails
+
+.. _api-document-analysis-service-usage:
+
+Usage
+=====
+
+.. code-block:: php
+   :caption: Analyzing a PDF
+
+   use Netresearch\NrLlm\Service\Option\ChatOptions;
+   use Netresearch\NrLlm\Specialized\Document\DocumentAnalysisService;
+
+   public function __construct(
+       private readonly DocumentAnalysisService $documentAnalysis,
+   ) {}
+
+   $result = $this->documentAnalysis->analyzeDocument(
+       $pdfBytes,
+       'List the key obligations defined in this contract.',
+       new ChatOptions(maxTokens: 1024),
+   );
+
+   $result->text;                    // the answer
+   $result->usedNativeDocumentPath;  // true: one whole-document call
+   $result->rasterizedPageCount;     // pages read on the fallback path
+
+.. _api-document-analysis-service-poppler:
+
+Optional system dependency: poppler
+===================================
+
+The rasterization fallback shells out to the poppler binaries
+``pdftoppm`` and ``pdfimages`` (Debian/Ubuntu package
+``poppler-utils``; declared in ``composer.json`` ``suggest``). They
+are only needed when the resolved provider has no native PDF
+support. Without them, the fallback fails with the typed
+:php:`ServiceUnavailableException` (code ``1784211009``) naming
+both remedies: install ``poppler-utils`` or configure a
+document-capable provider. The native path never touches poppler.
+
+Degradation policy is the caller's: on the fallback path a failed
+page fails the call — catch and retry (or degrade) in the consumer.
+
+.. _api-document-analysis-service-rasterizer:
+
+PdfRasterizerInterface
+======================
+
+.. php:class:: PdfRasterizerInterface
+
+   Rasterizes PDF pages to PNG blobs. The default implementation is
+   the poppler-backed :php:`PopplerPdfRenderer`; substitute it by
+   aliasing the interface to another class in your
+   :file:`Services.yaml`.
+
+   .. php:method:: imagePages(string $absolutePath): array
+
+      1-based page numbers carrying at least one embedded raster
+      image.
+
+   .. php:method:: renderPage(string $absolutePath, int $page): string
+
+      PNG bytes of one rasterized page.
+
+   .. php:method:: renderDocument(string $absolutePath): array
+
+      PNG bytes per 1-based page number for the whole document.
+
+   .. php:method:: isAvailable(): bool
+
+      Whether the system binaries are present.

--- a/Documentation/Api/DocumentAnalysisService.rst
+++ b/Documentation/Api/DocumentAnalysisService.rst
@@ -39,6 +39,10 @@ DocumentAnalysisService
          document path was used, and the rasterized page count
       :throws: :php:`UnsupportedFormatException` when the bytes are
          not a PDF
+      :throws: :php:`ProviderException` when no provider is
+         resolvable (no explicit provider and no active default
+         configuration) — the same error a plain :php:`chat()` call
+         raises
       :throws: :php:`ServiceUnavailableException` when the provider
          lacks native PDF support and poppler is not installed
       :throws: :php:`PdfRasterizationException` when rasterization

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -15,6 +15,7 @@ Complete API reference for the TYPO3 LLM extension.
    CompletionService
    EmbeddingService
    VisionService
+   DocumentAnalysisService
    TranslationService
    ToolCallingService
    KeywordSearch

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -55,21 +55,21 @@ final class PublicServicesPolicyTest extends TestCase
      *   LlmConfigurationServiceInterface, BudgetServiceInterface.
      * - Category C (Concrete-only documented surface): 1 —
      *   PromptSnippetComposer (ADR-031, no interface).
-     * - Category D (Specialized standalone consumer API): 4 —
-     *   Whisper, TextToSpeech, DallE, Fal.
+     * - Category D (Specialized standalone consumer API): 5 —
+     *   Whisper, TextToSpeech, DallE, Fal, DocumentAnalysis (ADR-076).
      * - Category E (resolved outside DI via makeInstance()): 2 —
      *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 16 + 5 + 1 + 4 + 2 = **28**.
+     * Total: 16 + 5 + 1 + 5 + 2 = **29**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr071PublicKeywordSearchFacade.rst` (the current
-     * count authority, superseding ADR-069's count) in the same PR — the
+     * `Documentation/Adr/Adr076DocumentUnderstanding.rst` (the current
+     * count authority, superseding ADR-071's count) in the same PR — the
      * diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 28;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 29;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
+++ b/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
@@ -146,7 +146,7 @@ class DocumentAnalysisServiceTest extends AbstractUnitTestCase
             $capturedMessages,
         );
         self::assertInstanceOf(ChatOptions::class, $capturedOptions);
-        self::assertSame('gemini', $capturedOptions->getProvider());
+        self::assertNull($capturedOptions->getProvider());
     }
 
     #[Test]
@@ -201,6 +201,36 @@ class DocumentAnalysisServiceTest extends AbstractUnitTestCase
         $result = $this->subject->analyzeDocument(self::PDF, self::PROMPT);
 
         self::assertTrue($result->usedNativeDocumentPath);
+    }
+
+    #[Test]
+    public function analyzeDocumentDoesNotPinConfigurationResolvedProviderOnDispatch(): void
+    {
+        // The configuration-derived key is for the capability probe only. Pinning
+        // it on dispatch would make chat() skip the default DB configuration
+        // (ConfigurationResolver returns null for any pinned provider) and fall
+        // to the ad-hoc registry without the record's credentials/model.
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getProviderType')->willReturn('gemini');
+
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn($configuration);
+        $this->llmManager->expects(self::once())->method('getProvider')->with('gemini')->willReturn($this->createDocumentCapableProvider());
+
+        $capturedOptions = null;
+        $this->llmManager
+            ->expects(self::once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages, ChatOptions $options) use (&$capturedOptions): CompletionResponse {
+                $capturedOptions = $options;
+
+                return $this->completionResponse('ok');
+            });
+
+        $this->subject->analyzeDocument(self::PDF, self::PROMPT, new ChatOptions(maxTokens: 1024));
+
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+        self::assertNull($capturedOptions->getProvider());
+        self::assertSame(1024, $capturedOptions->getMaxTokens());
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
+++ b/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
@@ -1,0 +1,376 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized\Document;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Specialized\Document\DocumentAnalysisService;
+use Netresearch\NrLlm\Specialized\Document\PdfRasterizerInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[AllowMockObjectsWithoutExpectations]
+#[CoversClass(DocumentAnalysisService::class)]
+class DocumentAnalysisServiceTest extends AbstractUnitTestCase
+{
+    private const PDF = "%PDF-1.7\nfake-document-bytes";
+    private const PROMPT = 'Summarize this document.';
+
+    private LlmServiceManagerInterface&MockObject $llmManager;
+    private VisionServiceInterface&MockObject $visionService;
+    private PdfRasterizerInterface&MockObject $rasterizer;
+    private DocumentAnalysisService $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $this->visionService = $this->createMock(VisionServiceInterface::class);
+        $this->rasterizer = $this->createMock(PdfRasterizerInterface::class);
+        $this->subject = new DocumentAnalysisService(
+            $this->llmManager,
+            $this->visionService,
+            $this->rasterizer,
+        );
+    }
+
+    /**
+     * @return (ProviderInterface&DocumentCapableInterface)&MockObject
+     */
+    private function createDocumentCapableProvider(
+        string $identifier = 'gemini',
+        bool $supportsDocuments = true,
+    ): MockObject {
+        $provider = $this->createMockForIntersectionOfInterfaces([
+            ProviderInterface::class,
+            DocumentCapableInterface::class,
+        ]);
+        $provider->method('getIdentifier')->willReturn($identifier);
+        $provider->method('supportsDocuments')->willReturn($supportsDocuments);
+        $provider->method('getSupportedDocumentFormats')->willReturn($supportsDocuments ? ['pdf'] : []);
+
+        return $provider;
+    }
+
+    private function completionResponse(string $content, string $model = 'gemini-3-pro', string $provider = 'gemini'): CompletionResponse
+    {
+        return new CompletionResponse(
+            content: $content,
+            model: $model,
+            usage: new UsageStatistics(10, 5, 15),
+            provider: $provider,
+        );
+    }
+
+    private function visionResponse(string $description): VisionResponse
+    {
+        return new VisionResponse(
+            description: $description,
+            model: 'gpt-5.2',
+            usage: new UsageStatistics(10, 5, 15),
+            provider: 'openai',
+        );
+    }
+
+    #[Test]
+    public function analyzeDocumentUsesNativePathWhenProviderIsDocumentCapable(): void
+    {
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn(null);
+        $this->llmManager->expects(self::once())->method('getProvider')->with(null)->willReturn($this->createDocumentCapableProvider());
+
+        $capturedMessages = null;
+        $capturedOptions = null;
+        $this->llmManager
+            ->expects(self::once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages, ChatOptions $options) use (&$capturedMessages, &$capturedOptions): CompletionResponse {
+                $capturedMessages = $messages;
+                $capturedOptions = $options;
+
+                return $this->completionResponse('Whole-document summary');
+            });
+
+        $this->rasterizer->expects(self::never())->method('isAvailable');
+        $this->rasterizer->expects(self::never())->method('renderDocument');
+        $this->visionService->expects(self::never())->method('analyzeImageFull');
+
+        $result = $this->subject->analyzeDocument(self::PDF, self::PROMPT);
+
+        self::assertTrue($result->usedNativeDocumentPath);
+        self::assertSame(0, $result->rasterizedPageCount);
+        self::assertSame('Whole-document summary', $result->text);
+        self::assertSame('gemini-3-pro', $result->model);
+        self::assertSame('gemini', $result->provider);
+
+        self::assertSame(
+            [
+                [
+                    'role' => 'user',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => self::PROMPT,
+                        ],
+                        [
+                            'type' => 'document',
+                            'source' => [
+                                'type' => 'base64',
+                                'media_type' => 'application/pdf',
+                                'data' => base64_encode(self::PDF),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $capturedMessages,
+        );
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+        self::assertSame('gemini', $capturedOptions->getProvider());
+    }
+
+    #[Test]
+    public function analyzeDocumentPassesOptionsThroughOnNativePath(): void
+    {
+        $this->llmManager->expects(self::once())->method('getProvider')->with('gemini')->willReturn($this->createDocumentCapableProvider());
+
+        $capturedOptions = null;
+        $this->llmManager
+            ->expects(self::once())
+            ->method('chat')
+            ->willReturnCallback(function (array $messages, ChatOptions $options) use (&$capturedOptions): CompletionResponse {
+                $capturedOptions = $options;
+
+                return $this->completionResponse('ok');
+            });
+
+        $options = new ChatOptions(
+            temperature: 0.3,
+            maxTokens: 512,
+            provider: 'gemini',
+            model: 'gemini-3-pro',
+            beUserUid: 7,
+            plannedCost: 0.5,
+        );
+
+        $this->subject->analyzeDocument(self::PDF, self::PROMPT, $options);
+
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+        self::assertSame(0.3, $capturedOptions->getTemperature());
+        self::assertSame(512, $capturedOptions->getMaxTokens());
+        self::assertSame('gemini', $capturedOptions->getProvider());
+        self::assertSame('gemini-3-pro', $capturedOptions->getModel());
+        self::assertSame(7, $capturedOptions->getBeUserUid());
+        self::assertSame(0.5, $capturedOptions->getPlannedCost());
+    }
+
+    #[Test]
+    public function analyzeDocumentProbesDefaultConfigurationProvider(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('getProviderType')->willReturn('claude');
+
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn($configuration);
+        $this->llmManager
+            ->expects(self::once())
+            ->method('getProvider')
+            ->with('claude')
+            ->willReturn($this->createDocumentCapableProvider('claude'));
+        $this->llmManager->method('chat')->willReturn($this->completionResponse('ok', 'claude-opus-4-5', 'claude'));
+
+        $result = $this->subject->analyzeDocument(self::PDF, self::PROMPT);
+
+        self::assertTrue($result->usedNativeDocumentPath);
+    }
+
+    #[Test]
+    public function analyzeDocumentAutoPopulatesBeUserUidOnNativePath(): void
+    {
+        $resolver = self::createStub(BackendUserContextResolverInterface::class);
+        $resolver->method('resolveBeUserUid')->willReturn(42);
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('resolveEffectiveConfiguration')->willReturn(null);
+        $llmManager->method('getProvider')->willReturn($this->createDocumentCapableProvider());
+
+        $capturedOptions = null;
+        $llmManager
+            ->method('chat')
+            ->willReturnCallback(function (array $messages, ChatOptions $options) use (&$capturedOptions): CompletionResponse {
+                $capturedOptions = $options;
+
+                return $this->completionResponse('ok');
+            });
+
+        $subject = new DocumentAnalysisService(
+            $llmManager,
+            $this->visionService,
+            $this->rasterizer,
+            $resolver,
+        );
+
+        $subject->analyzeDocument(self::PDF, self::PROMPT);
+
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+        self::assertSame(42, $capturedOptions->getBeUserUid());
+    }
+
+    #[Test]
+    public function analyzeDocumentFallsBackToRasterizationForNonDocumentProvider(): void
+    {
+        $provider = self::createStub(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('openai');
+
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn(null);
+        $this->llmManager->method('getProvider')->willReturn($provider);
+        $this->llmManager->expects(self::never())->method('chat');
+
+        $this->rasterizer->method('isAvailable')->willReturn(true);
+        $this->rasterizer
+            ->expects(self::once())
+            ->method('renderDocument')
+            ->willReturnCallback(static function (string $path): array {
+                // The temp file must carry the PDF bytes at rasterization time.
+                self::assertSame(self::PDF, file_get_contents($path));
+
+                return [1 => 'PNG-ONE', 2 => 'PNG-TWO'];
+            });
+
+        $capturedUris = [];
+        $capturedPrompts = [];
+        $this->visionService
+            ->expects(self::exactly(2))
+            ->method('analyzeImageFull')
+            ->willReturnCallback(function (string $imageUrl, string $prompt) use (&$capturedUris, &$capturedPrompts): VisionResponse {
+                $capturedUris[] = $imageUrl;
+                $capturedPrompts[] = $prompt;
+
+                return $this->visionResponse(sprintf('Answer for call %d', count($capturedUris)));
+            });
+
+        $result = $this->subject->analyzeDocument(self::PDF, self::PROMPT);
+
+        self::assertFalse($result->usedNativeDocumentPath);
+        self::assertSame(2, $result->rasterizedPageCount);
+        self::assertSame("[Page 1]\nAnswer for call 1\n\n[Page 2]\nAnswer for call 2", $result->text);
+        self::assertSame('gpt-5.2', $result->model);
+        self::assertSame('openai', $result->provider);
+        self::assertSame(
+            [
+                'data:image/png;base64,' . base64_encode('PNG-ONE'),
+                'data:image/png;base64,' . base64_encode('PNG-TWO'),
+            ],
+            $capturedUris,
+        );
+        self::assertSame([self::PROMPT, self::PROMPT], $capturedPrompts);
+    }
+
+    #[Test]
+    public function analyzeDocumentFallsBackWhenProviderDisablesDocumentSupport(): void
+    {
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn(null);
+        $this->llmManager->method('getProvider')->willReturn($this->createDocumentCapableProvider('gemini', false));
+        $this->llmManager->expects(self::never())->method('chat');
+
+        $this->rasterizer->method('isAvailable')->willReturn(true);
+        $this->rasterizer->method('renderDocument')->willReturn([1 => 'PNG-ONE']);
+        $this->visionService->method('analyzeImageFull')->willReturn($this->visionResponse('Page answer'));
+
+        $result = $this->subject->analyzeDocument(self::PDF, self::PROMPT);
+
+        self::assertFalse($result->usedNativeDocumentPath);
+    }
+
+    #[Test]
+    public function analyzeDocumentThrowsTypedErrorWhenPopplerIsAbsent(): void
+    {
+        $provider = self::createStub(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('openai');
+
+        $this->llmManager->method('resolveEffectiveConfiguration')->willReturn(null);
+        $this->llmManager->method('getProvider')->willReturn($provider);
+
+        $this->rasterizer->method('isAvailable')->willReturn(false);
+        $this->rasterizer->expects(self::never())->method('renderDocument');
+        $this->visionService->expects(self::never())->method('analyzeImageFull');
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionCode(1784211009);
+        $this->expectExceptionMessageMatches('/poppler/');
+
+        $this->subject->analyzeDocument(self::PDF, self::PROMPT);
+    }
+
+    #[Test]
+    public function analyzeDocumentPassesOptionsThroughToVisionFallback(): void
+    {
+        $provider = self::createStub(ProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('openai');
+
+        $this->llmManager->expects(self::once())->method('getProvider')->with('openai')->willReturn($provider);
+
+        $this->rasterizer->method('isAvailable')->willReturn(true);
+        $this->rasterizer->method('renderDocument')->willReturn([1 => 'PNG-ONE']);
+
+        $capturedOptions = null;
+        $this->visionService
+            ->expects(self::once())
+            ->method('analyzeImageFull')
+            ->willReturnCallback(function (string $imageUrl, string $prompt, ?VisionOptions $options) use (&$capturedOptions): VisionResponse {
+                $capturedOptions = $options;
+
+                return $this->visionResponse('Page answer');
+            });
+
+        $options = new ChatOptions(
+            temperature: 0.2,
+            maxTokens: 256,
+            provider: 'openai',
+            model: 'gpt-5.2',
+            beUserUid: 9,
+            plannedCost: 1.25,
+        );
+
+        $this->subject->analyzeDocument(self::PDF, self::PROMPT, $options);
+
+        self::assertInstanceOf(VisionOptions::class, $capturedOptions);
+        self::assertSame(0.2, $capturedOptions->getTemperature());
+        self::assertSame(256, $capturedOptions->getMaxTokens());
+        self::assertSame('openai', $capturedOptions->getProvider());
+        self::assertSame('gpt-5.2', $capturedOptions->getModel());
+        self::assertSame(9, $capturedOptions->getBeUserUid());
+        self::assertSame(1.25, $capturedOptions->getPlannedCost());
+    }
+
+    #[Test]
+    public function analyzeDocumentRejectsNonPdfInput(): void
+    {
+        $this->llmManager->expects(self::never())->method('getProvider');
+        $this->llmManager->expects(self::never())->method('chat');
+
+        $this->expectException(UnsupportedFormatException::class);
+        $this->expectExceptionCode(1784211010);
+
+        $this->subject->analyzeDocument('not a pdf', self::PROMPT);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     },
     "suggest": {
         "apache-solr-for-typo3/solr": "Site-search RAG tools retrieve evidence from the Solr index when installed",
+        "poppler-utils": "System package (not a Composer package) providing pdftoppm/pdfimages — enables DocumentAnalysisService's rasterization fallback for providers without native PDF ingestion",
         "tpwd/ke_search": "Site-search RAG tools retrieve evidence from the ke_search index when installed",
         "typo3/cms-dashboard": "Adds AI usage / cost widgets to the TYPO3 dashboard",
         "typo3/cms-indexed-search": "Site-search RAG tools retrieve evidence from the indexed_search index when installed"


### PR DESCRIPTION
## Summary

Implements #416: document understanding built on the existing `DocumentCapableInterface`, with rasterization as the compatibility fallback (ADR-076).

- `Specialized\Document\DocumentAnalysisService::analyzeDocument(string $pdf, string $prompt, ?ChatOptions $options)` — native path: one chat call carrying the PDF as a Base64 `document` block when the resolved provider (explicit per-call provider → default configuration's provider type → registry default, matching `LlmServiceManager::chat()` routing) implements `DocumentCapableInterface` with PDF support; fallback: rasterize every page via poppler and read each with `VisionServiceInterface`, `[Page N]`-marked concatenation.
- `PdfRasterizerInterface` / `PopplerPdfRenderer` / `PdfRasterizationException` — port of nr-ai-search's renderer trio (array-argv `proc_open`, temp-stub cleanup in `finally`), extended by whole-document `renderDocument()`; nr-ai-search adopts it consumer-side later (its ADR-028 amendment is out of scope here).
- poppler is an optional system dependency: `composer.json` `suggest` + docs page; when the fallback is needed without poppler the service throws `ServiceUnavailableException::rasterizerUnavailable()` (code 1784211009) naming both remedies. The native path never touches poppler.
- Out of scope per the issue: ingestion orchestration, per-page degradation contracts (a failed fallback page fails the call — consumers own retry/degrade), config flags, chunking.

## DI / public-services policy

`DocumentAnalysisService` joins Category D (`public: true`); `PdfRasterizerInterface` alias stays private. `PublicServicesPolicyTest` count 28 → 29; ADR-076 supersedes ADR-071 as count authority.

## Tests

`DocumentAnalysisServiceTest` (9 tests): native path chosen for document-capable provider (message shape + provider pinning asserted), default-configuration provider probing, fallback rasterize+vision per page (temp-file content asserted at rasterization time), poppler-absent typed error, option passthrough on both paths, beUserUid auto-population, non-PDF rejection, supportsDocuments()=false fallback.

`PopplerPdfRenderer` has no unit tests — its behavior is poppler-binary-dependent (same status as the nr-ai-search original); the service tests use a mocked rasterizer.

## Gates

unit (5045), integration, fuzzy, PHPStan level 10, cgl dry-run, rector dry-run: green on the final tree. `functional -d sqlite` was still running at hand-off — re-run before merge (Services.yaml DI change → container compile).

Resolves #416