### PR TITLE
fix: harden untrusted-boundary handling (translation, image, retries, token store)

### DIFF
--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Service\Skill\SkillSyncService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Http\JsonResponse;
@@ -50,6 +52,9 @@ final class SkillSourceController extends ActionController
         // audit record is simply skipped (the ingest records still come from
         // SkillSyncService).
         private readonly ?SkillAuditService $audit = null,
+        // Optional + trailing for the same reason; used only to log a vault
+        // store failure in setTokenAction. Null in lean test construction.
+        private readonly ?LoggerInterface $logger = null,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -168,10 +173,19 @@ final class SkillSourceController extends ActionController
         }
         $token = $this->stringFromBody($body, 'token');
         $uuid = $source->getGithubToken() !== '' ? $source->getGithubToken() : StringUtility::getUniqueId('ghtoken_');
-        $this->vault->store($uuid, $token);
-        $source->setGithubToken($uuid);
-        $this->sourceRepository->update($source);
-        $this->persistenceManager->persistAll();
+        try {
+            $this->vault->store($uuid, $token);
+            $source->setGithubToken($uuid);
+            $this->sourceRepository->update($source);
+            $this->persistenceManager->persistAll();
+        } catch (Throwable $e) {
+            // A vault/encryption or persistence failure must surface as a JSON
+            // error the backend module can render, not a raw HTML 500.
+            $this->logger?->error('Skill source: failed to store GitHub token', ['exception' => $e]);
+
+            return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.skill.tokenStoreFailed', 'Failed to store the token securely. See the system log for details.')], 500);
+        }
+
         return new JsonResponse(['success' => true]);
     }
 

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -64,6 +64,14 @@ abstract class AbstractProvider implements ProviderInterface
     protected int $maxRetries = 3;
     protected string $organizationId = '';
 
+    /**
+     * Upper bound for retries after the initial attempt, matching the
+     * `max_retries` TCA range (0–10). Clamped in configure() and defended in
+     * the send loop so a free-text options-JSON override cannot request an
+     * effectively unbounded retry loop against a down upstream.
+     */
+    protected const MAX_RETRIES_LIMIT = 10;
+
     /** @var array<string, string> */
     protected array $customHeaders = [];
 
@@ -93,7 +101,7 @@ abstract class AbstractProvider implements ProviderInterface
         $this->baseUrl = $this->getString($config, 'baseUrl', $this->getDefaultBaseUrl());
         $this->defaultModel = $this->getString($config, 'defaultModel', $this->getDefaultModel());
         $this->timeout = $this->getInt($config, 'timeout', 120);
-        $this->maxRetries = $this->getInt($config, 'maxRetries', 3);
+        $this->maxRetries = max(0, min(self::MAX_RETRIES_LIMIT, $this->getInt($config, 'maxRetries', 3)));
         $this->organizationId = $this->getString($config, 'organizationId');
         $this->customHeaders = $this->extractCustomHeaders($config);
 
@@ -318,10 +326,10 @@ abstract class AbstractProvider implements ProviderInterface
         $attempt = 0;
         $lastException = null;
         // maxRetries counts retries after the initial attempt; max_retries = 0
-        // still sends one request. Clamp negatives (reachable via the options
-        // JSON maxRetries override, which configure() does not range-check) so
-        // the loop always runs at least once.
-        $maxAttempts = max(0, $this->maxRetries) + 1;
+        // still sends one request. configure() clamps the stored value to
+        // [0, MAX_RETRIES_LIMIT]; re-clamp here so the loop is bounded even if
+        // the property is set through another path.
+        $maxAttempts = max(0, min(self::MAX_RETRIES_LIMIT, $this->maxRetries)) + 1;
 
         while ($attempt < $maxAttempts) {
             $attemptStart = microtime(true);

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -104,17 +104,17 @@ final class DallEImageService extends AbstractSpecializedService
         $this->setAuditContext(sprintf('%s, generate', $model));
         $response = $this->sendJsonRequest('generations', $payload);
 
-        /** @var array<int, array{url?: string, b64_json?: string, revised_prompt?: string}> $responseData */
+        /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
-        $data = $responseData[0] ?? [];
+        $data = $responseData[0] ?? null;
 
         $this->trackImageUsage($model, $size, $quality, 1, $response, $options->configuration, $options->getBeUserUid());
 
         return new ImageGenerationResult(
-            url: $data['url'] ?? '',
-            base64: $data['b64_json'] ?? null,
+            url: $this->imageString($data, 'url') ?? '',
+            base64: $this->imageString($data, 'b64_json'),
             prompt: $prompt,
-            revisedPrompt: $data['revised_prompt'] ?? null,
+            revisedPrompt: $this->imageString($data, 'revised_prompt'),
             model: $model,
             size: $size,
             provider: 'dall-e',
@@ -175,14 +175,14 @@ final class DallEImageService extends AbstractSpecializedService
         $response = $this->sendJsonRequest('generations', $payload);
 
         $results = [];
-        /** @var array<int, array{url?: string, b64_json?: string, revised_prompt?: string}> $responseData */
+        /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         foreach ($responseData as $data) {
             $results[] = new ImageGenerationResult(
-                url: $data['url'] ?? '',
-                base64: $data['b64_json'] ?? null,
+                url: $this->imageString($data, 'url') ?? '',
+                base64: $this->imageString($data, 'b64_json'),
                 prompt: $prompt,
-                revisedPrompt: $data['revised_prompt'] ?? null,
+                revisedPrompt: $this->imageString($data, 'revised_prompt'),
                 model: $model,
                 size: $size,
                 provider: 'dall-e',
@@ -235,12 +235,12 @@ final class DallEImageService extends AbstractSpecializedService
         ]);
 
         $results = [];
-        /** @var array<int, array{url?: string, b64_json?: string}> $responseData */
+        /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         foreach ($responseData as $data) {
             $results[] = new ImageGenerationResult(
-                url: $data['url'] ?? '',
-                base64: $data['b64_json'] ?? null,
+                url: $this->imageString($data, 'url') ?? '',
+                base64: $this->imageString($data, 'b64_json'),
                 prompt: '[variation of uploaded image]',
                 revisedPrompt: null,
                 model: 'dall-e-2',
@@ -294,15 +294,15 @@ final class DallEImageService extends AbstractSpecializedService
             'response_format' => 'url',
         ]);
 
-        /** @var array<int, array{url?: string, b64_json?: string}> $responseData */
+        /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
-        $data = $responseData[0] ?? [];
+        $data = $responseData[0] ?? null;
 
         $this->trackImageUsage('dall-e-2', $size, 'standard', 1, $response, beUserUid: $beUserUid);
 
         return new ImageGenerationResult(
-            url: $data['url'] ?? '',
-            base64: $data['b64_json'] ?? null,
+            url: $this->imageString($data, 'url') ?? '',
+            base64: $this->imageString($data, 'b64_json'),
             prompt: $prompt,
             revisedPrompt: null,
             model: 'dall-e-2',
@@ -415,6 +415,26 @@ final class DallEImageService extends AbstractSpecializedService
     private function capabilityKey(string $model): string
     {
         return str_starts_with($model, 'gpt-image-') ? 'gpt-image-1' : $model;
+    }
+
+    /**
+     * Read a string field from a single untrusted image `data[]` element.
+     *
+     * The response body is untrusted: an element may be a scalar rather than an
+     * object, or carry a non-string field. Returns null when the value is absent
+     * or not a string, so a malformed 2xx body degrades to an empty result
+     * instead of a raw TypeError (a 500 the caller cannot handle).
+     */
+    private function imageString(mixed $element, string $key): ?string
+    {
+        if (is_array($element)) {
+            $value = $element[$key] ?? null;
+            if (is_string($value)) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -109,9 +109,8 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $response = $this->sendDeeplRequest('translate', $payload);
 
-        /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
-        if ($translations === []) {
+        if (!is_array($translations) || $translations === []) {
             throw new ServiceUnavailableException(
                 'DeepL returned empty translation response',
                 'translation',
@@ -120,14 +119,15 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         }
 
         $translation = $translations[0];
-        $detectedSourceLanguage = strtolower($translation['detected_source_language'] ?? $sourceLanguage ?? 'en');
+        $translatedText = $this->extractTranslatedText($translation);
+        $detectedSourceLanguage = $this->extractDetectedSourceLanguage($translation, $sourceLanguage);
 
         $this->usageTracker->trackUsage('translation', 'deepl', [
             'characters' => mb_strlen($text),
         ], beUserUid: $this->extractBeUserUid($options));
 
         return new TranslatorResult(
-            translatedText: $translation['text'],
+            translatedText: $translatedText,
             sourceLanguage: $detectedSourceLanguage,
             targetLanguage: strtolower($targetLanguage),
             translator: 'deepl',
@@ -160,15 +160,22 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $response = $this->sendDeeplRequest('translate', $payload);
 
-        /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
+        if (!is_array($translations)) {
+            throw new ServiceUnavailableException(
+                'DeepL returned a malformed translation response',
+                'translation',
+                ['provider' => 'deepl'],
+            );
+        }
         $results = [];
 
         foreach ($translations as $index => $translation) {
-            $detectedSourceLanguage = strtolower($translation['detected_source_language'] ?? $sourceLanguage ?? 'en');
+            $translatedText = $this->extractTranslatedText($translation);
+            $detectedSourceLanguage = $this->extractDetectedSourceLanguage($translation, $sourceLanguage);
 
             $results[] = new TranslatorResult(
-                translatedText: $translation['text'],
+                translatedText: $translatedText,
                 sourceLanguage: $detectedSourceLanguage,
                 targetLanguage: strtolower($targetLanguage),
                 translator: 'deepl',
@@ -187,6 +194,43 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         ], beUserUid: $this->extractBeUserUid($options));
 
         return $results;
+    }
+
+    /**
+     * Extract the translated text from a single untrusted DeepL translation entry.
+     *
+     * The response body is untrusted: a broken upstream or an intermediary proxy
+     * can return a 200 whose `translations` element is not an object, or lacks a
+     * string `text`. Surface that as the typed service error rather than letting
+     * a raw TypeError escape as a 500.
+     *
+     * @throws ServiceUnavailableException
+     */
+    private function extractTranslatedText(mixed $translation): string
+    {
+        if (is_array($translation)) {
+            $text = $translation['text'] ?? null;
+            if (is_string($text)) {
+                return $text;
+            }
+        }
+
+        throw new ServiceUnavailableException(
+            'DeepL returned a malformed translation entry',
+            'translation',
+            ['provider' => 'deepl'],
+        );
+    }
+
+    /**
+     * Read the detected source language from an untrusted DeepL entry, falling
+     * back to the requested source (or `en`) when absent or non-string.
+     */
+    private function extractDetectedSourceLanguage(mixed $translation, ?string $fallback): string
+    {
+        $detected = is_array($translation) ? ($translation['detected_source_language'] ?? null) : null;
+
+        return strtolower(is_string($detected) ? $detected : ($fallback ?? 'en'));
     }
 
     public function getSupportedLanguages(): array

--- a/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
+use RuntimeException;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -228,5 +229,31 @@ final class SkillSourceControllerTest extends AbstractFunctionalTestCase
         self::assertNotSame('ghp_plaintext_secret', $reloaded->getGithubToken(), 'the column holds a vault UUID, not the plaintext token');
         self::assertSame($capturedId, $reloaded->getGithubToken());
         self::assertStringStartsWith('ghtoken_', $reloaded->getGithubToken());
+    }
+
+    #[Test]
+    public function setTokenActionReturnsJsonErrorWhenVaultStoreFails(): void
+    {
+        $source = $this->persistedSource();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1); // admin
+        $this->setUpBackendRequest();
+
+        // A vault/encryption failure must surface as a JSON 500 the module can
+        // render, not a raw HTML 500 from an uncaught exception.
+        $vault = $this->createMock(VaultServiceInterface::class);
+        $vault->method('store')->willThrowException(new RuntimeException('vault unavailable'));
+        $controller = $this->controllerWithVault($vault);
+
+        $uid = $source->getUid();
+        self::assertNotNull($uid);
+        $request = (new ServerRequest())->withParsedBody(['source' => $uid, 'token' => 'ghp_plaintext_secret']);
+        $response = $controller->setTokenAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertArrayHasKey('error', $payload);
     }
 }

--- a/Tests/Unit/Provider/AbstractProviderConfigureTest.php
+++ b/Tests/Unit/Provider/AbstractProviderConfigureTest.php
@@ -69,6 +69,51 @@ class AbstractProviderConfigureTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function configureClampsMaxRetriesToTheTcaUpperBound(): void
+    {
+        // A free-text options-JSON override above the TCA range (0-10) must be
+        // clamped so the send loop cannot request an effectively unbounded
+        // retry sequence against a down upstream.
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'maxRetries'       => 1000,
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        self::assertEquals(10, $reflection->getProperty('maxRetries')->getValue($provider));
+    }
+
+    #[Test]
+    public function configureClampsNegativeMaxRetriesToZero(): void
+    {
+        $provider = new GeminiProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+        );
+        $provider->setHttpClient($this->createHttpClientMock());
+
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'maxRetries'       => -5,
+        ]);
+
+        $reflection = new ReflectionClass($provider);
+        self::assertEquals(0, $reflection->getProperty('maxRetries')->getValue($provider));
+    }
+
+    #[Test]
     public function configureUsesProvidedTimeoutValue(): void
     {
         $provider = new GeminiProvider(

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -372,6 +372,34 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function generateDegradesGracefullyWhenDataElementIsScalar(): void
+    {
+        $subject = $this->createSubject();
+        // Untrusted 2xx body whose data[] element is a scalar, not an object:
+        // must degrade to an empty url rather than crash with a TypeError.
+        $this->setupSuccessfulRequest(['data' => ['not-an-object']]);
+
+        $result = $subject->generate('A cat');
+
+        self::assertInstanceOf(ImageGenerationResult::class, $result);
+        self::assertSame('', $result->url);
+        self::assertNull($result->base64);
+        self::assertNull($result->revisedPrompt);
+    }
+
+    #[Test]
+    public function generateIgnoresNonStringFieldsInDataElement(): void
+    {
+        $subject = $this->createSubject();
+        $this->setupSuccessfulRequest(['data' => [['url' => 12345, 'b64_json' => ['nested']]]]);
+
+        $result = $subject->generate('A cat');
+
+        self::assertSame('', $result->url);
+        self::assertNull($result->base64);
+    }
+
+    #[Test]
     public function generateThrowsWhenServiceUnavailable(): void
     {
         $subject = $this->createSubjectWithoutApiKey();

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -370,6 +370,83 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         self::assertEquals('fr', $result->targetLanguage);
     }
 
+    /**
+     * A malformed 2xx body (from a broken upstream or an intermediary proxy)
+     * whose translation entry is not an object or lacks a string `text` must
+     * raise the typed service error, not a raw TypeError -> 500.
+     *
+     * @param mixed $translationEntry the untrusted `translations[0]` value
+     */
+    #[Test]
+    #[DataProvider('malformedTranslationEntryProvider')]
+    public function translateThrowsServiceUnavailableOnMalformedEntry(mixed $translationEntry): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => [$translationEntry]]),
+        );
+        $subject = $this->buildTranslator($httpClientStub, $this->defaultConfig);
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->translate('Hello World', 'de');
+    }
+
+    #[Test]
+    #[DataProvider('malformedTranslationEntryProvider')]
+    public function translateBatchThrowsServiceUnavailableOnMalformedEntry(mixed $translationEntry): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => [$translationEntry]]),
+        );
+        $subject = $this->buildTranslator($httpClientStub, $this->defaultConfig);
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->translateBatch(['Hello World'], 'de');
+    }
+
+    #[Test]
+    public function translateThrowsServiceUnavailableWhenTranslationsContainerIsNotArray(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => 'not-an-array']),
+        );
+        $subject = $this->buildTranslator($httpClientStub, $this->defaultConfig);
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->translate('Hello World', 'de');
+    }
+
+    #[Test]
+    public function translateBatchThrowsServiceUnavailableWhenTranslationsContainerIsNotArray(): void
+    {
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub->method('sendRequest')->willReturn(
+            $this->createJsonResponseMock(['translations' => 'not-an-array']),
+        );
+        $subject = $this->buildTranslator($httpClientStub, $this->defaultConfig);
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        $subject->translateBatch(['Hello World'], 'de');
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function malformedTranslationEntryProvider(): array
+    {
+        return [
+            'entry missing text'    => [['detected_source_language' => 'EN']],
+            'entry text not string' => [['text' => 123]],
+            'entry is a scalar'     => ['plain-string-entry'],
+        ];
+    }
+
     #[Test]
     public function translateTracksUsage(): void
     {


### PR DESCRIPTION
An ultracode audit of un-audited subsystems (find → adversarial verify, 5 lenses) surfaced four confirmed defects at untrusted boundaries. Three false-positives were refuted (two SSRF-shaped ones turned out already guarded). Each fix is independently committed.

## Bug A — DeepL response crashes on a malformed 2xx body
A broken upstream or intermediary proxy returning a 200 whose `translations` container is a scalar, or whose entry is not an object / lacks a string `text`, made `DeepLTranslator` read `$translation['text']` and throw an uncaught `TypeError` → raw 500. Guarded via `extractTranslatedText()` / `extractDetectedSourceLanguage()` plus a container `is_array` check; malformed input now raises the typed `ServiceUnavailableException`. Covers `translate()` and `translateBatch()`.

## Bug B — DALL-E response elements read without type checks
A `data[]` element that is a scalar (or carries a non-string `url`/`b64_json`) crashed the generate/generateMultiple/createVariations/edit paths with a `TypeError`. Read each field through `imageString()`, degrading a malformed element to an empty result.

## Bug C — `maxRetries` upper-unbounded
`configure()` only lower-clamped `maxRetries`, so a large value from the free-text options-JSON override produced an effectively unbounded retry loop against a down upstream. Clamped to `[0, MAX_RETRIES_LIMIT]` (10, matching the `max_retries` TCA range) at the config source and re-clamped in the send loop.

## Bug D — non-JSON 500 on token-store failure
`SkillSourceController::setTokenAction` called `vault->store()` + persistence without a try/catch, so a vault/encryption failure returned a raw HTML 500 the backend module cannot render. Wrapped in a try/catch → JSON 500, mirroring `SetupWizardController`; logger injected as an optional trailing constructor argument.

## Tests
- DeepL: malformed container + malformed entry (missing/non-string text, scalar entry) → typed exception, for both `translate` and `translateBatch`.
- DALL-E: scalar element + non-string fields → empty degraded result (no crash).
- Provider: `maxRetries` 1000 → 10, −5 → 0.
- Controller: vault `store()` throws → JSON 500 with `success:false` + `error`.

## Gates
cgl, PHPStan level 10, unit (5275), Rector `-n`, fuzzy — green locally; the new functional file ran green (6 tests). Full functional runs in CI.

## Review
Adversarial review (find → verify) found no hard defects and flagged one LOW boundary-symmetry gap (the `translations` container guard), now applied.

## Investigated, not a defect — repository enable-fields
The audit also flagged that `LlmConfigurationRepository` / `ModelRepository` / `ProviderRepository` set `setIgnoreEnableFields(true)`, so `hidden` records still dispatch at runtime. Investigation of the design intent (ADR-070, ADR-034, ADR-056 and commit `63fb9b7b`) shows this is **intended**: `is_active` is the designed runtime enable/disable switch; `hidden` is backend-list/FormEngine visibility only. `hidden`-but-active is a deliberately supported state (`ModelRepository::countByProvider()` explicitly counts it). Adding a runtime `hidden` guard would revert that intentional behavior, so it is **not** changed here. Left out of this PR entirely.