### PR TITLE
feat(landingpage): bilingual developer feature deep-dive pages

### DIFF
--- a/landingpage/build/build.py
+++ b/landingpage/build/build.py
@@ -109,6 +109,17 @@ STRINGS = {
         "onThisPage": "On this page",
         "readAdrs": "Read the architecture decisions",
         "tocLabel": "Sections",
+        "featuresNav": "Features",
+        "featuresIndexTitle": "Feature deep dives",
+        "featuresIndexIntro": "Longer, developer-focused walk-throughs of the features that carry the "
+                              "most detail — what they are for, why they exist, how they work, and how to "
+                              "use them. Each links the authoritative ADRs and the developer docs.",
+        "featuresReadMore": "Read the deep dive",
+        "featuresBackToIndex": "All feature deep dives",
+        "featuresIndexMeta": "Developer deep dives into nr-llm's streaming, tool calling, RAG "
+                             "site-search, and provider fallback — with real code and ADR links.",
+        "gotchasHeading": "Gotchas",
+        "learnMoreHeading": "Go deeper",
     },
     "de": {
         "skip": "Zum Hauptinhalt springen",
@@ -153,6 +164,18 @@ STRINGS = {
         "onThisPage": "Auf dieser Seite",
         "readAdrs": "Architektur-Entscheidungen lesen",
         "tocLabel": "Abschnitte",
+        "featuresNav": "Features",
+        "featuresIndexTitle": "Feature-Deep-Dives",
+        "featuresIndexIntro": "Ausführlichere, entwicklerorientierte Durchläufe der detailreichsten "
+                              "Features – wozu sie da sind, warum es sie gibt, wie sie funktionieren und "
+                              "wie man sie nutzt. Jede Seite verlinkt die maßgeblichen ADRs und die "
+                              "Entwicklerdokumentation.",
+        "featuresReadMore": "Zum Deep-Dive",
+        "featuresBackToIndex": "Alle Feature-Deep-Dives",
+        "featuresIndexMeta": "Entwickler-Deep-Dives zu Streaming, Tool-Calling, RAG-Site-Search und "
+                             "Provider-Fallback von nr-llm – mit echtem Code und Links zu den ADRs.",
+        "gotchasHeading": "Fallstricke",
+        "learnMoreHeading": "Tiefer einsteigen",
     },
 }
 
@@ -357,16 +380,27 @@ def main():
     adr_meta = load("adr")
     brand = load("brand")
     seo = load("seo")
+    features_en = load("features") if (DATA / "features.json").exists() else []
+    features = {"en": features_en,
+                "de": load("features_de") if (DATA / "features_de.json").exists() else features_en}
 
     adrs = collect_adrs(adr_meta)
     group_order = [g["name"] for g in adr_meta.get("groups", [])]
     grouped = group_adrs(adrs, group_order)
 
-    # Autoescaping is enabled for html/xml below; raw HTML (ADR bodies, JSON-LD) is
-    # our own generated content, injected explicitly via |safe.
+    # Resolve each feature's ADR links to the rendered ADR page URLs.
+    adr_url_by_number = {a["number"]: a["url"] for a in adrs}
+    for lang in LANGS:
+        for f in features[lang]:
+            for a in f["adrLinks"]:
+                a["href"] = adr_url_by_number.get(a["number"], url("adr/"))
+
+    # Autoescape everything (templates use the .html.j2 suffix, so an
+    # extension allow-list would miss them); every deliberate raw-HTML injection
+    # — ADR bodies, JSON-LD, inline SVG icons — is marked |safe at its use site.
     env = Environment(  # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
         loader=FileSystemLoader(str(SRC / "templates")),
-        autoescape=select_autoescape(["html", "xml"]),
+        autoescape=select_autoescape(default=True, default_for_string=True),
         trim_blocks=True, lstrip_blocks=True,
     )
     env.globals.update(BASE=BASE, SITE_URL=SITE_URL, url=url)
@@ -405,6 +439,7 @@ def main():
             canonical=SITE_URL + url(f"{lang}/"), alternates=alternates,
             jsonld_blocks=blocks, adr_index_url=url("adr/"),
             show_nav=True, is_landing=True, nav_prefix="#",
+            feature_slugs=[f["slug"] for f in features[lang]],
             js_config={"indexUrl": url(SEARCH_INDEX), "lang": lang, "strings": js_strings(lang)},
         )
         outdir = OUT / lang
@@ -450,6 +485,61 @@ def main():
         )
         (OUT / "adr" / f"{a['slug']}.html").write_text(page, encoding="utf-8")
 
+    # Feature deep-dive pages (bilingual)
+    for lang in LANGS:
+        feats = features[lang]
+        if not feats:
+            continue
+        featdir = OUT / lang / "features"
+        featdir.mkdir(parents=True, exist_ok=True)
+        feat_alts = [
+            {"lang": "en", "href": SITE_URL + url("en/features/")},
+            {"lang": "de", "href": SITE_URL + url("de/features/")},
+            {"lang": "x-default", "href": SITE_URL + url("en/features/")},
+        ]
+        (featdir / INDEX_HTML).write_text(env.get_template("feature_index.html.j2").render(
+            lang=lang, s=STRINGS[lang], brand=brand, features=feats,
+            canonical=SITE_URL + url(f"{lang}/features/"), alternates=feat_alts,
+            jsonld_blocks=jsonld_common,
+            meta={"title": f"{STRINGS[lang]['featuresIndexTitle']} — nr-llm",
+                  "description": STRINGS[lang]["featuresIndexMeta"]},
+            show_nav=True, is_landing=False, nav_prefix=url(f"{lang}/") + "#",
+            js_config={"indexUrl": url(SEARCH_INDEX), "lang": lang, "strings": js_strings(lang)},
+        ), encoding="utf-8")
+
+        for f in feats:
+            page_path = f"{lang}/features/{f['slug']}.html"
+            crumb = [{"name": "nr-llm", "href": url(f"{lang}/")},
+                     {"name": STRINGS[lang]["featuresNav"], "href": url(f"{lang}/features/")},
+                     {"name": f["title"], "href": url(page_path)}]
+            breadcrumb_ld = json.dumps({
+                "@context": "https://schema.org", SCHEMA_TYPE: "BreadcrumbList",
+                "itemListElement": [
+                    {SCHEMA_TYPE: "ListItem", "position": i + 1, "name": x["name"], "item": SITE_URL + x["href"]}
+                    for i, x in enumerate(crumb)
+                ],
+            }, ensure_ascii=False)
+            techarticle_ld = json.dumps({
+                "@context": "https://schema.org", SCHEMA_TYPE: "TechArticle",
+                "headline": f["title"], "description": f["meta"]["description"],
+                "inLanguage": lang, "url": SITE_URL + url(page_path),
+                "isPartOf": {SCHEMA_TYPE: "SoftwareSourceCode", "name": "nr-llm"},
+            }, ensure_ascii=False)
+            (featdir / f"{f['slug']}.html").write_text(env.get_template("feature_page.html.j2").render(
+                lang=lang, s=STRINGS[lang], brand=brand, f=f,
+                canonical=SITE_URL + url(page_path),
+                alternates=[
+                    {"lang": "en", "href": SITE_URL + url(f"en/features/{f['slug']}.html")},
+                    {"lang": "de", "href": SITE_URL + url(f"de/features/{f['slug']}.html")},
+                    {"lang": "x-default", "href": SITE_URL + url(f"en/features/{f['slug']}.html")},
+                ],
+                jsonld_blocks=[{"name": "BreadcrumbList", "json": breadcrumb_ld},
+                               {"name": "TechArticle", "json": techarticle_ld}],
+                meta=f["meta"],
+                show_nav=True, is_landing=False, nav_prefix=url(f"{lang}/") + "#",
+                js_config={"indexUrl": url(SEARCH_INDEX), "lang": lang, "strings": js_strings(lang)},
+            ), encoding="utf-8")
+
     # Root chooser (x-default)
     root = env.get_template("root.html.j2").render(
         brand=brand, canonical=SITE_URL + BASE,
@@ -464,11 +554,26 @@ def main():
 
     # Search index
     docs = build_search_docs(content, adrs)
+    for lang in LANGS:
+        for f in features[lang]:
+            text = " ".join([f["tagline"], *f["why"]["paragraphs"], *f["technical"]["paragraphs"],
+                             *f["when"]["bullets"]])
+            # Feature text is already plain (not HTML); only collapse whitespace so that
+            # terms in angle brackets (<think>, provider-<identifier>.svg) stay searchable.
+            docs.append({"id": f"{lang}-feature-{f['slug']}", "title": f["title"],
+                         "section": STRINGS[lang]["featuresNav"],
+                         "text": re.sub(r"\s+", " ", text).strip()[:1000],
+                         "url": url(f"{lang}/features/{f['slug']}.html"), "kind": "feature", "lang": lang})
     (OUT / SEARCH_INDEX).write_text(
         json.dumps({"documents": docs}, ensure_ascii=False), encoding="utf-8")
 
     # sitemap.xml
-    paths = list(seo.get("sitemapPaths", [])) + [SITE_URL + a["url"] for a in adrs]
+    feature_paths = []
+    for lang in LANGS:
+        if features[lang]:
+            feature_paths.append(SITE_URL + url(f"{lang}/features/"))
+            feature_paths += [SITE_URL + url(f"{lang}/features/{f['slug']}.html") for f in features[lang]]
+    paths = list(seo.get("sitemapPaths", [])) + [SITE_URL + a["url"] for a in adrs] + feature_paths
     urls_xml = "\n".join(
         f"  <url><loc>{html.escape(p)}</loc></url>" for p in paths)
     (OUT / "sitemap.xml").write_text(

--- a/landingpage/build/data/features.json
+++ b/landingpage/build/data/features.json
@@ -1,0 +1,453 @@
+[
+  {
+    "slug": "streaming-and-tools",
+    "title": "Streaming & Tool/Function Calling",
+    "tagline": "Incremental SSE-style chat streaming and OpenAI-compatible tool calling behind one provider-agnostic interface, with budget, usage, and telemetry accounting on every path.",
+    "why": {
+      "heading": "Why it exists",
+      "paragraphs": [
+        "Every TYPO3 extension that wanted streamed output or function calling had to implement it per provider — parsing each vendor's SSE frames and each vendor's tool-call payload shape. nr-llm exposes both as single methods (streamChat, chatWithTools) that resolve the configured provider and translate to and from the OpenAI-compatible tool format (ADR-010), so an extension writes the integration once and works across OpenAI, Anthropic, Gemini, Ollama, OpenRouter and the rest.",
+        "Streaming used to bypass the middleware pipeline entirely: a streamed chat ran no budget pre-flight, wrote no usage row, and produced no telemetry — a live budget hole where an over-budget user could stream freely and the tokens stayed invisible. ADR-062 closes that with a dedicated streaming lifecycle so streamed calls are accounted for like every other call."
+      ]
+    },
+    "when": {
+      "heading": "When to use it",
+      "bullets": [
+        "Use streamChat() when perceived latency matters — long completions render token-by-token instead of after a multi-second wait.",
+        "Use chatWithTools() when the model needs to fetch data, run an action, or produce structured output; the model decides when to call a tool and you execute it and feed the result back.",
+        "Do not stream when you need fallback resilience across providers: fallback only works up to the first chunk (once a chunk is delivered a provider swap is impossible), and streamed responses are never cached.",
+        "Check provider capabilities first — only providers implementing StreamingCapableInterface stream, and only those implementing ToolCapableInterface accept tools.",
+        "For admin-driven agent runs (the bounded tool loop with per-group toggles and a live trace), drive it through the Playground / ToolLoopService rather than a single chatWithTools() call."
+      ]
+    },
+    "technical": {
+      "heading": "How it works",
+      "paragraphs": [
+        "streamChat() returns a PHP Generator that yields string chunks as the provider produces them. Because a generator is lazy, it cannot be pushed through the response middleware pipeline (every middleware would fire against a not-yet-started stream). Instead a private StreamingDispatcher wraps the provider generator and runs a four-stage lifecycle: eager budget pre-flight before any generator is returned, provider selection with shallow fallback that primes each candidate up to its first yield, lazy re-yielding of each chunk while buffering the completion, and settlement (usage + telemetry) in a finally block so accounting lands on normal completion, mid-stream exception, and abandoned/early-break streams alike. Stream token counts are estimated (~4 chars/token) since the streaming adapters yield only text deltas.",
+        "Tool calling follows the OpenAI-compatible schema: you pass a list of tool definitions ({type: function, function: {name, description, parameters}}) to chatWithTools(). The response's toolCalls is a nullable list of ToolCall value objects whose arguments are already a JSON-decoded associative array. You echo the assistant turn back with ChatMessage::assistantToolCalls(), execute each requested tool, answer each by id with ChatMessage::toolResult(), and call chat() again so the model can incorporate the results. nr-llm ships 41 built-in read-only tools in 8 toggleable groups; a bounded agent loop (ToolLoopService::runLoop) drives multi-round tool execution and is gated by a fail-closed cascade — global per-tool state, per-tool group state, per-configuration allowed groups, and the per-run allow-list — where each layer can only narrow, never widen.",
+        "Reasoning-model output is separated from the answer: AbstractProvider::extractThinkingBlocks() pulls inline <think>…</think> blocks (DeepSeek, Qwen, local models) and Claude's native thinking content blocks into CompletionResponse::$thinking, so thinking is available via hasThinking() for debugging without polluting the main content."
+      ],
+      "components": [
+        {
+          "name": "LlmServiceManagerInterface",
+          "role": "Public entry point: streamChat() / streamChatWithConfiguration() return a Generator of string chunks; chatWithTools() / chatWithToolsForConfiguration() return a CompletionResponse."
+        },
+        {
+          "name": "StreamingCapableInterface",
+          "role": "Provider contract for streaming — streamChatCompletion(array $messages, array $options = []): Generator and supportsStreaming(): bool."
+        },
+        {
+          "name": "ToolCapableInterface",
+          "role": "Provider contract for tools — chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse and supportsTools(): bool."
+        },
+        {
+          "name": "StreamingDispatcher",
+          "role": "Private wrapping generator that owns the streaming lifecycle: eager budget pre-flight, pre-first-chunk fallback priming, lazy re-yield, and usage/telemetry settlement in finally (ADR-062)."
+        },
+        {
+          "name": "ToolCall",
+          "role": "Readonly value object for one tool call — id, name, and arguments as an already JSON-decoded associative array; carried in CompletionResponse::$toolCalls."
+        },
+        {
+          "name": "ToolLoopService",
+          "role": "Bounded agent loop (runLoop) that runs multiple tool rounds against a configuration, intersecting each per-run allow-list with the globally enabled tool set (ToolAvailabilityService)."
+        }
+      ]
+    },
+    "how": {
+      "heading": "For developers",
+      "intro": "Both features are single calls on the injected LlmServiceManagerInterface. Streaming yields strings; tool calling returns a CompletionResponse you inspect and answer.",
+      "steps": [
+        {
+          "title": "Stream a chat response",
+          "body": "streamChat() returns a Generator of string chunks. Echo and flush each chunk as it arrives; budget, usage and telemetry are settled automatically when the stream ends or is abandoned.",
+          "code": "$stream = $this->llmManager->streamChat($messages);\n\nforeach ($stream as $chunk) {\n    echo $chunk;\n    ob_flush();\n    flush();\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Define tools in the OpenAI-compatible format",
+          "body": "Each tool is a function entry with a JSON-Schema parameters object. The model decides when to call one based on the conversation.",
+          "code": "$tools = [\n    [\n        'type' => 'function',\n        'function' => [\n            'name' => 'get_weather',\n            'description' => 'Get current weather for a location',\n            'parameters' => [\n                'type' => 'object',\n                'properties' => [\n                    'location' => [\n                        'type' => 'string',\n                        'description' => 'City name',\n                    ],\n                    'unit' => [\n                        'type' => 'string',\n                        'enum' => ['celsius', 'fahrenheit'],\n                    ],\n                ],\n                'required' => ['location'],\n            ],\n        ],\n    ],\n];",
+          "lang": "php"
+        },
+        {
+          "title": "Execute tool calls and feed results back",
+          "body": "toolCalls is a list of ToolCall value objects; arguments is already a decoded array. Echo the assistant turn, answer each call by its id, then call chat() again for the final answer.",
+          "code": "use Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage;\n\n$response = $this->llmManager->chatWithTools($messages, $tools);\n\nif ($response->hasToolCalls()) {\n    $messages[] = ChatMessage::assistantToolCalls($response->toolCalls, $response->content);\n\n    foreach ($response->toolCalls as $toolCall) {\n        $result = match ($toolCall->name) {\n            'get_weather' => $this->getWeather($toolCall->arguments['location']),\n            default => throw new \\RuntimeException(\"Unknown function: {$toolCall->name}\"),\n        };\n\n        $messages[] = ChatMessage::toolResult($toolCall->id, json_encode($result, JSON_THROW_ON_ERROR));\n    }\n\n    $response = $this->llmManager->chat($messages);\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Guard on provider capability",
+          "body": "Not every provider streams or accepts tools. Check the capability interface before using the feature to fail early rather than at the API call.",
+          "code": "$provider = $this->llmManager->getProvider('openai');\nif ($provider instanceof StreamingCapableInterface) {\n    // Provider supports streaming\n}",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Fallback stops at the first chunk",
+        "body": "The streaming dispatcher walks the configuration's fallback chain and primes candidates only up to their first yield. Once a chunk has been handed to the caller, a provider swap is impossible — so a mid-stream failure cannot be retried against another provider. This asymmetry with the non-streaming pipeline is intrinsic to streaming (ADR-062)."
+      },
+      {
+        "title": "Streamed token counts are estimated, not reported",
+        "body": "The streaming adapters yield only text deltas and emit no usage frame at stream end, so the dispatcher estimates tokens with a ~4 chars/token heuristic. An estimate is deliberately better than the previous silent zero for budget enforcement, but it is not the provider's exact figure. Streaming also never caches and always records cache_hit = false."
+      },
+      {
+        "title": "Tool availability is fail-closed and cascades",
+        "body": "A per-run allow-list can only narrow what is globally enabled. A globally disabled tool (ToolStateRepository) or a disabled tool group can never be re-enabled by a skill or playground selection — a per-tool override cannot re-enable a tool inside a disabled group (ADR-039, ADR-043). Third-party ToolInterface implementations must implement getGroup()."
+      },
+      {
+        "title": "No automatic tool execution",
+        "body": "chatWithTools() returns the model's requested calls; it never runs your functions. You must dispatch on $toolCall->name, execute, and return each result via ChatMessage::toolResult() before the model can produce a final answer. Treat every tool result and model output as untrusted content."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 10,
+        "title": "Tool/function calling design"
+      },
+      {
+        "number": 16,
+        "title": "Thinking/reasoning block extraction"
+      },
+      {
+        "number": 39,
+        "title": "Global per-tool availability state"
+      },
+      {
+        "number": 41,
+        "title": "Playground live run streaming"
+      },
+      {
+        "number": 43,
+        "title": "Tool groups with a fail-closed enable cascade"
+      },
+      {
+        "number": 62,
+        "title": "Streaming request lifecycle"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Streaming (Developer Guide)",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/Streaming.rst"
+      },
+      {
+        "label": "Tool/function calling (Developer Guide)",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/ToolCalling.rst"
+      }
+    ],
+    "meta": {
+      "title": "Streaming & Tool Calling — nr-llm",
+      "description": "Provider-agnostic SSE streaming and OpenAI-compatible tool calling in TYPO3, with budget, usage and telemetry accounting on every path."
+    }
+  },
+  {
+    "slug": "rag-site-search",
+    "title": "RAG Site-Search Tools",
+    "tagline": "Two function-calling tools that ground the model in the site's own public content, reading whichever TYPO3 search index is installed with a database fallback.",
+    "why": {
+      "heading": "Why it exists",
+      "paragraphs": [
+        "Agent runs should answer questions about the website's own content with cited evidence instead of model world-knowledge. The retrieval source usually already exists in a TYPO3 install: EXT:solr, ke_search, or the core's indexed_search. What was missing is a controlled retrieval layer that uses whichever index is present, degrades gracefully when none is, and hands the model a curated evidence package with resolvable source URLs rather than raw search hits (ADR-049).",
+        "A generic per-engine tool list (solr_search, ke_search_query, …) was rejected: the model would need to know what is installed, every engine would leak its own result shape into prompts, and the tool count would grow per engine. Instead nr_llm ships one retrieval core with many backends behind a single tool group. Grounding a model in the site's own content is treated as a cross-cutting primitive on the same footing as the content and introspection tools — nr_llm may read indexes others own and keep fresh, but it never owns a persistent index it has to keep synchronised (ADR-050). Vector/semantic RAG stays in the sibling extension nr_ai_search."
+      ]
+    },
+    "when": {
+      "heading": "When to use it",
+      "bullets": [
+        "An agent must answer questions about the site's own public content and cite where the answer came from, rather than rely on the model's training data.",
+        "You run any of EXT:solr, ke_search, or indexed_search — the tools read whichever is installed, in priority order, first-available-wins.",
+        "You run none of them: the always-available pages/tt_content database fallback still answers, labelled as such in the evidence header.",
+        "Evidence must be scoped to what an anonymous visitor could read — index-level filtering is always public-only (fail-closed without a backend user).",
+        "Use site_rag_query to get a curated evidence package, then site_fetch_source(source_id) to read a single source's full indexed text (capped).",
+        "For persistent vector store / chunking / reindex-on-change semantic retrieval, install nr_ai_search on top instead — that is deliberately out of scope here (ADR-050)."
+      ]
+    },
+    "technical": {
+      "heading": "How it works",
+      "paragraphs": [
+        "One retrieval core, many backends. A Service/Retrieval layer defines SearchBackendInterface (getIdentifier, getPriority, isAvailable, search, fetchSource), with four implementations collected via the nr_llm.retrieval_backend DI tag. RetrievalService asks the backends in priority order and uses the first available one — there is no cross-engine score merging, because Solr relevance, MySQL fulltext scores and LIKE hits are not comparable. A backend that throws is treated as unavailable and the cascade continues with a note; an empty result from an available backend is final by design. The answering backend is always named in the result so the model knows the evidence quality.",
+        "Two tools form one new group, rag: site_rag_query (question → evidence package of source_id · title · url plus a match excerpt per source) and site_fetch_source (source_id → the indexed full text, capped). These are 2 of the 41 built-in read-only tools across 8 toggleable groups. Tool arguments are model-chosen and untrusted, so length caps, source-id grammar validation and result caps apply.",
+        "Access is fail-closed and public-only: index-level filtering is always fe_group ''/0, gr_list 0,-1, and the Solr access filter {!typo3access}0,-1 — RAG evidence is exactly what the anonymous visitor could read. Because that content is public, no per-user page narrowing applies; the tools still require a backend user like every builtin."
+      ],
+      "components": [
+        {
+          "name": "SolrSearchBackend",
+          "role": "Talks to the EXT:solr server over the documented HTTP select API (site-config solr_*_read keys, per-language read cores) instead of EXT:solr's @internal PHP classes; carries the {!typo3access}0,-1 public filter and adds no composer dependency on EXT:solr."
+        },
+        {
+          "name": "KeSearchBackend",
+          "role": "Reads tx_kesearch_index directly — MATCH … AGAINST on MySQL/MariaDB, LIKE elsewhere; matches title/content only, never hidden_content."
+        },
+        {
+          "name": "IndexedSearchBackend",
+          "role": "Reads the core index_* tables directly (word-hash join with the md5 computed in PHP; LIKE over index_fulltext when the word tables are empty)."
+        },
+        {
+          "name": "DatabaseSearchBackend",
+          "role": "Always-available fallback (priority 0): LIKE across pages/tt_content search fields, grouped per page — works on a bare instance with no search extension."
+        },
+        {
+          "name": "RetrievalService",
+          "role": "The cascade: sorts backends by priority, asks the first available one, deduplicates same-URL hits, caps the source count, and labels the evidence with the answering backend."
+        },
+        {
+          "name": "SiteRagQueryTool / SiteFetchSourceTool",
+          "role": "The two builtin tools of the rag group; clamp model-supplied arguments and format the evidence list into a citable text block for the model."
+        }
+      ]
+    },
+    "how": {
+      "heading": "For developers",
+      "intro": "The retrieval core is extensible via a single DI tag. A niche search engine's adapter registers through nr_llm.retrieval_backend without a core release; the two rag tools consume RetrievalService and need no change.",
+      "steps": [
+        {
+          "title": "Implement a backend against the interface",
+          "body": "Every backend implements SearchBackendInterface. The tag is auto-applied via AutoconfigureTag, so implementing the interface is enough to enter the cascade. isAvailable() must be cheap and must not throw; keep every reference to an optional extension's classes behind availability checks so the class can always be instantiated.",
+          "code": "#[AutoconfigureTag(name: self::TAG_NAME)]\ninterface SearchBackendInterface\n{\n    public const TAG_NAME = 'nr_llm.retrieval_backend';\n\n    public function getIdentifier(): string;\n\n    public function getPriority(): int;\n\n    public function isAvailable(): bool;\n\n    public function search(RetrievalQuery $query, AccessContext $context): EvidenceList;\n\n    public function fetchSource(SourceReference $reference, AccessContext $context): ?string;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Understand the first-available-wins cascade",
+          "body": "RetrievalService sorts backends by descending priority, skips unavailable ones, treats a throwing backend as unavailable (adding a note and continuing), and returns the first available backend's result — deduplicated by URL and capped to maxSources. There is no cross-backend score merging.",
+          "code": "foreach ($this->prioritized() as $backend) {\n    if (!$this->available($backend)) {\n        continue;\n    }\n\n    try {\n        $result = $backend->search($query, $context);\n    } catch (Throwable) {\n        $notes[] = sprintf('Backend \"%s\" failed and was skipped.', $backend->getIdentifier());\n        continue;\n    }\n\n    return $this->deduplicate($result, $query->maxSources)->withNotes($notes);\n}\n\nreturn new EvidenceList('none', [], [...$notes, 'No search backend available.']);",
+          "lang": "php"
+        },
+        {
+          "title": "The rag group is defined per tool",
+          "body": "A builtin tool joins the rag group by returning it from getGroup(). SiteRagQueryTool clamps the model's question length and source count, runs RetrievalService with a public-only AccessContext for the acting backend user, and formats the evidence into a citable text block.",
+          "code": "public function getGroup(): string\n{\n    return 'rag';\n}\n\npublic function requiresAdmin(): bool\n{\n    // Evidence is public website content; the backend-user gate above\n    // (fail-closed) is the only narrowing needed.\n    return false;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Fuse rankings when you add your own dense arm (optional)",
+          "body": "The cascade itself never merges backends, but hybrid consumers that pair their own embedding arm with nr_llm's keyword facade can reuse the hosted Reciprocal Rank Fusion utility (ADR-074). It is a pure, newable final class — no DI, no interface — with a signature identical to the nr_ai_search original.",
+          "code": "$fused = (new ReciprocalRankFusion())->fuse(\n    $rankedKeyLists,   // one ranked list of ids per retrieval arm\n    k: 60,\n    weights: [],\n);",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Public-only, always",
+        "body": "Index-level filtering is fixed to public content (fe_group ''/0, gr_list 0,-1, Solr {!typo3access}0,-1). Evidence is what an anonymous visitor could read; there is no per-user page narrowing. AccessContext travels through the core so a future frontend endpoint could widen filtering per fe_group, but that is not consumed beyond public-only in this iteration."
+      },
+      {
+        "title": "First available backend wins — empty is final",
+        "body": "An empty result from an available backend is not a reason to fall through to the next engine; falling through would silently mix engines of different quality, and 'the site's search finds nothing' is itself honest evidence. Only an unavailable or throwing backend advances the cascade."
+      },
+      {
+        "title": "Direct table access can drift on future majors",
+        "body": "KeSearchBackend and IndexedSearchBackend read tx_kesearch_index and index_* directly, trading API stability for decoupling. The schemas are verified against currently supported versions (ke_search v6.6/v7, core 13.4/14.x) and pinned by functional tests, but a future major could drift; isAvailable() checks table presence."
+      },
+      {
+        "title": "Solr uses per-language cores, not a language filter",
+        "body": "EXT:solr separates languages by per-language cores (core_de, core_en, …) whose schema has no 'language' field. An earlier fq=language:<id> filtered on a non-existent field and returned zero results for every query; ADR-067 dropped it — language is handled by per-language read-core selection, access by {!typo3access}0,-1 only."
+      },
+      {
+        "title": "Stale indexes cite stale content",
+        "body": "ke_search incremental runs never delete and indexed_search only updates on render, so search-index RAG can cite content that has since changed. This is a known property of index-backed retrieval, documented for editors — the answering backend is always named so the evidence quality is visible."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 49,
+        "title": "RAG site-search tools over installed search indexes"
+      },
+      {
+        "number": 50,
+        "title": "Retrieval and embedding scope — the boundary with nr_ai_search"
+      },
+      {
+        "number": 67,
+        "title": "Solr per-language core — no language filter query"
+      },
+      {
+        "number": 72,
+        "title": "Retrieval-quality evaluation — golden questions and top-k hit rates"
+      },
+      {
+        "number": 74,
+        "title": "Reciprocal Rank Fusion as a hosted utility"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Administration guide — Tools",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Administration/Tools.rst"
+      },
+      {
+        "label": "ADR-049 source",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr049RagSiteSearchTools.rst"
+      }
+    ],
+    "meta": {
+      "title": "RAG Site-Search Tools — nr-llm",
+      "description": "Two function-calling tools ground the model in the site's own public content, reading Solr, ke_search, indexed_search, or a database fallback with cited sources."
+    }
+  },
+  {
+    "slug": "providers-fallback-keys",
+    "title": "Provider Abstraction, Fallback & Encrypted Keys",
+    "tagline": "One interface across seven LLM providers, with configuration-level fallback and API keys stored as nr-vault UUIDs rather than plaintext.",
+    "why": {
+      "heading": "Why it exists",
+      "paragraphs": [
+        "Each LLM provider ships a different endpoint, auth scheme, request/response shape, model naming, and capability set. nr-llm hides those differences behind a single contract (ProviderInterface) so consumers call one API regardless of whether OpenAI, Claude, Gemini, Groq, Mistral, Ollama, or OpenRouter answers. Switching providers is an admin change, not a code change (ADR-001).",
+        "Credentials, model catalogs, and use-case prompts change on different schedules and for different reasons, so they are normalized into three tiers: Provider (one API connection = one key = one billing relationship), Model (per-provider capabilities and pricing), and Configuration (system prompt, temperature, and other tunables for a use case). This lets a site keep separate prod/dev keys for the same adapter type and reuse model definitions across configurations (ADR-013).",
+        "API keys must be retrievable to authenticate, so they cannot be hashed. The original approach encrypted them at application level with sodium (ADR-012); that ADR is now Superseded — keys are stored as nr-vault identifiers (UUIDs) and resolved, injected, audited, and memory-scrubbed inside the vault, so the plaintext key never surfaces in this extension's code."
+      ]
+    },
+    "when": {
+      "heading": "When to use it",
+      "bullets": [
+        "You are adding AI to a TYPO3 extension and want provider selection, key handling, caching, and error handling managed for you — inject LlmServiceManagerInterface and call complete()/chatCompletion().",
+        "You need the same request to survive a provider outage: list sibling configurations on a configuration's fallback chain to retry on connection errors, HTTP 5xx, or 429 rate limits.",
+        "You must keep provider credentials out of the database, YAML, and logs — store the nr-vault UUID identifier, never the raw key.",
+        "You are integrating a new provider: implement ProviderInterface (or extend AbstractProvider), mark it with #[AsLlmProvider], and it auto-registers via ProviderCompilerPass.",
+        "You run multiple accounts of one provider type (prod/dev/backup) or custom endpoints (Azure OpenAI, Ollama, vLLM) that the three-tier model represents as distinct Provider rows."
+      ]
+    },
+    "technical": {
+      "heading": "How it works",
+      "paragraphs": [
+        "ProviderInterface is the core contract (getName, getIdentifier, configure, chatCompletion, complete, embeddings, testConnection, and capability checks). Optional features are opt-in capability interfaces — VisionCapableInterface, StreamingCapableInterface, ToolCapableInterface, DocumentCapableInterface — detected by instanceof, while embeddings remain a core method. AbstractProvider supplies shared behavior and every shipped adapter extends it.",
+        "Registration is attribute-driven: a class marked #[AsLlmProvider(priority: N)] in the Netresearch\\NrLlm\\ namespace is auto-tagged nr_llm.provider by ProviderCompilerPass at container-compile time (ADR-022). Providers are kept private; nothing resolves them by class name — access is via LlmServiceManager, resolved by the identifier returned from getIdentifier(). Priority is an ordering hint only. Third-party providers outside the namespace keep the legacy Services.yaml tag path.",
+        "The three tiers are Extbase entities over tx_nrllm_provider, tx_nrllm_model, and tx_nrllm_configuration. A Configuration references a Model, which references a Provider that owns the connection (endpoint_url, adapter_type, timeout, max_retries, and api_key stored as a vault UUID). Calls run through a middleware pipeline (ADR-026) ordered by tag priority: Telemetry (110), Cache (100), Budget (75), Fallback (50), Usage (25), CircuitBreaker (20).",
+        "FallbackMiddleware runs the primary configuration; on a retryable failure it walks the configuration's FallbackChain of sibling configuration identifiers, skipping not-found and inactive ones, until one succeeds or the chain is exhausted (FallbackChainExhaustedException). Retryable is ProviderConnectionException, a 429 ProviderResponseException, or CircuitOpenException. AbstractProvider::getHttpClient() authenticates through nr-vault's HTTP client (vault->http()->withAuthentication(identifier, placement, options)); api-key-less providers such as Ollama use the raw factory client behind an explicit SSRF host check."
+      ],
+      "components": [
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\Contract\\ProviderInterface",
+          "role": "Core provider contract every adapter implements — name, identifier, configure, chatCompletion, complete, embeddings, testConnection, capability checks."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\AbstractProvider",
+          "role": "Shared base for the seven adapters; stores apiKeyIdentifier and builds the vault-authenticated HTTP client in getHttpClient()."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Attribute\\AsLlmProvider",
+          "role": "#[AsLlmProvider(priority)] marker; ProviderCompilerPass auto-tags it nr_llm.provider so no Services.yaml entry is needed."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Domain\\DTO\\FallbackChain",
+          "role": "Immutable, normalized ordered list of LlmConfiguration identifiers to try when the primary fails; shallow (a fallback's own chain is ignored)."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\Middleware\\FallbackMiddleware",
+          "role": "Runtime enforcer (tag priority 50): retries the chain on retryable errors, skips inactive/missing configs, throws FallbackChainExhaustedException when all fail."
+        },
+        {
+          "name": "Netresearch\\NrVault\\Service\\VaultServiceInterface",
+          "role": "Resolves the stored UUID identifier to the real secret and injects it at send time; keeps plaintext keys out of nr-llm's code and database."
+        }
+      ]
+    },
+    "how": {
+      "heading": "For developers",
+      "intro": "Consume through LlmServiceManagerInterface, add providers via the attribute, keep keys as vault UUIDs, and declare fallbacks on the configuration.",
+      "steps": [
+        {
+          "title": "Consume the unified service",
+          "body": "Inject LlmServiceManagerInterface and call it. Provider selection, key resolution, caching, and error handling are handled by the pipeline — you never touch an HTTP client or a provider class directly.",
+          "code": "use Netresearch\\NrLlm\\Service\\LlmServiceManagerInterface;\n\nclass MyController\n{\n    public function __construct(\n        private readonly LlmServiceManagerInterface $llm,\n    ) {}\n\n    public function summarizeAction(string $text): string\n    {\n        return $this->llm->complete(\"Summarize: {$text}\")->content;\n    }\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Add a provider",
+          "body": "Implement ProviderInterface (in practice, extend AbstractProvider and add the capability interfaces you support), mark the class with #[AsLlmProvider] so ProviderCompilerPass auto-registers it, return the identifier from getIdentifier(), and add the icon at Resources/Public/Icons/provider-<identifier>.svg.",
+          "code": "#[AsLlmProvider(priority: 100)]\nfinal class OpenAiProvider extends AbstractProvider implements\n    VisionCapableInterface,\n    StreamingCapableInterface,\n    ToolCapableInterface\n{\n    public function getName(): string\n    {\n        return 'OpenAI';\n    }\n\n    public function getIdentifier(): string\n    {\n        return 'openai';\n    }\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Authenticate through nr-vault",
+          "body": "configure() reads apiKeyIdentifier (a vault UUID), not a raw key. isAvailable() is true only when the identifier is set and the vault holds it. getHttpClient() then builds a client via vault->http()->withAuthentication(...), so the secret is injected and audited inside the vault; api-key-less providers (Ollama) take the raw factory client behind an SSRF host check.",
+          "code": "protected function getHttpClient(?int $timeout = null): ClientInterface\n{\n    if ($this->configuredHttpClient !== null) {\n        return $this->configuredHttpClient;\n    }\n\n    $effective = ($timeout !== null && $timeout > 0) ? $timeout : $this->timeout;\n\n    if ($this->apiKeyIdentifier === '') {\n        $this->assertEndpointHostAllowed();\n        return $this->httpClientFactory->create($effective > 0 ? $effective : null);\n    }\n\n    $client = $this->vault->http()->withAuthentication(\n        $this->apiKeyIdentifier,\n        $this->getSecretPlacement(),\n        $this->getSecretPlacementOptions(),\n    );\n\n    return $effective > 0 ? $client->withTimeout($effective) : $client;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Declare a fallback chain",
+          "body": "A FallbackChain is an ordered, normalized (trimmed + lowercased) list of sibling LlmConfiguration identifiers. Build it immutably with withLink(); FallbackMiddleware walks it on retryable failures (connection error, 5xx, 429, or an open circuit), skipping the primary, and inactive or missing entries.",
+          "code": "$chain = (new FallbackChain())\n    ->withLink('blog-summarizer-openai')\n    ->withLink('blog-summarizer-claude');\n\n// Persisted on the primary configuration; walked by FallbackMiddleware\n// (shallow: a fallback configuration's own chain is ignored).",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Fallback is shallow",
+        "body": "A fallback configuration's own fallback chain is ignored, by design, to prevent recursion and cycles. Only the primary configuration's chain is walked. If the chain contains only the primary identifier, it becomes empty after filtering and the primary's original error is rethrown verbatim rather than a 'chain exhausted' error."
+      },
+      {
+        "title": "Streaming requests are not routed through fallback",
+        "body": "Once chunks have been emitted to the caller a provider cannot be swapped mid-stream, so FallbackMiddleware excludes streaming (Generator-returning) calls. Build the pipeline without FallbackMiddleware for streaming, or short-circuit on ProviderCallContext::operation === Stream."
+      },
+      {
+        "title": "Keys are vault UUIDs, never plaintext",
+        "body": "The api_key column stores an nr-vault identifier, not a secret. ADR-012's application-level sodium encryption is Superseded by the nr-vault integration. Never put a raw key in TCA, YAML, env, or logs; ErrorMessageSanitizerTrait::sanitizeErrorMessage() strips secret-bearing query params before messages are surfaced."
+      },
+      {
+        "title": "Attribute auto-registration is namespace-scoped",
+        "body": "ProviderCompilerPass only reflects service definitions whose class is in the Netresearch\\NrLlm\\ namespace. Third-party providers outside that namespace must keep the legacy Services.yaml tag (name: nr_llm.provider, priority: N), which is fully supported and takes precedence when both are present. Priority is an ordering hint only — providers are resolved by identifier at runtime."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 1,
+        "title": "Provider abstraction layer"
+      },
+      {
+        "number": 13,
+        "title": "Three-level configuration architecture (Provider-Model-Configuration)"
+      },
+      {
+        "number": 12,
+        "title": "API key encryption at application level (superseded by nr-vault)"
+      },
+      {
+        "number": 21,
+        "title": "Provider fallback chain"
+      },
+      {
+        "number": 22,
+        "title": "Attribute-based provider registration"
+      },
+      {
+        "number": 63,
+        "title": "Provider resilience: circuit breaker, health, idempotency"
+      },
+      {
+        "number": 80,
+        "title": "Typed provider HTTP exceptions (401 authentication, 429 rate-limit)"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Developer Guide",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/Index.rst"
+      },
+      {
+        "label": "Architecture & ADRs",
+        "href": "https://github.com/netresearch/t3x-nr-llm/tree/main/Documentation/Adr"
+      }
+    ],
+    "meta": {
+      "title": "Provider Abstraction, Fallback & Keys — nr-llm",
+      "description": "How nr-llm unifies seven LLM providers behind one interface, retries a configuration fallback chain, and stores API keys as nr-vault UUIDs."
+    }
+  }
+]

--- a/landingpage/build/data/features_de.json
+++ b/landingpage/build/data/features_de.json
@@ -1,0 +1,453 @@
+[
+  {
+    "slug": "streaming-and-tools",
+    "title": "Streaming & Tool-/Function-Calling",
+    "tagline": "Inkrementelles Chat-Streaming im SSE-Stil und OpenAI-kompatibles Tool-Calling hinter einer provider-agnostischen Schnittstelle – mit Budget-, Nutzungs- und Telemetrie-Erfassung auf jedem Pfad.",
+    "why": {
+      "heading": "Warum es existiert",
+      "paragraphs": [
+        "Jede TYPO3-Extension, die gestreamte Ausgabe oder Function-Calling wollte, musste das pro Provider selbst umsetzen – die SSE-Frames jedes Anbieters und die Payload-Form jedes Tool-Calls parsen. nr-llm stellt beides als einzelne Methoden bereit (streamChat, chatWithTools), die den konfigurierten Provider auflösen und in das OpenAI-kompatible Tool-Format und zurück übersetzen (ADR-010). So schreibt eine Extension die Integration einmal und arbeitet mit OpenAI, Anthropic, Gemini, Ollama, OpenRouter und den übrigen.",
+        "Streaming umging die Middleware-Pipeline früher vollständig: Ein gestreamter Chat führte keine Budget-Vorprüfung durch, schrieb keine Nutzungszeile und erzeugte keine Telemetrie – eine offene Budget-Lücke, über die ein Nutzer mit überschrittenem Budget frei streamen konnte, während die Tokens unsichtbar blieben. ADR-062 schließt das mit einem eigenen Streaming-Lebenszyklus, sodass gestreamte Aufrufe wie jeder andere Aufruf erfasst werden."
+      ]
+    },
+    "when": {
+      "heading": "Wann man es einsetzt",
+      "bullets": [
+        "streamChat() einsetzen, wenn die wahrgenommene Latenz zählt – lange Completions erscheinen Token für Token statt erst nach mehreren Sekunden Wartezeit.",
+        "chatWithTools() einsetzen, wenn das Modell Daten abrufen, eine Aktion ausführen oder strukturierte Ausgabe erzeugen muss; das Modell entscheidet, wann ein Tool aufgerufen wird, und man führt es aus und gibt das Ergebnis zurück.",
+        "Nicht streamen, wenn Fallback-Resilienz über mehrere Provider hinweg nötig ist: Der Fallback greift nur bis zum ersten Chunk (sobald ein Chunk ausgeliefert ist, ist ein Provider-Wechsel unmöglich), und gestreamte Antworten werden nie gecacht.",
+        "Zuerst die Provider-Fähigkeiten prüfen – nur Provider, die StreamingCapableInterface implementieren, streamen, und nur solche, die ToolCapableInterface implementieren, akzeptieren Tools.",
+        "Für admin-gesteuerte Agent-Läufe (die begrenzte Tool-Schleife mit Schaltern pro Gruppe und einem Live-Trace) den Weg über das Playground / ToolLoopService nehmen statt eines einzelnen chatWithTools()-Aufrufs."
+      ]
+    },
+    "technical": {
+      "heading": "Wie es funktioniert",
+      "paragraphs": [
+        "streamChat() gibt einen PHP-Generator zurück, der String-Chunks liefert (yield), sobald der Provider sie erzeugt. Da ein Generator lazy ist, lässt er sich nicht durch die Response-Middleware-Pipeline schieben (jede Middleware würde gegen einen noch nicht gestarteten Stream feuern). Stattdessen kapselt ein privater StreamingDispatcher den Provider-Generator und durchläuft einen vierstufigen Lebenszyklus: eine sofortige Budget-Vorprüfung, bevor überhaupt ein Generator zurückgegeben wird; die Provider-Auswahl mit flachem Fallback, die jeden Kandidaten bis zu seinem ersten yield vorbereitet; das lazy erneute Ausgeben (yield) jedes Chunks, während die Completion gepuffert wird; und die Verrechnung (Nutzung + Telemetrie) in einem finally-Block, sodass die Erfassung sowohl bei normalem Abschluss als auch bei einer Exception mitten im Stream und bei abgebrochenen bzw. früh beendeten Streams greift. Die Token-Zahlen eines Streams werden geschätzt (~4 Zeichen/Token), da die Streaming-Adapter nur Text-Deltas liefern.",
+        "Tool-Calling folgt dem OpenAI-kompatiblen Schema: Man übergibt chatWithTools() eine Liste von Tool-Definitionen ({type: function, function: {name, description, parameters}}). Das toolCalls der Antwort ist eine nullbare Liste von ToolCall-Value-Objects, deren arguments bereits ein JSON-dekodiertes assoziatives Array sind. Man gibt den Assistant-Zug mit ChatMessage::assistantToolCalls() zurück, führt jedes angeforderte Tool aus, beantwortet jeden Aufruf per id mit ChatMessage::toolResult() und ruft chat() erneut auf, damit das Modell die Ergebnisse einbeziehen kann. nr-llm bringt 41 eingebaute, lesende Tools in 8 schaltbaren Gruppen mit; eine begrenzte Agent-Schleife (ToolLoopService::runLoop) steuert die Tool-Ausführung über mehrere Runden und wird durch eine fail-closed-Kaskade abgesichert – globaler Zustand pro Tool, Zustand pro Tool-Gruppe, erlaubte Gruppen pro Konfiguration und die Allow-List pro Lauf –, wobei jede Schicht nur einschränken, nie erweitern kann.",
+        "Die Ausgabe von Reasoning-Modellen wird von der Antwort getrennt: AbstractProvider::extractThinkingBlocks() zieht inline <think>…</think>-Blöcke (DeepSeek, Qwen, lokale Modelle) und Claudes native Thinking-Content-Blöcke in CompletionResponse::$thinking, sodass das Thinking über hasThinking() zum Debuggen verfügbar ist, ohne den eigentlichen Content zu verunreinigen."
+      ],
+      "components": [
+        {
+          "name": "LlmServiceManagerInterface",
+          "role": "Öffentlicher Einstiegspunkt: streamChat() / streamChatWithConfiguration() geben einen Generator aus String-Chunks zurück; chatWithTools() / chatWithToolsForConfiguration() geben eine CompletionResponse zurück."
+        },
+        {
+          "name": "StreamingCapableInterface",
+          "role": "Provider-Vertrag für Streaming – streamChatCompletion(array $messages, array $options = []): Generator und supportsStreaming(): bool."
+        },
+        {
+          "name": "ToolCapableInterface",
+          "role": "Provider-Vertrag für Tools – chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse und supportsTools(): bool."
+        },
+        {
+          "name": "StreamingDispatcher",
+          "role": "Privater kapselnder Generator, dem der Streaming-Lebenszyklus gehört: sofortige Budget-Vorprüfung, Fallback-Vorbereitung vor dem ersten Chunk, lazy erneutes yield und Nutzungs-/Telemetrie-Verrechnung im finally (ADR-062)."
+        },
+        {
+          "name": "ToolCall",
+          "role": "Readonly-Value-Object für einen einzelnen Tool-Call – id, name und arguments als bereits JSON-dekodiertes assoziatives Array; wird in CompletionResponse::$toolCalls transportiert."
+        },
+        {
+          "name": "ToolLoopService",
+          "role": "Begrenzte Agent-Schleife (runLoop), die mehrere Tool-Runden gegen eine Konfiguration ausführt und dabei jede Allow-List pro Lauf mit der global aktivierten Tool-Menge schneidet (ToolAvailabilityService)."
+        }
+      ]
+    },
+    "how": {
+      "heading": "Für Entwickler",
+      "intro": "Beide Funktionen sind einzelne Aufrufe auf dem injizierten LlmServiceManagerInterface. Streaming liefert Strings (yield); Tool-Calling gibt eine CompletionResponse zurück, die man auswertet und beantwortet.",
+      "steps": [
+        {
+          "title": "Eine Chat-Antwort streamen",
+          "body": "streamChat() gibt einen Generator aus String-Chunks zurück. Jeden Chunk ausgeben und flushen, sobald er eintrifft; Budget, Nutzung und Telemetrie werden automatisch verrechnet, wenn der Stream endet oder abgebrochen wird.",
+          "code": "$stream = $this->llmManager->streamChat($messages);\n\nforeach ($stream as $chunk) {\n    echo $chunk;\n    ob_flush();\n    flush();\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Tools im OpenAI-kompatiblen Format definieren",
+          "body": "Jedes Tool ist ein function-Eintrag mit einem parameters-Objekt nach JSON-Schema. Das Modell entscheidet anhand des Gesprächs, wann eines aufgerufen wird.",
+          "code": "$tools = [\n    [\n        'type' => 'function',\n        'function' => [\n            'name' => 'get_weather',\n            'description' => 'Get current weather for a location',\n            'parameters' => [\n                'type' => 'object',\n                'properties' => [\n                    'location' => [\n                        'type' => 'string',\n                        'description' => 'City name',\n                    ],\n                    'unit' => [\n                        'type' => 'string',\n                        'enum' => ['celsius', 'fahrenheit'],\n                    ],\n                ],\n                'required' => ['location'],\n            ],\n        ],\n    ],\n];",
+          "lang": "php"
+        },
+        {
+          "title": "Tool-Calls ausführen und Ergebnisse zurückgeben",
+          "body": "toolCalls ist eine Liste von ToolCall-Value-Objects; arguments ist bereits ein dekodiertes Array. Den Assistant-Zug zurückgeben, jeden Aufruf per id beantworten und dann chat() erneut für die endgültige Antwort aufrufen.",
+          "code": "use Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage;\n\n$response = $this->llmManager->chatWithTools($messages, $tools);\n\nif ($response->hasToolCalls()) {\n    $messages[] = ChatMessage::assistantToolCalls($response->toolCalls, $response->content);\n\n    foreach ($response->toolCalls as $toolCall) {\n        $result = match ($toolCall->name) {\n            'get_weather' => $this->getWeather($toolCall->arguments['location']),\n            default => throw new \\RuntimeException(\"Unknown function: {$toolCall->name}\"),\n        };\n\n        $messages[] = ChatMessage::toolResult($toolCall->id, json_encode($result, JSON_THROW_ON_ERROR));\n    }\n\n    $response = $this->llmManager->chat($messages);\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Auf die Provider-Fähigkeit prüfen",
+          "body": "Nicht jeder Provider streamt oder akzeptiert Tools. Das Capability-Interface prüfen, bevor die Funktion genutzt wird, um früh fehlzuschlagen statt erst beim API-Aufruf.",
+          "code": "$provider = $this->llmManager->getProvider('openai');\nif ($provider instanceof StreamingCapableInterface) {\n    // Provider supports streaming\n}",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Der Fallback endet am ersten Chunk",
+        "body": "Der Streaming-Dispatcher läuft die Fallback-Kette der Konfiguration durch und bereitet Kandidaten nur bis zu ihrem ersten yield vor. Sobald ein Chunk an den Aufrufer übergeben wurde, ist ein Provider-Wechsel unmöglich – ein Fehler mitten im Stream lässt sich also nicht gegen einen anderen Provider erneut versuchen. Diese Asymmetrie zur nicht streamenden Pipeline ist dem Streaming inhärent (ADR-062)."
+      },
+      {
+        "title": "Token-Zahlen beim Streaming werden geschätzt, nicht gemeldet",
+        "body": "Die Streaming-Adapter liefern nur Text-Deltas und senden am Stream-Ende keinen usage-Frame, deshalb schätzt der Dispatcher die Tokens mit einer Heuristik von ~4 Zeichen/Token. Eine Schätzung ist für die Budget-Durchsetzung bewusst besser als die frühere stille Null, aber nicht der exakte Wert des Providers. Streaming cacht zudem nie und schreibt immer cache_hit = false."
+      },
+      {
+        "title": "Die Tool-Verfügbarkeit ist fail-closed und kaskadiert",
+        "body": "Eine Allow-List pro Lauf kann nur einschränken, was global aktiviert ist. Ein global deaktiviertes Tool (ToolStateRepository) oder eine deaktivierte Tool-Gruppe lässt sich über eine Skill- oder Playground-Auswahl nie wieder aktivieren – ein Override pro Tool kann ein Tool innerhalb einer deaktivierten Gruppe nicht reaktivieren (ADR-039, ADR-043). Fremde ToolInterface-Implementierungen müssen getGroup() implementieren."
+      },
+      {
+        "title": "Keine automatische Tool-Ausführung",
+        "body": "chatWithTools() gibt die vom Modell angeforderten Aufrufe zurück; es führt niemals selbst Funktionen aus. Man muss anhand von $toolCall->name verzweigen, ausführen und jedes Ergebnis über ChatMessage::toolResult() zurückgeben, bevor das Modell eine endgültige Antwort erzeugen kann. Jedes Tool-Ergebnis und jede Modellausgabe als nicht vertrauenswürdigen Content behandeln."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 10,
+        "title": "Design des Tool-/Function-Callings"
+      },
+      {
+        "number": 16,
+        "title": "Extraktion von Thinking-/Reasoning-Blöcken"
+      },
+      {
+        "number": 39,
+        "title": "Globaler Verfügbarkeitszustand pro Tool"
+      },
+      {
+        "number": 41,
+        "title": "Streaming von Live-Läufen im Playground"
+      },
+      {
+        "number": 43,
+        "title": "Tool-Gruppen mit fail-closed-Aktivierungskaskade"
+      },
+      {
+        "number": 62,
+        "title": "Lebenszyklus von Streaming-Anfragen"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Streaming (Entwickler-Handbuch)",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/Streaming.rst"
+      },
+      {
+        "label": "Tool-/Function-Calling (Entwickler-Handbuch)",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/ToolCalling.rst"
+      }
+    ],
+    "meta": {
+      "title": "Streaming & Tool-Calling — nr-llm",
+      "description": "Provider-agnostisches SSE-Streaming und OpenAI-kompatibles Tool-Calling in TYPO3 – mit Budget-, Nutzungs- und Telemetrie-Erfassung auf jedem Pfad."
+    }
+  },
+  {
+    "slug": "rag-site-search",
+    "title": "RAG-Site-Search-Tools",
+    "tagline": "Zwei Function-Calling-Tools, die das Modell im eigenen öffentlichen Content der Website verankern und dabei den jeweils installierten TYPO3-Suchindex lesen, mit einem Datenbank-Fallback.",
+    "why": {
+      "heading": "Warum es existiert",
+      "paragraphs": [
+        "Agent-Läufe sollen Fragen zum eigenen Content der Website mit belegten Quellen beantworten statt mit dem Weltwissen des Modells. Die Retrieval-Quelle existiert in einer TYPO3-Installation meist schon: EXT:solr, ke_search oder das indexed_search des Cores. Was fehlte, ist eine kontrollierte Retrieval-Schicht, die den jeweils vorhandenen Index nutzt, sauber degradiert, wenn keiner vorhanden ist, und dem Modell ein kuratiertes Evidence-Paket mit auflösbaren Quell-URLs übergibt statt roher Suchtreffer (ADR-049).",
+        "Eine generische Tool-Liste pro Engine (solr_search, ke_search_query, …) wurde verworfen: Das Modell müsste wissen, was installiert ist, jede Engine würde ihre eigene Ergebnisform in die Prompts durchsickern lassen, und die Anzahl der Tools würde pro Engine wachsen. Stattdessen bringt nr_llm einen Retrieval-Kern mit vielen Backends hinter einer einzigen Tool-Gruppe mit. Ein Modell im eigenen Content der Website zu verankern, gilt als querschnittliches Primitiv auf einer Stufe mit den Content- und Introspection-Tools – nr_llm darf Indizes lesen, die anderen gehören und die diese aktuell halten, besitzt aber nie einen persistenten Index, den es selbst synchron halten müsste (ADR-050). Vektor-/semantisches RAG bleibt in der Schwester-Extension nr_ai_search."
+      ]
+    },
+    "when": {
+      "heading": "Wann man es einsetzt",
+      "bullets": [
+        "Ein Agent muss Fragen zum eigenen öffentlichen Content der Website beantworten und belegen, woher die Antwort stammt, statt sich auf die Trainingsdaten des Modells zu verlassen.",
+        "Es läuft eines von EXT:solr, ke_search oder indexed_search – die Tools lesen das jeweils installierte in Prioritätsreihenfolge, das erste verfügbare gewinnt.",
+        "Es läuft keines davon: Der stets verfügbare Datenbank-Fallback über pages/tt_content antwortet trotzdem und wird im Evidence-Header entsprechend gekennzeichnet.",
+        "Die Belege müssen auf das beschränkt sein, was ein anonymer Besucher lesen könnte – die Filterung auf Indexebene ist immer nur öffentlich (fail-closed ohne Backend-Nutzer).",
+        "site_rag_query nutzen, um ein kuratiertes Evidence-Paket zu erhalten, dann site_fetch_source(source_id), um den vollständigen indizierten Text einer einzelnen Quelle zu lesen (begrenzt).",
+        "Für semantisches Retrieval mit persistentem Vector-Store, Chunking und Reindex-on-Change stattdessen nr_ai_search zusätzlich installieren – das liegt hier bewusst außerhalb des Umfangs (ADR-050)."
+      ]
+    },
+    "technical": {
+      "heading": "Wie es funktioniert",
+      "paragraphs": [
+        "Ein Retrieval-Kern, viele Backends. Eine Service-/Retrieval-Schicht definiert SearchBackendInterface (getIdentifier, getPriority, isAvailable, search, fetchSource) mit vier Implementierungen, die über den DI-Tag nr_llm.retrieval_backend gesammelt werden. RetrievalService fragt die Backends in Prioritätsreihenfolge ab und nutzt das erste verfügbare – es gibt kein Score-Merging über Engines hinweg, weil Solr-Relevanz, MySQL-Volltext-Scores und LIKE-Treffer nicht vergleichbar sind. Ein Backend, das eine Exception wirft, gilt als nicht verfügbar, und die Kaskade läuft mit einem Vermerk weiter; ein leeres Ergebnis eines verfügbaren Backends ist per Design endgültig. Das antwortende Backend wird im Ergebnis stets genannt, sodass das Modell die Qualität der Belege kennt.",
+        "Zwei Tools bilden eine neue Gruppe, rag: site_rag_query (Frage → Evidence-Paket aus source_id · title · url samt einem Treffer-Auszug pro Quelle) und site_fetch_source (source_id → der indizierte Volltext, begrenzt). Das sind 2 der 41 eingebauten, lesenden Tools in 8 schaltbaren Gruppen. Tool-Argumente werden vom Modell gewählt und sind nicht vertrauenswürdig, deshalb greifen Längenbegrenzungen, eine Grammatikprüfung der source-id und Begrenzungen der Ergebnismenge.",
+        "Der Zugriff ist fail-closed und ausschließlich öffentlich: Die Filterung auf Indexebene ist immer fe_group ''/0, gr_list 0,-1 und der Solr-Zugriffsfilter {!typo3access}0,-1 – RAG-Belege sind genau das, was der anonyme Besucher lesen könnte. Da dieser Content öffentlich ist, gibt es keine Einschränkung der Seiten pro Nutzer; die Tools setzen dennoch wie jedes eingebaute Tool einen Backend-Nutzer voraus."
+      ],
+      "components": [
+        {
+          "name": "SolrSearchBackend",
+          "role": "Spricht mit dem EXT:solr-Server über die dokumentierte HTTP-select-API (solr_*_read-Schlüssel der Site-Config, Read-Cores pro Sprache) statt über die @internal-PHP-Klassen von EXT:solr; trägt den öffentlichen Filter {!typo3access}0,-1 und fügt keine Composer-Abhängigkeit zu EXT:solr hinzu."
+        },
+        {
+          "name": "KeSearchBackend",
+          "role": "Liest tx_kesearch_index direkt – MATCH … AGAINST auf MySQL/MariaDB, sonst LIKE; trifft nur title/content, nie hidden_content."
+        },
+        {
+          "name": "IndexedSearchBackend",
+          "role": "Liest die index_*-Tabellen des Cores direkt (Word-Hash-Join mit dem in PHP berechneten md5; LIKE über index_fulltext, wenn die Word-Tabellen leer sind)."
+        },
+        {
+          "name": "DatabaseSearchBackend",
+          "role": "Stets verfügbarer Fallback (Priorität 0): LIKE über die Suchfelder von pages/tt_content, gruppiert pro Seite – funktioniert auf einer nackten Instanz ohne Such-Extension."
+        },
+        {
+          "name": "RetrievalService",
+          "role": "Die Kaskade: sortiert die Backends nach Priorität, fragt das erste verfügbare ab, dedupliziert Treffer mit gleicher URL, begrenzt die Anzahl der Quellen und kennzeichnet die Belege mit dem antwortenden Backend."
+        },
+        {
+          "name": "SiteRagQueryTool / SiteFetchSourceTool",
+          "role": "Die beiden eingebauten Tools der rag-Gruppe; sie begrenzen die vom Modell gelieferten Argumente und formatieren die Evidence-Liste in einen zitierbaren Textblock für das Modell."
+        }
+      ]
+    },
+    "how": {
+      "heading": "Für Entwickler",
+      "intro": "Der Retrieval-Kern lässt sich über einen einzigen DI-Tag erweitern. Der Adapter einer Nischen-Suchmaschine registriert sich über nr_llm.retrieval_backend ohne ein Core-Release; die beiden rag-Tools nutzen RetrievalService und brauchen keine Änderung.",
+      "steps": [
+        {
+          "title": "Ein Backend gegen das Interface implementieren",
+          "body": "Jedes Backend implementiert SearchBackendInterface. Der Tag wird über AutoconfigureTag automatisch gesetzt, deshalb reicht das Implementieren des Interfaces, um in die Kaskade zu gelangen. isAvailable() muss günstig sein und darf keine Exception werfen; jede Referenz auf Klassen einer optionalen Extension hinter Verfügbarkeitsprüfungen halten, damit die Klasse immer instanziiert werden kann.",
+          "code": "#[AutoconfigureTag(name: self::TAG_NAME)]\ninterface SearchBackendInterface\n{\n    public const TAG_NAME = 'nr_llm.retrieval_backend';\n\n    public function getIdentifier(): string;\n\n    public function getPriority(): int;\n\n    public function isAvailable(): bool;\n\n    public function search(RetrievalQuery $query, AccessContext $context): EvidenceList;\n\n    public function fetchSource(SourceReference $reference, AccessContext $context): ?string;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Die Kaskade nach dem Prinzip erstes-verfügbares-gewinnt verstehen",
+          "body": "RetrievalService sortiert die Backends nach absteigender Priorität, überspringt nicht verfügbare, behandelt ein Exception werfendes Backend als nicht verfügbar (fügt einen Vermerk hinzu und fährt fort) und gibt das Ergebnis des ersten verfügbaren Backends zurück – dedupliziert nach URL und auf maxSources begrenzt. Es gibt kein Score-Merging über Backends hinweg.",
+          "code": "foreach ($this->prioritized() as $backend) {\n    if (!$this->available($backend)) {\n        continue;\n    }\n\n    try {\n        $result = $backend->search($query, $context);\n    } catch (Throwable) {\n        $notes[] = sprintf('Backend \"%s\" failed and was skipped.', $backend->getIdentifier());\n        continue;\n    }\n\n    return $this->deduplicate($result, $query->maxSources)->withNotes($notes);\n}\n\nreturn new EvidenceList('none', [], [...$notes, 'No search backend available.']);",
+          "lang": "php"
+        },
+        {
+          "title": "Die rag-Gruppe wird pro Tool definiert",
+          "body": "Ein eingebautes Tool tritt der rag-Gruppe bei, indem es sie aus getGroup() zurückgibt. SiteRagQueryTool begrenzt Fragelänge und Quellenanzahl des Modells, führt RetrievalService mit einem ausschließlich öffentlichen AccessContext für den handelnden Backend-Nutzer aus und formatiert die Belege in einen zitierbaren Textblock.",
+          "code": "public function getGroup(): string\n{\n    return 'rag';\n}\n\npublic function requiresAdmin(): bool\n{\n    // Evidence is public website content; the backend-user gate above\n    // (fail-closed) is the only narrowing needed.\n    return false;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Rankings fusionieren, wenn man einen eigenen dichten Arm hinzufügt (optional)",
+          "body": "Die Kaskade selbst führt Backends nie zusammen, aber hybride Verbraucher, die einen eigenen Embedding-Arm mit der Keyword-Fassade von nr_llm koppeln, können das mitgelieferte Reciprocal-Rank-Fusion-Utility wiederverwenden (ADR-074). Es ist eine reine, newbare finale Klasse – ohne DI, ohne Interface – mit einer Signatur, die mit dem Original aus nr_ai_search identisch ist.",
+          "code": "$fused = (new ReciprocalRankFusion())->fuse(\n    $rankedKeyLists,   // one ranked list of ids per retrieval arm\n    k: 60,\n    weights: [],\n);",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Immer nur öffentlich",
+        "body": "Die Filterung auf Indexebene ist fest auf öffentlichen Content gesetzt (fe_group ''/0, gr_list 0,-1, Solr {!typo3access}0,-1). Die Belege sind das, was ein anonymer Besucher lesen könnte; es gibt keine Einschränkung der Seiten pro Nutzer. AccessContext wird durch den Kern durchgereicht, sodass ein künftiger Frontend-Endpunkt die Filterung pro fe_group erweitern könnte, doch das wird in dieser Iteration über das ausschließlich Öffentliche hinaus nicht genutzt."
+      },
+      {
+        "title": "Das erste verfügbare Backend gewinnt – leer ist endgültig",
+        "body": "Ein leeres Ergebnis eines verfügbaren Backends ist kein Grund, zur nächsten Engine durchzufallen; ein Durchfallen würde stillschweigend Engines unterschiedlicher Qualität mischen, und „die Suche der Website findet nichts“ ist selbst ein ehrlicher Beleg. Nur ein nicht verfügbares oder eine Exception werfendes Backend treibt die Kaskade voran."
+      },
+      {
+        "title": "Direkter Tabellenzugriff kann bei künftigen Major-Versionen driften",
+        "body": "KeSearchBackend und IndexedSearchBackend lesen tx_kesearch_index und index_* direkt und tauschen API-Stabilität gegen Entkopplung. Die Schemata sind gegen die derzeit unterstützten Versionen verifiziert (ke_search v6.6/v7, Core 13.4/14.x) und durch funktionale Tests fixiert, aber eine künftige Major-Version könnte driften; isAvailable() prüft, ob die Tabelle vorhanden ist."
+      },
+      {
+        "title": "Solr nutzt Cores pro Sprache, keinen Sprachfilter",
+        "body": "EXT:solr trennt Sprachen über Cores pro Sprache (core_de, core_en, …), deren Schema kein Feld 'language' hat. Ein früheres fq=language:<id> filterte auf ein nicht existierendes Feld und lieferte für jede Abfrage null Ergebnisse; ADR-067 entfernte es – die Sprache wird über die Auswahl des Read-Cores pro Sprache behandelt, der Zugriff allein über {!typo3access}0,-1."
+      },
+      {
+        "title": "Veraltete Indizes zitieren veralteten Content",
+        "body": "Inkrementelle Läufe von ke_search löschen nie, und indexed_search aktualisiert nur beim Rendern, deshalb kann index-basiertes RAG Content zitieren, der sich seither geändert hat. Das ist eine bekannte Eigenschaft index-gestützten Retrievals, für Redakteure dokumentiert – das antwortende Backend wird stets genannt, sodass die Qualität der Belege sichtbar ist."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 49,
+        "title": "RAG-Site-Search-Tools über installierte Suchindizes"
+      },
+      {
+        "number": 50,
+        "title": "Umfang von Retrieval und Embedding – die Grenze zu nr_ai_search"
+      },
+      {
+        "number": 67,
+        "title": "Solr-Core pro Sprache – keine Sprachfilter-Abfrage"
+      },
+      {
+        "number": 72,
+        "title": "Bewertung der Retrieval-Qualität – Golden Questions und Top-k-Trefferraten"
+      },
+      {
+        "number": 74,
+        "title": "Reciprocal Rank Fusion als mitgeliefertes Utility"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Administrationshandbuch — Tools",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Administration/Tools.rst"
+      },
+      {
+        "label": "ADR-049 source",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr049RagSiteSearchTools.rst"
+      }
+    ],
+    "meta": {
+      "title": "RAG-Site-Search-Tools — nr-llm",
+      "description": "Zwei Function-Calling-Tools verankern das Modell im öffentlichen Website-Content – aus Solr, ke_search, indexed_search oder Datenbank-Fallback, belegt."
+    }
+  },
+  {
+    "slug": "providers-fallback-keys",
+    "title": "Provider-Abstraktion, Fallback & verschlüsselte Keys",
+    "tagline": "Eine Schnittstelle über sieben LLM-Provider hinweg, mit Fallback auf Konfigurationsebene und API-Keys, die als nr-vault-UUIDs statt im Klartext gespeichert werden.",
+    "why": {
+      "heading": "Warum es existiert",
+      "paragraphs": [
+        "Jeder LLM-Provider bringt einen anderen Endpunkt, ein anderes Auth-Schema, eine andere Request-/Response-Form, eine andere Modellbenennung und einen anderen Funktionsumfang mit. nr-llm verbirgt diese Unterschiede hinter einem einzigen Vertrag (ProviderInterface), sodass Verbraucher eine API aufrufen, unabhängig davon, ob OpenAI, Claude, Gemini, Groq, Mistral, Ollama oder OpenRouter antwortet. Der Wechsel des Providers ist eine Admin-Änderung, keine Code-Änderung (ADR-001).",
+        "Zugangsdaten, Modellkataloge und Prompts pro Anwendungsfall ändern sich zu unterschiedlichen Zeitpunkten und aus unterschiedlichen Gründen, deshalb werden sie in drei Ebenen normalisiert: Provider (eine API-Verbindung = ein Key = eine Abrechnungsbeziehung), Model (Fähigkeiten und Preise pro Provider) und Configuration (System-Prompt, Temperature und weitere Stellgrößen für einen Anwendungsfall). So kann eine Site getrennte Prod-/Dev-Keys für denselben Adapter-Typ vorhalten und Modelldefinitionen über mehrere Konfigurationen hinweg wiederverwenden (ADR-013).",
+        "API-Keys müssen zur Authentifizierung abrufbar sein, deshalb lassen sie sich nicht hashen. Der ursprüngliche Ansatz verschlüsselte sie auf Anwendungsebene mit sodium (ADR-012); dieses ADR ist inzwischen abgelöst – Keys werden als nr-vault-Identifier (UUIDs) gespeichert und innerhalb des Vaults aufgelöst, injiziert, auditiert und aus dem Speicher entfernt, sodass der Klartext-Key im Code dieser Extension nie auftaucht."
+      ]
+    },
+    "when": {
+      "heading": "Wann man es einsetzt",
+      "bullets": [
+        "In eine TYPO3-Extension soll KI integriert werden, und Provider-Auswahl, Key-Handling, Caching und Fehlerbehandlung sollen übernommen werden – LlmServiceManagerInterface injizieren und complete()/chatCompletion() aufrufen.",
+        "Dieselbe Anfrage soll einen Provider-Ausfall überstehen: Geschwister-Konfigurationen in der Fallback-Kette einer Konfiguration eintragen, um bei Verbindungsfehlern, HTTP 5xx oder 429-Rate-Limits erneut zu versuchen.",
+        "Provider-Zugangsdaten müssen aus Datenbank, YAML und Logs herausgehalten werden – den nr-vault-UUID-Identifier speichern, nie den rohen Key.",
+        "Ein neuer Provider wird integriert: ProviderInterface implementieren (oder AbstractProvider erweitern), mit #[AsLlmProvider] markieren, und er registriert sich automatisch über ProviderCompilerPass.",
+        "Es laufen mehrere Konten eines Provider-Typs (Prod/Dev/Backup) oder eigene Endpunkte (Azure OpenAI, Ollama, vLLM), die das Drei-Ebenen-Modell als eigenständige Provider-Zeilen abbildet."
+      ]
+    },
+    "technical": {
+      "heading": "Wie es funktioniert",
+      "paragraphs": [
+        "ProviderInterface ist der zentrale Vertrag (getName, getIdentifier, configure, chatCompletion, complete, embeddings, testConnection und Fähigkeitsprüfungen). Optionale Funktionen sind zuschaltbare Capability-Interfaces – VisionCapableInterface, StreamingCapableInterface, ToolCapableInterface, DocumentCapableInterface –, die per instanceof erkannt werden, während embeddings eine Kernmethode bleibt. AbstractProvider stellt gemeinsames Verhalten bereit, und jeder mitgelieferte Adapter erweitert es.",
+        "Die Registrierung ist attributgesteuert: Eine mit #[AsLlmProvider(priority: N)] markierte Klasse im Namespace Netresearch\\NrLlm\\ wird vom ProviderCompilerPass zur Container-Compile-Zeit automatisch mit nr_llm.provider getaggt (ADR-022). Provider bleiben privat; nichts löst sie über den Klassennamen auf – der Zugriff erfolgt über LlmServiceManager, aufgelöst über den von getIdentifier() zurückgegebenen Identifier. Die Priorität ist lediglich ein Hinweis auf die Reihenfolge. Fremde Provider außerhalb des Namespaces behalten den alten Services.yaml-Tag-Pfad.",
+        "Die drei Ebenen sind Extbase-Entities über tx_nrllm_provider, tx_nrllm_model und tx_nrllm_configuration. Eine Configuration referenziert ein Model, das einen Provider referenziert, dem die Verbindung gehört (endpoint_url, adapter_type, timeout, max_retries und api_key, gespeichert als Vault-UUID). Aufrufe laufen durch eine Middleware-Pipeline (ADR-026), geordnet nach Tag-Priorität: Telemetry (110), Cache (100), Budget (75), Fallback (50), Usage (25), CircuitBreaker (20).",
+        "FallbackMiddleware führt die primäre Konfiguration aus; bei einem wiederholbaren Fehlschlag läuft sie die FallbackChain der Konfiguration aus Geschwister-Konfigurations-Identifiern durch, überspringt nicht gefundene und inaktive, bis einer erfolgreich ist oder die Kette erschöpft ist (FallbackChainExhaustedException). Wiederholbar sind ProviderConnectionException, eine 429-ProviderResponseException oder CircuitOpenException. AbstractProvider::getHttpClient() authentifiziert über den HTTP-Client von nr-vault (vault->http()->withAuthentication(identifier, placement, options)); Provider ohne API-Key wie Ollama nutzen den rohen Factory-Client hinter einer expliziten SSRF-Host-Prüfung."
+      ],
+      "components": [
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\Contract\\ProviderInterface",
+          "role": "Zentraler Provider-Vertrag, den jeder Adapter implementiert – name, identifier, configure, chatCompletion, complete, embeddings, testConnection, Fähigkeitsprüfungen."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\AbstractProvider",
+          "role": "Gemeinsame Basis der sieben Adapter; speichert apiKeyIdentifier und baut in getHttpClient() den über den Vault authentifizierten HTTP-Client."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Attribute\\AsLlmProvider",
+          "role": "#[AsLlmProvider(priority)]-Marker; der ProviderCompilerPass taggt ihn automatisch mit nr_llm.provider, sodass kein Services.yaml-Eintrag nötig ist."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Domain\\DTO\\FallbackChain",
+          "role": "Unveränderliche, normalisierte geordnete Liste von LlmConfiguration-Identifiern, die versucht werden, wenn die primäre fehlschlägt; flach (die eigene Kette eines Fallbacks wird ignoriert)."
+        },
+        {
+          "name": "Netresearch\\NrLlm\\Provider\\Middleware\\FallbackMiddleware",
+          "role": "Durchsetzung zur Laufzeit (Tag-Priorität 50): versucht die Kette bei wiederholbaren Fehlern erneut, überspringt inaktive/fehlende Konfigurationen, wirft FallbackChainExhaustedException, wenn alle fehlschlagen."
+        },
+        {
+          "name": "Netresearch\\NrVault\\Service\\VaultServiceInterface",
+          "role": "Löst den gespeicherten UUID-Identifier zum echten Secret auf und injiziert es zum Sendezeitpunkt; hält Klartext-Keys aus Code und Datenbank von nr-llm heraus."
+        }
+      ]
+    },
+    "how": {
+      "heading": "Für Entwickler",
+      "intro": "Über LlmServiceManagerInterface konsumieren, Provider per Attribut hinzufügen, Keys als Vault-UUIDs vorhalten und Fallbacks an der Konfiguration deklarieren.",
+      "steps": [
+        {
+          "title": "Den vereinheitlichten Service nutzen",
+          "body": "LlmServiceManagerInterface injizieren und aufrufen. Provider-Auswahl, Key-Auflösung, Caching und Fehlerbehandlung übernimmt die Pipeline – man fasst nie direkt einen HTTP-Client oder eine Provider-Klasse an.",
+          "code": "use Netresearch\\NrLlm\\Service\\LlmServiceManagerInterface;\n\nclass MyController\n{\n    public function __construct(\n        private readonly LlmServiceManagerInterface $llm,\n    ) {}\n\n    public function summarizeAction(string $text): string\n    {\n        return $this->llm->complete(\"Summarize: {$text}\")->content;\n    }\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Einen Provider hinzufügen",
+          "body": "ProviderInterface implementieren (in der Praxis AbstractProvider erweitern und die unterstützten Capability-Interfaces ergänzen), die Klasse mit #[AsLlmProvider] markieren, damit der ProviderCompilerPass sie automatisch registriert, den Identifier aus getIdentifier() zurückgeben und das Icon unter Resources/Public/Icons/provider-<identifier>.svg hinzufügen.",
+          "code": "#[AsLlmProvider(priority: 100)]\nfinal class OpenAiProvider extends AbstractProvider implements\n    VisionCapableInterface,\n    StreamingCapableInterface,\n    ToolCapableInterface\n{\n    public function getName(): string\n    {\n        return 'OpenAI';\n    }\n\n    public function getIdentifier(): string\n    {\n        return 'openai';\n    }\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Über nr-vault authentifizieren",
+          "body": "configure() liest apiKeyIdentifier (eine Vault-UUID), nicht einen rohen Key. isAvailable() ist nur dann true, wenn der Identifier gesetzt ist und der Vault ihn hält. getHttpClient() baut dann über vault->http()->withAuthentication(...) einen Client, sodass das Secret innerhalb des Vaults injiziert und auditiert wird; Provider ohne API-Key (Ollama) nehmen den rohen Factory-Client hinter einer SSRF-Host-Prüfung.",
+          "code": "protected function getHttpClient(?int $timeout = null): ClientInterface\n{\n    if ($this->configuredHttpClient !== null) {\n        return $this->configuredHttpClient;\n    }\n\n    $effective = ($timeout !== null && $timeout > 0) ? $timeout : $this->timeout;\n\n    if ($this->apiKeyIdentifier === '') {\n        $this->assertEndpointHostAllowed();\n        return $this->httpClientFactory->create($effective > 0 ? $effective : null);\n    }\n\n    $client = $this->vault->http()->withAuthentication(\n        $this->apiKeyIdentifier,\n        $this->getSecretPlacement(),\n        $this->getSecretPlacementOptions(),\n    );\n\n    return $effective > 0 ? $client->withTimeout($effective) : $client;\n}",
+          "lang": "php"
+        },
+        {
+          "title": "Eine Fallback-Kette deklarieren",
+          "body": "Eine FallbackChain ist eine geordnete, normalisierte (getrimmt + kleingeschrieben) Liste von Geschwister-LlmConfiguration-Identifiern. Sie wird unveränderlich mit withLink() aufgebaut; FallbackMiddleware läuft sie bei wiederholbaren Fehlschlägen durch (Verbindungsfehler, 5xx, 429 oder ein offener Circuit) und überspringt die primäre sowie inaktive oder fehlende Einträge.",
+          "code": "$chain = (new FallbackChain())\n    ->withLink('blog-summarizer-openai')\n    ->withLink('blog-summarizer-claude');\n\n// Persisted on the primary configuration; walked by FallbackMiddleware\n// (shallow: a fallback configuration's own chain is ignored).",
+          "lang": "php"
+        }
+      ]
+    },
+    "gotchas": [
+      {
+        "title": "Der Fallback ist flach",
+        "body": "Die eigene Fallback-Kette einer Fallback-Konfiguration wird per Design ignoriert, um Rekursion und Zyklen zu verhindern. Nur die Kette der primären Konfiguration wird durchlaufen. Enthält die Kette nur den primären Identifier, wird sie nach dem Filtern leer, und der ursprüngliche Fehler der primären Konfiguration wird wortgetreu erneut geworfen statt eines 'chain exhausted'-Fehlers."
+      },
+      {
+        "title": "Streaming-Anfragen werden nicht über den Fallback geleitet",
+        "body": "Sobald Chunks an den Aufrufer ausgegeben wurden, lässt sich ein Provider mitten im Stream nicht mehr wechseln, deshalb schließt FallbackMiddleware streamende (Generator zurückgebende) Aufrufe aus. Für Streaming die Pipeline ohne FallbackMiddleware bauen oder bei ProviderCallContext::operation === Stream kurzschließen."
+      },
+      {
+        "title": "Keys sind Vault-UUIDs, nie Klartext",
+        "body": "Die Spalte api_key speichert einen nr-vault-Identifier, kein Secret. Die sodium-Verschlüsselung auf Anwendungsebene aus ADR-012 ist durch die nr-vault-Integration abgelöst. Nie einen rohen Key in TCA, YAML, Umgebungsvariablen oder Logs ablegen; ErrorMessageSanitizerTrait::sanitizeErrorMessage() entfernt Secret-tragende Query-Parameter, bevor Meldungen nach außen gelangen."
+      },
+      {
+        "title": "Die automatische Attribut-Registrierung ist auf den Namespace beschränkt",
+        "body": "ProviderCompilerPass reflektiert nur Service-Definitionen, deren Klasse im Namespace Netresearch\\NrLlm\\ liegt. Fremde Provider außerhalb dieses Namespaces müssen den alten Services.yaml-Tag behalten (name: nr_llm.provider, priority: N), der vollständig unterstützt wird und Vorrang hat, wenn beide vorhanden sind. Die Priorität ist lediglich ein Hinweis auf die Reihenfolge – Provider werden zur Laufzeit über den Identifier aufgelöst."
+      }
+    ],
+    "adrLinks": [
+      {
+        "number": 1,
+        "title": "Provider-Abstraktionsschicht"
+      },
+      {
+        "number": 13,
+        "title": "Dreistufige Konfigurationsarchitektur (Provider-Model-Configuration)"
+      },
+      {
+        "number": 12,
+        "title": "API-Key-Verschlüsselung auf Anwendungsebene (abgelöst durch nr-vault)"
+      },
+      {
+        "number": 21,
+        "title": "Provider-Fallback-Kette"
+      },
+      {
+        "number": 22,
+        "title": "Attributbasierte Provider-Registrierung"
+      },
+      {
+        "number": 63,
+        "title": "Provider-Resilienz: Circuit Breaker, Health, Idempotenz"
+      },
+      {
+        "number": 80,
+        "title": "Typisierte Provider-HTTP-Exceptions (401 Authentifizierung, 429 Rate-Limit)"
+      }
+    ],
+    "docsLinks": [
+      {
+        "label": "GitHub source",
+        "href": "https://github.com/netresearch/t3x-nr-llm"
+      },
+      {
+        "label": "Entwickler-Handbuch",
+        "href": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Developer/Index.rst"
+      },
+      {
+        "label": "Architektur & ADRs",
+        "href": "https://github.com/netresearch/t3x-nr-llm/tree/main/Documentation/Adr"
+      }
+    ],
+    "meta": {
+      "title": "Provider-Abstraktion, Fallback & Keys — nr-llm",
+      "description": "Wie nr-llm sieben LLM-Provider hinter einer Schnittstelle vereint, eine Konfigurations-Fallback-Kette durchläuft und API-Keys als nr-vault-UUIDs speichert."
+    }
+  }
+]

--- a/landingpage/src/templates/base.html.j2
+++ b/landingpage/src/templates/base.html.j2
@@ -60,6 +60,7 @@
           <li><a href="{{ nav_prefix }}solution">{{ s.nav.solution }}</a></li>
           <li><a href="{{ nav_prefix }}concepts">{{ s.nav.concepts }}</a></li>
           <li><a href="{{ nav_prefix }}dev-kickstart">{{ s.nav.dev }}</a></li>
+          <li><a href="{{ url(lang + '/features/') }}">{{ s.featuresNav }}</a></li>
           <li><a href="{{ url('adr/') }}">{{ s.nav.adr }}</a></li>
           <li><a href="{{ nav_prefix }}faq">{{ s.nav.faq }}</a></li>
         </ul>

--- a/landingpage/src/templates/feature_index.html.j2
+++ b/landingpage/src/templates/feature_index.html.j2
@@ -1,0 +1,19 @@
+{% extends "base.html.j2" %}
+{% block main %}
+<section class="section">
+  <div class="container">
+    <p class="eyebrow">nr-llm</p>
+    <h1>{{ s.featuresIndexTitle }}</h1>
+    <p class="section__intro">{{ s.featuresIndexIntro }}</p>
+    <div class="grid grid--3">
+      {% for f in features %}
+      <article class="card">
+        <h3><a href="{{ url(lang + '/features/' + f.slug + '.html') }}">{{ f.title }}</a></h3>
+        <p>{{ f.tagline }}</p>
+        <p><a href="{{ url(lang + '/features/' + f.slug + '.html') }}">{{ s.featuresReadMore }} →</a></p>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/landingpage/src/templates/feature_page.html.j2
+++ b/landingpage/src/templates/feature_page.html.j2
@@ -1,0 +1,94 @@
+{% extends "base.html.j2" %}
+{% block main %}
+<section class="section">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="{{ url(lang + '/') }}">nr-llm</a> ›
+      <a href="{{ url(lang + '/features/') }}">{{ s.featuresNav }}</a> ›
+      <span aria-current="page">{{ f.title }}</span>
+    </nav>
+    <p class="eyebrow">{{ s.featuresNav }}</p>
+    <h1 class="hero__headline" style="font-size:clamp(1.9rem,4.4vw,2.8rem)">{{ f.title }}</h1>
+    <p class="hero__sub">{{ f.tagline }}</p>
+  </div>
+</section>
+
+<section class="section section--alt" aria-labelledby="why-h">
+  <div class="container section__intro">
+    <h2 id="why-h">{{ f.why.heading }}</h2>
+    {% for p in f.why.paragraphs %}<p>{{ p }}</p>{% endfor %}
+  </div>
+</section>
+
+<section class="section" aria-labelledby="when-h">
+  <div class="container">
+    <h2 id="when-h">{{ f.when.heading }}</h2>
+    <ul class="bullets">{% for b in f.when.bullets %}<li>{{ b }}</li>{% endfor %}</ul>
+  </div>
+</section>
+
+<section class="section section--alt" aria-labelledby="tech-h">
+  <div class="container">
+    <h2 id="tech-h">{{ f.technical.heading }}</h2>
+    {% for p in f.technical.paragraphs %}<p class="section__intro">{{ p }}</p>{% endfor %}
+    {% if f.technical.components %}
+    <div class="grid grid--2">
+      {% for comp in f.technical.components %}
+      <article class="card"><h3><code>{{ comp.name }}</code></h3><p>{{ comp.role }}</p></article>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</section>
+
+<section class="section" id="dev" aria-labelledby="dev-h">
+  <div class="container">
+    <h2 id="dev-h">{{ f.how.heading }}</h2>
+    {% if f.how.intro %}<p class="section__intro">{{ f.how.intro }}</p>{% endif %}
+    <div class="steps">
+      {% for step in f.how.steps %}
+      <div class="step">
+        <div class="step__num" aria-hidden="true"></div>
+        <div class="step__body">
+          <h3>{{ step.title }}</h3>
+          <p>{{ step.body }}</p>
+          {% if step.code %}
+          <div class="codeblock">
+            <span class="codeblock__label">{{ step.lang or 'php' }}</span>
+            <button class="copy-btn" type="button" data-copy="feat-code-{{ f.slug }}-{{ loop.index }}" aria-label="{{ s.copy }}" hidden>⧉</button>
+            <pre id="feat-code-{{ f.slug }}-{{ loop.index }}" tabindex="0"><code>{{ step.code }}</code></pre>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% if f.gotchas %}
+<section class="section section--alt" aria-labelledby="gotchas-h">
+  <div class="container">
+    <h2 id="gotchas-h">{{ s.gotchasHeading }}</h2>
+    <div class="grid grid--2">
+      {% for g in f.gotchas %}<article class="card"><h3>{{ g.title }}</h3><p>{{ g.body }}</p></article>{% endfor %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<section class="section" aria-labelledby="more-h">
+  <div class="container">
+    <h2 id="more-h">{{ s.learnMoreHeading }}</h2>
+    <ul class="linklist">
+      {% for a in f.adrLinks %}
+      <li><a href="{{ a.href }}"><b>ADR&nbsp;{{ '%03d'|format(a.number) }}</b><span>{{ a.title }}</span></a></li>
+      {% endfor %}
+      {% for d in f.docsLinks %}
+      <li><a href="{{ d.href }}"><b>{{ d.label }}</b>{% if d.desc %}<span>{{ d.desc }}</span>{% endif %}</a></li>
+      {% endfor %}
+    </ul>
+    <p style="margin-top:2rem"><a class="btn btn--secondary" href="{{ url(lang + '/features/') }}">← {{ s.featuresBackToIndex }}</a></p>
+  </div>
+</section>
+{% endblock %}

--- a/landingpage/src/templates/landing.html.j2
+++ b/landingpage/src/templates/landing.html.j2
@@ -88,11 +88,16 @@
     <h2 id="concepts-h">{{ c.concepts.heading }}</h2>
     <p class="section__intro">{{ c.concepts.intro }}</p>
     <div class="grid grid--3">
+      {% set concept_feature = {'streaming': 'streaming-and-tools', 'rag': 'rag-site-search', 'providers': 'providers-fallback-keys', 'keys': 'providers-fallback-keys'} %}
       {% for item in c.concepts['items'] %}
       <article class="card">
         <div class="card__icon" aria-hidden="true">{{ icon(item.icon) }}</div>
         <h3>{{ item.title }}</h3>
         <p>{{ item.body }}</p>
+        {% set fslug = concept_feature.get(item.icon) %}
+        {% if fslug and fslug in (feature_slugs or []) %}
+        <p class="card__more"><a href="{{ url(lang + '/features/' + fslug + '.html') }}">{{ s.featuresReadMore }} →</a></p>
+        {% endif %}
       </article>
       {% endfor %}
     </div>


### PR DESCRIPTION
## What

Adds bilingual (EN/DE) **feature deep-dive pages** for the three highest-detail features, bridging the terse landing sections and the dense ADRs. Hybrid approach: developer-focused narrative that **links** the authoritative ADRs and the developer docs rather than duplicating the reference.

Pages: **Streaming & Tool/Function Calling**, **RAG Site-Search Tools**, **Provider Abstraction, Fallback & Encrypted Keys**.

Each page covers: what it's for, why it exists, how it works (with the real classes — `StreamingDispatcher`, `RetrievalService`, `FallbackChain`, …), a developer how-to with verified code, and gotchas. Content is grounded in the actual code and ADRs.

## Structure

- `/{en,de}/features/` index + one page per feature; new `feature_page` + `feature_index` templates, content in `features.json` / `features_de.json`.
- Wired into nav, `sitemap.xml`, the client search index, and JSON-LD (`TechArticle`, `BreadcrumbList`).
- Landing concept cards link to the matching deep dive.

## Also in here

- **Autoescape fix:** the Jinja env used `select_autoescape(["html","xml"])`, but the templates end in `.html.j2`, so autoescape was effectively off and content was emitted raw. Switched to `default=True`; every deliberate raw-HTML injection (ADR bodies, JSON-LD, inline SVG) is `|safe` at its use site. This fixes latent cases like a literal `<think>` in prose being swallowed by the browser.

## Verification

- Build: 83 ADRs + landing + 8 feature pages + 117 search docs; 0 invalid JSON-LD, 0 leftover template tokens.
- axe-core at 390px **and** 1440px on feature pages (EN + DE): **0 WCAG 2.1 AA violations**; one `<h1>` per page; code blocks keyboard-focusable; the mobile search works on feature pages too.
- Rebased on current `main` (integrates #443 mobile search + #445 a11y).

Follows up #440.
