### PR TITLE
feat(translation): per-configuration translation entry point (#428, #429, #430)

### DIFF
--- a/Classes/Service/Feature/TranslationPromptBuilder.php
+++ b/Classes/Service/Feature/TranslationPromptBuilder.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+/**
+ * Builds the system/user prompt pair for LLM-based translation.
+ *
+ * Extracted from TranslationService so both translate() and
+ * translateForConfiguration() share one prompt template.
+ */
+final readonly class TranslationPromptBuilder
+{
+    /**
+     * Build translation prompt with template.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array{system: string, user: string}
+     */
+    public function build(
+        string $text,
+        string $sourceLanguage,
+        string $targetLanguage,
+        array $options,
+    ): array {
+        $formality = is_string($options['formality'] ?? null) ? $options['formality'] : 'default';
+        $domain = is_string($options['domain'] ?? null) ? $options['domain'] : 'general';
+        $glossary = is_array($options['glossary'] ?? null) ? $options['glossary'] : [];
+        $context = is_string($options['context'] ?? null) ? $options['context'] : '';
+        $preserveFormatting = $options['preserve_formatting'] ?? true;
+
+        // Build system prompt
+        $systemPrompt = sprintf(
+            "You are a professional %s translator. Translate the following text from %s to %s.\n",
+            $domain,
+            $this->getLanguageName($sourceLanguage),
+            $this->getLanguageName($targetLanguage),
+        );
+
+        // Add formality instruction
+        if ($formality !== 'default') {
+            $systemPrompt .= sprintf("Maintain %s tone.\n", $formality);
+        }
+
+        // Add formatting instruction
+        if ($preserveFormatting) {
+            $systemPrompt .= "Preserve all formatting, HTML tags, markdown, and special characters.\n";
+        }
+
+        // Add glossary if provided
+        if ($glossary !== []) {
+            $systemPrompt .= "\nUse these exact term translations:\n";
+            foreach ($glossary as $term => $translation) {
+                if (is_string($translation) || is_int($translation) || is_float($translation)) {
+                    $systemPrompt .= sprintf("- %s → %s\n", $term, $translation);
+                }
+            }
+        }
+
+        // Add context if provided
+        if ($context !== '') {
+            $systemPrompt .= sprintf("\nContext (for reference only):\n%s\n", $context);
+        }
+
+        $systemPrompt .= "\nProvide ONLY the translation, no explanations or notes.";
+
+        // Build user prompt
+        $userPrompt = sprintf("Translate this text:\n\n%s", $text);
+
+        return [
+            'system' => $systemPrompt,
+            'user' => $userPrompt,
+        ];
+    }
+
+    /**
+     * Get human-readable language name.
+     */
+    private function getLanguageName(string $code): string
+    {
+        $languages = [
+            'en' => 'English',
+            'de' => 'German',
+            'fr' => 'French',
+            'es' => 'Spanish',
+            'it' => 'Italian',
+            'pt' => 'Portuguese',
+            'nl' => 'Dutch',
+            'pl' => 'Polish',
+            'ru' => 'Russian',
+            'ja' => 'Japanese',
+            'zh' => 'Chinese',
+            'ko' => 'Korean',
+            'ar' => 'Arabic',
+        ];
+
+        return $languages[$code] ?? $code;
+    }
+}

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -59,6 +59,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         private LlmServiceManagerInterface $llmManager,
         private TranslatorRegistryInterface $translatorRegistry,
         private LlmConfigurationServiceInterface $configurationService,
+        private TranslationPromptBuilder $promptBuilder,
         private ?BackendUserContextResolverInterface $beUserContextResolver = null,
     ) {}
 
@@ -76,30 +77,13 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?TranslationOptions $options = null,
     ): TranslationResult {
         $options ??= new TranslationOptions();
-        $optionsArray = $options->toArray();
 
-        if (empty($text)) {
-            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 1478981390);
-        }
-
-        $this->validateLanguageCode($targetLanguage);
-
-        // Auto-detect source language if not provided
-        if ($sourceLanguage === null) {
-            $sourceLanguage = $this->detectLanguage($text, $options);
-        } else {
-            $this->validateLanguageCode($sourceLanguage);
-        }
-
-        // Validate options
-        $this->validateOptions($optionsArray);
-
-        // Build prompt
-        $prompt = $this->buildTranslationPrompt(
+        ['sourceLanguage' => $sourceLanguage, 'prompt' => $prompt] = $this->prepareTranslation(
             $text,
-            $sourceLanguage,
             $targetLanguage,
-            $optionsArray,
+            $sourceLanguage,
+            $options,
+            1478981390,
         );
 
         // Execute translation. REC #2 closure: build typed
@@ -167,32 +151,17 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?TranslationOptions $options = null,
     ): TranslationResult {
         $options ??= new TranslationOptions();
-        $optionsArray = $options->toArray();
-
-        if (empty($text)) {
-            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 1719410501);
-        }
-
-        $this->validateLanguageCode($targetLanguage);
-
-        // Auto-detect source language if not provided (mirrors translate()).
-        if ($sourceLanguage === null) {
-            $sourceLanguage = $this->detectLanguage($text, $options);
-        } else {
-            $this->validateLanguageCode($sourceLanguage);
-        }
-
-        $this->validateOptions($optionsArray);
 
         // Build the same task/constraints prompt as translate(), but fold the
         // instruction block into the USER message so no system message is sent —
         // that keeps the configuration's stored system_prompt as the system
         // message (see applySystemPrompt short-circuit).
-        $prompt = $this->buildTranslationPrompt(
+        ['sourceLanguage' => $sourceLanguage, 'prompt' => $prompt] = $this->prepareTranslation(
             $text,
-            $sourceLanguage,
             $targetLanguage,
-            $optionsArray,
+            $sourceLanguage,
+            $options,
+            1719410501,
         );
 
         $messages = [
@@ -503,65 +472,52 @@ final readonly class TranslationService implements TranslationServiceInterface
     }
 
     /**
-     * Build translation prompt with template.
+     * Shared preamble for translate() and translateForConfiguration():
+     * empty-text guard, language-code validation, source-language
+     * detection, option validation, and prompt construction. Only the
+     * message assembly and dispatch differ between the two callers.
      *
-     * @param array<string, mixed> $options
+     * @param int $emptyTextErrorCode caller-specific code for the empty-text guard
      *
-     * @return array{system: string, user: string}
+     * @throws InvalidArgumentException when input is empty or a language code is invalid
+     *
+     * @return array{sourceLanguage: string, prompt: array{system: string, user: string}}
      */
-    private function buildTranslationPrompt(
+    private function prepareTranslation(
         string $text,
-        string $sourceLanguage,
         string $targetLanguage,
-        array $options,
+        ?string $sourceLanguage,
+        TranslationOptions $options,
+        int $emptyTextErrorCode,
     ): array {
-        $formality = is_string($options['formality'] ?? null) ? $options['formality'] : 'default';
-        $domain = is_string($options['domain'] ?? null) ? $options['domain'] : 'general';
-        $glossary = is_array($options['glossary'] ?? null) ? $options['glossary'] : [];
-        $context = is_string($options['context'] ?? null) ? $options['context'] : '';
-        $preserveFormatting = $options['preserve_formatting'] ?? true;
+        if (empty($text)) {
+            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, $emptyTextErrorCode);
+        }
 
-        // Build system prompt
-        $systemPrompt = sprintf(
-            "You are a professional %s translator. Translate the following text from %s to %s.\n",
-            $domain,
-            $this->getLanguageName($sourceLanguage),
-            $this->getLanguageName($targetLanguage),
+        $optionsArray = $options->toArray();
+
+        $this->validateLanguageCode($targetLanguage);
+
+        // Auto-detect source language if not provided
+        if ($sourceLanguage === null) {
+            $sourceLanguage = $this->detectLanguage($text, $options);
+        } else {
+            $this->validateLanguageCode($sourceLanguage);
+        }
+
+        // Validate options
+        $this->validateOptions($optionsArray);
+
+        $prompt = $this->promptBuilder->build(
+            $text,
+            $sourceLanguage,
+            $targetLanguage,
+            $optionsArray,
         );
 
-        // Add formality instruction
-        if ($formality !== 'default') {
-            $systemPrompt .= sprintf("Maintain %s tone.\n", $formality);
-        }
-
-        // Add formatting instruction
-        if ($preserveFormatting) {
-            $systemPrompt .= "Preserve all formatting, HTML tags, markdown, and special characters.\n";
-        }
-
-        // Add glossary if provided
-        if ($glossary !== []) {
-            $systemPrompt .= "\nUse these exact term translations:\n";
-            foreach ($glossary as $term => $translation) {
-                if (is_string($translation) || is_int($translation) || is_float($translation)) {
-                    $systemPrompt .= sprintf("- %s → %s\n", $term, $translation);
-                }
-            }
-        }
-
-        // Add context if provided
-        if ($context !== '') {
-            $systemPrompt .= sprintf("\nContext (for reference only):\n%s\n", $context);
-        }
-
-        $systemPrompt .= "\nProvide ONLY the translation, no explanations or notes.";
-
-        // Build user prompt
-        $userPrompt = sprintf("Translate this text:\n\n%s", $text);
-
         return [
-            'system' => $systemPrompt,
-            'user' => $userPrompt,
+            'sourceLanguage' => $sourceLanguage,
+            'prompt' => $prompt,
         ];
     }
 
@@ -624,30 +580,6 @@ final readonly class TranslationService implements TranslationServiceInterface
         if (isset($options['glossary']) && !is_array($options['glossary'])) {
             throw new InvalidArgumentException('Glossary must be an associative array', 8571915742);
         }
-    }
-
-    /**
-     * Get human-readable language name.
-     */
-    private function getLanguageName(string $code): string
-    {
-        $languages = [
-            'en' => 'English',
-            'de' => 'German',
-            'fr' => 'French',
-            'es' => 'Spanish',
-            'it' => 'Italian',
-            'pt' => 'Portuguese',
-            'nl' => 'Dutch',
-            'pl' => 'Polish',
-            'ru' => 'Russian',
-            'ja' => 'Japanese',
-            'zh' => 'Chinese',
-            'ko' => 'Korean',
-            'ar' => 'Arabic',
-        ];
-
-        return $languages[$code] ?? $code;
     }
 
     /**

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -111,11 +113,97 @@ final readonly class TranslationService implements TranslationServiceInterface
             temperature: $options->getTemperature() ?? 0.3,
             maxTokens: $options->getMaxTokens() ?? 2000,
             provider: $options->getProvider(),
+            model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
         );
 
         $response = $this->llmManager->chat($messages, $chatOptions);
+
+        return new TranslationResult(
+            translation: $response->content,
+            sourceLanguage: $sourceLanguage,
+            targetLanguage: $targetLanguage,
+            confidence: $this->calculateConfidence($response->finishReason),
+            usage: $response->usage,
+        );
+    }
+
+    /**
+     * Translate text using the persona/tone of a stored LlmConfiguration.
+     *
+     * Unlike {@see self::translate()} — which supplies its own system
+     * message and therefore short-circuits
+     * {@see \Netresearch\NrLlm\Service\MessageShaper::applySystemPrompt()},
+     * so the configuration's stored `system_prompt` never applies — this
+     * method routes through {@see LlmServiceManagerInterface::chatWithConfiguration()}
+     * so the configuration drives the provider/model/skills AND its
+     * `system_prompt` becomes the system message.
+     *
+     * The translation task itself (target/source language, formality,
+     * glossary, preserve-formatting, "output only the translation") is
+     * carried in the USER message rather than a second system message:
+     * a system message would re-trigger the short-circuit and clobber the
+     * configuration's persona. The configuration's `system_prompt` is the
+     * persona/tone layer; this user-message preamble is the task layer.
+     *
+     * Source-language auto-detection (when `$sourceLanguage` is null) runs
+     * through the options' provider, not the configuration — pass an explicit
+     * `$sourceLanguage` to avoid that extra call and keep the whole operation
+     * on the chosen configuration.
+     *
+     * @param string      $text           Text to translate
+     * @param string      $targetLanguage Target language code (ISO 639-1)
+     * @param string|null $sourceLanguage Source language code (auto-detected if null)
+     *
+     * @throws InvalidArgumentException when input is empty or a language code is invalid
+     */
+    public function translateForConfiguration(
+        string $text,
+        string $targetLanguage,
+        LlmConfiguration $configuration,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): TranslationResult {
+        $options ??= new TranslationOptions();
+        $optionsArray = $options->toArray();
+
+        if (empty($text)) {
+            throw new InvalidArgumentException('Text cannot be empty', 1719410501);
+        }
+
+        $this->validateLanguageCode($targetLanguage);
+
+        // Auto-detect source language if not provided (mirrors translate()).
+        if ($sourceLanguage === null) {
+            $sourceLanguage = $this->detectLanguage($text, $options);
+        } else {
+            $this->validateLanguageCode($sourceLanguage);
+        }
+
+        $this->validateOptions($optionsArray);
+
+        // Build the same task/constraints prompt as translate(), but fold the
+        // instruction block into the USER message so no system message is sent —
+        // that keeps the configuration's stored system_prompt as the system
+        // message (see applySystemPrompt short-circuit).
+        $prompt = $this->buildTranslationPrompt(
+            $text,
+            $sourceLanguage,
+            $targetLanguage,
+            $optionsArray,
+        );
+
+        $messages = [
+            ChatMessage::user($prompt['system'] . "\n\n" . $prompt['user']),
+        ];
+
+        $response = $this->llmManager->chatWithConfiguration(
+            $messages,
+            $configuration,
+            $this->buildBudgetMetadata($options),
+            $this->buildOptionOverrides($options),
+        );
 
         return new TranslationResult(
             translation: $response->content,
@@ -174,6 +262,7 @@ final readonly class TranslationService implements TranslationServiceInterface
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
+            model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
         );
@@ -223,6 +312,7 @@ final readonly class TranslationService implements TranslationServiceInterface
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
+            model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
         );
@@ -240,7 +330,7 @@ final readonly class TranslationService implements TranslationServiceInterface
      *
      * Supports dual-path translation with priority routing:
      * 1. Explicit translator specified in options
-     * 2. Translator from LlmConfiguration preset
+     * 2. Translator pinned on a selected LlmConfiguration (options configuration key)
      * 3. Default LLM-based translation
      *
      * @param string      $text           Text to translate
@@ -373,11 +463,13 @@ final readonly class TranslationService implements TranslationServiceInterface
             return $this->translatorRegistry->get($translator);
         }
 
-        // Priority 2: Preset specified - check for translator in configuration
-        $preset = $options['preset'] ?? '';
-        if (is_string($preset) && $preset !== '') {
+        // Priority 2: Configuration identifier specified - use the translator
+        // pinned on that LlmConfiguration, if any. Reachable via
+        // TranslationOptions::withConfiguration() (#430).
+        $configurationIdentifier = $options['configuration'] ?? '';
+        if (is_string($configurationIdentifier) && $configurationIdentifier !== '') {
             try {
-                $configuration = $this->configurationService->getConfiguration($preset);
+                $configuration = $this->configurationService->getConfiguration($configurationIdentifier);
                 if ($configuration->getTranslator() !== '') {
                     return $this->translatorRegistry->get($configuration->getTranslator());
                 }
@@ -554,5 +646,62 @@ final readonly class TranslationService implements TranslationServiceInterface
     private function resolveBeUserUid(TranslationOptions $options): ?int
     {
         return $options->getBeUserUid() ?? $this->beUserContextResolver?->resolveBeUserUid();
+    }
+
+    /**
+     * Budget pre-flight metadata for the per-configuration path.
+     *
+     * `chatWithConfiguration()` takes budget context as pipeline metadata
+     * (not on an options object), so the resolved uid and planned cost are
+     * mapped onto the keys BudgetMiddleware reads. Absent keys mean "skip
+     * the check", matching the middleware's contract.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildBudgetMetadata(TranslationOptions $options): array
+    {
+        $metadata = [];
+
+        $beUserUid = $this->resolveBeUserUid($options);
+        if ($beUserUid !== null) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
+
+        $plannedCost = $options->getPlannedCost();
+        if ($plannedCost !== null) {
+            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Per-call option overrides for the per-configuration path.
+     *
+     * Only the generation knobs are forwarded; each takes precedence over
+     * the configuration's stored default when set, and an absent key leaves
+     * the configuration's value untouched. `provider` is intentionally not
+     * forwarded — the configuration selects the provider (mirrors
+     * `chatWithToolsForConfiguration()`).
+     *
+     * @return array<string, mixed>
+     */
+    private function buildOptionOverrides(TranslationOptions $options): array
+    {
+        $overrides = [];
+
+        if ($options->getTemperature() !== null) {
+            $overrides['temperature'] = $options->getTemperature();
+        }
+
+        if ($options->getMaxTokens() !== null) {
+            $overrides['max_tokens'] = $options->getMaxTokens();
+        }
+
+        if ($options->getModel() !== null) {
+            $overrides['model'] = $options->getModel();
+        }
+
+        return $overrides;
     }
 }

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -51,6 +51,7 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  */
 final readonly class TranslationService implements TranslationServiceInterface
 {
+    private const EMPTY_TEXT_ERROR = 'Text cannot be empty';
     private const SUPPORTED_FORMALITIES = ['default', 'formal', 'informal'];
     private const SUPPORTED_DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];
 
@@ -78,7 +79,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         $optionsArray = $options->toArray();
 
         if (empty($text)) {
-            throw new InvalidArgumentException('Text cannot be empty', 1478981390);
+            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 1478981390);
         }
 
         $this->validateLanguageCode($targetLanguage);
@@ -169,7 +170,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         $optionsArray = $options->toArray();
 
         if (empty($text)) {
-            throw new InvalidArgumentException('Text cannot be empty', 1719410501);
+            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 1719410501);
         }
 
         $this->validateLanguageCode($targetLanguage);
@@ -198,12 +199,31 @@ final readonly class TranslationService implements TranslationServiceInterface
             ChatMessage::user($prompt['system'] . "\n\n" . $prompt['user']),
         ];
 
-        $response = $this->llmManager->chatWithConfiguration(
-            $messages,
-            $configuration,
-            $this->buildBudgetMetadata($options),
-            $this->buildOptionOverrides($options),
-        );
+        // Budget metadata for chatWithConfiguration's pipeline (ADR-052):
+        // absent keys mean "skip the check", matching the middleware contract.
+        $metadata = [];
+        $beUserUid = $this->resolveBeUserUid($options);
+        if ($beUserUid !== null) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
+        if ($options->getPlannedCost() !== null) {
+            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $options->getPlannedCost();
+        }
+
+        // Only forward set generation knobs; unset ones let the configuration's
+        // stored defaults apply. Provider is omitted — the configuration owns it.
+        $overrides = [];
+        if ($options->getTemperature() !== null) {
+            $overrides['temperature'] = $options->getTemperature();
+        }
+        if ($options->getMaxTokens() !== null) {
+            $overrides['max_tokens'] = $options->getMaxTokens();
+        }
+        if ($options->getModel() !== null) {
+            $overrides['model'] = $options->getModel();
+        }
+
+        $response = $this->llmManager->chatWithConfiguration($messages, $configuration, $metadata, $overrides);
 
         return new TranslationResult(
             translation: $response->content,
@@ -349,7 +369,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         $optionsArray = $this->attachBeUserUid($options->toArray(), $options);
 
         if (empty($text)) {
-            throw new InvalidArgumentException('Text cannot be empty', 3459949413);
+            throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 3459949413);
         }
 
         $this->validateLanguageCode($targetLanguage);
@@ -646,62 +666,5 @@ final readonly class TranslationService implements TranslationServiceInterface
     private function resolveBeUserUid(TranslationOptions $options): ?int
     {
         return $options->getBeUserUid() ?? $this->beUserContextResolver?->resolveBeUserUid();
-    }
-
-    /**
-     * Budget pre-flight metadata for the per-configuration path.
-     *
-     * `chatWithConfiguration()` takes budget context as pipeline metadata
-     * (not on an options object), so the resolved uid and planned cost are
-     * mapped onto the keys BudgetMiddleware reads. Absent keys mean "skip
-     * the check", matching the middleware's contract.
-     *
-     * @return array<string, mixed>
-     */
-    private function buildBudgetMetadata(TranslationOptions $options): array
-    {
-        $metadata = [];
-
-        $beUserUid = $this->resolveBeUserUid($options);
-        if ($beUserUid !== null) {
-            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
-        }
-
-        $plannedCost = $options->getPlannedCost();
-        if ($plannedCost !== null) {
-            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * Per-call option overrides for the per-configuration path.
-     *
-     * Only the generation knobs are forwarded; each takes precedence over
-     * the configuration's stored default when set, and an absent key leaves
-     * the configuration's value untouched. `provider` is intentionally not
-     * forwarded — the configuration selects the provider (mirrors
-     * `chatWithToolsForConfiguration()`).
-     *
-     * @return array<string, mixed>
-     */
-    private function buildOptionOverrides(TranslationOptions $options): array
-    {
-        $overrides = [];
-
-        if ($options->getTemperature() !== null) {
-            $overrides['temperature'] = $options->getTemperature();
-        }
-
-        if ($options->getMaxTokens() !== null) {
-            $overrides['max_tokens'] = $options->getMaxTokens();
-        }
-
-        if ($options->getModel() !== null) {
-            $overrides['model'] = $options->getModel();
-        }
-
-        return $overrides;
     }
 }

--- a/Classes/Service/Feature/TranslationServiceInterface.php
+++ b/Classes/Service/Feature/TranslationServiceInterface.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Feature;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
@@ -50,6 +51,26 @@ interface TranslationServiceInterface
     ): TranslationResult;
 
     /**
+     * Translate text with a stored LlmConfiguration's persona/tone.
+     *
+     * Routes through `LlmServiceManager::chatWithConfiguration()` so the
+     * configuration's `system_prompt`, model, provider and skills apply,
+     * while the translation task/constraints are layered into the user
+     * message. Mirrors `chatWithToolsForConfiguration`/`embedForConfiguration`.
+     *
+     * @param string|null $sourceLanguage ISO 639-1 code, or null for auto-detection
+     *
+     * @throws InvalidArgumentException when input is empty or a language code is invalid
+     */
+    public function translateForConfiguration(
+        string $text,
+        string $targetLanguage,
+        LlmConfiguration $configuration,
+        ?string $sourceLanguage = null,
+        ?TranslationOptions $options = null,
+    ): TranslationResult;
+
+    /**
      * Translate multiple texts using the LLM-based path. Empty input returns `[]`.
      *
      * @param array<int, string> $texts
@@ -79,7 +100,7 @@ interface TranslationServiceInterface
     ): float;
 
     /**
-     * Translate via a specialized translator (DeepL etc.) resolved from options/preset/default.
+     * Translate via a specialized translator (DeepL etc.) resolved from options/configuration/default.
      *
      * @throws InvalidArgumentException when input is empty or language code invalid
      */

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -32,6 +32,7 @@ class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsIn
         private ?int $maxTokens = null,
         private ?string $provider = null,
         private ?string $model = null,
+        private ?string $configuration = null,
         ?int $beUserUid = null,
         ?float $plannedCost = null,
     ) {
@@ -192,6 +193,18 @@ class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsIn
         return $clone;
     }
 
+    /**
+     * Pin a stored LlmConfiguration by identifier. On the specialized-translator
+     * path (`translateWithTranslator()`), the translator bound to that
+     * configuration (`LlmConfiguration::getTranslator()`) is used when set.
+     */
+    public function withConfiguration(string $configuration): static
+    {
+        $clone = clone $this;
+        $clone->configuration = $configuration;
+        return $clone;
+    }
+
     // Budget pre-flight setters provided by `BudgetFieldsTrait`.
 
     // ========================================
@@ -246,6 +259,11 @@ class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsIn
         return $this->model;
     }
 
+    public function getConfiguration(): ?string
+    {
+        return $this->configuration;
+    }
+
     // Budget pre-flight getters provided by `BudgetFieldsTrait`.
 
     // ========================================
@@ -264,6 +282,7 @@ class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsIn
             'max_tokens' => $this->maxTokens,
             'provider' => $this->provider,
             'model' => $this->model,
+            'configuration' => $this->configuration,
         ]);
     }
 

--- a/Documentation/Api/TranslationService.rst
+++ b/Documentation/Api/TranslationService.rst
@@ -32,6 +32,49 @@ TranslationService
         'marketing', 'general'
       - ``glossary``: array of term translations
       - ``preserve_formatting``: bool
+      - ``provider``, ``model``: pin the provider /
+        model for this call
+      - ``configuration``: identifier of a stored
+        ``LlmConfiguration`` whose translator is used on
+        the specialized-translator path
+        (``translateWithTranslator()``)
+
+   .. php:method:: translateForConfiguration(string $text, string $targetLanguage, LlmConfiguration $configuration, ?string $sourceLanguage = null, ?TranslationOptions $options = null): TranslationResult
+
+      Translate with a stored ``LlmConfiguration``'s
+      persona/tone.
+
+      Unlike :php:meth:`translate`, this routes through
+      ``LlmServiceManager::chatWithConfiguration()`` so the
+      configuration's stored ``system_prompt``, model,
+      provider and skills apply. ``translate()`` supplies
+      its own system message and therefore short-circuits
+      ``MessageShaper::applySystemPrompt()``, so a
+      configuration's ``system_prompt`` never reaches the
+      model on that path. Here the translation task and
+      constraints (target/source language, formality,
+      glossary, "output only the translation") are layered
+      into the **user** message instead, keeping the
+      configuration's ``system_prompt`` as the system
+      message.
+
+      Mirrors ``chatWithToolsForConfiguration()`` and
+      ``embedForConfiguration()``.
+
+      :param string $text: Text to translate
+      :param string $targetLanguage: Target language
+         code (e.g., 'de', 'fr')
+      :param LlmConfiguration $configuration: The
+         configuration whose persona/model drive the call
+      :param string|null $sourceLanguage: Source
+         language code (auto-detected if null)
+      :param TranslationOptions|null $options:
+         Translation options; ``temperature``,
+         ``max_tokens`` and ``model`` override the
+         configuration's stored defaults when set. The
+         ``provider`` field is ignored — the configuration
+         selects the provider.
+      :returns: TranslationResult
 
    .. php:method:: translateBatch(array $texts, string $targetLanguage, ?string $sourceLanguage = null, ?TranslationOptions $options = null): array
 
@@ -66,3 +109,39 @@ TranslationService
       :param TranslationOptions|null $options:
          Translation options
       :returns: float Quality score (0.0 to 1.0)
+
+.. _api-translation-service-configuration-recipe:
+
+Editor localization menu: translate with a chosen configuration
+===============================================================
+
+An editor localization menu that lets the user pick between
+configurations with different tones/prompts resolves the chosen
+``LlmConfiguration`` and hands it to
+:php:meth:`TranslationService::translateForConfiguration` — the
+configuration's ``system_prompt`` (persona/tone) and model then drive
+the call, while the translation task itself is layered in automatically.
+
+.. code-block:: php
+
+   use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+   use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
+
+   public function __construct(
+       private readonly TranslationServiceInterface $translationService,
+       private readonly LlmConfigurationServiceInterface $configurationService,
+   ) {}
+
+   // 1. Offer the configurations the current backend user may use.
+   $choices = $this->configurationService->getAccessibleConfigurations();
+
+   // 2. Resolve the one the editor selected in the menu.
+   $configuration = $this->configurationService->getConfiguration($selectedIdentifier);
+
+   // 3. Translate with that configuration's persona/tone and model.
+   $result = $this->translationService->translateForConfiguration(
+       $text,
+       'de',
+       $configuration,
+       // $sourceLanguage: null => auto-detected
+   );

--- a/Tests/Unit/Service/Feature/TranslationPromptBuilderTest.php
+++ b/Tests/Unit/Service/Feature/TranslationPromptBuilderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
+
+use Netresearch\NrLlm\Service\Feature\TranslationPromptBuilder;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(TranslationPromptBuilder::class)]
+class TranslationPromptBuilderTest extends AbstractUnitTestCase
+{
+    private TranslationPromptBuilder $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new TranslationPromptBuilder();
+    }
+
+    /**
+     * Invoke build() with a fully-controlled raw options array and return
+     * the ['system', 'user'] strings.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array{system: string, user: string}
+     */
+    private function invokeBuildPrompt(string $text, string $source, string $target, array $options): array
+    {
+        $prompt = $this->subject->build($text, $source, $target, $options);
+
+        $system = $prompt['system'] ?? null;
+        $user = $prompt['user'] ?? null;
+        self::assertIsString($system);
+        self::assertIsString($user);
+
+        return ['system' => $system, 'user' => $user];
+    }
+
+    #[Test]
+    public function buildTranslationPromptRendersMinimalPrompt(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello World', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+            'glossary' => [],
+            'context' => '',
+            'preserve_formatting' => true,
+        ]);
+
+        $system = $prompt['system'];
+        // Domain + language-name resolution (en -> English, de -> German).
+        self::assertStringContainsString(
+            'You are a professional general translator. Translate the following text from English to German.',
+            $system,
+        );
+        // formality 'default' => no tone line.
+        self::assertStringNotContainsString('Maintain', $system);
+        // preserve_formatting true => formatting line present.
+        self::assertStringContainsString(
+            'Preserve all formatting, HTML tags, markdown, and special characters.',
+            $system,
+        );
+        // Empty glossary / context => their sections are absent.
+        self::assertStringNotContainsString('Use these exact term translations:', $system);
+        self::assertStringNotContainsString('Context (for reference only):', $system);
+        // Trailing instruction is appended, not replacing the prompt.
+        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
+
+        self::assertSame("Translate this text:\n\nHello World", $prompt['user']);
+    }
+
+    #[Test]
+    public function buildTranslationPromptDefaultsPreserveFormattingToTrueWhenKeyAbsent(): void
+    {
+        // No 'preserve_formatting' key => the `?? true` default applies.
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+        ]);
+
+        self::assertStringContainsString(
+            'Preserve all formatting, HTML tags, markdown, and special characters.',
+            $prompt['system'],
+        );
+    }
+
+    #[Test]
+    public function buildTranslationPromptOmitsFormattingLineWhenPreserveFormattingFalse(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'default',
+            'domain' => 'general',
+            'preserve_formatting' => false,
+        ]);
+
+        self::assertStringNotContainsString('Preserve all formatting', $prompt['system']);
+    }
+
+    #[Test]
+    public function buildTranslationPromptRendersAllSectionsWithFullOptions(): void
+    {
+        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
+            'formality' => 'formal',
+            'domain' => 'legal',
+            'glossary' => [
+                'Hello' => 'Hallo',   // string value
+                'count' => 5,         // int value
+                'ratio' => 1.5,       // float value
+                'bad' => ['x'],       // non-scalar => filtered out
+            ],
+            'context' => 'Software docs',
+            'preserve_formatting' => false,
+        ]);
+
+        $system = $prompt['system'];
+
+        // Intro must survive every section append (guards against `.=` -> `=`).
+        self::assertStringContainsString(
+            'You are a professional legal translator. Translate the following text from English to German.',
+            $system,
+        );
+        // formality 'formal' => tone line.
+        self::assertStringContainsString('Maintain formal tone.', $system);
+        // preserve false => no formatting line.
+        self::assertStringNotContainsString('Preserve all formatting', $system);
+        // Glossary header + one line per scalar term.
+        self::assertStringContainsString('Use these exact term translations:', $system);
+        self::assertStringContainsString('- Hello → Hallo', $system);
+        self::assertStringContainsString('- count → 5', $system);
+        self::assertStringContainsString('- ratio → 1.5', $system);
+        // Non-scalar glossary value is filtered out entirely.
+        self::assertStringNotContainsString('- bad', $system);
+        // Context section rendered.
+        self::assertStringContainsString("Context (for reference only):\nSoftware docs", $system);
+        // Closing instruction still appended.
+        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
+    }
+
+    #[Test]
+    public function buildTranslationPromptResolvesKnownLanguageNames(): void
+    {
+        // getLanguageName maps known codes; an unknown code falls back to itself.
+        $prompt = $this->invokeBuildPrompt('Hi', 'fr', 'zz', [
+            'formality' => 'default',
+            'domain' => 'general',
+        ]);
+
+        self::assertStringContainsString('from French to zz.', $prompt['system']);
+    }
+}

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\Feature\TranslationService;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
@@ -853,7 +854,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function resolveTranslatorUsesPresetTranslatorWhenConfigurationFound(): void
+    public function resolveTranslatorUsesConfigurationTranslatorWhenConfigurationFound(): void
     {
         $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
@@ -863,7 +864,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $configServiceMock
             ->expects(self::once())->method('getConfiguration')
-            ->with('my-preset')
+            ->with('my-config')
             ->willReturn($configurationStub);
 
         $translatorStub = self::createStub(TranslatorInterface::class);
@@ -882,13 +883,13 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $reflection = new ReflectionClass($subject);
         $method = $reflection->getMethod('resolveTranslator');
-        $result = $method->invoke($subject, ['preset' => 'my-preset']);
+        $result = $method->invoke($subject, ['configuration' => 'my-config']);
 
         self::assertSame($translatorStub, $result);
     }
 
     #[Test]
-    public function resolveTranslatorFallsBackToLlmWhenPresetConfigurationNotFound(): void
+    public function resolveTranslatorFallsBackToLlmWhenConfigurationNotFound(): void
     {
         $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
@@ -913,13 +914,13 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $reflection = new ReflectionClass($subject);
         $method = $reflection->getMethod('resolveTranslator');
-        $result = $method->invoke($subject, ['preset' => 'missing-preset']);
+        $result = $method->invoke($subject, ['configuration' => 'missing-config']);
 
         self::assertSame($translatorStub, $result);
     }
 
     #[Test]
-    public function resolveTranslatorFallsBackToLlmWhenPresetHasNoTranslator(): void
+    public function resolveTranslatorFallsBackToLlmWhenConfigurationHasNoTranslator(): void
     {
         $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
@@ -948,7 +949,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $reflection = new ReflectionClass($subject);
         $method = $reflection->getMethod('resolveTranslator');
-        $result = $method->invoke($subject, ['preset' => 'preset-without-translator']);
+        $result = $method->invoke($subject, ['configuration' => 'config-without-translator']);
 
         self::assertSame($translatorStub, $result);
     }
@@ -1520,11 +1521,11 @@ class TranslationServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function resolveTranslatorSkipsPresetLookupForEmptyPresetString(): void
+    public function resolveTranslatorSkipsConfigurationLookupForEmptyConfigurationString(): void
     {
-        // preset === '' must NOT trigger a configuration lookup: the guard is
-        // `is_string($preset) && $preset !== ''`. Swapping && for || would enter
-        // the branch and call getConfiguration('').
+        // configuration === '' must NOT trigger a lookup: the guard is
+        // `is_string($configurationIdentifier) && $configurationIdentifier !== ''`.
+        // Swapping && for || would enter the branch and call getConfiguration('').
         $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
         $configServiceMock
             ->expects(self::never())
@@ -1546,7 +1547,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
 
         $reflection = new ReflectionClass($subject);
         $method = $reflection->getMethod('resolveTranslator');
-        $result = $method->invoke($subject, ['preset' => '']);
+        $result = $method->invoke($subject, ['configuration' => '']);
 
         self::assertSame($translatorStub, $result);
     }
@@ -1661,5 +1662,404 @@ class TranslationServiceTest extends AbstractUnitTestCase
         ]);
 
         self::assertStringContainsString('from French to zz.', $prompt['system']);
+    }
+
+    // ==================== #429: configured model reaches ChatOptions ====================
+
+    #[Test]
+    public function translateForwardsConfiguredModelOntoChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            'Hallo',
+            static fn(TranslationService $subject): object => $subject->translate(
+                'Hello',
+                'de',
+                'en',
+                new TranslationOptions(model: 'gpt-5.2-mini'),
+            ),
+        );
+
+        self::assertSame('gpt-5.2-mini', $captured['options']->getModel());
+    }
+
+    #[Test]
+    public function detectLanguageForwardsConfiguredModelOntoChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            'fr',
+            static fn(TranslationService $subject): string => $subject->detectLanguage(
+                'Bonjour',
+                new TranslationOptions(model: 'gpt-5.2-mini'),
+            ),
+        );
+
+        self::assertSame('gpt-5.2-mini', $captured['options']->getModel());
+    }
+
+    #[Test]
+    public function scoreTranslationQualityForwardsConfiguredModelOntoChatOptions(): void
+    {
+        $captured = $this->captureSingleChat(
+            '0.9',
+            static fn(TranslationService $subject): float => $subject->scoreTranslationQuality(
+                'Hello',
+                'Hallo',
+                'de',
+                new TranslationOptions(model: 'gpt-5.2-mini'),
+            ),
+        );
+
+        self::assertSame('gpt-5.2-mini', $captured['options']->getModel());
+    }
+
+    // ==================== #428: translateForConfiguration ====================
+
+    /**
+     * Capture the arguments handed to LlmServiceManager::chatWithConfiguration().
+     *
+     * @param Closure(TranslationService): mixed $call
+     *
+     * @return array{messages: array<array-key, mixed>, configuration: LlmConfiguration, metadata: array<array-key, mixed>, overrides: array<array-key, mixed>}
+     */
+    private function captureChatWithConfiguration(
+        string $responseContent,
+        Closure $call,
+        ?BackendUserContextResolverInterface $resolver = null,
+    ): array {
+        /** @var array<array-key, mixed> $capturedMessages */
+        $capturedMessages = [];
+        $capturedConfiguration = null;
+        /** @var array<string, mixed> $capturedMetadata */
+        $capturedMetadata = [];
+        /** @var array<string, mixed> $capturedOverrides */
+        $capturedOverrides = [];
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        // detectLanguage() (auto-detection) routes through chat(); default stub
+        // return keeps that sub-call alive when a test omits the source language.
+        $llmManagerMock
+            ->method('chat')
+            ->willReturn($this->createChatResponse('en'));
+        $llmManagerMock
+            ->method('chatWithConfiguration')
+            ->willReturnCallback(
+                /**
+                 * @param array<array-key, mixed> $messages
+                 * @param array<string, mixed>    $metadata
+                 * @param array<string, mixed>    $optionOverrides
+                 */
+                function (
+                    array $messages,
+                    LlmConfiguration $configuration,
+                    array $metadata = [],
+                    array $optionOverrides = [],
+                ) use (
+                    &$capturedMessages,
+                    &$capturedConfiguration,
+                    &$capturedMetadata,
+                    &$capturedOverrides,
+                    $responseContent,
+                ): CompletionResponse {
+                    $capturedMessages = $messages;
+                    $capturedConfiguration = $configuration;
+                    $capturedMetadata = $metadata;
+                    $capturedOverrides = $optionOverrides;
+
+                    return $this->createChatResponse($responseContent);
+                },
+            );
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            $resolver,
+        );
+
+        $call($subject);
+
+        self::assertInstanceOf(LlmConfiguration::class, $capturedConfiguration);
+
+        return [
+            'messages' => $capturedMessages,
+            'configuration' => $capturedConfiguration,
+            'metadata' => $capturedMetadata,
+            'overrides' => $capturedOverrides,
+        ];
+    }
+
+    #[Test]
+    public function translateForConfigurationRoutesThroughChatWithConfiguration(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo Welt',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello World',
+                'de',
+                $configuration,
+                'en',
+            ),
+        );
+
+        self::assertSame($configuration, $captured['configuration']);
+    }
+
+    #[Test]
+    public function translateForConfigurationReturnsTranslationResult(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createChatResponse('Hallo Welt'));
+        $llmManagerMock
+            ->expects(self::never())
+            ->method('chat');
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+        );
+
+        $result = $subject->translateForConfiguration('Hello World', 'de', $configuration, 'en');
+
+        self::assertSame('Hallo Welt', $result->translation);
+        self::assertSame('en', $result->sourceLanguage);
+        self::assertSame('de', $result->targetLanguage);
+        self::assertSame(0.9, $result->confidence);
+    }
+
+    #[Test]
+    public function translateForConfigurationSendsNoSystemMessageSoConfigurationPromptSurvives(): void
+    {
+        // The whole point of #428: no system message is sent, so
+        // MessageShaper::applySystemPrompt() keeps the configuration's
+        // stored system_prompt as the system message. A single USER
+        // message carries the translation task/constraints instead.
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo Welt',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello World',
+                'de',
+                $configuration,
+                'en',
+                new TranslationOptions(formality: 'formal', glossary: ['Hello' => 'Hallo']),
+            ),
+        );
+
+        $messages = $captured['messages'];
+        self::assertCount(1, $messages);
+
+        $user = $messages[0];
+        self::assertInstanceOf(ChatMessage::class, $user);
+        self::assertTrue($user->isUser());
+        self::assertFalse($user->isSystem());
+
+        // Task + constraints reach the model through the user message.
+        self::assertStringContainsString('from English to German', $user->content);
+        self::assertStringContainsString('Maintain formal tone.', $user->content);
+        self::assertStringContainsString('- Hello → Hallo', $user->content);
+        self::assertStringContainsString('Provide ONLY the translation', $user->content);
+        self::assertStringContainsString('Hello World', $user->content);
+    }
+
+    #[Test]
+    public function translateForConfigurationForwardsGenerationOverridesButNotProvider(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello',
+                'de',
+                $configuration,
+                'en',
+                new TranslationOptions(
+                    temperature: 0.4,
+                    maxTokens: 1234,
+                    provider: 'claude',
+                    model: 'claude-x',
+                ),
+            ),
+        );
+
+        $overrides = $captured['overrides'];
+        self::assertSame(0.4, $overrides['temperature'] ?? null);
+        self::assertSame(1234, $overrides['max_tokens'] ?? null);
+        self::assertSame('claude-x', $overrides['model'] ?? null);
+        // The configuration selects the provider; a provider option must NOT override it.
+        self::assertArrayNotHasKey('provider', $overrides);
+    }
+
+    #[Test]
+    public function translateForConfigurationOmitsOverridesWhenOptionsAreDefault(): void
+    {
+        // No generation knobs set => the configuration's stored defaults apply
+        // (empty overrides), rather than translate()'s 0.3/2000 fallbacks.
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello',
+                'de',
+                $configuration,
+                'en',
+            ),
+        );
+
+        self::assertSame([], $captured['overrides']);
+    }
+
+    #[Test]
+    public function translateForConfigurationForwardsResolvedBeUserUidAsMetadata(): void
+    {
+        $resolver = $this->createMock(BackendUserContextResolverInterface::class);
+        $resolver->method('resolveBeUserUid')->willReturn(42);
+
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello',
+                'de',
+                $configuration,
+                'en',
+            ),
+            $resolver,
+        );
+
+        self::assertSame(42, $captured['metadata'][BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
+    }
+
+    #[Test]
+    public function translateForConfigurationForwardsExplicitBudgetFieldsAsMetadata(): void
+    {
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $captured = $this->captureChatWithConfiguration(
+            'Hallo',
+            static fn(TranslationService $subject): object => $subject->translateForConfiguration(
+                'Hello',
+                'de',
+                $configuration,
+                'en',
+                (new TranslationOptions())->withBeUserUid(99)->withPlannedCost(0.05),
+            ),
+        );
+
+        self::assertSame(99, $captured['metadata'][BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
+        self::assertSame(0.05, $captured['metadata'][BudgetMiddleware::METADATA_PLANNED_COST] ?? null);
+    }
+
+    #[Test]
+    public function translateForConfigurationAutoDetectsSourceLanguageViaChat(): void
+    {
+        // Source omitted => detectLanguage() runs first (through chat()),
+        // then the translation runs through chatWithConfiguration().
+        $configuration = self::createStub(LlmConfiguration::class);
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chat')
+            ->willReturn($this->createChatResponse('fr'));
+        $llmManagerMock
+            ->expects(self::once())
+            ->method('chatWithConfiguration')
+            ->willReturn($this->createChatResponse('Hallo'));
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+        );
+
+        $result = $subject->translateForConfiguration('Bonjour', 'de', $configuration);
+
+        self::assertSame('fr', $result->sourceLanguage);
+    }
+
+    #[Test]
+    public function translateForConfigurationThrowsOnEmptyText(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1719410501);
+
+        $this->subject->translateForConfiguration('', 'de', self::createStub(LlmConfiguration::class), 'en');
+    }
+
+    #[Test]
+    public function translateForConfigurationThrowsOnInvalidTargetLanguageCode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(8727807751);
+
+        $this->subject->translateForConfiguration('Hello', 'invalid', self::createStub(LlmConfiguration::class), 'en');
+    }
+
+    #[Test]
+    public function translateForConfigurationThrowsOnInvalidSourceLanguageCode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(8727807751);
+
+        $this->subject->translateForConfiguration('Hello', 'de', self::createStub(LlmConfiguration::class), 'invalid');
+    }
+
+    // ==================== #430: configuration-selected translator ====================
+
+    #[Test]
+    public function translateWithTranslatorUsesConfigurationTranslatorFromOptions(): void
+    {
+        // End-to-end reachability of the resolveTranslator() configuration
+        // branch through the public API: an options `configuration` now emits
+        // the key that resolveTranslator() reads (previously an unreachable
+        // `preset` branch, #430).
+        $configurationStub = self::createStub(LlmConfiguration::class);
+        $configurationStub->method('getTranslator')->willReturn('deepl');
+
+        $configServiceMock = $this->createMock(LlmConfigurationServiceInterface::class);
+        $configServiceMock
+            ->expects(self::once())
+            ->method('getConfiguration')
+            ->with('editorial')
+            ->willReturn($configurationStub);
+
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->method('translate')
+            ->willReturn(new TranslatorResult('Hallo Welt', 'en', 'de', 'deepl'));
+
+        $translatorRegistryMock = $this->createMock(TranslatorRegistryInterface::class);
+        $translatorRegistryMock
+            ->expects(self::once())
+            ->method('get')
+            ->with('deepl')
+            ->willReturn($translatorMock);
+
+        $subject = new TranslationService(
+            $this->llmManagerStub,
+            $translatorRegistryMock,
+            $configServiceMock,
+        );
+
+        $result = $subject->translateWithTranslator(
+            'Hello World',
+            'de',
+            'en',
+            (new TranslationOptions())->withConfiguration('editorial'),
+        );
+
+        self::assertSame('deepl', $result->translator);
     }
 }

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\Feature\TranslationPromptBuilder;
 use Netresearch\NrLlm\Service\Feature\TranslationService;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -55,6 +56,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
     }
 
@@ -128,6 +130,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $result = $subject->translate('Hello', 'de');
@@ -299,6 +302,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $result = $subject->translateBatch(['One', 'Two', 'Three'], 'de', 'en');
@@ -652,6 +656,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $options = new TranslationOptions(formality: 'formal');
@@ -879,6 +884,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $translatorRegistryMock,
             $configServiceMock,
+            new TranslationPromptBuilder(),
         );
 
         $reflection = new ReflectionClass($subject);
@@ -910,6 +916,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $translatorRegistryMock,
             $configServiceMock,
+            new TranslationPromptBuilder(),
         );
 
         $reflection = new ReflectionClass($subject);
@@ -945,6 +952,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $translatorRegistryMock,
             $configServiceMock,
+            new TranslationPromptBuilder(),
         );
 
         $reflection = new ReflectionClass($subject);
@@ -986,6 +994,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $options = new TranslationOptions(formality: 'informal');
@@ -1072,6 +1081,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1100,6 +1110,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1133,6 +1144,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1161,6 +1173,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1223,6 +1236,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1345,6 +1359,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $call($subject);
@@ -1352,29 +1367,6 @@ class TranslationServiceTest extends AbstractUnitTestCase
         self::assertInstanceOf(ChatOptions::class, $capturedOptions);
 
         return ['messages' => $capturedMessages, 'options' => $capturedOptions];
-    }
-
-    /**
-     * Invoke the private buildTranslationPrompt() with a fully-controlled raw
-     * options array and return the ['system', 'user'] strings.
-     *
-     * @param array<string, mixed> $options
-     *
-     * @return array{system: string, user: string}
-     */
-    private function invokeBuildPrompt(string $text, string $source, string $target, array $options): array
-    {
-        $reflection = new ReflectionClass($this->subject);
-        $method = $reflection->getMethod('buildTranslationPrompt');
-        $prompt = $method->invoke($this->subject, $text, $source, $target, $options);
-
-        self::assertIsArray($prompt);
-        $system = $prompt['system'] ?? null;
-        $user = $prompt['user'] ?? null;
-        self::assertIsString($system);
-        self::assertIsString($user);
-
-        return ['system' => $system, 'user' => $user];
     }
 
     #[Test]
@@ -1543,6 +1535,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $translatorRegistryMock,
             $configServiceMock,
+            new TranslationPromptBuilder(),
         );
 
         $reflection = new ReflectionClass($subject);
@@ -1550,118 +1543,6 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $result = $method->invoke($subject, ['configuration' => '']);
 
         self::assertSame($translatorStub, $result);
-    }
-
-    #[Test]
-    public function buildTranslationPromptRendersMinimalPrompt(): void
-    {
-        $prompt = $this->invokeBuildPrompt('Hello World', 'en', 'de', [
-            'formality' => 'default',
-            'domain' => 'general',
-            'glossary' => [],
-            'context' => '',
-            'preserve_formatting' => true,
-        ]);
-
-        $system = $prompt['system'];
-        // Domain + language-name resolution (en -> English, de -> German).
-        self::assertStringContainsString(
-            'You are a professional general translator. Translate the following text from English to German.',
-            $system,
-        );
-        // formality 'default' => no tone line.
-        self::assertStringNotContainsString('Maintain', $system);
-        // preserve_formatting true => formatting line present.
-        self::assertStringContainsString(
-            'Preserve all formatting, HTML tags, markdown, and special characters.',
-            $system,
-        );
-        // Empty glossary / context => their sections are absent.
-        self::assertStringNotContainsString('Use these exact term translations:', $system);
-        self::assertStringNotContainsString('Context (for reference only):', $system);
-        // Trailing instruction is appended, not replacing the prompt.
-        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
-
-        self::assertSame("Translate this text:\n\nHello World", $prompt['user']);
-    }
-
-    #[Test]
-    public function buildTranslationPromptDefaultsPreserveFormattingToTrueWhenKeyAbsent(): void
-    {
-        // No 'preserve_formatting' key => the `?? true` default applies.
-        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
-            'formality' => 'default',
-            'domain' => 'general',
-        ]);
-
-        self::assertStringContainsString(
-            'Preserve all formatting, HTML tags, markdown, and special characters.',
-            $prompt['system'],
-        );
-    }
-
-    #[Test]
-    public function buildTranslationPromptOmitsFormattingLineWhenPreserveFormattingFalse(): void
-    {
-        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
-            'formality' => 'default',
-            'domain' => 'general',
-            'preserve_formatting' => false,
-        ]);
-
-        self::assertStringNotContainsString('Preserve all formatting', $prompt['system']);
-    }
-
-    #[Test]
-    public function buildTranslationPromptRendersAllSectionsWithFullOptions(): void
-    {
-        $prompt = $this->invokeBuildPrompt('Hello', 'en', 'de', [
-            'formality' => 'formal',
-            'domain' => 'legal',
-            'glossary' => [
-                'Hello' => 'Hallo',   // string value
-                'count' => 5,         // int value
-                'ratio' => 1.5,       // float value
-                'bad' => ['x'],       // non-scalar => filtered out
-            ],
-            'context' => 'Software docs',
-            'preserve_formatting' => false,
-        ]);
-
-        $system = $prompt['system'];
-
-        // Intro must survive every section append (guards against `.=` -> `=`).
-        self::assertStringContainsString(
-            'You are a professional legal translator. Translate the following text from English to German.',
-            $system,
-        );
-        // formality 'formal' => tone line.
-        self::assertStringContainsString('Maintain formal tone.', $system);
-        // preserve false => no formatting line.
-        self::assertStringNotContainsString('Preserve all formatting', $system);
-        // Glossary header + one line per scalar term.
-        self::assertStringContainsString('Use these exact term translations:', $system);
-        self::assertStringContainsString('- Hello → Hallo', $system);
-        self::assertStringContainsString('- count → 5', $system);
-        self::assertStringContainsString('- ratio → 1.5', $system);
-        // Non-scalar glossary value is filtered out entirely.
-        self::assertStringNotContainsString('- bad', $system);
-        // Context section rendered.
-        self::assertStringContainsString("Context (for reference only):\nSoftware docs", $system);
-        // Closing instruction still appended.
-        self::assertStringContainsString('Provide ONLY the translation, no explanations or notes.', $system);
-    }
-
-    #[Test]
-    public function buildTranslationPromptResolvesKnownLanguageNames(): void
-    {
-        // getLanguageName maps known codes; an unknown code falls back to itself.
-        $prompt = $this->invokeBuildPrompt('Hi', 'fr', 'zz', [
-            'formality' => 'default',
-            'domain' => 'general',
-        ]);
-
-        self::assertStringContainsString('from French to zz.', $prompt['system']);
     }
 
     // ==================== #429: configured model reaches ChatOptions ====================
@@ -1773,6 +1654,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
             $resolver,
         );
 
@@ -1824,6 +1706,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $result = $subject->translateForConfiguration('Hello World', 'de', $configuration, 'en');
@@ -1982,6 +1865,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $llmManagerMock,
             $this->translatorRegistryMock,
             $this->configServiceStub,
+            new TranslationPromptBuilder(),
         );
 
         $result = $subject->translateForConfiguration('Bonjour', 'de', $configuration);
@@ -2051,6 +1935,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             $this->llmManagerStub,
             $translatorRegistryMock,
             $configServiceMock,
+            new TranslationPromptBuilder(),
         );
 
         $result = $subject->translateWithTranslator(

--- a/Tests/Unit/Service/Option/TranslationOptionsTest.php
+++ b/Tests/Unit/Service/Option/TranslationOptionsTest.php
@@ -357,6 +357,18 @@ class TranslationOptionsTest extends AbstractUnitTestCase
         self::assertEquals('model2', $options2->getModel());
     }
 
+    #[Test]
+    public function withConfigurationReturnsNewInstanceAndIsEmittedInArray(): void
+    {
+        $options1 = new TranslationOptions();
+        $options2 = $options1->withConfiguration('editorial');
+
+        self::assertNull($options1->getConfiguration());
+        self::assertEquals('editorial', $options2->getConfiguration());
+        self::assertArrayNotHasKey('configuration', $options1->toArray());
+        self::assertSame('editorial', $options2->toArray()['configuration'] ?? null);
+    }
+
     // Array Conversion
 
     #[Test]


### PR DESCRIPTION
From discussion #422. Three tightly-coupled translation fixes on one branch.

## #429 — configured model was dropped
`translate()`, `detectLanguage()` and `scoreTranslationQuality()` built `ChatOptions` forwarding `provider` but not `model`, so `TranslationOptions::getModel()` was ignored on the LLM path. Now forwarded on all three, with tests capturing the dispatched `ChatOptions`.

## #428 — translate with an LlmConfiguration
New `translateForConfiguration(string $text, string $targetLanguage, LlmConfiguration $configuration, ?string $sourceLanguage = null, ?TranslationOptions $options = null): TranslationResult` on the interface and service. Routes through `chatWithConfiguration()` so the configuration's `system_prompt`, model, provider and skills apply.

Prompt composition: the configuration's `system_prompt` stays the system message (persona/tone). The translation task + constraints (target/source language, formality, glossary, preserve-formatting, "output only the translation") are folded into the **user** message. A second system message would re-trigger `MessageShaper::applySystemPrompt()`'s "already has a system message" short-circuit and drop the configuration's prompt — the exact reason plain `translate()` can't use a configuration.

Attribution (beUserUid/ADR-052) and usage tracking are preserved. Documented in `Documentation/Api/TranslationService.rst` incl. the editor-menu recipe (getAccessibleConfigurations → getConfiguration → translateForConfiguration).

## #430 — unreachable preset branch in resolveTranslator()
The branch read `$options['preset']`, a key `TranslationOptions::toArray()` never emitted. Made reachable rather than removed: added a nullable `configuration` field to `TranslationOptions` and rewired the branch to it. A configuration selected this way uses the translator pinned on that `LlmConfiguration` (`getTranslator()`) on the specialized-translator path.

## Notes
- Public surface unchanged: a new method on the already-public `TranslationServiceInterface` adds no `public: true` entry; `PublicServicesPolicyTest` (30) unaffected.
- Source-language auto-detection on the per-configuration path uses the options' provider, not the configuration (documented on the method); pass an explicit `$sourceLanguage` to keep the whole call on the chosen configuration.

## Gates
unit (5094), phpstan L10, cgl, rector — green locally. Reviewed for message-composition correctness and public-surface/tests; only doc/guard nits, applied.
