### PR TITLE
feat(guardrail): cover reasoning, system-prompt and vision boundaries (ADR-089)

### DIFF
--- a/Classes/Domain/ValueObject/GuardrailResult.php
+++ b/Classes/Domain/ValueObject/GuardrailResult.php
@@ -13,10 +13,13 @@ use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 
 /**
  * The outcome of a guardrail check (ADR-085): the verdict, a human-readable
- * reason, and — for a {@see GuardrailVerdict::REDACT} — the replacement content.
+ * reason, and — for a {@see GuardrailVerdict::REDACT} — the replacement content
+ * and, optionally, the replacement reasoning/`thinking` block (ADR-089): a model
+ * echoes a secret into its reasoning trace as readily as into its answer.
  *
  * Built through the named constructors so a guardrail never has to remember
- * which fields a verdict needs.
+ * which fields a verdict needs. A null `redactedThinking` on a REDACT means
+ * "leave the thinking as-is".
  */
 final readonly class GuardrailResult
 {
@@ -24,6 +27,7 @@ final readonly class GuardrailResult
         public GuardrailVerdict $verdict,
         public string $reason = '',
         public ?string $redactedContent = null,
+        public ?string $redactedThinking = null,
     ) {}
 
     public static function allow(): self
@@ -31,9 +35,9 @@ final readonly class GuardrailResult
         return new self(GuardrailVerdict::ALLOW);
     }
 
-    public static function redact(string $redactedContent, string $reason = ''): self
+    public static function redact(string $redactedContent, string $reason = '', ?string $redactedThinking = null): self
     {
-        return new self(GuardrailVerdict::REDACT, $reason, $redactedContent);
+        return new self(GuardrailVerdict::REDACT, $reason, $redactedContent, $redactedThinking);
     }
 
     public static function deny(string $reason): self

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -77,7 +77,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
                 case GuardrailVerdict::ALLOW:
                     break;
                 case GuardrailVerdict::REDACT:
-                    $response = $this->withContent($response, $result->redactedContent ?? $response->content);
+                    $response = $this->withContent($response, $result->redactedContent ?? $response->content, $result->redactedThinking);
                     break;
                 case GuardrailVerdict::DENY:
                     throw new GuardrailViolationException(
@@ -108,9 +108,10 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         return $response;
     }
 
-    private function withContent(CompletionResponse $response, string $content): CompletionResponse
+    private function withContent(CompletionResponse $response, string $content, ?string $thinking): CompletionResponse
     {
-        // CompletionResponse is final readonly — rebuild it with the new content.
+        // CompletionResponse is final readonly — rebuild it with the new content
+        // (and redacted thinking, if the guardrail supplied one; null keeps it).
         return new CompletionResponse(
             content: $content,
             model: $response->model,
@@ -119,7 +120,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             provider: $response->provider,
             toolCalls: $response->toolCalls,
             metadata: $response->metadata,
-            thinking: $response->thinking,
+            thinking: $thinking ?? $response->thinking,
         );
     }
 }

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -29,6 +29,24 @@ final readonly class SecretRedactionGuardrail implements GuardrailInterface, Str
 
     public function checkOutput(CompletionResponse $response): GuardrailResult
     {
-        return $this->redactionResult($response->content, 'response');
+        // Screen both the answer and the model's reasoning trace: a secret in
+        // context is echoed into the `thinking` block as readily as the content
+        // (ADR-089). Tool-call arguments are NOT redacted — they are functional
+        // parameters the tool consumes, and masking them would break the call.
+        $redactedContent  = $this->redactSecrets($response->content);
+        $redactedThinking = $response->thinking !== null ? $this->redactSecrets($response->thinking) : null;
+
+        $contentChanged  = $redactedContent !== $response->content;
+        $thinkingChanged = $redactedThinking !== $response->thinking;
+
+        if (!$contentChanged && !$thinkingChanged) {
+            return GuardrailResult::allow();
+        }
+
+        return GuardrailResult::redact(
+            $redactedContent,
+            'Redacted secret-shaped strings from the response.',
+            $thinkingChanged ? $redactedThinking : null,
+        );
     }
 }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -142,6 +142,23 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     }
 
     /**
+     * Apply the system prompt to the outgoing messages, then screen the final
+     * assembled list through the input guardrails (ADR-089) — so a secret in the
+     * system prompt is redacted before the provider sees it, closing the gap
+     * where the same secret was masked in a user turn but leaked in the system
+     * turn. Re-screening the already-screened user turns is an idempotent no-op.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param array<string, mixed>                   $options
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function applyAndScreenSystemPrompt(array $messages, array $options): array
+    {
+        return $this->screenInput($this->messageShaper->applySystemPrompt($messages, $options));
+    }
+
+    /**
      * Resolve the effective configuration for a configuration-driven completion.
      *
      * Delegates to {@see ConfigurationResolver}; retained on the manager
@@ -222,7 +239,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
-            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
+            fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->applyAndScreenSystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
     }
@@ -332,6 +349,21 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $content,
         ));
 
+        // Screen the text prompt(s) sent alongside the images (ADR-089): a pasted
+        // secret in the vision prompt is redacted / a denied prompt blocked before
+        // it reaches the provider, matching the chat and tool send paths.
+        $normalisedContent = array_map(
+            function (VisionContent $item): VisionContent {
+                if (!$item->isText() || $item->text === null) {
+                    return $item;
+                }
+                $screened = $this->screenInputPrompt($item->text);
+
+                return $screened === $item->text ? $item : VisionContent::text($screened);
+            },
+            $normalisedContent,
+        );
+
         return $this->runThroughPipeline(
             $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
             ProviderOperation::Vision,
@@ -389,7 +421,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->assertStreamingCapable($provider, 1581627129);
 
             return $provider->streamChatCompletion(
-                $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $optionsArray),
+                $this->applyAndScreenSystemPrompt($this->messageShaper->normalise($messages), $optionsArray),
                 $optionsArray,
             );
         };
@@ -452,7 +484,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                     );
                 }
 
-                return $provider->chatCompletionWithTools($this->messageShaper->applySystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
+                return $provider->chatCompletionWithTools($this->applyAndScreenSystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
             },
             $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
         );
@@ -508,7 +540,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 $callOptions = $this->buildCallOptions($config, $llmModel, $optionOverrides);
 
                 return $adapter->chatCompletionWithTools(
-                    $this->messageShaper->applySystemPrompt($normalisedMessages, $callOptions),
+                    $this->applyAndScreenSystemPrompt($normalisedMessages, $callOptions),
                     $normalisedTools,
                     $callOptions,
                 );
@@ -754,7 +786,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 $llmModel = $this->resolveModelForConfiguration($config);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
-                return $adapter->chatCompletion($this->messageShaper->applySystemPrompt($normalisedMessages, $options), $options);
+                return $adapter->chatCompletion($this->applyAndScreenSystemPrompt($normalisedMessages, $options), $options);
             },
             $metadata,
         );
@@ -1043,7 +1075,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->assertStreamingCapable($adapter, 1735300101);
 
             return $adapter->streamChatCompletion(
-                $this->messageShaper->applySystemPrompt($this->messageShaper->normalise($messages), $options),
+                $this->applyAndScreenSystemPrompt($this->messageShaper->normalise($messages), $options),
                 $options,
             );
         };

--- a/Documentation/Adr/Adr089GuardrailBoundaryCompleteness.rst
+++ b/Documentation/Adr/Adr089GuardrailBoundaryCompleteness.rst
@@ -1,0 +1,72 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-089:
+
+============================================================================
+ADR-089: Guardrail boundary completeness — reasoning, system prompt, vision
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-18
+:Authors: Netresearch DTT GmbH
+
+.. _adr-089-context:
+
+Context
+=======
+
+ADR-085/087 guard the model's answer (output) and the user turns (input). An
+adversarial audit of the merged layer found the secret-redaction guardrail — a
+defense against a model echoing a secret it was given, or a user pasting one —
+missed three reachable boundaries, so the same secret masked in one place leaked
+in another:
+
+- the model's **reasoning / ``thinking`` block** (surfaced in the playground
+  glass-box, ADR-040) — screened on the answer, not the reasoning;
+- the **system prompt** — added after input screening, so it reached the
+  provider unscreened on every path except ``completeForConfiguration``;
+- the **vision** text prompt — ``vision()`` forwarded its text items to the
+  provider without screening, on both sides.
+
+.. _adr-089-decision:
+
+Decision
+========
+
+**Cover every boundary the same secret can cross.**
+
+- **Reasoning.** ``GuardrailResult`` gains an optional ``redactedThinking``;
+  ``SecretRedactionGuardrail`` masks both the content and the ``thinking`` block,
+  and ``GuardrailMiddleware`` rebuilds the response with the redacted reasoning
+  (null = leave as-is). Tool-call **arguments are deliberately not redacted** —
+  they are functional parameters the tool consumes, and masking them would break
+  the call.
+- **System prompt.** The six ``applySystemPrompt()`` call sites in
+  ``LlmServiceManager`` route through ``applyAndScreenSystemPrompt()``, which
+  screens the *final assembled* message list — so the prepended system turn is
+  screened too. Re-screening the already-screened user turns is an idempotent
+  no-op.
+- **Vision.** ``vision()`` screens the text items of its ``VisionContent`` before
+  dispatch, matching the chat/tool paths.
+
+.. _adr-089-consequences:
+
+Consequences
+============
+
+- A secret is now masked (or the prompt blocked) across answer, reasoning,
+  user turn, system prompt and vision text — the "enumerate all boundaries"
+  completion of ADR-085/087.
+- ``embed()`` remains unscreened: its input is embedding text, not a chat
+  prompt; screening/redacting it would corrupt the vector semantics. Documented
+  as out of scope.
+- Redacting reasoning depends on the provider populating ``thinking``
+  (Ollama ``message.thinking``, ADR-016); providers that fold reasoning into
+  the content are covered by the content redaction already.
+- On the streaming paths the system prompt is screened inside the lazy opener
+  (that is where ``applySystemPrompt`` runs), so a REDACT is applied before the
+  provider send, but a DENY / REQUIRE_APPROVAL triggered *only* by system-prompt
+  content would throw on first drain rather than at call time — unlike the eager
+  user-turn screening. Latent: the shipped ``SecretRedactionInputGuardrail`` only
+  REDACTs, which is correct here; a future DENY-returning input guardrail would
+  need the effective system prompt hoisted and screened before the opener.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -386,3 +386,4 @@ Tools
    Adr086GuardrailEnforcementGaps
    Adr087InputGuardrails
    Adr088StreamingRedaction
+   Adr089GuardrailBoundaryCompleteness

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -60,6 +60,33 @@ final class GuardrailMiddlewareTest extends TestCase
     }
 
     #[Test]
+    public function redactAppliesTheRedactedThinkingToTheResponse(): void
+    {
+        $middleware = new GuardrailMiddleware([
+            $this->guardrail(GuardrailResult::redact('[redacted]', 'secret', '[thinking-redacted]')),
+        ]);
+        $terminal = fn(): CompletionResponse => new CompletionResponse('raw', 'test-model', UsageStatistics::fromTokens(1, 1), 'stop', '', null, null, 'raw thinking');
+
+        $result = $this->screen($middleware, $terminal);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('[redacted]', $result->content);
+        self::assertSame('[thinking-redacted]', $result->thinking);
+    }
+
+    #[Test]
+    public function redactWithNullThinkingKeepsTheOriginalThinking(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::redact('[redacted]', 'secret'))]);
+        $terminal   = fn(): CompletionResponse => new CompletionResponse('raw', 'test-model', UsageStatistics::fromTokens(1, 1), 'stop', '', null, null, 'original thinking');
+
+        $result = $this->screen($middleware, $terminal);
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('original thinking', $result->thinking);
+    }
+
+    #[Test]
     public function denyThrowsAViolation(): void
     {
         $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))]);

--- a/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
@@ -64,6 +64,47 @@ final class SecretRedactionGuardrailTest extends TestCase
         self::assertStringContainsString('Bearer ***', $result->redactedContent);
     }
 
+    #[Test]
+    public function redactsASecretEchoedIntoTheReasoningBlockLeavingCleanContent(): void
+    {
+        $response = new CompletionResponse(
+            'a perfectly clean answer',
+            'test-model',
+            UsageStatistics::fromTokens(1, 1),
+            'stop',
+            '',
+            null,
+            null,
+            'reasoning: the key is sk-abcdef0123456789ABCDEF, use it',
+        );
+
+        $result = (new SecretRedactionGuardrail())->checkOutput($response);
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedThinking);
+        self::assertStringContainsString('sk-***', $result->redactedThinking);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $result->redactedThinking);
+        // Clean content passes through unchanged.
+        self::assertSame('a perfectly clean answer', $result->redactedContent);
+    }
+
+    #[Test]
+    public function leavesAResponseWithNoSecretsInEitherContentOrThinkingAlone(): void
+    {
+        $response = new CompletionResponse(
+            'clean answer',
+            'test-model',
+            UsageStatistics::fromTokens(1, 1),
+            'stop',
+            '',
+            null,
+            null,
+            'clean reasoning',
+        );
+
+        self::assertSame(GuardrailVerdict::ALLOW, (new SecretRedactionGuardrail())->checkOutput($response)->verdict);
+    }
+
     private function response(string $content): CompletionResponse
     {
         return new CompletionResponse($content, 'test-model', UsageStatistics::fromTokens(1, 1));

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\AbstractProvider;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -874,6 +875,108 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager->chat([['role' => 'user', 'content' => 'a perfectly normal question']], new ChatOptions(provider: 'openai'));
 
         self::assertStringContainsString('a perfectly normal question', $this->joinContents($provider->capturedMessages));
+    }
+
+    #[Test]
+    public function screensASecretInTheSystemPrompt(): void
+    {
+        $provider = new TestableProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        // The system prompt is prepended after user-message screening; it must be
+        // screened too (ADR-089), not only the user turns.
+        $manager->chat(
+            [['role' => 'user', 'content' => 'hello']],
+            new ChatOptions(provider: 'openai', systemPrompt: 'You hold key sk-abcdef0123456789ABCDEF now'),
+        );
+
+        $joined = $this->joinContents($provider->capturedMessages);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function chatWithConfigurationScreensASecretInTheSystemPrompt(): void
+    {
+        $model  = self::createStub(Model::class);
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('getIdentifier')->willReturn('test-config');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $received    = null;
+        $mockAdapter = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('chatCompletion')->willReturnCallback(
+            function (array $messages) use (&$received): CompletionResponse {
+                $received = $messages;
+
+                return new CompletionResponse('ok', 'gpt-4o', new UsageStatistics(1, 1, 2));
+            },
+        );
+        $registryMock = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryMock->method('createAdapterFromModel')->willReturn($mockAdapter);
+
+        $screener = new InputGuardrailScreener([new SecretRedactionInputGuardrail()]);
+        $manager  = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $registryMock,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            null,
+            null,
+            null,
+            null,
+            $screener,
+        );
+
+        // The configuration-driven path (the dominant production path) must screen
+        // the system prompt too, not only user turns (ADR-089).
+        $manager->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'hello']],
+            $config,
+            [],
+            ['system_prompt' => 'You hold key sk-abcdef0123456789ABCDEF now'],
+        );
+
+        self::assertIsArray($received);
+        $joined = implode("\n", array_map(static fn(ChatMessage $m): string => $m->content, $received));
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+    }
+
+    #[Test]
+    public function screensASecretInTheVisionTextPrompt(): void
+    {
+        $provider = new TestableVisionProvider();
+        $manager  = $this->managerWithInputScreener($provider);
+
+        $manager->vision(
+            [
+                VisionContent::text('describe this using key sk-abcdef0123456789ABCDEF'),
+                VisionContent::imageUrl('https://example.com/x.png'),
+            ],
+            new VisionOptions(provider: 'openai-vision'),
+        );
+
+        $texts = array_map(
+            static fn(VisionContent $c): string => $c->text ?? '',
+            array_values(array_filter(
+                $provider->capturedContent,
+                static fn(VisionContent|array $c): bool => $c instanceof VisionContent && $c->isText(),
+            )),
+        );
+        $joined = implode("\n", $texts);
+        self::assertStringContainsString('sk-***', $joined);
+        self::assertStringNotContainsString('sk-abcdef0123456789ABCDEF', $joined);
+
+        // Non-text items pass through untouched (redaction must not drop the image).
+        $images = array_values(array_filter(
+            $provider->capturedContent,
+            static fn(VisionContent|array $c): bool => $c instanceof VisionContent && !$c->isText(),
+        ));
+        self::assertCount(1, $images);
+        self::assertSame('https://example.com/x.png', $images[0]->imageUrl);
     }
 
     private function managerWithInputScreener(TestableProvider $provider, ?InputGuardrailScreener $screener = null): LlmServiceManager
@@ -2692,6 +2795,9 @@ class TestableVisionProvider extends TestableProvider implements VisionCapableIn
 {
     private ?VisionResponse $nextVisionResponse = null;
 
+    /** @var list<VisionContent|array<string, mixed>> */
+    public array $capturedContent = [];
+
     public function __construct()
     {
         parent::__construct('openai-vision', 'OpenAI Vision', true);
@@ -2704,6 +2810,8 @@ class TestableVisionProvider extends TestableProvider implements VisionCapableIn
 
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
+        $this->capturedContent = $content;
+
         return $this->nextVisionResponse ?? new VisionResponse(
             description: 'Default description',
             model: 'gpt-4o',


### PR DESCRIPTION
The "enumerate all boundaries" completion of the guardrail work. An adversarial audit of the merged layer found the secret-redaction guardrail missed three reachable boundaries the same secret can cross — masked in one place, leaked in another.

## Fixes
- **Reasoning (`thinking`) block** — was unscreened (it's surfaced in the playground glass-box). `GuardrailResult` gains an optional `redactedThinking`; `SecretRedactionGuardrail` masks both content and thinking; `GuardrailMiddleware` rebuilds the response with the redacted reasoning (null = keep as-is). **Tool-call arguments are deliberately not redacted** — functional parameters; masking would break the call.
- **System prompt** — added *after* input screening, so it reached the provider unscreened on every path but `completeForConfiguration`. The six `applySystemPrompt()` sites route through `applyAndScreenSystemPrompt()`, which screens the final assembled list.
- **Vision** — `vision()` forwarded its text prompt unscreened; it now screens the text items of its `VisionContent` before dispatch.

`embed()` stays out of scope: its input is embedding text, not a chat prompt — redacting it would corrupt the vector semantics (documented in the ADR).

## Tests
Secret in the `thinking` block redacted while clean content is untouched; middleware applies `redactedThinking` (and null keeps the original); system prompt screened on **both** the ad-hoc and the configuration-driven path (`chatWithConfiguration`); vision text masked before the provider receives it while the image item passes through unchanged.

Built through an adversarial review round that caught the config-path system-prompt test gap (the ad-hoc test alone left the dominant path untested) and a vision image-passthrough gap; both fixed. A latent streaming-system-prompt DENY-timing note is documented in the ADR (the shipped REDACT guardrail is correct on all paths).

All 6 gates green (cgl, phpstan L10, unit 5245, functional, rector -n, fuzzy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)