### PR TITLE
feat(agent): persist agent runs and a durable event stream (ADR-081)

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -21,6 +21,8 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
@@ -32,6 +34,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use ReflectionClass;
+use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
@@ -87,6 +90,11 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         private readonly AllowedToolsResolver $allowedToolsResolver,
         private readonly SkillRepository $skillRepository,
         private readonly PromptSnippetRepository $promptSnippetRepository,
+        // Optional and last so the existing direct constructions in the
+        // functional tests keep compiling (they run with persistence off — a
+        // free characterization guard that the loop path is unchanged); the DI
+        // container autowires the real persister in production.
+        private readonly ?AgentRunPersister $agentRunPersister = null,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -188,21 +196,42 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $messages      = [ChatMessage::user($prompt)];
         $maxIterations = $maxRounds > 0 ? $maxRounds : null;
 
+        // Persist the run (ADR-081): open a RUNNING row and get a handle to
+        // thread each recorded step through. Null when persistence is
+        // unavailable — the run then proceeds unpersisted, exactly as before.
+        $handle = $this->agentRunPersister?->begin($config, $this->currentBackendUserUid());
+
         // Live path: stream each recorded step to the browser as it happens.
         if ($this->boolFromBody($body, 'stream')) {
-            return $this->runStreamed($messages, $config, $allowed, $options, $maxIterations, $augmentation, $captureRaw);
+            return $this->runStreamed($messages, $config, $allowed, $options, $maxIterations, $augmentation, $captureRaw, $handle);
         }
 
         // Batch path: run the whole loop, then return the full trace as one JSON
         // document (the no-JS fallback and the shape the functional tests assert).
-        $trace = new RunTrace(captureRaw: $captureRaw);
+        // The onRecord hook persists each step as it is recorded (ADR-081) —
+        // additive to the loop, which is unaware of it.
+        $trace = new RunTrace(
+            captureRaw: $captureRaw,
+            onRecord: $handle !== null
+                ? function (RunStep $step) use ($handle): void {
+                    $this->agentRunPersister?->recordStep($handle, $step);
+                }
+            : null,
+        );
 
         try {
             $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
         } catch (Throwable $e) {
+            if ($handle !== null) {
+                $this->agentRunPersister?->settleFailed($handle, $e);
+            }
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
 
             return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
+        }
+
+        if ($handle !== null) {
+            $this->agentRunPersister?->settleCompleted($handle, $result);
         }
 
         $response = new PlaygroundRunResponse(
@@ -241,6 +270,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         ?int $maxIterations,
         RunAugmentation $augmentation,
         bool $captureRaw,
+        ?AgentRunHandle $handle = null,
     ): ResponseInterface {
         ini_set('zlib.output_compression', '0');
         ini_set('output_buffering', '0');
@@ -265,6 +295,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             $maxIterations,
             $augmentation,
             $captureRaw,
+            $handle,
         );
 
         return new NullResponse();
@@ -290,16 +321,25 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         ?int $maxIterations,
         RunAugmentation $augmentation,
         bool $captureRaw,
+        ?AgentRunHandle $handle = null,
     ): void {
         $trace = new RunTrace(
             captureRaw: $captureRaw,
-            onRecord: static function (RunStep $step) use ($emit): void {
+            onRecord: function (RunStep $step) use ($emit, $handle): void {
                 $emit(['event' => 'step', 'step' => $step->toArray()]);
+                if ($handle !== null) {
+                    $this->agentRunPersister?->recordStep($handle, $step);
+                }
             },
         );
 
+        $settled = false;
         try {
             $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
+            if ($handle !== null) {
+                $this->agentRunPersister?->settleCompleted($handle, $result);
+                $settled = true;
+            }
             $emit([
                 'event'        => 'done',
                 'success'      => true,
@@ -315,8 +355,19 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 ],
             ]);
         } catch (Throwable $e) {
+            if ($handle !== null) {
+                $this->agentRunPersister?->settleFailed($handle, $e);
+                $settled = true;
+            }
             $this->logger?->error('Tool playground run failed', ['exception' => $e]);
             $emit(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($e)]);
+        } finally {
+            // A client disconnect (or a fatal mid-stream) can abandon the run
+            // before either branch settles it; mark it failed so no run is left
+            // stuck RUNNING. Mirrors StreamingDispatcher's finally-block settle.
+            if ($handle !== null && !$settled) {
+                $this->agentRunPersister?->settleFailed($handle, new RuntimeException('Agent run did not complete'));
+            }
         }
     }
 

--- a/Classes/Domain/Enum/AgentEventKind.php
+++ b/Classes/Domain/Enum/AgentEventKind.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+
+/**
+ * Kind of a persisted agent-run event (ADR-081).
+ *
+ * These map one-to-one onto the four {@see RunStep} kinds the tool loop emits
+ * through {@see \Netresearch\NrLlm\Service\Tool\RunTrace}. The enum is
+ * intentionally limited to what the loop actually produces today; richer kinds
+ * (approval requests, artifacts, streamed text deltas) are added by the epics
+ * that emit them, not speculatively here.
+ */
+enum AgentEventKind: string
+{
+    case REQUEST = 'request';
+    case LLM = 'llm';
+    case TOOL = 'tool';
+    case ASSEMBLED = 'assembled';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+
+    /**
+     * Map a {@see RunStep} kind constant onto its event kind. Returns null for an
+     * unknown value so a future RunStep kind cannot silently masquerade as a
+     * known one.
+     */
+    public static function fromRunStepKind(string $kind): ?self
+    {
+        return self::tryFrom($kind);
+    }
+}

--- a/Classes/Domain/Enum/AgentRunStatus.php
+++ b/Classes/Domain/Enum/AgentRunStatus.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * Lifecycle status of a persisted agent run (ADR-081).
+ *
+ * A run starts {@see self::RUNNING} (or {@see self::QUEUED} once a batch engine
+ * exists), then settles into one of the terminal states. The suspend states
+ * ({@see self::WAITING_FOR_APPROVAL}, {@see self::WAITING_FOR_INPUT}) are part
+ * of the vocabulary from the outset so the human-in-the-loop and batch epics can
+ * reuse this enum without a migration; the persistence layer added here only
+ * ever writes RUNNING → COMPLETED/FAILED.
+ */
+enum AgentRunStatus: string
+{
+    case QUEUED = 'queued';
+    case RUNNING = 'running';
+    case WAITING_FOR_APPROVAL = 'waiting_for_approval';
+    case WAITING_FOR_INPUT = 'waiting_for_input';
+    case COMPLETED = 'completed';
+    case FAILED = 'failed';
+    case CANCELLED = 'cancelled';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+
+    public static function tryFromString(string $value): ?self
+    {
+        return self::tryFrom($value);
+    }
+
+    /**
+     * A terminal status is one the run can never leave: the loop has finished,
+     * failed, or been cancelled. Suspend states are NOT terminal — a waiting run
+     * resumes.
+     */
+    public function isTerminal(): bool
+    {
+        return match ($this) {
+            self::COMPLETED, self::FAILED, self::CANCELLED => true,
+            default => false,
+        };
+    }
+}

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+
+/**
+ * A persisted agent run, read back from `tx_nrllm_agentrun` (ADR-081).
+ *
+ * The immutable read model of one run of {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}.
+ * The mutable in-flight counterpart is {@see \Netresearch\NrLlm\Service\Tool\AgentRunHandle},
+ * which the persister threads through a run before this read model exists.
+ */
+final readonly class AgentRun
+{
+    public function __construct(
+        public int $uid,
+        public string $uuid,
+        public string $status,
+        public int $configurationUid,
+        public string $configurationIdentifier,
+        public int $beUser,
+        public int $iterations,
+        public bool $truncated,
+        public int $totalPromptTokens,
+        public int $totalCompletionTokens,
+        public int $totalTokens,
+        public float $estimatedCost,
+        public string $errorClass,
+        public int $startedAt,
+        public int $finishedAt,
+        public int $crdate,
+    ) {}
+
+    /**
+     * The status as a typed enum, or null when the stored string is unknown
+     * (a forward-compatibility guard — an unrecognised status is not coerced).
+     */
+    public function statusEnum(): ?AgentRunStatus
+    {
+        return AgentRunStatus::tryFromString($this->status);
+    }
+}

--- a/Classes/Domain/ValueObject/AgentRunEvent.php
+++ b/Classes/Domain/ValueObject/AgentRunEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
+
+/**
+ * One persisted event of an agent run, read back from `tx_nrllm_agentrun_event`
+ * (ADR-081).
+ *
+ * Each event is the durable form of a {@see RunStep}: the replayable stream a
+ * consumer UI can render after the fact. The full step payload is preserved in
+ * {@see self::$payload} (the {@see RunStep::toArray()} shape); the promoted
+ * columns (kind, round, duration) exist for querying and ordering.
+ */
+final readonly class AgentRunEvent
+{
+    /**
+     * @param array<string, mixed> $payload The decoded {@see RunStep::toArray()} snapshot.
+     */
+    public function __construct(
+        public int $uid,
+        public int $run,
+        public int $sequence,
+        public string $kind,
+        public int $round,
+        public float $durationMs,
+        public array $payload,
+        public int $crdate,
+    ) {}
+
+    /**
+     * The kind as a typed enum, or null when the stored string is unknown.
+     */
+    public function kindEnum(): ?AgentEventKind
+    {
+        return AgentEventKind::fromRunStepKind($this->kind);
+    }
+}

--- a/Classes/Service/Tool/AgentRunHandle.php
+++ b/Classes/Service/Tool/AgentRunHandle.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * A live handle to an in-flight agent run (ADR-081).
+ *
+ * Returned by {@see AgentRunPersister::begin()} and threaded back into
+ * {@see AgentRunPersister::recordStep()} and the settle methods. It carries the
+ * new run's primary key and uuid plus the per-run event sequence counter — the
+ * only mutable state a run needs while it executes. The persister itself is a
+ * stateless singleton, so this handle (not the service) owns the sequence.
+ */
+final class AgentRunHandle
+{
+    /**
+     * The next event's zero-based sequence number, incremented as each step is
+     * recorded.
+     */
+    public int $sequence = 0;
+
+    public function __construct(
+        public readonly int $runUid,
+        public readonly string $uuid,
+    ) {}
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * Persists an agent run and its event stream (ADR-081).
+ *
+ * A thin, fail-soft orchestrator over {@see AgentRunRepositoryInterface}. It is
+ * driven from the same {@see RunTrace} `onRecord` hook the playground already
+ * uses to stream steps, so persistence is purely additive — the tool loop is
+ * untouched and unaware of it.
+ *
+ * Every method is fail-soft: a persistence error is logged and swallowed so a
+ * database hiccup can never break an otherwise-successful run. {@see self::begin()}
+ * returns null on failure, which the caller treats as "do not record" — exactly
+ * as a null {@see RunTrace} callback would.
+ *
+ * Note (ADR-081): a run that exhausts its iteration cap OR is denied by the
+ * budget guard both surface as COMPLETED with `truncated = true`, because
+ * {@see ToolLoopService} swallows the budget denial internally and returns a
+ * normal result. Distinguishing "cap hit" from "budget denied" as a FAILED run
+ * is deferred to the human-in-the-loop epic, which reshapes the loop's exit
+ * paths.
+ */
+final readonly class AgentRunPersister
+{
+    public function __construct(
+        private AgentRunRepositoryInterface $repository,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Open a new run in the RUNNING state. Returns a handle to thread back into
+     * {@see self::recordStep()} and the settle methods, or null when the run
+     * could not be started (the caller then records nothing).
+     */
+    public function begin(?LlmConfiguration $configuration, int $beUser): ?AgentRunHandle
+    {
+        try {
+            $uuid   = Uuid::v4()->toRfc4122();
+            $runUid = $this->repository->startRun(
+                $uuid,
+                $configuration?->getUid() ?? 0,
+                $configuration?->getIdentifier() ?? '',
+                $beUser,
+            );
+
+            return new AgentRunHandle($runUid, $uuid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be started; the run will not be persisted', ['exception' => $exception]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Persist one recorded step as the next event in the run's stream.
+     */
+    public function recordStep(AgentRunHandle $handle, RunStep $step): void
+    {
+        try {
+            $payload = json_encode($step->toArray(), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR);
+            $this->repository->recordEvent(
+                $handle->runUid,
+                $handle->sequence,
+                $step->kind,
+                $step->round,
+                $step->durationMs,
+                $payload,
+            );
+            ++$handle->sequence;
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun step could not be persisted', ['exception' => $exception]);
+        }
+    }
+
+    /**
+     * Settle a run that finished normally. The status is always COMPLETED; the
+     * `truncated` flag on the result carries whether the loop hit its cap.
+     */
+    public function settleCompleted(AgentRunHandle $handle, ToolLoopResult $result): void
+    {
+        $this->finish(
+            $handle,
+            AgentRunStatus::COMPLETED,
+            $result->iterations,
+            $result->truncated,
+            $result->usage->promptTokens,
+            $result->usage->completionTokens,
+            $result->usage->totalTokens,
+            $result->usage->estimatedCost ?? 0.0,
+            '',
+        );
+    }
+
+    /**
+     * Settle a run that ended in an uncaught throwable (a provider failure that
+     * exhausted every fallback, or an unexpected error). The exception FQCN is
+     * stored; the message is never persisted (it can carry payload fragments).
+     */
+    public function settleFailed(AgentRunHandle $handle, Throwable $error): void
+    {
+        $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class);
+    }
+
+    private function finish(
+        AgentRunHandle $handle,
+        AgentRunStatus $status,
+        int $iterations,
+        bool $truncated,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        float $estimatedCost,
+        string $errorClass,
+    ): void {
+        try {
+            $this->repository->finishRun(
+                $handle->runUid,
+                $status->value,
+                $iterations,
+                $truncated,
+                $promptTokens,
+                $completionTokens,
+                $totalTokens,
+                $estimatedCost,
+                $errorClass,
+            );
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be settled', ['exception' => $exception]);
+        }
+    }
+}

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Tool;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -26,6 +27,8 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 final readonly class AgentRunRepository implements AgentRunRepositoryInterface, SingletonInterface
 {
+    use SafeCastTrait;
+
     private const TABLE_RUN = 'tx_nrllm_agentrun';
 
     private const TABLE_EVENT = 'tx_nrllm_agentrun_event';
@@ -142,19 +145,35 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
 
     public function purgeOlderThan(int $timestamp): int
     {
+        // Delete the runs' events by run id first, then the runs — deleting each
+        // table independently by crdate would orphan events of a run that began
+        // before the cutoff but recorded events after it.
+        $runConnection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $selectBuilder = $runConnection->createQueryBuilder();
+        $rows          = $selectBuilder
+            ->select('uid')
+            ->from(self::TABLE_RUN)
+            ->where($selectBuilder->expr()->lt('crdate', $selectBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $uids = array_map(fn(array $row): int => self::toInt($row['uid'] ?? 0), $rows);
+        if ($uids === []) {
+            return 0;
+        }
+
         $eventConnection = $this->connectionPool->getConnectionForTable(self::TABLE_EVENT);
         $eventBuilder    = $eventConnection->createQueryBuilder();
         $eventBuilder
             ->delete(self::TABLE_EVENT)
-            ->where($eventBuilder->expr()->lt('crdate', $eventBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->where($eventBuilder->expr()->in('run', $eventBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)))
             ->executeStatement();
 
-        $runConnection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
-        $runBuilder    = $runConnection->createQueryBuilder();
+        $deleteBuilder = $runConnection->createQueryBuilder();
 
-        return (int)$runBuilder
+        return (int)$deleteBuilder
             ->delete(self::TABLE_RUN)
-            ->where($runBuilder->expr()->lt('crdate', $runBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->where($deleteBuilder->expr()->lt('crdate', $deleteBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
             ->executeStatement();
     }
 
@@ -164,22 +183,22 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
     private function hydrateRun(array $row): AgentRun
     {
         return new AgentRun(
-            uid: $this->intOf($row['uid'] ?? 0),
-            uuid: $this->stringOf($row['uuid'] ?? ''),
-            status: $this->stringOf($row['status'] ?? ''),
-            configurationUid: $this->intOf($row['configuration_uid'] ?? 0),
-            configurationIdentifier: $this->stringOf($row['configuration_identifier'] ?? ''),
-            beUser: $this->intOf($row['be_user'] ?? 0),
-            iterations: $this->intOf($row['iterations'] ?? 0),
-            truncated: $this->intOf($row['truncated'] ?? 0) === 1,
-            totalPromptTokens: $this->intOf($row['total_prompt_tokens'] ?? 0),
-            totalCompletionTokens: $this->intOf($row['total_completion_tokens'] ?? 0),
-            totalTokens: $this->intOf($row['total_tokens'] ?? 0),
-            estimatedCost: $this->floatOf($row['estimated_cost'] ?? 0),
-            errorClass: $this->stringOf($row['error_class'] ?? ''),
-            startedAt: $this->intOf($row['started_at'] ?? 0),
-            finishedAt: $this->intOf($row['finished_at'] ?? 0),
-            crdate: $this->intOf($row['crdate'] ?? 0),
+            uid: self::toInt($row['uid'] ?? 0),
+            uuid: self::toStr($row['uuid'] ?? ''),
+            status: self::toStr($row['status'] ?? ''),
+            configurationUid: self::toInt($row['configuration_uid'] ?? 0),
+            configurationIdentifier: self::toStr($row['configuration_identifier'] ?? ''),
+            beUser: self::toInt($row['be_user'] ?? 0),
+            iterations: self::toInt($row['iterations'] ?? 0),
+            truncated: self::toInt($row['truncated'] ?? 0) === 1,
+            totalPromptTokens: self::toInt($row['total_prompt_tokens'] ?? 0),
+            totalCompletionTokens: self::toInt($row['total_completion_tokens'] ?? 0),
+            totalTokens: self::toInt($row['total_tokens'] ?? 0),
+            estimatedCost: self::toFloat($row['estimated_cost'] ?? 0),
+            errorClass: self::toStr($row['error_class'] ?? ''),
+            startedAt: self::toInt($row['started_at'] ?? 0),
+            finishedAt: self::toInt($row['finished_at'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
         );
     }
 
@@ -199,29 +218,15 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         }
 
         return new AgentRunEvent(
-            uid: $this->intOf($row['uid'] ?? 0),
-            run: $this->intOf($row['run'] ?? 0),
-            sequence: $this->intOf($row['sequence'] ?? 0),
-            kind: $this->stringOf($row['kind'] ?? ''),
-            round: $this->intOf($row['round'] ?? 0),
-            durationMs: $this->floatOf($row['duration_ms'] ?? 0),
+            uid: self::toInt($row['uid'] ?? 0),
+            run: self::toInt($row['run'] ?? 0),
+            sequence: self::toInt($row['sequence'] ?? 0),
+            kind: self::toStr($row['kind'] ?? ''),
+            round: self::toInt($row['round'] ?? 0),
+            durationMs: self::toFloat($row['duration_ms'] ?? 0),
             payload: $payload,
-            crdate: $this->intOf($row['crdate'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
         );
     }
 
-    private function intOf(mixed $value): int
-    {
-        return is_numeric($value) ? (int)$value : 0;
-    }
-
-    private function floatOf(mixed $value): float
-    {
-        return is_numeric($value) ? (float)$value : 0.0;
-    }
-
-    private function stringOf(mixed $value): string
-    {
-        return is_scalar($value) ? (string)$value : '';
-    }
 }

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Writes and reads agent runs and their event streams (ADR-081).
+ *
+ * Uses the Doctrine ConnectionPool directly — both tables are UI-less logs with
+ * no Extbase persistence needs, mirroring how {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepository}
+ * writes the telemetry table. A run row is inserted RUNNING, events are appended
+ * as the loop progresses, and the row is updated once to its terminal state.
+ */
+final readonly class AgentRunRepository implements AgentRunRepositoryInterface, SingletonInterface
+{
+    private const TABLE_RUN = 'tx_nrllm_agentrun';
+
+    private const TABLE_EVENT = 'tx_nrllm_agentrun_event';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int
+    {
+        $now        = time();
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $connection->insert(self::TABLE_RUN, [
+            'pid'                      => 0,
+            'uuid'                     => $uuid,
+            'status'                   => AgentRunStatus::RUNNING->value,
+            'configuration_uid'        => $configurationUid,
+            'configuration_identifier' => $configurationIdentifier,
+            'be_user'                  => $beUser,
+            'iterations'               => 0,
+            'truncated'                => 0,
+            'total_prompt_tokens'      => 0,
+            'total_completion_tokens'  => 0,
+            'total_tokens'             => 0,
+            'estimated_cost'           => 0.0,
+            'error_class'              => '',
+            'started_at'               => $now,
+            'finished_at'              => 0,
+            'tstamp'                   => $now,
+            'crdate'                   => $now,
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE_EVENT)->insert(self::TABLE_EVENT, [
+            'pid'         => 0,
+            'run'         => $runUid,
+            'sequence'    => $sequence,
+            'kind'        => $kind,
+            'round'       => $round,
+            'duration_ms' => $durationMs,
+            'payload'     => $payloadJson,
+            'crdate'      => time(),
+        ]);
+    }
+
+    public function finishRun(
+        int $runUid,
+        string $status,
+        int $iterations,
+        bool $truncated,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        float $estimatedCost,
+        string $errorClass,
+    ): void {
+        $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'status'                  => $status,
+                'iterations'              => $iterations,
+                'truncated'               => $truncated ? 1 : 0,
+                'total_prompt_tokens'     => $promptTokens,
+                'total_completion_tokens' => $completionTokens,
+                'total_tokens'            => $totalTokens,
+                'estimated_cost'          => $estimatedCost,
+                'error_class'             => $errorClass,
+                'finished_at'             => time(),
+                'tstamp'                  => time(),
+            ],
+            ['uid' => $runUid],
+        );
+    }
+
+    public function findByUuid(string $uuid): ?AgentRun
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $row = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_RUN)
+            ->where($queryBuilder->expr()->eq('uuid', $queryBuilder->createNamedParameter($uuid)))
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return $this->hydrateRun($row);
+    }
+
+    public function findEvents(int $runUid): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_EVENT);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_EVENT)
+            ->where($queryBuilder->expr()->eq('run', $queryBuilder->createNamedParameter($runUid, Connection::PARAM_INT)))
+            ->orderBy('sequence', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrateEvent(...), $rows);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $eventConnection = $this->connectionPool->getConnectionForTable(self::TABLE_EVENT);
+        $eventBuilder    = $eventConnection->createQueryBuilder();
+        $eventBuilder
+            ->delete(self::TABLE_EVENT)
+            ->where($eventBuilder->expr()->lt('crdate', $eventBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeStatement();
+
+        $runConnection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $runBuilder    = $runConnection->createQueryBuilder();
+
+        return (int)$runBuilder
+            ->delete(self::TABLE_RUN)
+            ->where($runBuilder->expr()->lt('crdate', $runBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeStatement();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateRun(array $row): AgentRun
+    {
+        return new AgentRun(
+            uid: $this->intOf($row['uid'] ?? 0),
+            uuid: $this->stringOf($row['uuid'] ?? ''),
+            status: $this->stringOf($row['status'] ?? ''),
+            configurationUid: $this->intOf($row['configuration_uid'] ?? 0),
+            configurationIdentifier: $this->stringOf($row['configuration_identifier'] ?? ''),
+            beUser: $this->intOf($row['be_user'] ?? 0),
+            iterations: $this->intOf($row['iterations'] ?? 0),
+            truncated: $this->intOf($row['truncated'] ?? 0) === 1,
+            totalPromptTokens: $this->intOf($row['total_prompt_tokens'] ?? 0),
+            totalCompletionTokens: $this->intOf($row['total_completion_tokens'] ?? 0),
+            totalTokens: $this->intOf($row['total_tokens'] ?? 0),
+            estimatedCost: $this->floatOf($row['estimated_cost'] ?? 0),
+            errorClass: $this->stringOf($row['error_class'] ?? ''),
+            startedAt: $this->intOf($row['started_at'] ?? 0),
+            finishedAt: $this->intOf($row['finished_at'] ?? 0),
+            crdate: $this->intOf($row['crdate'] ?? 0),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateEvent(array $row): AgentRunEvent
+    {
+        $payload = [];
+        $raw     = $row['payload'] ?? '';
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                /** @var array<string, mixed> $decoded */
+                $payload = $decoded;
+            }
+        }
+
+        return new AgentRunEvent(
+            uid: $this->intOf($row['uid'] ?? 0),
+            run: $this->intOf($row['run'] ?? 0),
+            sequence: $this->intOf($row['sequence'] ?? 0),
+            kind: $this->stringOf($row['kind'] ?? ''),
+            round: $this->intOf($row['round'] ?? 0),
+            durationMs: $this->floatOf($row['duration_ms'] ?? 0),
+            payload: $payload,
+            crdate: $this->intOf($row['crdate'] ?? 0),
+        );
+    }
+
+    private function intOf(mixed $value): int
+    {
+        return is_numeric($value) ? (int)$value : 0;
+    }
+
+    private function floatOf(mixed $value): float
+    {
+        return is_numeric($value) ? (float)$value : 0.0;
+    }
+
+    private function stringOf(mixed $value): string
+    {
+        return is_scalar($value) ? (string)$value : '';
+    }
+}

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+
+/**
+ * Persistence contract for agent runs and their event streams (ADR-081).
+ *
+ * A UI-less append-and-update log, mirroring {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface}:
+ * raw Doctrine access, no Extbase. Split out as an interface so the persister
+ * can be unit-tested against a double.
+ */
+interface AgentRunRepositoryInterface
+{
+    /**
+     * Insert a new run in the RUNNING state and return its primary key.
+     */
+    public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int;
+
+    /**
+     * Append one event to a run's stream.
+     */
+    public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void;
+
+    /**
+     * Move a run into a terminal state, recording its final totals.
+     */
+    public function finishRun(
+        int $runUid,
+        string $status,
+        int $iterations,
+        bool $truncated,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        float $estimatedCost,
+        string $errorClass,
+    ): void;
+
+    public function findByUuid(string $uuid): ?AgentRun;
+
+    /**
+     * @return list<AgentRunEvent> Events for a run, ordered by sequence ascending.
+     */
+    public function findEvents(int $runUid): array;
+
+    /**
+     * Delete runs (and their events) created before the given timestamp.
+     *
+     * @return int Number of run rows deleted.
+     */
+    public function purgeOlderThan(int $timestamp): int;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -202,6 +202,13 @@ services:
     alias: Netresearch\NrLlm\Service\Telemetry\TelemetryRepository
     public: false
 
+  # Agent-run persistence (ADR-081) — private; consumed by AgentRunPersister,
+  # which the tool playground drives. The concrete repository stays private too;
+  # functional tests instantiate it directly with the real ConnectionPool.
+  Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Tool\AgentRunRepository
+    public: false
+
   # Circuit breaker state store (ADR-063) — private; consumed by
   # CircuitBreakerMiddleware. The cache-backed default is instantiated directly
   # in its functional test with the real core cache manager.

--- a/Documentation/Adr/Adr081AgentRunPersistence.rst
+++ b/Documentation/Adr/Adr081AgentRunPersistence.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-081:
+
+============================================================================
+ADR-081: Agent run persistence and a durable event stream
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-081-context:
+
+Context
+=======
+
+A run of the tool-calling agent loop (`ToolLoopService::runLoop()`) existed only
+for the lifetime of one HTTP request. It returned a `ToolLoopResult` value object
+and was then gone. The only inspectable trace, `RunTrace`, is an in-memory
+collector the admin playground builds to stream steps to the browser; nothing was
+written to storage.
+
+That is the missing foundation under every larger agent capability: a run cannot
+be resumed after a worker restart, queued for later execution, paused for a human
+approval, audited, or replayed by a consumer UI, because there is no persisted run
+to attach any of that to. Cross-call usage already carried a `correlation_id`
+(`tx_nrllm_telemetry`), but nothing promoted it into a first-class run.
+
+.. _adr-081-decision:
+
+Decision
+========
+
+**Persist each run and its steps in two UI-less log tables**,
+`tx_nrllm_agentrun` (one summary row per run) and `tx_nrllm_agentrun_event` (one
+row per recorded step, ordered by ``sequence``). Both follow the telemetry
+precedent (:ref:`ADR-058 <adr-058>`): raw Doctrine access through
+`AgentRunRepository`, no Extbase model and no TCA, because a run log is written
+and read programmatically, never edited in FormEngine.
+
+**Drive persistence from the existing `RunTrace.onRecord` hook.** A fail-soft
+`AgentRunPersister` opens a run (`begin()` → RUNNING), records each `RunStep` as
+an event as it is emitted (`recordStep()`), and settles the run to a terminal
+state (`settleCompleted()` / `settleFailed()`). The tool loop is **not touched**:
+the persister is wired through the same per-step callback the playground already
+uses to stream steps, so the loop's control flow is unchanged and unaware of it.
+
+**Type the vocabulary without inventing what the loop cannot emit.**
+`AgentRunStatus` carries the full lifecycle the later epics need (``queued``,
+``running``, ``waiting_for_approval``, ``waiting_for_input``, ``completed``,
+``failed``, ``cancelled``), but this change only ever writes RUNNING →
+COMPLETED/FAILED. `AgentEventKind` is limited to the four kinds `RunStep` actually
+produces (``request``, ``llm``, ``tool``, ``assembled``); richer kinds are added
+by the epics that emit them.
+
+**Fail-soft is a hard requirement.** Every persister method logs and swallows a
+storage error; `begin()` returns null on failure, which the caller treats exactly
+as a null `RunTrace` callback — "record nothing". A database hiccup can therefore
+never break an otherwise-successful run. The streamed path settles the run in a
+``finally`` block (mirroring `StreamingDispatcher`), so a client disconnect
+mid-stream cannot leave a run stuck RUNNING.
+
+.. _adr-081-consequences:
+
+Consequences
+============
+
+- Playground runs (batch and streamed) now persist. The admin playground is the
+  first consumer; the tables are the substrate the human-in-the-loop, batch/queue
+  and feedback epics build on.
+- A run that exhausts its iteration cap **or** is denied by the budget guard both
+  surface as COMPLETED with ``truncated = true``, because `ToolLoopService`
+  catches the budget denial internally and returns a normal result. Recording a
+  budget denial as a distinct FAILED run is deferred to the human-in-the-loop
+  epic, which reshapes the loop's exit paths.
+- Event payloads store the full `RunStep` snapshot, which includes the messages
+  sent (the prompt). `AgentRunRepository::purgeOlderThan()` provides the retention
+  hook; a scheduled purge command is a follow-up. Runs are admin-authored for now
+  (the playground is admin-only), so the exposure is limited.
+- The persister depends on `AgentRunRepositoryInterface`, so it is unit-tested
+  against a recording double; the raw SQL and schema are covered by a functional
+  round-trip.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -378,4 +378,5 @@ Tools
    Adr078SpecializedServiceBudgetEnforcement
    Adr079FirstPartyCompletionVisionBudgetFakes
    Adr080TypedProviderHttpExceptions
+   Adr081AgentRunPersistence
    Adr082StructuredOutputs

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -23,6 +23,8 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
@@ -247,6 +249,73 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         // Token usage is summed across both round-trips (7+3 then 5+4 => 19).
         self::assertIsArray($payload['usage']);
         self::assertSame(19, $payload['usage']['totalTokens']);
+    }
+
+    #[Test]
+    public function runActionPersistsCompletedAgentRunWithItsEventStream(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-tools');
+        $configuration->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($configuration);
+
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn(new ScriptedToolAdapter());
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = $this->createLlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+
+        // Wire the real persister (ADR-081): the batch runAction path must open a
+        // run, record each step, and settle it COMPLETED.
+        $persister  = new AgentRunPersister(new AgentRunRepository($this->toolConnectionPool()), new NullLogger());
+        $controller = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService, $persister);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody(['configuration' => 1, 'prompt' => 'Show me the last logs.']);
+        $response = $controller->runAction($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        // Exactly one run persisted, COMPLETED, with the iteration count and token
+        // total the response reported.
+        $runs = $this->toolConnectionPool()
+            ->getConnectionForTable('tx_nrllm_agentrun')
+            ->select(['*'], 'tx_nrllm_agentrun')
+            ->fetchAllAssociative();
+        self::assertCount(1, $runs);
+        self::assertSame('completed', $runs[0]['status']);
+        self::assertSame(2, (int)$runs[0]['iterations']);
+        self::assertSame(19, (int)$runs[0]['total_tokens']);
+
+        // The five-step interleaving (request, llm, tool, request, llm) is persisted.
+        $eventCount = $this->toolConnectionPool()
+            ->getConnectionForTable('tx_nrllm_agentrun_event')
+            ->count('*', 'tx_nrllm_agentrun_event', ['run' => (int)$runs[0]['uid']]);
+        self::assertSame(5, $eventCount);
     }
 
     #[Test]
@@ -526,6 +595,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         LlmConfigurationRepository $configurationRepository,
         ToolRegistry $toolRegistry,
         ToolLoopService $toolLoopService,
+        ?AgentRunPersister $agentRunPersister = null,
     ): ToolPlaygroundController {
         $moduleTemplateFactory = $this->get(ModuleTemplateFactory::class);
         self::assertInstanceOf(ModuleTemplateFactory::class, $moduleTemplateFactory);
@@ -546,6 +616,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             $this->get(AllowedToolsResolver::class),
             $skillRepository,
             $promptSnippetRepository,
+            $agentRunPersister,
         );
     }
 

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end round-trip of the agent-run persistence layer against the real
+ * schema: the persister writes through the raw-SQL repository, and the same
+ * repository reads the run and its ordered event stream back.
+ *
+ * The repository is instantiated directly with the real ConnectionPool (as the
+ * telemetry repository's tests do) — both are private DI services.
+ */
+#[CoversClass(AgentRunPersister::class)]
+#[CoversClass(AgentRunRepository::class)]
+final class AgentRunPersisterTest extends AbstractFunctionalTestCase
+{
+    private AgentRunRepository $repository;
+
+    private AgentRunPersister $persister;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $this->repository = new AgentRunRepository($connectionPool);
+        $this->persister  = new AgentRunPersister($this->repository, new NullLogger());
+    }
+
+    #[Test]
+    public function aCompletedRunPersistsItsSummaryAndOrderedEventStream(): void
+    {
+        $handle = $this->persister->begin(null, 5);
+        self::assertNotNull($handle);
+
+        // While running, the row exists and is in the RUNNING state.
+        $running = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($running);
+        self::assertSame('running', $running->status);
+        self::assertSame(5, $running->beUser);
+        self::assertSame(0, $running->finishedAt);
+
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_REQUEST, round: 1, durationMs: 0.0, messagesSent: [['role' => 'user', 'content' => 'hi']], toolSpecs: ['fetch_logs']));
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 12.5, content: 'answer', promptTokens: 7, completionTokens: 3, totalTokens: 10));
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_TOOL, round: 1, durationMs: 5.0, toolName: 'fetch_logs', toolArguments: ['limit' => 5], toolResult: 'ok', toolIsError: false));
+
+        $this->persister->settleCompleted($handle, new ToolLoopResult('answer', [], 2, false, UsageStatistics::fromTokens(10, 20, 0.05)));
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('completed', $run->status);
+        self::assertSame(2, $run->iterations);
+        self::assertFalse($run->truncated);
+        self::assertSame(10, $run->totalPromptTokens);
+        self::assertSame(20, $run->totalCompletionTokens);
+        self::assertSame(30, $run->totalTokens);
+        self::assertEqualsWithDelta(0.05, $run->estimatedCost, 0.0001);
+        self::assertGreaterThan(0, $run->finishedAt);
+
+        $events = $this->repository->findEvents($handle->runUid);
+        self::assertCount(3, $events);
+        self::assertSame([0, 1, 2], array_map(static fn($e): int => $e->sequence, $events));
+        self::assertSame(['request', 'llm', 'tool'], array_map(static fn($e): string => $e->kind, $events));
+        // The full RunStep snapshot survives the round-trip.
+        self::assertSame('answer', $events[1]->payload['content'] ?? null);
+        self::assertSame('fetch_logs', $events[2]->payload['toolName'] ?? null);
+        self::assertSame(['limit' => 5], $events[2]->payload['toolArguments'] ?? null);
+    }
+
+    #[Test]
+    public function aFailedRunRecordsTheFailedStatusWithItsExceptionClassAndPartialEvents(): void
+    {
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_REQUEST, round: 1, durationMs: 0.0, messagesSent: [['role' => 'user', 'content' => 'hi']]));
+        $this->persister->settleFailed($handle, new RuntimeException('provider exhausted'));
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('failed', $run->status);
+        self::assertSame(RuntimeException::class, $run->errorClass);
+        // The partial event recorded before the failure is retained.
+        self::assertCount(1, $this->repository->findEvents($handle->runUid));
+    }
+
+    #[Test]
+    public function purgeOlderThanRemovesRunsAndTheirEvents(): void
+    {
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 1.0, content: 'x'));
+        $this->persister->settleCompleted($handle, new ToolLoopResult('x', [], 1, false, UsageStatistics::fromTokens(0, 0)));
+
+        // Purge everything created up to now.
+        $deleted = $this->repository->purgeOlderThan(time() + 1);
+
+        self::assertGreaterThanOrEqual(1, $deleted);
+        self::assertNull($this->repository->findByUuid($handle->uuid));
+        self::assertSame([], $this->repository->findEvents($handle->runUid));
+    }
+}

--- a/Tests/Unit/Domain/Enum/AgentEventKindTest.php
+++ b/Tests/Unit/Domain/Enum/AgentEventKindTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class AgentEventKindTest extends TestCase
+{
+    #[Test]
+    public function valuesListsAllBackingStrings(): void
+    {
+        self::assertSame(['request', 'llm', 'tool', 'assembled'], AgentEventKind::values());
+    }
+
+    #[Test]
+    public function isValidIsTrueForKnownAndFalseForUnknown(): void
+    {
+        self::assertTrue(AgentEventKind::isValid('llm'));
+        self::assertFalse(AgentEventKind::isValid('approval'));
+    }
+
+    #[Test]
+    public function fromRunStepKindMapsEveryRunStepKind(): void
+    {
+        self::assertSame(AgentEventKind::REQUEST, AgentEventKind::fromRunStepKind(RunStep::KIND_REQUEST));
+        self::assertSame(AgentEventKind::LLM, AgentEventKind::fromRunStepKind(RunStep::KIND_LLM));
+        self::assertSame(AgentEventKind::TOOL, AgentEventKind::fromRunStepKind(RunStep::KIND_TOOL));
+        self::assertSame(AgentEventKind::ASSEMBLED, AgentEventKind::fromRunStepKind(RunStep::KIND_ASSEMBLED));
+    }
+
+    #[Test]
+    public function fromRunStepKindReturnsNullForUnknown(): void
+    {
+        self::assertNull(AgentEventKind::fromRunStepKind('approval'));
+    }
+}

--- a/Tests/Unit/Domain/Enum/AgentRunStatusTest.php
+++ b/Tests/Unit/Domain/Enum/AgentRunStatusTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class AgentRunStatusTest extends TestCase
+{
+    #[Test]
+    public function valuesListsAllBackingStrings(): void
+    {
+        self::assertSame(
+            ['queued', 'running', 'waiting_for_approval', 'waiting_for_input', 'completed', 'failed', 'cancelled'],
+            AgentRunStatus::values(),
+        );
+    }
+
+    #[Test]
+    public function isValidIsTrueForKnownAndFalseForUnknown(): void
+    {
+        self::assertTrue(AgentRunStatus::isValid('running'));
+        self::assertTrue(AgentRunStatus::isValid('waiting_for_approval'));
+        self::assertFalse(AgentRunStatus::isValid('bogus'));
+    }
+
+    #[Test]
+    public function tryFromStringReturnsNullForUnknown(): void
+    {
+        self::assertNull(AgentRunStatus::tryFromString('bogus'));
+        self::assertSame(AgentRunStatus::COMPLETED, AgentRunStatus::tryFromString('completed'));
+    }
+
+    #[Test]
+    public function terminalStatesAreCompletedFailedCancelled(): void
+    {
+        self::assertTrue(AgentRunStatus::COMPLETED->isTerminal());
+        self::assertTrue(AgentRunStatus::FAILED->isTerminal());
+        self::assertTrue(AgentRunStatus::CANCELLED->isTerminal());
+    }
+
+    #[Test]
+    public function nonTerminalStatesAreQueuedRunningAndWaiting(): void
+    {
+        self::assertFalse(AgentRunStatus::QUEUED->isTerminal());
+        self::assertFalse(AgentRunStatus::RUNNING->isTerminal());
+        self::assertFalse(AgentRunStatus::WAITING_FOR_APPROVAL->isTerminal());
+        self::assertFalse(AgentRunStatus::WAITING_FOR_INPUT->isTerminal());
+    }
+}

--- a/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(AgentRunPersister::class)]
+#[CoversClass(AgentRunHandle::class)]
+final class AgentRunPersisterTest extends TestCase
+{
+    #[Test]
+    public function beginOpensRunAndReturnsHandleCarryingAGeneratedUuid(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $repository->nextUid = 42;
+        $persister = new AgentRunPersister($repository);
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg-tools');
+
+        $handle = $persister->begin($config, 7);
+
+        self::assertNotNull($handle);
+        self::assertSame(42, $handle->runUid);
+        // RFC 4122 UUID: 36 chars, 8-4-4-4-12 hyphenation.
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            $handle->uuid,
+        );
+        self::assertSame(0, $handle->sequence);
+        self::assertCount(1, $repository->startedRuns);
+        self::assertSame('cfg-tools', $repository->startedRuns[0]['configurationIdentifier']);
+        self::assertSame(0, $repository->startedRuns[0]['configurationUid']);
+        self::assertSame(7, $repository->startedRuns[0]['beUser']);
+    }
+
+    #[Test]
+    public function beginToleratesANullConfiguration(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository);
+
+        $handle = $persister->begin(null, 0);
+
+        self::assertNotNull($handle);
+        self::assertSame('', $repository->startedRuns[0]['configurationIdentifier']);
+        self::assertSame(0, $repository->startedRuns[0]['configurationUid']);
+    }
+
+    #[Test]
+    public function recordStepAppendsSequentialEventsAndAdvancesTheHandle(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository);
+        $handle     = $persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        $persister->recordStep($handle, new RunStep(kind: RunStep::KIND_REQUEST, round: 1, durationMs: 0.0, messagesSent: [['role' => 'user', 'content' => 'hi']], toolSpecs: ['fetch_logs']));
+        $persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 12.5, content: 'answer', promptTokens: 7, completionTokens: 3, totalTokens: 10));
+        $persister->recordStep($handle, new RunStep(kind: RunStep::KIND_TOOL, round: 1, durationMs: 5.0, toolName: 'fetch_logs', toolArguments: ['limit' => 5], toolResult: 'ok', toolIsError: false));
+
+        self::assertCount(3, $repository->events);
+        self::assertSame([0, 1, 2], array_column($repository->events, 'sequence'));
+        self::assertSame(['request', 'llm', 'tool'], array_column($repository->events, 'kind'));
+        self::assertSame(3, $handle->sequence);
+
+        // The event payload is the full RunStep snapshot, JSON-encoded.
+        $llmPayload = json_decode($repository->events[1]['payloadJson'], true);
+        self::assertIsArray($llmPayload);
+        self::assertSame('answer', $llmPayload['content']);
+        self::assertSame(10, $llmPayload['totalTokens']);
+    }
+
+    #[Test]
+    public function settleCompletedWritesCompletedStatusAndSummedTotals(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository);
+        $handle     = $persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        $result = new ToolLoopResult('done', [], 2, false, UsageStatistics::fromTokens(10, 20, 0.05));
+        $persister->settleCompleted($handle, $result);
+
+        self::assertNotNull($repository->finished);
+        self::assertSame('completed', $repository->finished['status']);
+        self::assertSame(2, $repository->finished['iterations']);
+        self::assertFalse($repository->finished['truncated']);
+        self::assertSame(10, $repository->finished['promptTokens']);
+        self::assertSame(20, $repository->finished['completionTokens']);
+        self::assertSame(30, $repository->finished['totalTokens']);
+        self::assertSame(0.05, $repository->finished['estimatedCost']);
+        self::assertSame('', $repository->finished['errorClass']);
+    }
+
+    #[Test]
+    public function settleCompletedCarriesTheTruncatedFlag(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository);
+        $handle     = $persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        $persister->settleCompleted($handle, new ToolLoopResult('', [], 5, true, UsageStatistics::fromTokens(0, 0)));
+
+        self::assertNotNull($repository->finished);
+        self::assertSame('completed', $repository->finished['status']);
+        self::assertTrue($repository->finished['truncated']);
+    }
+
+    #[Test]
+    public function settleFailedWritesFailedStatusAndTheExceptionClass(): void
+    {
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository);
+        $handle     = $persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        $persister->settleFailed($handle, new RuntimeException('boom'));
+
+        self::assertNotNull($repository->finished);
+        self::assertSame('failed', $repository->finished['status']);
+        self::assertSame(RuntimeException::class, $repository->finished['errorClass']);
+    }
+
+    #[Test]
+    public function beginReturnsNullWhenTheRepositoryThrows(): void
+    {
+        $repository               = new RecordingAgentRunRepository();
+        $repository->throwOnStart = true;
+        $persister                = new AgentRunPersister($repository);
+
+        self::assertNull($persister->begin(null, 0));
+    }
+
+    #[Test]
+    public function recordStepSwallowsARepositoryErrorAndDoesNotAdvanceTheHandle(): void
+    {
+        $repository                = new RecordingAgentRunRepository();
+        $repository->throwOnRecord = true;
+        $persister                 = new AgentRunPersister($repository);
+        $handle                    = new AgentRunHandle(1, 'uuid');
+
+        $persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 1.0, content: 'x'));
+
+        // No exception escaped, and the sequence only advances on a successful write.
+        self::assertSame(0, $handle->sequence);
+    }
+
+    #[Test]
+    public function settleSwallowsARepositoryError(): void
+    {
+        $repository                = new RecordingAgentRunRepository();
+        $repository->throwOnFinish = true;
+        $persister                 = new AgentRunPersister($repository);
+        $handle                    = new AgentRunHandle(1, 'uuid');
+
+        $persister->settleCompleted($handle, new ToolLoopResult('', [], 1, false, UsageStatistics::fromTokens(0, 0)));
+        $persister->settleFailed($handle, new RuntimeException('boom'));
+
+        // Both settle paths returned without throwing.
+        self::assertNull($repository->finished);
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
+use RuntimeException;
+
+/**
+ * In-memory {@see AgentRunRepositoryInterface} for unit-testing the persister:
+ * captures every call for assertion and can be told to throw on any method to
+ * exercise the persister's fail-soft behaviour.
+ */
+final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
+{
+    public int $nextUid = 1;
+
+    public bool $throwOnStart = false;
+
+    public bool $throwOnRecord = false;
+
+    public bool $throwOnFinish = false;
+
+    /** @var list<array{uuid: string, configurationUid: int, configurationIdentifier: string, beUser: int}> */
+    public array $startedRuns = [];
+
+    /** @var list<array{runUid: int, sequence: int, kind: string, round: int, durationMs: float, payloadJson: string}> */
+    public array $events = [];
+
+    /** @var array{runUid: int, status: string, iterations: int, truncated: bool, promptTokens: int, completionTokens: int, totalTokens: int, estimatedCost: float, errorClass: string}|null */
+    public ?array $finished = null;
+
+    public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int
+    {
+        if ($this->throwOnStart) {
+            throw new RuntimeException('startRun failed', 5383517209);
+        }
+        $this->startedRuns[] = [
+            'uuid'                     => $uuid,
+            'configurationUid'         => $configurationUid,
+            'configurationIdentifier'  => $configurationIdentifier,
+            'beUser'                   => $beUser,
+        ];
+
+        return $this->nextUid++;
+    }
+
+    public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
+    {
+        if ($this->throwOnRecord) {
+            throw new RuntimeException('recordEvent failed', 9973913396);
+        }
+        $this->events[] = [
+            'runUid'      => $runUid,
+            'sequence'    => $sequence,
+            'kind'        => $kind,
+            'round'       => $round,
+            'durationMs'  => $durationMs,
+            'payloadJson' => $payloadJson,
+        ];
+    }
+
+    public function finishRun(
+        int $runUid,
+        string $status,
+        int $iterations,
+        bool $truncated,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        float $estimatedCost,
+        string $errorClass,
+    ): void {
+        if ($this->throwOnFinish) {
+            throw new RuntimeException('finishRun failed', 7543565687);
+        }
+        $this->finished = [
+            'runUid'           => $runUid,
+            'status'           => $status,
+            'iterations'       => $iterations,
+            'truncated'        => $truncated,
+            'promptTokens'     => $promptTokens,
+            'completionTokens' => $completionTokens,
+            'totalTokens'      => $totalTokens,
+            'estimatedCost'    => $estimatedCost,
+            'errorClass'       => $errorClass,
+        ];
+    }
+
+    public function findByUuid(string $uuid): ?AgentRun
+    {
+        return null;
+    }
+
+    public function findEvents(int $runUid): array
+    {
+        return [];
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        return 0;
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -647,3 +647,67 @@ CREATE TABLE tx_nrllm_eval_result (
     -- Quality-routing read path: latest runs per set for a model.
     KEY model_lookup (model_id, run_date)
 );
+
+#
+# Persisted agent runs (ADR-081): one row per ToolLoopService run, promoted from
+# the in-memory RunTrace so runs survive the request. UI-less append-and-update
+# log, mirroring tx_nrllm_telemetry (no TCA, no Extbase).
+#
+CREATE TABLE tx_nrllm_agentrun (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    uuid varchar(36) DEFAULT '' NOT NULL,
+    status varchar(32) DEFAULT 'queued' NOT NULL,
+    configuration_uid int(11) unsigned DEFAULT '0' NOT NULL,
+    configuration_identifier varchar(150) DEFAULT '' NOT NULL,
+    be_user int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Outcome
+    iterations int(11) unsigned DEFAULT '0' NOT NULL,
+    truncated smallint(5) unsigned DEFAULT '0' NOT NULL,
+    total_prompt_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    total_completion_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    total_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    estimated_cost decimal(10,6) DEFAULT '0.000000' NOT NULL,
+    error_class varchar(255) DEFAULT '' NOT NULL,
+
+    -- Time tracking
+    started_at int(11) unsigned DEFAULT '0' NOT NULL,
+    finished_at int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    KEY run_uuid (uuid),
+    KEY be_user (be_user, crdate),
+    KEY status_lookup (status, crdate),
+    KEY crdate (crdate)
+);
+
+#
+# Agent-run event stream (ADR-081): the durable, replayable form of each
+# RunStep, one row per step, ordered by sequence within a run.
+#
+CREATE TABLE tx_nrllm_agentrun_event (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    run int(11) unsigned DEFAULT '0' NOT NULL,
+    sequence int(11) unsigned DEFAULT '0' NOT NULL,
+    kind varchar(32) DEFAULT '' NOT NULL,
+    round int(11) unsigned DEFAULT '0' NOT NULL,
+    duration_ms decimal(10,2) DEFAULT '0.00' NOT NULL,
+    payload mediumtext,
+
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- Replay read path: a run's events in order.
+    KEY run_sequence (run, sequence),
+    KEY crdate (crdate)
+);


### PR DESCRIPTION
## Epic A — AgentRun persistence + typed event stream (P0)

First epic of the MCP-free, de-duplicated platform roadmap. It is the keystone: resumable/queued runs, approval pauses, batch execution, audit, and a replayable event stream all need a **persisted** run to attach to — today a run exists only for one HTTP request.

### What this adds
- **Two UI-less log tables** (raw SQL, no TCA/Extbase — the `tx_nrllm_telemetry` precedent): `tx_nrllm_agentrun` (one summary row per run) and `tx_nrllm_agentrun_event` (one row per step, ordered by `sequence`).
- **`AgentRunPersister`** — a fail-soft orchestrator driven through the **existing** `RunTrace.onRecord` hook: opens a run, records each `RunStep` as an event, settles it to a terminal state. `ToolLoopService` is **untouched**.
- **`AgentRunStatus`** enum (full lifecycle the later epics consume) and **`AgentEventKind`** (only the four kinds `RunStep` actually emits — no speculative kinds).
- Playground batch + streamed paths persist runs; the streamed path settles in a `finally` block (client-disconnect safety, mirroring `StreamingDispatcher`).
- ADR-081.

### Design notes
- **Fail-soft is a hard guarantee:** every persistence error is logged and swallowed; `begin()` returns null on failure and the caller records nothing. A DB hiccup cannot break a run.
- **Additive, non-invasive:** the persister is optional/last on the controller constructor, so the existing direct constructions in the functional tests keep compiling and run with persistence off — a characterization guard that the loop path is unchanged. DI autowires the real persister in production.
- **Known limitation (documented in ADR-081):** a cap-hit run and a budget-denied run both surface as `completed` with `truncated = true`, because `ToolLoopService` swallows the budget denial internally. Distinguishing them as `failed` is deferred to the human-in-the-loop epic, which reshapes the loop's exit paths.

### Tests
- Unit: `AgentRunStatus`/`AgentEventKind` (validity + unknown handling), `AgentRunPersister` logic + fail-soft (recording double).
- Functional: DB round-trip (begin → record → settle → read back run + ordered events), failed-run path, purge; controller path persists a completed run + its 5-event stream.

### Verification
Local `runTests.sh -p 8.4`: `cgl`, `phpstan` (level 10), `unit` (5162), `functional -d sqlite` (scoped), `rector -n`, `fuzzy` — all green.

Part of the P0/P1 roadmap sweep; next PRs: structured outputs (B), sessions (E), human-in-the-loop approval (D), guardrail pipeline (C).
