### PR TITLE
feat(agent): human-in-the-loop tool approval with suspend/resume (ADR-084)

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -299,9 +299,10 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $state = SuspendedRunState::fromArray($decoded);
 
         // Continue the SAME run: rebuild the handle so events keep ascending.
-        $handle  = $this->agentRunPersister?->resumeHandle($run);
-        $options = new ToolOptions(beUserUid: $this->currentBackendUserUid());
-        $trace   = new RunTrace(
+        // The allow-list and options are restored from the suspended state inside
+        // resume() — the run keeps its original constraints (ADR-084).
+        $handle = $this->agentRunPersister?->resumeHandle($run);
+        $trace  = new RunTrace(
             onRecord: $handle !== null
                 ? function (RunStep $step) use ($handle): void {
                     $this->agentRunPersister?->recordStep($handle, $step);
@@ -310,7 +311,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         );
 
         try {
-            $result = $this->toolLoopService->resume($state, $approved, $config, null, $options, null, $trace);
+            $result = $this->toolLoopService->resume($state, $approved, $config, null, $trace);
         } catch (ToolApprovalRequiredException $approval) {
             if ($handle !== null) {
                 $this->agentRunPersister?->suspend($handle, $approval->state);

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use Closure;
 use Netresearch\NrLlm\Controller\Backend\Response\PlaygroundRunResponse;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
@@ -19,11 +20,14 @@ use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
@@ -221,6 +225,16 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         try {
             $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
+        } catch (ToolApprovalRequiredException $approval) {
+            // ADR-084: a called tool requires human approval. Persist the
+            // suspended state (transcript + pending calls) so a later resume can
+            // continue, and return an awaiting-approval response — caught BEFORE
+            // the generic Throwable below so a suspension is not a failed run.
+            if ($handle !== null) {
+                $this->agentRunPersister?->suspend($handle, $approval->state);
+            }
+
+            return $this->respondJson($this->awaitingApprovalPayload($handle !== null ? $handle->uuid : '', $approval, $trace));
         } catch (Throwable $e) {
             if ($handle !== null) {
                 $this->agentRunPersister?->settleFailed($handle, $e);
@@ -247,6 +261,108 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         );
 
         return $this->respondJson($response->toArray());
+    }
+
+    /**
+     * Resume a run suspended for human approval (ADR-084).
+     *
+     * Admin-gated like {@see runAction()}. Loads the suspended run by uuid,
+     * rehydrates its state, executes (or, when not approved, refuses) the pending
+     * tool call(s) via {@see ToolLoopService::resume()}, and returns the continued
+     * run's result — which may itself suspend again on another approval-required
+     * tool.
+     */
+    public function resumeAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body     = $request->getParsedBody();
+        $runUuid  = trim($this->stringFromBody($body, 'runUuid'));
+        $approved = $this->boolFromBody($body, 'approve');
+
+        $run = $this->agentRunPersister?->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.notAwaitingApproval', 'No run is awaiting approval for that id.')], 400);
+        }
+
+        $config = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($config === null) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.configGone', 'The run configuration no longer exists.')], 400);
+        }
+
+        $decoded = json_decode($run->suspendedState, true);
+        if (!is_array($decoded)) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.corruptState', 'The suspended run state could not be read.')], 500);
+        }
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Continue the SAME run: rebuild the handle so events keep ascending.
+        $handle  = $this->agentRunPersister?->resumeHandle($run);
+        $options = new ToolOptions(beUserUid: $this->currentBackendUserUid());
+        $trace   = new RunTrace(
+            onRecord: $handle !== null
+                ? function (RunStep $step) use ($handle): void {
+                    $this->agentRunPersister?->recordStep($handle, $step);
+                }
+            : null,
+        );
+
+        try {
+            $result = $this->toolLoopService->resume($state, $approved, $config, null, $options, null, $trace);
+        } catch (ToolApprovalRequiredException $approval) {
+            if ($handle !== null) {
+                $this->agentRunPersister?->suspend($handle, $approval->state);
+            }
+
+            return $this->respondJson($this->awaitingApprovalPayload($run->uuid, $approval, $trace));
+        } catch (Throwable $e) {
+            if ($handle !== null) {
+                $this->agentRunPersister?->settleFailed($handle, $e);
+            }
+            $this->logger?->error('Tool playground resume failed', ['exception' => $e]);
+
+            return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
+        }
+
+        if ($handle !== null) {
+            $this->agentRunPersister?->settleCompleted($handle, $result);
+        }
+
+        $response = new PlaygroundRunResponse(
+            finalContent: $result->finalContent,
+            iterations: $result->iterations,
+            truncated: $result->truncated,
+            dryRun: false,
+            steps: $trace->getSteps(),
+            promptTokens: $result->usage->promptTokens,
+            completionTokens: $result->usage->completionTokens,
+            totalTokens: $result->usage->totalTokens,
+            estimatedCost: $result->usage->estimatedCost,
+        );
+
+        return $this->respondJson($response->toArray());
+    }
+
+    /**
+     * The JSON body for a run that suspended for approval: the pending tool calls
+     * the operator must approve, plus the steps recorded up to the pause.
+     *
+     * @return array<string, mixed>
+     */
+    private function awaitingApprovalPayload(string $runUuid, ToolApprovalRequiredException $approval, RunTrace $trace): array
+    {
+        return [
+            'success'      => true,
+            'status'       => 'awaiting_approval',
+            'runUuid'      => $runUuid,
+            'pendingTools' => array_map(
+                static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
+                $approval->state->toolCalls(),
+            ),
+            'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $trace->getSteps()),
+        ];
     }
 
     /**
@@ -353,6 +469,22 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                     'totalTokens'      => $result->usage->totalTokens,
                     'estimatedCost'    => $result->usage->estimatedCost,
                 ],
+            ]);
+        } catch (ToolApprovalRequiredException $approval) {
+            // ADR-084: a called tool requires approval — suspend the run and emit
+            // an awaiting-approval event instead of failing.
+            if ($handle !== null) {
+                $this->agentRunPersister?->suspend($handle, $approval->state);
+                $settled = true;
+            }
+            $emit([
+                'event'        => 'awaiting_approval',
+                'success'      => true,
+                'runUuid'      => $handle !== null ? $handle->uuid : '',
+                'pendingTools' => array_map(
+                    static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
+                    $approval->state->toolCalls(),
+                ),
             ]);
         } catch (Throwable $e) {
             if ($handle !== null) {

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -37,6 +37,9 @@ final readonly class AgentRun
         public int $startedAt,
         public int $finishedAt,
         public int $crdate,
+        // Serialised SuspendedRunState JSON while status = waiting_for_approval
+        // (ADR-084); null once the run is running or terminal.
+        public ?string $suspendedState = null,
     ) {}
 
     /**

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * The serialisable state of a tool-loop run suspended for human approval
+ * (ADR-084).
+ *
+ * Captured the moment {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}
+ * reaches an approval-required tool call: the full message transcript up to and
+ * including the assistant's tool-call turn, the pending calls of that turn (the
+ * whole turn is held so a multi-call turn stays consistent), and the
+ * iteration/token counters accumulated so far. Stored as JSON on the AgentRun
+ * and rehydrated on resume.
+ *
+ * Messages and calls are held in their already-serialised
+ * ({@see ChatMessage::toArray()} / {@see ToolCall::toArray()}) form so the state
+ * is a plain JSON-encodable structure; {@see self::toolCalls()} rebuilds the
+ * typed calls for execution on resume.
+ */
+final readonly class SuspendedRunState
+{
+    /**
+     * @param list<array<string, mixed>> $messages     serialised ChatMessage transcript (ends with the assistant tool-call turn)
+     * @param list<array<string, mixed>> $pendingCalls serialised ToolCall list of the suspended turn
+     */
+    public function __construct(
+        public array $messages,
+        public array $pendingCalls,
+        public int $iterations,
+        public int $promptTokens,
+        public int $completionTokens,
+    ) {}
+
+    /**
+     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'messages'         => $this->messages,
+            'pendingCalls'     => $this->pendingCalls,
+            'iterations'       => $this->iterations,
+            'promptTokens'     => $this->promptTokens,
+            'completionTokens' => $this->completionTokens,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            self::listOfArrays($data['messages'] ?? null),
+            self::listOfArrays($data['pendingCalls'] ?? null),
+            is_numeric($data['iterations'] ?? null) ? (int)$data['iterations'] : 0,
+            is_numeric($data['promptTokens'] ?? null) ? (int)$data['promptTokens'] : 0,
+            is_numeric($data['completionTokens'] ?? null) ? (int)$data['completionTokens'] : 0,
+        );
+    }
+
+    /**
+     * The pending turn's calls, rebuilt as typed {@see ToolCall} objects for
+     * execution on resume.
+     *
+     * @return list<ToolCall>
+     */
+    public function toolCalls(): array
+    {
+        $calls = [];
+        foreach ($this->pendingCalls as $call) {
+            $calls[] = ToolCall::fromArray($call);
+        }
+
+        return $calls;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function listOfArrays(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $item) {
+            if (is_array($item)) {
+                /** @var array<string, mixed> $item */
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -28,8 +28,10 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 final readonly class SuspendedRunState
 {
     /**
-     * @param list<array<string, mixed>> $messages     serialised ChatMessage transcript (ends with the assistant tool-call turn)
-     * @param list<array<string, mixed>> $pendingCalls serialised ToolCall list of the suspended turn
+     * @param list<array<string, mixed>> $messages         serialised ChatMessage transcript (ends with the assistant tool-call turn)
+     * @param list<array<string, mixed>> $pendingCalls     serialised ToolCall list of the suspended turn
+     * @param list<string>|null          $allowedToolNames the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
+     * @param array<string, mixed>       $options          the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
      */
     public function __construct(
         public array $messages,
@@ -37,10 +39,12 @@ final readonly class SuspendedRunState
         public int $iterations,
         public int $promptTokens,
         public int $completionTokens,
+        public ?array $allowedToolNames = null,
+        public array $options = [],
     ) {}
 
     /**
-     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int}
+     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>}
      */
     public function toArray(): array
     {
@@ -50,6 +54,8 @@ final readonly class SuspendedRunState
             'iterations'       => $this->iterations,
             'promptTokens'     => $this->promptTokens,
             'completionTokens' => $this->completionTokens,
+            'allowedToolNames' => $this->allowedToolNames,
+            'options'          => $this->options,
         ];
     }
 
@@ -58,12 +64,21 @@ final readonly class SuspendedRunState
      */
     public static function fromArray(array $data): self
     {
+        $allowed          = $data['allowedToolNames'] ?? null;
+        $allowedToolNames = is_array($allowed) ? array_values(array_filter($allowed, is_string(...))) : null;
+
+        $options = $data['options'] ?? null;
+        /** @var array<string, mixed> $options */
+        $options = is_array($options) ? $options : [];
+
         return new self(
             self::listOfArrays($data['messages'] ?? null),
             self::listOfArrays($data['pendingCalls'] ?? null),
             is_numeric($data['iterations'] ?? null) ? (int)$data['iterations'] : 0,
             is_numeric($data['promptTokens'] ?? null) ? (int)$data['promptTokens'] : 0,
             is_numeric($data['completionTokens'] ?? null) ? (int)$data['completionTokens'] : 0,
+            $allowedToolNames,
+            $options,
         );
     }
 

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -162,6 +162,38 @@ class ToolOptions extends ChatOptions
     // Array Conversion
     // ========================================
 
+    /**
+     * Rebuild options from a {@see self::toArray()} snapshot (ADR-084 resume).
+     *
+     * The budget fields (beUserUid, plannedCost) are intentionally not part of
+     * toArray() and are therefore not restored — a resumed run is budget-checked
+     * for the acting user, not the original one.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): static
+    {
+        $stop          = $data['stop_sequences'] ?? null;
+        $stopSequences = is_array($stop) ? array_values(array_filter($stop, is_string(...))) : null;
+
+        return new static(
+            temperature: is_numeric($data['temperature'] ?? null) ? (float)$data['temperature'] : null,
+            maxTokens: is_numeric($data['max_tokens'] ?? null) ? (int)$data['max_tokens'] : null,
+            topP: is_numeric($data['top_p'] ?? null) ? (float)$data['top_p'] : null,
+            frequencyPenalty: is_numeric($data['frequency_penalty'] ?? null) ? (float)$data['frequency_penalty'] : null,
+            presencePenalty: is_numeric($data['presence_penalty'] ?? null) ? (float)$data['presence_penalty'] : null,
+            responseFormat: is_string($data['response_format'] ?? null) ? $data['response_format'] : null,
+            systemPrompt: is_string($data['system_prompt'] ?? null) ? $data['system_prompt'] : null,
+            stopSequences: $stopSequences,
+            provider: is_string($data['provider'] ?? null) ? $data['provider'] : null,
+            model: is_string($data['model'] ?? null) ? $data['model'] : null,
+            think: is_bool($data['think'] ?? null) ? $data['think'] : null,
+            toolChoice: is_string($data['tool_choice'] ?? null) ? $data['tool_choice'] : null,
+            parallelToolCalls: is_bool($data['parallel_tool_calls'] ?? null) ? $data['parallel_tool_calls'] : null,
+            captureRaw: ($data['_capture_raw'] ?? false) === true,
+        );
+    }
+
     public function toArray(): array
     {
         $extra = $this->filterNull([

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -11,7 +11,9 @@ namespace Netresearch\NrLlm\Service\Tool;
 
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -116,6 +118,52 @@ final readonly class AgentRunPersister
     public function settleFailed(AgentRunHandle $handle, Throwable $error): void
     {
         $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class);
+    }
+
+    /**
+     * Suspend a run for human approval (ADR-084): persist the transcript and
+     * pending tool calls and move the run to WAITING_FOR_APPROVAL. Fail-soft.
+     */
+    public function suspend(AgentRunHandle $handle, SuspendedRunState $state): void
+    {
+        try {
+            $stateJson = json_encode($state->toArray(), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR);
+            $this->repository->suspendRun($handle->runUid, $stateJson);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be suspended', ['exception' => $exception]);
+        }
+    }
+
+    /**
+     * Load a persisted run by uuid. Exposed on the persister (a service) so a
+     * controller can reach a run without depending on the repository directly
+     * (the layered-architecture rule). Null when unknown or unavailable.
+     */
+    public function findRun(string $uuid): ?AgentRun
+    {
+        try {
+            return $this->repository->findByUuid($uuid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be loaded', ['exception' => $exception]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Rebuild a live handle for an existing (suspended) run so a resume continues
+     * its event stream at the right sequence.
+     */
+    public function resumeHandle(AgentRun $run): AgentRunHandle
+    {
+        $handle = new AgentRunHandle($run->uid, $run->uuid);
+        try {
+            $handle->sequence = count($this->repository->findEvents($run->uid));
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun events could not be counted for resume; sequence restarts at 0', ['exception' => $exception]);
+        }
+
+        return $handle;
     }
 
     private function finish(

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -100,8 +100,25 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
                 'total_tokens'            => $totalTokens,
                 'estimated_cost'          => $estimatedCost,
                 'error_class'             => $errorClass,
+                // A terminal run is no longer suspended.
+                'suspended_state'         => '',
                 'finished_at'             => time(),
                 'tstamp'                  => time(),
+            ],
+            ['uid' => $runUid],
+        );
+    }
+
+    public function suspendRun(int $runUid, string $stateJson): void
+    {
+        // Non-terminal transition (ADR-084): store the resumable state and move
+        // the run to WAITING_FOR_APPROVAL without setting finished_at.
+        $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'status'          => AgentRunStatus::WAITING_FOR_APPROVAL->value,
+                'suspended_state' => $stateJson,
+                'tstamp'          => time(),
             ],
             ['uid' => $runUid],
         );
@@ -199,7 +216,17 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             startedAt: self::toInt($row['started_at'] ?? 0),
             finishedAt: self::toInt($row['finished_at'] ?? 0),
             crdate: self::toInt($row['crdate'] ?? 0),
+            suspendedState: $this->suspendedStateOf($row['suspended_state'] ?? null),
         );
+    }
+
+    /**
+     * The stored suspended-state JSON, or null when the run is not suspended
+     * (empty column) — distinct from a genuine payload.
+     */
+    private function suspendedStateOf(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
     }
 
     /**

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -46,6 +46,13 @@ interface AgentRunRepositoryInterface
         string $errorClass,
     ): void;
 
+    /**
+     * Suspend a run for human approval (ADR-084): persist its serialised state
+     * and move it to WAITING_FOR_APPROVAL — a non-terminal transition, distinct
+     * from finishRun which sets a terminal status and finished_at.
+     */
+    public function suspendRun(int $runUid, string $stateJson): void;
+
     public function findByUuid(string $uuid): ?AgentRun;
 
     /**

--- a/Classes/Service/Tool/Exception/ToolApprovalRequiredException.php
+++ b/Classes/Service/Tool/Exception/ToolApprovalRequiredException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use RuntimeException;
+
+/**
+ * Thrown by {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService::runLoop()}
+ * when the model calls a tool that requires human approval (ADR-084).
+ *
+ * It is a control-flow signal, not a failure: it propagates out of the loop
+ * (the loop's only catch is for {@see \Netresearch\NrLlm\Exception\BudgetExceededException})
+ * carrying the {@see SuspendedRunState} the caller persists to suspend the run.
+ * The caller MUST catch this before any generic `catch (Throwable)` so a
+ * suspension is not mistaken for a failed run.
+ */
+final class ToolApprovalRequiredException extends RuntimeException
+{
+    public function __construct(
+        public readonly SuspendedRunState $state,
+    ) {
+        parent::__construct('Tool loop suspended: a called tool requires human approval.', 1784600100);
+    }
+
+    /**
+     * Named constructor — thrown via this factory (not `throw new`) so the code
+     * is fixed inside the constructor rather than appended at each throw site.
+     */
+    public static function fromState(SuspendedRunState $state): self
+    {
+        return new self($state);
+    }
+}

--- a/Classes/Service/Tool/RequiresApprovalInterface.php
+++ b/Classes/Service/Tool/RequiresApprovalInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Opt-in marker: a {@see ToolInterface} that also implements this must be
+ * approved by a human before the agent loop executes it (ADR-084).
+ *
+ * A marker (not a method on {@see ToolInterface}) so the 41 existing read-only
+ * tools are untouched and their behaviour is provably unchanged — the loop only
+ * pauses for a tool that opts in. A write/side-effecting tool implements this to
+ * require a human in the loop; {@see ToolLoopService} then suspends the run when
+ * the model calls it and resumes only on an explicit approval.
+ */
+interface RequiresApprovalInterface {}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -123,30 +123,8 @@ final readonly class ToolLoopService
             return new ToolLoopResult('', [], 0, false, UsageStatistics::fromTokens(0, 0));
         }
 
-        // Fail-closed global gate: the effective allow-set is always intersected
-        // with the globally-enabled tools. A null caller list means "no per-run
-        // restriction" and collapses to the enabled set (NOT every registered
-        // tool); a disabled tool can therefore never be offered, even when a
-        // caller — or a model steered by injected skill prose — names it.
-        $enabled   = $this->availability->enabledNames();
-        $effective = $allowedToolNames === null
-            ? $enabled
-            : array_values(array_intersect($allowedToolNames, $enabled));
-
-        // Fail-closed RBAC gate: admin-only tools (logs, environment, phpinfo,
-        // backend user/group listings) are never offered unless the ACTING
-        // backend user is an admin — enforced here in the runtime, not just the
-        // (admin-only) playground, so the public service cannot be invoked on a
-        // non-admin's behalf to reach them. An unknown tool name is treated as
-        // admin-only (fail-closed).
-        if (!$this->actingUserIsAdmin()) {
-            $effective = array_values(array_filter(
-                $effective,
-                fn(string $name): bool => $this->registry->get($name)?->requiresAdmin() === false,
-            ));
-        }
-
-        $specs = $this->registry->specs($effective);
+        $effective = $this->resolveOfferedNames($allowedToolNames);
+        $specs     = $this->registry->specs($effective);
 
         // No tools offered (an empty allow-list, or nothing registered): a tools
         // request with an empty `tools` array makes some providers (OpenAI) 400.
@@ -213,6 +191,11 @@ final readonly class ToolLoopService
                             $iterations,
                             $promptTokens,
                             $completionTokens,
+                            // Persist the run's constraints so resume re-applies the
+                            // SAME allow-list and options instead of falling back to
+                            // defaults (ADR-084).
+                            $allowedToolNames,
+                            $options?->toArray() ?? [],
                         ));
                     }
                 }
@@ -275,39 +258,45 @@ final readonly class ToolLoopService
     /**
      * Resume a run suspended for human approval (ADR-084).
      *
-     * Executes the pending turn's calls when $approved — appending each tool
-     * result to the restored transcript — then re-enters {@see self::runLoop()}
+     * Restores the run's original allow-list and options from the suspended state
+     * (so the continuation keeps the same constraints, not defaults), then
+     * executes the pending turn's calls when $approved — appending each tool
+     * result to the restored transcript — and re-enters {@see self::runLoop()}
      * with assembly skipped (the transcript already carries the system prompt and
      * skills). When not approved, a denial result is appended for each pending
-     * call instead, and the model continues from the refusal. The pre-suspend
-     * iteration and token counters are folded into the returned result so the
-     * totals span the whole run.
+     * call; the model then continues from the refusal.
      *
-     * @param list<string>|null $allowedToolNames same semantics as {@see self::runLoop()}
+     * The gate is re-applied at resume time: a pending call whose tool has since
+     * been disabled or become admin-only is NOT executed even when approved
+     * (fail-closed). The pre-suspend iteration and token counters are folded into
+     * the returned result so the totals span the whole run.
      */
     public function resume(
         SuspendedRunState $state,
         bool $approved,
         LlmConfiguration $configuration,
-        ?array $allowedToolNames,
-        ?ToolOptions $options = null,
         ?int $maxIterations = null,
         ?RunTrace $runTrace = null,
     ): ToolLoopResult {
         $messages     = $state->messages;
         $pendingCalls = $state->toolCalls();
-        // The pending calls were offered and called by the model in the suspended
-        // run; on approval they execute against exactly that set.
-        $pendingNames = array_map(static fn(ToolCall $c): string => $c->name, $pendingCalls);
+        $options      = ToolOptions::fromArray($state->options);
+        // Re-apply the gate NOW (a tool may have been disabled or restricted while
+        // the run was suspended) rather than trusting the names captured at
+        // suspend time.
+        $offered = $this->resolveOfferedNames($state->allowedToolNames);
 
         foreach ($pendingCalls as $call) {
-            if ($approved) {
-                $tt0                = hrtime(true);
-                [$result, $isError] = $this->invoke($call, $pendingNames);
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
-            } else {
+            if (!$approved) {
                 $result = sprintf('Error: tool "%s" was denied by the operator.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } elseif (!in_array($call->name, $offered, true)) {
+                $result = sprintf('Error: tool "%s" is no longer permitted and was not executed.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } else {
+                $tt0                = hrtime(true);
+                [$result, $isError] = $this->invoke($call, $offered);
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
             }
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
@@ -315,7 +304,7 @@ final readonly class ToolLoopService
         $result = $this->runLoop(
             $messages,
             $configuration,
-            $allowedToolNames,
+            $state->allowedToolNames,
             $options,
             $maxIterations,
             $runTrace,
@@ -407,11 +396,54 @@ final readonly class ToolLoopService
      * X@host') that URL-sanitising would not strip, so it must never reach the
      * provider.
      *
-     * @param list<string> $allowedNames Names of the tools actually offered this
-     *                                   run; a call to any other registered tool
-     *                                   is rejected unexecuted.
      *
      * @return array{0: string, 1: bool} [result, isError]
+     */
+    /**
+     * Resolve the tool names offered for a run: the caller's per-run allow-list
+     * intersected with the globally-enabled set, then admin-only tools filtered
+     * out unless the acting backend user is an admin. Both gates are fail-closed.
+     * Reused by {@see self::resume()} so a resume re-applies the gate at approval
+     * time — a tool disabled or restricted while suspended is not executed.
+     *
+     * @param list<string>|null $allowedToolNames null ⇒ the globally-enabled set;
+     *                                            a list ⇒ that set ∩ enabled;
+     *                                            `[]` ⇒ no tools
+     *
+     * @return list<string>
+     */
+    private function resolveOfferedNames(?array $allowedToolNames): array
+    {
+        // Fail-closed global gate: the effective allow-set is always intersected
+        // with the globally-enabled tools. A null caller list means "no per-run
+        // restriction" and collapses to the enabled set (NOT every registered
+        // tool); a disabled tool can therefore never be offered, even when a
+        // caller — or a model steered by injected skill prose — names it.
+        $enabled   = $this->availability->enabledNames();
+        $effective = $allowedToolNames === null
+            ? $enabled
+            : array_values(array_intersect($allowedToolNames, $enabled));
+
+        // Fail-closed RBAC gate: admin-only tools (logs, environment, phpinfo,
+        // backend user/group listings) are never offered unless the ACTING
+        // backend user is an admin — enforced here in the runtime, not just the
+        // (admin-only) playground, so the public service cannot be invoked on a
+        // non-admin's behalf to reach them. An unknown tool name is treated as
+        // admin-only (fail-closed).
+        if (!$this->actingUserIsAdmin()) {
+            $effective = array_values(array_filter(
+                $effective,
+                fn(string $name): bool => $this->registry->get($name)?->requiresAdmin() === false,
+            ));
+        }
+
+        return $effective;
+    }
+
+    /**
+     * @param list<string> $allowedNames
+     *
+     * @return array{string, bool} the tool result and whether it is an error
      */
     private function invoke(ToolCall $call, array $allowedNames): array
     {

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Tool;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
@@ -23,6 +24,7 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesActingBackendUserTrait;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -94,6 +96,7 @@ final readonly class ToolLoopService
         ?int $maxIterations = null,
         ?RunTrace $runTrace = null,
         ?RunAugmentation $augmentation = null,
+        bool $skipAssembly = false,
     ): ToolLoopResult {
         $max = $maxIterations ?? $this->defaultMaxIterations;
 
@@ -104,7 +107,15 @@ final readonly class ToolLoopService
         // loop re-sends its own accumulating array). A RunAugmentation adds the
         // playground extras (forced skills/snippets, baked system prompt) and
         // the dry-run flag.
-        [$messages, $dryRun] = $this->assemble($messages, $configuration, $options, $augmentation);
+        //
+        // On resume (ADR-084, skipAssembly) the transcript is already fully
+        // assembled and carries the conversation, so re-assembling would double
+        // the system prompt and skills.
+        if ($skipAssembly) {
+            $dryRun = false;
+        } else {
+            [$messages, $dryRun] = $this->assemble($messages, $configuration, $options, $augmentation);
+        }
 
         if ($dryRun) {
             $runTrace?->recordAssembledMessages($messages);
@@ -188,6 +199,24 @@ final readonly class ToolLoopService
                 }
 
                 $messages[] = ChatMessage::assistantToolCalls($resp->toolCalls ?? [], $resp->content);
+
+                // Human-in-the-loop (ADR-084): if any call in this turn opts into
+                // approval, suspend BEFORE executing any of the turn's calls so a
+                // multi-call turn stays consistent. Existing read-only tools never
+                // implement the marker, so this loop is inert for them and the
+                // synchronous path below is unchanged.
+                foreach ($resp->toolCalls ?? [] as $call) {
+                    if ($this->registry->get($call->name) instanceof RequiresApprovalInterface) {
+                        throw ToolApprovalRequiredException::fromState(new SuspendedRunState(
+                            array_map(static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m, $messages),
+                            array_map(static fn(ToolCall $c): array => $c->toArray(), $resp->toolCalls ?? []),
+                            $iterations,
+                            $promptTokens,
+                            $completionTokens,
+                        ));
+                    }
+                }
+
                 foreach ($resp->toolCalls ?? [] as $call) {
                     $tt0                = hrtime(true);
                     [$result, $isError] = $this->invoke($call, $allowedNames);
@@ -241,6 +270,71 @@ final readonly class ToolLoopService
                 UsageStatistics::fromTokens($promptTokens, $completionTokens),
             );
         }
+    }
+
+    /**
+     * Resume a run suspended for human approval (ADR-084).
+     *
+     * Executes the pending turn's calls when $approved — appending each tool
+     * result to the restored transcript — then re-enters {@see self::runLoop()}
+     * with assembly skipped (the transcript already carries the system prompt and
+     * skills). When not approved, a denial result is appended for each pending
+     * call instead, and the model continues from the refusal. The pre-suspend
+     * iteration and token counters are folded into the returned result so the
+     * totals span the whole run.
+     *
+     * @param list<string>|null $allowedToolNames same semantics as {@see self::runLoop()}
+     */
+    public function resume(
+        SuspendedRunState $state,
+        bool $approved,
+        LlmConfiguration $configuration,
+        ?array $allowedToolNames,
+        ?ToolOptions $options = null,
+        ?int $maxIterations = null,
+        ?RunTrace $runTrace = null,
+    ): ToolLoopResult {
+        $messages     = $state->messages;
+        $pendingCalls = $state->toolCalls();
+        // The pending calls were offered and called by the model in the suspended
+        // run; on approval they execute against exactly that set.
+        $pendingNames = array_map(static fn(ToolCall $c): string => $c->name, $pendingCalls);
+
+        foreach ($pendingCalls as $call) {
+            if ($approved) {
+                $tt0                = hrtime(true);
+                [$result, $isError] = $this->invoke($call, $pendingNames);
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+            } else {
+                $result = sprintf('Error: tool "%s" was denied by the operator.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            }
+            $messages[] = ChatMessage::toolResult($call->id, $result);
+        }
+
+        $result = $this->runLoop(
+            $messages,
+            $configuration,
+            $allowedToolNames,
+            $options,
+            $maxIterations,
+            $runTrace,
+            null,
+            true,
+        );
+
+        // Fold the pre-suspend counters into the continued run so the totals span
+        // the whole run, not just the post-resume segment.
+        return new ToolLoopResult(
+            $result->finalContent,
+            $result->trace,
+            $state->iterations + $result->iterations,
+            $result->truncated,
+            UsageStatistics::fromTokens(
+                $state->promptTokens + $result->usage->promptTokens,
+                $state->completionTokens + $result->usage->completionTokens,
+            ),
+        );
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -167,6 +167,11 @@ return [
         'path' => '/nrllm/tool/run',
         'target' => ToolPlaygroundController::class . '::runAction',
     ],
+    // Resume a run suspended for human approval (ADR-084)
+    'nrllm_tool_resume' => [
+        'path' => '/nrllm/tool/resume',
+        'target' => ToolPlaygroundController::class . '::resumeAction',
+    ],
     // Tool management route (global enable/disable)
     'nrllm_tool_toggle' => [
         'path' => '/nrllm/tool/toggle',

--- a/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
+++ b/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
@@ -1,0 +1,79 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-084:
+
+============================================================================
+ADR-084: Human-in-the-loop tool approval with suspend and resume
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-084-context:
+
+Context
+=======
+
+The agent loop (`ToolLoopService`) executes every tool the model calls
+immediately. That is correct for the 41 shipped tools, which are read-only. But
+a write or side-effecting tool must not run unattended — an operator has to
+approve it first. The loop is synchronous (it runs to a result or throws), so
+there was no way to pause it, get a human decision, and continue. The persisted
+`AgentRun` (:ref:`ADR-081 <adr-081>`) already reserved the
+``WAITING_FOR_APPROVAL`` status for exactly this.
+
+.. _adr-084-decision:
+
+Decision
+========
+
+**Opt-in marker, not a new interface method.** A tool that needs approval
+implements the empty `RequiresApprovalInterface` marker. The 41 existing tools
+are untouched, so their behaviour is provably unchanged — the loop only pauses
+for a tool that opts in. (Adding a ``requiresApproval()`` method to
+`ToolInterface` would have forced a change to every tool and every test double.)
+
+**Suspend via a thrown control-flow signal.** When a turn contains an
+approval-required call, `ToolLoopService` checks the whole turn *before executing
+any of its calls* (so a multi-call turn stays consistent) and throws
+`ToolApprovalRequiredException` carrying a `SuspendedRunState` — the serialised
+transcript up to the assistant tool-call turn, the pending calls, and the
+iteration/token counters. Using an exception keeps `runLoop()`'s return type
+unchanged; the caller catches it **before** any generic ``catch (Throwable)`` so
+a suspension is never mistaken for a failed run. The check is inert for the
+existing tools, so the synchronous path is byte-for-byte the same.
+
+**Persist and resume.** A new ``suspended_state`` column on ``tx_nrllm_agentrun``
+stores the state; `AgentRunRepository::suspendRun()` is a *non-terminal*
+transition to ``WAITING_FOR_APPROVAL`` (distinct from ``finishRun()``, which sets
+a terminal status and clears the state). `ToolLoopService::resume()` rehydrates
+the transcript, executes the pending calls (on approval) or feeds back a denial
+result (on refusal), then re-enters `runLoop()` with assembly skipped — the
+transcript already carries the system prompt and skills. The pre-suspend counters
+are folded into the returned result so the totals span the whole run. The
+playground exposes it through a ``resumeAction`` / ``nrllm_tool_resume`` route.
+
+.. _adr-084-consequences:
+
+Consequences
+============
+
+- A side-effecting tool now gets a human gate for free by implementing one empty
+  marker; nothing else about the tool changes.
+- Approval is per **suspension** (approve/deny the pending turn), not per
+  individual call — the whole turn is held and resumed together, which keeps the
+  provider transcript valid.
+- The resumed tool execution is recorded on the run's event stream (the
+  playground step list), but not in the lean `ToolLoopResult::$trace`
+  (``ToolInvocation`` list), which only covers the continued loop. The event
+  stream is the audit record; the invocation list is a summary.
+- ``suspended_state`` stores the transcript (including prompts). It is cleared on
+  settle, and — like the rest of the run — bounded by the AgentRun retention
+  purge.
+- The primitive lives in the runtime (`ToolLoopService` + the persistence layer),
+  so any consumer — not only the playground — can suspend and resume; a
+  downstream editor "review before the AI writes" flow builds on it.
+- Not in scope: a resume that re-plans (the model is simply continued from the
+  approved result or the refusal), and per-call approval within a multi-call
+  turn.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -381,4 +381,5 @@ Tools
    Adr081AgentRunPersistence
    Adr082StructuredOutputs
    Adr083ConversationSessions
+   Adr084HumanInTheLoopApproval
    Adr085GuardrailPipeline

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
@@ -46,6 +47,45 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
 
         $this->repository = new AgentRunRepository($connectionPool);
         $this->persister  = new AgentRunPersister($this->repository, new NullLogger());
+    }
+
+    #[Test]
+    public function suspendPersistsWaitingStateAndResumeContinuesThenSettleClearsIt(): void
+    {
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_REQUEST, round: 1, durationMs: 0.0));
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 1.0, content: 'x'));
+
+        $state = new SuspendedRunState(
+            [['role' => 'user', 'content' => 'delete it']],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            1,
+            5,
+            2,
+        );
+        $this->persister->suspend($handle, $state);
+
+        // The run is now WAITING_FOR_APPROVAL with its state persisted.
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('waiting_for_approval', $run->status);
+        self::assertNotNull($run->suspendedState);
+        $decoded = json_decode($run->suspendedState, true);
+        self::assertIsArray($decoded);
+        self::assertSame(1, $decoded['iterations']);
+
+        // resumeHandle continues the event stream after the two recorded events.
+        $resumed = $this->persister->resumeHandle($run);
+        self::assertSame($handle->runUid, $resumed->runUid);
+        self::assertSame(2, $resumed->sequence);
+
+        // Settling a resumed run clears the suspended state.
+        $this->persister->settleCompleted($resumed, new ToolLoopResult('done', [], 2, false, UsageStatistics::fromTokens(8, 6)));
+        $settled = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($settled);
+        self::assertSame('completed', $settled->status);
+        self::assertNull($settled->suspendedState);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -94,6 +94,14 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         ];
     }
 
+    /** @var array{runUid: int, stateJson: string}|null */
+    public ?array $suspended = null;
+
+    public function suspendRun(int $runUid, string $stateJson): void
+    {
+        $this->suspended = ['runUid' => $runUid, 'stateJson' => $stateJson];
+    }
+
     public function findByUuid(string $uuid): ?AgentRun
     {
         return null;

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -644,7 +644,7 @@ final class ToolLoopServiceTest extends TestCase
         $state = $this->suspend($service);
 
         $trace  = new RunTrace();
-        $result = $service->resume($state, true, new LlmConfiguration(), null, null, null, $trace);
+        $result = $service->resume($state, true, new LlmConfiguration(), null, $trace);
 
         self::assertSame('deleted and done', $result->finalContent);
         // The approved tool really executed (recorded on the trace) with its result.
@@ -671,7 +671,7 @@ final class ToolLoopServiceTest extends TestCase
         $state = $this->suspend($service);
 
         $trace  = new RunTrace();
-        $result = $service->resume($state, false, new LlmConfiguration(), null, null, null, $trace);
+        $result = $service->resume($state, false, new LlmConfiguration(), null, $trace);
 
         self::assertSame('ok, cancelled', $result->finalContent);
         // The pending tool was NOT executed; a denial result was fed back instead.
@@ -679,6 +679,60 @@ final class ToolLoopServiceTest extends TestCase
         self::assertCount(1, $toolSteps);
         self::assertTrue($toolSteps[0]->toolIsError);
         self::assertStringContainsString('denied', $toolSteps[0]->toolResult ?? '');
+    }
+
+    #[Test]
+    public function suspendCapturesTheAllowListAndOptionsForRestoreOnResume(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'delete_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        $options = new ToolOptions(temperature: 0.3, maxTokens: 512);
+
+        $state = null;
+        try {
+            $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['delete_thing'], $options);
+        } catch (ToolApprovalRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertNotNull($state);
+        self::assertSame(['delete_thing'], $state->allowedToolNames);
+        self::assertSame(0.3, $state->options['temperature'] ?? null);
+        self::assertSame(512, $state->options['max_tokens'] ?? null);
+    }
+
+    #[Test]
+    public function resumeReAppliesTheGateAndRefusesANoLongerOfferedTool(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        // The tool was disabled while the run was suspended: the registry no longer
+        // offers it, so resolveOfferedNames() returns nothing and the continuation
+        // does a single plain completion.
+        $mgr->method('chatWithConfiguration')->willReturn($this->response('closed out'));
+        $service = $this->service($mgr, new ToolRegistry([]));
+
+        $assistantTurn = ['role' => 'assistant', 'content' => '', 'tool_calls' => [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]]];
+        $state         = new SuspendedRunState(
+            [['role' => 'user', 'content' => 'delete it'], $assistantTurn],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            1,
+            5,
+            2,
+            ['delete_thing'],
+            [],
+        );
+
+        $trace = new RunTrace();
+        $service->resume($state, true, new LlmConfiguration(), null, $trace);
+
+        // Approved, but the tool is no longer offered → fail-closed, NOT executed.
+        $toolSteps = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL));
+        self::assertCount(1, $toolSteps);
+        self::assertTrue($toolSteps[0]->toolIsError);
+        self::assertStringContainsString('no longer permitted', $toolSteps[0]->toolResult ?? '');
     }
 
     /**

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -15,12 +15,15 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -607,6 +610,126 @@ final class ToolLoopServiceTest extends TestCase
      * tests target). Gating-specific tests build the service inline with a
      * restricted {@see FakeToolAvailability}.
      */
+    #[Test]
+    public function suspendsWhenTheModelCallsAnApprovalRequiredTool(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'delete_thing', ['id' => 7])], 5, 2));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        $state = $this->suspend($service);
+
+        self::assertCount(1, $state->pendingCalls);
+        self::assertSame('delete_thing', $state->toolCalls()[0]->name);
+        self::assertSame(['id' => 7], $state->toolCalls()[0]->arguments);
+        // The transcript holds the user turn + the assistant tool-call turn,
+        // captured before any tool executed.
+        self::assertCount(2, $state->messages);
+        self::assertSame(1, $state->iterations);
+        self::assertSame(5, $state->promptTokens);
+    }
+
+    #[Test]
+    public function resumeApprovedExecutesThePendingCallThenContinues(): void
+    {
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'delete_thing', [])], 5, 2),
+            $this->response('deleted and done', null, 3, 4),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        $state = $this->suspend($service);
+
+        $trace  = new RunTrace();
+        $result = $service->resume($state, true, new LlmConfiguration(), null, null, null, $trace);
+
+        self::assertSame('deleted and done', $result->finalContent);
+        // The approved tool really executed (recorded on the trace) with its result.
+        $toolSteps = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL));
+        self::assertCount(1, $toolSteps);
+        self::assertSame('delete_thing', $toolSteps[0]->toolName);
+        self::assertSame('DELETED', $toolSteps[0]->toolResult);
+        self::assertFalse($toolSteps[0]->toolIsError);
+        // Totals span the whole run: pre-suspend (5+2) + post-resume (3+4).
+        self::assertSame(14, $result->usage->totalTokens);
+    }
+
+    #[Test]
+    public function resumeDeniedInjectsARefusalThenContinues(): void
+    {
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'delete_thing', [])]),
+            $this->response('ok, cancelled'),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        $state = $this->suspend($service);
+
+        $trace  = new RunTrace();
+        $result = $service->resume($state, false, new LlmConfiguration(), null, null, null, $trace);
+
+        self::assertSame('ok, cancelled', $result->finalContent);
+        // The pending tool was NOT executed; a denial result was fed back instead.
+        $toolSteps = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL));
+        self::assertCount(1, $toolSteps);
+        self::assertTrue($toolSteps[0]->toolIsError);
+        self::assertStringContainsString('denied', $toolSteps[0]->toolResult ?? '');
+    }
+
+    /**
+     * Drive a run to its approval suspension and return the captured state.
+     */
+    private function suspend(ToolLoopService $service): SuspendedRunState
+    {
+        try {
+            $service->runLoop([$this->userTurn('delete it')], new LlmConfiguration(), null);
+        } catch (ToolApprovalRequiredException $e) {
+            return $e->state;
+        }
+        self::fail('Expected the run to suspend for approval.');
+    }
+
+    /**
+     * A tool that opts into human approval (marker), returning 'DELETED' when run.
+     */
+    private function approvalTool(): ToolInterface
+    {
+        return new class implements ToolInterface, RequiresApprovalInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('delete_thing', 'deletes a thing', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments): string
+            {
+                return 'DELETED';
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+        };
+    }
+
     private function service(
         LlmServiceManagerInterface $mgr,
         ToolRegistry $registry,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -672,6 +672,10 @@ CREATE TABLE tx_nrllm_agentrun (
     estimated_cost decimal(10,6) DEFAULT '0.000000' NOT NULL,
     error_class varchar(255) DEFAULT '' NOT NULL,
 
+    -- Resumable state (ADR-084): serialised transcript + pending tool calls while
+    -- status = waiting_for_approval; empty otherwise.
+    suspended_state mediumtext,
+
     -- Time tracking
     started_at int(11) unsigned DEFAULT '0' NOT NULL,
     finished_at int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## Epic D — Human-in-the-loop tool approval + suspend/resume (P1)

Fourth roadmap PR. Builds on Epic A (AgentRun persistence, #437, merged). ADR-084.

### Problem
The agent loop executes every tool the model calls immediately — right for the 41 read-only tools, but a **write/side-effecting** tool must be approved by a human first. The loop was synchronous, with no way to pause → get a decision → continue.

### Design (minimal blast radius)
- **Opt-in marker, not an interface method.** A tool needing approval implements the empty `RequiresApprovalInterface`. The 41 existing tools are **untouched** → their behaviour is *provably* unchanged (the loop only pauses for a tool that opts in). No 41-tool churn, no `ToolInterface` change.
- **Suspend via a thrown control-flow signal.** When a turn contains an approval-required call, `ToolLoopService` checks the whole turn *before executing any of it* (multi-call turns stay consistent) and throws `ToolApprovalRequiredException` carrying a serialised `SuspendedRunState` (transcript + pending calls + counters). An exception keeps `runLoop()`'s **return type unchanged**; the caller catches it *before* the generic `Throwable` so a suspension is never a failed run.
- **Persist + resume.** New `suspended_state` column; `AgentRunRepository::suspendRun()` is a **non-terminal** transition to `WAITING_FOR_APPROVAL` (cleared on settle). `ToolLoopService::resume()` rehydrates the transcript, executes the pending calls (approve) or feeds back a denial (deny), then re-enters `runLoop()` with `skipAssembly: true`; pre-suspend counters are folded into the result. Playground exposes it via `resumeAction` + the `nrllm_tool_resume` route (batch **and** stream paths).

### Why these choices
- The marker + thrown-signal combo means the risky loop reshape is **inert** for every current tool — the existing `ToolLoopServiceTest` and `ToolPlaygroundControllerTest` pass unchanged, which *is* the characterization guard that the synchronous path is byte-for-byte the same.
- Approval is per **suspension** (approve/deny the pending turn), not per call, so the provider transcript stays valid across a multi-call turn.

### Documented limitations (ADR-084)
- The resumed tool execution is recorded on the run's **event stream** (playground steps), not in the lean `ToolLoopResult::$trace` (which only covers the continued loop).
- No re-planning on resume (the model is simply continued); no per-call approval within one turn.

### Tests
- `ToolLoopServiceTest`: suspends on an approval-required tool (correct pending call + transcript + counters); resume-approved executes it + continues + folds totals; resume-denied injects a refusal + continues.
- `AgentRunPersisterTest` (functional): suspend → `waiting_for_approval` + persisted state → `resumeHandle` continues the event sequence → settle clears the state.

### Verification
Local `runTests.sh -p 8.4`: `cgl`, `phpstan` (L10), `unit` (5179), `functional -d sqlite` (tool + playground scope), `rector -n`, `fuzzy` — all green.

Roadmap sweep: A (#437) + B (#438) merged; E (#439) armed; D here; **C (guardrail pipeline)** next — its `require_approval` verdict wires into this.
