### PR TITLE
feat(guardrail): live streaming redaction with a holdback buffer (ADR-088)

### DIFF
--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -23,7 +23,7 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
  * something — otherwise ALLOW (a pass-through), so a normal response is
  * untouched. The prompt-side counterpart is {@see SecretRedactionInputGuardrail}.
  */
-final readonly class SecretRedactionGuardrail implements GuardrailInterface
+final readonly class SecretRedactionGuardrail implements GuardrailInterface, StreamRedactableInterface
 {
     use RedactsSecretsTrait;
 

--- a/Classes/Service/Guardrail/StreamRedactableInterface.php
+++ b/Classes/Service/Guardrail/StreamRedactableInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+/**
+ * Marker for a {@see GuardrailInterface} whose REDACT verdict should also be
+ * applied to the LIVE stream (ADR-088).
+ *
+ * Only a guardrail that actually redacts (returns REDACT) benefits from the
+ * streaming holdback buffer in
+ * {@see \Netresearch\NrLlm\Service\Streaming\StreamingDispatcher}: a policy-only
+ * guardrail (DENY / REQUIRE_APPROVAL, e.g. the provider content filter) cannot
+ * retract a sent stream, so it must NOT pull the dispatcher onto the buffered,
+ * holdback path — that would cost memory and latency for no masking. Such a
+ * guardrail is still run by the end-of-stream audit; it simply does not opt into
+ * live redaction by implementing this marker.
+ */
+interface StreamRedactableInterface {}

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -23,12 +23,14 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\StreamRedactableInterface;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Throwable;
+use Traversable;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
@@ -102,6 +104,29 @@ final readonly class StreamingDispatcher
     private const MAX_GUARDRAIL_BUFFER_BYTES = 50000;
 
     /**
+     * Trailing bytes of the redacted output held back from the live stream, so a
+     * match still in progress near the end is never emitted before it completes
+     * (ADR-088). Redaction is recomputed on the raw buffer each chunk, so a
+     * complete secret always collapses to its marker; the only unstable region is
+     * a partial anchor / sub-minimum match at the very tail, whose reach-back is
+     * an anchor plus the pattern minimum (``sk-`` + 15, ``Bearer `` + 7, a
+     * credential URL-param name + 1) — well under this window. A credential whose
+     * anchor/param-name alone exceeds 128 bytes and straddles the final boundary
+     * can still partially leak: a documented limit of a lazy stream.
+     */
+    private const HOLDBACK_BYTES = 128;
+
+    /** @var list<GuardrailInterface> */
+    private array $guardrails;
+
+    /**
+     * The subset of guardrails that opt into live-stream redaction (ADR-088).
+     *
+     * @var list<GuardrailInterface&StreamRedactableInterface>
+     */
+    private array $streamRedactors;
+
+    /**
      * @param iterable<GuardrailInterface> $guardrails
      */
     public function __construct(
@@ -113,8 +138,17 @@ final readonly class StreamingDispatcher
         private Context $context,
         private ExtensionConfiguration $extensionConfiguration,
         #[AutowireIterator(GuardrailInterface::TAG_NAME)]
-        private iterable $guardrails = [],
-    ) {}
+        iterable $guardrails = [],
+    ) {
+        // Materialise once: the full set is walked for the end-of-stream audit;
+        // only the redaction-capable subset drives the live holdback path, so a
+        // policy-only (DENY) guardrail adds no streaming buffer or latency.
+        $this->guardrails      = array_values($guardrails instanceof Traversable ? iterator_to_array($guardrails) : $guardrails);
+        $this->streamRedactors = array_values(array_filter(
+            $this->guardrails,
+            static fn(GuardrailInterface $g): bool => $g instanceof StreamRedactableInterface,
+        ));
+    }
 
     /**
      * Enter the streaming lifecycle.
@@ -156,6 +190,10 @@ final readonly class StreamingDispatcher
         $firstTokenNs    = null;
         $completionBytes = 0;
         $completion      = '';
+        $raw             = '';
+        $emitted         = 0;
+        $redacts         = $this->streamRedactors !== [];
+        $overflow        = false;
         $served          = $configuration;
         $success         = false;
         $errorClass      = '';
@@ -168,16 +206,64 @@ final readonly class StreamingDispatcher
                     $firstTokenNs = hrtime(true);
                 }
                 $chunk = $inner->current();
-                // Count bytes as they pass; token estimation and logging only need
-                // the length. A bounded leading window is also buffered for the
-                // end-of-stream guardrail audit (ADR-086) — never the whole
-                // response, which would defeat streaming's memory benefit.
+                // Usage/telemetry count the RAW provider output. A bounded leading
+                // window is buffered raw for the end-of-stream audit (ADR-086).
                 $completionBytes += \strlen($chunk);
                 if (\strlen($completion) < self::MAX_GUARDRAIL_BUFFER_BYTES) {
                     $completion .= $chunk;
                 }
-                yield $chunk;
+
+                if (!$redacts || $overflow) {
+                    // No redaction-capable guardrail, or the redaction buffer has
+                    // hit its cap: pass through with no holdback / no added latency.
+                    yield $chunk;
+                    $inner->next();
+                    continue;
+                }
+
+                // Live redaction (ADR-088). Redact the RAW accumulated text FRESH
+                // each chunk — never re-processing an earlier redaction marker,
+                // which would orphan the tail of a secret whose recognizable head
+                // was already masked (``sk-***`` + continuation no longer matches).
+                // Emit only the redacted prefix that is stable: everything but a
+                // holdback tail large enough to cover any match still in progress
+                // near the end, so a secret is only ever emitted once masked in
+                // full — including one split across chunk boundaries.
+                $raw .= $chunk;
+
+                if (\strlen($raw) > self::MAX_GUARDRAIL_BUFFER_BYTES) {
+                    // Bound memory + the per-chunk rescan on a pathologically long
+                    // stream: flush what we have and pass the rest through raw.
+                    // Past this cap content is neither masked NOR recorded — the
+                    // audit buffer ($completion) caps at the same size — so a
+                    // secret beyond ~50 KB into a single completion can leak; a
+                    // documented limit for a runaway stream.
+                    $full = $this->redactStream($raw);
+                    if (\strlen($full) > $emitted) {
+                        yield \substr($full, $emitted);
+                    }
+                    $raw      = '';
+                    $overflow = true;
+                    $inner->next();
+                    continue;
+                }
+
+                $full   = $this->redactStream($raw);
+                $stable = $this->utf8SafeLength($full, \strlen($full) - self::HOLDBACK_BYTES);
+                if ($stable > $emitted) {
+                    yield \substr($full, $emitted, $stable - $emitted);
+                    $emitted = $stable;
+                }
                 $inner->next();
+            }
+
+            // Flush the redacted remainder once the stream is complete (unless the
+            // overflow path already drained and switched to passthrough).
+            if ($redacts && !$overflow) {
+                $full = $this->redactStream($raw);
+                if (\strlen($full) > $emitted) {
+                    yield \substr($full, $emitted);
+                }
             }
 
             $success = true;
@@ -421,7 +507,10 @@ final readonly class StreamingDispatcher
                 }
 
                 $this->logger->warning(
-                    'Streamed LLM response tripped a guardrail after delivery (audit only — chunks were already sent)',
+                    // REDACT was already applied to the live stream (ADR-088); this
+                    // records that a policy matched, and is the only signal for a
+                    // DENY / REQUIRE_APPROVAL, which cannot retract a sent stream.
+                    'Streamed LLM response matched a guardrail (REDACT masked live where possible; a stream cannot be retracted)',
                     $this->logContext($context, [
                         'guardrail' => $guardrail::class,
                         'verdict'   => $verdict->verdict->value,
@@ -439,6 +528,59 @@ final readonly class StreamingDispatcher
                 // Never let guardrail auditing break a delivered stream.
             }
         }
+    }
+
+    /**
+     * Apply the output guardrails' REDACT verdicts to a text fragment (ADR-088).
+     *
+     * Always called on the RAW accumulated completion (never on already-redacted
+     * output), so a secret is re-matched in full on every chunk regardless of how
+     * it was split — this is what lets {@see self::drain()} mask a boundary-split
+     * secret without an earlier marker orphaning its tail. Only REDACT is applied;
+     * DENY / REQUIRE_APPROVAL cannot retract a sent stream and are left to the
+     * end-of-stream audit ({@see self::screenStreamedOutput()}). Fail-soft: a
+     * guardrail that throws leaves the fragment unchanged rather than breaking the
+     * stream.
+     */
+    private function redactStream(string $text): string
+    {
+        foreach ($this->streamRedactors as $guardrail) {
+            try {
+                $verdict = $guardrail->checkOutput(new CompletionResponse($text, '', UsageStatistics::fromTokens(0, 0)));
+            } catch (Throwable) {
+                continue;
+            }
+
+            if ($verdict->verdict === GuardrailVerdict::REDACT && $verdict->redactedContent !== null) {
+                $text = $verdict->redactedContent;
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Back off a byte length so it never lands inside a multibyte UTF-8 sequence
+     * (ADR-088) — the redaction path re-chunks the stream, so without this a
+     * codepoint could be split across two yielded deltas and a per-delta SSE
+     * consumer would decode mojibake on that boundary. Continuation bytes are
+     * ``10xxxxxx`` (0x80–0xBF); walk back off any run of them. The held-back
+     * remainder carries the rest of the codepoint and is emitted next.
+     */
+    private function utf8SafeLength(string $text, int $length): int
+    {
+        if ($length <= 0) {
+            return 0;
+        }
+        if ($length >= \strlen($text)) {
+            return \strlen($text);
+        }
+
+        while ($length > 0 && (\ord($text[$length]) & 0xC0) === 0x80) {
+            --$length;
+        }
+
+        return $length;
     }
 
     private function recordUsage(

--- a/Documentation/Adr/Adr088StreamingRedaction.rst
+++ b/Documentation/Adr/Adr088StreamingRedaction.rst
@@ -1,0 +1,86 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-088:
+
+============================================================================
+ADR-088: Live streaming redaction with a holdback buffer
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-088-context:
+
+Context
+=======
+
+ADR-086 added an end-of-stream guardrail *audit*: once a stream finishes,
+``StreamingDispatcher`` screens the assembled completion and records any
+non-ALLOW verdict. It is audit-only — the chunks have already been yielded to
+the caller, so a secret a model streamed was recorded but not masked. The gap
+left open was live redaction: masking a secret *before* the byte is sent.
+
+The hard part is chunk boundaries. A secret can be split across two chunks
+(``sk-abcdef012`` + ``3456789…``), so redacting each chunk in isolation misses
+it. Catching it requires not emitting a byte until enough following bytes have
+arrived to know it is not part of an in-progress secret.
+
+.. _adr-088-decision:
+
+Decision
+========
+
+**Redact the raw buffer fresh, emit its stable prefix.** ``drain()`` accumulates
+the raw completion and, each chunk, redacts the whole raw buffer
+(``redactStream()`` applies the output guardrails' REDACT verdicts) and emits
+only the redacted prefix beyond the last ``HOLDBACK_BYTES`` (128); the remainder
+is flushed at end-of-stream. Redacting the RAW text every time — never
+re-processing an earlier redaction marker — is essential: a marker such as
+``sk-***`` breaks the pattern's own character class, so re-redacting
+``sk-*** + continuation`` would leave the continuation of a boundary-split key
+unmatched and leak it. Because the raw buffer re-matches a secret in full on
+every chunk, a complete secret always collapses to its marker; the holdback then
+withholds only a match still in progress at the tail (whose reach-back is an
+anchor plus the pattern minimum, far under 128), so no unredacted secret byte is
+emitted, including one split across chunk boundaries.
+
+- **Only REDACT is actionable live.** DENY / REQUIRE_APPROVAL cannot retract a
+  sent stream; they remain the job of the end-of-stream audit (ADR-086), which
+  still runs and records them. The audit's log wording now reflects that REDACT
+  was masked live.
+- **Only redaction-capable guardrails trigger the buffer.** A guardrail opts into
+  live redaction by implementing the ``StreamRedactableInterface`` marker
+  (``SecretRedactionGuardrail`` does). When none is registered — or only
+  policy-only DENY guardrails are — the loop passes chunks straight through with
+  no buffer and no latency.
+- **Bounded.** The raw buffer is capped at ``MAX_GUARDRAIL_BUFFER_BYTES`` (50 KB,
+  the same cap the audit buffer uses); past it the stream is flushed and passed
+  through raw, so memory and the per-chunk rescan stay bounded on a
+  pathologically long stream.
+- **Multibyte-safe.** The emit boundary is backed off a UTF-8 continuation run so
+  a codepoint is never split across two yielded deltas.
+- **Usage/telemetry count the RAW provider output**, unchanged — the redacted
+  emitted length is not the billable token count.
+
+.. _adr-088-consequences:
+
+Consequences
+============
+
+- Streamed secrets in the common shapes (``sk-…`` keys, ``Bearer …`` tokens,
+  credential-bearing URL params) are masked before delivery, closing the
+  streaming blind spot the ADR-086 audit only recorded.
+- Cost: the last ``HOLDBACK_BYTES`` of every stream that has a redacting
+  guardrail arrive at end-of-stream rather than incrementally — a small,
+  bounded latency on the stream tail. Accepted as the price of live masking.
+- Limits: a credential whose anchor / URL-param name alone exceeds the holdback
+  window and straddles the final boundary can still partially leak. Past the
+  50 KB cap a secret is neither masked nor recorded — the audit buffer caps at
+  the same size — so it can leak silently on a runaway (>50 KB) single
+  completion; accepted as the bound on memory and rescan cost. Correctness relies
+  on the redactor collapsing a complete secret to a marker outside its own
+  character class (so a partial anchor at the tail is the only unstable region) —
+  true for the shipped ``SecretRedactionGuardrail``.
+- DENY on a stream stays unenforceable — a hard block needs the non-streaming
+  path.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -385,3 +385,4 @@ Tools
    Adr085GuardrailPipeline
    Adr086GuardrailEnforcementGaps
    Adr087InputGuardrails
+   Adr088StreamingRedaction

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
@@ -88,12 +89,12 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->staticStream(['here is ', 'sk-secret-value', ' — oops']),
         ));
 
-        // The chunks are delivered unchanged: the audit runs AFTER delivery and
-        // cannot retract or redact what was already streamed.
+        // A DENY guardrail is not StreamRedactable, so it never pulls the stream
+        // onto the buffered path: chunks pass through 1:1, unchanged.
         self::assertSame(['here is ', 'sk-secret-value', ' — oops'], $chunks);
 
         // The verdict is recorded for audit so streamed output is not a blind spot.
-        $record = $this->logger->firstMatching('warning', 'tripped a guardrail');
+        $record = $this->logger->firstMatching('warning', 'matched a guardrail');
         self::assertNotNull($record);
         self::assertSame($guardrail::class, $record['context']['guardrail'] ?? null);
         self::assertSame('deny', $record['context']['verdict'] ?? null);
@@ -117,7 +118,258 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->staticStream(['a perfectly ', 'normal answer']),
         ));
 
-        self::assertNull($this->logger->firstMatching('warning', 'tripped a guardrail'));
+        self::assertNull($this->logger->firstMatching('warning', 'matched a guardrail'));
+    }
+
+    #[Test]
+    public function redactsASecretSpanningAChunkBoundaryBeforeEmittingIt(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // The key 'sk-abcdef0123456789ABCDEF' is split across the two chunks, then
+        // followed by > HOLDBACK bytes of filler so the (now redacted) secret
+        // exits the holdback window and is actually emitted, not just flushed.
+        $filler = str_repeat('x', 200);
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['start sk-abcdef012', '3456789ABCDEF end ' . $filler]),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('sk-***', $emitted);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $emitted);
+        // Non-secret text is preserved verbatim.
+        self::assertStringContainsString('start ', $emitted);
+        self::assertStringContainsString(' end ', $emitted);
+    }
+
+    #[Test]
+    public function redactsASecretAtTheVeryEndOfTheStreamOnFlush(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // The secret straddles the last boundary and completes only at end — the
+        // holdback keeps it unsent until the flush redacts it.
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['final answer sk-', 'abcdef0123456789ABCDEF']),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('sk-***', $emitted);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $emitted);
+        self::assertStringContainsString('final answer ', $emitted);
+    }
+
+    #[Test]
+    public function leavesACleanStreamContentUnchangedThroughTheHoldback(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        $tail   = str_repeat('y', 200);
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['a perfectly ', 'normal answer ', $tail]),
+        ));
+
+        self::assertSame('a perfectly normal answer ' . $tail, implode('', $chunks));
+    }
+
+    #[Test]
+    public function flushesAShortStreamThroughTheHoldback(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // Whole stream is shorter than the holdback: nothing emits mid-stream, the
+        // flush delivers it all at end — concatenation is intact.
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['hi ', 'there']),
+        ));
+
+        self::assertSame('hi there', implode('', $chunks));
+    }
+
+    #[Test]
+    public function masksASecretWhoseTailArrivesAfterItsHeadWasFirstMatched(): void
+    {
+        // The 16-char body prefix arrives in chunk 1 (enough for the pattern to
+        // match); the rest of the SAME key arrives in chunk 2. Re-redacting the
+        // marker would orphan the tail ('sk-***' + continuation no longer
+        // matches); redacting the raw buffer fresh re-masks the whole key.
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['key sk-0123456789abcdef', 'ghijklmnopqrstuvwxyz done']),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('sk-***', $emitted);
+        self::assertStringNotContainsString('sk-0123456789abcdef', $emitted);
+        self::assertStringNotContainsString('ghijklmnopqrstuvwxyz', $emitted);
+        self::assertStringContainsString('key ', $emitted);
+        self::assertStringContainsString(' done', $emitted);
+    }
+
+    #[Test]
+    public function masksASecretStreamedInSmallDeltas(): void
+    {
+        // A 51-char key streamed 4 bytes at a time — the pattern matches at 16
+        // body chars, long before the key completes.
+        $key    = 'sk-' . str_repeat('A', 48);
+        $deltas = str_split('here ' . $key . ' there ' . str_repeat('z', 200), 4);
+
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+        $chunks     = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream($deltas),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('sk-***', $emitted);
+        self::assertStringNotContainsString($key, $emitted);
+        self::assertStringNotContainsString('AAAA', $emitted, 'no run of key characters may leak');
+    }
+
+    #[Test]
+    public function masksABearerTokenSplitAcrossChunks(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['auth Bearer abc123', 'def456ghi789 rest ' . str_repeat('q', 200)]),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('Bearer ***', $emitted);
+        self::assertStringNotContainsString('abc123def456ghi789', $emitted);
+        self::assertStringNotContainsString('def456ghi789', $emitted);
+    }
+
+    #[Test]
+    public function emitsContentMidStreamNotOnlyAtTheFlush(): void
+    {
+        // A long clean stream must deliver incrementally (more than one yielded
+        // chunk), proving the mid-stream emit path runs, not just the end flush.
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+        $long       = str_repeat('word ', 200);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(str_split($long, 50)),
+        ));
+
+        self::assertGreaterThan(1, count($chunks), 'content must be emitted incrementally, not only at flush');
+        self::assertSame($long, implode('', $chunks));
+    }
+
+    #[Test]
+    public function usageCountsRawProviderBytesEvenWhenRedactionShortensTheStream(): void
+    {
+        $model      = $this->model(pricing: false);
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // Raw completion is 92 bytes ('sk-' + 48 + ' ' + 40); the redacted output
+        // ('sk-*** ' + 40) is far shorter. Usage must reflect the RAW length.
+        iterator_to_array($dispatcher->stream(
+            $this->context([StreamingDispatcher::METADATA_PROMPT_CHARS => 0]),
+            $this->configuration('primary', providerType: 'openai', modelId: 'gpt-4o', model: $model, uid: 9),
+            $this->staticStream(['sk-' . str_repeat('A', 48) . ' ', str_repeat('z', 40)]),
+        ));
+
+        self::assertCount(1, $this->usage->calls);
+        // ceil(92 / 4) = 23 raw-byte tokens, not the ~12 of the redacted output.
+        self::assertSame(23, $this->usage->calls[0]['metrics']['completionTokens']);
+    }
+
+    #[Test]
+    public function masksAUrlCredentialSplitAcrossChunks(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['see https://api.example.com/x?api_key=SUPER', 'SECRETvalue123 done ' . str_repeat('q', 200)]),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringNotContainsString('SUPERSECRETvalue123', $emitted);
+        self::assertStringContainsString('see https://', $emitted);
+    }
+
+    #[Test]
+    public function yieldsValidUtf8ChunksForMultibyteContentThroughTheHoldback(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // A run of 3-byte chars longer than the holdback, fed in 7-byte deltas
+        // (misaligned to the 3-byte boundary), so the emit boundary lands inside
+        // multibyte sequences unless backed off.
+        $text   = str_repeat('—', 200);
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(str_split($text, 7)),
+        ));
+
+        foreach ($chunks as $chunk) {
+            self::assertTrue(mb_check_encoding($chunk, 'UTF-8'), 'each yielded chunk must be valid UTF-8');
+        }
+        self::assertSame($text, implode('', $chunks));
+    }
+
+    #[Test]
+    public function aPolicyOnlyGuardrailDoesNotTriggerTheHoldback(): void
+    {
+        // A DENY guardrail is NOT StreamRedactable, so it must not pull the stream
+        // onto the buffered path — chunks pass through 1:1, no re-chunking.
+        $guardrail = new class implements GuardrailInterface {
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::deny('policy');
+            }
+        };
+        $dispatcher = $this->dispatcher(guardrails: [$guardrail]);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['one ', 'two ', 'three']),
+        ));
+
+        self::assertSame(['one ', 'two ', 'three'], $chunks);
+    }
+
+    #[Test]
+    public function stopsRedactingPastTheBufferCapAndPassesTheTailThrough(): void
+    {
+        $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
+
+        // A complete key early in the stream is masked; > 50000 bytes of filler
+        // push past MAX_GUARDRAIL_BUFFER_BYTES, after which content passes through
+        // raw (the documented redaction-cap limit).
+        $preSecret = 'sk-' . str_repeat('B', 20);
+        $chunks    = iterator_to_array($dispatcher->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $this->staticStream(['start ' . $preSecret . ' ', str_repeat('a', 60000), ' TAIL-AFTER-CAP']),
+        ));
+
+        $emitted = implode('', $chunks);
+        self::assertStringContainsString('sk-***', $emitted);
+        self::assertStringNotContainsString($preSecret, $emitted);
+        self::assertStringContainsString('TAIL-AFTER-CAP', $emitted);
     }
 
     #[Test]


### PR DESCRIPTION
Closes the second "smaller gap": live redaction of streamed output. ADR-086 (#447, merged) added an end-of-stream *audit* — a streamed secret was recorded but already sent. This masks it *before* delivery.

## How
`StreamingDispatcher.drain()` accumulates the raw completion and, each chunk, redacts the whole **raw** buffer (`redactStream()` applies the output guardrails' REDACT verdicts) and emits only the redacted prefix beyond the last `HOLDBACK_BYTES` (128); the remainder is flushed at end-of-stream.

Redacting the **raw** text every time — never re-processing an earlier marker — is what makes a boundary-split secret safe: a marker like `sk-***` breaks the pattern's character class, so re-redacting `sk-*** + continuation` would orphan and leak the tail of a key split across chunks. Redacting raw re-matches the whole secret each chunk; the holdback withholds only a match still in progress at the tail.

- **Only redaction-capable guardrails trigger the buffer** — a guardrail opts in via the `StreamRedactableInterface` marker (`SecretRedactionGuardrail` does). A policy-only DENY guardrail adds no buffer/latency and stays on passthrough.
- **Bounded** — the raw buffer caps at 50 KB (as the audit buffer does); past it the stream is flushed and passed through raw.
- **Multibyte-safe** — the emit boundary backs off a UTF-8 continuation run so a codepoint is never split across yielded deltas.
- **Usage/telemetry count the RAW provider output**, unchanged.
- Only REDACT is live; DENY/REQUIRE_APPROVAL still cannot retract a stream and remain the end-of-stream audit's job.

## Limits (documented in the ADR)
- A credential whose anchor/param-name exceeds the holdback and straddles the final boundary can partially leak.
- Past the 50 KB cap a secret is neither masked nor recorded (a runaway-stream bound).

## Review
Built and hardened through **three adversarial review rounds**, which caught (and this PR fixes) issues all-green gates would have shipped:
1. **secret leak** — the first holdback re-processed the `sk-***` marker, leaking a key's tail when split across chunks (tests only completed keys in one chunk).
2. **DoS / over-broad activation** — an uncapped per-chunk rescan and buffering for any guardrail, even DENY-only.
3. **doc accuracy + coverage** — the audit-covers-past-cap claim was false; the overflow branch was untested.

## Tests
Boundary-split secret (key tail in a later chunk than its matched head), 4-byte-delta streaming, split Bearer token, split URL credential, multibyte per-chunk validity, raw-byte usage counting, DENY-only passthrough, >50 KB overflow. All 5 gates green (cgl, phpstan L10, unit 5231, rector -n, fuzzy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)