### PR TITLE
fix(tool): exclude workspace drafts from LLM read tools

### DIFF
--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Where is this file used? (ADR-047).
@@ -89,7 +91,12 @@ final readonly class GetFalReferencesTool implements ToolInterface
         }
 
         $refQuery = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
+        // removeAll() intentionally surfaces hidden references (deleted stays
+        // filtered by the explicit where below), but sys_file_reference is
+        // workspace-aware: re-add a live-workspace restriction so unpublished
+        // draft references never egress to the LLM.
         $refQuery->getRestrictions()->removeAll();
+        $refQuery->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
         $rows = $refQuery
             ->select('tablenames', 'uid_foreign', 'fieldname', 'hidden')
             ->from('sys_file_reference')

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -18,7 +18,9 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Return one page's header data and its content elements in column/sorting
@@ -173,6 +175,9 @@ final readonly class GetPageContentTool implements ToolInterface
     private function fetchPage(int $uid, bool $isAdmin): ?array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        // Never send workspace draft/versioned rows to the external LLM provider
+        // (the default restrictions do not exclude them). Applies to admins too.
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
         if ($isAdmin) {
             // Admins may inspect hidden and timed-out pages; the [hidden]
             // marker makes it explicit. Soft-deleted rows stay excluded.
@@ -203,6 +208,9 @@ final readonly class GetPageContentTool implements ToolInterface
     private function fetchContent(int $pageUid, int $language, bool $isAdmin): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        // Never send workspace draft/versioned rows to the external LLM provider
+        // (the default restrictions do not exclude them). Applies to admins too.
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
         if ($isAdmin) {
             $queryBuilder->getRestrictions()
                 ->removeByType(HiddenRestriction::class)

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -14,7 +14,9 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Return the backend page tree (`pages`) as a depth-indented outline.
@@ -134,6 +136,9 @@ final readonly class GetPageTreeTool implements ToolInterface
         // and sys_language_uid is pinned so translated rows do not duplicate the
         // tree.
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        // Never send workspace draft/versioned pages to the external LLM provider
+        // (they would also appear as duplicate tree nodes). Mirrors DatabaseSearchBackend.
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
         $queryBuilder
             ->select('uid', 'title', 'doktype')
             ->from(self::TABLE)

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -16,7 +16,9 @@ use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Generic filtered read of one TCA table — never raw SQL.
@@ -294,6 +296,10 @@ final readonly class ReadRecordsTool implements ToolInterface
     private function fetchRows(string $table, array $fields, array $filters, int $limit, int $offset): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        // A tool result is sent verbatim to an external LLM provider, so exclude
+        // workspace draft/versioned rows (the default restrictions do not) — the
+        // provider must never see unpublished content. Mirrors DatabaseSearchBackend.
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
         $queryBuilder
             ->select(...$fields)
             ->from($table)

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -15,8 +15,10 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Schema\SearchableSchemaFieldsCollector;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Full-text search across the tables that declare TCA `searchFields`.
@@ -219,7 +221,11 @@ final readonly class SearchRecordsTool implements ToolInterface
         )));
 
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
-        $like         = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
+        // A tool result is sent verbatim to an external LLM provider, so exclude
+        // workspace draft/versioned rows (the default restrictions do not) — the
+        // provider must never see unpublished content. Mirrors DatabaseSearchBackend.
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, 0));
+        $like = '%' . $queryBuilder->escapeLikeWildcards($query) . '%';
 
         $orConditions = [];
         foreach ($searchFields as $field) {

--- a/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
@@ -81,6 +81,26 @@ final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function workspaceDraftReferencesAreExcluded(): void
+    {
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('sys_file_reference');
+        self::assertInstanceOf(Connection::class, $connection);
+        // Unpublished workspace draft reference (t3ver_wsid > 0) must not egress.
+        $connection->insert('sys_file_reference', [
+            'uid' => 203, 'uid_local' => 20, 'uid_foreign' => 77, 'tablenames' => 'tt_content',
+            'fieldname' => 'image', 'deleted' => 0, 'hidden' => 0,
+            't3ver_wsid' => 1, 't3ver_oid' => 200, 't3ver_state' => 0,
+        ]);
+
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['uid' => 20]);
+
+        self::assertStringNotContainsString('tt_content:77', $output);
+        self::assertStringContainsString('References to logo.svg (2):', $output);
+    }
+
+    #[Test]
     public function unusedFileSaysSoWithTheSoftReferenceCaveat(): void
     {
         $this->setUpBackendUser(1);

--- a/Tests/Functional/Service/Tool/GetPageContentToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageContentToolTest.php
@@ -87,6 +87,27 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function workspaceDraftContentIsExcludedEvenForAdmin(): void
+    {
+        $content = $this->get(ConnectionPool::class)->getConnectionForTable('tt_content');
+        self::assertInstanceOf(Connection::class, $content);
+        // Unpublished workspace draft (t3ver_wsid > 0) must never egress to the
+        // LLM — not even for an admin, who may otherwise inspect hidden rows.
+        $content->insert('tt_content', [
+            'uid' => 29, 'pid' => 1, 'colPos' => 0, 'sorting' => 9, 'CType' => 'text',
+            'header' => 'DraftOnlyMarker', 'bodytext' => 'draft body',
+            't3ver_wsid' => 1, 't3ver_oid' => 21, 't3ver_state' => 0,
+        ]);
+
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['uid' => 1]);
+
+        self::assertStringNotContainsString('DraftOnlyMarker', $output);
+        self::assertStringContainsString('Intro', $output);
+    }
+
+    #[Test]
     public function nonAdminWithoutPagePermissionIsDenied(): void
     {
         $this->setUpBackendUser(2); // editor, no rights on page 1

--- a/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
@@ -84,6 +84,24 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function excludesWorkspaceDraftPages(): void
+    {
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $connection);
+        // Unpublished workspace draft page (t3ver_wsid > 0) must not surface in
+        // the tree sent to the LLM (it would also appear as a duplicate node).
+        $connection->insert('pages', [
+            'uid' => 6, 'pid' => 1, 'title' => 'Draft Branch', 'doktype' => 1, 'sorting' => 4,
+            't3ver_wsid' => 1, 't3ver_oid' => 2, 't3ver_state' => 0,
+        ]);
+
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3]);
+
+        self::assertStringNotContainsString('Draft Branch', $output);
+        self::assertStringContainsString('[2] About', $output);
+    }
+
+    #[Test]
     public function depthOneStopsAtImmediateChildren(): void
     {
         $output = $this->tool->execute(['rootUid' => 1, 'depth' => 1]);

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -96,6 +96,27 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function workspaceDraftRowsAreExcluded(): void
+    {
+        $content = $this->get(ConnectionPool::class)->getConnectionForTable('tt_content');
+        self::assertInstanceOf(Connection::class, $content);
+        // Unpublished workspace draft (t3ver_wsid > 0) must never egress to the LLM.
+        $content->insert('tt_content', [
+            'uid' => 99, 'pid' => 1, 'colPos' => 0, 'sorting' => 9,
+            'CType' => 'text', 'header' => 'DraftSecret',
+            't3ver_wsid' => 1, 't3ver_oid' => 30, 't3ver_state' => 0,
+        ]);
+
+        $this->setUpBackendUser(1);
+
+        $output = $this->tool->execute(['table' => 'tt_content']);
+
+        self::assertStringNotContainsString('DraftSecret', $output);
+        self::assertStringNotContainsString('tt_content:99', $output);
+        self::assertStringContainsString('tt_content:30', $output);
+    }
+
+    #[Test]
     public function nonAdminWithoutTableRightsIsDenied(): void
     {
         $this->setUpBackendUser(2); // editor without any group rights

--- a/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
@@ -93,4 +93,21 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
 
         self::assertSame('Table not found or not permitted.', $output);
     }
+
+    #[Test]
+    public function workspaceDraftRowsNeverReachTheOutput(): void
+    {
+        $content = $this->get(ConnectionPool::class)->getConnectionForTable('tt_content');
+        self::assertInstanceOf(Connection::class, $content);
+        // Unpublished workspace draft (t3ver_wsid > 0) must never egress to the LLM.
+        $content->insert('tt_content', [
+            'uid' => 14, 'pid' => 1, 'colPos' => 0, 'sorting' => 3, 'CType' => 'text',
+            'header' => 'Draft', 'bodytext' => 'Netresearch workspacedraftmarker.',
+            't3ver_wsid' => 1, 't3ver_oid' => 10, 't3ver_state' => 0,
+        ]);
+
+        $output = $this->tool->execute(['query' => 'workspacedraftmarker']);
+
+        self::assertSame('No matches.', $output);
+    }
 }

--- a/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
@@ -21,6 +21,8 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Unit tests for {@see ReadRecordsTool}: spec shape, field resolution
@@ -96,6 +98,9 @@ final class ReadRecordsToolTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Drop any TcaSchemaFactory stub queued by tool() but not consumed
+        // (tests that never reach fetchRows), so it cannot leak into the next test.
+        GeneralUtility::purgeInstances();
         $GLOBALS['TCA'] = $this->tcaBackup;
         if ($this->beUserBackup !== null) {
             $GLOBALS['BE_USER'] = $this->beUserBackup;
@@ -357,6 +362,12 @@ final class ReadRecordsToolTest extends TestCase
      */
     private function tool(array $rows): ReadRecordsTool
     {
+        // fetchRows() adds a WorkspaceRestriction, whose constructor pulls a
+        // TcaSchemaFactory from the container; provide a stub so the pure-unit
+        // environment can build it (its buildExpression never runs here — the
+        // query builder is a stub that does not execute).
+        GeneralUtility::addInstance(TcaSchemaFactory::class, self::createStub(TcaSchemaFactory::class));
+
         $result = self::createStub(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
 


### PR DESCRIPTION
An ultracode security audit of the LLM **tool-execution** system (5 lenses → adversarial verify, 13 confirmed of 14) found that the record/content/tree read tools query the database with default restrictions only, which do **not** exclude workspace draft/versioned rows. Because a tool result is sent verbatim to an external LLM provider, **unpublished workspace content leaks off-site**.

## Fix
Add a live-workspace `WorkspaceRestriction` (workspace 0) to each read query, mirroring the canonical `Service/Retrieval/DatabaseSearchBackend::liveQueryBuilder()`:

- `search_records` (`SearchRecordsTool`)
- `read_records` (`ReadRecordsTool`)
- `get_page_content` (`GetPageContentTool` — pages + tt_content, applied for admins too)
- `get_pagetree` (`GetPageTreeTool`)
- `get_fal_references` (`GetFalReferencesTool` — `sys_file_reference` is workspace-aware; second commit, closing the class after the adversarial review flagged it)

`WorkspaceRestriction` no-ops on non-versioned tables and non-workspace installs, so live records are unaffected; it is applied even for admins, since an admin must not egress drafts to the provider either.

## Tests
A workspace-draft-exclusion functional test per tool (insert a `t3ver_wsid > 0` row → assert it never reaches the tool output while live rows still do). The `ReadRecordsTool` unit test builds the query with a non-executing stub query builder, so it registers a stub `TcaSchemaFactory` (pulled by the `WorkspaceRestriction` constructor) and purges it on teardown.

## Gates
cgl, PHPStan level 10, unit (5275), Rector `-n`, fuzzy — green; tool functional suite green locally (incl. the 5 new workspace tests). Full functional runs in CI. Adversarial review found no defects in the fix and flagged the `get_fal_references` gap, now closed here.

## Scope
This PR closes the workspace-draft class across all affected tools. The same audit surfaced further tool findings handled separately (FAL tools gating by storage rather than file-mount; secret-egress denylist gaps; a language-access check) — each a distinct concern with its own review surface.