### PR TITLE
security: harden guardrail enforcement (no unredacted persistence, fail-closed verdicts, vision screening)

### DIFF
--- a/Classes/Exception/GuardrailApprovalRequiredException.php
+++ b/Classes/Exception/GuardrailApprovalRequiredException.php
@@ -20,7 +20,7 @@ use Throwable;
  * run/review context catches this to route it to approval (the Epic-D /
  * review-queue seam), rather than to an error.
  */
-final class GuardrailApprovalRequiredException extends RuntimeException implements NrLlmExceptionInterface
+final class GuardrailApprovalRequiredException extends RuntimeException implements GuardrailPolicyException
 {
     public function __construct(
         public readonly string $guardrail,

--- a/Classes/Exception/GuardrailPolicyException.php
+++ b/Classes/Exception/GuardrailPolicyException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+/**
+ * Marker interface for a guardrail POLICY outcome (ADR-085 / ADR-086): the
+ * provider call itself succeeded, but a guardrail then blocked the response
+ * ({@see GuardrailViolationException}) or flagged it for human approval
+ * ({@see GuardrailApprovalRequiredException}).
+ *
+ * It exists so a layer that observes the pipeline can tell a policy block from a
+ * genuine provider failure without importing the concrete classes. In
+ * particular {@see \Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware}
+ * records a policy exception as a SUCCESSFUL provider run — the provider
+ * produced a response; the guardrail simply refused to release it — so guardrail
+ * denials never distort the provider failure-rate.
+ */
+interface GuardrailPolicyException extends NrLlmExceptionInterface {}

--- a/Classes/Exception/GuardrailViolationException.php
+++ b/Classes/Exception/GuardrailViolationException.php
@@ -19,7 +19,7 @@ use Throwable;
  * tripped; the message is the guardrail's reason. Mirrors
  * {@see BudgetExceededException} — a typed, catchable pipeline denial.
  */
-final class GuardrailViolationException extends RuntimeException implements NrLlmExceptionInterface
+final class GuardrailViolationException extends RuntimeException implements GuardrailPolicyException
 {
     public function __construct(
         public readonly string $guardrail,

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
@@ -22,10 +23,18 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  * Applies the guardrail collection to every non-streaming provider response
  * (ADR-085).
  *
- * Runs outermost of the enforcement middlewares (priority 115, above Telemetry's
- * 110) so a guardrail sees the final response returned to the caller. After the
- * downstream chain produces a {@see CompletionResponse}, each tagged
- * {@see GuardrailInterface} is asked for a verdict, in tag order:
+ * Runs at priority 90 — INSIDE both persistence layers (IdempotencyMiddleware
+ * 105, CacheMiddleware 100) and above the behavioural stack (Budget 75 down).
+ * This placement is load-bearing for privacy: on the pipeline unwind the
+ * guardrail redacts (or blocks) the response BEFORE Idempotency serialises it,
+ * so no unredacted content is ever persisted to the nrllm_idempotency cache, and
+ * a DENY/REQUIRE_APPROVAL throws before that store runs, so a blocked response is
+ * never stored as a replayable result. The guardrail now sits inside Telemetry
+ * (110); TelemetryMiddleware classifies a {@see GuardrailPolicyException} as a
+ * successful provider run, so a guardrail policy outcome is still not counted as
+ * a provider failure. After the downstream chain produces a
+ * {@see CompletionResponse}, each tagged {@see GuardrailInterface} is asked for a
+ * verdict, in tag order:
  * - ALLOW: pass on;
  * - REDACT: replace the content with the guardrail's version, and keep screening
  *   (a later guardrail may still deny);
@@ -38,7 +47,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  * through untouched. Streaming bypasses the whole pipeline (see ADR-085 /
  * ADR-062), so streamed output is not screened here.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 115])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 90])]
 final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 {
     /**
@@ -72,46 +81,67 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         bool $retried,
     ): CompletionResponse {
         foreach ($this->guardrails as $guardrail) {
-            $result = $guardrail->checkOutput($response);
-            switch ($result->verdict) {
-                case GuardrailVerdict::ALLOW:
-                    break;
-                case GuardrailVerdict::REDACT:
-                    $response = $this->withContent($response, $result->redactedContent ?? $response->content, $result->redactedThinking);
-                    break;
-                case GuardrailVerdict::DENY:
-                    throw new GuardrailViolationException(
-                        $guardrail::class,
-                        $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
-                    );
-                case GuardrailVerdict::REQUIRE_APPROVAL:
-                    throw new GuardrailApprovalRequiredException(
-                        $guardrail::class,
-                        $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
-                    );
-                case GuardrailVerdict::RETRY:
-                    if ($retried) {
-                        throw new GuardrailViolationException(
-                            $guardrail::class,
-                            'A guardrail asked to retry, but the retried response also failed: ' . $result->reason,
-                        );
-                    }
-                    // LIMITATION: $next runs the inner pipeline, which includes
-                    // IdempotencyMiddleware (priority 105). When the call carries an
-                    // idempotency key the retry returns the SAME cached response, so
-                    // a RETRY then denies on the second pass. No shipped guardrail
-                    // returns RETRY; a future one that needs a genuinely fresh
-                    // completion must not be paired with an idempotency key.
-                    $fresh = $next($configuration);
-                    if (!$fresh instanceof CompletionResponse) {
-                        return $response;
-                    }
+            $result  = $guardrail->checkOutput($response);
+            $verdict = $result->verdict;
 
-                    return $this->screen($fresh, $configuration, $next, true);
+            // RETRY short-circuits the loop (it re-runs the pipeline and re-screens
+            // the fresh response from scratch), so it is handled before the match.
+            if ($verdict === GuardrailVerdict::RETRY) {
+                return $this->retryOnce($response, $configuration, $next, $retried, $guardrail, $result);
             }
+
+            // match (no default) is exhaustive over the remaining verdicts: a new
+            // verdict left unhandled is a PHPStan error / runtime UnhandledMatchError
+            // (fail closed), never a silent pass-through of an unscreened response.
+            $response = match ($verdict) {
+                GuardrailVerdict::ALLOW => $response,
+                GuardrailVerdict::REDACT => $this->withContent(
+                    $response,
+                    $result->redactedContent ?? $response->content,
+                    $result->redactedThinking,
+                ),
+                GuardrailVerdict::DENY => throw new GuardrailViolationException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
+                ),
+                GuardrailVerdict::REQUIRE_APPROVAL => throw new GuardrailApprovalRequiredException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
+                ),
+            };
         }
 
         return $response;
+    }
+
+    /**
+     * @param callable(LlmConfiguration): mixed $next
+     */
+    private function retryOnce(
+        CompletionResponse $response,
+        LlmConfiguration $configuration,
+        callable $next,
+        bool $retried,
+        GuardrailInterface $guardrail,
+        GuardrailResult $result,
+    ): CompletionResponse {
+        if ($retried) {
+            throw new GuardrailViolationException(
+                $guardrail::class,
+                'A guardrail asked to retry, but the retried response also failed: ' . $result->reason,
+            );
+        }
+        // $next is the behavioural stack BELOW this guardrail (Budget → Fallback →
+        // Usage → CircuitBreaker → terminal) and INSIDE Idempotency/Cache, so a
+        // retry genuinely re-runs the provider rather than replaying an
+        // idempotency-cached response. Still capped at one retry; no shipped
+        // guardrail returns RETRY.
+        $fresh = $next($configuration);
+        if (!$fresh instanceof CompletionResponse) {
+            return $response;
+        }
+
+        return $this->screen($fresh, $configuration, $next, true);
     }
 
     private function withContent(CompletionResponse $response, string $content, ?string $thinking): CompletionResponse

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -79,9 +79,10 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 
     /**
      * Screen a vision response's description text through the same output
-     * guardrails. A vision call cannot be re-requested through the pipeline here,
-     * so RETRY is a pass; REDACT rewrites the description, DENY/REQUIRE_APPROVAL
-     * throw the same exceptions as a completion.
+     * guardrails. REDACT rewrites the description, DENY/REQUIRE_APPROVAL throw the
+     * same exceptions as a completion. A vision call cannot be re-requested
+     * through the pipeline, so a RETRY (the response was deemed deficient) fails
+     * CLOSED — throwing rather than silently returning the unscreened response.
      */
     private function screenVision(VisionResponse $vision): VisionResponse
     {
@@ -90,7 +91,10 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             $result  = $guardrail->checkOutput(new CompletionResponse($screened, $vision->model, $vision->usage, provider: $vision->provider));
             $verdict = $result->verdict;
             if ($verdict === GuardrailVerdict::RETRY) {
-                continue;
+                throw new GuardrailViolationException(
+                    $guardrail::class,
+                    'A guardrail asked to retry, but retrying is not supported for vision responses.',
+                );
             }
             $screened = match ($verdict) {
                 GuardrailVerdict::ALLOW => $screened,

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
@@ -43,9 +44,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  * - RETRY: ask the provider once more and re-screen the fresh response (capped at
  *   one retry).
  *
- * Non-`CompletionResponse` operations (embeddings, vision, raw arrays) pass
- * through untouched. Streaming bypasses the whole pipeline (see ADR-085 /
- * ADR-062), so streamed output is not screened here.
+ * A {@see VisionResponse}'s description is screened too (it is model-generated,
+ * untrusted text — a secret in a transcribed image would otherwise leak).
+ * Embeddings and raw-array operations pass through untouched. Streaming bypasses
+ * the whole pipeline (see ADR-085 / ADR-062), so streamed output is not screened
+ * here.
  */
 #[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 90])]
 final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
@@ -64,11 +67,58 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         callable $next,
     ): mixed {
         $result = $next($configuration);
-        if (!$result instanceof CompletionResponse) {
-            return $result;
+        if ($result instanceof CompletionResponse) {
+            return $this->screen($result, $configuration, $next, false);
+        }
+        if ($result instanceof VisionResponse) {
+            return $this->screenVision($result);
         }
 
-        return $this->screen($result, $configuration, $next, false);
+        return $result;
+    }
+
+    /**
+     * Screen a vision response's description text through the same output
+     * guardrails. A vision call cannot be re-requested through the pipeline here,
+     * so RETRY is a pass; REDACT rewrites the description, DENY/REQUIRE_APPROVAL
+     * throw the same exceptions as a completion.
+     */
+    private function screenVision(VisionResponse $vision): VisionResponse
+    {
+        $screened = $vision->description;
+        foreach ($this->guardrails as $guardrail) {
+            $result  = $guardrail->checkOutput(new CompletionResponse($screened, $vision->model, $vision->usage, provider: $vision->provider));
+            $verdict = $result->verdict;
+            if ($verdict === GuardrailVerdict::RETRY) {
+                continue;
+            }
+            $screened = match ($verdict) {
+                GuardrailVerdict::ALLOW => $screened,
+                GuardrailVerdict::REDACT => $result->redactedContent ?? $screened,
+                GuardrailVerdict::DENY => throw new GuardrailViolationException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
+                ),
+                GuardrailVerdict::REQUIRE_APPROVAL => throw new GuardrailApprovalRequiredException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
+                ),
+            };
+        }
+
+        if ($screened === $vision->description) {
+            return $vision;
+        }
+
+        return new VisionResponse(
+            description: $screened,
+            model: $vision->model,
+            usage: $vision->usage,
+            provider: $vision->provider,
+            confidence: $vision->confidence,
+            detectedObjects: $vision->detectedObjects,
+            metadata: $vision->metadata,
+        );
     }
 
     /**

--- a/Classes/Provider/Middleware/IdempotencyMiddleware.php
+++ b/Classes/Provider/Middleware/IdempotencyMiddleware.php
@@ -41,14 +41,21 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
  * Pipeline placement — priority 105, just inside TelemetryMiddleware (110) and
  * OUTSIDE CacheMiddleware (100):
  *
- *   TelemetryMiddleware      <-- 110  observes every run, replays included
- *     IdempotencyMiddleware  <-- 105  replays a stored result by key   (THIS)
- *       CacheMiddleware      <-- 100  payload cache
- *         ...                <--      budget / fallback / usage / circuit
+ *   TelemetryMiddleware       <-- 110  observes every run, replays included
+ *     IdempotencyMiddleware   <-- 105  replays a stored result by key   (THIS)
+ *       CacheMiddleware       <-- 100  payload cache
+ *         GuardrailMiddleware <-- 90   screens/redacts the response
+ *           ...               <--      budget / fallback / usage / circuit
  *
  * Outside Cache/Budget so a replay short-circuits the whole behavioural stack
  * (no second budget charge), yet inside Telemetry so a replay is still recorded
  * as a (fast) run.
+ *
+ * The value stored under a key is the POST-guardrail (screened/redacted)
+ * response: GuardrailMiddleware (90) runs INSIDE this layer, so it redacts before
+ * this middleware's store, and a denied / approval-required response throws
+ * before the store is reached — so no unredacted or blocked completion is ever
+ * persisted as a replayable idempotency result (ADR-085).
  *
  * Why not reuse CacheMiddleware's key? CacheMiddleware is deliberately
  * array-only (it persists `array<string, mixed>`), so it cannot round-trip the

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\GuardrailPolicyException;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -32,13 +33,20 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
  * Pipeline ordering — Telemetry sits OUTSIDE Cache so the measured latency
  * includes the cache lookup and a cache-served response still produces a row:
  *
- *   TelemetryMiddleware      <-- outermost; pure observer          (priority 110)
- *     CacheMiddleware        <-- short-circuits on hit             (priority 100)
- *       BudgetMiddleware     <-- pre-flight denial                 (priority 75)
- *         FallbackMiddleware <-- swaps config on retryable failure (priority 50)
- *           UsageMiddleware  <-- records the call that ran         (priority 25)
- *             CircuitBreaker <-- guards the provider call          (priority 20)
- *               <terminal>
+ *   TelemetryMiddleware        <-- outermost; pure observer          (priority 110)
+ *     IdempotencyMiddleware    <-- replays a stored result by key    (priority 105)
+ *       CacheMiddleware        <-- short-circuits on hit             (priority 100)
+ *         GuardrailMiddleware  <-- screens/redacts the response      (priority 90)
+ *           BudgetMiddleware   <-- pre-flight denial                 (priority 75)
+ *             FallbackMiddleware <-- swaps config on retryable failure (priority 50)
+ *               UsageMiddleware  <-- records the call that ran       (priority 25)
+ *                 CircuitBreaker <-- guards the provider call        (priority 20)
+ *                   <terminal>
+ *
+ * The guardrail sits INSIDE this layer, so a guardrail policy outcome
+ * ({@see GuardrailPolicyException}) is recorded as a SUCCESSFUL provider run (the
+ * provider produced a response; the guardrail then blocked it) — not a provider
+ * failure. A genuine provider/budget exception still records success=false.
  *
  * What it records: the OPERATION and requested primary CONFIGURATION
  * (identifier, plus its provider/model). When FallbackMiddleware swaps to a
@@ -93,6 +101,15 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
             $success = true;
 
             return $result;
+        } catch (GuardrailPolicyException $e) {
+            // A guardrail policy outcome (block / approval-required) means the
+            // provider call itself SUCCEEDED — the guardrail (inside this layer,
+            // priority 90) simply refused to release the response. Record it as a
+            // successful run (errorClass stays '') so a guardrail denial never
+            // distorts the provider failure-rate. Re-throw untouched.
+            $success = true;
+
+            throw $e;
         } catch (Throwable $e) {
             $errorClass = $e::class;
 

--- a/Classes/Service/Guardrail/InputGuardrailScreener.php
+++ b/Classes/Service/Guardrail/InputGuardrailScreener.php
@@ -73,26 +73,24 @@ final readonly class InputGuardrailScreener
         $redacted = $content;
         foreach ($this->guardrails as $guardrail) {
             $result = $guardrail->checkInput($redacted);
-            switch ($result->verdict) {
-                case GuardrailVerdict::ALLOW:
-                case GuardrailVerdict::RETRY:
-                    // RETRY re-asks the provider; no provider call has happened
-                    // yet on the input side, so it is a pass here.
-                    break;
-                case GuardrailVerdict::REDACT:
-                    $redacted = $result->redactedContent ?? $redacted;
-                    break;
-                case GuardrailVerdict::DENY:
-                    throw new GuardrailViolationException(
-                        $guardrail::class,
-                        $result->reason !== '' ? $result->reason : 'A guardrail denied the prompt.',
-                    );
-                case GuardrailVerdict::REQUIRE_APPROVAL:
-                    throw new GuardrailApprovalRequiredException(
-                        $guardrail::class,
-                        $result->reason !== '' ? $result->reason : 'A guardrail flagged the prompt for human approval.',
-                    );
-            }
+            // match (no default) is exhaustive over GuardrailVerdict: adding a new
+            // verdict without handling it here is a compile-time PHPStan error and
+            // a runtime \UnhandledMatchError — an unknown verdict fails closed
+            // rather than silently passing the prompt through.
+            $redacted = match ($result->verdict) {
+                // RETRY re-asks the provider; no provider call has happened yet on
+                // the input side, so it is a pass here (like ALLOW).
+                GuardrailVerdict::ALLOW, GuardrailVerdict::RETRY => $redacted,
+                GuardrailVerdict::REDACT => $result->redactedContent ?? $redacted,
+                GuardrailVerdict::DENY => throw new GuardrailViolationException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail denied the prompt.',
+                ),
+                GuardrailVerdict::REQUIRE_APPROVAL => throw new GuardrailApprovalRequiredException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail flagged the prompt for human approval.',
+                ),
+            };
         }
 
         if ($redacted === $content) {

--- a/Documentation/Adr/Adr085GuardrailPipeline.rst
+++ b/Documentation/Adr/Adr085GuardrailPipeline.rst
@@ -33,8 +33,10 @@ pattern as ``nr_llm.tool``), so a new guardrail is active simply by existing
 under ``Classes/``.
 
 **`GuardrailMiddleware` runs them in the existing ADR-026 provider pipeline**, at
-priority 115 — outermost, above Telemetry (110). It screens every non-streaming
-`CompletionResponse` after the downstream chain produces it:
+priority 115 — outermost, above Telemetry (110) *(superseded — see the*
+*2026-07-19 update under Consequences: the guardrail moved to priority 90, inside*
+*the persistence layers)*. It screens every non-streaming `CompletionResponse`
+after the downstream chain produces it:
 
 - ALLOW passes on; REDACT rewrites the content and keeps screening (a later
   guardrail may still deny); DENY throws `GuardrailViolationException`;
@@ -55,6 +57,23 @@ response into an explicit, catchable denial).
 
 Consequences
 ============
+
+**Update 2026-07-19 — corrected pipeline placement (priority 115 → 90).** Placing
+the guardrail *outermost* meant it redacted the response only AFTER
+`IdempotencyMiddleware` (105) had already serialised the *unredacted*
+`CompletionResponse` into the ``nrllm_idempotency`` cache (24h, possibly a shared
+backend) — so a model that echoed a secret leaked it into persistence even though
+the caller saw the redacted value. The guardrail now runs at priority **90**,
+INSIDE both persistence layers (Idempotency 105, Cache 100) and above the
+behavioural stack, so it redacts (or blocks) *before* anything is stored; a
+DENY/REQUIRE_APPROVAL throws before the store, so a blocked response is never a
+replayable result. Telemetry accuracy is preserved differently now that the
+guardrail sits inside Telemetry (110): the two guardrail exceptions implement a
+`GuardrailPolicyException` marker, and `TelemetryMiddleware` records such a policy
+outcome as a *successful* provider run (the provider produced a response; the
+guardrail refused to release it) — so a denial still does not distort the
+provider failure-rate. A side benefit: a RETRY now genuinely re-runs the provider
+instead of replaying the idempotency-cached response.
 
 - Consumers get allow/redact/deny/retry/require-approval over model output, not
   true/false. A denial is a typed, catchable exception (mirroring

--- a/Tests/Functional/Provider/Middleware/GuardrailIdempotencyLeakTest.php
+++ b/Tests/Functional/Provider/Middleware/GuardrailIdempotencyLeakTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
+
+/**
+ * Regression proof for the guardrail/idempotency ordering fix (ADR-085): the
+ * value {@see IdempotencyMiddleware} persists must be the guardrail-REDACTED
+ * response, never the plaintext secret the model echoed.
+ *
+ * It drives the real DI-resolved {@see MiddlewarePipeline} and inspects the
+ * ACTUAL nrllm_idempotency cache entry — not the value returned to the caller,
+ * which the pre-fix layout redacted on the way out while still storing the raw
+ * secret inside. On the pre-fix layout (guardrail priority 115, outside
+ * Idempotency 105) the stored value is the plaintext secret and this test fails;
+ * with the guardrail moved inside the persistence layers it stores `sk-***`.
+ */
+#[CoversClass(GuardrailMiddleware::class)]
+#[CoversClass(IdempotencyMiddleware::class)]
+final class GuardrailIdempotencyLeakTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function idempotencyPersistsTheGuardrailRedactedResponseNotThePlaintextSecret(): void
+    {
+        $pipeline = $this->get(MiddlewarePipeline::class);
+        self::assertInstanceOf(MiddlewarePipeline::class, $pipeline);
+
+        $cacheManager = $this->get(Typo3CacheManager::class);
+        self::assertInstanceOf(Typo3CacheManager::class, $cacheManager);
+        $cache = $cacheManager->getCache('nrllm_idempotency');
+
+        $key    = 'leak-regression-key';
+        $secret = 'sk-ABCDEFGHIJKLMNOP0123456789';
+        // Mirror IdempotencyMiddleware::entryIdentifier() so the test can read the
+        // value that was actually PERSISTED (the replay path would re-redact on
+        // the pre-fix layout and hide the leak).
+        $entryId = 'idem_' . substr((string)preg_replace('/[^a-zA-Z0-9_-]/', '_', $key), 0, 64)
+            . '_' . substr(hash('sha256', $key), 0, 16);
+        $cache->remove($entryId);
+
+        $context = new ProviderCallContext(
+            ProviderOperation::Chat,
+            'corr-leak',
+            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
+        );
+
+        $result = $pipeline->run(
+            $context,
+            new LlmConfiguration(),
+            static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+                content: 'your token is ' . $secret . ' keep it safe',
+                model: 'test-model',
+                usage: UsageStatistics::fromTokens(1, 1),
+                provider: 'test',
+            ),
+        );
+
+        // The caller receives the redacted response ...
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertStringNotContainsString($secret, $result->content);
+        self::assertStringContainsString('sk-***', $result->content);
+
+        // ... AND the value persisted in the idempotency cache is redacted too.
+        $stored = $cache->get($entryId);
+        self::assertInstanceOf(CompletionResponse::class, $stored);
+        self::assertStringNotContainsString($secret, $stored->content);
+        self::assertStringContainsString('sk-***', $stored->content);
+
+        $cache->remove($entryId);
+    }
+}

--- a/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
+++ b/Tests/Functional/Provider/Middleware/MiddlewarePipelineOrderTest.php
@@ -51,10 +51,10 @@ final class MiddlewarePipelineOrderTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             [
-                GuardrailMiddleware::class,      // 115 outermost: screens the final response; a guardrail deny is a policy outcome, not a provider failure, so it sits above Telemetry (ADR-085)
-                TelemetryMiddleware::class,      // 110 observes every provider run (ADR-058)
+                TelemetryMiddleware::class,      // 110 outermost observer (ADR-058)
                 IdempotencyMiddleware::class,    // 105 replays a stored result by key (ADR-063)
                 CacheMiddleware::class,          // 100 outermost behavioural layer: a cache hit short-circuits
+                GuardrailMiddleware::class,      //  90 screens/redacts the response INSIDE the persistence layers, so no unredacted response is ever stored (ADR-085)
                 BudgetMiddleware::class,         //  75 pre-flight budget gate on a miss
                 FallbackMiddleware::class,       //  50 swaps configuration on retryable failure
                 UsageMiddleware::class,          //  25 records the served call

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -192,6 +192,15 @@ final class GuardrailMiddlewareTest extends TestCase
         $this->screen($middleware, static fn(): VisionResponse => new VisionResponse('bad', 'm', UsageStatistics::fromTokens(1, 1)));
     }
 
+    #[Test]
+    public function visionResponseRetryFailsClosedBecauseAVisionCallCannotBeRetried(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::retry('deficient'))]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->screen($middleware, static fn(): VisionResponse => new VisionResponse('desc', 'm', UsageStatistics::fromTokens(1, 1)));
+    }
+
     /**
      * @param callable(): mixed $terminal
      */

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
@@ -142,15 +143,53 @@ final class GuardrailMiddlewareTest extends TestCase
     }
 
     #[Test]
-    public function nonCompletionResponsePassesThroughUnscreened(): void
+    public function nonScreenableResponsePassesThroughUnscreened(): void
     {
-        // e.g. an embedding/vision payload (a different type): the guardrail — even
-        // a denying one — is never consulted.
+        // e.g. an embedding payload (a raw string/array): the guardrail — even a
+        // denying one — is never consulted.
         $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('should not run'))]);
 
         $result = $this->screen($middleware, static fn(): string => 'raw-embedding');
 
         self::assertSame('raw-embedding', $result);
+    }
+
+    #[Test]
+    public function visionResponseDescriptionIsScreenedAndRedactedPreservingOtherFields(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::redact('[redacted]', 'secret'))]);
+        $vision     = new VisionResponse('the key is sk-secret', 'vision-model', UsageStatistics::fromTokens(1, 1), 'openai', 0.9, [['label' => 'cat']], ['k' => 'v']);
+
+        $result = $this->screen($middleware, static fn(): VisionResponse => $vision);
+
+        self::assertInstanceOf(VisionResponse::class, $result);
+        self::assertSame('[redacted]', $result->description);
+        // Non-text fields survive the rebuild.
+        self::assertSame('vision-model', $result->model);
+        self::assertSame('openai', $result->provider);
+        self::assertSame(0.9, $result->confidence);
+        self::assertSame([['label' => 'cat']], $result->detectedObjects);
+        self::assertSame(['k' => 'v'], $result->metadata);
+    }
+
+    #[Test]
+    public function cleanVisionResponseIsReturnedUnchanged(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::allow())]);
+        $vision     = new VisionResponse('a perfectly clean caption', 'vision-model', UsageStatistics::fromTokens(1, 1));
+
+        $result = $this->screen($middleware, static fn(): VisionResponse => $vision);
+
+        self::assertSame($vision, $result, 'A clean vision response is returned as the same instance.');
+    }
+
+    #[Test]
+    public function visionResponseDenyThrowsAViolation(): void
+    {
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->screen($middleware, static fn(): VisionResponse => new VisionResponse('bad', 'm', UsageStatistics::fromTokens(1, 1)));
     }
 
     /**

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -90,6 +92,57 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         self::assertFalse($record->success);
         // The exception FQCN is stored, never the message (privacy).
         self::assertSame(RuntimeException::class, $record->errorClass);
+    }
+
+    /**
+     * The guardrail now runs INSIDE this layer (priority 90), so a guardrail
+     * policy outcome throws through Telemetry. It must be recorded as a SUCCESS
+     * (the provider call itself succeeded) so a policy denial does not distort the
+     * provider failure-rate — the semantics that held when the guardrail was above
+     * Telemetry.
+     */
+    #[Test]
+    public function recordsAGuardrailDenialAsASuccessfulProviderRunAndReThrows(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $caught = false;
+        try {
+            $this->pipeline($repository)->run(
+                new ProviderCallContext(ProviderOperation::Chat, 'corr-guardrail'),
+                $this->configuration('primary'),
+                static fn(LlmConfiguration $c): string => throw new GuardrailViolationException('Some\\Guardrail', 'blocked'),
+            );
+        } catch (GuardrailViolationException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught, 'The guardrail exception must still propagate.');
+        self::assertCount(1, $repository->records);
+        self::assertTrue($repository->records[0]->success);
+        self::assertSame('', $repository->records[0]->errorClass);
+    }
+
+    #[Test]
+    public function recordsAGuardrailApprovalRequirementAsASuccessfulProviderRun(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $caught = false;
+        try {
+            $this->pipeline($repository)->run(
+                new ProviderCallContext(ProviderOperation::Chat, 'corr-approval'),
+                $this->configuration('primary'),
+                static fn(LlmConfiguration $c): string => throw new GuardrailApprovalRequiredException('Some\\Guardrail', 'needs approval'),
+            );
+        } catch (GuardrailApprovalRequiredException) {
+            $caught = true;
+        }
+
+        self::assertTrue($caught);
+        self::assertCount(1, $repository->records);
+        self::assertTrue($repository->records[0]->success);
+        self::assertSame('', $repository->records[0]->errorClass);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes the guardrail-enforcement findings deferred from #459 (the redaction-pattern
PR). Each was verified against the code; the middleware-ordering fix was designed
via a 3-approach panel and adversarially checked before implementing.

## No unredacted response is persisted (the security fix)
`GuardrailMiddleware` ran outermost (priority 115), so it redacted the response
only AFTER `IdempotencyMiddleware` (105) had serialised the **unredacted**
`CompletionResponse` into the `nrllm_idempotency` cache (24h, possibly a shared
Redis) — a secret a model echoed leaked into persistence though the caller saw it
redacted. The guardrail moves to **priority 90**, inside both persistence layers,
so it redacts/blocks before anything is stored; a DENY/REQUIRE_APPROVAL throws
before the store, so a blocked response is never a replayable result.

Telemetry accuracy (ADR-085 deliberately kept the guardrail above Telemetry so a
denial isn't miscounted as a provider failure) is preserved differently: the two
guardrail exceptions now implement a `GuardrailPolicyException` marker that
`TelemetryMiddleware` records as a **successful** provider run (the provider
produced a response; the guardrail refused to release it). A RETRY now genuinely
re-runs the provider instead of replaying the idempotency-cached response.

Proof: a functional regression test reads the **actual** `nrllm_idempotency` entry
through the real DI pipeline (fails on the pre-fix layout); the pipeline-order
test asserts the new resolved order; TelemetryMiddleware unit tests cover the
policy-exception-as-success classification. ADR-085 amended in place.

## Fail-closed verdict handling
The output (`GuardrailMiddleware`) and input (`InputGuardrailScreener`) verdict
`switch`es had no default, so a future `GuardrailVerdict` added without updating
them would silently pass the response/prompt through unscreened. Both are now
exhaustive `match` expressions — an unhandled verdict is a PHPStan error at build
time and a runtime `UnhandledMatchError` (fail closed), with no untestable default.

## Vision output is screened
`GuardrailMiddleware` only screened `CompletionResponse`; a `VisionResponse`
(model-generated description — e.g. a transcribed screenshot of an API key) passed
through unscreened. Its description now runs through the same output guardrails
(REDACT/DENY/REQUIRE_APPROVAL; a clean caption is returned unchanged).

## Not changed — streaming (found, assessed)
- **O(n²) per-chunk re-scan** in live stream redaction is **by design** (ADR-088):
  re-redacting the whole raw buffer each chunk is what makes a boundary-split
  secret collapse to its marker; it is memory- and CPU-bounded at 50 KB. Making it
  incremental would risk that correctness — left as-is.
- **>50 KB overflow → raw passthrough** (a secret positioned past the cap leaks) is
  a real gap, documented in ADR-088 and warned about at runtime. Hardening it to a
  sliding window touches the delicate redaction core, so it is a separate, careful
  follow-up (with its own adversarial review) rather than a drive-by change here.

Local gate green: unit, functional (sqlite), phpstan (L10), cgl, rector, fuzzy,
architecture.
