### PR TITLE
fix: harden provider response parsing against malformed and hostile upstreams

### DIFF
--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -115,6 +115,24 @@ final readonly class ToolCall implements JsonSerializable
     }
 
     /**
+     * Tolerant variant of {@see self::fromArray()} for UNTRUSTED provider output:
+     * returns null instead of throwing when the raw entry cannot form a valid
+     * call (missing / empty id or name), so a nonconforming provider degrades —
+     * the bad call is skipped — instead of crashing the whole completion with an
+     * uncaught exception (a 500 the frontend cannot parse).
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function tryFromArray(array $data): ?self
+    {
+        try {
+            return self::fromArray($data);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
      * Convenience factory mirroring `ToolSpec::function()`.
      *
      * @param array<string, mixed> $arguments

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -536,6 +536,8 @@ final class ClaudeProvider extends AbstractProvider implements
 
                 yield $event['text'];
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -260,11 +260,16 @@ final class GeminiProvider extends AbstractProvider implements
                 // reset to 0 each loop turn and collide across turns in
                 // buildToolCallIdToName(); uniqid(more_entropy: true) is
                 // collision-free even for multiple calls in one response.
-                $toolCalls[] = ToolCall::function(
-                    id: uniqid('call_', true),
-                    name: $this->getString($functionCall, 'name'),
-                    arguments: $this->getArray($functionCall, 'args'),
-                );
+                // Untrusted provider output: skip a functionCall with no name
+                // instead of crashing the whole response.
+                $functionName = $this->getString($functionCall, 'name');
+                if ($functionName !== '') {
+                    $toolCalls[] = ToolCall::function(
+                        id: uniqid('call_', true),
+                        name: $functionName,
+                        arguments: $this->getArray($functionCall, 'args'),
+                    );
+                }
             }
         }
 
@@ -533,6 +538,8 @@ final class GeminiProvider extends AbstractProvider implements
                     yield $text;
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -230,7 +230,12 @@ final class GroqProvider extends AbstractProvider implements
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
+                // Untrusted provider output: skip a malformed tool call (missing
+                // id/name) instead of crashing the whole completion.
+                $call = ToolCall::tryFromArray($this->asArray($tc));
+                if ($call !== null) {
+                    $toolCalls[] = $call;
+                }
             }
         }
 
@@ -320,6 +325,8 @@ final class GroqProvider extends AbstractProvider implements
                     yield $content;
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -215,7 +215,12 @@ final class MistralProvider extends AbstractProvider implements
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
+                // Untrusted provider output: skip a malformed tool call (missing
+                // id/name) instead of crashing the whole completion.
+                $call = ToolCall::tryFromArray($this->asArray($tc));
+                if ($call !== null) {
+                    $toolCalls[] = $call;
+                }
             }
         }
 
@@ -349,6 +354,8 @@ final class MistralProvider extends AbstractProvider implements
                     yield $content;
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -288,7 +288,12 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                 // arrives as an object, which ToolCall normalises straight
                 // through.
                 $callData['id'] = 'call_' . $index;
-                $toolCalls[]    = ToolCall::fromArray($callData);
+                // Untrusted provider output: skip a malformed call (missing name)
+                // instead of crashing the whole completion.
+                $call = ToolCall::tryFromArray($callData);
+                if ($call !== null) {
+                    $toolCalls[] = $call;
+                }
                 ++$index;
             }
         }
@@ -531,6 +536,8 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                     return;
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -211,7 +211,12 @@ final class OpenAiProvider extends AbstractProvider implements
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
+                // Untrusted provider output: skip a malformed tool call (missing
+                // id/name) instead of crashing the whole completion.
+                $call = ToolCall::tryFromArray($this->asArray($tc));
+                if ($call !== null) {
+                    $toolCalls[] = $call;
+                }
             }
         }
 
@@ -411,6 +416,8 @@ final class OpenAiProvider extends AbstractProvider implements
                     }
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
+use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
@@ -402,7 +403,12 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($rawToolCalls !== []) {
             $toolCalls = [];
             foreach ($rawToolCalls as $tc) {
-                $toolCalls[] = ToolCall::fromArray($this->asArray($tc));
+                // Untrusted provider output: skip a malformed tool call (missing
+                // id/name) instead of crashing the whole completion.
+                $call = ToolCall::tryFromArray($this->asArray($tc));
+                if ($call !== null) {
+                    $toolCalls[] = $call;
+                }
             }
         }
 
@@ -602,6 +608,8 @@ final class OpenRouterProvider extends AbstractProvider implements
                     yield $content;
                 }
             }
+
+            $this->guardStreamLineBuffer($buffer);
         }
     }
 
@@ -911,7 +919,15 @@ final class OpenRouterProvider extends AbstractProvider implements
             $this->handleOpenRouterError($statusCode, $responseBody, $endpoint);
         }
 
-        return $this->decodeJsonResponse($responseBody);
+        try {
+            return $this->decodeJsonResponse($responseBody);
+        } catch (JsonException|InvalidArgumentException $e) {
+            // A 2xx body that is not valid JSON (an upstream HTML error page, a
+            // truncated response from a fronted model) — surface it as the typed,
+            // retryable provider error the shared AbstractProvider path produces,
+            // not a raw uncaught exception (a 500 the caller cannot handle).
+            throw new ProviderConnectionException('OpenRouter returned an unparseable response body', 1784600500, $e);
+        }
     }
 
     /**

--- a/Classes/Provider/ResponseParserTrait.php
+++ b/Classes/Provider/ResponseParserTrait.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider;
 
+use JsonException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 
 /**
  * Trait for type-safe API response parsing.
@@ -19,6 +21,38 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  */
 trait ResponseParserTrait
 {
+    /**
+     * Upper bound for a single unterminated line while consuming a streamed
+     * response body. Streaming loops accumulate raw bytes into a line buffer
+     * and flush on each newline; a broken or hostile upstream that never emits
+     * a newline would otherwise grow the buffer to the full response size in
+     * memory. 1 MiB is far above any legitimate single SSE/NDJSON line while
+     * still bounding memory.
+     */
+    protected const MAX_STREAM_LINE_BYTES = 1_048_576;
+
+    /**
+     * Guard a streaming line buffer against unbounded growth.
+     *
+     * Call after draining all complete (newline-terminated) lines from the
+     * buffer: if the residual — a single line still awaiting its newline —
+     * exceeds {@see self::MAX_STREAM_LINE_BYTES}, the upstream is not framing
+     * its response and continuing would accumulate the whole body in memory.
+     * Surface it as a typed, retryable provider error rather than exhausting
+     * memory.
+     */
+    protected function guardStreamLineBuffer(string $buffer): void
+    {
+        if (strlen($buffer) > self::MAX_STREAM_LINE_BYTES) {
+            throw new ProviderConnectionException(
+                sprintf(
+                    'Streamed response exceeded the %d-byte single-line limit without a line terminator',
+                    self::MAX_STREAM_LINE_BYTES,
+                ),
+                1784600600,
+            );
+        }
+    }
     /**
      * Get a string value from array, with optional default.
      *
@@ -324,8 +358,8 @@ trait ResponseParserTrait
     /**
      * Safely decode JSON and return as array.
      *
-     *
-     * @throws InvalidArgumentException If JSON is invalid
+     * @throws JsonException            If $json is not valid JSON (JSON_THROW_ON_ERROR)
+     * @throws InvalidArgumentException If the decoded JSON is not an object
      *
      * @return array<string, mixed>
      */

--- a/Tests/Unit/Domain/ValueObject/ToolCallTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolCallTest.php
@@ -203,4 +203,41 @@ final class ToolCallTest extends TestCase
 
         self::assertSame($call->toArray(), $call->jsonSerialize());
     }
+
+    #[Test]
+    public function tryFromArrayReturnsInstanceForValidWire(): void
+    {
+        $call = ToolCall::tryFromArray([
+            'id'   => 'call_abc',
+            'type' => 'function',
+            'function' => [
+                'name'      => 'get_weather',
+                'arguments' => '{"city":"Berlin"}',
+            ],
+        ]);
+
+        self::assertInstanceOf(ToolCall::class, $call);
+        self::assertSame('call_abc', $call->id);
+        self::assertSame('get_weather', $call->name);
+        self::assertSame(['city' => 'Berlin'], $call->arguments);
+    }
+
+    #[Test]
+    public function tryFromArrayReturnsNullWhenIdMissing(): void
+    {
+        // A malformed provider payload that would make fromArray() throw must
+        // instead yield null so adapters can skip the entry rather than crash.
+        self::assertNull(ToolCall::tryFromArray([
+            'function' => ['name' => 'fn', 'arguments' => '{}'],
+        ]));
+    }
+
+    #[Test]
+    public function tryFromArrayReturnsNullWhenNameEmpty(): void
+    {
+        self::assertNull(ToolCall::tryFromArray([
+            'id'   => 'call_abc',
+            'function' => ['name' => '', 'arguments' => '{}'],
+        ]));
+    }
 }

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -444,6 +444,52 @@ class GeminiProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionWithToolsSkipsFunctionCallWithEmptyName(): void
+    {
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $messages = [['role' => 'user', 'content' => 'What is the weather in London?']];
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => [
+                    'name' => 'get_weather',
+                    'parameters' => ['type' => 'object', 'properties' => []],
+                ],
+            ]),
+        ];
+
+        // A functionCall part with no usable name must be skipped rather than
+        // build an invalid ToolCall (empty name) and abort the response.
+        $apiResponse = [
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['functionCall' => ['name' => '', 'args' => ['location' => 'London']]],
+                            ['functionCall' => ['name' => 'get_weather', 'args' => ['location' => 'London']]],
+                        ],
+                        'role' => 'model',
+                    ],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+            'usageMetadata' => ['promptTokenCount' => 15, 'candidatesTokenCount' => 10],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $subject->chatCompletionWithTools($messages, $tools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('get_weather', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function embeddingsReturnsValidResponse(): void
     {
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -282,6 +282,53 @@ class GroqProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionWithToolsSkipsMalformedToolCall(): void
+    {
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'get_weather', 'parameters' => ['type' => 'object', 'properties' => []]],
+            ]),
+        ];
+
+        // A tool call with an empty function name must be skipped, not crash the
+        // whole completion (ToolCall::tryFromArray returns null for it).
+        $apiResponse = [
+            'id'     => 'chatcmpl-test',
+            'object' => 'chat.completion',
+            'model'  => 'llama-3.3-70b-versatile',
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role'       => 'assistant',
+                        'content'    => '',
+                        'tool_calls' => [
+                            ['id' => 'call_bad', 'type' => 'function', 'function' => ['name' => '', 'arguments' => '{}']],
+                            ['id' => 'call_ok', 'type' => 'function', 'function' => ['name' => 'get_weather', 'arguments' => '{"location": "London"}']],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 10, 'total_tokens' => 25],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'weather?']], $tools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('get_weather', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function embeddingsThrowsUnsupportedFeatureException(): void
     {
         $this->expectException(UnsupportedFeatureException::class);

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -282,6 +282,53 @@ class MistralProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionWithToolsSkipsMalformedToolCall(): void
+    {
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();
+
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'get_weather', 'parameters' => ['type' => 'object', 'properties' => []]],
+            ]),
+        ];
+
+        // A tool call with an empty function name must be skipped, not crash the
+        // whole completion (ToolCall::tryFromArray returns null for it).
+        $apiResponse = [
+            'id'     => 'cmpl-test',
+            'object' => 'chat.completion',
+            'model'  => 'mistral-large-latest',
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role'       => 'assistant',
+                        'content'    => '',
+                        'tool_calls' => [
+                            ['id' => 'call_bad', 'type' => 'function', 'function' => ['name' => '', 'arguments' => '{}']],
+                            ['id' => 'call_ok', 'type' => 'function', 'function' => ['name' => 'get_weather', 'arguments' => '{"location": "Paris"}']],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 10, 'total_tokens' => 25],
+        ];
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'weather?']], $tools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('get_weather', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function embeddingsReturnsValidResponse(): void
     {
         ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createSubjectWithMockHttpClient();

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OllamaProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -697,6 +698,44 @@ class OllamaProviderTest extends AbstractUnitTestCase
         $chunks = iterator_to_array($generator);
 
         self::assertEquals(['Test'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionAbortsOnUnterminatedOversizedLine(): void
+    {
+        // Ollama's NDJSON loop uses the `$buffer .= read()` accumulation shape;
+        // a single unterminated line beyond the 1 MiB cap must trip the guard
+        // rather than grow the buffer without bound.
+        $subject = new OllamaProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $subject->configure([
+            'apiKeyIdentifier' => '',
+            'defaultModel'     => 'llama3.2',
+            'baseUrl'          => 'http://localhost:11434',
+            'timeout'          => 30,
+        ]);
+
+        $streamStub = self::createStub(StreamInterface::class);
+        $streamStub->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $streamStub->method('read')->willReturn(str_repeat('a', 1_048_577));
+
+        $responseStub = self::createStub(ResponseInterface::class);
+        $responseStub->method('getStatusCode')->willReturn(200);
+        $responseStub->method('getBody')->willReturn($streamStub);
+
+        $httpClientMock = $this->createHttpClientWithExpectations();
+        $httpClientMock->method('sendRequest')->willReturn($responseStub);
+        $subject->setHttpClient($httpClientMock);
+
+        $this->expectException(ProviderConnectionException::class);
+        $this->expectExceptionCode(1784600600);
+
+        iterator_to_array($subject->streamChatCompletion([['role' => 'user', 'content' => 'Test']]));
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -92,6 +92,33 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function skipsMalformedToolCallWithEmptyName(): void
+    {
+        // A tool_call carrying no name would make ToolCall construction throw
+        // even after id synthesis; the malformed entry must be skipped so the
+        // valid one still reaches the caller.
+        $subject = $this->buildSubject([
+            'model'   => 'llama3.2',
+            'message' => [
+                'role'       => 'assistant',
+                'content'    => '',
+                'tool_calls' => [
+                    ['function' => ['name' => '', 'arguments' => ['limit' => 5]]],
+                    ['function' => ['name' => 'fetch_logs', 'arguments' => ['limit' => 5]]],
+                ],
+            ],
+            'done'        => true,
+            'done_reason' => 'stop',
+        ]);
+
+        $result = $subject->chatCompletionWithTools([['role' => 'user', 'content' => 'logs']], []);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('fetch_logs', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function translatesReplayedAssistantAndToolTurnsToNativeShape(): void
     {
         $subject = $this->buildSubject($this->plainAssistantResponse('ok'));

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
@@ -553,6 +554,60 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionWithToolsSkipsMalformedToolCall(): void
+    {
+        $messages = [['role' => 'user', 'content' => 'What is the weather?']];
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => [
+                    'name' => 'get_weather',
+                    'parameters' => ['type' => 'object', 'properties' => []],
+                ],
+            ]),
+        ];
+
+        // A provider that emits a tool call with an empty function name would
+        // previously make ToolCall::fromArray() throw and abort the whole
+        // response; the malformed entry must now be skipped, keeping the valid one.
+        $apiResponse = [
+            'id'    => 'chatcmpl-test',
+            'model' => 'gpt-4o',
+            'choices' => [
+                [
+                    'message' => [
+                        'content'    => '',
+                        'tool_calls' => [
+                            [
+                                'id'   => 'call_bad',
+                                'type' => 'function',
+                                'function' => ['name' => '', 'arguments' => '{}'],
+                            ],
+                            [
+                                'id'   => 'call_ok',
+                                'type' => 'function',
+                                'function' => ['name' => 'get_weather', 'arguments' => '{"location": "Tokyo"}'],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 15, 'total_tokens' => 35],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletionWithTools($messages, $tools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('get_weather', $result->toolCalls[0]->name);
+    }
+
+    #[Test]
     public function chatCompletionWithToolsAndToolChoice(): void
     {
         $messages = [['role' => 'user', 'content' => 'Get weather']];
@@ -791,6 +846,38 @@ class OpenAiProviderTest extends AbstractUnitTestCase
         }
 
         self::assertEquals(['Valid'], $chunks);
+    }
+
+    #[Test]
+    public function streamChatCompletionAbortsOnUnterminatedOversizedLine(): void
+    {
+        // A broken/hostile upstream that streams a single line with no newline
+        // must not grow the in-memory buffer without bound — the guard trips
+        // once the residual passes the per-line limit.
+        $streamData = str_repeat('a', 1_048_577);
+
+        $stream = self::createStub(StreamInterface::class);
+        $eofCallCount = 0;
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+            return ++$eofCallCount > 1;
+        });
+        $stream->method('read')->willReturn($streamData);
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($stream);
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $this->expectException(ProviderConnectionException::class);
+        $this->expectExceptionCode(1784600600);
+
+        foreach ($this->subject->streamChatCompletion([['role' => 'user', 'content' => 'test']]) as $chunk) {
+            // Draining the generator triggers the buffer guard.
+            unset($chunk);
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -224,6 +224,22 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionMapsNonJsonSuccessBodyToConnectionException(): void
+    {
+        // A 2xx whose body is not JSON (an upstream HTML error page, a
+        // truncated response) must surface as a typed provider error rather
+        // than a raw uncaught JsonException bubbling up as a 500.
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createHttpResponseMock(200, '<html><body>502 Bad Gateway</body></html>'));
+
+        $this->expectException(ProviderConnectionException::class);
+        $this->expectExceptionCode(1784600500);
+
+        $this->subject->chatCompletion([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    #[Test]
     public function chatCompletionSendsCustomHeaders(): void
     {
         $capturedRequest = null;
@@ -584,6 +600,49 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $toolCall = $result->toolCalls[0];
         self::assertEquals('get_weather', $toolCall->name);
         self::assertEquals(['location' => 'San Francisco'], $toolCall->arguments);
+    }
+
+    #[Test]
+    public function chatCompletionWithToolsSkipsMalformedToolCall(): void
+    {
+        $tools = [
+            ToolSpec::fromArray([
+                'type' => 'function',
+                'function' => ['name' => 'get_weather', 'parameters' => ['type' => 'object', 'properties' => []]],
+            ]),
+        ];
+
+        // A tool call with an empty function name must be skipped, not crash the
+        // whole completion (ToolCall::tryFromArray returns null for it).
+        $apiResponse = [
+            'id'    => 'gen-test',
+            'model' => 'anthropic/claude-3.5-sonnet',
+            'choices' => [
+                [
+                    'message' => [
+                        'role'       => 'assistant',
+                        'content'    => '',
+                        'tool_calls' => [
+                            ['id' => 'call_bad', 'type' => 'function', 'function' => ['name' => '', 'arguments' => '{}']],
+                            ['id' => 'call_ok', 'type' => 'function', 'function' => ['name' => 'get_weather', 'arguments' => '{"location":"San Francisco"}']],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 50, 'completion_tokens' => 20, 'total_tokens' => 70],
+            'provider' => 'anthropic',
+        ];
+
+        $this->httpClientMock
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletionWithTools([['role' => 'user', 'content' => 'weather?']], $tools);
+
+        self::assertNotNull($result->toolCalls);
+        self::assertCount(1, $result->toolCalls);
+        self::assertSame('get_weather', $result->toolCalls[0]->name);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/ResponseParserTraitTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
 use InvalidArgumentException;
 use JsonException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\ResponseParserTrait;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -468,6 +469,26 @@ class ResponseParserTraitTest extends AbstractUnitTestCase
 
         $this->subject->decodeJsonResponse('"just a string"');
     }
+
+    // ==================== guardStreamLineBuffer tests ====================
+
+    #[Test]
+    public function guardStreamLineBufferAllowsBufferAtLimit(): void
+    {
+        // A single unterminated line up to the limit is tolerated (no throw).
+        $this->subject->guardStreamLineBuffer(str_repeat('a', 1_048_576));
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function guardStreamLineBufferThrowsWhenBufferExceedsLimit(): void
+    {
+        $this->expectException(ProviderConnectionException::class);
+        $this->expectExceptionCode(1784600600);
+
+        $this->subject->guardStreamLineBuffer(str_repeat('a', 1_048_577));
+    }
 }
 
 /**
@@ -498,5 +519,6 @@ class ResponseParserTraitTestSubject
         asInt as public;
         asFloat as public;
         decodeJsonResponse as public;
+        guardStreamLineBuffer as public;
     }
 }


### PR DESCRIPTION
Audit of the provider response-parsing paths found three defects, all triggered by **untrusted upstream output** (a misbehaving or hostile provider endpoint), not by user input. Each produced an uncaught error the frontend cannot handle or an unbounded resource use.

## Bug A — malformed tool calls crash the whole completion
A `tool_calls` entry with an empty `id` or `name` made `ToolCall::fromArray()` throw `InvalidArgumentException`, aborting the entire completion with an uncaught 500.

Fix: add `ToolCall::tryFromArray()` (returns `null` on invalid input); the six tool-capable adapters skip the bad entry and keep the valid ones. Gemini builds calls via `ToolCall::function()` and guards on a non-empty name.

## Bug B — OpenRouter non-JSON 2xx bubbles up as a raw JsonException
`OpenRouterProvider`'s non-streaming path raised an uncaught `JsonException` when a `2xx` response body was not JSON (an upstream HTML error page, a truncated body) — surfacing as a 500.

Fix: wrap the decode and map it to the typed `ProviderConnectionException` the shared `AbstractProvider` path already produces. Also correct `decodeJsonResponse()`'s `@throws` to declare the `JsonException` it actually raises.

## Bug C — streaming read buffer is unbounded
The streaming loops accumulate the body into an in-memory line buffer flushed on each newline. A broken or hostile upstream that never emits a line terminator grows the buffer to the full response size.

Fix: `guardStreamLineBuffer()` caps a single unterminated line at 1 MiB (`MAX_STREAM_LINE_BYTES`), called after each flush across all seven providers.

## Tests
- `ToolCall::tryFromArray` — valid / empty-id / empty-name
- Per-adapter malformed-tool-call skip — OpenAi, Groq, Mistral, OpenRouter, Ollama, Gemini
- OpenRouter non-JSON `2xx` → `ProviderConnectionException`
- Line-buffer guard — at the trait (at-limit / over-limit) and both loop shapes (OpenAi `$chunk .=`, Ollama `$buffer .=`)

## Gates
cgl, PHPStan level 10, unit (5252), Rector `-n`, fuzzy — all green locally. Functional runs in CI (WSL2 functional stalls locally; no DB/DI/TCA code is touched).

## Review
Adversarial review (correctness / security-DoS / edge-tests lenses → verify) refuted a "total-stream unbounded / slow-loris" concern: the PSR-18 Guzzle client fully buffers the body with a total-duration timeout (no `stream => true`), so the loop iterates already-downloaded bytes bounded by the request timeout. The only confirmed findings were the per-adapter regression-coverage gaps, now closed by the tests above.