### PR TITLE
feat(conversation): persistent AI sessions and memory (ADR-083)

### DIFF
--- a/Classes/Command/PurgeAiSessionsCommand.php
+++ b/Classes/Command/PurgeAiSessionsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Deletes conversation sessions (and their messages) that have been inactive
+ * longer than the retention window (ADR-083).
+ *
+ * Session messages carry the conversation content (prompts and replies), so a
+ * retention purge is the GDPR counterpart to the telemetry/privacy purges.
+ * Mirrors {@see PurgeTelemetryCommand}.
+ */
+#[AsCommand(
+    name: 'nrllm:session:purge',
+    description: 'Delete conversation sessions inactive for longer than the retention window (default 30 days).',
+)]
+final class PurgeAiSessionsCommand extends Command
+{
+    private const DEFAULT_DAYS = 30;
+
+    public function __construct(
+        private readonly AiSessionRepositoryInterface $repository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'days',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Delete sessions with no activity for this many days.',
+            self::DEFAULT_DAYS,
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $daysOption = $input->getOption('days');
+        $days       = is_numeric($daysOption) ? (int)$daysOption : 0;
+
+        if ($days < 1) {
+            $io->error('The --days option must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $cutoff  = time() - ($days * 86400);
+        $deleted = $this->repository->purgeInactiveSince($cutoff);
+
+        $io->success(sprintf('Deleted %d conversation session(s) inactive for %d+ day(s).', $deleted, $days));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Domain/ValueObject/AiSession.php
+++ b/Classes/Domain/ValueObject/AiSession.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * A persisted conversation session, read back from `tx_nrllm_ai_session`
+ * (ADR-083).
+ *
+ * The immutable read model of one multi-turn conversation. Messages live in
+ * `tx_nrllm_ai_session_message` and are read as {@see AiSessionMessage} value
+ * objects; this row carries the session's identity, owner and activity summary.
+ */
+final readonly class AiSession
+{
+    public function __construct(
+        public int $uid,
+        public string $uuid,
+        public int $beUser,
+        public string $configurationIdentifier,
+        public string $title,
+        public int $messageCount,
+        public int $lastActivity,
+        public int $crdate,
+    ) {}
+}

--- a/Classes/Domain/ValueObject/AiSessionMessage.php
+++ b/Classes/Domain/ValueObject/AiSessionMessage.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One persisted turn of a conversation session, read back from
+ * `tx_nrllm_ai_session_message` (ADR-083).
+ *
+ * Ordered by {@see self::$sequence} within a session. The token columns are
+ * populated for assistant turns (from the completion's usage) and zero for user
+ * turns.
+ */
+final readonly class AiSessionMessage
+{
+    public function __construct(
+        public int $uid,
+        public int $session,
+        public int $sequence,
+        public string $role,
+        public string $content,
+        public string $model,
+        public int $promptTokens,
+        public int $completionTokens,
+        public int $totalTokens,
+        public int $crdate,
+    ) {}
+
+    /**
+     * Rehydrate this turn into a {@see ChatMessage} for replay into the provider.
+     */
+    public function toChatMessage(): ChatMessage
+    {
+        return new ChatMessage($this->role, $this->content);
+    }
+}

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Enum\MessageRole;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Stateful conversation service (ADR-083).
+ *
+ * Turns the stateless completion path into a multi-turn conversation: prior
+ * turns are loaded from `tx_nrllm_ai_session_message` and replayed to the
+ * provider, and the new user turn plus the assistant reply are persisted. The
+ * provider call itself is unchanged — this only assembles the message array and
+ * records the turns around it.
+ */
+final readonly class ConversationService implements ConversationServiceInterface
+{
+    public function __construct(
+        private LlmServiceManagerInterface $llmManager,
+        private AiSessionRepositoryInterface $sessions,
+        private ?BackendUserContextResolverInterface $beUserContextResolver = null,
+    ) {}
+
+    public function startSession(string $title = '', ?LlmConfiguration $configuration = null): AiSession
+    {
+        $uuid   = Uuid::v4()->toRfc4122();
+        $beUser = $this->beUserContextResolver?->resolveBeUserUid() ?? 0;
+
+        $this->sessions->startSession($uuid, $beUser, $configuration?->getIdentifier() ?? '', $title);
+
+        $session = $this->sessions->findByUuid($uuid);
+        if ($session === null) {
+            throw new RuntimeException('The conversation session could not be loaded immediately after creation.', 1784600002);
+        }
+
+        return $session;
+    }
+
+    public function send(string $sessionUuid, string $userMessage, ?ChatOptions $options = null): CompletionResponse
+    {
+        $session = $this->sessions->findByUuid($sessionUuid);
+        if ($session === null) {
+            throw new InvalidArgumentException(sprintf('Unknown AI session "%s".', $sessionUuid), 1784600001);
+        }
+
+        $options ??= new ChatOptions();
+        $history   = $this->sessions->findMessages($session->uid);
+
+        $messages = [];
+        // Prepend the system prompt only on the first turn: once the persisted
+        // history carries the conversation, re-adding it would duplicate it.
+        $systemPrompt = $options->toArray()['system_prompt'] ?? null;
+        if ($history === [] && is_string($systemPrompt) && $systemPrompt !== '') {
+            $messages[] = ChatMessage::system($systemPrompt);
+        }
+        foreach ($history as $message) {
+            $messages[] = $message->toChatMessage();
+        }
+        $messages[] = ChatMessage::user($userMessage);
+
+        $nextSequence = $session->messageCount;
+        // Persist the user turn before the call: it is a real turn regardless of
+        // whether the provider then succeeds.
+        $this->sessions->appendMessage($session->uid, $nextSequence, MessageRole::USER->value, $userMessage, '', 0, 0, 0);
+
+        $response = $this->llmManager->chat($messages, $options);
+
+        $this->sessions->appendMessage(
+            $session->uid,
+            $nextSequence + 1,
+            MessageRole::ASSISTANT->value,
+            $response->content,
+            $response->model,
+            $response->usage->promptTokens,
+            $response->usage->completionTokens,
+            $response->usage->totalTokens,
+        );
+        $this->sessions->touch($session->uid, $nextSequence + 2);
+
+        return $response;
+    }
+}

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -65,10 +65,12 @@ final readonly class ConversationService implements ConversationServiceInterface
         $history   = $this->sessions->findMessages($session->uid);
 
         $messages = [];
-        // Prepend the system prompt only on the first turn: once the persisted
-        // history carries the conversation, re-adding it would duplicate it.
+        // Prepend the system prompt on every turn: it is never persisted in the
+        // session history (only user and assistant turns are), so re-adding it
+        // does not duplicate it — and omitting it would drop the system
+        // instructions from the second turn onward.
         $systemPrompt = $options->toArray()['system_prompt'] ?? null;
-        if ($history === [] && is_string($systemPrompt) && $systemPrompt !== '') {
+        if (is_string($systemPrompt) && $systemPrompt !== '') {
             $messages[] = ChatMessage::system($systemPrompt);
         }
         foreach ($history as $message) {
@@ -78,8 +80,10 @@ final readonly class ConversationService implements ConversationServiceInterface
 
         $nextSequence = $session->messageCount;
         // Persist the user turn before the call: it is a real turn regardless of
-        // whether the provider then succeeds.
+        // whether the provider then succeeds. Advance the message count right
+        // away so a failed call cannot leave the next turn reusing this sequence.
         $this->sessions->appendMessage($session->uid, $nextSequence, MessageRole::USER->value, $userMessage, '', 0, 0, 0);
+        $this->sessions->touch($session->uid, $nextSequence + 1);
 
         $response = $this->llmManager->chat($messages, $options);
 

--- a/Classes/Service/Feature/ConversationServiceInterface.php
+++ b/Classes/Service/Feature/ConversationServiceInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+
+/**
+ * Public surface of the stateful conversation service (ADR-083).
+ *
+ * Wraps stateless completion with a persisted message history: a session is
+ * opened once, and each {@see self::send()} replays the prior turns to the
+ * provider and stores the new user turn and the assistant reply. Consumers
+ * depend on this interface so the implementation can be substituted.
+ */
+interface ConversationServiceInterface
+{
+    /**
+     * Open a new conversation session owned by the current backend user.
+     */
+    public function startSession(string $title = '', ?LlmConfiguration $configuration = null): AiSession;
+
+    /**
+     * Send a user message into an existing session and return the assistant's
+     * reply, persisting both turns.
+     *
+     * @throws InvalidArgumentException when the session uuid is unknown
+     */
+    public function send(string $sessionUuid, string $userMessage, ?ChatOptions $options = null): CompletionResponse;
+}

--- a/Classes/Service/Session/AiSessionRepository.php
+++ b/Classes/Service/Session/AiSessionRepository.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Session;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
+use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Writes and reads conversation sessions and their message turns (ADR-083).
+ *
+ * Uses the Doctrine ConnectionPool directly — both tables are UI-less logs with
+ * no Extbase persistence needs, mirroring {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepository}.
+ * Unlike telemetry, a session has a read path (load the session and its ordered
+ * turns) and a mutable activity summary (last-activity + message count).
+ */
+final readonly class AiSessionRepository implements AiSessionRepositoryInterface, SingletonInterface
+{
+    private const TABLE_SESSION = 'tx_nrllm_ai_session';
+
+    private const TABLE_MESSAGE = 'tx_nrllm_ai_session_message';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function startSession(string $uuid, int $beUser, string $configurationIdentifier, string $title): int
+    {
+        $now        = time();
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_SESSION);
+        $connection->insert(self::TABLE_SESSION, [
+            'pid'                      => 0,
+            'uuid'                     => $uuid,
+            'be_user'                  => $beUser,
+            'configuration_identifier' => $configurationIdentifier,
+            'title'                    => $title,
+            'message_count'            => 0,
+            'last_activity'            => $now,
+            'tstamp'                   => $now,
+            'crdate'                   => $now,
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    public function appendMessage(
+        int $sessionUid,
+        int $sequence,
+        string $role,
+        string $content,
+        string $model,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+    ): void {
+        $this->connectionPool->getConnectionForTable(self::TABLE_MESSAGE)->insert(self::TABLE_MESSAGE, [
+            'pid'               => 0,
+            'session'           => $sessionUid,
+            'sequence'          => $sequence,
+            'role'              => $role,
+            'content'           => $content,
+            'model'             => $model,
+            'prompt_tokens'     => $promptTokens,
+            'completion_tokens' => $completionTokens,
+            'total_tokens'      => $totalTokens,
+            'crdate'            => time(),
+        ]);
+    }
+
+    public function touch(int $sessionUid, int $messageCount): void
+    {
+        $now = time();
+        $this->connectionPool->getConnectionForTable(self::TABLE_SESSION)->update(
+            self::TABLE_SESSION,
+            [
+                'message_count' => $messageCount,
+                'last_activity' => $now,
+                'tstamp'        => $now,
+            ],
+            ['uid' => $sessionUid],
+        );
+    }
+
+    public function findByUuid(string $uuid): ?AiSession
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_SESSION);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $row = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_SESSION)
+            ->where($queryBuilder->expr()->eq('uuid', $queryBuilder->createNamedParameter($uuid)))
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new AiSession(
+            uid: $this->intOf($row['uid'] ?? 0),
+            uuid: $this->stringOf($row['uuid'] ?? ''),
+            beUser: $this->intOf($row['be_user'] ?? 0),
+            configurationIdentifier: $this->stringOf($row['configuration_identifier'] ?? ''),
+            title: $this->stringOf($row['title'] ?? ''),
+            messageCount: $this->intOf($row['message_count'] ?? 0),
+            lastActivity: $this->intOf($row['last_activity'] ?? 0),
+            crdate: $this->intOf($row['crdate'] ?? 0),
+        );
+    }
+
+    public function findMessages(int $sessionUid): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_MESSAGE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_MESSAGE)
+            ->where($queryBuilder->expr()->eq('session', $queryBuilder->createNamedParameter($sessionUid, Connection::PARAM_INT)))
+            ->orderBy('sequence', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(fn(array $row): AiSessionMessage => new AiSessionMessage(
+            uid: $this->intOf($row['uid'] ?? 0),
+            session: $this->intOf($row['session'] ?? 0),
+            sequence: $this->intOf($row['sequence'] ?? 0),
+            role: $this->stringOf($row['role'] ?? ''),
+            content: $this->stringOf($row['content'] ?? ''),
+            model: $this->stringOf($row['model'] ?? ''),
+            promptTokens: $this->intOf($row['prompt_tokens'] ?? 0),
+            completionTokens: $this->intOf($row['completion_tokens'] ?? 0),
+            totalTokens: $this->intOf($row['total_tokens'] ?? 0),
+            crdate: $this->intOf($row['crdate'] ?? 0),
+        ), $rows);
+    }
+
+    public function purgeInactiveSince(int $timestamp): int
+    {
+        $sessionConnection = $this->connectionPool->getConnectionForTable(self::TABLE_SESSION);
+        $selectBuilder     = $sessionConnection->createQueryBuilder();
+        $rows              = $selectBuilder
+            ->select('uid')
+            ->from(self::TABLE_SESSION)
+            ->where($selectBuilder->expr()->lt('last_activity', $selectBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $uids = array_map(fn(array $row): int => $this->intOf($row['uid'] ?? 0), $rows);
+        if ($uids === []) {
+            return 0;
+        }
+
+        $messageConnection = $this->connectionPool->getConnectionForTable(self::TABLE_MESSAGE);
+        $messageBuilder    = $messageConnection->createQueryBuilder();
+        $messageBuilder
+            ->delete(self::TABLE_MESSAGE)
+            ->where($messageBuilder->expr()->in('session', $messageBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)))
+            ->executeStatement();
+
+        $deleteBuilder = $sessionConnection->createQueryBuilder();
+
+        return (int)$deleteBuilder
+            ->delete(self::TABLE_SESSION)
+            ->where($deleteBuilder->expr()->lt('last_activity', $deleteBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeStatement();
+    }
+
+    private function intOf(mixed $value): int
+    {
+        return is_numeric($value) ? (int)$value : 0;
+    }
+
+    private function stringOf(mixed $value): string
+    {
+        return is_scalar($value) ? (string)$value : '';
+    }
+}

--- a/Classes/Service/Session/AiSessionRepository.php
+++ b/Classes/Service/Session/AiSessionRepository.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Session;
 
 use Netresearch\NrLlm\Domain\ValueObject\AiSession;
 use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -25,6 +26,8 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 final readonly class AiSessionRepository implements AiSessionRepositoryInterface, SingletonInterface
 {
+    use SafeCastTrait;
+
     private const TABLE_SESSION = 'tx_nrllm_ai_session';
 
     private const TABLE_MESSAGE = 'tx_nrllm_ai_session_message';
@@ -108,14 +111,14 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
         }
 
         return new AiSession(
-            uid: $this->intOf($row['uid'] ?? 0),
-            uuid: $this->stringOf($row['uuid'] ?? ''),
-            beUser: $this->intOf($row['be_user'] ?? 0),
-            configurationIdentifier: $this->stringOf($row['configuration_identifier'] ?? ''),
-            title: $this->stringOf($row['title'] ?? ''),
-            messageCount: $this->intOf($row['message_count'] ?? 0),
-            lastActivity: $this->intOf($row['last_activity'] ?? 0),
-            crdate: $this->intOf($row['crdate'] ?? 0),
+            uid: self::toInt($row['uid'] ?? 0),
+            uuid: self::toStr($row['uuid'] ?? ''),
+            beUser: self::toInt($row['be_user'] ?? 0),
+            configurationIdentifier: self::toStr($row['configuration_identifier'] ?? ''),
+            title: self::toStr($row['title'] ?? ''),
+            messageCount: self::toInt($row['message_count'] ?? 0),
+            lastActivity: self::toInt($row['last_activity'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
         );
     }
 
@@ -133,16 +136,16 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             ->fetchAllAssociative();
 
         return array_map(fn(array $row): AiSessionMessage => new AiSessionMessage(
-            uid: $this->intOf($row['uid'] ?? 0),
-            session: $this->intOf($row['session'] ?? 0),
-            sequence: $this->intOf($row['sequence'] ?? 0),
-            role: $this->stringOf($row['role'] ?? ''),
-            content: $this->stringOf($row['content'] ?? ''),
-            model: $this->stringOf($row['model'] ?? ''),
-            promptTokens: $this->intOf($row['prompt_tokens'] ?? 0),
-            completionTokens: $this->intOf($row['completion_tokens'] ?? 0),
-            totalTokens: $this->intOf($row['total_tokens'] ?? 0),
-            crdate: $this->intOf($row['crdate'] ?? 0),
+            uid: self::toInt($row['uid'] ?? 0),
+            session: self::toInt($row['session'] ?? 0),
+            sequence: self::toInt($row['sequence'] ?? 0),
+            role: self::toStr($row['role'] ?? ''),
+            content: self::toStr($row['content'] ?? ''),
+            model: self::toStr($row['model'] ?? ''),
+            promptTokens: self::toInt($row['prompt_tokens'] ?? 0),
+            completionTokens: self::toInt($row['completion_tokens'] ?? 0),
+            totalTokens: self::toInt($row['total_tokens'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
         ), $rows);
     }
 
@@ -157,7 +160,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        $uids = array_map(fn(array $row): int => $this->intOf($row['uid'] ?? 0), $rows);
+        $uids = array_map(fn(array $row): int => self::toInt($row['uid'] ?? 0), $rows);
         if ($uids === []) {
             return 0;
         }
@@ -177,13 +180,4 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             ->executeStatement();
     }
 
-    private function intOf(mixed $value): int
-    {
-        return is_numeric($value) ? (int)$value : 0;
-    }
-
-    private function stringOf(mixed $value): string
-    {
-        return is_scalar($value) ? (string)$value : '';
-    }
 }

--- a/Classes/Service/Session/AiSessionRepositoryInterface.php
+++ b/Classes/Service/Session/AiSessionRepositoryInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Session;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
+use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
+
+/**
+ * Persistence contract for conversation sessions and their message turns
+ * (ADR-083).
+ *
+ * A UI-less log with a read path, mirroring how {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepository}
+ * writes raw rows — no Extbase. Split out as an interface so the conversation
+ * service can be unit-tested against a double.
+ */
+interface AiSessionRepositoryInterface
+{
+    /**
+     * Insert a new session and return its primary key.
+     */
+    public function startSession(string $uuid, int $beUser, string $configurationIdentifier, string $title): int;
+
+    /**
+     * Append one message turn to a session.
+     */
+    public function appendMessage(
+        int $sessionUid,
+        int $sequence,
+        string $role,
+        string $content,
+        string $model,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+    ): void;
+
+    /**
+     * Update a session's activity summary (last-activity timestamp + message count).
+     */
+    public function touch(int $sessionUid, int $messageCount): void;
+
+    public function findByUuid(string $uuid): ?AiSession;
+
+    /**
+     * @return list<AiSessionMessage> The session's turns, ordered by sequence ascending.
+     */
+    public function findMessages(int $sessionUid): array;
+
+    /**
+     * Delete sessions whose last activity predates the given timestamp, together
+     * with their messages.
+     *
+     * @return int Number of session rows deleted.
+     */
+    public function purgeInactiveSince(int $timestamp): int;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -121,6 +121,15 @@ services:
     alias: Netresearch\NrLlm\Service\Feature\CompletionService
     public: true
 
+  # Stateful conversation service (ADR-083) — public feature surface, like the
+  # other completion services.
+  Netresearch\NrLlm\Service\Feature\ConversationService:
+    public: true
+
+  Netresearch\NrLlm\Service\Feature\ConversationServiceInterface:
+    alias: Netresearch\NrLlm\Service\Feature\ConversationService
+    public: true
+
   Netresearch\NrLlm\Service\Feature\VisionService:
     public: true
 
@@ -207,6 +216,13 @@ services:
   # functional tests instantiate it directly with the real ConnectionPool.
   Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface:
     alias: Netresearch\NrLlm\Service\Tool\AgentRunRepository
+    public: false
+
+  # Conversation session store (ADR-083) — private; consumed by ConversationService
+  # and the nrllm:session:purge command. The concrete repository stays private too;
+  # functional tests instantiate it directly with the real ConnectionPool.
+  Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Session\AiSessionRepository
     public: false
 
   # Circuit breaker state store (ADR-063) — private; consumed by

--- a/Documentation/Adr/Adr083ConversationSessions.rst
+++ b/Documentation/Adr/Adr083ConversationSessions.rst
@@ -1,0 +1,81 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-083:
+
+============================================================================
+ADR-083: Conversation sessions and memory
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-083-context:
+
+Context
+=======
+
+Completion is stateless per call: `CompletionService::complete()` builds a fresh
+``[system?, user]`` message array every time. Anything conversational — a backend
+assistant, a multi-turn task — had to re-assemble and re-send the whole history
+itself, and there was nowhere to persist it. Consumers were re-implementing
+conversation memory badly and inconsistently.
+
+.. _adr-083-decision:
+
+Decision
+========
+
+**Add an explicit, persisted session model** in two UI-less log tables,
+`tx_nrllm_ai_session` (one row per conversation) and
+`tx_nrllm_ai_session_message` (one row per turn, ordered by ``sequence``), read
+and written by a raw-SQL `AiSessionRepository` — the telemetry pattern
+(:ref:`ADR-058 <adr-058>`), no Extbase and no TCA. The turns are read back as
+`AiSession` / `AiSessionMessage` value objects.
+
+**Add a `ConversationService`** (a public feature service beside
+`CompletionService`) that turns the stateless path into a conversation:
+
+- ``startSession()`` opens a session owned by the current backend user (resolved
+  through the existing `BackendUserContextResolverInterface`, not a raw
+  ``$GLOBALS`` read),
+- ``send()`` loads the prior turns, replays them plus the new user message to the
+  provider via the unchanged `LlmServiceManager::chat()`, and persists the user
+  turn and the assistant reply (with the reply's model and token usage).
+
+The provider call is untouched — this only assembles the message array and
+records the turns around it. The user turn is persisted **before** the call, so a
+provider failure still leaves an honest record of what the user asked.
+
+**Retention is explicit and by inactivity.** `AiSessionRepository::purgeInactiveSince()`
+deletes sessions (and their messages) whose ``last_activity`` predates a window,
+driven by a ``nrllm:session:purge`` command that mirrors ``nrllm:telemetry:purge``.
+There is **no** implicit, unbounded "the model remembers everything": memory is a
+named session, scoped, purgeable, and cost-attributed (token counts per turn).
+
+.. _adr-083-consequences:
+
+Consequences
+============
+
+- Consumers get a conversation primitive instead of hand-rolling history. The
+  stateless ``complete*()`` methods are unchanged for one-shot callers.
+- Message rows store the conversation content (prompts and replies). That is the
+  point (replayable memory), but it is privacy-relevant: retention is bounded by
+  the purge command, and sessions are owned/attributed to a backend user. A
+  scheduled purge task registration is a follow-up.
+- The system prompt is prepended only on the first turn, so it is not duplicated
+  once the persisted history already carries the conversation.
+- Context-window management (summarising or truncating a long history before
+  replay) is **not** in this change — the full history is replayed. A windowing
+  strategy is a follow-up once real conversation lengths are observed.
+- `ConversationService` depends on `AiSessionRepositoryInterface`, so it is
+  unit-tested against a double; the raw SQL and schema are covered by a functional
+  round-trip.
+- **Public-service policy (ADR-028 count authority).** This change adds two
+  ``public: true`` overrides — the ``ConversationService`` concrete and the
+  ``ConversationServiceInterface`` alias — a Category-A documented downstream
+  LLM-API feature pair, exactly like the Completion/Vision/Embedding services.
+  The session repository stays private. The audited count therefore rises from
+  **30 to 32** (Category A 17 → 19); ``PublicServicesPolicyTest`` is updated to
+  match, and this ADR supersedes ADR-075 as the count authority.

--- a/Documentation/Adr/Adr083ConversationSessions.rst
+++ b/Documentation/Adr/Adr083ConversationSessions.rst
@@ -64,8 +64,12 @@ Consequences
   point (replayable memory), but it is privacy-relevant: retention is bounded by
   the purge command, and sessions are owned/attributed to a backend user. A
   scheduled purge task registration is a follow-up.
-- The system prompt is prepended only on the first turn, so it is not duplicated
-  once the persisted history already carries the conversation.
+- The system prompt is prepended on **every** turn: the session history stores
+  only user and assistant turns, so re-adding it does not duplicate it, and
+  omitting it would drop the system instructions from the second turn onward.
+- The user turn advances the session's message count immediately (before the
+  provider call), so a failed call cannot leave the next turn reusing the same
+  sequence number.
 - Context-window management (summarising or truncating a long history before
   replay) is **not** in this change — the full history is replayed. A windowing
   strategy is a follow-up once real conversation lengths are observed.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -380,3 +380,4 @@ Tools
    Adr080TypedProviderHttpExceptions
    Adr081AgentRunPersistence
    Adr082StructuredOutputs
+   Adr083ConversationSessions

--- a/Tests/Functional/Service/Session/AiSessionRepositoryTest.php
+++ b/Tests/Functional/Service/Session/AiSessionRepositoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Session;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
+use Netresearch\NrLlm\Service\Session\AiSessionRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end round-trip of the conversation-session store against the real
+ * schema, mirroring the telemetry repository's functional test: the private
+ * raw-SQL repository is instantiated directly with the real ConnectionPool.
+ */
+#[CoversClass(AiSessionRepository::class)]
+final class AiSessionRepositoryTest extends AbstractFunctionalTestCase
+{
+    private AiSessionRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $this->repository = new AiSessionRepository($connectionPool);
+    }
+
+    #[Test]
+    public function aSessionRoundTripsWithItsOrderedMessages(): void
+    {
+        $uuid = '11111111-1111-1111-1111-111111111111';
+        $uid  = $this->repository->startSession($uuid, 7, 'cfg-chat', 'Greeting');
+
+        $running = $this->repository->findByUuid($uuid);
+        self::assertNotNull($running);
+        self::assertSame('Greeting', $running->title);
+        self::assertSame(7, $running->beUser);
+        self::assertSame('cfg-chat', $running->configurationIdentifier);
+        self::assertSame(0, $running->messageCount);
+
+        $this->repository->appendMessage($uid, 0, 'user', 'Hi', '', 0, 0, 0);
+        $this->repository->appendMessage($uid, 1, 'assistant', 'Hello', 'model-x', 5, 3, 8);
+        $this->repository->touch($uid, 2);
+
+        $reloaded = $this->repository->findByUuid($uuid);
+        self::assertNotNull($reloaded);
+        self::assertSame(2, $reloaded->messageCount);
+        self::assertGreaterThan(0, $reloaded->lastActivity);
+
+        $messages = $this->repository->findMessages($uid);
+        self::assertCount(2, $messages);
+        self::assertSame(['user', 'assistant'], array_map(static fn(AiSessionMessage $m): string => $m->role, $messages));
+        self::assertSame('Hello', $messages[1]->content);
+        self::assertSame('model-x', $messages[1]->model);
+        self::assertSame(8, $messages[1]->totalTokens);
+        // Rehydrates into a ChatMessage for replay.
+        self::assertSame('Hello', $messages[1]->toChatMessage()->content);
+    }
+
+    #[Test]
+    public function purgeInactiveSinceRemovesSessionsAndTheirMessages(): void
+    {
+        $uuid = '22222222-2222-2222-2222-222222222222';
+        $uid  = $this->repository->startSession($uuid, 0, '', '');
+        $this->repository->appendMessage($uid, 0, 'user', 'Hi', '', 0, 0, 0);
+
+        $deleted = $this->repository->purgeInactiveSince(time() + 3600);
+
+        self::assertGreaterThanOrEqual(1, $deleted);
+        self::assertNull($this->repository->findByUuid($uuid));
+        self::assertSame([], $this->repository->findMessages($uid));
+    }
+}

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -46,7 +46,9 @@ final class PublicServicesPolicyTest extends TestCase
      *   services + 7 interface aliases + 2 keyword-search facade entries
      *   (ADR-071: KeywordSearchInterface alias and the named
      *   `nr_llm.keyword_search.index_backed` variant) + 1 reranker
-     *   protocol entry (ADR-075: RerankerInterface, factory-built) = 17 —
+     *   protocol entry (ADR-075: RerankerInterface, factory-built), plus the
+     *   ConversationService concrete + ConversationServiceInterface alias
+     *   (ADR-083: a stateful feature service beside Completion) = 19 —
      *   LlmServiceManager, ProviderAdapterRegistry, and the
      *   Completion/Vision/Embedding/Translation/ToolCalling (ADR-051)
      *   feature pairs.
@@ -62,15 +64,15 @@ final class PublicServicesPolicyTest extends TestCase
      *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 17 + 5 + 1 + 5 + 2 = **30**.
+     * Total: 19 + 5 + 1 + 5 + 2 = **32**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr075RerankerProtocol.rst` (the current
-     * count authority, superseding ADR-076's count) in the same PR — the
+     * `Documentation/Adr/Adr083ConversationSessions.rst` (the current
+     * count authority, superseding ADR-075's count) in the same PR — the
      * diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 30;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 32;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -15,10 +15,13 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\Feature\ConversationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Tests\Unit\Service\Session\Fixtures\RecordingAiSessionRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
 
 #[CoversClass(ConversationService::class)]
 final class ConversationServiceTest extends TestCase
@@ -75,6 +78,72 @@ final class ConversationServiceTest extends TestCase
         self::assertSame('first', $secondCall[0]->content);
         self::assertSame('reply', $secondCall[1]->content);
         self::assertSame('second', $secondCall[2]->content);
+    }
+
+    #[Test]
+    public function sendPrependsTheSystemPromptOnEveryTurn(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $captured   = [];
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chat')->willReturnCallback(function (array $messages) use (&$captured): CompletionResponse {
+            $captured[] = $messages;
+
+            return $this->response('reply');
+        });
+        $service = new ConversationService($llmManager, $repository);
+        $options = (new ChatOptions())->withSystemPrompt('You are terse.');
+
+        $session = $service->startSession();
+        $service->send($session->uuid, 'first', $options);
+        $service->send($session->uuid, 'second', $options);
+
+        // Both turns lead with the system prompt — it is never persisted in the
+        // history, so it must be re-added every turn or it is lost from turn 2.
+        self::assertCount(2, $captured);
+
+        $turn1System = $captured[0][0];
+        self::assertInstanceOf(ChatMessage::class, $turn1System);
+        self::assertSame('system', $turn1System->getRole()->value);
+        self::assertSame('You are terse.', $turn1System->content);
+
+        $turn2System = $captured[1][0];
+        self::assertInstanceOf(ChatMessage::class, $turn2System);
+        self::assertSame('system', $turn2System->getRole()->value);
+
+        // Second turn: system, user 'first', assistant 'reply', user 'second'.
+        $turn2Last = $captured[1][3];
+        self::assertInstanceOf(ChatMessage::class, $turn2Last);
+        self::assertSame('second', $turn2Last->content);
+    }
+
+    #[Test]
+    public function aFailedTurnStillAdvancesTheSequenceSoTheNextTurnDoesNotCollide(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $calls      = 0;
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chat')->willReturnCallback(function () use (&$calls): CompletionResponse {
+            ++$calls;
+            if ($calls === 1) {
+                throw new RuntimeException('provider down', 4844402126);
+            }
+
+            return $this->response('ok');
+        });
+        $service = new ConversationService($llmManager, $repository);
+        $session = $service->startSession();
+
+        try {
+            $service->send($session->uuid, 'first');
+        } catch (Throwable) {
+            // The first provider call fails; the user turn is already recorded.
+        }
+        $service->send($session->uuid, 'second');
+
+        // No two turns share a sequence number, even across the failed attempt.
+        $sequences = array_map(static fn($m): int => $m->sequence, $repository->findMessages($session->uid));
+        self::assertSame($sequences, array_values(array_unique($sequences)));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Feature\ConversationService;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Tests\Unit\Service\Session\Fixtures\RecordingAiSessionRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConversationService::class)]
+final class ConversationServiceTest extends TestCase
+{
+    #[Test]
+    public function sendPersistsBothTurnsAndReturnsTheReply(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->expects(self::once())->method('chat')->willReturn($this->response('Hello there'));
+        $service = new ConversationService($llmManager, $repository);
+
+        $session  = $service->startSession('greeting');
+        $response = $service->send($session->uuid, 'Hi');
+
+        self::assertSame('Hello there', $response->content);
+
+        $messages = $repository->findMessages($session->uid);
+        self::assertCount(2, $messages);
+        self::assertSame('user', $messages[0]->role);
+        self::assertSame('Hi', $messages[0]->content);
+        self::assertSame('assistant', $messages[1]->role);
+        self::assertSame('Hello there', $messages[1]->content);
+
+        // The session's activity summary advanced by both turns.
+        $reloaded = $repository->findByUuid($session->uuid);
+        self::assertNotNull($reloaded);
+        self::assertSame(2, $reloaded->messageCount);
+    }
+
+    #[Test]
+    public function sendReplaysPriorTurnsToTheProvider(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $captured   = [];
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chat')->willReturnCallback(function (array $messages) use (&$captured): CompletionResponse {
+            $captured[] = $messages;
+
+            return $this->response('reply');
+        });
+        $service = new ConversationService($llmManager, $repository);
+
+        $session = $service->startSession();
+        $service->send($session->uuid, 'first');
+        $service->send($session->uuid, 'second');
+
+        // The second call replays the prior turns before the new user message:
+        // user 'first', assistant 'reply', then user 'second'.
+        self::assertCount(2, $captured);
+        $secondCall = $captured[1];
+        self::assertCount(3, $secondCall);
+        self::assertContainsOnlyInstancesOf(ChatMessage::class, $secondCall);
+        self::assertSame('first', $secondCall[0]->content);
+        self::assertSame('reply', $secondCall[1]->content);
+        self::assertSame('second', $secondCall[2]->content);
+    }
+
+    #[Test]
+    public function sendThrowsForAnUnknownSession(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->expects(self::never())->method('chat');
+        $service = new ConversationService($llmManager, $repository);
+
+        $this->expectException(InvalidArgumentException::class);
+        $service->send('00000000-0000-0000-0000-000000000000', 'hi');
+    }
+
+    #[Test]
+    public function startSessionStampsTitleAndZeroOwnerWithoutAResolver(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $service    = new ConversationService($this->createMock(LlmServiceManagerInterface::class), $repository);
+
+        $session = $service->startSession('my chat');
+
+        self::assertSame('my chat', $session->title);
+        self::assertSame(0, $session->beUser);
+        self::assertNotSame('', $session->uuid);
+    }
+
+    private function response(string $content): CompletionResponse
+    {
+        return new CompletionResponse($content, 'test-model', UsageStatistics::fromTokens(5, 3));
+    }
+}

--- a/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
+++ b/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Session\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
+use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
+use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
+
+/**
+ * Stateful in-memory {@see AiSessionRepositoryInterface} for unit-testing the
+ * conversation service: it stores sessions and messages so a full send() round
+ * (find session, load history, append turns, touch) behaves realistically.
+ *
+ * @phpstan-type SessionRow array{uuid: string, beUser: int, configId: string, title: string, messageCount: int, lastActivity: int, crdate: int}
+ * @phpstan-type MessageRow array{session: int, sequence: int, role: string, content: string, model: string, prompt: int, completion: int, total: int}
+ */
+final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
+{
+    public int $nextUid = 1;
+
+    /** @var array<int, SessionRow> */
+    public array $sessions = [];
+
+    /** @var list<MessageRow> */
+    public array $messages = [];
+
+    /** @var list<array{session: int, messageCount: int}> */
+    public array $touchCalls = [];
+
+    public function startSession(string $uuid, int $beUser, string $configurationIdentifier, string $title): int
+    {
+        $uid                  = $this->nextUid++;
+        $this->sessions[$uid] = [
+            'uuid'         => $uuid,
+            'beUser'       => $beUser,
+            'configId'     => $configurationIdentifier,
+            'title'        => $title,
+            'messageCount' => 0,
+            'lastActivity' => 0,
+            'crdate'       => 0,
+        ];
+
+        return $uid;
+    }
+
+    public function appendMessage(
+        int $sessionUid,
+        int $sequence,
+        string $role,
+        string $content,
+        string $model,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+    ): void {
+        $this->messages[] = [
+            'session'    => $sessionUid,
+            'sequence'   => $sequence,
+            'role'       => $role,
+            'content'    => $content,
+            'model'      => $model,
+            'prompt'     => $promptTokens,
+            'completion' => $completionTokens,
+            'total'      => $totalTokens,
+        ];
+    }
+
+    public function touch(int $sessionUid, int $messageCount): void
+    {
+        if (isset($this->sessions[$sessionUid])) {
+            $this->sessions[$sessionUid]['messageCount'] = $messageCount;
+            $this->sessions[$sessionUid]['lastActivity'] = 1;
+        }
+        $this->touchCalls[] = ['session' => $sessionUid, 'messageCount' => $messageCount];
+    }
+
+    public function findByUuid(string $uuid): ?AiSession
+    {
+        foreach ($this->sessions as $uid => $row) {
+            if ($row['uuid'] === $uuid) {
+                return new AiSession(
+                    $uid,
+                    $row['uuid'],
+                    $row['beUser'],
+                    $row['configId'],
+                    $row['title'],
+                    $row['messageCount'],
+                    $row['lastActivity'],
+                    $row['crdate'],
+                );
+            }
+        }
+
+        return null;
+    }
+
+    public function findMessages(int $sessionUid): array
+    {
+        $out = [];
+        foreach ($this->messages as $row) {
+            if ($row['session'] === $sessionUid) {
+                $out[] = new AiSessionMessage(
+                    0,
+                    $row['session'],
+                    $row['sequence'],
+                    $row['role'],
+                    $row['content'],
+                    $row['model'],
+                    $row['prompt'],
+                    $row['completion'],
+                    $row['total'],
+                    0,
+                );
+            }
+        }
+        usort($out, static fn(AiSessionMessage $a, AiSessionMessage $b): int => $a->sequence <=> $b->sequence);
+
+        return $out;
+    }
+
+    public function purgeInactiveSince(int $timestamp): int
+    {
+        return 0;
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -711,3 +711,58 @@ CREATE TABLE tx_nrllm_agentrun_event (
     KEY run_sequence (run, sequence),
     KEY crdate (crdate)
 );
+
+#
+# Conversation sessions (ADR-083): one row per multi-turn conversation, so a
+# stateful assistant can resume. UI-less append-and-update log (no TCA, no
+# Extbase), mirroring tx_nrllm_telemetry.
+#
+CREATE TABLE tx_nrllm_ai_session (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    uuid varchar(36) DEFAULT '' NOT NULL,
+    be_user int(11) unsigned DEFAULT '0' NOT NULL,
+    configuration_identifier varchar(150) DEFAULT '' NOT NULL,
+    title varchar(255) DEFAULT '' NOT NULL,
+    message_count int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Retention is by inactivity: the purge deletes sessions whose last_activity
+    -- predates the window.
+    last_activity int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    KEY session_uuid (uuid),
+    KEY be_user (be_user, last_activity),
+    KEY inactivity (last_activity)
+);
+
+#
+# Conversation session messages (ADR-083): one row per turn, ordered by sequence
+# within a session. `content` carries the prompt/reply text.
+#
+CREATE TABLE tx_nrllm_ai_session_message (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    session int(11) unsigned DEFAULT '0' NOT NULL,
+    sequence int(11) unsigned DEFAULT '0' NOT NULL,
+    role varchar(32) DEFAULT '' NOT NULL,
+    content mediumtext,
+    model varchar(128) DEFAULT '' NOT NULL,
+    prompt_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    completion_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    total_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- Replay read path: a session's turns in order.
+    KEY session_sequence (session, sequence)
+);


### PR DESCRIPTION
## Epic E — Conversation sessions + memory (P1)

Third roadmap PR. Independent of A (#437) and B (#438).

### Problem
Completion is stateless per call — anything conversational had to re-assemble and re-send the whole history itself, with nowhere to persist it. Consumers re-implemented conversation memory badly.

### What this adds
- **Two UI-less log tables** (raw SQL, telemetry pattern — no Extbase/TCA): `tx_nrllm_ai_session` (one row per conversation) + `tx_nrllm_ai_session_message` (one row per turn, ordered by `sequence`), read/written by `AiSessionRepository`, read back as `AiSession`/`AiSessionMessage` value objects.
- **`ConversationService`** (public feature service beside `CompletionService`): `startSession()` opens a session owned by the current backend user (via the existing `BackendUserContextResolverInterface`, not a raw `$GLOBALS` read); `send()` loads prior turns, replays them + the new user message to the provider via the **unchanged** `LlmServiceManager::chat()`, and persists the user turn (before the call) and the assistant reply (with its model + token usage).
- **Explicit retention by inactivity:** `purgeInactiveSince()` + a `nrllm:session:purge` command mirroring `nrllm:telemetry:purge`.
- ADR-083.

### Design notes
- **No implicit unbounded memory:** a session is named, scoped, purgeable, and cost-attributed (per-turn token counts). Message rows store conversation content, so retention is bounded by the purge command and ownership is attributed to a BE user.
- **User turn persisted before the call** so a provider failure still leaves an honest record of what the user asked.
- **System prompt prepended only on the first turn** so it isn't duplicated once the persisted history carries it.
- **Provider call untouched** — this only assembles the message array and records the turns around it.
- **Out of scope (documented in ADR-083):** context-window management (summarise/truncate a long history before replay) — a follow-up once real conversation lengths are observed.
- **Public-service policy:** adds two `public: true` entries (concrete + interface, like the other completion services) — `PublicServicesPolicyTest` count 30→32, ADR-083 is now the count authority. The session repository stays private.

### Tests
- `ConversationServiceTest` — persists both turns, replays prior turns to the provider, throws on unknown session, stamps title/owner.
- `AiSessionRepositoryTest` (functional) — session + ordered-messages round-trip, retention purge cascades to messages.

### Verification
Local `runTests.sh -p 8.4`: `cgl`, `phpstan` (L10), `unit` (5150), `functional -d sqlite` (session scope), `rector -n`, `fuzzy` — all green.

Roadmap sweep: A (#437), B (#438), E shipped; next — human-in-the-loop approval (D, needs A), then guardrail pipeline (C).
