### PR TITLE
fix(landingpage): make scrollable code blocks and tables keyboard-focusable

### DIFF
--- a/landingpage/build/build.py
+++ b/landingpage/build/build.py
@@ -255,6 +255,13 @@ def strip_html(s: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", s)).strip()
 
 
+def make_scrollables_focusable(html_fragment: str) -> str:
+    """Add tabindex=0 to horizontally scrollable blocks (<pre>, <table>) so keyboard
+    users can scroll them (WCAG 2.1.1 / axe scrollable-region-focusable). The trailing
+    [\\s>] boundary matches only the exact tags, never <preview>/<table-foo>."""
+    return re.sub(r'<(pre|table)([\s>])', r'<\1 tabindex="0"\2', html_fragment)
+
+
 # ---------------------------------------------------------------------------
 # Build
 # ---------------------------------------------------------------------------
@@ -283,7 +290,7 @@ def collect_adrs(adr_meta: dict) -> list[dict]:
             "slug": slug,
             "file": f"adr/{slug}.html",
             "url": url(f"adr/{slug}.html"),
-            "body": rendered["body"],
+            "body": make_scrollables_focusable(rendered["body"]),
         })
     return adrs
 

--- a/landingpage/src/templates/landing.html.j2
+++ b/landingpage/src/templates/landing.html.j2
@@ -18,7 +18,7 @@
 <div class="codeblock">
   <span class="codeblock__label">{{ lang }}</span>
   <button class="copy-btn" type="button" data-copy="{{ id }}" aria-label="{{ s.copy }}" hidden>⧉</button>
-  <pre id="{{ id }}"><code>{{ code }}</code></pre>
+  <pre id="{{ id }}" tabindex="0"><code>{{ code }}</code></pre>
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
## What

Fixes a WCAG 2.1.1 issue on the landing page: horizontally scrollable blocks were not keyboard-scrollable.

At narrow viewports, code blocks (`<pre>`) on the landing page and in rendered ADRs, and ADR tables (`<table>`), overflow horizontally but had no `tabindex`, so keyboard users could not scroll them. axe-core flags this as `scrollable-region-focusable`.

## Change

- Landing code blocks: `tabindex="0"` on the `<pre>` (template).
- Rendered ADR content: a build-time pass adds `tabindex="0"` to every `<pre>` and `<table>` in the docutils output.

## Verification

axe-core at 390px:
- Landing page — search **open and closed**: 0 WCAG 2.1 AA violations.
- ADR page (adr013, 6 `<pre>` + 3 `<table>`): 0 violations (was 7 `scrollable-region-focusable`).

Follows up the landing page (#440). Independent of the mobile-search change (#443).
