### PR TITLE
feat(provider): typed 401/429 exceptions (ADR-080)

### DIFF
--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -57,6 +57,8 @@
             <file>../Classes/Provider/Exception/ProviderConnectionException.php</file>
             <file>../Classes/Provider/Exception/ProviderConfigurationException.php</file>
             <file>../Classes/Provider/Exception/ProviderResponseException.php</file>
+            <file>../Classes/Provider/Exception/ProviderAuthenticationException.php</file>
+            <file>../Classes/Provider/Exception/ProviderRateLimitException.php</file>
             <file>../Classes/Provider/Exception/UnsupportedFeatureException.php</file>
             <file>../Classes/Specialized/Exception/ImageGenerationException.php</file>
             <file>../Classes/Specialized/Exception/SpeechServiceException.php</file>

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -14,8 +14,10 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -416,11 +418,11 @@ abstract class AbstractProvider implements ProviderInterface
             $body = (string)$response->getBody();
             $decoded = json_decode($body, true);
             $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => self::UNKNOWN_ERROR]];
-            throw new ProviderResponseException(
-                message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
-                httpStatus: $statusCode,
-                responseBody: $body,
-                endpoint: $endpoint,
+            throw $this->clientErrorException(
+                $statusCode,
+                $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
+                $body,
+                $endpoint,
             );
         }
 
@@ -547,11 +549,11 @@ abstract class AbstractProvider implements ProviderInterface
         if ($statusCode >= 400 && $statusCode < 500) {
             $decoded = json_decode($body, true);
             $error = is_array($decoded) ? $this->asArray($decoded) : ['error' => ['message' => self::UNKNOWN_ERROR]];
-            throw new ProviderResponseException(
-                message: $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
-                httpStatus: $statusCode,
-                responseBody: $body,
-                endpoint: $endpoint,
+            throw $this->clientErrorException(
+                $statusCode,
+                $this->sanitizeErrorMessage($this->extractErrorMessage($error)),
+                $body,
+                $endpoint,
             );
         }
 
@@ -559,6 +561,24 @@ abstract class AbstractProvider implements ProviderInterface
             sprintf('Server returned status %d', $statusCode),
             $statusCode,
         );
+    }
+
+    /**
+     * Map a 4xx client-error status to the most specific
+     * {@see ProviderResponseException} subclass — 401 →
+     * {@see ProviderAuthenticationException}, 429 →
+     * {@see ProviderRateLimitException}, everything else the base class — so
+     * callers can branch on the exception type (ADR-080). Every result is a
+     * `ProviderResponseException` carrying `httpStatus`, so existing catches and
+     * the `getCode() === 429` middleware keep working.
+     */
+    private function clientErrorException(int $statusCode, string $message, string $responseBody, string $endpoint): ProviderResponseException
+    {
+        return match ($statusCode) {
+            401 => new ProviderAuthenticationException(message: $message, httpStatus: $statusCode, responseBody: $responseBody, endpoint: $endpoint),
+            429 => new ProviderRateLimitException(message: $message, httpStatus: $statusCode, responseBody: $responseBody, endpoint: $endpoint),
+            default => new ProviderResponseException(message: $message, httpStatus: $statusCode, responseBody: $responseBody, endpoint: $endpoint),
+        };
     }
 
     /**

--- a/Classes/Provider/Exception/ProviderAuthenticationException.php
+++ b/Classes/Provider/Exception/ProviderAuthenticationException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Exception;
+
+/**
+ * Thrown when a provider rejects the request with HTTP 401 (invalid or missing
+ * API key / unauthorized).
+ *
+ * A status-specific subclass of {@see ProviderResponseException} (ADR-080) so a
+ * caller can `catch (ProviderAuthenticationException)` instead of inspecting the
+ * message text or the raw `httpStatus`. All typed fields (`httpStatus`,
+ * `responseBody`, `endpoint`) and `getCode() === 401` are inherited unchanged,
+ * so existing `catch (ProviderResponseException)` handlers keep matching.
+ */
+final class ProviderAuthenticationException extends ProviderResponseException {}

--- a/Classes/Provider/Exception/ProviderRateLimitException.php
+++ b/Classes/Provider/Exception/ProviderRateLimitException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Exception;
+
+/**
+ * Thrown when a provider throttles the request with HTTP 429 (rate limit /
+ * quota exceeded).
+ *
+ * A status-specific subclass of {@see ProviderResponseException} (ADR-080) so a
+ * caller can `catch (ProviderRateLimitException)` instead of inspecting the
+ * message text or the raw `httpStatus`. All typed fields (`httpStatus`,
+ * `responseBody`, `endpoint`) are inherited unchanged, and — critically —
+ * `getCode() === 429` is preserved, so the retry/fallback and circuit-breaker
+ * middleware that key off code 429 keep firing.
+ */
+final class ProviderRateLimitException extends ProviderResponseException {}

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -39,8 +39,15 @@ use Throwable;
  * so providers like Gemini (which embed the API key in the URL via
  * `?key=<secret>`) don't accidentally leak credentials through
  * exception logging or telemetry.
+ *
+ * Not `final`: the two status-specific subclasses
+ * {@see ProviderAuthenticationException} (401) and
+ * {@see ProviderRateLimitException} (429) extend this so callers can branch on
+ * the exception class, while `catch (ProviderResponseException)` still catches
+ * every non-2xx decoded response (ADR-080). The constructor and typed fields
+ * are inherited unchanged.
  */
-final class ProviderResponseException extends ProviderException
+class ProviderResponseException extends ProviderException
 {
     public readonly int $httpStatus;
     public readonly string $endpoint;

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -22,8 +22,10 @@ use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Psr\Http\Message\RequestInterface;
 use Throwable;
@@ -926,19 +928,27 @@ final class OpenRouterProvider extends AbstractProvider implements
         $message = $this->sanitizeErrorMessage($rawMessage);
 
         match ($statusCode) {
-            401 => throw new ProviderConfigurationException(
-                'Invalid OpenRouter API key',
-                $statusCode,
+            // 401/429 use the typed HTTP subclasses (ADR-080) for consistency
+            // with AbstractProvider; 402 (billing) and 503 (unavailable) keep
+            // their config/connection classes.
+            401 => throw new ProviderAuthenticationException(
+                message: 'Invalid OpenRouter API key',
+                httpStatus: $statusCode,
+                responseBody: $responseBody,
+                endpoint: $endpoint,
             ),
             402 => throw new ProviderConfigurationException(
                 'Insufficient OpenRouter credits',
                 $statusCode,
             ),
-            429, 503 => throw new ProviderConnectionException(
-                match ($statusCode) {
-                    429 => 'Rate limit exceeded',
-                    503 => 'Model or provider unavailable',
-                },
+            429 => throw new ProviderRateLimitException(
+                message: 'Rate limit exceeded',
+                httpStatus: $statusCode,
+                responseBody: $responseBody,
+                endpoint: $endpoint,
+            ),
+            503 => throw new ProviderConnectionException(
+                'Model or provider unavailable',
                 $statusCode,
             ),
             default => throw new ProviderResponseException(

--- a/Documentation/Adr/Adr080TypedProviderHttpExceptions.rst
+++ b/Documentation/Adr/Adr080TypedProviderHttpExceptions.rst
@@ -1,0 +1,80 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-080:
+
+============================================================================
+ADR-080: Typed provider HTTP exceptions (authentication 401, rate-limit 429)
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-080-context:
+
+Context
+=======
+
+A provider's 4xx responses were all flattened into one class. The standard
+adapter path (`AbstractProvider::handleResponse()` and
+`assertStreamingResponseOk()`) mapped every 4xx — including **401**
+(authentication) and **429** (rate limit) — to a generic
+`ProviderResponseException` carrying the numeric `httpStatus`. A consumer that
+wanted to react differently to "the API key is wrong" versus "we are being
+throttled" (a controller turning either into user-facing copy, a retry policy)
+had to inspect `getCode()`/`$httpStatus` or, worse, re-parse the message string
+— the exact fragile string-matching :ref:`ADR-053 <adr-053>`'s marker interface
+was meant to end.
+
+The mapping was also **inconsistent** across adapters:
+`OpenRouterProvider::handleOpenRouterError()` routed 401 to
+`ProviderConfigurationException` and 429 to `ProviderConnectionException`, so the
+same HTTP status produced a different class on OpenRouter than on the other six
+providers.
+
+.. _adr-080-decision:
+
+Decision
+========
+
+**Introduce two status-specific subclasses of `ProviderResponseException`:**
+`ProviderAuthenticationException` (401) and `ProviderRateLimitException` (429).
+They are empty `final` subclasses — they inherit the constructor and the typed
+`httpStatus` / `responseBody` / `endpoint` fields unchanged. `ProviderResponseException`
+drops its own `final` so it can be extended; it stays otherwise identical.
+
+A private `AbstractProvider::clientErrorException()` factory picks the class from
+the status (401 → authentication, 429 → rate-limit, every other 4xx → the base
+`ProviderResponseException`) and is used by both the buffered and the streaming
+4xx branches, so the two paths never drift. `OpenRouterProvider` is realigned to
+the same 401/429 classes (402 stays `ProviderConfigurationException`, 503 stays
+`ProviderConnectionException`).
+
+**Backward compatibility is preserved by inheritance:**
+
+- ``catch (ProviderResponseException)`` still catches a 401 or 429 — the new
+  classes *are* `ProviderResponseException`.
+- ``catch (ProviderException)`` and ``catch (\Netresearch\NrLlm\Exception\NrLlmExceptionInterface)``
+  are unaffected.
+- ``getCode()`` still returns the HTTP status, so the retry/fallback
+  (`FallbackMiddleware`) and circuit-breaker (`CircuitBreakerMiddleware`) checks
+  that key off ``getCode() === 429`` keep firing for the rate-limit class.
+
+.. _adr-080-consequences:
+
+Consequences
+============
+
+- Consumers branch on the exception class (``catch (ProviderRateLimitException)``)
+  instead of the status code or the message text.
+- **Behaviour change on OpenRouter only:** a 401 is now
+  `ProviderAuthenticationException` (was `ProviderConfigurationException`) and a
+  429 is now `ProviderRateLimitException` (was `ProviderConnectionException`).
+  Both remain `ProviderResponseException`/`ProviderException`, and 429 keeps
+  ``getCode() === 429``, so retry/circuit-breaker semantics are unchanged; only a
+  consumer catching those two *specific* OpenRouter classes sees the more correct
+  type. The realignment is a separate commit in the introducing PR.
+- ``ProviderResponseException`` is no longer `final`; the two shipped subclasses
+  are the only intended extensions.
+- The exceptions carry no `Retry-After` value — none is parsed today; adding it
+  is a separate change.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -377,3 +377,4 @@ Tools
    Adr077NamedConfigurationCompletion
    Adr078SpecializedServiceBudgetEnforcement
    Adr079FirstPartyCompletionVisionBudgetFakes
+   Adr080TypedProviderHttpExceptions

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -15,8 +15,10 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\AbstractProvider;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Provider\GroqProvider;
@@ -475,6 +477,83 @@ class AbstractProviderTest extends AbstractUnitTestCase
         } catch (ProviderResponseException $e) {
             self::assertStringContainsString('key=***', $e->getMessage());
             self::assertStringNotContainsString('sk-secret123', $e->getMessage());
+        }
+    }
+
+    /**
+     * Build an OpenAI provider whose HTTP client returns the given status with a
+     * decodable error body, bypassing the pipeline so `handleResponse()`'s
+     * status-to-exception mapping is exercised directly (ADR-080).
+     */
+    private function openAiProviderReturning(int $statusCode): OpenAiProvider
+    {
+        $provider = new OpenAiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel'     => 'gpt-5.2',
+            'maxRetries'       => 0,
+        ]);
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['error' => ['message' => 'boom']], $statusCode),
+        );
+        $provider->setHttpClient($client);
+
+        return $provider;
+    }
+
+    #[Test]
+    public function status401MapsToProviderAuthenticationException(): void
+    {
+        try {
+            $this->openAiProviderReturning(401)->complete('hello');
+            self::fail('Expected ProviderAuthenticationException was not thrown');
+        } catch (ProviderAuthenticationException $e) {
+            self::assertSame(401, $e->getCode());
+            self::assertSame(401, $e->httpStatus);
+        }
+    }
+
+    #[Test]
+    public function status429MapsToProviderRateLimitException(): void
+    {
+        try {
+            $this->openAiProviderReturning(429)->complete('hello');
+            self::fail('Expected ProviderRateLimitException was not thrown');
+        } catch (ProviderRateLimitException $e) {
+            // getCode() === 429 is the BC anchor for the retry/circuit-breaker middleware.
+            self::assertSame(429, $e->getCode());
+        }
+    }
+
+    #[Test]
+    public function otherClientErrorsStayTheBaseProviderResponseException(): void
+    {
+        try {
+            $this->openAiProviderReturning(403)->complete('hello');
+            self::fail('Expected ProviderResponseException was not thrown');
+        } catch (ProviderResponseException $e) {
+            // The discriminator only fires on 401/429 — 403 stays the base class.
+            self::assertNotInstanceOf(ProviderAuthenticationException::class, $e);
+            self::assertNotInstanceOf(ProviderRateLimitException::class, $e);
+            self::assertSame(403, $e->getCode());
+        }
+    }
+
+    #[Test]
+    public function streamingStatus429MapsToProviderRateLimitException(): void
+    {
+        try {
+            $this->openAiProviderReturning(429)->streamChatCompletion([['role' => 'user', 'content' => 'hi']])->current();
+            self::fail('Expected ProviderRateLimitException was not thrown');
+        } catch (ProviderRateLimitException $e) {
+            self::assertSame(429, $e->getCode());
         }
     }
 

--- a/Tests/Unit/Provider/Exception/ProviderAuthenticationExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderAuthenticationExceptionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Exception;
+
+use Netresearch\NrLlm\Exception\NrLlmExceptionInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Excluded from the coverage source set in `Build/phpunit.xml`; behaviour is
+ * still asserted here (see ProviderResponseExceptionTest for the rationale).
+ */
+#[CoversNothing]
+final class ProviderAuthenticationExceptionTest extends TestCase
+{
+    #[Test]
+    public function isCaughtAsProviderResponseExceptionForBackwardCompatibility(): void
+    {
+        $exception = new ProviderAuthenticationException(message: 'Invalid API key', httpStatus: 401);
+
+        // ADR-080: the typed subclass must remain catchable via every existing arm.
+        self::assertInstanceOf(ProviderResponseException::class, $exception);
+        self::assertInstanceOf(ProviderException::class, $exception);
+        self::assertInstanceOf(NrLlmExceptionInterface::class, $exception);
+    }
+
+    #[Test]
+    public function inheritsTypedFieldsAndStatusAsCode(): void
+    {
+        $exception = new ProviderAuthenticationException(
+            message: 'Invalid API key',
+            httpStatus: 401,
+            responseBody: '{"error":{"message":"Unauthorized"}}',
+            endpoint: 'chat/completions',
+        );
+
+        self::assertSame(401, $exception->httpStatus);
+        self::assertSame(401, $exception->getCode());
+        self::assertSame('{"error":{"message":"Unauthorized"}}', $exception->responseBody);
+        self::assertSame('chat/completions', $exception->endpoint);
+    }
+}

--- a/Tests/Unit/Provider/Exception/ProviderRateLimitExceptionTest.php
+++ b/Tests/Unit/Provider/Exception/ProviderRateLimitExceptionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Exception;
+
+use Netresearch\NrLlm\Exception\NrLlmExceptionInterface;
+use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Excluded from the coverage source set in `Build/phpunit.xml`; behaviour is
+ * still asserted here (see ProviderResponseExceptionTest for the rationale).
+ */
+#[CoversNothing]
+final class ProviderRateLimitExceptionTest extends TestCase
+{
+    #[Test]
+    public function isCaughtAsProviderResponseExceptionForBackwardCompatibility(): void
+    {
+        $exception = new ProviderRateLimitException(message: 'Rate limit exceeded', httpStatus: 429);
+
+        self::assertInstanceOf(ProviderResponseException::class, $exception);
+        self::assertInstanceOf(ProviderException::class, $exception);
+        self::assertInstanceOf(NrLlmExceptionInterface::class, $exception);
+    }
+
+    #[Test]
+    public function preservesCode429SoRetryAndCircuitBreakerMiddlewareStillFire(): void
+    {
+        // ADR-080 BC anchor: FallbackMiddleware and CircuitBreakerMiddleware
+        // key off getCode() === 429. The typed class must keep that code.
+        $exception = new ProviderRateLimitException(
+            message: 'Rate limit exceeded',
+            httpStatus: 429,
+            responseBody: '{"error":{"message":"Too Many Requests"}}',
+            endpoint: 'chat/completions',
+        );
+
+        self::assertSame(429, $exception->getCode());
+        self::assertSame(429, $exception->httpStatus);
+        self::assertSame('{"error":{"message":"Too Many Requests"}}', $exception->responseBody);
+    }
+}

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -15,9 +15,11 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -817,6 +819,38 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $this->expectExceptionMessageMatches("/{$expectedMessage}/");
 
         $this->subject->chatCompletion($messages);
+    }
+
+    #[Test]
+    public function openRouterMaps401ToProviderAuthenticationException(): void
+    {
+        // ADR-080: realigned from ProviderConfigurationException.
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'bad key']], 401));
+
+        try {
+            $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
+            self::fail('Expected ProviderAuthenticationException was not thrown');
+        } catch (ProviderAuthenticationException $e) {
+            self::assertSame(401, $e->getCode());
+        }
+    }
+
+    #[Test]
+    public function openRouterMaps429ToProviderRateLimitException(): void
+    {
+        // ADR-080: realigned from ProviderConnectionException; getCode() stays 429.
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'slow down']], 429));
+
+        try {
+            $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
+            self::fail('Expected ProviderRateLimitException was not thrown');
+        } catch (ProviderRateLimitException $e) {
+            self::assertSame(429, $e->getCode());
+        }
     }
 
     /**


### PR DESCRIPTION
## What

Add typed provider HTTP exceptions so callers branch on the **class** instead of the status code or message text (ADR-080):

- `ProviderAuthenticationException` (401) and `ProviderRateLimitException` (429), empty `final` subclasses of `ProviderResponseException` (which drops its own `final`).
- A private `AbstractProvider::clientErrorException()` factory maps the 4xx status → class, used by **both** the buffered (`handleResponse`) and streaming (`assertStreamingResponseOk`) branches so they can't drift.
- `OpenRouterProvider` realigned to the same 401/429 classes (it previously routed 401→`ProviderConfigurationException`, 429→`ProviderConnectionException`).

## Why

Every 4xx was flattened into a generic `ProviderResponseException`, so a consumer (a controller turning errors into user copy, a retry policy) had to inspect `getCode()`/`$httpStatus` or re-parse the message — the string-matching ADR-053's marker interface exists to end.

## Backward compatibility (by inheritance)

- `catch (ProviderResponseException)` still catches a 401/429 — they *are* `ProviderResponseException`.
- `catch (ProviderException)` / `catch (NrLlmExceptionInterface)` unaffected.
- `getCode()` still returns the HTTP status, so `FallbackMiddleware` and `CircuitBreakerMiddleware` (which key off `getCode() === 429`) keep firing. Asserted in `ProviderRateLimitExceptionTest`.

## Behaviour change (flagged, separate commit)

The **OpenRouter** realignment is the only behaviour change: a 401 becomes `ProviderAuthenticationException` (was `ProviderConfigurationException`), a 429 becomes `ProviderRateLimitException` (was `ProviderConnectionException`). Both remain `ProviderResponseException`/`ProviderException`, 429 keeps code 429, and 402/503 are unchanged — so only a consumer catching those two *specific* OpenRouter classes sees the (more correct) type. It's in its own commit and can be dropped to make the PR purely additive.

## Tests

New `ProviderAuthenticationExceptionTest` / `ProviderRateLimitExceptionTest` (instanceof chain + `getCode()` anchors), and `AbstractProviderTest` + `OpenRouterProviderTest` assert 401→auth, 429→rate-limit, other 4xx→base — for buffered and streaming paths.

Local gate: `unit` ✅, `cgl` ✅, `rector -n` ✅, `fuzzy` ✅. `phpstan` has the pre-existing `ProviderDetector.php` finding on `main` (unrelated) — this branch adds no new errors.
