### PR TITLE
feat(testing): first-party fakes for Completion, Vision and Budget services (ADR-079)

### DIFF
--- a/Classes/Testing/FakeBudgetService.php
+++ b/Classes/Testing/FakeBudgetService.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Testing;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Throwable;
+
+/**
+ * Consumer-facing test double for {@see BudgetServiceInterface}.
+ *
+ * Ships in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace so
+ * downstream extensions that gate on the budget check can fake it in their unit
+ * tests instead of hand-rolling a double — exactly the double that broke across
+ * consumers when {@see BudgetServiceInterface::check()} gained its
+ * `?LlmConfiguration` parameter. Implementing the real interface means PHPStan
+ * keeps this double in sync with the production contract, so a future signature
+ * change fails the build here instead of silently in every consumer.
+ *
+ * {@see self::check()} returns {@see $checkResult} (defaulting to an allowing
+ * result) and records every call in {@see $checkCalls}; set {@see $throwable} to
+ * make the next call throw.
+ *
+ * Not a DI service: excluded from container autoconfiguration in
+ * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
+ * never wire it into production.
+ */
+final class FakeBudgetService implements BudgetServiceInterface
+{
+    /** Canned result; a default allowing result is returned when left null. */
+    public ?BudgetCheckResult $checkResult = null;
+
+    /**
+     * When set, the next call throws this instead of returning. Cleared before
+     * throwing, so subsequent calls return the canned result again.
+     */
+    public ?Throwable $throwable = null;
+
+    /** @var list<array{beUserUid: int, plannedCost: float, configuration: ?LlmConfiguration}> */
+    public array $checkCalls = [];
+
+    public function check(int $beUserUid, float $plannedCost = 0.0, ?LlmConfiguration $configuration = null): BudgetCheckResult
+    {
+        $this->checkCalls[] = ['beUserUid' => $beUserUid, 'plannedCost' => $plannedCost, 'configuration' => $configuration];
+
+        if ($this->throwable instanceof Throwable) {
+            $throwable = $this->throwable;
+            $this->throwable = null;
+
+            throw $throwable;
+        }
+
+        return $this->checkResult ?? BudgetCheckResult::allowed();
+    }
+}

--- a/Classes/Testing/FakeCompletionService.php
+++ b/Classes/Testing/FakeCompletionService.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Testing;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Throwable;
+
+/**
+ * Consumer-facing test double for {@see CompletionServiceInterface}.
+ *
+ * Ships in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace so
+ * downstream extensions can fake the completion surface in their unit tests
+ * instead of hand-rolling a double that fatals whenever the interface grows
+ * (the failure mode ADR-051/ADR-073 record). Implementing the real interface
+ * means PHPStan keeps this double in sync with the production contract.
+ *
+ * The six {@see CompletionResponse}-returning methods (`complete`,
+ * `completeFactual`, `completeCreative` and their `*ForConfiguration` twins)
+ * return {@see $responses} in FIFO order; queue one per expected call. The JSON
+ * and Markdown methods return the canned {@see $jsonResult} / {@see $markdownResult}.
+ * Every call is captured in the matching `*Calls` array; set {@see $throwable}
+ * to make the next call throw instead of returning.
+ *
+ * Not a DI service: excluded from container autoconfiguration in
+ * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
+ * never wire it into production.
+ */
+final class FakeCompletionService implements CompletionServiceInterface
+{
+    /**
+     * CompletionResponses returned in FIFO order, one per call across the six
+     * response-returning methods.
+     *
+     * @var list<CompletionResponse>
+     */
+    public array $responses = [];
+
+    /**
+     * Canned result for {@see self::completeJson()} and
+     * {@see self::completeJsonForConfiguration()}.
+     *
+     * @var array<string, mixed>
+     */
+    public array $jsonResult = [];
+
+    /** Canned result for {@see self::completeMarkdown()} and {@see self::completeMarkdownForConfiguration()}. */
+    public string $markdownResult = '';
+
+    /**
+     * When set, the next call throws this instead of returning. Cleared before
+     * throwing, so subsequent calls return queued/canned values again.
+     */
+    public ?Throwable $throwable = null;
+
+    /** @var list<array{prompt: string, options: ?ChatOptions}> */
+    public array $completeCalls = [];
+
+    /** @var list<array{prompt: string, options: ?ChatOptions}> */
+    public array $completeJsonCalls = [];
+
+    /** @var list<array{prompt: string, options: ?ChatOptions}> */
+    public array $completeMarkdownCalls = [];
+
+    /** @var list<array{prompt: string, options: ?ChatOptions}> */
+    public array $completeFactualCalls = [];
+
+    /** @var list<array{prompt: string, options: ?ChatOptions}> */
+    public array $completeCreativeCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
+    public array $completeForConfigurationCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
+    public array $completeJsonForConfigurationCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
+    public array $completeMarkdownForConfigurationCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
+    public array $completeFactualForConfigurationCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
+    public array $completeCreativeForConfigurationCalls = [];
+
+    public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeCalls[] = ['prompt' => $prompt, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    public function completeJson(string $prompt, ?ChatOptions $options = null): array
+    {
+        $this->completeJsonCalls[] = ['prompt' => $prompt, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->jsonResult;
+    }
+
+    public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string
+    {
+        $this->completeMarkdownCalls[] = ['prompt' => $prompt, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->markdownResult;
+    }
+
+    public function completeFactual(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeFactualCalls[] = ['prompt' => $prompt, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    public function completeCreative(string $prompt, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeCreativeCalls[] = ['prompt' => $prompt, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    public function completeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array
+    {
+        $this->completeJsonForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->jsonResult;
+    }
+
+    public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string
+    {
+        $this->completeMarkdownForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->markdownResult;
+    }
+
+    public function completeFactualForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeFactualForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    public function completeCreativeForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): CompletionResponse
+    {
+        $this->completeCreativeForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'options' => $options];
+
+        return $this->nextResponse(__FUNCTION__);
+    }
+
+    private function nextResponse(string $method): CompletionResponse
+    {
+        $this->guardThrow();
+
+        $response = array_shift($this->responses);
+        if (!$response instanceof CompletionResponse) {
+            throw new LogicException(sprintf('%s::%s() was called but no response was queued in $responses.', self::class, $method), 7126400010);
+        }
+
+        return $response;
+    }
+
+    private function guardThrow(): void
+    {
+        if ($this->throwable instanceof Throwable) {
+            $throwable = $this->throwable;
+            $this->throwable = null;
+
+            throw $throwable;
+        }
+    }
+}

--- a/Classes/Testing/FakeVisionService.php
+++ b/Classes/Testing/FakeVisionService.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Testing;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Throwable;
+
+/**
+ * Consumer-facing test double for {@see VisionServiceInterface}.
+ *
+ * Ships in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace so
+ * downstream extensions can fake the vision surface in their unit tests instead
+ * of hand-rolling a double that breaks whenever the interface grows.
+ * Implementing the real interface means PHPStan keeps this double in sync with
+ * the production contract.
+ *
+ * The four string-or-array methods return the matching canned string, echoing
+ * the caller's arity: a single image yields the string, a batch yields one
+ * canned string per input. {@see self::analyzeImageFull()} returns the canned
+ * {@see $analyzeImageFullResult} (a default is built when left null). Every call
+ * is captured in the matching `*Calls` array; set {@see $throwable} to make the
+ * next call throw.
+ *
+ * Not a DI service: excluded from container autoconfiguration in
+ * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
+ * never wire it into production.
+ */
+final class FakeVisionService implements VisionServiceInterface
+{
+    public string $altTextResult = 'fake alt text';
+
+    public string $titleResult = 'fake title';
+
+    public string $descriptionResult = 'fake description';
+
+    public string $analyzeImageResult = 'fake analysis';
+
+    /** Canned response for {@see self::analyzeImageFull()}; a default is built when left null. */
+    public ?VisionResponse $analyzeImageFullResult = null;
+
+    /**
+     * When set, the next call throws this instead of returning. Cleared before
+     * throwing, so subsequent calls return canned values again.
+     */
+    public ?Throwable $throwable = null;
+
+    /** @var list<array{imageUrl: string|array<int, string>, options: ?VisionOptions}> */
+    public array $generateAltTextCalls = [];
+
+    /** @var list<array{imageUrl: string|array<int, string>, options: ?VisionOptions}> */
+    public array $generateTitleCalls = [];
+
+    /** @var list<array{imageUrl: string|array<int, string>, options: ?VisionOptions}> */
+    public array $generateDescriptionCalls = [];
+
+    /** @var list<array{imageUrl: string|array<int, string>, customPrompt: string, options: ?VisionOptions}> */
+    public array $analyzeImageCalls = [];
+
+    /** @var list<array{imageUrl: string, prompt: string, options: ?VisionOptions}> */
+    public array $analyzeImageFullCalls = [];
+
+    /**
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateAltText(string|array $imageUrl, ?VisionOptions $options = null): string|array
+    {
+        $this->generateAltTextCalls[] = ['imageUrl' => $imageUrl, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->echoArity($imageUrl, $this->altTextResult);
+    }
+
+    /**
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateTitle(string|array $imageUrl, ?VisionOptions $options = null): string|array
+    {
+        $this->generateTitleCalls[] = ['imageUrl' => $imageUrl, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->echoArity($imageUrl, $this->titleResult);
+    }
+
+    /**
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function generateDescription(string|array $imageUrl, ?VisionOptions $options = null): string|array
+    {
+        $this->generateDescriptionCalls[] = ['imageUrl' => $imageUrl, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->echoArity($imageUrl, $this->descriptionResult);
+    }
+
+    /**
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    public function analyzeImage(string|array $imageUrl, string $customPrompt, ?VisionOptions $options = null): string|array
+    {
+        $this->analyzeImageCalls[] = ['imageUrl' => $imageUrl, 'customPrompt' => $customPrompt, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->echoArity($imageUrl, $this->analyzeImageResult);
+    }
+
+    public function analyzeImageFull(string $imageUrl, string $prompt, ?VisionOptions $options = null): VisionResponse
+    {
+        $this->analyzeImageFullCalls[] = ['imageUrl' => $imageUrl, 'prompt' => $prompt, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->analyzeImageFullResult ?? new VisionResponse(
+            description: $this->descriptionResult,
+            model: 'fake-vision-model',
+            usage: new UsageStatistics(0, 0, 0),
+        );
+    }
+
+    /**
+     * Echo the caller's arity: a single image returns the canned string, a batch
+     * returns one canned string per input (matching the string|array contract).
+     *
+     * @param string|array<int, string> $imageUrl
+     *
+     * @return string|array<int, string>
+     */
+    private function echoArity(string|array $imageUrl, string $canned): string|array
+    {
+        if (is_array($imageUrl)) {
+            return array_map(static fn(): string => $canned, $imageUrl);
+        }
+
+        return $canned;
+    }
+
+    private function guardThrow(): void
+    {
+        if ($this->throwable instanceof Throwable) {
+            $throwable = $this->throwable;
+            $this->throwable = null;
+
+            throw $throwable;
+        }
+    }
+}

--- a/Documentation/Adr/Adr079FirstPartyCompletionVisionBudgetFakes.rst
+++ b/Documentation/Adr/Adr079FirstPartyCompletionVisionBudgetFakes.rst
@@ -1,0 +1,80 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-079:
+
+============================================================================
+ADR-079: First-party fakes for Completion, Vision and Budget services
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-17
+:Authors: Netresearch DTT GmbH
+
+.. _adr-079-context:
+
+Context
+=======
+
+:ref:`ADR-073 <adr-073>` shipped maintained, first-party test doubles for
+the tool-calling and embedding feature services under the runtime-autoloaded
+``Netresearch\NrLlm\Testing\`` namespace, because consumers were hand-rolling
+doubles that fatal the moment the interface grows. It deliberately deferred
+the remaining feature interfaces: "Other feature interfaces (completion,
+vision, translation) gain a first-party fake only when a consumer needs one."
+
+That consumer now exists. ``nr_repurpose`` (podcast/diagram/story generation)
+consumes ``CompletionService`` and ``VisionService`` and gates image/speech
+spend through ``BudgetServiceInterface`` — and its hand-written
+``BudgetServiceInterface`` double is exactly the one that broke across
+consumers when ``check()`` gained its ``?LlmConfiguration`` parameter (the
+0.20 signature change), the failure ADR-073 exists to prevent.
+
+.. _adr-079-decision:
+
+Decision
+========
+
+**Ship three more first-party fakes**, extending ADR-073 to the surfaces a
+concrete consumer now uses:
+
+- ``FakeCompletionService`` — the six ``CompletionResponse``-returning methods
+  (``complete``, ``completeFactual``, ``completeCreative`` and their
+  ``*ForConfiguration`` twins from :ref:`ADR-077 <adr-077>`) draw from a FIFO
+  ``$responses`` queue; ``completeJson*`` and ``completeMarkdown*`` return
+  canned properties. Every call is recorded.
+- ``FakeVisionService`` — the four string-or-array methods return the canned
+  string echoing the caller's arity (single image → string, batch → one per
+  input); ``analyzeImageFull`` returns a canned ``VisionResponse``.
+- ``FakeBudgetService`` — ``check()`` returns a canned ``BudgetCheckResult``
+  (allowing by default) and records every call.
+
+Each is a plain ``final class`` (not ``readonly`` — the canned-value and
+call-recording properties are set by tests) implementing the real interface,
+so PHPStan level 10 keeps the double in lock-step with the production
+contract. Each carries a one-shot ``$throwable`` to exercise a consumer's
+error path.
+
+Beyond ADR-073's named trio, this includes **Budget** (not a
+``Service\Feature\`` interface, but the one whose signature drift concretely
+broke consumers) and omits **translation** (no consumer needs it yet — the
+same demand-pull rule ADR-073 set).
+
+.. _adr-079-consequences:
+
+Consequences
+============
+
+- Consumers type-hint their unit tests against a maintained fake instead of a
+  hand-rolled double; a future signature change fails the build *here* rather
+  than silently in every consumer.
+- The three interfaces each gain a second implementor (the fake). A future
+  signature change now has a production + fake blast radius — intended: the
+  fake failing PHPStan is the guardrail.
+- Purely additive and DI-neutral: ``Classes/Testing/*`` is already excluded
+  from container autoconfiguration (``Configuration/Services.yaml``) and
+  covered by the production PSR-4 autoload, so the public-service count
+  (:ref:`ADR-028 <adr-028>`) is unchanged and consumers get the doubles
+  without nr_llm dev dependencies.
+- The ``Testing\`` surface (property and method names) is a supported public
+  API, as ADR-073 established: renames are breaking changes and belong in
+  release notes.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -375,3 +375,4 @@ Tools
    Adr075RerankerProtocol
    Adr076DocumentUnderstanding
    Adr077NamedConfigurationCompletion
+   Adr079FirstPartyCompletionVisionBudgetFakes

--- a/Tests/Unit/Testing/FakeBudgetServiceTest.php
+++ b/Tests/Unit/Testing/FakeBudgetServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Testing;
+
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Testing\FakeBudgetService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(FakeBudgetService::class)]
+final class FakeBudgetServiceTest extends TestCase
+{
+    #[Test]
+    public function implementsTheRealInterface(): void
+    {
+        self::assertInstanceOf(BudgetServiceInterface::class, new FakeBudgetService());
+    }
+
+    #[Test]
+    public function defaultsToAnAllowingResult(): void
+    {
+        $result = (new FakeBudgetService())->check(1, 0.5);
+
+        self::assertTrue($result->allowed);
+    }
+
+    #[Test]
+    public function returnsTheCannedResult(): void
+    {
+        $subject = new FakeBudgetService();
+        $subject->checkResult = BudgetCheckResult::denied('cost_per_day', 9.0, 9.0, 'exhausted');
+
+        $result = $subject->check(1, 0.5);
+
+        self::assertFalse($result->allowed);
+    }
+
+    #[Test]
+    public function recordsEveryCallWithItsArguments(): void
+    {
+        $configuration = new LlmConfiguration();
+
+        $subject = new FakeBudgetService();
+        $subject->check(42, 0.75, $configuration);
+
+        self::assertCount(1, $subject->checkCalls);
+        self::assertSame(42, $subject->checkCalls[0]['beUserUid']);
+        self::assertSame(0.75, $subject->checkCalls[0]['plannedCost']);
+        self::assertSame($configuration, $subject->checkCalls[0]['configuration']);
+    }
+
+    #[Test]
+    public function throwsConfiguredThrowableInsteadOfReturning(): void
+    {
+        $subject = new FakeBudgetService();
+        $subject->throwable = new RuntimeException('boom');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $subject->check(1);
+    }
+
+    #[Test]
+    public function throwableIsOneShotAndTheNextCallReturnsAgain(): void
+    {
+        $subject = new FakeBudgetService();
+        $subject->throwable = new RuntimeException('boom');
+
+        try {
+            $subject->check(1);
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // one-shot: cleared before throwing
+        }
+
+        self::assertNull($subject->throwable);
+        self::assertTrue($subject->check(1)->allowed);
+    }
+}

--- a/Tests/Unit/Testing/FakeCompletionServiceTest.php
+++ b/Tests/Unit/Testing/FakeCompletionServiceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Testing;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\CompletionServiceInterface;
+use Netresearch\NrLlm\Testing\FakeCompletionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(FakeCompletionService::class)]
+final class FakeCompletionServiceTest extends TestCase
+{
+    #[Test]
+    public function implementsTheRealInterface(): void
+    {
+        self::assertInstanceOf(CompletionServiceInterface::class, new FakeCompletionService());
+    }
+
+    #[Test]
+    public function returnsQueuedResponsesInFifoOrderAcrossTheResponseMethods(): void
+    {
+        $first  = self::response('first');
+        $second = self::response('second');
+
+        $subject = new FakeCompletionService();
+        $subject->responses = [$first, $second];
+
+        self::assertSame($first, $subject->complete('a'));
+        self::assertSame($second, $subject->completeForConfiguration('b', new LlmConfiguration()));
+    }
+
+    #[Test]
+    public function factualAndCreativeAlsoDrawFromTheResponseQueue(): void
+    {
+        $first  = self::response('factual');
+        $second = self::response('creative');
+
+        $subject = new FakeCompletionService();
+        $subject->responses = [$first, $second];
+
+        self::assertSame($first, $subject->completeFactual('a'));
+        self::assertSame($second, $subject->completeCreative('b'));
+    }
+
+    #[Test]
+    public function completeJsonReturnsTheCannedArray(): void
+    {
+        $subject = new FakeCompletionService();
+        $subject->jsonResult = ['answer' => 42];
+
+        self::assertSame(['answer' => 42], $subject->completeJson('a'));
+        self::assertSame(['answer' => 42], $subject->completeJsonForConfiguration('b', new LlmConfiguration()));
+    }
+
+    #[Test]
+    public function completeMarkdownReturnsTheCannedString(): void
+    {
+        $subject = new FakeCompletionService();
+        $subject->markdownResult = '# heading';
+
+        self::assertSame('# heading', $subject->completeMarkdown('a'));
+        self::assertSame('# heading', $subject->completeMarkdownForConfiguration('b', new LlmConfiguration()));
+    }
+
+    #[Test]
+    public function recordsPromptAndOptionsPerMethod(): void
+    {
+        $subject = new FakeCompletionService();
+        $subject->responses = [self::response('ok')];
+
+        $subject->complete('the prompt');
+
+        self::assertCount(1, $subject->completeCalls);
+        self::assertSame('the prompt', $subject->completeCalls[0]['prompt']);
+        self::assertNull($subject->completeCalls[0]['options']);
+    }
+
+    #[Test]
+    public function recordsConfigurationPassedToPerConfigurationCalls(): void
+    {
+        $configuration = new LlmConfiguration();
+
+        $subject = new FakeCompletionService();
+        $subject->responses = [self::response('ok')];
+
+        $subject->completeForConfiguration('p', $configuration);
+
+        self::assertCount(1, $subject->completeForConfigurationCalls);
+        self::assertSame($configuration, $subject->completeForConfigurationCalls[0]['configuration']);
+    }
+
+    #[Test]
+    public function throwsConfiguredThrowableInsteadOfReturning(): void
+    {
+        $subject = new FakeCompletionService();
+        $subject->responses = [self::response('unused')];
+        $subject->throwable = new RuntimeException('boom');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $subject->complete('a');
+    }
+
+    #[Test]
+    public function throwableIsOneShotForTheJsonMethodToo(): void
+    {
+        $subject = new FakeCompletionService();
+        $subject->jsonResult = ['ok' => true];
+        $subject->throwable = new RuntimeException('boom');
+
+        try {
+            $subject->completeJson('a');
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // one-shot: cleared before throwing
+        }
+
+        self::assertNull($subject->throwable);
+        self::assertSame(['ok' => true], $subject->completeJson('a'));
+    }
+
+    #[Test]
+    public function throwsWhenAResponseMethodIsCalledWithoutAQueuedResponse(): void
+    {
+        $subject = new FakeCompletionService();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('no response was queued');
+
+        $subject->complete('a');
+    }
+
+    private static function response(string $content): CompletionResponse
+    {
+        return new CompletionResponse($content, 'fake-model', new UsageStatistics(0, 0, 0));
+    }
+}

--- a/Tests/Unit/Testing/FakeVisionServiceTest.php
+++ b/Tests/Unit/Testing/FakeVisionServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Testing;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Testing\FakeVisionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(FakeVisionService::class)]
+final class FakeVisionServiceTest extends TestCase
+{
+    #[Test]
+    public function implementsTheRealInterface(): void
+    {
+        self::assertInstanceOf(VisionServiceInterface::class, new FakeVisionService());
+    }
+
+    #[Test]
+    public function returnsTheCannedStringForASingleImage(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->altTextResult = 'a red bus';
+
+        self::assertSame('a red bus', $subject->generateAltText('https://example.test/a.png'));
+    }
+
+    #[Test]
+    public function echoesArityReturningOneResultPerImageForABatch(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->titleResult = 'canned title';
+
+        $result = $subject->generateTitle(['https://example.test/a.png', 'https://example.test/b.png']);
+
+        self::assertSame(['canned title', 'canned title'], $result);
+    }
+
+    #[Test]
+    public function analyzeImageEchoesArityAndRecordsTheCustomPrompt(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->analyzeImageResult = 'analysis';
+
+        self::assertSame('analysis', $subject->analyzeImage('https://example.test/a.png', 'What is this?'));
+        self::assertSame('What is this?', $subject->analyzeImageCalls[0]['customPrompt']);
+    }
+
+    #[Test]
+    public function analyzeImageFullReturnsADefaultResponseWhenNoneIsCanned(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->descriptionResult = 'a cat on a mat';
+
+        $response = $subject->analyzeImageFull('https://example.test/a.png', 'describe');
+
+        self::assertInstanceOf(VisionResponse::class, $response);
+        self::assertSame('a cat on a mat', $response->description);
+    }
+
+    #[Test]
+    public function analyzeImageFullReturnsTheCannedResponse(): void
+    {
+        $canned  = new VisionResponse('canned', 'm', new UsageStatistics(0, 0, 0));
+        $subject = new FakeVisionService();
+        $subject->analyzeImageFullResult = $canned;
+
+        self::assertSame($canned, $subject->analyzeImageFull('https://example.test/a.png', 'describe'));
+    }
+
+    #[Test]
+    public function recordsCallsPerMethod(): void
+    {
+        $options = new VisionOptions();
+
+        $subject = new FakeVisionService();
+        $subject->generateDescription('https://example.test/a.png', $options);
+
+        self::assertCount(1, $subject->generateDescriptionCalls);
+        self::assertSame('https://example.test/a.png', $subject->generateDescriptionCalls[0]['imageUrl']);
+        self::assertSame($options, $subject->generateDescriptionCalls[0]['options']);
+    }
+
+    #[Test]
+    public function throwsConfiguredThrowableInsteadOfReturning(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->throwable = new RuntimeException('boom');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $subject->generateAltText('https://example.test/a.png');
+    }
+
+    #[Test]
+    public function throwableIsOneShotAndTheNextCallReturnsAgain(): void
+    {
+        $subject = new FakeVisionService();
+        $subject->altTextResult = 'after';
+        $subject->throwable = new RuntimeException('boom');
+
+        try {
+            $subject->generateAltText('https://example.test/a.png');
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // one-shot: cleared before throwing
+        }
+
+        self::assertNull($subject->throwable);
+        self::assertSame('after', $subject->generateAltText('https://example.test/a.png'));
+    }
+}


### PR DESCRIPTION
## What

Ship maintained first-party test doubles for **Completion**, **Vision** and **Budget** in the runtime-autoloaded `Netresearch\NrLlm\Testing\` namespace — extending ADR-073 (which shipped only tool-calling + embedding fakes) to the surfaces a concrete consumer now uses (ADR-079).

> 📌 **Stacked on #423** (ADR-077 named-configuration completion). `FakeCompletionService` implements the `completeForConfiguration` family that PR adds, so this targets that branch and will auto-retarget to `main` once #423 merges.

## Why

ADR-073 deferred completion/vision fakes "until a consumer needs one." `nr_repurpose` now consumes `CompletionService` and `VisionService` and gates image/speech spend through `BudgetServiceInterface` — whose hand-written double is **exactly the one that broke across consumers** when `check()` gained its `?LlmConfiguration` parameter (the 0.20 signature change). That is the failure ADR-073 exists to prevent; a maintained fake that implements the real interface fails PHPStan on drift instead of silently breaking every consumer.

## Changes (all new, under `Classes/Testing/`)

- **`FakeCompletionService`** — FIFO `$responses` queue for the six `CompletionResponse` methods (incl. the ADR-077 `*ForConfiguration` twins); canned `$jsonResult` / `$markdownResult`; per-method call recording; one-shot `$throwable`.
- **`FakeVisionService`** — canned strings echoing caller arity (single image → string, batch → one per input); canned `VisionResponse` for `analyzeImageFull`.
- **`FakeBudgetService`** — canned `BudgetCheckResult` (allowing by default), records every `check()` call.

Each is a plain `final class` implementing the real interface (PHPStan level 10 keeps it in sync). Includes a unit test per fake.

## DI / packaging

Purely additive: `Classes/Testing/*` is already excluded from container autoconfiguration (`Configuration/Services.yaml`) and covered by the production PSR-4 autoload — no `Services.yaml`/`composer.json` change, public-service count unchanged, and consumers get the doubles without nr_llm dev dependencies. The `Testing\` surface is a supported public API (ADR-073); renames are breaking.

## Verification

Local gate: `unit` ✅ (5084), `cgl` ✅, `rector -n` ✅, `fuzzy` ✅. `phpstan`/`functional` fail identically on the base branch (pre-existing `ProviderDetector` PHP-8.5 finding; testing-framework warning) — this branch adds no new failures.
