### PR TITLE
fix(tool): harden secret-egress denylist (credential columns, Composer auth.json)

### DIFF
--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -44,7 +44,9 @@ final readonly class SourcePathGuard
 
     private const DENIED_EXTENSIONS = ['key', 'pem', 'crt', 'p12', 'pfx'];
 
-    private const DENIED_BASENAME_PATTERN = '/^(settings|additional)\.php$/i';
+    // settings/additional.php hold TYPO3 secrets; auth.json holds Composer
+    // registry/OAuth credentials (deploy tokens) — none may be read by read_source.
+    private const DENIED_BASENAME_PATTERN = '/^(?:settings|additional)\.php$|^auth\.json$/i';
 
     /** Lines whose key looks credential-bearing get their value replaced. */
     private const SECRET_LINE_PATTERN

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -55,10 +55,12 @@ final readonly class TableReadAccessService
     /**
      * Credential-ish field-name segments whose values must never egress.
      * Matched per underscore-separated segment so `api_key` and
-     * `identifier_hash` hit while `author` does not.
+     * `identifier_hash` hit while `author` does not. The optional trailing
+     * digit run also catches confirm-style suffixes (`token2`, `secret2`)
+     * without listing each one.
      */
     private const SENSITIVE_FIELD_PATTERN
-        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa)($|_)/i';
+        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa)(\d+)?($|_)/i';
 
     /**
      * Unambiguous credential nouns matched boundary-free, catching concatenated
@@ -69,7 +71,7 @@ final readonly class TableReadAccessService
      * their separated forms stay covered by {@see self::SENSITIVE_FIELD_PATTERN}.
      */
     private const SENSITIVE_FIELD_SUBSTRING_PATTERN
-        = '/(password|passphrase|apikey|accesstoken|authtoken|refreshtoken|credential|privatekey|clientsecret)/i';
+        = '/(password|passphrase|apikey|apitoken|accesstoken|authtoken|refreshtoken|credential|privatekey|clientsecret)/i';
 
     /**
      * Whether the acting user may read rows of the given table. Fail-closed:

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -61,6 +61,17 @@ final readonly class TableReadAccessService
         = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa)($|_)/i';
 
     /**
+     * Unambiguous credential nouns matched boundary-free, catching concatenated
+     * or camelCase forms the segment pattern misses (`apikey`, `accessToken`,
+     * `password2`, `clientSecret`). Only words that never legitimately appear
+     * inside a non-secret column name are listed here — deliberately excluding
+     * `secret`/`token` as bare substrings, which would flag `secretary`/`tokenizer`;
+     * their separated forms stay covered by {@see self::SENSITIVE_FIELD_PATTERN}.
+     */
+    private const SENSITIVE_FIELD_SUBSTRING_PATTERN
+        = '/(password|passphrase|apikey|accesstoken|authtoken|refreshtoken|credential|privatekey|clientsecret)/i';
+
+    /**
      * Whether the acting user may read rows of the given table. Fail-closed:
      * no user, unknown table, denylisted table, or (for non-admins) a table
      * outside the user's `tables_select` rights or flagged `adminOnly` all
@@ -121,7 +132,8 @@ final readonly class TableReadAccessService
      */
     public function isSensitiveField(string $field): bool
     {
-        return preg_match(self::SENSITIVE_FIELD_PATTERN, $field) === 1;
+        return preg_match(self::SENSITIVE_FIELD_PATTERN, $field) === 1
+            || preg_match(self::SENSITIVE_FIELD_SUBSTRING_PATTERN, $field) === 1;
     }
 
     /**

--- a/Tests/Unit/Service/Tool/SourcePathGuardTest.php
+++ b/Tests/Unit/Service/Tool/SourcePathGuardTest.php
@@ -106,6 +106,17 @@ final class SourcePathGuardTest extends TestCase
     }
 
     #[Test]
+    public function deniesComposerAuthJson(): void
+    {
+        // Composer auth.json holds registry/OAuth deploy tokens — read_source must
+        // never surface it, at the root or nested.
+        self::assertTrue($this->guard->isDeniedRelativePath('auth.json'));
+        self::assertTrue($this->guard->isDeniedRelativePath('some/dir/auth.json'));
+        // A non-credential JSON of a similar name is still readable.
+        self::assertFalse($this->guard->isDeniedRelativePath('Configuration/author.json'));
+    }
+
+    #[Test]
     public function deniesCredentialMentioningPath(): void
     {
         self::assertTrue($this->guard->isDeniedRelativePath('Classes/CredentialStore.php'));

--- a/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
+++ b/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
@@ -120,6 +120,11 @@ final class TableReadAccessServiceTest extends TestCase
             'password2'         => ['password2', true],
             'clientSecret'      => ['clientSecret', true],
             'refreshtoken'      => ['refreshtoken', true],
+            'apitoken'          => ['apitoken', true],
+            // Digit-suffixed segment secrets (confirm-style columns):
+            'secret2'           => ['secret2', true],
+            'token2'            => ['token2', true],
+            'key2'              => ['key2', true],
             // No false positives on editorial columns:
             'author'            => ['author', false],
             'author_email'      => ['author_email', false],

--- a/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
+++ b/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
@@ -113,12 +113,22 @@ final class TableReadAccessServiceTest extends TestCase
             'ses_token'         => ['ses_token', true],
             'mfa'               => ['mfa', true],
             'salt'              => ['salt', true],
+            // Concatenated / camelCase / digit-suffixed forms the segment
+            // pattern misses, caught by the substring pattern:
+            'apikey'            => ['apikey', true],
+            'accessToken'       => ['accessToken', true],
+            'password2'         => ['password2', true],
+            'clientSecret'      => ['clientSecret', true],
+            'refreshtoken'      => ['refreshtoken', true],
             // No false positives on editorial columns:
             'author'            => ['author', false],
             'author_email'      => ['author_email', false],
             'title'             => ['title', false],
             'keywords'          => ['keywords', false],
             'monkey'            => ['monkey', false],
+            // Bare secret/token as substrings must NOT flag these:
+            'secretary'         => ['secretary', false],
+            'tokenizer'         => ['tokenizer', false],
         ];
     }
 


### PR DESCRIPTION
Two secret-egress findings from the ultracode tool-execution security audit. Tool results egress verbatim to the external LLM provider, so a secret that slips past the denylist leaks off-site.

## Bug A — concatenated credential column names bypass the field denylist
`TableReadAccessService::isSensitiveField()` matched keywords only per underscore segment (`api_key`, `password`), so concatenated/camelCase/digit-suffixed secret columns bypassed it: `apikey`, `accessToken`, `password2`, `clientSecret`. Their values could then be selected by `read_records`/`search_records` and sent to the provider.

Add a second, boundary-free pattern for **unambiguous credential nouns only** (`password`, `passphrase`, `apikey`, `accesstoken`, `authtoken`, `refreshtoken`, `credential`, `privatekey`, `clientsecret`). Bare `secret`/`token` are deliberately kept out of the substring pattern so `secretary`/`tokenizer` are not false-flagged — their separated forms stay covered by the existing segment pattern.

## Bug B — read_source could read Composer auth.json
`SourcePathGuard` denied `settings.php`/`additional.php` but not `auth.json`, which holds Composer registry/OAuth deploy tokens. Add it to the denied-basename pattern (matched at any depth). A similarly named non-credential file (`author.json`) stays readable.

## Tests
- `isSensitiveField` data provider: the four bypass forms now flagged; `secretary`/`tokenizer`/`keywords`/`monkey` still not (no false positives).
- `isDeniedRelativePath('auth.json')` / nested denied; `author.json` allowed.

## Gates
cgl, PHPStan level 10, unit (5283), Rector `-n`, fuzzy — green; tool functional suite green locally (152 tests, no regression). Full functional runs in CI.

## Scope
Part of the tool-audit follow-ups. Remaining: FAL tools gating by storage rather than file-mount (3 tools) and a backend-language-access check — separate PRs, deferred until the workspace-restriction PR (#461) lands (they touch overlapping files).