### PR TITLE
security: harden secret redaction (connection strings, JWT/vendor tokens, full Bearer masking)

### DIFF
--- a/Classes/Service/Guardrail/RedactsSecretsTrait.php
+++ b/Classes/Service/Guardrail/RedactsSecretsTrait.php
@@ -43,18 +43,41 @@ trait RedactsSecretsTrait
     private function redactSecrets(string $content): string
     {
         $redacted = $this->sanitizeErrorMessage($content);
-        // API-key and Bearer-token shapes the URL-param sanitiser does not cover.
+        // Best-effort masking of common secret shapes the URL sanitiser does not
+        // cover — unknown formats still pass through. Each preg_replace is
+        // guarded: on failure (e.g. a backtrack-limit hit on a huge payload) it
+        // returns null, which a bare (string) cast would turn into '' — silently
+        // wiping the whole content; keep the last good string instead.
+        //
         // The sk- class allows hyphens/underscores so modern project keys
-        // (sk-proj-…) match. Each preg_replace is guarded: on failure (e.g. a
-        // backtrack-limit hit on a huge payload) it returns null, which a bare
-        // (string) cast would turn into '' — silently wiping the whole content.
+        // (sk-proj-…) match.
         $withoutApiKeys = preg_replace('/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-***', (string)$redacted);
         if (is_string($withoutApiKeys)) {
             $redacted = $withoutApiKeys;
         }
-        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._\-]{8,}/i', '$1***', (string)$redacted);
+        // Bearer token — the class covers base64-standard chars (+ / =) so a
+        // token's tail is not left behind (parity with {@see ContentRedactor}).
+        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._~+\/\-]+=*/i', '$1***', (string)$redacted);
         if (is_string($withoutBearer)) {
             $redacted = $withoutBearer;
+        }
+        // High-signal vendor secret shapes. A JWT is the canonical bearer secret
+        // even without a `Bearer ` prefix; the rest are fixed-prefix provider
+        // tokens. All patterns are anchored and linear (no ReDoS).
+        $withoutVendor = preg_replace(
+            [
+                '/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/', // JWT (header.payload.signature)
+                '/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}/',            // GitHub token
+                '/\bgithub_pat_[A-Za-z0-9_]{22,}/',                        // GitHub fine-grained PAT
+                '/\bAKIA[0-9A-Z]{16,}/',                                   // AWS access-key id
+                '/\bAIza[0-9A-Za-z_\-]{35,}/',                             // Google API key
+                '/\bxox[baprs]-[A-Za-z0-9\-]{10,}/',                       // Slack token
+            ],
+            '***',
+            (string)$redacted,
+        );
+        if (is_string($withoutVendor)) {
+            $redacted = $withoutVendor;
         }
 
         return $redacted;

--- a/Classes/Utility/ErrorMessageSanitizerTrait.php
+++ b/Classes/Utility/ErrorMessageSanitizerTrait.php
@@ -10,26 +10,39 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Utility;
 
 /**
- * Trait for redacting known credential query parameters from error
- * messages before they are logged or surfaced.
+ * Trait for redacting credential-bearing URLs from error messages (and, via the
+ * secret guardrails, model output) before they are logged or surfaced.
  *
  * HTTP client exceptions may include the full request URL (e.g., Gemini's
- * `?key=...` pattern). This redacts the values of the well-known credential
- * query parameters (`key`, `api_key`, `apikey`, `token`, `secret`,
- * `access_token`) in any URL embedded in the message. It deliberately does
- * NOT scrub other secret material such as header values — callers must not
- * write raw header dumps into error messages in the first place.
+ * `?key=...` pattern). This redacts two shapes:
+ * - the values of the well-known credential query parameters (`key`, `api_key`,
+ *   `apikey`, `token`, `secret`, `access_token`);
+ * - the password in a `scheme://user:password@host` userinfo component
+ *   (database/service connection strings such as `postgres://…`, `redis://…`).
+ * It deliberately does NOT scrub other secret material such as header values —
+ * callers must not write raw header dumps into error messages in the first place.
  */
 trait ErrorMessageSanitizerTrait
 {
     /**
-     * Redact well-known credential query parameters from URLs in the message.
+     * Redact credential query parameters and connection-string passwords from
+     * URLs in the message.
      */
     protected function sanitizeErrorMessage(string $message): string
     {
         return (string)preg_replace(
-            '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
-            '$1$2=***',
+            [
+                // credential query parameters (?key=, ?token=, …)
+                '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
+                // the password in a `scheme://user:password@host` userinfo (the
+                // username may be empty, e.g. `redis://:password@host`). Uses a ~
+                // delimiter because the pattern itself contains '#'.
+                '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s]+@~i',
+            ],
+            [
+                '$1$2=***',
+                '$1:***@',
+            ],
             $message,
         );
     }

--- a/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionGuardrailTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -103,6 +104,73 @@ final class SecretRedactionGuardrailTest extends TestCase
         );
 
         self::assertSame(GuardrailVerdict::ALLOW, (new SecretRedactionGuardrail())->checkOutput($response)->verdict);
+    }
+
+    #[Test]
+    public function redactsConnectionStringPasswords(): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response(
+            'DATABASE_URL=postgres://appuser:S3cr3tP4ss@db.internal:5432/prod and redis://:MyRedisPw123@10.0.0.5:6379/0',
+        ));
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString('S3cr3tP4ss', $result->redactedContent);
+        self::assertStringNotContainsString('MyRedisPw123', $result->redactedContent);
+        // Scheme, user and host are preserved; only the password is masked.
+        self::assertStringContainsString('postgres://appuser:***@db.internal', $result->redactedContent);
+        self::assertStringContainsString('redis://:***@10.0.0.5', $result->redactedContent);
+    }
+
+    #[Test]
+    public function redactsAJsonWebTokenWithoutABearerPrefix(): void
+    {
+        $jwt = 'eyJ' . str_repeat('a', 12) . '.' . str_repeat('b', 20) . '.' . str_repeat('c', 30);
+
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response('session token ' . $jwt . ' expires soon'));
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString($jwt, $result->redactedContent);
+    }
+
+    #[Test]
+    #[DataProvider('vendorTokenProvider')]
+    public function redactsHighSignalVendorTokens(string $secret): void
+    {
+        $result = (new SecretRedactionGuardrail())->checkOutput($this->response('here is ' . $secret . ' ok'));
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString($secret, $result->redactedContent);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function vendorTokenProvider(): iterable
+    {
+        yield 'github classic token'   => ['ghp_' . str_repeat('A', 36)];
+        yield 'github fine-grained pat' => ['github_pat_' . str_repeat('B', 30)];
+        yield 'aws access key id'      => ['AKIA' . str_repeat('C', 16)];
+        yield 'google api key'         => ['AIza' . str_repeat('D', 35)];
+        yield 'slack bot token'        => ['xoxb-' . str_repeat('1', 20)];
+    }
+
+    #[Test]
+    public function masksTheEntireBearerTokenIncludingBase64PaddingChars(): void
+    {
+        // A base64-standard token (containing + / =) must be masked whole — the
+        // pre-fix character class stopped at the first such char, leaking the tail.
+        $result = (new SecretRedactionGuardrail())->checkOutput(
+            $this->response('Authorization: Bearer AAAABBBBCCCCDDDD+EEEE/FFFF=='),
+        );
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringContainsString('Bearer ***', $result->redactedContent);
+        self::assertStringNotContainsString('EEEE', $result->redactedContent);
+        self::assertStringNotContainsString('FFFF', $result->redactedContent);
     }
 
     private function response(string $content): CompletionResponse

--- a/Tests/Unit/Service/Guardrail/SecretRedactionInputGuardrailTest.php
+++ b/Tests/Unit/Service/Guardrail/SecretRedactionInputGuardrailTest.php
@@ -44,6 +44,19 @@ final class SecretRedactionInputGuardrailTest extends TestCase
     }
 
     #[Test]
+    public function redactsAConnectionStringPasswordFromThePrompt(): void
+    {
+        $result = (new SecretRedactionInputGuardrail())->checkInput(
+            'connect to postgres://appuser:S3cr3tP4ss@db.internal:5432/prod please',
+        );
+
+        self::assertSame(GuardrailVerdict::REDACT, $result->verdict);
+        self::assertNotNull($result->redactedContent);
+        self::assertStringNotContainsString('S3cr3tP4ss', $result->redactedContent);
+        self::assertStringContainsString('postgres://appuser:***@db.internal', $result->redactedContent);
+    }
+
+    #[Test]
     public function allowsACleanPrompt(): void
     {
         $result = (new SecretRedactionInputGuardrail())->checkInput('just a normal question about the weather');


### PR DESCRIPTION
From an adversarial audit of the guardrail / HITL / redaction suite (ADR-084…088).
Five reviewers each attacked one property; every finding was verified against the
code before acting. This PR fixes the clear, testable redaction bugs; the rest are
documented below (verified real but architectural, by-design, or out of scope for a
drive-by patch).

## Fixed (this PR)
The secret guardrails and `ContentRedactor` share the redaction traits for
best-effort masking. Three gaps let real secrets through:

- **Connection-string passwords** (`scheme://user:password@host`) were never masked
  — only URL *query parameters* were. `SecretRedactionGuardrail`'s own doc block
  claimed connection strings were covered; the code did not. Now masked (incl.
  passwordless `redis://:pw@host`), keeping scheme/user/host.
- **Bearer tail leak**: the character class stopped at the first base64-standard
  char (`+ / =`), so `Bearer AAAA+BBBB/CCCC==` → `Bearer ***+BBBB/CCCC==` leaked the
  tail. Widened to match `ContentRedactor`.
- **Uncovered high-signal formats**: JWTs (canonical bearer secret, even without a
  `Bearer ` prefix), GitHub / AWS / Google / Slack tokens. Added anchored, linear
  (no-ReDoS) patterns; unknown shapes still pass (best-effort, documented).

Tests cover every case (connection strings, JWT, each vendor token, the Bearer
base64 tail) plus benign-text no-ops. Local gate green: unit, phpstan (L10), cgl,
rector, fuzzy.

## Found & verified, deferred (need a maintainer decision — not fixed here)
- **`IdempotencyMiddleware` persists the *unredacted* response** (medium/high). It
  runs at priority 105, *inside* `GuardrailMiddleware` (115), so it serialises the
  raw `CompletionResponse` into the `nrllm_idempotency` cache (24h, possibly a shared
  Redis) *before* the output redaction runs. The caller and the replay path both get
  the redacted value, but the stored copy is plaintext. Fixing it means reordering
  the middleware redaction below the persistence layers while keeping DENY/telemetry
  at the outer layer (ADR-085 deliberately places the guardrail outermost) — an
  architecture change, not a patch.
- **`VisionResponse` output is never screened** (medium). `GuardrailMiddleware` only
  handles `CompletionResponse`; a vision model echoing a secret from an image (a
  screenshot of an API key) returns it unmasked. Documented as intentional
  pass-through today.
- **Fail-open verdict switches** (low). `GuardrailMiddleware` and
  `InputGuardrailScreener` `switch` on `GuardrailVerdict` with no `default`; a future
  6th verdict silently passes. Recommend converting to `match` so PHPStan enforces
  exhaustiveness (fail-closed at dev time). Left out of this PR because a `default`
  arm is untestable (an invalid enum case can't be constructed) → coverage/mutation
  noise.
- **Streaming redaction limits** (low, documented in ADR-088): a >50 KB stream drops
  to raw passthrough, and the per-chunk full-buffer re-scan is O(n²). Both are
  accepted trade-offs in ADR-088; the passthrough could be hardened to a sliding
  window later.

## Clean bills
The **HITL approval gate (ADR-084) held under every attack** — no
`RequiresApprovalInterface` tool can execute without an explicit human approval:
the turn-level suspend check throws before any call executes, resume re-applies the
RBAC/offered-set gate, denial is fail-closed, and exactly-once execution is enforced
by a conditional claim. RETRY is capped at one extra call; exception/telemetry
surfaces carry no content; the streaming holdback correctly masks boundary-split
secrets for the shipped patterns.
