### PR TITLE
feat(guardrail): close enforcement gaps — playground verdicts + streaming audit (ADR-086)

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -22,6 +22,8 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
@@ -235,6 +237,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             }
 
             return $this->respondJson($this->awaitingApprovalPayload($handle !== null ? $handle->uuid : '', $approval, $trace));
+        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
+            return $this->handleGuardrailBlock($guardrail, $handle, $trace);
         } catch (Throwable $e) {
             if ($handle !== null) {
                 $this->agentRunPersister?->settleFailed($handle, $e);
@@ -318,6 +322,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             }
 
             return $this->respondJson($this->awaitingApprovalPayload($run->uuid, $approval, $trace));
+        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
+            return $this->handleGuardrailBlock($guardrail, $handle, $trace);
         } catch (Throwable $e) {
             if ($handle !== null) {
                 $this->agentRunPersister?->settleFailed($handle, $e);
@@ -364,6 +370,74 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             ),
             'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $trace->getSteps()),
         ];
+    }
+
+    /**
+     * Common handling for a guardrail verdict on a non-streamed run (ADR-086):
+     * record the run as blocked so it is not left RUNNING, then return the
+     * blocked payload. A guardrail DENY or REQUIRE_APPROVAL is a policy outcome,
+     * not a server error — the HTTP status stays 200 with ``success:false``.
+     */
+    private function handleGuardrailBlock(
+        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
+        ?AgentRunHandle $handle,
+        RunTrace $trace,
+    ): ResponseInterface {
+        if ($handle !== null) {
+            $this->agentRunPersister?->settleFailed($handle, $guardrail);
+        }
+        $this->logger?->warning('Tool playground run blocked by guardrail', ['exception' => $guardrail]);
+
+        return $this->respondJson($this->guardrailBlockedPayload($guardrail, $trace));
+    }
+
+    /**
+     * The JSON body for a run a guardrail blocked (ADR-086): the status
+     * (denied vs flagged for approval), the deciding guardrail FQCN and its
+     * reason, plus the steps recorded up to the block.
+     *
+     * @return array<string, mixed>
+     */
+    private function guardrailBlockedPayload(
+        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
+        RunTrace $trace,
+    ): array {
+        return [
+            'success'   => false,
+            'status'    => $this->guardrailStatus($guardrail),
+            'guardrail' => $guardrail->guardrail,
+            'error'     => $guardrail->getMessage(),
+            'steps'     => array_map(static fn(RunStep $step): array => $step->toArray(), $trace->getSteps()),
+        ];
+    }
+
+    /**
+     * The terminal streamed event for a guardrail block (ADR-086): same status
+     * and reason as {@see self::guardrailBlockedPayload()}, shaped as a stream
+     * event rather than a full JSON response.
+     *
+     * @return array<string, mixed>
+     */
+    private function guardrailBlockedEvent(
+        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
+    ): array {
+        $status = $this->guardrailStatus($guardrail);
+
+        return [
+            'event'     => $status,
+            'success'   => false,
+            'status'    => $status,
+            'guardrail' => $guardrail->guardrail,
+            'error'     => $guardrail->getMessage(),
+        ];
+    }
+
+    private function guardrailStatus(
+        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
+    ): string {
+        return $guardrail instanceof GuardrailApprovalRequiredException
+            ? 'guardrail_approval_required'
+            : 'guardrail_blocked';
     }
 
     /**
@@ -487,6 +561,16 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                     $approval->state->toolCalls(),
                 ),
             ]);
+        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
+            // ADR-085/086: a guardrail verdict is a policy outcome, not a failure
+            // — settle the run as blocked and emit a distinct terminal event
+            // instead of a generic error.
+            if ($handle !== null) {
+                $this->agentRunPersister?->settleFailed($handle, $guardrail);
+                $settled = true;
+            }
+            $this->logger?->warning('Tool playground stream blocked by guardrail', ['exception' => $guardrail]);
+            $emit($this->guardrailBlockedEvent($guardrail));
         } catch (Throwable $e) {
             if ($handle !== null) {
                 $this->agentRunPersister?->settleFailed($handle, $e);

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -10,7 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Streaming;
 
 use Generator;
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
@@ -19,10 +22,12 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Throwable;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
@@ -87,6 +92,18 @@ final readonly class StreamingDispatcher
 
     private const CHARS_PER_TOKEN = 4;
 
+    /**
+     * Upper bound on the completion text buffered for the end-of-stream guardrail
+     * audit (ADR-086). Streaming deliberately avoids holding the whole response
+     * (see the class doc block); a secret a model echoes appears near where it
+     * was given, so the leading window is enough to screen while keeping the
+     * memory cost bounded on a pathologically long stream.
+     */
+    private const MAX_GUARDRAIL_BUFFER_BYTES = 50000;
+
+    /**
+     * @param iterable<GuardrailInterface> $guardrails
+     */
     public function __construct(
         private BudgetServiceInterface $budgetService,
         private UsageTrackerServiceInterface $usageTracker,
@@ -95,6 +112,8 @@ final readonly class StreamingDispatcher
         private LoggerInterface $logger,
         private Context $context,
         private ExtensionConfiguration $extensionConfiguration,
+        #[AutowireIterator(GuardrailInterface::TAG_NAME)]
+        private iterable $guardrails = [],
     ) {}
 
     /**
@@ -136,6 +155,7 @@ final readonly class StreamingDispatcher
         $startNs         = hrtime(true);
         $firstTokenNs    = null;
         $completionBytes = 0;
+        $completion      = '';
         $served          = $configuration;
         $success         = false;
         $errorClass      = '';
@@ -148,15 +168,20 @@ final readonly class StreamingDispatcher
                     $firstTokenNs = hrtime(true);
                 }
                 $chunk = $inner->current();
-                // Count bytes as they pass; never buffer the whole completion —
-                // token estimation and logging only need the length, and holding
-                // the full response would defeat streaming's memory benefit.
+                // Count bytes as they pass; token estimation and logging only need
+                // the length. A bounded leading window is also buffered for the
+                // end-of-stream guardrail audit (ADR-086) — never the whole
+                // response, which would defeat streaming's memory benefit.
                 $completionBytes += \strlen($chunk);
+                if (\strlen($completion) < self::MAX_GUARDRAIL_BUFFER_BYTES) {
+                    $completion .= $chunk;
+                }
                 yield $chunk;
                 $inner->next();
             }
 
             $success = true;
+            $this->screenStreamedOutput($context, $served, $completion);
         } catch (Throwable $e) {
             $errorClass = $e::class;
 
@@ -353,6 +378,65 @@ final readonly class StreamingDispatcher
                 );
             } catch (Throwable) {
                 // Nothing safe left to do; never let accounting break the call.
+            }
+        }
+    }
+
+    /**
+     * End-of-stream guardrail audit (ADR-086).
+     *
+     * The pipeline's {@see \Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware}
+     * never runs on a streamed response — a lazy generator cannot be the pipeline
+     * terminal (see the class doc block) — so streamed output would otherwise be
+     * a guardrail blind spot. This screens the assembled completion once the
+     * stream finishes and records any non-ALLOW verdict.
+     *
+     * It is an AUDIT, not enforcement: the chunks have already been yielded to
+     * the caller, so a DENY / REDACT cannot retract or live-redact them. Catching
+     * a secret mid-stream would need a delta-oriented guardrail contract, a
+     * deliberate ADR-086 follow-up. Fail-soft — the stream already succeeded, so
+     * this never throws (a broken guardrail must not turn a delivered response
+     * into an error).
+     */
+    private function screenStreamedOutput(
+        ProviderCallContext $context,
+        LlmConfiguration $served,
+        string $completion,
+    ): void {
+        if ($completion === '') {
+            return;
+        }
+
+        try {
+            $response = new CompletionResponse(
+                content: $completion,
+                model: $served->getModelId(),
+                usage: UsageStatistics::fromTokens(0, 0),
+            );
+
+            foreach ($this->guardrails as $guardrail) {
+                $verdict = $guardrail->checkOutput($response);
+                if ($verdict->verdict === GuardrailVerdict::ALLOW) {
+                    continue;
+                }
+
+                $this->logger->warning(
+                    'Streamed LLM response tripped a guardrail after delivery (audit only — chunks were already sent)',
+                    $this->logContext($context, [
+                        'guardrail' => $guardrail::class,
+                        'verdict'   => $verdict->verdict->value,
+                        'reason'    => $verdict->reason,
+                    ]),
+                );
+            }
+        } catch (Throwable $e) {
+            try {
+                $this->logger->error(
+                    'Failed to screen streamed LLM output for guardrails',
+                    $this->logContext($context, ['exception' => $e]),
+                );
+            } catch (Throwable) {
+                // Never let guardrail auditing break a delivered stream.
             }
         }
     }

--- a/Documentation/Adr/Adr086GuardrailEnforcementGaps.rst
+++ b/Documentation/Adr/Adr086GuardrailEnforcementGaps.rst
@@ -1,0 +1,80 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-086:
+
+============================================================================
+ADR-086: Guardrail enforcement gaps — playground verdicts and streamed output
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-086-context:
+
+Context
+=======
+
+ADR-085 added the guardrail pipeline: ``GuardrailMiddleware`` (priority 115)
+screens every non-streaming ``CompletionResponse`` and, on a DENY or
+REQUIRE_APPROVAL verdict, throws ``GuardrailViolationException`` /
+``GuardrailApprovalRequiredException``. Two gaps remained:
+
+- **Tool playground.** The tool loop (ADR-084) calls the provider through the
+  same pipeline, so those guardrail exceptions can surface mid-run. The
+  playground caught only ``ToolApprovalRequiredException`` and
+  ``BudgetExceededException``; a guardrail verdict fell through to the generic
+  ``catch (Throwable)`` and returned an HTTP 500, so a *policy* outcome looked
+  like a server error and the run row was recorded as a crash.
+- **Streaming.** A streamed response cannot go through the pipeline — a lazy
+  generator can't be the pipeline terminal (ADR-062) — so ``GuardrailMiddleware``
+  never runs on streamed output. Streamed responses were an unscreened,
+  unaudited blind spot.
+
+.. _adr-086-decision:
+
+Decision
+========
+
+**Playground: a guardrail verdict is a policy outcome, not a 500.** The
+``ToolPlaygroundController`` catches ``GuardrailViolationException`` and
+``GuardrailApprovalRequiredException`` before the generic ``Throwable`` in all
+three run paths (batch ``runAction``, ``resumeAction``, streamed ``streamRun``).
+The run is settled as blocked (so it is not left RUNNING) and a clean payload is
+returned — HTTP 200 with ``success:false`` and a ``status`` of
+``guardrail_blocked`` (DENY) or ``guardrail_approval_required``
+(REQUIRE_APPROVAL), naming the deciding guardrail and its reason. The streamed
+path emits the same as a terminal event instead of the generic ``error``.
+
+A full response-release resume for REQUIRE_APPROVAL (persisting the flagged
+response and re-delivering it on approval, mirroring ADR-084 for a completion
+rather than for pending tool calls) is **not** built here: the exception carries
+only the guardrail and reason, not a resumable state. The verdict is surfaced
+and recorded; releasing an approved response is a separate future step.
+
+**Streaming: end-of-stream guardrail audit.** ``StreamingDispatcher`` collects
+the guardrail iterator (``nr_llm.guardrail``) and, once a stream drains
+successfully, screens the assembled completion via ``checkOutput()`` and records
+any non-ALLOW verdict (a structured ``warning``). This is an **audit**, not
+enforcement: the chunks have already been yielded to the caller, so a DENY or
+REDACT cannot retract or live-redact them. The buffer is bounded
+(``MAX_GUARDRAIL_BUFFER_BYTES``, 50 000 bytes) so a pathologically long stream
+keeps streaming's memory benefit; a model echoing a secret does so near where it
+was given, so the leading window is enough to screen. Screening is fail-soft — a
+broken guardrail never turns a delivered stream into an error.
+
+.. _adr-086-consequences:
+
+Consequences
+============
+
+- A guardrail decision in the playground is a clean, distinguishable outcome
+  (blocked vs flagged-for-approval), and the ``AgentRun`` row reflects it rather
+  than a spurious failure.
+- Streamed output is no longer a guardrail blind spot: a leaked secret or a
+  policy trip is recorded for audit even though it cannot be un-sent.
+- Live protection of a stream (redacting a secret *before* the chunk is sent, or
+  denying mid-stream) needs a delta-oriented guardrail contract and per-chunk
+  buffering — deliberately out of scope here and tracked as a follow-up.
+- Input-side screening (redacting or blocking the outgoing prompt) is a separate
+  change on the send path, tracked in its own ADR.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -383,3 +383,4 @@ Tools
    Adr083ConversationSessions
    Adr084HumanInTheLoopApproval
    Adr085GuardrailPipeline
+   Adr086GuardrailEnforcementGaps

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
@@ -18,9 +19,12 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
@@ -547,6 +551,111 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertIsArray($last['usage']);
     }
 
+    #[Test]
+    public function runActionReturnsGuardrailBlockedInsteadOf500WhenAGuardrailDenies(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::deny('blocked by test policy');
+            }
+        };
+        [$controller] = $this->guardedController($guardrail);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody(['configuration' => 1, 'prompt' => 'do it']);
+        $response = $controller->runAction($request);
+
+        // A guardrail denial is a policy outcome, not a server error.
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertSame('guardrail_blocked', $payload['status']);
+        self::assertSame($guardrail::class, $payload['guardrail']);
+        self::assertSame('blocked by test policy', $payload['error']);
+    }
+
+    #[Test]
+    public function runActionReturnsApprovalRequiredWhenAGuardrailFlagsTheResponse(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::requireApproval('needs a human');
+            }
+        };
+        [$controller] = $this->guardedController($guardrail);
+
+        $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
+            ->withParsedBody(['configuration' => 1, 'prompt' => 'do it']);
+        $response = $controller->runAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertSame('guardrail_approval_required', $payload['status']);
+        self::assertSame('needs a human', $payload['error']);
+    }
+
+    #[Test]
+    public function streamRunEmitsGuardrailBlockedEventWhenAGuardrailDenies(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::deny('blocked by test policy');
+            }
+        };
+        [$controller, $config] = $this->guardedController($guardrail);
+
+        $events = [];
+        $emit   = static function (array $event) use (&$events): void {
+            $events[] = $event;
+        };
+
+        $method = new ReflectionMethod($controller, 'streamRun');
+        $method->invoke(
+            $controller,
+            $emit,
+            [ChatMessage::user('do it')],
+            $config,
+            ['fetch_logs'],
+            new ToolOptions(),
+            null,
+            new RunAugmentation(),
+            false,
+        );
+
+        $kinds = array_map(static fn(array $e): mixed => $e['event'] ?? null, $events);
+        // A guardrail verdict ends the stream with a distinct terminal event, not
+        // the generic 'error' and not a 'done'.
+        self::assertContains('guardrail_blocked', $kinds);
+        self::assertNotContains('done', $kinds);
+        self::assertNotContains('error', $kinds);
+
+        $blocked = null;
+        foreach ($events as $event) {
+            if (($event['event'] ?? null) === 'guardrail_blocked') {
+                $blocked = $event;
+            }
+        }
+        self::assertIsArray($blocked);
+        self::assertFalse($blocked['success']);
+        self::assertSame($guardrail::class, $blocked['guardrail']);
+        self::assertSame('blocked by test policy', $blocked['error']);
+    }
+
     /**
      * Build a controller wired to the scripted tool adapter (one tool call, then
      * a plain answer) over an in-memory configuration.
@@ -582,6 +691,51 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             new NullLogger(),
             $adapterRegistry,
             new MiddlewarePipeline([]),
+            self::createStub(CacheManagerInterface::class),
+        );
+
+        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+
+        return [$this->makeController($configurationRepository, $toolRegistry, $toolLoopService), $config];
+    }
+
+    /**
+     * Like {@see self::scriptedController()} but with a guardrail wired into the
+     * provider pipeline, so a DENY / REQUIRE_APPROVAL verdict propagates out of
+     * the tool loop exactly as it does in production (ADR-086).
+     *
+     * @return array{0: ToolPlaygroundController, 1: LlmConfiguration}
+     */
+    private function guardedController(GuardrailInterface $guardrail): array
+    {
+        $provider = new Provider();
+        $provider->setIdentifier('fake-provider');
+        $provider->setAdapterType('openai');
+        $provider->setApiKey('nr_tools_vault_key');
+
+        $model = new Model();
+        $model->setModelId('priced-model-x');
+        $model->setProvider($provider);
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg-tools');
+        $config->setLlmModel($model);
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn(new ScriptedToolAdapter());
+
+        $extensionConfig = self::createStub(ExtensionConfiguration::class);
+        $extensionConfig->method('get')->willReturn([]);
+
+        $manager = $this->createLlmServiceManager(
+            $extensionConfig,
+            new NullLogger(),
+            $adapterRegistry,
+            new MiddlewarePipeline([new GuardrailMiddleware([$guardrail])]),
             self::createStub(CacheManagerInterface::class),
         );
 

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -12,9 +12,11 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Streaming;
 use Generator;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
@@ -22,6 +24,7 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
@@ -64,6 +67,57 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         ));
 
         self::assertSame(['Hello', ' ', 'World'], $chunks);
+    }
+
+    #[Test]
+    public function auditsTheAssembledStreamedResponseAgainstGuardrailsAfterDelivery(): void
+    {
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return str_contains($response->content, 'sk-secret')
+                    ? GuardrailResult::deny('a secret was streamed')
+                    : GuardrailResult::allow();
+            }
+        };
+        $dispatcher = $this->dispatcher(guardrails: [$guardrail]);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['here is ', 'sk-secret-value', ' — oops']),
+        ));
+
+        // The chunks are delivered unchanged: the audit runs AFTER delivery and
+        // cannot retract or redact what was already streamed.
+        self::assertSame(['here is ', 'sk-secret-value', ' — oops'], $chunks);
+
+        // The verdict is recorded for audit so streamed output is not a blind spot.
+        $record = $this->logger->firstMatching('warning', 'tripped a guardrail');
+        self::assertNotNull($record);
+        self::assertSame($guardrail::class, $record['context']['guardrail'] ?? null);
+        self::assertSame('deny', $record['context']['verdict'] ?? null);
+        self::assertSame('a secret was streamed', $record['context']['reason'] ?? null);
+    }
+
+    #[Test]
+    public function doesNotRecordAGuardrailAuditForACleanStream(): void
+    {
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::allow();
+            }
+        };
+        $dispatcher = $this->dispatcher(guardrails: [$guardrail]);
+
+        iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['a perfectly ', 'normal answer']),
+        ));
+
+        self::assertNull($this->logger->firstMatching('warning', 'tripped a guardrail'));
     }
 
     #[Test]
@@ -681,10 +735,14 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         return $record;
     }
 
+    /**
+     * @param iterable<GuardrailInterface> $guardrails
+     */
     private function dispatcher(
         ?BudgetServiceInterface $budget = null,
         ?LlmConfigurationRepository $repository = null,
         ?ExtensionConfiguration $extensionConfiguration = null,
+        iterable $guardrails = [],
     ): StreamingDispatcher {
         return new StreamingDispatcher(
             $budget ?? $this->budget(BudgetCheckResult::allowed()),
@@ -694,6 +752,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->logger,
             $this->contextWithAmbientUser(0),
             $extensionConfiguration ?? $this->extensionConfiguration(true),
+            $guardrails,
         );
     }
 


### PR DESCRIPTION
Follow-ups to the guardrail pipeline (ADR-085), closing two enforcement gaps it left open. Builds on #444 (guardrails) and #442 (approval suspend/resume), both merged.

## Playground verdict handling (fixes a live 500)
Guardrails run on every tool-loop provider call (ADR-085 middleware, priority 115), so a `DENY`/`REQUIRE_APPROVAL` verdict can surface mid-run. The playground caught only `ToolApprovalRequiredException`/`BudgetExceededException`; a guardrail verdict fell through to the generic `Throwable` handler → **HTTP 500**, with the run recorded as a crash.

`runAction`, `resumeAction`, `streamRun` now catch `GuardrailViolationException`/`GuardrailApprovalRequiredException` before the generic `Throwable`: the run is settled as blocked (not left RUNNING) and a clean payload is returned — HTTP 200, `success:false`, `status` of `guardrail_blocked` or `guardrail_approval_required`, naming the deciding guardrail and reason. The streamed path emits the same as a terminal event.

## Streaming guardrail audit
Streamed responses bypass the pipeline (a lazy generator can't be the terminal, ADR-062), so `GuardrailMiddleware` never screened them. `StreamingDispatcher` now screens the assembled completion at end-of-stream and records any non-ALLOW verdict.

This is an **audit, not enforcement**: chunks are already delivered, so a `DENY`/`REDACT` can't retract or live-redact them (live protection needs a delta-oriented contract — follow-up). The buffer is bounded (`MAX_GUARDRAIL_BUFFER_BYTES`, 50 KB) so streaming keeps its memory benefit; screening is fail-soft.

## Deliberately out of scope
- **Response-release resume** for `REQUIRE_APPROVAL` (persist + re-deliver an approved response) — the exception carries no resumable state; a separate step.
- **Input-side screening** (redact/block the outgoing prompt) — a separate change on the send path, shipping as its own PR + ADR next.

## Tests
- `ToolPlaygroundControllerTest`: guardrail DENY → `guardrail_blocked` (not 500); REQUIRE_APPROVAL → `guardrail_approval_required`; streamed DENY → terminal `guardrail_blocked` event. (12/12 pass locally.)
- `StreamingDispatcherTest`: end-of-stream audit records a DENY verdict while chunks stay unchanged; a clean stream records nothing.

Local gates green: cgl, phpstan (L10), unit, rector -n, fuzzy. Full functional suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)