### PR TITLE
feat(completion): schema-validated structured outputs with repair (ADR-082)

### DIFF
--- a/Classes/Service/Evaluation/Grader/DeterministicGrader.php
+++ b/Classes/Service/Evaluation/Grader/DeterministicGrader.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Enum\AssertionType;
 use Netresearch\NrLlm\Service\Evaluation\Assertion;
 use Netresearch\NrLlm\Service\Evaluation\GoldenPrompt;
 use Netresearch\NrLlm\Service\Evaluation\GradingResult;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 
 /**
  * Grades a response by evaluating a golden prompt's deterministic
@@ -27,6 +28,10 @@ use Netresearch\NrLlm\Service\Evaluation\GradingResult;
 final readonly class DeterministicGrader implements GraderInterface
 {
     public const IDENTIFIER = 'deterministic';
+
+    public function __construct(
+        private JsonSchemaValidator $schemaValidator = new JsonSchemaValidator(),
+    ) {}
 
     public function getIdentifier(): string
     {
@@ -69,80 +74,7 @@ final readonly class DeterministicGrader implements GraderInterface
             AssertionType::EXACT => trim($response) === trim($assertion->value),
             AssertionType::CONTAINS => str_contains($response, $assertion->value),
             AssertionType::REGEX => preg_match($assertion->value, $response) === 1,
-            AssertionType::JSON_SCHEMA => $this->matchesJsonSchema($response, $assertion->value),
-        };
-    }
-
-    /**
-     * Lightweight structural JSON match: valid JSON whose shape satisfies a
-     * subset schema (top-level `type`, object `required` keys, and recursive
-     * `properties` types). Extra keys are allowed; this is deliberately not a
-     * full JSON Schema draft validator.
-     */
-    private function matchesJsonSchema(string $response, string $schemaJson): bool
-    {
-        $data = json_decode($response, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            return false;
-        }
-        $schema = json_decode($schemaJson, true);
-        if (!is_array($schema)) {
-            return false;
-        }
-
-        return $this->validateAgainstSchema($data, $schema);
-    }
-
-    /**
-     * @param array<array-key, mixed> $schema
-     */
-    private function validateAgainstSchema(mixed $data, array $schema): bool
-    {
-        $type = $schema['type'] ?? null;
-        if (is_string($type) && !$this->matchesType($data, $type)) {
-            return false;
-        }
-
-        if (isset($schema['required']) && is_array($schema['required'])) {
-            // An empty JSON object decodes to []; treat it as an object here
-            // (consistent with matchesType()) so an empty object is not
-            // mistaken for a list and the required-key checks still run.
-            if (!is_array($data) || ($data !== [] && array_is_list($data))) {
-                return false;
-            }
-            foreach ($schema['required'] as $key) {
-                if (!is_string($key) || !array_key_exists($key, $data)) {
-                    return false;
-                }
-            }
-        }
-
-        if (isset($schema['properties']) && is_array($schema['properties']) && is_array($data)) {
-            foreach ($schema['properties'] as $key => $propSchema) {
-                if (is_array($propSchema) && array_key_exists($key, $data)
-                    && !$this->validateAgainstSchema($data[$key], $propSchema)
-                ) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private function matchesType(mixed $data, string $type): bool
-    {
-        return match ($type) {
-            // An empty JSON object and array both decode to []; ambiguity is
-            // accepted for this lightweight matcher.
-            'object' => is_array($data) && (!array_is_list($data) || $data === []),
-            'array' => is_array($data) && array_is_list($data),
-            'string' => is_string($data),
-            'number' => is_int($data) || is_float($data),
-            'integer' => is_int($data),
-            'boolean' => is_bool($data),
-            'null' => $data === null,
-            default => true,
+            AssertionType::JSON_SCHEMA => $this->schemaValidator->validateJson($response, $assertion->value),
         };
     }
 

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 
 /**
  * High-level service for text completion.
@@ -41,6 +42,7 @@ final readonly class CompletionService implements CompletionServiceInterface
     public function __construct(
         private LlmServiceManagerInterface $llmManager,
         private ?BackendUserContextResolverInterface $beUserContextResolver = null,
+        private JsonSchemaValidator $schemaValidator = new JsonSchemaValidator(),
     ) {}
 
     /**
@@ -99,6 +101,50 @@ final readonly class CompletionService implements CompletionServiceInterface
     }
 
     /**
+     * Generate a completion whose JSON response is validated against a subset
+     * JSON Schema, with one controlled repair round-trip on a decode or schema
+     * failure (ADR-082).
+     *
+     * Provider-agnostic: the schema is injected into the prompt and JSON mode is
+     * requested, then the decoded payload is validated locally with
+     * {@see JsonSchemaValidator}. A native provider structured-output guarantee
+     * is a separate concern (see ADR-082).
+     *
+     * @param array<string, mixed> $schema Subset JSON Schema: top-level `type`,
+     *                                     object `required` keys and per-key
+     *                                     `properties` types are enforced.
+     *
+     * @throws InvalidArgumentException when the response still fails to match the
+     *                                  schema after one repair attempt
+     *
+     * @return array<string, mixed> The decoded, schema-valid JSON payload
+     */
+    public function completeStructured(string $prompt, array $schema, ?ChatOptions $options = null): array
+    {
+        $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
+        $schemaJson = $this->encodeSchema($schema);
+
+        $first  = $this->complete($this->withSchemaInstruction($prompt, $schemaJson), $options)->content;
+        $result = $this->decodeAndValidate($first, $schema);
+        if ($result !== null) {
+            return $result;
+        }
+
+        // One controlled repair round-trip: show the model its invalid output
+        // and the schema, and ask again.
+        $repaired = $this->complete($this->withRepairInstruction($prompt, $schemaJson, $first), $options)->content;
+        $result   = $this->decodeAndValidate($repaired, $schema);
+        if ($result !== null) {
+            return $result;
+        }
+
+        throw new InvalidArgumentException(
+            'Structured completion did not match the required schema after one repair attempt.',
+            1784500001,
+        );
+    }
+
+    /**
      * Generate markdown-formatted completion.
      *
      * @param string $prompt The user prompt
@@ -149,6 +195,85 @@ final readonly class CompletionService implements CompletionServiceInterface
         return $this->decodeJsonResponse(
             $this->completeForConfiguration($prompt, $configuration, $options)->content,
         );
+    }
+
+    /**
+     * The named-configuration counterpart to {@see completeStructured()}.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @throws InvalidArgumentException when the response still fails to match the
+     *                                  schema after one repair attempt
+     *
+     * @return array<string, mixed>
+     */
+    public function completeStructuredForConfiguration(string $prompt, LlmConfiguration $configuration, array $schema, ?ChatOptions $options = null): array
+    {
+        $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
+        $schemaJson = $this->encodeSchema($schema);
+
+        $first  = $this->completeForConfiguration($this->withSchemaInstruction($prompt, $schemaJson), $configuration, $options)->content;
+        $result = $this->decodeAndValidate($first, $schema);
+        if ($result !== null) {
+            return $result;
+        }
+
+        $repaired = $this->completeForConfiguration($this->withRepairInstruction($prompt, $schemaJson, $first), $configuration, $options)->content;
+        $result   = $this->decodeAndValidate($repaired, $schema);
+        if ($result !== null) {
+            return $result;
+        }
+
+        throw new InvalidArgumentException(
+            'Structured completion did not match the required schema after one repair attempt.',
+            1784500002,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    private function encodeSchema(array $schema): string
+    {
+        return json_encode($schema, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    private function withSchemaInstruction(string $prompt, string $schemaJson): string
+    {
+        return $prompt
+            . "\n\nRespond with ONLY a single JSON value conforming to this JSON Schema. "
+            . "Do not wrap it in Markdown code fences and do not add any prose:\n"
+            . $schemaJson;
+    }
+
+    private function withRepairInstruction(string $prompt, string $schemaJson, string $invalid): string
+    {
+        return $this->withSchemaInstruction($prompt, $schemaJson)
+            . "\n\nYour previous response did not conform to the schema. It was:\n"
+            . mb_substr($invalid, 0, 2000);
+    }
+
+    /**
+     * Decode a response and validate it against the schema. Returns the decoded
+     * payload only when it is a schema-valid JSON value, null otherwise (an
+     * invalid decode or a schema mismatch), so the caller can trigger a repair.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>|null
+     */
+    private function decodeAndValidate(string $content, array $schema): ?array
+    {
+        $decoded = json_decode($content, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+        if (!$this->schemaValidator->validate($decoded, $schema)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -248,9 +248,16 @@ final readonly class CompletionService implements CompletionServiceInterface
 
     private function withRepairInstruction(string $prompt, string $schemaJson, string $invalid): string
     {
+        // Mark truncation so the model does not mistake a system-cut JSON tail
+        // for the model's own malformed output.
+        $snippet = mb_substr($invalid, 0, 2000);
+        if (mb_strlen($invalid) > 2000) {
+            $snippet .= "\n[... truncated ...]";
+        }
+
         return $this->withSchemaInstruction($prompt, $schemaJson)
             . "\n\nYour previous response did not conform to the schema. It was:\n"
-            . mb_substr($invalid, 0, 2000);
+            . $snippet;
     }
 
     /**

--- a/Classes/Service/Feature/CompletionServiceInterface.php
+++ b/Classes/Service/Feature/CompletionServiceInterface.php
@@ -41,6 +41,21 @@ interface CompletionServiceInterface
     public function completeJson(string $prompt, ?ChatOptions $options = null): array;
 
     /**
+     * Generate a completion validated against a subset JSON Schema, with one
+     * controlled repair round-trip on a decode or schema failure (ADR-082).
+     *
+     * @param array<string, mixed> $schema Subset JSON Schema (top-level `type`,
+     *                                     object `required` keys, per-key
+     *                                     `properties` types)
+     *
+     * @throws InvalidArgumentException when the response still fails to match the
+     *                                  schema after one repair attempt
+     *
+     * @return array<string, mixed> The decoded, schema-valid JSON payload
+     */
+    public function completeStructured(string $prompt, array $schema, ?ChatOptions $options = null): array;
+
+    /**
      * Generate a Markdown-formatted completion (system prompt augmented to request Markdown).
      */
     public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string;
@@ -76,6 +91,18 @@ interface CompletionServiceInterface
      * @return array<string, mixed> Parsed JSON response
      */
     public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array;
+
+    /**
+     * The named-configuration counterpart to {@see completeStructured()}.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @throws InvalidArgumentException when the response still fails to match the
+     *                                  schema after one repair attempt
+     *
+     * @return array<string, mixed>
+     */
+    public function completeStructuredForConfiguration(string $prompt, LlmConfiguration $configuration, array $schema, ?ChatOptions $options = null): array;
 
     /**
      * Generate a Markdown-formatted completion against a specific LlmConfiguration record.

--- a/Classes/Service/Schema/JsonSchemaValidator.php
+++ b/Classes/Service/Schema/JsonSchemaValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Schema;
+
+/**
+ * Lightweight structural JSON-Schema matcher (ADR-082).
+ *
+ * Validates a decoded value against a subset schema — the top-level ``type``,
+ * an object's ``required`` keys, and recursive ``properties`` types. Extra keys
+ * are allowed; this is deliberately **not** a full JSON Schema draft validator,
+ * so there is no runtime dependency.
+ *
+ * The logic was extracted verbatim from `DeterministicGrader` (ADR-060) so the
+ * evaluation grader and the structured-completion path share one matcher instead
+ * of duplicating it.
+ */
+final readonly class JsonSchemaValidator
+{
+    /**
+     * Validate a decoded value against a subset JSON Schema.
+     *
+     * @param array<array-key, mixed> $schema
+     */
+    public function validate(mixed $data, array $schema): bool
+    {
+        $type = $schema['type'] ?? null;
+        if (is_string($type) && !$this->matchesType($data, $type)) {
+            return false;
+        }
+
+        if (isset($schema['required']) && is_array($schema['required'])) {
+            // An empty JSON object decodes to []; treat it as an object here
+            // (consistent with matchesType()) so an empty object is not
+            // mistaken for a list and the required-key checks still run.
+            if (!is_array($data) || ($data !== [] && array_is_list($data))) {
+                return false;
+            }
+            foreach ($schema['required'] as $key) {
+                if (!is_string($key) || !array_key_exists($key, $data)) {
+                    return false;
+                }
+            }
+        }
+
+        if (isset($schema['properties']) && is_array($schema['properties']) && is_array($data)) {
+            foreach ($schema['properties'] as $key => $propSchema) {
+                if (is_array($propSchema) && array_key_exists($key, $data)
+                    && !$this->validate($data[$key], $propSchema)
+                ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a JSON response string against a JSON-encoded subset schema.
+     * Returns false when either side is not valid JSON.
+     */
+    public function validateJson(string $json, string $schemaJson): bool
+    {
+        $data = json_decode($json, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return false;
+        }
+        $schema = json_decode($schemaJson, true);
+        if (!is_array($schema)) {
+            return false;
+        }
+
+        return $this->validate($data, $schema);
+    }
+
+    private function matchesType(mixed $data, string $type): bool
+    {
+        return match ($type) {
+            // An empty JSON object and array both decode to []; ambiguity is
+            // accepted for this lightweight matcher.
+            'object' => is_array($data) && (!array_is_list($data) || $data === []),
+            'array' => is_array($data) && array_is_list($data),
+            'string' => is_string($data),
+            'number' => is_int($data) || is_float($data),
+            'integer' => is_int($data),
+            'boolean' => is_bool($data),
+            'null' => $data === null,
+            default => true,
+        };
+    }
+}

--- a/Classes/Testing/FakeCompletionService.php
+++ b/Classes/Testing/FakeCompletionService.php
@@ -54,6 +54,14 @@ final class FakeCompletionService implements CompletionServiceInterface
      */
     public array $jsonResult = [];
 
+    /**
+     * Canned result for {@see self::completeStructured()} and
+     * {@see self::completeStructuredForConfiguration()}.
+     *
+     * @var array<string, mixed>
+     */
+    public array $structuredResult = [];
+
     /** Canned result for {@see self::completeMarkdown()} and {@see self::completeMarkdownForConfiguration()}. */
     public string $markdownResult = '';
 
@@ -93,6 +101,12 @@ final class FakeCompletionService implements CompletionServiceInterface
     /** @var list<array{prompt: string, configuration: LlmConfiguration, options: ?ChatOptions}> */
     public array $completeCreativeForConfigurationCalls = [];
 
+    /** @var list<array{prompt: string, schema: array<string, mixed>, options: ?ChatOptions}> */
+    public array $completeStructuredCalls = [];
+
+    /** @var list<array{prompt: string, configuration: LlmConfiguration, schema: array<string, mixed>, options: ?ChatOptions}> */
+    public array $completeStructuredForConfigurationCalls = [];
+
     public function complete(string $prompt, ?ChatOptions $options = null): CompletionResponse
     {
         $this->completeCalls[] = ['prompt' => $prompt, 'options' => $options];
@@ -106,6 +120,14 @@ final class FakeCompletionService implements CompletionServiceInterface
         $this->guardThrow();
 
         return $this->jsonResult;
+    }
+
+    public function completeStructured(string $prompt, array $schema, ?ChatOptions $options = null): array
+    {
+        $this->completeStructuredCalls[] = ['prompt' => $prompt, 'schema' => $schema, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->structuredResult;
     }
 
     public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string
@@ -143,6 +165,14 @@ final class FakeCompletionService implements CompletionServiceInterface
         $this->guardThrow();
 
         return $this->jsonResult;
+    }
+
+    public function completeStructuredForConfiguration(string $prompt, LlmConfiguration $configuration, array $schema, ?ChatOptions $options = null): array
+    {
+        $this->completeStructuredForConfigurationCalls[] = ['prompt' => $prompt, 'configuration' => $configuration, 'schema' => $schema, 'options' => $options];
+        $this->guardThrow();
+
+        return $this->structuredResult;
     }
 
     public function completeMarkdownForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): string

--- a/Documentation/Adr/Adr082StructuredOutputs.rst
+++ b/Documentation/Adr/Adr082StructuredOutputs.rst
@@ -1,0 +1,81 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-082:
+
+============================================================================
+ADR-082: Schema-validated structured outputs with one repair round-trip
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-082-context:
+
+Context
+=======
+
+`CompletionService::completeJson()` only enabled JSON mode and ran `json_decode`,
+checking the result was valid JSON and an array. No *business* schema was
+enforced — a consumer that needed, say, ``{title, description, keywords[]}`` back
+got an untyped ``array<string, mixed>`` that could be missing keys or carry the
+wrong types, and a single malformed response threw with no recovery. That makes
+AI results unreliable to program against.
+
+A lightweight structural JSON-Schema matcher already existed inside
+`DeterministicGrader` (:ref:`ADR-060 <adr-060>`, the evaluation subsystem):
+top-level ``type``, object ``required`` keys, recursive ``properties`` types.
+Its logic was exactly what a validated completion path needs, but it was private
+to the grader.
+
+.. _adr-082-decision:
+
+Decision
+========
+
+**Extract the grader's matcher into a shared `JsonSchemaValidator`** (`Service/Schema/`)
+and have both `DeterministicGrader` and the new completion path use it — one
+matcher, no duplication. The behaviour is byte-for-byte the grader's (including
+the empty-object-decodes-to-`[]` handling); the grader now delegates to it.
+
+**Add `completeStructured()` (and its `*ForConfiguration` twin)** to
+`CompletionServiceInterface` / `CompletionService`. Given a prompt and a subset
+JSON Schema, it:
+
+1. requests JSON mode and injects the schema into the prompt (an instruction to
+   return only conforming JSON),
+2. decodes and validates the response with `JsonSchemaValidator`,
+3. on a decode failure **or** a schema mismatch, performs **one** controlled
+   repair round-trip — re-asking with the invalid output and the schema,
+4. returns the validated payload, or throws `InvalidArgumentException` if the
+   repair also fails.
+
+**Provider-agnostic by design.** The guarantee is prompt-injection + local
+validation + one repair, which works on every provider (OpenAI, Claude, Gemini,
+Ollama, Groq, Mistral, OpenRouter) uniformly. Native provider structured outputs
+were **deliberately not** used here: OpenAI's ``response_format: json_schema``
+requires *strict* schemas (``additionalProperties: false`` and every property
+required), which arbitrary consumer schemas do not satisfy and which would 400
+the request; Claude has no native parameter at all. Wiring native, per-provider
+enforcement — behind a schema-compatibility normaliser — is a separate, additive
+change and is noted as a follow-up, not a blocker.
+
+.. _adr-082-consequences:
+
+Consequences
+============
+
+- Consumers get a reliable typed contract: a schema in, validated data out, with
+  automatic single-shot repair. `completeJson()` is unchanged for callers that do
+  not need a schema.
+- The matcher lives in one place; a fix to the structural rules now benefits both
+  the grader and structured completions.
+- Validation is *structural* (the documented subset), not full JSON Schema draft
+  semantics — no ``enum``, ``minLength``, ``pattern``, ``oneOf`` etc. That is the
+  same contract the grader has always offered; a full validator would add a
+  runtime dependency and is out of scope.
+- The repair round-trip costs at most one extra provider call, only when the first
+  response fails. It is capped at one attempt to bound cost.
+- `CompletionService` and `DeterministicGrader` take the validator as a
+  constructor dependency with a default instance, so existing direct
+  constructions (tests) keep working and DI autowires the shared service.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -378,3 +378,4 @@ Tools
    Adr078SpecializedServiceBudgetEnforcement
    Adr079FirstPartyCompletionVisionBudgetFakes
    Adr080TypedProviderHttpExceptions
+   Adr082StructuredOutputs

--- a/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
+++ b/Tests/Unit/Service/Evaluation/Fixture/StaticCompletionService.php
@@ -54,6 +54,13 @@ final class StaticCompletionService implements CompletionServiceInterface
         return [];
     }
 
+    public function completeStructured(string $prompt, array $schema, ?ChatOptions $options = null): array
+    {
+        $this->receivedPrompts[] = $prompt;
+
+        return [];
+    }
+
     public function completeMarkdown(string $prompt, ?ChatOptions $options = null): string
     {
         return $this->content;
@@ -75,6 +82,13 @@ final class StaticCompletionService implements CompletionServiceInterface
     }
 
     public function completeJsonForConfiguration(string $prompt, LlmConfiguration $configuration, ?ChatOptions $options = null): array
+    {
+        $this->receivedPrompts[] = $prompt;
+
+        return [];
+    }
+
+    public function completeStructuredForConfiguration(string $prompt, LlmConfiguration $configuration, array $schema, ?ChatOptions $options = null): array
     {
         $this->receivedPrompts[] = $prompt;
 

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -1004,6 +1004,92 @@ class CompletionServiceTest extends AbstractUnitTestCase
         $subject->completeForConfiguration('hello', $configuration);
     }
 
+    #[Test]
+    public function completeStructuredReturnsValidatedPayloadOnFirstAttempt(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        $llmManagerMock->expects(self::once())->method('chat')
+            ->willReturn($this->createMockResponse('{"title": "Hello", "description": "World"}'));
+
+        $schema = [
+            'type'       => 'object',
+            'required'   => ['title', 'description'],
+            'properties' => [
+                'title'       => ['type' => 'string'],
+                'description' => ['type' => 'string'],
+            ],
+        ];
+
+        $result = $subject->completeStructured('Generate metadata', $schema);
+
+        self::assertSame('Hello', $result['title']);
+        self::assertSame('World', $result['description']);
+    }
+
+    #[Test]
+    public function completeStructuredRepairsOnceWhenTheFirstResponseFailsTheSchema(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        // First response omits the required 'description'; the single repair
+        // round-trip supplies it.
+        $responses = [
+            $this->createMockResponse('{"title": "Hello"}'),
+            $this->createMockResponse('{"title": "Hello", "description": "World"}'),
+        ];
+        $index = 0;
+        $llmManagerMock->expects(self::exactly(2))->method('chat')
+            ->willReturnCallback(function () use (&$responses, &$index): CompletionResponse {
+                return $responses[$index++];
+            });
+
+        $result = $subject->completeStructured('Generate metadata', ['type' => 'object', 'required' => ['title', 'description']]);
+
+        self::assertSame('World', $result['description']);
+    }
+
+    #[Test]
+    public function completeStructuredRepairsOnceWhenTheFirstResponseIsNotJson(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        $responses = [
+            $this->createMockResponse('Sure, here you go:'),
+            $this->createMockResponse('{"ok": true}'),
+        ];
+        $index = 0;
+        $llmManagerMock->expects(self::exactly(2))->method('chat')
+            ->willReturnCallback(function () use (&$responses, &$index): CompletionResponse {
+                return $responses[$index++];
+            });
+
+        $result = $subject->completeStructured('Generate', ['type' => 'object', 'required' => ['ok']]);
+
+        self::assertTrue($result['ok']);
+    }
+
+    #[Test]
+    public function completeStructuredThrowsWhenTheSchemaStillFailsAfterRepair(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        // Both the initial attempt and the repair omit the required key.
+        $llmManagerMock->expects(self::exactly(2))->method('chat')
+            ->willReturn($this->createMockResponse('{"title": "Hello"}'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $subject->completeStructured('Generate', ['type' => 'object', 'required' => ['description']]);
+    }
+
+    #[Test]
+    public function completeStructuredForConfigurationValidatesAgainstTheSchema(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        $llmManagerMock->expects(self::once())->method('completeForConfiguration')
+            ->willReturn($this->createMockResponse('{"score": 5}'));
+
+        $result = $subject->completeStructuredForConfiguration('Rate this', new LlmConfiguration(), ['type' => 'object', 'required' => ['score']]);
+
+        self::assertSame(5, $result['score']);
+    }
+
     /**
      * Create mock CompletionResponse.
      */

--- a/Tests/Unit/Service/Schema/JsonSchemaValidatorTest.php
+++ b/Tests/Unit/Service/Schema/JsonSchemaValidatorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Schema;
+
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JsonSchemaValidator::class)]
+final class JsonSchemaValidatorTest extends TestCase
+{
+    private JsonSchemaValidator $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new JsonSchemaValidator();
+    }
+
+    #[Test]
+    public function acceptsAnObjectSatisfyingTypeRequiredAndProperties(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'required'   => ['title', 'description'],
+            'properties' => [
+                'title'       => ['type' => 'string'],
+                'description' => ['type' => 'string'],
+            ],
+        ];
+
+        self::assertTrue($this->subject->validate(['title' => 'a', 'description' => 'b'], $schema));
+    }
+
+    #[Test]
+    public function rejectsAMissingRequiredKey(): void
+    {
+        $schema = ['type' => 'object', 'required' => ['title', 'description']];
+
+        self::assertFalse($this->subject->validate(['title' => 'a'], $schema));
+    }
+
+    #[Test]
+    public function allowsExtraKeysNotDeclaredInTheSchema(): void
+    {
+        $schema = ['type' => 'object', 'required' => ['title']];
+
+        self::assertTrue($this->subject->validate(['title' => 'a', 'extra' => 1], $schema));
+    }
+
+    #[Test]
+    public function rejectsAWrongTopLevelType(): void
+    {
+        self::assertFalse($this->subject->validate('a string', ['type' => 'object']));
+        self::assertFalse($this->subject->validate(['a', 'b'], ['type' => 'object']));
+        self::assertTrue($this->subject->validate(['a', 'b'], ['type' => 'array']));
+    }
+
+    #[Test]
+    public function treatsAnEmptyArrayAsAnEmptyObject(): void
+    {
+        self::assertTrue($this->subject->validate([], ['type' => 'object']));
+        self::assertFalse($this->subject->validate([], ['type' => 'object', 'required' => ['x']]));
+    }
+
+    #[Test]
+    public function validatesScalarPropertyTypes(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'count'  => ['type' => 'integer'],
+                'ratio'  => ['type' => 'number'],
+                'active' => ['type' => 'boolean'],
+                'name'   => ['type' => 'string'],
+            ],
+        ];
+
+        self::assertTrue($this->subject->validate(['count' => 3, 'ratio' => 1.5, 'active' => true, 'name' => 'x'], $schema));
+        self::assertFalse($this->subject->validate(['count' => '3'], $schema));
+        self::assertFalse($this->subject->validate(['active' => 'yes'], $schema));
+    }
+
+    #[Test]
+    public function validatesNestedObjectProperties(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'meta' => ['type' => 'object', 'required' => ['id']],
+            ],
+        ];
+
+        self::assertTrue($this->subject->validate(['meta' => ['id' => 1]], $schema));
+        self::assertFalse($this->subject->validate(['meta' => ['other' => 1]], $schema));
+    }
+
+    #[Test]
+    public function validateJsonParsesBothSides(): void
+    {
+        self::assertTrue($this->subject->validateJson('{"a": 1}', '{"type": "object", "required": ["a"]}'));
+        self::assertFalse($this->subject->validateJson('{"b": 1}', '{"type": "object", "required": ["a"]}'));
+    }
+
+    #[Test]
+    public function validateJsonRejectsMalformedInput(): void
+    {
+        self::assertFalse($this->subject->validateJson('not json', '{"type": "object"}'));
+        self::assertFalse($this->subject->validateJson('{"a": 1}', 'not json'));
+    }
+}


### PR DESCRIPTION
## Epic B — Structured outputs (JSON Schema + validation + repair) (P0)

Second epic of the platform roadmap. Independent of Epic A (#437).

### Problem
`completeJson()` only enabled JSON mode and checked the result decoded to an array — no *business* schema was enforced, and one malformed response threw with no recovery. Consumers got an untyped `array<string, mixed>` they couldn't rely on.

### What this adds
- **`completeStructured()`** (+ `*ForConfiguration` twin) on `CompletionServiceInterface`/`CompletionService`: given a prompt and a subset JSON Schema → requests JSON mode, injects the schema into the prompt, validates the decoded payload, and on a decode **or** schema failure performs **one** controlled repair round-trip before throwing.
- **`JsonSchemaValidator`** (`Service/Schema/`): the lightweight structural matcher that already lived *private* inside `DeterministicGrader` (ADR-060), extracted and now shared by both the grader and the completion path — **one matcher, no duplication**. The grader delegates to it; behaviour is byte-for-byte unchanged.
- ADR-082.

### Design notes
- **Provider-agnostic:** prompt-injection + local validation + one repair works uniformly on every provider (OpenAI, Claude, Gemini, Ollama, Groq, Mistral, OpenRouter). `completeJson()` is untouched for callers that don't need a schema.
- **Native provider structured outputs deliberately not used** (documented in ADR-082): OpenAI's `response_format: json_schema` *strict* mode requires `additionalProperties:false` + all-required schemas that arbitrary consumer schemas don't satisfy (and would 400); Claude has no native param. A schema-compatibility normaliser behind native enforcement is a noted follow-up, not a blocker.
- **Non-breaking:** both `CompletionService` and `DeterministicGrader` take the validator as a constructor dependency **with a default instance**, so existing direct constructions (tests) keep compiling and DI autowires the shared service. All four `CompletionServiceInterface` implementers (concrete + `FakeCompletionService` + `StaticCompletionService` fixture) updated.
- **Structural subset only** (top-level `type`, object `required`, per-key `properties` types) — the same contract the grader has always offered; full JSON Schema draft semantics would add a runtime dependency and are out of scope.

### Tests
- `JsonSchemaValidatorTest` — object/array/type matching, required keys, nested properties, empty-object handling, malformed JSON.
- `CompletionServiceTest` — valid-first-attempt, repair-on-schema-miss, repair-on-non-JSON, throw-after-repair, and the config twin.

### Verification
Local `runTests.sh -p 8.4`: `cgl`, `phpstan` (L10), `unit` (5158), `functional -d sqlite` (eval scope — confirms DI container compiles), `rector -n`, `fuzzy` — all green.

Roadmap sweep: A (#437) shipped; next PRs — sessions (E), human-in-the-loop approval (D), guardrail pipeline (C).
