### PR TITLE
feat(guardrail): screen input on the ad-hoc provider-key path (ADR-087 completion)

### DIFF
--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -214,6 +214,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             );
         }
 
+        // Ad-hoc pinned-provider path: screen the prompt too (ADR-087), matching
+        // the configuration-driven entry points.
+        $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
 
         return $this->runThroughPipeline(
@@ -242,6 +245,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 $optionsArray,
             );
         }
+
+        // Ad-hoc pinned-provider path: screen the raw prompt too (ADR-087).
+        $prompt = $this->screenInputPrompt($prompt);
 
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
@@ -374,8 +380,11 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         }
 
         // Ad-hoc: a pinned provider with no configuration entity — no fallback
-        // chain, provider resolved by key.
-        $open = function () use ($messages, $optionsArray, $providerKey): Generator {
+        // chain, provider resolved by key. Screen the prompt before the opener
+        // captures it (ADR-087), so a redaction reaches the provider and a DENY
+        // throws at call time.
+        $messages = $this->screenInput($messages);
+        $open     = function () use ($messages, $optionsArray, $providerKey): Generator {
             $provider = $this->getProvider($providerKey);
             $this->assertStreamingCapable($provider, 1581627129);
 
@@ -423,6 +432,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $options ??= new ToolOptions();
         [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
+        // Ad-hoc pinned-provider path: screen the prompt too (ADR-087).
+        $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
             static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),

--- a/Documentation/Adr/Adr087InputGuardrails.rst
+++ b/Documentation/Adr/Adr087InputGuardrails.rst
@@ -78,9 +78,10 @@ Consequences
   input on the send path (here). The alternative — threading the payload onto
   ``ProviderCallContext`` — was rejected to keep the context payload-free
   (ADR-026); the trade is two locations instead of one.
-- Scope is the configuration-driven surface. The ad-hoc pinned-provider-key
-  path (``chat()`` / ``chatWithTools()`` / ``streamChat()`` with an explicit
-  provider and no DB configuration) is not input-screened; it is the ADR-034
-  escape hatch and out of scope here.
+- Screening covers both the configuration-driven surface and the ad-hoc
+  pinned-provider-key path. The ad-hoc branches of ``chat()`` / ``complete()`` /
+  ``chatWithTools()`` / ``streamChat()`` (an explicit provider, no DB
+  configuration — the ADR-034 escape hatch) screen the prompt as well, so every
+  message-carrying send path is covered.
 - Input guardrails support ALLOW / REDACT / DENY / REQUIRE_APPROVAL. RETRY is
   ignored on the input side.

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -22,8 +22,10 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
@@ -40,6 +42,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\Guardrail\SecretRedactionInputGuardrail;
 use Netresearch\NrLlm\Service\LlmServiceManager;
@@ -772,6 +775,151 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         self::assertIsString($received);
         self::assertStringContainsString('sk-***', $received);
         self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $received);
+    }
+
+    #[Test]
+    public function chatScreensInputOnTheAdHocProviderKeyPath(): void
+    {
+        $provider = new TestableProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        $manager->chat([['role' => 'user', 'content' => 'key sk-abcdef0123456789ABCDEF end']], new ChatOptions(provider: 'openai'));
+
+        $joined = $this->joinContents($provider->capturedMessages);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function completeScreensInputOnTheAdHocProviderKeyPath(): void
+    {
+        $provider = new TestableProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        $manager->complete('key sk-abcdef0123456789ABCDEF end', new ChatOptions(provider: 'openai'));
+
+        $joined = $this->joinContents($provider->capturedMessages);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function chatWithToolsScreensInputOnTheAdHocProviderKeyPath(): void
+    {
+        $provider = new TestableToolProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        $manager->chatWithTools(
+            [['role' => 'user', 'content' => 'key sk-abcdef0123456789ABCDEF end']],
+            [],
+            new ToolOptions(provider: 'openai-tools'),
+        );
+
+        $joined = $this->joinContents($provider->capturedMessages);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function streamChatScreensInputOnTheAdHocProviderKeyPath(): void
+    {
+        $provider = new StubStreamingProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        iterator_to_array($manager->streamChat(
+            [['role' => 'user', 'content' => 'key sk-abcdef0123456789ABCDEF end']],
+            new ChatOptions(provider: 'mock'),
+        ));
+
+        $joined = $this->joinContents($provider->capturedMessages);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function chatBlocksAndDoesNotCallTheProviderWhenAnAdHocInputGuardrailDenies(): void
+    {
+        $provider = new TestableProvider();
+        $manager  = $this->managerWithInputScreener($provider, $this->denyingInputScreener('blocked prompt'));
+
+        try {
+            $manager->chat([['role' => 'user', 'content' => 'anything']], new ChatOptions(provider: 'openai'));
+            self::fail('Expected GuardrailViolationException.');
+        } catch (GuardrailViolationException $e) {
+            self::assertSame('blocked prompt', $e->getMessage());
+        }
+
+        self::assertSame([], $provider->capturedMessages, 'A denied prompt must never reach the provider.');
+    }
+
+    #[Test]
+    public function streamChatThrowsAtCallTimeWhenAnAdHocInputGuardrailDenies(): void
+    {
+        $provider = new StubStreamingProvider();
+        $manager  = $this->managerWithInputScreener($provider, $this->denyingInputScreener('blocked stream'));
+
+        // The DENY must throw synchronously on the streamChat() call — screenInput
+        // runs before the $open closure, so an over-policy prompt never opens a
+        // stream. (No iterator_to_array: the throw is at call time, not on drain.)
+        $this->expectException(GuardrailViolationException::class);
+        $manager->streamChat([['role' => 'user', 'content' => 'anything']], new ChatOptions(provider: 'mock'));
+    }
+
+    #[Test]
+    public function chatLeavesACleanAdHocPromptUnchanged(): void
+    {
+        $provider = new TestableProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        $manager->chat([['role' => 'user', 'content' => 'a perfectly normal question']], new ChatOptions(provider: 'openai'));
+
+        self::assertStringContainsString('a perfectly normal question', $this->joinContents($provider->capturedMessages));
+    }
+
+    private function managerWithInputScreener(TestableProvider $provider, ?InputGuardrailScreener $screener = null): LlmServiceManager
+    {
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            null,
+            $screener ?? new InputGuardrailScreener([new SecretRedactionInputGuardrail()]),
+        );
+        $manager->registerProvider($provider);
+
+        return $manager;
+    }
+
+    private function denyingInputScreener(string $reason): InputGuardrailScreener
+    {
+        return new InputGuardrailScreener([
+            new class ($reason) implements InputGuardrailInterface {
+                public function __construct(private readonly string $reason) {}
+
+                public function checkInput(string $text): GuardrailResult
+                {
+                    return GuardrailResult::deny($this->reason);
+                }
+            },
+        ]);
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function joinContents(array $messages): string
+    {
+        return implode("\n", array_map(
+            static fn(ChatMessage|array $m): string => $m instanceof ChatMessage
+                ? $m->content
+                : (is_string($m['content'] ?? null) ? $m['content'] : ''),
+            $messages,
+        ));
     }
 
     /**
@@ -2424,6 +2572,13 @@ class TestableProvider extends AbstractProvider
     private array $lastOptions = [];
     /** @var array<string, mixed> */
     private array $lastConfiguration = [];
+    /**
+     * Messages the provider last received (for asserting input screening on the
+     * ad-hoc provider-key path, ADR-087).
+     *
+     * @var list<ChatMessage|array<string, mixed>>
+     */
+    public array $capturedMessages = [];
 
     public function __construct(
         private readonly string $id = 'openai',
@@ -2456,7 +2611,8 @@ class TestableProvider extends AbstractProvider
 
     public function chatCompletion(array $messages, array $options = []): CompletionResponse
     {
-        $this->lastOptions = $options;
+        $this->lastOptions      = $options;
+        $this->capturedMessages = $messages;
         return $this->nextResponse ?? new CompletionResponse(
             content: 'Default response',
             model: 'gpt-4o',


### PR DESCRIPTION
Completes the input-guardrail coverage from ADR-087 (#448, merged). That PR screened the configuration-driven entry points but left the ad-hoc pinned-provider-key branches unscreened — an asymmetry with the output guardrails, which run in the pipeline and so already cover ad-hoc calls.

## Change
The ad-hoc branches of `chat()`, `complete()`, `chatWithTools()`, `streamChat()` (an explicit provider, no DB configuration — the ADR-034 escape hatch) now screen the prompt too: `screenInput()` on the message paths, `screenInputPrompt()` on the raw-string `complete()`. Every message-carrying send path now redacts a secret and blocks a denied prompt before it reaches the provider. For streaming, screening runs before the `$open` closure captures the messages, so a DENY throws at call time.

No double-screening: the config branches delegate to the `*Configuration` methods (which already screen); the ad-hoc branches screen in their own path only.

## Tests
- Each ad-hoc path (`chat`/`complete`/`chatWithTools`/`streamChat`) masks a secret before the registered provider receives it (`TestableProvider` now records the messages it was given).
- A DENY input guardrail blocks `chat()` (provider never called) and makes `streamChat()` throw **at call time** (not on drain) — guarding the eager-throw placement.
- A clean prompt reaches the provider unchanged.

Local gates green: cgl, phpstan L10, unit (5225), rector -n, fuzzy. Reviewed via an adversarial 3-dimension pass (correctness/security, boundary-completeness, test-adequacy) — the DENY + clean-prompt tests were added in response to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)