### PR TITLE
fix(guardrail): audit follow-ups — streaming overflow log, docblock, RETRY note

### DIFF
--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -131,8 +131,10 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * tool checkboxes the operator ticked (defaulting to the globally-enabled
      * set when none are sent); {@see ToolLoopService} still intersects it with
      * the global gate, so a disabled tool can never be offered. Any unexpected
-     * provider/tool failure returns a generic JSON 500 — never the exception
-     * message, which can carry DBAL/PDO credentials — while the detail is
+     * provider/tool failure returns a JSON 500 carrying a SANITIZED diagnosis
+     * (exception class + message with secret-bearing URL params stripped via
+     * {@see ErrorMessageSanitizerTrait}, plus a truncated sanitized provider
+     * response body) — never the raw message verbatim — while the full detail is
      * logged downstream.
      */
     public function runAction(ServerRequestInterface $request): ResponseInterface

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -96,6 +96,12 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
                             'A guardrail asked to retry, but the retried response also failed: ' . $result->reason,
                         );
                     }
+                    // LIMITATION: $next runs the inner pipeline, which includes
+                    // IdempotencyMiddleware (priority 105). When the call carries an
+                    // idempotency key the retry returns the SAME cached response, so
+                    // a RETRY then denies on the second pass. No shipped guardrail
+                    // returns RETRY; a future one that needs a genuinely fresh
+                    // completion must not be paired with an idempotency key.
                     $fresh = $next($configuration);
                     if (!$fresh instanceof CompletionResponse) {
                         return $response;

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -244,6 +244,13 @@ final readonly class StreamingDispatcher
                     }
                     $raw      = '';
                     $overflow = true;
+                    // Observability for the silent-bypass limit: a secret past this
+                    // point is neither masked nor audited, so record that live
+                    // redaction stopped for this stream.
+                    $this->logger->warning(
+                        'Streamed LLM response exceeded the live-redaction cap; further content passes through unredacted and unaudited',
+                        $this->logContext($context, ['capBytes' => self::MAX_GUARDRAIL_BUFFER_BYTES]),
+                    );
                     $inner->next();
                     continue;
                 }

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -370,6 +370,10 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertStringContainsString('sk-***', $emitted);
         self::assertStringNotContainsString($preSecret, $emitted);
         self::assertStringContainsString('TAIL-AFTER-CAP', $emitted);
+
+        // The silent-bypass limit is observable: a warning records that live
+        // redaction stopped for this stream.
+        self::assertNotNull($this->logger->firstMatching('warning', 'exceeded the live-redaction cap'));
     }
 
     #[Test]


### PR DESCRIPTION
The remaining low-severity items from the guardrail-layer audit (the actionable ones; the O(n²) rescan stays a documented tradeoff).

- **Streaming overflow observability** — `StreamingDispatcher` logs a warning when a stream exceeds the 50 KB live-redaction cap and switches to passthrough, so the documented silent-bypass limit (content past the cap is neither masked nor audited) is at least visible in the log/telemetry. Asserted in the existing >50 KB test.
- **Docblock accuracy** — `runAction`'s docblock claimed the exception message is "never surfaced", but `diagnoseRunFailure` returns a *sanitized* message (secret-bearing URL params stripped) plus a truncated provider body. The docblock now matches the code.
- **RETRY vs idempotency note** — documents in `GuardrailMiddleware` that a `RETRY` verdict re-runs the inner pipeline, so with an idempotency key it returns the same cached response. No shipped guardrail returns RETRY; a future one must not be paired with an idempotency key.

All 6 gates green (cgl, phpstan L10, unit, functional, rector -n, fuzzy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)