### PR TITLE
ci: run a single PHP version in the merge queue, full matrix on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,16 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2","8.3","8.4","8.5"]'
+      # Full PHP matrix on pull_request (and the nightly schedule) for complete
+      # coverage; the merge queue re-validates the merged result on a single PHP
+      # (8.4) against BOTH TYPO3 majors — the queue's job is to catch two
+      # independently-green PRs that break when combined, and such integration
+      # breaks are a TYPO3-major axis (TCA/DI/schema), essentially never a PHP
+      # patch axis, which the PR already proved across all four versions. This
+      # cuts the queue's slowest matrix (functional, 8-11min/cell) from 8 cells
+      # to 2. The required-status-checks ruleset is reduced to match (only the
+      # 8.4 cells stay required); the other cells remain visible on the PR.
+      php-versions: ${{ github.event_name == 'merge_group' && '["8.4"]' || '["8.2","8.3","8.4","8.5"]' }}
       typo3-versions: '["^13.4","^14.3"]'
       # Keeps the unit job's Codecov upload on every PR — that job is ~1min, so
       # its Xdebug tax is negligible and patch coverage stays useful. The


### PR DESCRIPTION
## Cut the merge-queue's redundant full-matrix re-run

Every merged PR triggers **~100 CI jobs** because the same workflow set runs on **three** events — `pull_request`, `merge_group`, and `push:main`. Measured on recent merges:

| Event | CI-workflow jobs | Notes |
|-------|------------------|-------|
| `pull_request` | 43 | PR feedback |
| `merge_group` | **43** | the full 8-cell matrix re-runs in the queue |
| `push:main` | ~3 real (16/19 skipped) | already trimmed |

The 8-cell matrix (PHP 8.2/8.3/8.4/8.5 × TYPO3 ^13.4/^14.3) fanned across the suites is the bulk, and the **functional** cells (8–11 min each) are the critical path — run **twice** per merge.

### Change
Run the **full matrix on `pull_request`** (and the nightly `schedule`) for complete coverage; run **PHP 8.4 × both TYPO3 majors** on `merge_group`:

```yaml
php-versions: ${{ github.event_name == 'merge_group' && '["8.4"]' || '["8.2","8.3","8.4","8.5"]' }}
```

The merge queue exists to catch two independently-green PRs that break *when combined*. Those integration breaks live on the **TYPO3-major axis** (TCA/DI/schema) — kept (both majors) — essentially never on a **PHP-patch axis**, which the PR already proved across all four versions. So the queue re-runs 2 cells instead of 8, cutting its slowest matrix by 75%.

### Required companion: ruleset reconciliation (applied)
The merge queue must produce every **required** status check, so the `main-branch-rules` required-status-checks list is reduced to drop the now-merge-queue-absent contexts — the **8.2/8.3/8.5** cells of Lint/PHPStan/Unit/Functional (21 contexts). **They still run and are visible on every PR**, they are just no longer *required*. A PHP-patch-specific failure on 8.2/8.3/8.5 would therefore be visible-but-non-blocking on the PR (rare; the nightly full-serial run and the PR matrix both still exercise them).

Net: **~28 fewer jobs per merge**, and the functional critical path runs once at full width (PR) + once narrow (queue) instead of twice at full width.

### Stricter alternative (not taken here)
If you'd rather keep the full matrix *required* on PRs, the clean way is an **aggregate gate** job (`needs:` all matrix cells) required as a single context, letting the queue run a reduced matrix while the gate still enforces the full matrix on PRs. That's a larger change to the shared `typo3-ci-workflows` reusable workflow; happy to follow up with it if preferred.
