### PR TITLE
feat(completion): named-configuration completion family (ADR-077)

### DIFF
--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
@@ -69,14 +70,7 @@ final readonly class CompletionService implements CompletionServiceInterface
 
         $messages[] = ChatMessage::user($prompt);
 
-        // Handle response format
-        $responseFormat = $optionsArray['response_format'] ?? null;
-        if (is_string($responseFormat)) {
-            $normalizedFormat = $this->normalizeResponseFormat($responseFormat);
-            $options = $options->withResponseFormat(
-                is_string($normalizedFormat) ? $normalizedFormat : 'json',
-            );
-        }
+        $options = $this->normalizeOptionsResponseFormat($options, $optionsArray);
 
         // Pass the (immutable) options straight through: they already carry
         // every typed field — including stopSequences, which toArray() emits as
@@ -101,26 +95,7 @@ final readonly class CompletionService implements CompletionServiceInterface
         $options ??= new ChatOptions();
         $options = $options->withResponseFormat('json');
 
-        $response = $this->complete($prompt, $options);
-
-        $decoded = json_decode($response->content, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new InvalidArgumentException(
-                'Failed to decode JSON response: ' . json_last_error_msg(),
-                2805117333,
-            );
-        }
-
-        if (!is_array($decoded)) {
-            throw new InvalidArgumentException(
-                'JSON response must be an object, got ' . gettype($decoded),
-                2805117334,
-            );
-        }
-
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
+        return $this->decodeJsonResponse($this->complete($prompt, $options)->content);
     }
 
     /**
@@ -132,16 +107,9 @@ final readonly class CompletionService implements CompletionServiceInterface
      */
     public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string
     {
-        $options ??= new ChatOptions();
-        $options = $options->withResponseFormat('markdown');
+        $options = $this->applyMarkdownPresets($options ?? new ChatOptions());
 
-        $systemPrompt = $options->getSystemPrompt() ?? '';
-        $systemPrompt .= "\n\nFormat your response in clean, well-structured Markdown.";
-        $options = $options->withSystemPrompt(trim($systemPrompt));
-
-        $response = $this->complete($prompt, $options);
-
-        return $response->content;
+        return $this->complete($prompt, $options)->content;
     }
 
     /**
@@ -151,16 +119,7 @@ final readonly class CompletionService implements CompletionServiceInterface
      */
     public function completeFactual(string $prompt, ?ChatOptions $options = null): CompletionResponse
     {
-        $options ??= new ChatOptions();
-
-        if ($options->getTemperature() === null) {
-            $options = $options->withTemperature(0.2);
-        }
-        if ($options->getTopP() === null) {
-            $options = $options->withTopP(0.9);
-        }
-
-        return $this->complete($prompt, $options);
+        return $this->complete($prompt, $this->applyFactualPresets($options ?? new ChatOptions()));
     }
 
     /**
@@ -170,19 +129,43 @@ final readonly class CompletionService implements CompletionServiceInterface
      */
     public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse
     {
-        $options ??= new ChatOptions();
+        return $this->complete($prompt, $this->applyCreativePresets($options ?? new ChatOptions()));
+    }
 
-        if ($options->getTemperature() === null) {
-            $options = $options->withTemperature(1.2);
-        }
-        if ($options->getTopP() === null) {
-            $options = $options->withTopP(1.0);
-        }
-        if ($options->getPresencePenalty() === null) {
-            $options = $options->withPresencePenalty(0.6);
-        }
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        $options      = $this->autoPopulateBeUserUid($options ?? new ChatOptions());
+        $optionsArray = $options->toArray();
+        $this->validateOptions($optionsArray);
+        $options = $this->normalizeOptionsResponseFormat($options, $optionsArray);
 
-        return $this->complete($prompt, $options);
+        return $this->llmManager->completeForConfiguration($prompt, $configuration, $options);
+    }
+
+    public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array
+    {
+        $options = ($options ?? new ChatOptions())->withResponseFormat('json');
+
+        return $this->decodeJsonResponse(
+            $this->completeForConfiguration($prompt, $configuration, $options)->content,
+        );
+    }
+
+    public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string
+    {
+        $options = $this->applyMarkdownPresets($options ?? new ChatOptions());
+
+        return $this->completeForConfiguration($prompt, $configuration, $options)->content;
+    }
+
+    public function completeFactualForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->completeForConfiguration($prompt, $configuration, $this->applyFactualPresets($options ?? new ChatOptions()));
+    }
+
+    public function completeCreativeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->completeForConfiguration($prompt, $configuration, $this->applyCreativePresets($options ?? new ChatOptions()));
     }
 
     /**
@@ -247,6 +230,104 @@ final readonly class CompletionService implements CompletionServiceInterface
             'markdown', 'text' => 'text',
             default => 'text',
         };
+    }
+
+    /**
+     * Apply the provider-compatible response-format normalization to the options.
+     *
+     * Shared by the instance-default and configuration completion paths so both
+     * emit the identical `response_format` the providers expect.
+     *
+     * @param array<string, mixed> $optionsArray already-materialized $options->toArray()
+     */
+    private function normalizeOptionsResponseFormat(ChatOptions $options, array $optionsArray): ChatOptions
+    {
+        $responseFormat = $optionsArray['response_format'] ?? null;
+        if (!is_string($responseFormat)) {
+            return $options;
+        }
+
+        $normalizedFormat = $this->normalizeResponseFormat($responseFormat);
+
+        return $options->withResponseFormat(is_string($normalizedFormat) ? $normalizedFormat : 'json');
+    }
+
+    /**
+     * Decode a JSON completion into an object array.
+     *
+     * @throws InvalidArgumentException when the content is not a valid JSON object
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeJsonResponse(string $content): array
+    {
+        $decoded = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidArgumentException(
+                'Failed to decode JSON response: ' . json_last_error_msg(),
+                2805117333,
+            );
+        }
+
+        if (!is_array($decoded)) {
+            throw new InvalidArgumentException(
+                'JSON response must be an object, got ' . gettype($decoded),
+                2805117334,
+            );
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Request Markdown output: force the markdown format and augment the system
+     * prompt. Shared by the instance-default and configuration paths.
+     */
+    private function applyMarkdownPresets(ChatOptions $options): ChatOptions
+    {
+        $options = $options->withResponseFormat('markdown');
+
+        $systemPrompt = $options->getSystemPrompt() ?? '';
+        $systemPrompt .= "\n\nFormat your response in clean, well-structured Markdown.";
+
+        return $options->withSystemPrompt(trim($systemPrompt));
+    }
+
+    /**
+     * Low-creativity (factual, consistent) presets, applied only where unset.
+     * Shared by the instance-default and configuration paths.
+     */
+    private function applyFactualPresets(ChatOptions $options): ChatOptions
+    {
+        if ($options->getTemperature() === null) {
+            $options = $options->withTemperature(0.2);
+        }
+        if ($options->getTopP() === null) {
+            $options = $options->withTopP(0.9);
+        }
+
+        return $options;
+    }
+
+    /**
+     * High-creativity (diverse) presets, applied only where unset.
+     * Shared by the instance-default and configuration paths.
+     */
+    private function applyCreativePresets(ChatOptions $options): ChatOptions
+    {
+        if ($options->getTemperature() === null) {
+            $options = $options->withTemperature(1.2);
+        }
+        if ($options->getTopP() === null) {
+            $options = $options->withTopP(1.0);
+        }
+        if ($options->getPresencePenalty() === null) {
+            $options = $options->withPresencePenalty(0.6);
+        }
+
+        return $options;
     }
 
     // `autoPopulateBeUserUid()` is provided by `AutoPopulatesBeUserUidTrait`

--- a/Classes/Service/Feature/CompletionServiceInterface.php
+++ b/Classes/Service/Feature/CompletionServiceInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 
@@ -53,4 +54,41 @@ interface CompletionServiceInterface
      * Generate a high-creativity completion (creative / diverse presets).
      */
     public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
+     * Generate a text completion against a specific LlmConfiguration record.
+     *
+     * The named-configuration counterpart to {@see complete()}: the given
+     * configuration decides provider, model, API key and cost attribution,
+     * while per-user budget and idempotency metadata are threaded through so
+     * BudgetMiddleware still enforces the configuration's and the user's
+     * limits. Mirrors {@see EmbeddingServiceInterface::embedForConfiguration()}.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
+     * Generate a JSON-formatted completion against a specific LlmConfiguration record.
+     *
+     * @throws InvalidArgumentException when the response is not valid JSON
+     *
+     * @return array<string, mixed> Parsed JSON response
+     */
+    public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array;
+
+    /**
+     * Generate a Markdown-formatted completion against a specific LlmConfiguration record.
+     */
+    public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string;
+
+    /**
+     * Generate a low-creativity completion (factual presets) against a specific LlmConfiguration record.
+     */
+    public function completeFactualForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
+     * Generate a high-creativity completion (creative presets) against a specific LlmConfiguration record.
+     */
+    public function completeCreativeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse;
 }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -724,6 +724,36 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     }
 
     /**
+     * Complete a prompt against a specific configuration from a ChatOptions object.
+     *
+     * The named-configuration counterpart to chat(): it takes the same route as
+     * chat()'s default-configuration branch — build the system/user messages,
+     * inject the configuration's skills, thread the per-user budget and
+     * idempotency metadata — but against the caller's chosen configuration
+     * instead of the resolved instance default. A pinned provider on the options
+     * is irrelevant on the configuration path and is dropped, matching chat().
+     */
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        $options ??= new ChatOptions();
+        [, $optionsArray] = $this->splitProviderKey($options->toArray());
+
+        $messages     = [];
+        $systemPrompt = $optionsArray['system_prompt'] ?? null;
+        if (is_string($systemPrompt) && $systemPrompt !== '') {
+            $messages[] = ChatMessage::system($systemPrompt);
+        }
+        $messages[] = ChatMessage::user($prompt);
+
+        return $this->chatWithConfiguration(
+            $this->injectConfigSkillsIntoMessages($messages, $configuration),
+            $configuration,
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
+            $optionsArray,
+        );
+    }
+
+    /**
      * Invoke the provider middleware pipeline for a per-configuration call.
      *
      * The pipeline composes every service tagged

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -76,6 +76,20 @@ interface LlmServiceManagerInterface
     public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse;
 
     /**
+     * Complete a prompt against a specific LLM configuration from a high-level
+     * ChatOptions object.
+     *
+     * The named-configuration counterpart to chat(): builds the system/user
+     * messages, injects the configuration's skills, and threads the per-user
+     * budget and idempotency metadata from the options so BudgetMiddleware
+     * enforces the configuration's and the user's limits — the parity
+     * embedForConfiguration() already provides for embeddings. Unlike the
+     * low-level completeWithConfiguration(), the caller passes a typed
+     * ChatOptions rather than a raw metadata/override array.
+     */
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse;
+
+    /**
      * Chat using a specific LLM configuration (database-backed provider resolution).
      *
      * Legacy array-shaped message fixtures are accepted for back-compat

--- a/Documentation/Adr/Adr077NamedConfigurationCompletion.rst
+++ b/Documentation/Adr/Adr077NamedConfigurationCompletion.rst
@@ -1,0 +1,92 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-077:
+
+============================================================================
+ADR-077: Plain completion joins the named-configuration path
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-077-context:
+
+Context
+=======
+
+The three-tier model (Provider → Model → Configuration,
+:ref:`ADR-001 <adr-001>`) reaches every chat-shaped and embedding
+capability through a ``*ForConfiguration`` entry point:
+``chatWithConfiguration()``, ``streamChatWithConfiguration()``,
+``chatWithToolsForConfiguration()`` and — since
+:ref:`ADR-055 <adr-055>` — ``embedForConfiguration()`` all resolve the
+adapter from a DB-backed ``LlmConfiguration`` and run through the
+middleware pipeline, so budgets are enforced and cost is attributed per
+configuration.
+
+The high-level ``CompletionService`` did not. Its ``complete()`` family
+resolves only the *instance-default* configuration (``chat()`` picks the
+active default, :ref:`ADR-034 <adr-034>`). A consumer that needs several
+distinct named text configurations — a summariser, a classifier and a
+chatbot in one extension — could not target them by identifier; every
+plain completion went to the single default. The low-level
+``LlmServiceManager::completeWithConfiguration()`` existed but routes
+through the provider's raw ``complete`` operation (no system-prompt
+shaping, no response-format normalisation, no per-user budget metadata),
+so it is not a drop-in for the message-based ``complete()`` path.
+
+.. _adr-077-decision:
+
+Decision
+========
+
+**Plain completion joins the configuration path.**
+``LlmServiceManager::completeForConfiguration(string $prompt,
+LlmConfiguration $configuration, ?ChatOptions $options = null)`` mirrors
+``chat()``'s default-configuration branch — it builds the system/user
+``ChatMessage`` value objects, injects the configuration's skills, and
+threads the per-user budget and idempotency metadata from the options —
+but against the caller's chosen configuration instead of the resolved
+default. A pinned provider on the options is irrelevant on the
+configuration path and is dropped, exactly as ``chat()`` does. The method
+takes a typed ``ChatOptions`` rather than the low-level
+``completeWithConfiguration()`` metadata/override arrays, so budget and
+idempotency parity is handled once inside the manager.
+
+The high-level feature service follows.
+``CompletionServiceInterface`` gains the named-configuration counterparts
+of its whole family: ``completeForConfiguration()``,
+``completeJsonForConfiguration()``, ``completeMarkdownForConfiguration()``,
+``completeFactualForConfiguration()`` and
+``completeCreativeForConfiguration()``. Each applies the *same* option
+transforms as its instance-default twin (response-format normalisation,
+Markdown system-prompt augmentation, factual/creative presets) before
+delegating to the manager — the shared transforms are extracted into
+private helpers so the two paths cannot drift.
+
+Method-based, not a ``ChatOptions`` field. Targeting a configuration is
+expressed as an explicit ``LlmConfiguration`` parameter, consistent with
+the entire ``*ForConfiguration`` family, keeping ``ChatOptions`` a pure
+scalar readonly DTO.
+
+.. _adr-077-consequences:
+
+Consequences
+============
+
+- Completion consumers select a backend-managed configuration by
+  identifier instead of relying on the single instance default;
+  per-configuration budgets and cost attribution apply to plain
+  completion like to every other capability.
+- Behaviour parity holds: the JSON/Markdown/factual/creative variants
+  apply identical transforms on the configuration path as on the
+  instance-default path, guaranteed by shared private helpers rather
+  than duplicated logic.
+- ``CompletionServiceInterface`` and ``LlmServiceManagerInterface``
+  gained methods — implementers outside this repo must add them. In-repo
+  the concrete services and the hand-written ``StaticCompletionService``
+  test double are updated.
+- The low-level ``completeWithConfiguration()`` (raw ``complete``
+  operation) is unchanged and remains available for callers that
+  deliberately want the non-chat completion endpoint.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -374,3 +374,4 @@ Tools
    Adr074ReciprocalRankFusionUtility
    Adr075RerankerProtocol
    Adr076DocumentUnderstanding
+   Adr077NamedConfigurationCompletion

--- a/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
+++ b/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Evaluation\Fixture;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -64,6 +65,35 @@ final class StaticCompletionService implements CompletionServiceInterface
     }
 
     public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->complete($prompt, $options);
+    }
+
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->complete($prompt, $options);
+    }
+
+    public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array
+    {
+        $this->receivedPrompts[] = $prompt;
+
+        return [];
+    }
+
+    public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string
+    {
+        $this->receivedPrompts[] = $prompt;
+
+        return $this->content;
+    }
+
+    public function completeFactualForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        return $this->complete($prompt, $options);
+    }
+
+    public function completeCreativeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
     {
         return $this->complete($prompt, $options);
     }

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
@@ -845,6 +846,162 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('ok'));
 
         $subject->complete('hello');
+    }
+
+    #[Test]
+    public function completeForConfigurationDelegatesToTheManagerWithTheConfiguration(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+        $mockResponse  = $this->createMockResponse('Configured response');
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with('Prompt', self::identicalTo($configuration), self::isInstanceOf(ChatOptions::class))
+            ->willReturn($mockResponse);
+
+        $result = $subject->completeForConfiguration('Prompt', $configuration);
+
+        self::assertSame('Configured response', $result->content);
+    }
+
+    #[Test]
+    public function completeForConfigurationValidatesOptions(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('temperature must be between 0 and 2');
+
+        $this->subject->completeForConfiguration('Test', $configuration, new ChatOptions(temperature: 3.0));
+    }
+
+    #[Test]
+    public function completeJsonForConfigurationDecodesTheResponse(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with(
+                'Prompt',
+                self::identicalTo($configuration),
+                self::callback(static fn(ChatOptions $o): bool => $o->getResponseFormat() === 'json'),
+            )
+            ->willReturn($this->createMockResponse('{"key": "value", "number": 42}'));
+
+        $result = $subject->completeJsonForConfiguration('Prompt', $configuration);
+
+        self::assertSame('value', $result['key']);
+        self::assertSame(42, $result['number']);
+    }
+
+    #[Test]
+    public function completeJsonForConfigurationThrowsOnInvalidJson(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->willReturn($this->createMockResponse('not json'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Failed to decode JSON response');
+
+        $subject->completeJsonForConfiguration('Prompt', $configuration);
+    }
+
+    #[Test]
+    public function completeMarkdownForConfigurationAugmentsTheSystemPrompt(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with(
+                'Prompt',
+                self::identicalTo($configuration),
+                self::callback(static fn(ChatOptions $o): bool => str_contains($o->getSystemPrompt() ?? '', 'Markdown')),
+            )
+            ->willReturn($this->createMockResponse('# Heading'));
+
+        self::assertSame('# Heading', $subject->completeMarkdownForConfiguration('Prompt', $configuration));
+    }
+
+    #[Test]
+    public function completeFactualForConfigurationAppliesFactualPresets(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with(
+                'Prompt',
+                self::identicalTo($configuration),
+                self::callback(static fn(ChatOptions $o): bool => $o->getTemperature() === 0.2 && $o->getTopP() === 0.9),
+            )
+            ->willReturn($this->createMockResponse('Factual'));
+
+        $subject->completeFactualForConfiguration('Prompt', $configuration);
+    }
+
+    #[Test]
+    public function completeCreativeForConfigurationAppliesCreativePresets(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with(
+                'Prompt',
+                self::identicalTo($configuration),
+                self::callback(static fn(ChatOptions $o): bool => $o->getTemperature() === 1.2
+                        && $o->getTopP() === 1.0
+                        && $o->getPresencePenalty() === 0.6),
+            )
+            ->willReturn($this->createMockResponse('Creative'));
+
+        $subject->completeCreativeForConfiguration('Prompt', $configuration);
+    }
+
+    #[Test]
+    public function completeForConfigurationAutoPopulatesBeUserUidFromResolver(): void
+    {
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $resolver       = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->expects(self::once())->method('resolveBeUserUid')->willReturn(42);
+
+        $subject       = new CompletionService($llmManagerMock, $resolver);
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('completeForConfiguration')
+            ->with(
+                'hello',
+                self::identicalTo($configuration),
+                self::callback(static fn(ChatOptions $o): bool => $o->getBeUserUid() === 42),
+            )
+            ->willReturn($this->createMockResponse('ok'));
+
+        $subject->completeForConfiguration('hello', $configuration);
     }
 
     /**

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -679,6 +679,58 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     /**
+     * completeForConfiguration() takes chat()'s configuration route: it builds a
+     * leading system message from the option's system prompt and a trailing user
+     * message from the prompt, then dispatches through the chat adapter — not the
+     * raw ``complete`` provider operation.
+     */
+    #[Test]
+    public function completeForConfigurationBuildsChatMessagesAndReturnsAdapterResponse(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $expectedResponse = new CompletionResponse(
+            content: 'Configured completion',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'test',
+        );
+
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->expects(self::once())
+            ->method('chatCompletion')
+            ->with(
+                self::callback(static function (array $messages): bool {
+                    $first = $messages[0] ?? null;
+                    $last  = $messages[array_key_last($messages)] ?? null;
+
+                    return $first instanceof ChatMessage
+                        && $first->isSystem()
+                        && $first->content === 'Sys prompt'
+                        && $last instanceof ChatMessage
+                        && $last->isUser()
+                        && $last->content === 'Do the thing';
+                }),
+                self::anything(),
+            )
+            ->willReturn($expectedResponse);
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
+
+        $result = $manager->completeForConfiguration('Do the thing', $config, new ChatOptions(systemPrompt: 'Sys prompt'));
+
+        self::assertSame($expectedResponse, $result);
+    }
+
+    /**
      * A configuration's stored system prompt must reach the adapter as a
      * leading system message — the adapters read the system instruction from
      * the message list, not from options['system_prompt'].


### PR DESCRIPTION
## What

Add the named-configuration completion family so consumers can target a specific `LlmConfiguration` record for plain text completion — closing the last `*ForConfiguration` gap (ADR-077).

## Why

The three-tier model reaches every chat-shaped and embedding capability through a `*ForConfiguration` entry point (`chatWithConfiguration`, `chatWithToolsForConfiguration`, and — since ADR-055 — `embedForConfiguration`). Plain completion did not: `CompletionService::complete()` resolves only the **instance-default** configuration. A consumer needing several distinct named text configurations (a summariser, a classifier, a chatbot in one extension) could not target them by identifier. The low-level `LlmServiceManager::completeWithConfiguration()` exists but routes through the provider's **raw `complete`** operation — no system-prompt shaping, no response-format normalization, no per-user budget metadata — so it is not a drop-in for the message-based `complete()` path.

## Changes

- **`LlmServiceManager::completeForConfiguration(string, LlmConfiguration, ?ChatOptions)`** — mirrors `chat()`'s default-configuration branch: builds the system/user `ChatMessage`s, injects the configuration's skills, threads per-user budget + idempotency metadata from the options, and dispatches through the **chat** adapter. A pinned provider is dropped on the configuration path, as `chat()` does.
- **`CompletionService`** gains the whole family: `completeForConfiguration`, `completeJsonForConfiguration`, `completeMarkdownForConfiguration`, `completeFactualForConfiguration`, `completeCreativeForConfiguration`. Each applies the **same** option transforms as its instance-default twin (response-format normalization, Markdown system-prompt augmentation, factual/creative presets), extracted into shared private helpers so the two paths cannot drift.
- `CompletionServiceInterface` and `LlmServiceManagerInterface` grow accordingly; the `StaticCompletionService` test double is updated.

## Design notes

- **Method-based, not a `ChatOptions.configuration` field** — consistent with the entire `*ForConfiguration` family, keeps `ChatOptions` a pure scalar readonly DTO.
- **Budget parity preserved** — the manager owns budget-metadata construction (as `embedForConfiguration` does), so per-user enforcement works on the configuration path; a feature-service delegate could not reach the private `buildBudgetMetadata()`.
- **Behaviour parity guaranteed by shared helpers**, not duplicated logic — the divergence risk between the two paths is structurally removed.
- `completeWithConfiguration()` (raw `complete` operation) is unchanged and still available for callers who deliberately want the non-chat endpoint.

## Tests / verification

New unit tests cover the manager method (system/user message building, chat dispatch) and all five feature methods (delegation, JSON decode + error, Markdown augmentation, factual/creative preset values, beUserUid auto-population).

Local gate: `unit` ✅ (5059), `cgl` ✅, `rector -n` ✅, `fuzzy` ✅. `phpstan` and `functional` have a pre-existing failure/warning on `main` unrelated to this change (`ProviderDetector.php` nullsafe on PHP 8.5; a testing-framework `PackageManager`/`Testbase` warning) — this branch is byte-identical to `main` on both.
