### PR TITLE
fix(agent): harden approval suspend/resume — atomic claim, budget, counters, gate (ADR-084)

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -302,6 +302,13 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
         $state = SuspendedRunState::fromArray($decoded);
 
+        // Atomically claim the run before executing its pending (approval-gated,
+        // possibly destructive) tool calls, so two concurrent Approve requests
+        // — an admin double-click, a client retry — cannot both run them (ADR-084).
+        if ($this->agentRunPersister !== null && !$this->agentRunPersister->claimResume($run)) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.alreadyResuming', 'This run is already being processed.')], 409);
+        }
+
         // Continue the SAME run: rebuild the handle so events keep ascending.
         // The allow-list and options are restored from the suspended state inside
         // resume() — the run keeps its original constraints (ADR-084).
@@ -315,7 +322,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         );
 
         try {
-            $result = $this->toolLoopService->resume($state, $approved, $config, null, $trace);
+            $result = $this->toolLoopService->resume($state, $approved, $config, null, $trace, $this->currentBackendUserUid());
         } catch (ToolApprovalRequiredException $approval) {
             if ($handle !== null) {
                 $this->agentRunPersister?->suspend($handle, $approval->state);

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -165,18 +165,19 @@ class ToolOptions extends ChatOptions
     /**
      * Rebuild options from a {@see self::toArray()} snapshot (ADR-084 resume).
      *
-     * The budget fields (beUserUid, plannedCost) are intentionally not part of
-     * toArray() and are therefore not restored — a resumed run is budget-checked
-     * for the acting user, not the original one.
+     * The budget fields are not part of toArray(): $beUserUid is supplied by the
+     * caller (the acting user, so the resumed continuation is budget-checked for
+     * whoever approved it) and plannedCost is not restored.
      *
      * @param array<string, mixed> $data
      */
-    public static function fromArray(array $data): static
+    public static function fromArray(array $data, ?int $beUserUid = null): static
     {
         $stop          = $data['stop_sequences'] ?? null;
         $stopSequences = is_array($stop) ? array_values(array_filter($stop, is_string(...))) : null;
 
         return new static(
+            beUserUid: $beUserUid,
             temperature: is_numeric($data['temperature'] ?? null) ? (float)$data['temperature'] : null,
             maxTokens: is_numeric($data['max_tokens'] ?? null) ? (int)$data['max_tokens'] : null,
             topP: is_numeric($data['top_p'] ?? null) ? (float)$data['top_p'] : null,

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -151,6 +151,22 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * Atomically claim a suspended run before resuming it (ADR-084). Fail-closed:
+     * returns false — refusing the resume — if the claim is lost to a concurrent
+     * approval or the store errors, so the gated tool is never double-executed.
+     */
+    public function claimResume(AgentRun $run): bool
+    {
+        try {
+            return $this->repository->claimForResume($run->uid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be claimed for resume', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
      * Rebuild a live handle for an existing (suspended) run so a resume continues
      * its event stream at the right sequence.
      */

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -124,6 +124,30 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         );
     }
 
+    /**
+     * Atomically claim a suspended run for resume (ADR-084): move it off
+     * WAITING_FOR_APPROVAL to RUNNING only if it is still awaiting approval, in a
+     * single conditional UPDATE. Returns true for the caller that won the claim,
+     * false if another resume already claimed it — so two concurrent Approve
+     * requests cannot both execute the gated (destructive) tool.
+     */
+    public function claimForResume(int $runUid): bool
+    {
+        $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'status' => AgentRunStatus::RUNNING->value,
+                'tstamp' => time(),
+            ],
+            [
+                'uid'    => $runUid,
+                'status' => AgentRunStatus::WAITING_FOR_APPROVAL->value,
+            ],
+        );
+
+        return $affected === 1;
+    }
+
     public function findByUuid(string $uuid): ?AgentRun
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -53,6 +53,13 @@ interface AgentRunRepositoryInterface
      */
     public function suspendRun(int $runUid, string $stateJson): void;
 
+    /**
+     * Atomically claim a WAITING_FOR_APPROVAL run for resume (move it to RUNNING);
+     * true for the winner, false if already claimed. Prevents two concurrent
+     * approvals from double-executing the gated tool (ADR-084).
+     */
+    public function claimForResume(int $runUid): bool;
+
     public function findByUuid(string $uuid): ?AgentRun;
 
     /**

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -97,6 +97,12 @@ final readonly class ToolLoopService
         ?RunTrace $runTrace = null,
         ?RunAugmentation $augmentation = null,
         bool $skipAssembly = false,
+        // Counters carried over from a suspended run (ADR-084) so a run that
+        // suspends more than once accumulates its totals instead of each segment
+        // starting from zero; a re-suspend then persists the running total.
+        int $seedIterations = 0,
+        int $seedPromptTokens = 0,
+        int $seedCompletionTokens = 0,
     ): ToolLoopResult {
         $max = $maxIterations ?? $this->defaultMaxIterations;
 
@@ -135,12 +141,18 @@ final readonly class ToolLoopService
             $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options));
             $runTrace?->recordLlmCall(1, self::elapsedMs($t0), $resp);
 
+            // Fold in any carried-over counters (a resume whose continuation has
+            // no offered tools still ran this synthesis round on top of the
+            // pre-suspend total) — otherwise the whole run is under-reported.
             return new ToolLoopResult(
                 $resp->content,
                 [],
-                1,
+                $seedIterations + 1,
                 false,
-                UsageStatistics::fromTokens($resp->usage->promptTokens, $resp->usage->completionTokens),
+                UsageStatistics::fromTokens(
+                    $seedPromptTokens + $resp->usage->promptTokens,
+                    $seedCompletionTokens + $resp->usage->completionTokens,
+                ),
             );
         }
 
@@ -150,9 +162,9 @@ final readonly class ToolLoopService
         $allowedNames = array_map(static fn(ToolSpec $s): string => $s->name, $specs);
 
         $trace            = [];
-        $promptTokens     = 0;
-        $completionTokens = 0;
-        $iterations       = 0;
+        $promptTokens     = $seedPromptTokens;
+        $completionTokens = $seedCompletionTokens;
+        $iterations       = $seedIterations;
 
         try {
             for ($i = 0; $i < $max; $i++) {
@@ -184,7 +196,13 @@ final readonly class ToolLoopService
                 // implement the marker, so this loop is inert for them and the
                 // synchronous path below is unchanged.
                 foreach ($resp->toolCalls ?? [] as $call) {
-                    if ($this->registry->get($call->name) instanceof RequiresApprovalInterface) {
+                    // Fail-closed like invoke()/resolveOfferedNames(): only an
+                    // OFFERED approval tool suspends. A registered-but-not-offered
+                    // approval tool (a model steered by injected prose naming it)
+                    // falls through to invoke(), which refuses it — no spurious
+                    // pending-approval prompt for a tool the run never allowed.
+                    if (in_array($call->name, $allowedNames, true)
+                        && $this->registry->get($call->name) instanceof RequiresApprovalInterface) {
                         throw ToolApprovalRequiredException::fromState(new SuspendedRunState(
                             array_map(static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m, $messages),
                             array_map(static fn(ToolCall $c): array => $c->toArray(), $resp->toolCalls ?? []),
@@ -277,10 +295,14 @@ final readonly class ToolLoopService
         LlmConfiguration $configuration,
         ?int $maxIterations = null,
         ?RunTrace $runTrace = null,
+        ?int $beUserUid = null,
     ): ToolLoopResult {
         $messages     = $state->messages;
         $pendingCalls = $state->toolCalls();
-        $options      = ToolOptions::fromArray($state->options);
+        // Restore the run's options and re-inject the acting user's uid so the
+        // resumed continuation is budget-checked — the uid is intentionally not
+        // part of the persisted options (ADR-084).
+        $options = ToolOptions::fromArray($state->options, $beUserUid);
         // Re-apply the gate NOW (a tool may have been disabled or restricted while
         // the run was suspended) rather than trusting the names captured at
         // suspend time.
@@ -301,7 +323,10 @@ final readonly class ToolLoopService
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
 
-        $result = $this->runLoop(
+        // Seed the loop with the pre-suspend counters so the returned totals span
+        // the whole run — and a further suspend inside the continuation persists
+        // the running total, not just its own segment (ADR-084).
+        return $this->runLoop(
             $messages,
             $configuration,
             $state->allowedToolNames,
@@ -310,19 +335,9 @@ final readonly class ToolLoopService
             $runTrace,
             null,
             true,
-        );
-
-        // Fold the pre-suspend counters into the continued run so the totals span
-        // the whole run, not just the post-resume segment.
-        return new ToolLoopResult(
-            $result->finalContent,
-            $result->trace,
-            $state->iterations + $result->iterations,
-            $result->truncated,
-            UsageStatistics::fromTokens(
-                $state->promptTokens + $result->usage->promptTokens,
-                $state->completionTokens + $result->usage->completionTokens,
-            ),
+            $state->iterations,
+            $state->promptTokens,
+            $state->completionTokens,
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -18,8 +18,10 @@ use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
@@ -40,6 +42,7 @@ use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -654,6 +657,48 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertFalse($blocked['success']);
         self::assertSame($guardrail::class, $blocked['guardrail']);
         self::assertSame('blocked by test policy', $blocked['error']);
+    }
+
+    #[Test]
+    public function resumeActionRejectsASecondConcurrentApprovalWithoutExecutingTheTool(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // A suspended run whose atomic claim is LOST to a concurrent approval:
+        // findByUuid still returns it WAITING, but claimForResume returns false.
+        $state   = new SuspendedRunState([['role' => 'user', 'content' => 'delete it']], [], 1, 5, 2, [], []);
+        $encoded = json_encode($state->toArray());
+        self::assertIsString($encoded);
+        $run = new AgentRun(1, 'run-uuid-1', 'waiting_for_approval', 1, 'cfg', 1, 1, false, 5, 2, 7, 0.0, '', 0, 0, 0, $encoded);
+
+        $repo                = new RecordingAgentRunRepository();
+        $repo->findResult    = $run;
+        $repo->claimsGranted = 1; // the next claim loses
+        $persister           = new AgentRunPersister($repo, new NullLogger());
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg');
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        // The provider must never be touched — resume() is never reached.
+        $manager = $this->createMock(LlmServiceManagerInterface::class);
+        $manager->expects(self::never())->method('chatWithToolsForConfiguration');
+        $manager->expects(self::never())->method('chatWithConfiguration');
+
+        $registry        = new ToolRegistry([new FakeTool('safe_tool')]);
+        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
+
+        $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+            ->withParsedBody(['runUuid' => 'run-uuid-1', 'approve' => '1']);
+        $response = $controller->resumeAction($request);
+
+        self::assertSame(409, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
     }
 
     /**

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -89,6 +89,34 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function claimForResumeIsAtomicSoOnlyTheFirstConcurrentApprovalWins(): void
+    {
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+        $state = new SuspendedRunState(
+            [['role' => 'user', 'content' => 'delete it']],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            1,
+            5,
+            2,
+        );
+        $this->persister->suspend($handle, $state);
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+
+        // First claim wins (WAITING_FOR_APPROVAL -> RUNNING).
+        self::assertTrue($this->persister->claimResume($run));
+        $afterFirst = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($afterFirst);
+        self::assertSame('running', $afterFirst->status);
+
+        // A second, concurrent/duplicate approval on the same run loses — the
+        // gated (destructive) tool cannot be double-executed.
+        self::assertFalse($this->persister->claimResume($run));
+    }
+
+    #[Test]
     public function aCompletedRunPersistsItsSummaryAndOrderedEventStream(): void
     {
         $handle = $this->persister->begin(null, 5);

--- a/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
@@ -138,6 +139,19 @@ final class AgentRunPersisterTest extends TestCase
         self::assertNotNull($repository->finished);
         self::assertSame('failed', $repository->finished['status']);
         self::assertSame(RuntimeException::class, $repository->finished['errorClass']);
+    }
+
+    #[Test]
+    public function claimResumeReturnsFalseWhenTheRepositoryThrows(): void
+    {
+        $repository               = new RecordingAgentRunRepository();
+        $repository->throwOnClaim = true;
+        $persister                = new AgentRunPersister($repository);
+        $run                      = new AgentRun(1, 'uuid', 'waiting_for_approval', 0, '', 0, 0, false, 0, 0, 0, 0.0, '', 0, 0, 0, '{}');
+
+        // Fail-closed: a store error refuses the resume rather than risk a
+        // double-execute of the gated tool.
+        self::assertFalse($persister->claimResume($run));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -102,9 +102,31 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         $this->suspended = ['runUid' => $runUid, 'stateJson' => $stateJson];
     }
 
+    public bool $throwOnClaim = false;
+
+    /** Number of resume claims that were granted; false is returned after the first. */
+    public int $claimsGranted = 0;
+
+    public function claimForResume(int $runUid): bool
+    {
+        if ($this->throwOnClaim) {
+            throw new RuntimeException('claimForResume failed', 1784600400);
+        }
+        // First claim wins; a second concurrent claim on the same run loses.
+        if ($this->claimsGranted > 0) {
+            return false;
+        }
+        ++$this->claimsGranted;
+
+        return true;
+    }
+
+    /** Run returned by findByUuid() (default null = unknown). */
+    public ?AgentRun $findResult = null;
+
     public function findByUuid(string $uuid): ?AgentRun
     {
-        return null;
+        return $this->findResult;
     }
 
     public function findEvents(int $runUid): array

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -725,19 +725,108 @@ final class ToolLoopServiceTest extends TestCase
             [],
         );
 
-        $trace = new RunTrace();
-        $service->resume($state, true, new LlmConfiguration(), null, $trace);
+        $trace  = new RunTrace();
+        $result = $service->resume($state, true, new LlmConfiguration(), null, $trace);
 
         // Approved, but the tool is no longer offered → fail-closed, NOT executed.
         $toolSteps = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL));
         self::assertCount(1, $toolSteps);
         self::assertTrue($toolSteps[0]->toolIsError);
         self::assertStringContainsString('no longer permitted', $toolSteps[0]->toolResult ?? '');
+
+        // The no-offered-tools synthesis branch still folds the pre-suspend
+        // counters (1 iteration + 5/2 tokens) into the totals, not just its own
+        // single round — the whole run is not under-reported.
+        self::assertSame(2, $result->iterations);
+        self::assertGreaterThanOrEqual(5, $result->usage->promptTokens);
+        self::assertGreaterThanOrEqual(2, $result->usage->completionTokens);
     }
 
     /**
      * Drive a run to its approval suspension and return the captured state.
      */
+    #[Test]
+    public function doesNotSuspendForARegisteredApprovalToolThatIsNotOffered(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_1', 'delete_thing', [])]),
+            $this->response('handled'),
+        ]));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool(), new FakeTool('safe_tool')]));
+
+        // Only safe_tool is offered; delete_thing (an approval tool) is registered
+        // but NOT in the allow-list. A model naming it must be refused by the gate,
+        // not raise a spurious pending-approval suspension.
+        $result = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['safe_tool']);
+
+        self::assertSame('handled', $result->finalContent);
+        self::assertCount(1, $result->trace);
+        self::assertTrue($result->trace[0]->isError);
+        self::assertNotSame('DELETED', $result->trace[0]->result);
+    }
+
+    #[Test]
+    public function accumulatesCountersAcrossASecondSuspend(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        // The resumed continuation immediately calls the approval tool again.
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_2', 'delete_thing', [])]),
+        ]));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        // A state that already accumulated 3 iterations before the first suspend.
+        $assistantTurn = ['role' => 'assistant', 'content' => '', 'tool_calls' => [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]]];
+        $state         = new SuspendedRunState(
+            [$this->userTurn('go'), $assistantTurn],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            3,
+            30,
+            12,
+            ['delete_thing'],
+            [],
+        );
+
+        $second = null;
+        try {
+            $service->resume($state, true, new LlmConfiguration(), null, null, 7);
+        } catch (ToolApprovalRequiredException $e) {
+            $second = $e->state;
+        }
+
+        self::assertNotNull($second);
+        // The re-suspend carries the ACCUMULATED counters (3 prior iterations +
+        // the continuation's one round; the pre-suspend tokens preserved), not
+        // just the continuation's own segment.
+        self::assertSame(4, $second->iterations);
+        self::assertGreaterThanOrEqual(30, $second->promptTokens);
+        self::assertGreaterThanOrEqual(12, $second->completionTokens);
+    }
+
+    #[Test]
+    public function resumeInjectsTheActingUserUidForBudgetChecks(): void
+    {
+        $capturedOptions = null;
+        $mgr             = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (array $messages, array $tools, LlmConfiguration $config, ?ToolOptions $options = null) use (&$capturedOptions): CompletionResponse {
+                $capturedOptions = $options;
+
+                return $this->response('done');
+            },
+        );
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('safe_tool')]));
+        $state   = new SuspendedRunState([$this->userTurn('go')], [], 1, 5, 2, ['safe_tool'], []);
+
+        $service->resume($state, true, new LlmConfiguration(), null, null, 42);
+
+        // The resumed continuation carries the acting user's uid so BudgetMiddleware
+        // gates it (the uid is not part of the persisted options).
+        self::assertInstanceOf(ToolOptions::class, $capturedOptions);
+        self::assertSame(42, $capturedOptions->getBeUserUid());
+    }
+
     private function suspend(ToolLoopService $service): SuspendedRunState
     {
         try {


### PR DESCRIPTION
Fixes four defects an adversarial audit of the merged HITL layer (ADR-084, #442) confirmed. The audit was a find→verify multi-agent pass over the whole guardrail/HITL surface; this PR addresses its strongest cluster.

## Fixes
1. **Double-execution of the gated tool** (the sharpest — it defeats the entire point of a human-in-the-loop gate). `resumeAction` checked the `WAITING_FOR_APPROVAL` status then executed the pending (often destructive) tool calls, moving the status only afterwards — no atomic claim. Two near-simultaneous Approve requests (admin double-click, client retry) both passed the check and both ran the tool. Added `AgentRunRepository::claimForResume()` — a single conditional `UPDATE … WHERE status = WAITING_FOR_APPROVAL` — exposed as `AgentRunPersister::claimResume()` (fail-closed on error); `resumeAction` claims the run before executing and returns **409** if the claim is lost.
2. **Budget bypassed on resume.** `ToolOptions::fromArray` didn't carry the acting user's uid, so `BudgetMiddleware`'s pre-flight check was skipped for every round of the resumed continuation. `resume()` now takes the acting uid and threads it into the restored options.
3. **Counters lost across multiple suspends.** `runLoop` now seeds its iteration/token counters from the resumed state (both the main loop and the no-tools synthesis branch), so a re-suspend persists the running total and the final summary spans the whole run.
4. **Approval scan not fail-closed.** The suspend scan keyed off the global registry, so a model (or injected prose) naming a registered-but-not-offered approval tool raised a spurious pending-approval prompt. It now intersects the offered set, matching `invoke()`/`resolveOfferedNames()`.

## Tests
Atomic claim (first wins / second loses) against the real DB; `resumeAction` returns 409 on a lost claim **without invoking the provider**; fail-closed claim on a store error; not-offered approval tool refused not suspended; counters accumulate across a second suspend (and through the no-tools branch); resume injects the acting uid.

Built through **two adversarial review rounds** — the first caught a real counter regression (the empty-tools branch ignored the seeds) and the missing controller-level double-execution test; both fixed. All 6 gates green (cgl, phpstan L10, unit 5242, functional, rector -n, fuzzy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)