### PR TITLE
feat(budget): pre-flight budget enforcement for specialized image/speech services (ADR-078)

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -81,6 +81,7 @@ return RectorConfig::configure()
         AddErrorCodeToExceptionRector::class => [
             __DIR__ . '/../../Classes/Provider/Middleware/BudgetMiddleware.php',
             __DIR__ . '/../../Classes/Service/Streaming/StreamingDispatcher.php',
+            __DIR__ . '/../../Classes/Specialized/AbstractSpecializedService.php',
         ],
         // Skip Fuzzy tests - Eris\Generator namespace functions conflict with auto-imports
         __DIR__ . '/../../Tests/Fuzzy/',

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -92,9 +94,45 @@ abstract class AbstractSpecializedService
         protected readonly SpecializedCostCalculatorInterface $costCalculator,
         protected readonly ?ModelRepository $modelRepository = null,
         protected readonly ?LlmConfigurationRepository $configurationRepository = null,
+        protected readonly ?BudgetServiceInterface $budgetService = null,
     ) {
         $this->timeout = $this->getDefaultTimeout();
         $this->loadConfiguration();
+    }
+
+    /**
+     * Pre-flight budget gate for the specialized (image / speech) send path.
+     *
+     * Unlike the chat-shaped feature services, the specialized services dispatch
+     * HTTP directly and bypass the middleware pipeline, so BudgetMiddleware never
+     * sees them (ADR-057 deferred this enforcement; ADR-078 adds it here). This
+     * mirrors BudgetMiddleware::handle(): resolve the named configuration, run the
+     * per-user and per-configuration check, and throw before any spend when a
+     * limit is exceeded.
+     *
+     * Fail-open by construction: when no BudgetServiceInterface is wired (the
+     * constructor param is optional, so unconfigured deployments and unit tests
+     * that omit it are unaffected) the gate is a no-op. When wired, the shared
+     * BudgetService still short-circuits to "allowed" for calls without a backend
+     * user or without configured limits, so nothing changes until an operator
+     * actually sets a cap.
+     *
+     * @throws BudgetExceededException when the pre-flight check denies the call
+     */
+    protected function enforceBudget(?int $beUserUid, ?float $plannedCost, ?string $configurationIdentifier = null): void
+    {
+        if ($this->budgetService === null) {
+            return;
+        }
+
+        $configuration = $configurationIdentifier !== null
+            ? $this->findActiveConfiguration($configurationIdentifier)
+            : null;
+
+        $result = $this->budgetService->check($beUserUid ?? 0, $plannedCost ?? 0.0, $configuration);
+        if (!$result->allowed) {
+            throw new BudgetExceededException($result);
+        }
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -98,6 +98,7 @@ final class DallEImageService extends AbstractSpecializedService
         $style = is_string($optionsArray['style'] ?? null) ? $optionsArray['style'] : 'vivid';
 
         $this->validatePrompt($prompt, $model);
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $this->setAuditContext(sprintf('%s, generate', $model));
@@ -165,6 +166,7 @@ final class DallEImageService extends AbstractSpecializedService
         $count = min($count, 10);
 
         $this->validatePrompt($prompt, $model);
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $payload['n'] = $count;
@@ -221,6 +223,7 @@ final class DallEImageService extends AbstractSpecializedService
         $this->ensureAvailable();
 
         $this->validateImageFile($imagePath);
+        $this->enforceBudget($beUserUid, null, null);
 
         $count = min(max($count, 1), 10);
 
@@ -282,6 +285,7 @@ final class DallEImageService extends AbstractSpecializedService
         if ($maskPath !== null) {
             $this->validateImageFile($maskPath);
         }
+        $this->enforceBudget($beUserUid, null, null);
 
         $this->setAuditContext('dall-e-2, edit');
         $response = $this->sendImageMultipart('edits', $imagePath, $maskPath, [

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -87,6 +87,7 @@ final class FalImageService extends AbstractSpecializedService
         array $options = [],
     ): ImageGenerationResult {
         $this->ensureAvailable();
+        $this->enforceBudget($this->extractBeUserUid($options), $this->extractPlannedCost($options), null);
 
         $modelEndpoint = $this->resolveModelEndpoint($model);
 
@@ -147,6 +148,8 @@ final class FalImageService extends AbstractSpecializedService
 
         $count = min(max($count, 1), 4);
         $options['num_images'] = $count;
+
+        $this->enforceBudget($this->extractBeUserUid($options), $this->extractPlannedCost($options), null);
 
         $modelEndpoint = $this->resolveModelEndpoint($model);
         $payload = $this->buildGeneratePayload($prompt, $options);
@@ -430,6 +433,21 @@ final class FalImageService extends AbstractSpecializedService
         $beUserUid = $options['beUserUid'] ?? null;
 
         return is_int($beUserUid) && $beUserUid >= 0 ? $beUserUid : null;
+    }
+
+    /**
+     * Extract the planned cost from the options payload for the budget
+     * pre-flight (ADR-078). Like `beUserUid`, this is consumer metadata that
+     * must never reach the FAL API — the allowlist payload builder drops it.
+     * Negative values are treated as absent.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function extractPlannedCost(array $options): ?float
+    {
+        $plannedCost = $options['plannedCost'] ?? null;
+
+        return (is_float($plannedCost) || is_int($plannedCost)) && $plannedCost >= 0 ? (float)$plannedCost : null;
     }
 
     /**

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -82,6 +82,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             : SpeechSynthesisOptions::fromArray($options);
 
         $this->validateInput($text);
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $optionsArray = $options->toArray();
         $modelValue = $optionsArray['model'] ?? null;

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -78,6 +78,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             : TranscriptionOptions::fromArray($options);
 
         $this->validateAudioFile($audioPath);
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->sendTranscriptionRequest($audioPath, $options);
 
@@ -116,6 +117,8 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             throw UnsupportedFormatException::audioFormat($extension);
         }
 
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
+
         $response = $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options);
 
         return $this->parseTranscriptionResponse($response, $options);
@@ -143,6 +146,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             : TranscriptionOptions::fromArray($options);
 
         $this->validateAudioFile($audioPath);
+        $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->sendTranslationRequest($audioPath, $options);
 

--- a/Documentation/Adr/Adr078SpecializedServiceBudgetEnforcement.rst
+++ b/Documentation/Adr/Adr078SpecializedServiceBudgetEnforcement.rst
@@ -1,0 +1,97 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-078:
+
+============================================================================
+ADR-078: Budget pre-flight for the specialized image/speech services
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-078-context:
+
+Context
+=======
+
+Chat-shaped calls run through the provider middleware pipeline, so
+``BudgetMiddleware`` (:ref:`ADR-025 <adr-025>`) enforces per-user and
+per-configuration spend ceilings before any provider request. The
+specialized image/speech services (DALL-E, FAL, Whisper, TTS) dispatch
+HTTP directly from ``AbstractSpecializedService`` and **bypass** that
+pipeline.
+
+:ref:`ADR-057 <adr-057>` gave the specialized option DTOs the
+``beUserUid``/``plannedCost`` fields (via ``BudgetFieldsTrait`` /
+``BudgetAwareOptionsInterface``) and wired them into *usage attribution*
+— but deliberately deferred *enforcement*, recording that "routing these
+services through a budget pre-flight is a separate decision with its own
+trade-offs (no token cost model for FAL, multipart flows)" and leaving
+``plannedCost`` carried-but-unused on the send path. This ADR is that
+deferred follow-up.
+
+.. _adr-078-decision:
+
+Decision
+========
+
+**Add a pre-flight budget gate to** ``AbstractSpecializedService``. A new
+protected ``enforceBudget(?int $beUserUid, ?float $plannedCost, ?string
+$configurationIdentifier)`` mirrors ``BudgetMiddleware::handle()``: it
+resolves the named configuration (reusing the existing
+``findActiveConfiguration()``), calls ``BudgetServiceInterface::check()``
+and throws ``BudgetExceededException`` before any HTTP dispatch when a
+limit is exceeded. Each concrete service calls it after option resolution
+and input validation, before building its request:
+
+- ``DallEImageService`` — ``generate()``, ``generateMultiple()`` (from the
+  options), and ``createVariations()``/``edit()`` (from the scalar
+  ``beUserUid``, no cost/configuration).
+- ``TextToSpeechService`` — ``synthesize()`` (``synthesizeToFile()`` /
+  ``synthesizeLong()`` delegate to it, so they inherit the gate without
+  double-gating).
+- ``WhisperTranscriptionService`` — all three entry points
+  (``transcribe()``, ``transcribeFromContent()``, ``translateToEnglish()``);
+  gating only some would leave an enforcement bypass.
+- ``FalImageService`` — ``generate()``/``generateMultiple()``, reading
+  ``beUserUid``/``plannedCost`` from its allow-listed options array (a new
+  ``extractPlannedCost()`` mirrors the existing ``extractBeUserUid()``; the
+  payload builder drops both, so neither reaches the FAL API).
+
+``DeepLTranslator`` also extends the base but its options carry no budget
+fields — it is intentionally **not** gated.
+
+**Fail-open by construction.** The gate hangs on a new *optional* trailing
+constructor parameter ``?BudgetServiceInterface $budgetService = null``. It
+autowires from the existing ``BudgetServiceInterface`` alias in production;
+when absent (unconfigured deployments, unit tests) ``enforceBudget()`` is a
+no-op. Even when wired, ``BudgetService::check()`` short-circuits to
+"allowed" for calls without a backend user or without configured limits, so
+nothing changes until an operator actually sets a cap.
+
+.. _adr-078-consequences:
+
+Consequences
+============
+
+- **Behavioural change, gated on configuration.** Deployments that already
+  set per-user or per-configuration limits will start receiving
+  ``BudgetExceededException`` on image/speech calls once a cap is hit —
+  previously those calls were only *attributed* (ADR-057), never blocked.
+  Deployments with no limits are unaffected.
+- **FAL and DALL-E variations/edit have no cost model.** FAL publishes no
+  static price list and the variations/edit endpoints carry no
+  ``plannedCost``, so *cost* caps cannot trip for those paths — only
+  request-count/token caps enforce. Operators must not assume a cost ceiling
+  protects FAL image spend.
+- **Catch surface.** ``BudgetExceededException`` lives in ``Exception\`` (the
+  shared budget exception, ADR-025), not ``Specialized\Exception\``.
+  Consumers that catch only ``SpecializedServiceException`` will not catch a
+  budget denial — this is the intended shared-exception behaviour.
+- Consumers that hand-rolled their own specialized pre-gate (e.g. an
+  extension guarding image/TTS spend itself) can drop it; ``check()`` has no
+  side effects, so a transitional double-gate is idempotent and harmless.
+- The optional constructor parameter is a semver-minor change in the 0.x
+  line, consistent with ADR-052/ADR-057; implementers that construct the
+  specialized services by hand gain a nullable trailing argument.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -375,4 +375,5 @@ Tools
    Adr075RerankerProtocol
    Adr076DocumentUnderstanding
    Adr077NamedConfigurationCompletion
+   Adr078SpecializedServiceBudgetEnforcement
    Adr079FirstPartyCompletionVisionBudgetFakes

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -10,11 +10,14 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized;
 
 use LogicException;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -76,6 +79,87 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         // Reaching here = no exception = pass.
         self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function enforceBudgetIsNoOpWhenNoBudgetServiceIsWired(): void
+    {
+        $subject = $this->createSubject();
+
+        // Fail-open: an unconfigured deployment (no budget service) is never gated.
+        $subject->callEnforceBudget(42, 0.5, null);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function enforceBudgetThrowsBudgetExceededWhenTheCheckDenies(): void
+    {
+        $budget = $this->createMock(BudgetServiceInterface::class);
+        $budget->expects(self::once())
+            ->method('check')
+            ->with(42, 0.5, null)
+            ->willReturn(BudgetCheckResult::denied('cost_per_day', 9.0, 9.0, 'exhausted'));
+
+        $subject = $this->createSubject(budgetService: $budget);
+
+        $this->expectException(BudgetExceededException::class);
+
+        $subject->callEnforceBudget(42, 0.5, null);
+    }
+
+    #[Test]
+    public function enforceBudgetPassesWhenTheCheckAllows(): void
+    {
+        $budget = $this->createMock(BudgetServiceInterface::class);
+        $budget->expects(self::once())
+            ->method('check')
+            ->with(7, 0.25, null)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $subject = $this->createSubject(budgetService: $budget);
+
+        $subject->callEnforceBudget(7, 0.25, null);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function enforceBudgetDefaultsAbsentBeUserUidAndCostToZero(): void
+    {
+        $budget = $this->createMock(BudgetServiceInterface::class);
+        $budget->expects(self::once())
+            ->method('check')
+            ->with(0, 0.0, null)
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $subject = $this->createSubject(budgetService: $budget);
+
+        $subject->callEnforceBudget(null, null, null);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function enforceBudgetResolvesTheConfigurationIdentifierAndPassesItToTheCheck(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('isActive')->willReturn(true);
+
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        $budget = $this->createMock(BudgetServiceInterface::class);
+        $budget->expects(self::once())
+            ->method('check')
+            ->with(5, 0.1, self::identicalTo($configuration))
+            ->willReturn(BudgetCheckResult::allowed());
+
+        $subject = $this->createSubject(configurationRepository: $repository, budgetService: $budget);
+
+        $subject->callEnforceBudget(5, 0.1, 'nr_repurpose_image');
+
+        $this->addToAssertionCount(1);
     }
 
     #[Test]
@@ -1027,6 +1111,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         ?ClientInterface $httpClient = null,
         ?ModelRepository $modelRepository = null,
         ?LlmConfigurationRepository $configurationRepository = null,
+        ?BudgetServiceInterface $budgetService = null,
     ): TestableSpecializedService {
         $extConf = self::createStub(ExtensionConfiguration::class);
         $extConf->method('get')->willReturn(['apiKeyIdentifier' => $apiKeyIdentifier, 'baseUrl' => $baseUrl]);
@@ -1041,6 +1126,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             modelRepository: $modelRepository,
             configurationRepository: $configurationRepository,
+            budgetService: $budgetService,
         );
 
         // Inject the plain test client through the test seam; this bypasses the
@@ -1142,6 +1228,11 @@ final class TestableSpecializedService extends AbstractSpecializedService
     public function callEnsureAvailable(): void
     {
         $this->ensureAvailable();
+    }
+
+    public function callEnforceBudget(?int $beUserUid, ?float $plannedCost, ?string $configurationIdentifier = null): void
+    {
+        $this->enforceBudget($beUserUid, $plannedCost, $configurationIdentifier);
     }
 
     public function callBuildEndpointUrl(string $endpoint): string

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -79,7 +82,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
      * plain HTTP client through the test seam (bypasses the vault secure client
      * so request/response assertions can read the request the service built).
      *
-     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null} $repositories
+     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null, budget?: BudgetServiceInterface|null} $repositories
      */
     private function buildService(
         ClientInterface $httpClient,
@@ -100,6 +103,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->costCalculator,
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
+            $repositories['budget'] ?? null,
         );
         $service->setHttpClient($httpClient);
 
@@ -121,6 +125,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         array $config = [],
         ?ModelRepository $modelRepository = null,
         ?LlmConfigurationRepository $configurationRepository = null,
+        ?BudgetServiceInterface $budgetService = null,
     ): DallEImageService {
         $defaultConfig = [
             'providers' => [
@@ -142,8 +147,23 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->extensionConfigMock,
             $this->usageTrackerStub,
             $this->loggerStub,
-            ['model' => $modelRepository, 'configuration' => $configurationRepository],
+            ['model' => $modelRepository, 'configuration' => $configurationRepository, 'budget' => $budgetService],
         );
+    }
+
+    #[Test]
+    public function generateEnforcesTheBudgetBeforeAnyHttpCall(): void
+    {
+        $budget = self::createStub(BudgetServiceInterface::class);
+        $budget->method('check')->willReturn(BudgetCheckResult::denied('cost_per_day', 5.0, 5.0, 'exhausted'));
+
+        $subject = $this->createSubject(budgetService: $budget);
+
+        // The gate short-circuits with BudgetExceededException; a removed gate
+        // would instead proceed into the (stubbed) HTTP path and fail otherwise.
+        $this->expectException(BudgetExceededException::class);
+
+        $subject->generate('A cat', new ImageGenerationOptions(beUserUid: 5, plannedCost: 10.0));
     }
 
     private function createSubjectWithoutApiKey(): DallEImageService


### PR DESCRIPTION
## What

Add a pre-flight **budget gate** to the specialized image/speech services (DALL-E, FAL, Whisper, TTS) so per-user and per-configuration spend caps are enforced before any provider call — the enforcement half that ADR-057 deliberately deferred (ADR-078).

> ⚠️ **This reverses a documented deferral and is a behavioural change.** ADR-057 explicitly left specialized-service budget enforcement out "as a separate decision with its own trade-offs." This PR makes that decision; it is designed **fail-open** so it is inert until an operator configures a cap. Flagging for maintainer review of the intent, not just the code.

## Why

Chat-shaped calls run through `BudgetMiddleware` and are gated. The specialized services dispatch HTTP directly from `AbstractSpecializedService`, bypassing the pipeline — ADR-057 wired `beUserUid`/`plannedCost` into their options for **attribution** but left `plannedCost` carried-but-unused on the send path. A consumer that sets budget caps got them enforced on chat/embedding but silently **not** on image/speech spend.

## Changes

- **`AbstractSpecializedService::enforceBudget(?int, ?float, ?string)`** — mirrors `BudgetMiddleware::handle()`: resolves the named configuration via the existing `findActiveConfiguration()`, runs `BudgetServiceInterface::check()`, throws `BudgetExceededException` before dispatch on denial.
- Call sites (after option resolution + validation, before request build): DALL-E `generate`/`generateMultiple`/`createVariations`/`edit`; TTS `synthesize` (`synthesizeToFile`/`synthesizeLong` delegate → inherit); Whisper `transcribe`/`transcribeFromContent`/`translateToEnglish` (**all three** — no bypass); FAL `generate`/`generateMultiple` (new `extractPlannedCost()` mirrors `extractBeUserUid()`; neither reaches the FAL API). `DeepLTranslator` carries no budget fields → intentionally not gated.
- New optional trailing constructor param `?BudgetServiceInterface $budgetService = null` (autowired from the existing alias; no `Services.yaml` change — the services autowire).

## Fail-open posture (why this is safe by default)

- No `BudgetServiceInterface` wired → `enforceBudget()` is a no-op. Unconfigured deployments and unit tests that omit it are unaffected.
- Wired but no caps / no backend user → `BudgetService::check()` short-circuits to *allowed*. Nothing changes until an operator sets a limit.

## Known trade-offs (documented in ADR-078)

- **FAL and DALL-E variations/edit have no cost model** → only request-count/token caps can trip for them, never a *cost* ceiling.
- `BudgetExceededException` is the shared `Exception\` type (ADR-025), not `Specialized\Exception\` — consumers catching only `SpecializedServiceException` won't catch a denial (intended).
- Consumers hand-rolling their own specialized pre-gate can drop it (`check()` is side-effect-free; a transitional double-gate is harmless).

## Tests / verification

`AbstractSpecializedServiceTest` covers the gate (denied → throws, allowed → passes, null → no-op, defaults, configuration resolution + pass-through). `DallEImageServiceTest` proves `generate()` short-circuits with `BudgetExceededException` before HTTP.

Local gate: `unit` ✅ (5056), `cgl` ✅, `rector -n` ✅, `fuzzy` ✅. `phpstan`/`functional` fail identically on `main` (pre-existing `ProviderDetector` PHP-8.5 finding; testing-framework warning) — this branch adds no new failures.

Rector's `AddErrorCodeToExceptionRector` is skipped for the base class, matching the existing skip for the other `BudgetExceededException` throwers (its constructor is `(BudgetCheckResult, ?Throwable)`, not `(message, code)`).
