### PR TITLE
feat(guardrail): input-side guardrails — screen and redact the outgoing prompt (ADR-087)

### DIFF
--- a/Classes/Service/Guardrail/InputGuardrailInterface.php
+++ b/Classes/Service/Guardrail/InputGuardrailInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A content-policy guardrail applied to the OUTGOING prompt before a provider
+ * call (ADR-087) — the input-side complement of {@see GuardrailInterface}.
+ *
+ * Implementers are auto-collected via the `nr_llm.input_guardrail` DI tag (this
+ * attribute) and run by {@see InputGuardrailScreener} on each message's text, in
+ * tag order, before the request reaches the provider.
+ *
+ * The two sides differ in where they run and therefore in what they can do. The
+ * output side runs inside the provider pipeline (ADR-085), where the prompt is
+ * not reachable. Input screening runs on the send path in
+ * {@see \Netresearch\NrLlm\Service\LlmServiceManager}, where the messages ARE
+ * reachable — so a REDACT verdict rewrites the prompt content in place (a
+ * middleware-side check could not). A DENY / REQUIRE_APPROVAL blocks the call
+ * with the same typed exception the output side throws. RETRY has no meaning
+ * before a provider call and is ignored.
+ */
+#[AutoconfigureTag(name: self::TAG_NAME)]
+interface InputGuardrailInterface
+{
+    public const TAG_NAME = 'nr_llm.input_guardrail';
+
+    public function checkInput(string $text): GuardrailResult;
+}

--- a/Classes/Service/Guardrail/InputGuardrailScreener.php
+++ b/Classes/Service/Guardrail/InputGuardrailScreener.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Runs the input guardrails over an outgoing message list before it reaches a
+ * provider (ADR-087).
+ *
+ * The output guardrails run inside the provider pipeline (ADR-085), where the
+ * prompt payload is not reachable. Input screening therefore runs here, on the
+ * send path, where the messages ARE reachable — so a REDACT verdict rewrites the
+ * prompt in place (which a middleware-side check could not).
+ *
+ * Each message's text content is screened in tag order: a REDACT rewrites that
+ * message's content and screening continues (a later guardrail may still deny);
+ * a DENY / REQUIRE_APPROVAL throws the same typed exception the output side uses,
+ * so a caller handles both identically; RETRY — which asks the provider again,
+ * meaningless before the call — is ignored. Messages are handled in both their
+ * typed {@see ChatMessage} and legacy array forms; a message with no string
+ * content passes through untouched (an assistant tool-call turn, a structured
+ * payload).
+ */
+final readonly class InputGuardrailScreener
+{
+    /**
+     * @param iterable<InputGuardrailInterface> $guardrails
+     */
+    public function __construct(
+        #[AutowireIterator(InputGuardrailInterface::TAG_NAME)]
+        private iterable $guardrails,
+    ) {}
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    public function screen(array $messages): array
+    {
+        $screened = [];
+        foreach ($messages as $message) {
+            $screened[] = $this->screenMessage($message);
+        }
+
+        return $screened;
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     *
+     * @return ChatMessage|array<string, mixed>
+     */
+    private function screenMessage(ChatMessage|array $message): ChatMessage|array
+    {
+        $content = $this->contentOf($message);
+        if ($content === '') {
+            return $message;
+        }
+
+        $redacted = $content;
+        foreach ($this->guardrails as $guardrail) {
+            $result = $guardrail->checkInput($redacted);
+            switch ($result->verdict) {
+                case GuardrailVerdict::ALLOW:
+                case GuardrailVerdict::RETRY:
+                    // RETRY re-asks the provider; no provider call has happened
+                    // yet on the input side, so it is a pass here.
+                    break;
+                case GuardrailVerdict::REDACT:
+                    $redacted = $result->redactedContent ?? $redacted;
+                    break;
+                case GuardrailVerdict::DENY:
+                    throw new GuardrailViolationException(
+                        $guardrail::class,
+                        $result->reason !== '' ? $result->reason : 'A guardrail denied the prompt.',
+                    );
+                case GuardrailVerdict::REQUIRE_APPROVAL:
+                    throw new GuardrailApprovalRequiredException(
+                        $guardrail::class,
+                        $result->reason !== '' ? $result->reason : 'A guardrail flagged the prompt for human approval.',
+                    );
+            }
+        }
+
+        if ($redacted === $content) {
+            return $message;
+        }
+
+        return $this->withContent($message, $redacted);
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    private function contentOf(ChatMessage|array $message): string
+    {
+        if ($message instanceof ChatMessage) {
+            return $message->content;
+        }
+
+        $content = $message['content'] ?? null;
+
+        return is_string($content) ? $content : '';
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     *
+     * @return ChatMessage|array<string, mixed>
+     */
+    private function withContent(ChatMessage|array $message, string $content): ChatMessage|array
+    {
+        if ($message instanceof ChatMessage) {
+            // Rebuild the immutable VO, preserving role and the tool-turn fields.
+            return new ChatMessage($message->getRole(), $content, $message->toolCalls, $message->toolCallId);
+        }
+
+        return [...$message, 'content' => $content];
+    }
+}

--- a/Classes/Service/Guardrail/RedactsSecretsTrait.php
+++ b/Classes/Service/Guardrail/RedactsSecretsTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+
+/**
+ * Secret-masking shared by the output ({@see SecretRedactionGuardrail}) and
+ * input ({@see SecretRedactionInputGuardrail}) reference guardrails (ADR-085 /
+ * ADR-087).
+ *
+ * The two guardrails are separate classes — a single class cannot implement both
+ * {@see GuardrailInterface} and {@see InputGuardrailInterface}, whose ``TAG_NAME``
+ * constants would collide — but the masking is identical, so it lives here once.
+ */
+trait RedactsSecretsTrait
+{
+    use ErrorMessageSanitizerTrait;
+
+    /**
+     * REDACT when the masking changed something, otherwise ALLOW (a pass-through)
+     * so normal content is untouched. ``$where`` names the side for the reason.
+     */
+    private function redactionResult(string $content, string $where): GuardrailResult
+    {
+        $redacted = $this->redactSecrets($content);
+
+        if ($redacted === $content) {
+            return GuardrailResult::allow();
+        }
+
+        return GuardrailResult::redact($redacted, sprintf('Redacted secret-shaped strings from the %s.', $where));
+    }
+
+    private function redactSecrets(string $content): string
+    {
+        $redacted = $this->sanitizeErrorMessage($content);
+        // API-key and Bearer-token shapes the URL-param sanitiser does not cover.
+        // The sk- class allows hyphens/underscores so modern project keys
+        // (sk-proj-…) match. Each preg_replace is guarded: on failure (e.g. a
+        // backtrack-limit hit on a huge payload) it returns null, which a bare
+        // (string) cast would turn into '' — silently wiping the whole content.
+        $withoutApiKeys = preg_replace('/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-***', (string)$redacted);
+        if (is_string($withoutApiKeys)) {
+            $redacted = $withoutApiKeys;
+        }
+        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', (string)$redacted);
+        if (is_string($withoutBearer)) {
+            $redacted = $withoutBearer;
+        }
+
+        return $redacted;
+    }
+}

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Service\Guardrail;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 
 /**
  * Redacts secrets a model may have echoed into its response (ADR-085).
@@ -19,35 +18,17 @@ use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
  * A model given secret-bearing context (a connection string, an API key, a
  * Bearer header) can repeat it verbatim. This guardrail masks the common shapes:
  * credential-bearing URL query params (via the shared
- * {@see ErrorMessageSanitizerTrait}), ``sk-…`` API keys, and ``Bearer …``
- * tokens. It only returns REDACT when it actually changed something — otherwise
- * ALLOW (a pass-through), so a normal response is untouched.
+ * {@see \Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait}), ``sk-…`` API
+ * keys, and ``Bearer …`` tokens. It only returns REDACT when it actually changed
+ * something — otherwise ALLOW (a pass-through), so a normal response is
+ * untouched. The prompt-side counterpart is {@see SecretRedactionInputGuardrail}.
  */
 final readonly class SecretRedactionGuardrail implements GuardrailInterface
 {
-    use ErrorMessageSanitizerTrait;
+    use RedactsSecretsTrait;
 
     public function checkOutput(CompletionResponse $response): GuardrailResult
     {
-        $redacted = $this->sanitizeErrorMessage($response->content);
-        // API-key and Bearer-token shapes the URL-param sanitiser does not cover.
-        // The sk- class allows hyphens/underscores so modern project keys
-        // (sk-proj-…) match. Each preg_replace is guarded: on failure (e.g. a
-        // backtrack-limit hit on a huge payload) it returns null, which a bare
-        // (string) cast would turn into '' — silently wiping the whole response.
-        $withoutApiKeys = preg_replace('/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-***', $redacted);
-        if (is_string($withoutApiKeys)) {
-            $redacted = $withoutApiKeys;
-        }
-        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', $redacted);
-        if (is_string($withoutBearer)) {
-            $redacted = $withoutBearer;
-        }
-
-        if ($redacted === $response->content) {
-            return GuardrailResult::allow();
-        }
-
-        return GuardrailResult::redact($redacted, 'Redacted secret-shaped strings from the response.');
+        return $this->redactionResult($response->content, 'response');
     }
 }

--- a/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+
+/**
+ * Redacts secrets from the OUTGOING prompt before it reaches a provider
+ * (ADR-087) — the input-side counterpart of {@see SecretRedactionGuardrail}.
+ *
+ * A user can paste a secret (an API key, a credential-bearing URL, a Bearer
+ * header) into a prompt that should not be forwarded verbatim to a third-party
+ * provider. This masks the same shapes on the prompt as the response side, and
+ * only returns REDACT when it actually changed something. Because input
+ * screening runs on the send path ({@see InputGuardrailScreener}), the REDACT
+ * rewrites the prompt in place.
+ */
+final readonly class SecretRedactionInputGuardrail implements InputGuardrailInterface
+{
+    use RedactsSecretsTrait;
+
+    public function checkInput(string $text): GuardrailResult
+    {
+        return $this->redactionResult($text, 'prompt');
+    }
+}

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -30,6 +30,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
@@ -50,6 +51,11 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         private ?SkillInjectionService $skillInjection = null,
         private ?ModelSelectionServiceInterface $modelSelectionService = null,
         private ?StreamingDispatcher $streaming = null,
+        // Input-side guardrails (ADR-087): screen/redact the outgoing prompt on
+        // the send path (the pipeline cannot reach the payload). Optional so the
+        // lean unit-test constructions keep working — absent it, input screening
+        // is a no-op, exactly as with the other optional collaborators above.
+        private ?InputGuardrailScreener $inputScreener = null,
     ) {}
 
     /**
@@ -92,6 +98,28 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $messages,
             SkillInjectionService::toList($configuration->getSkills()),
         );
+    }
+
+    /**
+     * Screen (and redact) the outgoing messages through the input guardrails
+     * before they reach a provider (ADR-087). A no-op when no screener is wired
+     * (lean unit-test constructions). Throws
+     * {@see \Netresearch\NrLlm\Exception\GuardrailViolationException} /
+     * {@see \Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException} on a
+     * DENY / REQUIRE_APPROVAL verdict — at call time, so an over-policy prompt
+     * never opens a stream.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function screenInput(array $messages): array
+    {
+        if ($this->inputScreener === null) {
+            return $messages;
+        }
+
+        return $this->inputScreener->screen($messages);
     }
 
     /**
@@ -427,6 +455,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $optionOverrides = $options->toArray();
         unset($optionOverrides['provider']);
 
+        $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
@@ -685,6 +714,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse
     {
+        $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
 
         return $this->runThroughPipeline(
@@ -968,6 +998,11 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     public function streamChatWithConfiguration(array $messages, LlmConfiguration $configuration, array $optionOverrides = [], array $metadata = []): Generator
     {
+        // Screen the prompt before it is captured by the opener or measured for
+        // token estimation, so a redaction reaches the provider and a DENY throws
+        // at call time rather than on first iteration (ADR-087).
+        $messages = $this->screenInput($messages);
+
         $open = function (LlmConfiguration $config) use ($messages, $optionOverrides): Generator {
             $llmModel = $this->resolveModelForConfiguration($config);
             $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -123,6 +123,25 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     }
 
     /**
+     * Screen a raw string prompt through the input guardrails (ADR-087) — the
+     * ``complete`` entry points take a bare string, not a message list, so they
+     * cannot use {@see self::screenInput()}. Wraps the prompt as a single user
+     * message, screens it (so a REDACT rewrites it and a DENY / REQUIRE_APPROVAL
+     * throws), and returns the redacted text. A no-op when no screener is wired.
+     */
+    private function screenInputPrompt(string $prompt): string
+    {
+        if ($this->inputScreener === null) {
+            return $prompt;
+        }
+
+        $screened = $this->inputScreener->screen([ChatMessage::user($prompt)]);
+        $message  = $screened[0] ?? null;
+
+        return $message instanceof ChatMessage ? $message->content : $prompt;
+    }
+
+    /**
      * Resolve the effective configuration for a configuration-driven completion.
      *
      * Delegates to {@see ConfigurationResolver}; retained on the manager
@@ -740,6 +759,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     public function completeWithConfiguration(string $prompt, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = []): CompletionResponse
     {
+        $prompt = $this->screenInputPrompt($prompt);
+
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Completion,

--- a/Documentation/Adr/Adr087InputGuardrails.rst
+++ b/Documentation/Adr/Adr087InputGuardrails.rst
@@ -52,9 +52,12 @@ provider) has no meaning before the call and is ignored.
 Screening is applied at the configuration-driven entry points —
 ``chatWithConfiguration``, ``chatWithToolsForConfiguration``,
 ``streamChatWithConfiguration`` — which is where ``chat()`` / ``streamChat()``
-funnel once a default configuration resolves (ADR-034). For streaming it runs
-before the opener captures the messages, so a redaction reaches the provider and
-a DENY throws at call time, not on first iteration. The screener handles both
+funnel once a default configuration resolves (ADR-034). The raw-string
+``completeWithConfiguration`` (where ``complete()`` funnels) takes a prompt
+string rather than a message list, so it screens through a string variant that
+wraps, screens, and unwraps the prompt. For streaming, screening runs before the
+opener captures the messages, so a redaction reaches the provider and a DENY
+throws at call time, not on first iteration. The screener handles both
 typed ``ChatMessage`` and legacy array messages; a message with no string
 content (an assistant tool-call turn) passes through untouched.
 

--- a/Documentation/Adr/Adr087InputGuardrails.rst
+++ b/Documentation/Adr/Adr087InputGuardrails.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-087:
+
+============================================================================
+ADR-087: Input-side guardrails — screening and redacting the outgoing prompt
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-087-context:
+
+Context
+=======
+
+ADR-085 established the guardrail pipeline for provider *responses*:
+``GuardrailMiddleware`` screens every non-streaming ``CompletionResponse`` and a
+guardrail returns an ALLOW / REDACT / DENY / RETRY / REQUIRE_APPROVAL verdict.
+It screens output only, and said so: the prompt payload is not on the
+``ProviderCallContext`` (ADR-026 keeps the context payload-free), so a
+middleware cannot see — let alone rewrite — the outgoing messages.
+
+The prompt is untrusted too. A user can paste a secret (an API key, a
+credential-bearing URL) that should not be forwarded verbatim to a third-party
+provider, and an operator may want to block a prompt on policy before spending a
+call.
+
+.. _adr-087-decision:
+
+Decision
+========
+
+**An input guardrail is an ``InputGuardrailInterface``** whose ``checkInput()``
+returns the same ``GuardrailResult`` verdict type as the output side.
+Implementers are auto-collected through the ``nr_llm.input_guardrail`` DI tag —
+separate from ``nr_llm.guardrail`` so an output-only guardrail (e.g. the
+provider content-filter, which reacts to a response attribute) is not forced to
+implement a meaningless input check.
+
+**Screening runs on the send path, not in the pipeline.** An
+``InputGuardrailScreener`` runs the input guardrails over the message list inside
+``LlmServiceManager`` — before the pipeline, where the messages are reachable.
+This is the key difference from the output side: because the screener holds the
+payload, a **REDACT verdict rewrites the prompt in place** (a middleware could
+not). A DENY / REQUIRE_APPROVAL throws the same
+``GuardrailViolationException`` / ``GuardrailApprovalRequiredException`` the
+output side uses, so a caller handles both identically; RETRY (re-ask the
+provider) has no meaning before the call and is ignored.
+
+Screening is applied at the configuration-driven entry points —
+``chatWithConfiguration``, ``chatWithToolsForConfiguration``,
+``streamChatWithConfiguration`` — which is where ``chat()`` / ``streamChat()``
+funnel once a default configuration resolves (ADR-034). For streaming it runs
+before the opener captures the messages, so a redaction reaches the provider and
+a DENY throws at call time, not on first iteration. The screener handles both
+typed ``ChatMessage`` and legacy array messages; a message with no string
+content (an assistant tool-call turn) passes through untouched.
+
+``SecretRedactionInputGuardrail`` ships as the reference implementation,
+applying the same secret masking to the prompt that ``SecretRedactionGuardrail``
+applies to the response (shared via ``RedactsSecretsTrait``). They are separate
+classes because a single class cannot implement both ``GuardrailInterface`` and
+``InputGuardrailInterface`` — their ``TAG_NAME`` constants would collide.
+
+.. _adr-087-consequences:
+
+Consequences
+============
+
+- The prompt is screened and can be redacted before it leaves the extension —
+  the input complement of ADR-085.
+- Guardrail execution is deliberately split: output in the pipeline (ADR-085),
+  input on the send path (here). The alternative — threading the payload onto
+  ``ProviderCallContext`` — was rejected to keep the context payload-free
+  (ADR-026); the trade is two locations instead of one.
+- Scope is the configuration-driven surface. The ad-hoc pinned-provider-key
+  path (``chat()`` / ``chatWithTools()`` / ``streamChat()`` with an explicit
+  provider and no DB configuration) is not input-screened; it is the ADR-034
+  escape hatch and out of scope here.
+- Input guardrails support ALLOW / REDACT / DENY / REQUIRE_APPROVAL. RETRY is
+  ignored on the input side.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -384,3 +384,4 @@ Tools
    Adr084HumanInTheLoopApproval
    Adr085GuardrailPipeline
    Adr086GuardrailEnforcementGaps
+   Adr087InputGuardrails

--- a/Tests/LlmServiceManagerTestFactory.php
+++ b/Tests/LlmServiceManagerTestFactory.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Service\EmbedCacheKeyBuilder;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\KeyedProviderRegistry;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\MessageShaper;
@@ -52,6 +53,7 @@ trait LlmServiceManagerTestFactory
         ?SkillInjectionService $skillInjection = null,
         ?ModelSelectionServiceInterface $modelSelectionService = null,
         ?StreamingDispatcher $streaming = null,
+        ?InputGuardrailScreener $inputScreener = null,
     ): LlmServiceManager {
         return new LlmServiceManager(
             $adapterRegistry,
@@ -63,6 +65,7 @@ trait LlmServiceManagerTestFactory
             $skillInjection,
             $modelSelectionService,
             $streaming,
+            $inputScreener,
         );
     }
 }

--- a/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
+++ b/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InputGuardrailScreener::class)]
+final class InputGuardrailScreenerTest extends TestCase
+{
+    #[Test]
+    public function passesMessagesThroughUnchangedWhenEveryGuardrailAllows(): void
+    {
+        $screener = new InputGuardrailScreener([$this->allowing()]);
+        $messages = [ChatMessage::user('hello'), ['role' => 'system', 'content' => 'be nice']];
+
+        self::assertSame($messages, $screener->screen($messages));
+    }
+
+    #[Test]
+    public function passesMessagesThroughUnchangedWhenNoGuardrailsAreRegistered(): void
+    {
+        $screener = new InputGuardrailScreener([]);
+        $messages = [ChatMessage::user('hello')];
+
+        self::assertSame($messages, $screener->screen($messages));
+    }
+
+    #[Test]
+    public function redactsAChatMessageContentInPlacePreservingRole(): void
+    {
+        $screener = new InputGuardrailScreener([$this->redacting('secret', '***')]);
+
+        $result = $screener->screen([ChatMessage::user('my secret here')]);
+
+        self::assertCount(1, $result);
+        $message = $result[0];
+        self::assertInstanceOf(ChatMessage::class, $message);
+        self::assertSame('my *** here', $message->content);
+        self::assertSame('user', $message->role);
+    }
+
+    #[Test]
+    public function redactsALegacyArrayMessageContentPreservingOtherKeys(): void
+    {
+        $screener = new InputGuardrailScreener([$this->redacting('secret', '***')]);
+
+        $result = $screener->screen([['role' => 'user', 'content' => 'a secret value', 'name' => 'kept']]);
+
+        $message = $result[0];
+        self::assertIsArray($message);
+        self::assertSame('a *** value', $message['content']);
+        self::assertSame('kept', $message['name']);
+    }
+
+    #[Test]
+    public function passesAMessageWithNoStringContentThrough(): void
+    {
+        $screener = new InputGuardrailScreener([$this->redacting('x', 'y')]);
+        // An assistant tool-call turn carries empty content — nothing to screen.
+        $message = ChatMessage::assistantToolCalls([new ToolCall('call_1', 'do_it', [])]);
+
+        $result = $screener->screen([$message]);
+
+        self::assertSame($message, $result[0]);
+    }
+
+    #[Test]
+    public function appliesEveryGuardrailInOrder(): void
+    {
+        $screener = new InputGuardrailScreener([
+            $this->redacting('one', '1'),
+            $this->redacting('two', '2'),
+        ]);
+
+        $result = $screener->screen([ChatMessage::user('one and two')]);
+
+        $message = $result[0];
+        self::assertInstanceOf(ChatMessage::class, $message);
+        self::assertSame('1 and 2', $message->content);
+    }
+
+    #[Test]
+    public function throwsWhenAGuardrailDeniesThePrompt(): void
+    {
+        $screener = new InputGuardrailScreener([$this->denying('policy says no')]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->expectExceptionMessage('policy says no');
+        $screener->screen([ChatMessage::user('anything')]);
+    }
+
+    #[Test]
+    public function throwsApprovalRequiredWhenAGuardrailFlagsThePrompt(): void
+    {
+        $screener = new InputGuardrailScreener([$this->requireApproval('needs review')]);
+
+        $this->expectException(GuardrailApprovalRequiredException::class);
+        $this->expectExceptionMessage('needs review');
+        $screener->screen([ChatMessage::user('anything')]);
+    }
+
+    #[Test]
+    public function ignoresARetryVerdictOnTheInputSide(): void
+    {
+        $screener = new InputGuardrailScreener([$this->retrying()]);
+        $messages = [ChatMessage::user('hello')];
+
+        // RETRY re-asks the provider — meaningless before a call, so it is a pass.
+        self::assertSame($messages, $screener->screen($messages));
+    }
+
+    private function allowing(): InputGuardrailInterface
+    {
+        return new class implements InputGuardrailInterface {
+            public function checkInput(string $text): GuardrailResult
+            {
+                return GuardrailResult::allow();
+            }
+        };
+    }
+
+    private function redacting(string $needle, string $replacement): InputGuardrailInterface
+    {
+        return new class ($needle, $replacement) implements InputGuardrailInterface {
+            public function __construct(private readonly string $needle, private readonly string $replacement) {}
+
+            public function checkInput(string $text): GuardrailResult
+            {
+                if (!str_contains($text, $this->needle)) {
+                    return GuardrailResult::allow();
+                }
+
+                return GuardrailResult::redact(str_replace($this->needle, $this->replacement, $text), 'redacted');
+            }
+        };
+    }
+
+    private function denying(string $reason): InputGuardrailInterface
+    {
+        return new class ($reason) implements InputGuardrailInterface {
+            public function __construct(private readonly string $reason) {}
+
+            public function checkInput(string $text): GuardrailResult
+            {
+                return GuardrailResult::deny($this->reason);
+            }
+        };
+    }
+
+    private function requireApproval(string $reason): InputGuardrailInterface
+    {
+        return new class ($reason) implements InputGuardrailInterface {
+            public function __construct(private readonly string $reason) {}
+
+            public function checkInput(string $text): GuardrailResult
+            {
+                return GuardrailResult::requireApproval($this->reason);
+            }
+        };
+    }
+
+    private function retrying(): InputGuardrailInterface
+    {
+        return new class implements InputGuardrailInterface {
+            public function checkInput(string $text): GuardrailResult
+            {
+                return GuardrailResult::retry('later');
+            }
+        };
+    }
+}

--- a/Tests/Unit/Service/Guardrail/SecretRedactionInputGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionInputGuardrailTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionInputGuardrail;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SecretRedactionInputGuardrail::class)]
+final class SecretRedactionInputGuardrailTest extends TestCase
+{
+    #[Test]
+    public function redactsAnApiKeyFromTheOutgoingPrompt(): void
+    {
+        $result = (new SecretRedactionInputGuardrail())->checkInput('please use sk-abcdef0123456789ABCDEF for this');
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringContainsString('sk-***', $result->redactedContent);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $result->redactedContent);
+        self::assertStringContainsString('prompt', $result->reason);
+    }
+
+    #[Test]
+    public function redactsAUrlCredentialAndABearerTokenFromThePrompt(): void
+    {
+        $result = (new SecretRedactionInputGuardrail())->checkInput(
+            'call https://api.example.com/x?api_key=SUPERSECRET1 with Bearer abc123def456ghi789',
+        );
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString('SUPERSECRET1', $result->redactedContent);
+        self::assertStringContainsString('Bearer ***', $result->redactedContent);
+    }
+
+    #[Test]
+    public function allowsACleanPrompt(): void
+    {
+        $result = (new SecretRedactionInputGuardrail())->checkInput('just a normal question about the weather');
+
+        self::assertSame(GuardrailVerdict::ALLOW, $result->verdict);
+        self::assertNull($result->redactedContent);
+    }
+}

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -729,6 +729,51 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
     }
 
+    #[Test]
+    public function completeWithConfigurationRedactsSecretsFromTheRawPromptViaInputGuardrails(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $received    = null;
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('complete')->willReturnCallback(
+            function (string $prompt) use (&$received): CompletionResponse {
+                $received = $prompt;
+
+                return new CompletionResponse('ok', 'gpt-4o', new UsageStatistics(1, 1, 2));
+            },
+        );
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        // The raw-string completion path also screens input (ADR-087) — it does
+        // not funnel through chatWithConfiguration.
+        $screener = new InputGuardrailScreener([new SecretRedactionInputGuardrail()]);
+        $manager  = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryMock,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            null,
+            $screener,
+        );
+
+        $manager->completeWithConfiguration('my key is sk-abcdef0123456789ABCDEF ok', $config);
+
+        self::assertIsString($received);
+        self::assertStringContainsString('sk-***', $received);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $received);
+    }
+
     /**
      * completeForConfiguration() takes chat()'s configuration route: it builds a
      * leading system message from the option's system prompt and a trailing user

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -40,6 +40,8 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionInputGuardrail;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -676,6 +678,55 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         );
 
         self::assertSame($expectedResponse, $result);
+    }
+
+    #[Test]
+    public function chatWithConfigurationRedactsSecretsFromTheOutgoingPromptViaInputGuardrails(): void
+    {
+        $model = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $received    = null;
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('chatCompletion')->willReturnCallback(
+            function (array $messages) use (&$received): CompletionResponse {
+                $received = $messages;
+
+                return new CompletionResponse('ok', 'gpt-4o', new UsageStatistics(1, 1, 2));
+            },
+        );
+
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        // A real SecretRedactionInputGuardrail: the prompt secret must be masked
+        // before the adapter is called (ADR-087).
+        $screener = new InputGuardrailScreener([new SecretRedactionInputGuardrail()]);
+        $manager  = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryMock,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            null,
+            $screener,
+        );
+
+        $manager->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'my key is sk-abcdef0123456789ABCDEF ok']],
+            $config,
+        );
+
+        self::assertIsArray($received);
+        $joined = implode("\n", array_map(static fn(ChatMessage $m): string => $m->content, $received));
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
     }
 
     /**


### PR DESCRIPTION
The input complement to the guardrail pipeline (ADR-085), which screens only responses. Builds on #444 (guardrails), merged.

## Why
The prompt is untrusted too: a user can paste a secret (an API key, a credential-bearing URL) that shouldn't be forwarded verbatim to a third-party provider, and an operator may want to block a prompt on policy before spending a call. Output guardrails run inside the provider pipeline, where the prompt payload isn't reachable (ADR-026 keeps the context payload-free) — so ADR-085 explicitly deferred the input side.

## What
Input screening runs on the **send path** in `LlmServiceManager`, where the messages *are* reachable — so a REDACT verdict can rewrite the prompt in place (a middleware couldn't).

- **`InputGuardrailInterface`** (tag `nr_llm.input_guardrail`) — input-side complement of `GuardrailInterface`, same `GuardrailResult` verdict.
- **`InputGuardrailScreener`** — screens each message's text: REDACT rewrites content, DENY/REQUIRE_APPROVAL throw the same typed exceptions the output side uses (so a caller — e.g. the playground handler in #447 — handles both identically), RETRY is ignored (meaningless before a call). Handles typed `ChatMessage` and legacy array messages; empty-content turns pass through.
- **`LlmServiceManager`** screens at `chatWithConfiguration`, `chatWithToolsForConfiguration`, `streamChatWithConfiguration` — where `chat()`/`streamChat()` funnel once a default config resolves (ADR-034). For streaming, before the opener captures the messages, so a DENY throws at call time. Optional collaborator (no-op when unwired).
- **`SecretRedactionInputGuardrail`** — reference impl, sharing masking with the response-side `SecretRedactionGuardrail` via `RedactsSecretsTrait`. Two classes because one can't implement both guardrail interfaces (colliding `TAG_NAME`).

## Deliberately out of scope
The ad-hoc pinned-provider-key path (`chat()`/`chatWithTools()`/`streamChat()` with an explicit provider and no DB configuration) is not input-screened — the ADR-034 escape hatch.

## Tests
- `InputGuardrailScreenerTest`: redact rewrites `ChatMessage` + array content in place; deny/approval throw; retry ignored; empty-content passes through; multiple guardrails apply in order.
- `SecretRedactionInputGuardrailTest`: masks API key / URL credential / Bearer token in a prompt; allows a clean prompt.
- `LlmServiceManagerTest`: a redacting input guardrail masks the secret before the adapter is called (end-to-end wiring).

Local gates green: cgl, phpstan (L10), unit, rector -n, fuzzy. Full functional suite runs in CI.

Note: shares ADR-index territory with #447 (ADR-086) — a trivial `Index.rst` line, will reconcile on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)