### PR TITLE
fix(landingpage): render AI answers as Markdown; widen prose measure

### DIFF
--- a/landingpage/src/assets/css/site.css
+++ b/landingpage/src/assets/css/site.css
@@ -59,7 +59,7 @@
   --radius: 10px;
   --radius-sm: 6px;
   --maxw: 1200px;
-  --maxw-prose: 74ch;
+  --maxw-prose: 90ch;
   --gap: clamp(1.5rem, 3vw, 3rem);
   --section-y: clamp(3rem, 7vw, 6rem);
 }

--- a/landingpage/src/assets/css/site.css
+++ b/landingpage/src/assets/css/site.css
@@ -332,7 +332,7 @@ mark { background: color-mix(in srgb, var(--orange) 30%, transparent); color: in
 .ai__output code { background: var(--code-bg); color: var(--code-ink); padding: 0.05em 0.35em; border-radius: 4px; font-size: 0.9em; }
 .ai__output a { color: var(--link); }
 .ai__output strong { color: var(--ink-strong); }
-.ai__output:empty { display: none; }
+.ai__output:empty:not([aria-busy='true']) { display: none; }
 .ai__output[aria-busy='true']::after { content: '▋'; animation: blink 1s steps(2) infinite; color: var(--teal); }
 @keyframes blink { 50% { opacity: 0; } }
 .ai__status { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }

--- a/landingpage/src/assets/css/site.css
+++ b/landingpage/src/assets/css/site.css
@@ -322,7 +322,17 @@ mark { background: color-mix(in srgb, var(--orange) 30%, transparent); color: in
 .ai__form { display: flex; gap: 0.6rem; margin: 1rem 0 0.6rem; flex-wrap: wrap; }
 .ai__form input { flex: 1 1 16rem; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--ink); font: inherit; padding: 0.6rem 0.8rem; }
 .ai__form input:focus-visible { border-color: var(--teal); }
-.ai__output { min-height: 1.5rem; margin-top: 0.8rem; padding: 0.9rem 1rem; background: var(--bg-alt); border-radius: var(--radius-sm); white-space: pre-wrap; }
+.ai__output { min-height: 1.5rem; margin-top: 0.8rem; padding: 0.9rem 1rem; background: var(--bg-alt); border-radius: var(--radius-sm); }
+.ai__output > *:first-child { margin-top: 0; }
+.ai__output > *:last-child { margin-bottom: 0; }
+.ai__output p { margin: 0 0 0.7rem; }
+.ai__output ul, .ai__output ol { margin: 0 0 0.7rem; padding-left: 1.3rem; }
+.ai__output li { margin: 0.2rem 0; }
+.ai__output li > p { margin: 0; }
+.ai__output code { background: var(--code-bg); color: var(--code-ink); padding: 0.05em 0.35em; border-radius: 4px; font-size: 0.9em; }
+.ai__output a { color: var(--link); }
+.ai__output strong { color: var(--ink-strong); }
+.ai__output:empty { display: none; }
 .ai__output[aria-busy='true']::after { content: '▋'; animation: blink 1s steps(2) infinite; color: var(--teal); }
 @keyframes blink { 50% { opacity: 0; } }
 .ai__status { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }

--- a/landingpage/src/assets/js/ai-assistant.js
+++ b/landingpage/src/assets/js/ai-assistant.js
@@ -29,6 +29,45 @@
 
   function setEl(el, text) { if (el) el.textContent = text; }
 
+  /* ---- Minimal, safe Markdown -> HTML (the model answers in Markdown) ---- */
+  function escapeHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+  function inlineMd(escaped) {
+    // Input is already HTML-escaped; only our own known tags are introduced.
+    return escaped
+      .replace(/`([^`]+)`/g, function (_, c) { return '<code>' + c + '</code>'; })
+      .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, function (_, t, u) {
+        u = u.trim();
+        if (!/^(https?:|mailto:|#|\/)/i.test(u)) return t; // drop unsafe schemes
+        return '<a href="' + u + '" rel="noopener nofollow">' + t + '</a>';
+      })
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*\s][^*]*?)\*/g, '$1<em>$2</em>');
+  }
+  function renderMarkdown(md) {
+    var out = '', list = null, para = [];
+    function flushPara() { if (para.length) { out += '<p>' + inlineMd(para.join(' ')) + '</p>'; para = []; } }
+    function closeList() { if (list) { out += '</' + list + '>'; list = null; } }
+    md.replace(/\r\n?/g, '\n').split('\n').forEach(function (line) {
+      var ul = line.match(/^\s*[-*]\s+(.*)$/);
+      var ol = line.match(/^\s*\d+[.)]\s+(.*)$/);
+      if (ul) { flushPara(); if (list !== 'ul') { closeList(); out += '<ul>'; list = 'ul'; } out += '<li>' + inlineMd(escapeHtml(ul[1])) + '</li>'; }
+      else if (ol) { flushPara(); if (list !== 'ol') { closeList(); out += '<ol>'; list = 'ol'; } out += '<li>' + inlineMd(escapeHtml(ol[1])) + '</li>'; }
+      else if (line.trim() === '') { flushPara(); closeList(); }
+      else { closeList(); para.push(escapeHtml(line.trim())); }
+    });
+    flushPara(); closeList();
+    return out;
+  }
+  function setHtml(el, htmlStr) {
+    while (el.firstChild) el.removeChild(el.firstChild);
+    var doc = new DOMParser().parseFromString('<body>' + htmlStr + '</body>', 'text/html');
+    Array.prototype.slice.call(doc.body.childNodes).forEach(function (n) {
+      el.appendChild(document.importNode(n, true));
+    });
+  }
+
   function buildSystemPrompt() {
     return [
       'You are a concise assistant for "nr-llm", a TYPO3 extension that provides a shared',
@@ -151,7 +190,7 @@
             } else {
               acc += chunk;
             }
-            output.textContent = acc;
+            setHtml(output, renderMarkdown(acc));
           }
         })();
       }).then(function () {

--- a/landingpage/src/templates/feature_page.html.j2
+++ b/landingpage/src/templates/feature_page.html.j2
@@ -14,9 +14,9 @@
 </section>
 
 <section class="section section--alt" aria-labelledby="why-h">
-  <div class="container section__intro">
+  <div class="container">
     <h2 id="why-h">{{ f.why.heading }}</h2>
-    {% for p in f.why.paragraphs %}<p>{{ p }}</p>{% endfor %}
+    {% for p in f.why.paragraphs %}<p class="section__intro">{{ p }}</p>{% endfor %}
   </div>
 </section>
 


### PR DESCRIPTION
Two landing-page polish fixes from review feedback.

## 1. Render on-device AI answers as Markdown

The **Ask nr-llm** widget printed the model's raw Markdown (literal `**bold**`, backtick code, `-`/`1.` list markers). Added a small, safe Markdown renderer:
- HTML-escape first, then emit only `strong`/`em`/`code`/`a`/`ul`/`ol`/`li`/`p`; links restricted to `http(s)`/`mailto`/`#`/relative (a `javascript:` URL is dropped). No raw HTML from the model survives.
- Output set via `DOMParser` + `importNode` (no `innerHTML`). Styled lists, code chips, and links in `.ai__output`.

## 2. Prose width

- `.section__intro` was capped at **74ch**, leaving a large void beside the full-width hero and cards → widened to **90ch** (still readable).
- On feature pages the *Why it exists* section had `section__intro` on the `.container` itself, so `max-width` + `margin-inline:auto` rendered it as a narrow, centred, indented column. Moved the class to the paragraphs (full-width container, left-aligned prose) to match the rest of the site.

## Verification

- Markdown renderer unit-checked (lists, bold, code, safe + unsafe links); axe-core on the landing with a rendered answer: **0 WCAG 2.1 AA violations** (code chip and link contrast pass).
- Feature *Why* section now full-width left-aligned (prose 875px, not a centred 660px column); landing prose fills the container.
- Rebased on current `main` (includes the feature pages, #446).

Follows up #440 / #446.
