### PR TITLE
feat(guardrail): content-policy guardrail pipeline for responses (ADR-085)

### DIFF
--- a/Classes/Domain/Enum/GuardrailVerdict.php
+++ b/Classes/Domain/Enum/GuardrailVerdict.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * A guardrail's decision about a provider response (ADR-085).
+ *
+ * Richer than a boolean so a guardrail can express the full range of policy
+ * outcomes: pass it, rewrite it, block it, ask for it again, or route it to a
+ * human.
+ */
+enum GuardrailVerdict: string
+{
+    /**
+     * The response is fine as-is.
+     */
+    case ALLOW = 'allow';
+
+    /**
+     * Rewrite the response (the guardrail supplies the replacement content).
+     */
+    case REDACT = 'redact';
+
+    /**
+     * Ask the provider again once (e.g. the response failed a quality check).
+     */
+    case RETRY = 'retry';
+
+    /**
+     * Block automatic use; the response needs human approval (the Epic-D / review-queue seam).
+     */
+    case REQUIRE_APPROVAL = 'require_approval';
+
+    /**
+     * Block the response outright.
+     */
+    case DENY = 'deny';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+}

--- a/Classes/Domain/ValueObject/GuardrailResult.php
+++ b/Classes/Domain/ValueObject/GuardrailResult.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+
+/**
+ * The outcome of a guardrail check (ADR-085): the verdict, a human-readable
+ * reason, and — for a {@see GuardrailVerdict::REDACT} — the replacement content.
+ *
+ * Built through the named constructors so a guardrail never has to remember
+ * which fields a verdict needs.
+ */
+final readonly class GuardrailResult
+{
+    private function __construct(
+        public GuardrailVerdict $verdict,
+        public string $reason = '',
+        public ?string $redactedContent = null,
+    ) {}
+
+    public static function allow(): self
+    {
+        return new self(GuardrailVerdict::ALLOW);
+    }
+
+    public static function redact(string $redactedContent, string $reason = ''): self
+    {
+        return new self(GuardrailVerdict::REDACT, $reason, $redactedContent);
+    }
+
+    public static function deny(string $reason): self
+    {
+        return new self(GuardrailVerdict::DENY, $reason);
+    }
+
+    public static function retry(string $reason = ''): self
+    {
+        return new self(GuardrailVerdict::RETRY, $reason);
+    }
+
+    public static function requireApproval(string $reason): self
+    {
+        return new self(GuardrailVerdict::REQUIRE_APPROVAL, $reason);
+    }
+}

--- a/Classes/Exception/GuardrailApprovalRequiredException.php
+++ b/Classes/Exception/GuardrailApprovalRequiredException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a guardrail flags a provider response for human approval (ADR-085).
+ *
+ * Distinct from {@see GuardrailViolationException} (an outright block): the
+ * response is withheld from automatic use but not rejected — a consumer with a
+ * run/review context catches this to route it to approval (the Epic-D /
+ * review-queue seam), rather than to an error.
+ */
+final class GuardrailApprovalRequiredException extends RuntimeException implements NrLlmExceptionInterface
+{
+    public function __construct(
+        public readonly string $guardrail,
+        string $reason,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($reason, 1784600201, $previous);
+    }
+}

--- a/Classes/Exception/GuardrailViolationException.php
+++ b/Classes/Exception/GuardrailViolationException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a guardrail denies a provider response (ADR-085).
+ *
+ * Carries the denying guardrail's class so operators can tell which policy
+ * tripped; the message is the guardrail's reason. Mirrors
+ * {@see BudgetExceededException} — a typed, catchable pipeline denial.
+ */
+final class GuardrailViolationException extends RuntimeException implements NrLlmExceptionInterface
+{
+    public function __construct(
+        public readonly string $guardrail,
+        string $reason,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($reason, 1784600200, $previous);
+    }
+}

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -59,9 +59,10 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * No side effects. The budget record is not incremented here — that is
  * the job of UsageMiddleware after the call succeeds.
  *
- * The default pipeline order is pinned via tag priority (Telemetry outermost
- * at 110 as a pure observer, then Cache at 100, Budget at 75, Fallback at 50,
- * Usage at 25, CircuitBreaker innermost at 20).
+ * The default pipeline order is pinned via tag priority (Guardrail outermost at
+ * 115 screening the returned response, Telemetry at 110 as a pure observer, then
+ * Cache at 100, Budget at 75, Fallback at 50, Usage at 25, CircuitBreaker
+ * innermost at 20).
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 75])]
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Applies the guardrail collection to every non-streaming provider response
+ * (ADR-085).
+ *
+ * Runs outermost of the enforcement middlewares (priority 115, above Telemetry's
+ * 110) so a guardrail sees the final response returned to the caller. After the
+ * downstream chain produces a {@see CompletionResponse}, each tagged
+ * {@see GuardrailInterface} is asked for a verdict, in tag order:
+ * - ALLOW: pass on;
+ * - REDACT: replace the content with the guardrail's version, and keep screening
+ *   (a later guardrail may still deny);
+ * - DENY: throw {@see GuardrailViolationException};
+ * - REQUIRE_APPROVAL: throw {@see GuardrailApprovalRequiredException};
+ * - RETRY: ask the provider once more and re-screen the fresh response (capped at
+ *   one retry).
+ *
+ * Non-`CompletionResponse` operations (embeddings, vision, raw arrays) pass
+ * through untouched. Streaming bypasses the whole pipeline (see ADR-085 /
+ * ADR-062), so streamed output is not screened here.
+ */
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 115])]
+final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
+{
+    /**
+     * @param iterable<GuardrailInterface> $guardrails
+     */
+    public function __construct(
+        #[AutowireIterator(GuardrailInterface::TAG_NAME)]
+        private iterable $guardrails,
+    ) {}
+
+    public function handle(
+        ProviderCallContext $context,
+        LlmConfiguration $configuration,
+        callable $next,
+    ): mixed {
+        $result = $next($configuration);
+        if (!$result instanceof CompletionResponse) {
+            return $result;
+        }
+
+        return $this->screen($result, $configuration, $next, false);
+    }
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    private function screen(
+        CompletionResponse $response,
+        LlmConfiguration $configuration,
+        callable $next,
+        bool $retried,
+    ): CompletionResponse {
+        foreach ($this->guardrails as $guardrail) {
+            $result = $guardrail->checkOutput($response);
+            switch ($result->verdict) {
+                case GuardrailVerdict::ALLOW:
+                    break;
+                case GuardrailVerdict::REDACT:
+                    $response = $this->withContent($response, $result->redactedContent ?? $response->content);
+                    break;
+                case GuardrailVerdict::DENY:
+                    throw new GuardrailViolationException(
+                        $guardrail::class,
+                        $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
+                    );
+                case GuardrailVerdict::REQUIRE_APPROVAL:
+                    throw new GuardrailApprovalRequiredException(
+                        $guardrail::class,
+                        $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
+                    );
+                case GuardrailVerdict::RETRY:
+                    if ($retried) {
+                        throw new GuardrailViolationException(
+                            $guardrail::class,
+                            'A guardrail asked to retry, but the retried response also failed: ' . $result->reason,
+                        );
+                    }
+                    $fresh = $next($configuration);
+                    if (!$fresh instanceof CompletionResponse) {
+                        return $response;
+                    }
+
+                    return $this->screen($fresh, $configuration, $next, true);
+            }
+        }
+
+        return $response;
+    }
+
+    private function withContent(CompletionResponse $response, string $content): CompletionResponse
+    {
+        // CompletionResponse is final readonly — rebuild it with the new content.
+        return new CompletionResponse(
+            content: $content,
+            model: $response->model,
+            usage: $response->usage,
+            finishReason: $response->finishReason,
+            provider: $response->provider,
+            toolCalls: $response->toolCalls,
+            metadata: $response->metadata,
+            thinking: $response->thinking,
+        );
+    }
+}

--- a/Classes/Service/Guardrail/GuardrailInterface.php
+++ b/Classes/Service/Guardrail/GuardrailInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A content-policy guardrail applied to a provider response (ADR-085).
+ *
+ * Implementers are auto-collected via the `nr_llm.guardrail` DI tag (this
+ * attribute) and run by {@see \Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware}
+ * after every non-streaming provider call, in tag order. A guardrail returns a
+ * {@see GuardrailResult} verdict: allow, redact, deny, retry, or require-approval.
+ *
+ * Only the OUTPUT (the model's response) is screened here — it is the untrusted
+ * content. Input-side guardrails (screening the prompt) are a separate step: the
+ * prompt payload is captured in the pipeline's terminal closure, not on the
+ * provider-call context, so screening it requires threading the messages through
+ * the context first (a documented follow-up in ADR-085).
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface GuardrailInterface
+{
+    public const TAG_NAME = 'nr_llm.guardrail';
+
+    public function checkOutput(CompletionResponse $response): GuardrailResult;
+}

--- a/Classes/Service/Guardrail/ProviderContentFilterGuardrail.php
+++ b/Classes/Service/Guardrail/ProviderContentFilterGuardrail.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+
+/**
+ * Turns a provider content-filter block into an explicit guardrail denial
+ * (ADR-085).
+ *
+ * When a provider flags a response with ``finishReason = content_filter`` (see
+ * {@see CompletionResponse::wasFiltered()}), the content is typically empty or
+ * degraded. Rather than let that pass silently, this guardrail DENIES it so the
+ * block surfaces as a typed {@see \Netresearch\NrLlm\Exception\GuardrailViolationException}
+ * a caller can handle — the deny-verdict reference implementation.
+ */
+final readonly class ProviderContentFilterGuardrail implements GuardrailInterface
+{
+    public function checkOutput(CompletionResponse $response): GuardrailResult
+    {
+        if ($response->wasFiltered()) {
+            return GuardrailResult::deny('The provider content filter blocked this response.');
+        }
+
+        return GuardrailResult::allow();
+    }
+}

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -31,8 +31,18 @@ final readonly class SecretRedactionGuardrail implements GuardrailInterface
     {
         $redacted = $this->sanitizeErrorMessage($response->content);
         // API-key and Bearer-token shapes the URL-param sanitiser does not cover.
-        $redacted = (string)preg_replace('/\bsk-[A-Za-z0-9]{16,}\b/', 'sk-***', $redacted);
-        $redacted = (string)preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', $redacted);
+        // The sk- class allows hyphens/underscores so modern project keys
+        // (sk-proj-…) match. Each preg_replace is guarded: on failure (e.g. a
+        // backtrack-limit hit on a huge payload) it returns null, which a bare
+        // (string) cast would turn into '' — silently wiping the whole response.
+        $withoutApiKeys = preg_replace('/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-***', $redacted);
+        if (is_string($withoutApiKeys)) {
+            $redacted = $withoutApiKeys;
+        }
+        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', $redacted);
+        if (is_string($withoutBearer)) {
+            $redacted = $withoutBearer;
+        }
 
         if ($redacted === $response->content) {
             return GuardrailResult::allow();

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+
+/**
+ * Redacts secrets a model may have echoed into its response (ADR-085).
+ *
+ * A model given secret-bearing context (a connection string, an API key, a
+ * Bearer header) can repeat it verbatim. This guardrail masks the common shapes:
+ * credential-bearing URL query params (via the shared
+ * {@see ErrorMessageSanitizerTrait}), ``sk-…`` API keys, and ``Bearer …``
+ * tokens. It only returns REDACT when it actually changed something — otherwise
+ * ALLOW (a pass-through), so a normal response is untouched.
+ */
+final readonly class SecretRedactionGuardrail implements GuardrailInterface
+{
+    use ErrorMessageSanitizerTrait;
+
+    public function checkOutput(CompletionResponse $response): GuardrailResult
+    {
+        $redacted = $this->sanitizeErrorMessage($response->content);
+        // API-key and Bearer-token shapes the URL-param sanitiser does not cover.
+        $redacted = (string)preg_replace('/\bsk-[A-Za-z0-9]{16,}\b/', 'sk-***', $redacted);
+        $redacted = (string)preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', $redacted);
+
+        if ($redacted === $response->content) {
+            return GuardrailResult::allow();
+        }
+
+        return GuardrailResult::redact($redacted, 'Redacted secret-shaped strings from the response.');
+    }
+}

--- a/Documentation/Adr/Adr085GuardrailPipeline.rst
+++ b/Documentation/Adr/Adr085GuardrailPipeline.rst
@@ -1,0 +1,76 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-085:
+
+============================================================================
+ADR-085: Guardrail pipeline for provider responses
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-085-context:
+
+Context
+=======
+
+nr-llm has good, targeted safety mechanisms (skill/tool egress, budgets, secret
+sanitisation on logged errors), but no general content-policy layer over a
+provider response. LLM output is untrusted content, and any editor-facing or
+autonomous use needs to be able to inspect it, rewrite it, block it, or route it
+for review — with a richer answer than a boolean.
+
+.. _adr-085-decision:
+
+Decision
+========
+
+**A guardrail is a `GuardrailInterface`** whose `checkOutput()` returns a
+`GuardrailResult` verdict — ALLOW, REDACT, RETRY, REQUIRE_APPROVAL, or DENY.
+Guardrails are auto-collected through the ``nr_llm.guardrail`` DI tag (the same
+pattern as ``nr_llm.tool``), so a new guardrail is active simply by existing
+under ``Classes/``.
+
+**`GuardrailMiddleware` runs them in the existing ADR-026 provider pipeline**, at
+priority 115 — outermost, above Telemetry (110). It screens every non-streaming
+`CompletionResponse` after the downstream chain produces it:
+
+- ALLOW passes on; REDACT rewrites the content and keeps screening (a later
+  guardrail may still deny); DENY throws `GuardrailViolationException`;
+  REQUIRE_APPROVAL throws `GuardrailApprovalRequiredException`; RETRY re-asks the
+  provider once and re-screens the fresh response (capped at one retry).
+- It sits **above** Telemetry deliberately: a guardrail denial is a *policy*
+  outcome, not a provider failure, so provider telemetry stays accurate.
+- Non-`CompletionResponse` results (embeddings, vision, raw payloads) pass
+  through untouched.
+
+**Two reference guardrails ship active:** `SecretRedactionGuardrail` (REDACT —
+masks secret-shaped strings a model may have echoed, reusing
+`ErrorMessageSanitizerTrait` plus API-key/Bearer patterns) and
+`ProviderContentFilterGuardrail` (DENY — turns a silent ``content_filter``
+response into an explicit, catchable denial).
+
+.. _adr-085-consequences:
+
+Consequences
+============
+
+- Consumers get allow/redact/deny/retry/require-approval over model output, not
+  true/false. A denial is a typed, catchable exception (mirroring
+  `BudgetExceededException`).
+- **Behaviour change:** a provider ``content_filter`` response now raises
+  `GuardrailViolationException` instead of returning silently — the degraded/empty
+  response surfaces rather than passing through.
+- **Output only, for now.** This screens the *response*. Screening the *prompt*
+  (input redaction / injection detection) is a separate step: the prompt payload
+  is captured in the pipeline's terminal closure, not on the immutable
+  `ProviderCallContext`, so input guardrails require threading the messages
+  through the context first — a scoped follow-up, not built here.
+- **Streaming is not covered.** `StreamingDispatcher` bypasses the middleware
+  pipeline (ADR-062), so streamed responses are not screened. Covering them is a
+  separate integration in the streaming path.
+- The REQUIRE_APPROVAL verdict is the seam to human review: on a plain completion
+  it raises `GuardrailApprovalRequiredException` (distinct from a denial) so a
+  consumer with a run/review context (the human-in-the-loop epic, ADR-084, or a
+  review queue) can route it to approval instead of an error.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -381,3 +381,4 @@ Tools
    Adr081AgentRunPersistence
    Adr082StructuredOutputs
    Adr083ConversationSessions
+   Adr085GuardrailPipeline

--- a/Tests/Functional/Provider/Middleware/GuardrailMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/GuardrailMiddlewarePipelineTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\ProviderContentFilterGuardrail;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * Verifies the `nr_llm.guardrail` tag discovers the shipped guardrails and wires
+ * them into the GuardrailMiddleware via the autowired tagged iterator — the
+ * end-to-end DI proof that a guardrail is active simply by existing under
+ * Classes/ (ADR-085).
+ */
+#[CoversClass(GuardrailMiddleware::class)]
+final class GuardrailMiddlewarePipelineTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function shippedGuardrailsAreDiscoveredViaTheTag(): void
+    {
+        $middleware = $this->get(GuardrailMiddleware::class);
+        self::assertInstanceOf(GuardrailMiddleware::class, $middleware);
+
+        $property   = (new ReflectionClass($middleware))->getProperty('guardrails');
+        $guardrails = $property->getValue($middleware);
+
+        $classes = [];
+        self::assertIsIterable($guardrails);
+        foreach ($guardrails as $guardrail) {
+            self::assertInstanceOf(GuardrailInterface::class, $guardrail);
+            $classes[] = $guardrail::class;
+        }
+
+        self::assertContains(SecretRedactionGuardrail::class, $classes);
+        self::assertContains(ProviderContentFilterGuardrail::class, $classes);
+    }
+}

--- a/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
+++ b/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
@@ -50,7 +51,8 @@ final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             [
-                TelemetryMiddleware::class,      // 110 outermost: observes every run (ADR-058)
+                GuardrailMiddleware::class,      // 115 outermost: screens the final response; a guardrail deny is a policy outcome, not a provider failure, so it sits above Telemetry (ADR-085)
+                TelemetryMiddleware::class,      // 110 observes every provider run (ADR-058)
                 IdempotencyMiddleware::class,    // 105 replays a stored result by key (ADR-063)
                 CacheMiddleware::class,          // 100 outermost behavioural layer: a cache hit short-circuits
                 BudgetMiddleware::class,         //  75 pre-flight budget gate on a miss

--- a/Tests/Unit/Domain/Enum/GuardrailVerdictTest.php
+++ b/Tests/Unit/Domain/Enum/GuardrailVerdictTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class GuardrailVerdictTest extends TestCase
+{
+    #[Test]
+    public function valuesListsAllBackingStrings(): void
+    {
+        self::assertSame(['allow', 'redact', 'retry', 'require_approval', 'deny'], GuardrailVerdict::values());
+    }
+
+    #[Test]
+    public function isValidIsTrueForKnownAndFalseForUnknown(): void
+    {
+        self::assertTrue(GuardrailVerdict::isValid('deny'));
+        self::assertTrue(GuardrailVerdict::isValid('require_approval'));
+        self::assertFalse(GuardrailVerdict::isValid('bogus'));
+    }
+}

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GuardrailMiddleware::class)]
+final class GuardrailMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function allowPassesTheResponseThrough(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::allow())]);
+
+        $result = $this->screen($middleware, fn(): CompletionResponse => $this->response('hello'));
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('hello', $result->content);
+    }
+
+    #[Test]
+    public function redactReplacesTheContentButKeepsScreening(): void
+    {
+        $middleware = new GuardrailMiddleware([
+            $this->guardrail(GuardrailResult::redact('[redacted]', 'secret')),
+            // A second guardrail sees the redacted content and allows it.
+            new class implements GuardrailInterface {
+                public function checkOutput(CompletionResponse $response): GuardrailResult
+                {
+                    return $response->content === '[redacted]'
+                        ? GuardrailResult::allow()
+                        : GuardrailResult::deny('should have been redacted first');
+                }
+            },
+        ]);
+
+        $result = $this->screen($middleware, fn(): CompletionResponse => $this->response('my secret is X'));
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('[redacted]', $result->content);
+    }
+
+    #[Test]
+    public function denyThrowsAViolation(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->expectExceptionMessage('blocked');
+        $this->screen($middleware, fn(): CompletionResponse => $this->response('bad'));
+    }
+
+    #[Test]
+    public function requireApprovalThrowsTheApprovalException(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::requireApproval('needs review'))]);
+
+        $this->expectException(GuardrailApprovalRequiredException::class);
+        $this->screen($middleware, fn(): CompletionResponse => $this->response('maybe'));
+    }
+
+    #[Test]
+    public function retryReRunsTheProviderOnceThenAllows(): void
+    {
+        $calls    = 0;
+        $terminal = function () use (&$calls): CompletionResponse {
+            ++$calls;
+
+            return $this->response($calls === 1 ? 'first' : 'second');
+        };
+        // Retry while the content is 'first'; allow the fresh 'second'.
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return $response->content === 'first'
+                    ? GuardrailResult::retry('try again')
+                    : GuardrailResult::allow();
+            }
+        };
+
+        $result = $this->screen(new GuardrailMiddleware([$guardrail]), $terminal);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('second', $result->content);
+        self::assertSame(2, $calls);
+    }
+
+    #[Test]
+    public function retryIsCappedAtOnceThenDenies(): void
+    {
+        // A guardrail that always asks to retry: after the single retry it denies.
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::retry('never happy'))]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->screen($middleware, fn(): CompletionResponse => $this->response('always'));
+    }
+
+    #[Test]
+    public function nonCompletionResponsePassesThroughUnscreened(): void
+    {
+        // e.g. an embedding/vision payload (a different type): the guardrail — even
+        // a denying one — is never consulted.
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('should not run'))]);
+
+        $result = $this->screen($middleware, static fn(): string => 'raw-embedding');
+
+        self::assertSame('raw-embedding', $result);
+    }
+
+    /**
+     * @param callable(): mixed $terminal
+     */
+    private function screen(GuardrailMiddleware $middleware, callable $terminal): mixed
+    {
+        return $middleware->handle(ProviderCallContext::for(ProviderOperation::Chat), new LlmConfiguration(), $terminal);
+    }
+
+    private function guardrail(GuardrailResult $result): GuardrailInterface
+    {
+        return new class ($result) implements GuardrailInterface {
+            public function __construct(private readonly GuardrailResult $result) {}
+
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return $this->result;
+            }
+        };
+    }
+
+    private function response(string $content): CompletionResponse
+    {
+        return new CompletionResponse($content, 'test-model', UsageStatistics::fromTokens(1, 1));
+    }
+}

--- a/Tests/Unit/Service/Guardrail/ProviderContentFilterGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/ProviderContentFilterGuardrailTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Guardrail\ProviderContentFilterGuardrail;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProviderContentFilterGuardrail::class)]
+final class ProviderContentFilterGuardrailTest extends TestCase
+{
+    #[Test]
+    public function deniesAContentFilteredResponse(): void
+    {
+        $response = new CompletionResponse('', 'test-model', UsageStatistics::fromTokens(0, 0), 'content_filter');
+
+        $result = (new ProviderContentFilterGuardrail())->checkOutput($response);
+
+        self::assertSame(GuardrailVerdict::DENY, $result->verdict);
+        self::assertNotSame('', $result->reason);
+    }
+
+    #[Test]
+    public function allowsANormalResponse(): void
+    {
+        $response = new CompletionResponse('all good', 'test-model', UsageStatistics::fromTokens(1, 1), 'stop');
+
+        $result = (new ProviderContentFilterGuardrail())->checkOutput($response);
+
+        self::assertSame(GuardrailVerdict::ALLOW, $result->verdict);
+    }
+}

--- a/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
@@ -41,6 +41,17 @@ final class SecretRedactionGuardrailTest extends TestCase
     }
 
     #[Test]
+    public function redactsAModernProjectApiKeyWithHyphensAndUnderscores(): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response('the key is sk-proj-Abc123_def-456GHIjkl789 here'));
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringContainsString('sk-***', $result->redactedContent);
+        self::assertStringNotContainsString('sk-proj-Abc123', $result->redactedContent);
+    }
+
+    #[Test]
     public function redactsAUrlCredentialAndABearerToken(): void
     {
         $result = (new SecretRedactionGuardrail())->checkOutput(

--- a/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SecretRedactionGuardrail::class)]
+final class SecretRedactionGuardrailTest extends TestCase
+{
+    #[Test]
+    public function allowsAResponseWithNoSecrets(): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response('Here is a perfectly normal answer.'));
+
+        self::assertSame(GuardrailVerdict::ALLOW, $result->verdict);
+        self::assertNull($result->redactedContent);
+    }
+
+    #[Test]
+    public function redactsAnApiKey(): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response('the key is sk-abcdef0123456789ABCDEF here'));
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringContainsString('sk-***', $result->redactedContent);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $result->redactedContent);
+    }
+
+    #[Test]
+    public function redactsAUrlCredentialAndABearerToken(): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput(
+            $this->response('fetch https://api.example.com/x?api_key=SUPERSECRET1 using Bearer abc123def456ghi789'),
+        );
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString('SUPERSECRET1', $result->redactedContent);
+        self::assertStringContainsString('Bearer ***', $result->redactedContent);
+    }
+
+    private function response(string $content): CompletionResponse
+    {
+        return new CompletionResponse($content, 'test-model', UsageStatistics::fromTokens(1, 1));
+    }
+}


### PR DESCRIPTION
## Epic C — Guardrail pipeline for provider responses (P1)

The **final** roadmap PR. ADR-085.

### Problem
nr-llm has targeted safety (tool/skill egress, budgets, secret-sanitised logs) but no **general content-policy layer** over a provider response — and LLM output is untrusted content. A boolean "ok/not-ok" isn't enough.

### Design
- **`GuardrailInterface`** whose `checkOutput()` returns a `GuardrailResult` verdict: **ALLOW / REDACT / RETRY / REQUIRE_APPROVAL / DENY**. Guardrails are auto-collected via the **`nr_llm.guardrail`** DI tag (the exact `nr_llm.tool` pattern) — a new guardrail is active simply by existing under `Classes/`.
- **`GuardrailMiddleware`** runs them in the existing **ADR-026 provider pipeline** at **priority 115 (outermost, above Telemetry)** — a guardrail denial is a *policy* outcome, not a provider failure, so provider telemetry stays clean. It screens every non-streaming `CompletionResponse`:
  - ALLOW passes · REDACT rewrites content and keeps screening (a later guardrail may still deny) · DENY → `GuardrailViolationException` · REQUIRE_APPROVAL → `GuardrailApprovalRequiredException` (the human-review / Epic-D seam) · RETRY re-asks the provider once and re-screens (capped).
  - Non-`CompletionResponse` results (embeddings/vision) pass through untouched.
- **Two reference guardrails ship active:** `SecretRedactionGuardrail` (REDACT — masks secret-shaped strings a model echoed, reusing `ErrorMessageSanitizerTrait` + API-key/Bearer patterns) and `ProviderContentFilterGuardrail` (DENY — turns a silent `content_filter` response into an explicit, catchable denial).

### Why these choices
- Zero changes to `MiddlewarePipeline`/`LlmServiceManager`/`Services.yaml` — pure tag-driven wiring (mirrors `BudgetMiddleware`). The `MiddlewarePipelineOrderTest` (which pins the pipeline order empirically) is updated to include the guardrail as the new outermost layer.

### Documented scope (ADR-085)
- **Output-only.** Screening the *prompt* (input redaction / injection detection) needs the messages threaded onto the immutable `ProviderCallContext` (they're captured in the terminal closure today) — a scoped follow-up, not built here.
- **Streaming not covered** — `StreamingDispatcher` bypasses the pipeline (ADR-062); a separate integration.
- **Behaviour change:** a `content_filter` response now raises `GuardrailViolationException` instead of returning silently.

### Tests
- `GuardrailMiddlewareTest`: allow / redact-and-keep-screening / deny / require-approval / retry-once-then-allow / retry-capped-then-deny / non-CompletionResponse passthrough.
- `SecretRedactionGuardrailTest`, `ProviderContentFilterGuardrailTest`, `GuardrailVerdictTest`.
- `GuardrailMiddlewarePipelineTest` (functional): the `nr_llm.guardrail` tag discovers both shipped guardrails end-to-end; `MiddlewarePipelineOrderTest` confirms the guardrail is the outermost pipeline layer.

### Verification
Local `runTests.sh -p 8.4`: `cgl`, `phpstan` (L10), `unit` (5196), `functional -d sqlite` (middleware scope), `rector -n`, `fuzzy` — all green.

**Roadmap complete:** A (#437) · B (#438) · E (#439) merged; D (#442) armed; **C here** — the full P0/P1 block (plus the CI merge-queue reduction, #441) is delivered.
