### PR TITLE
fix(tool): enforce file-mount boundaries in FAL tools

### DIFF
--- a/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
+++ b/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
@@ -117,7 +117,27 @@ final readonly class FindMissingFilesTool implements ToolInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        $lines = [sprintf('%d missing file%s (showing %d):', $total, $total === 1 ? '' : 's', count($rows))];
+        // effectiveStorages() only gates the storage; drop identifiers outside
+        // the acting user's file mounts so a subfolder-mounted non-admin does
+        // not learn missing-file paths elsewhere in the storage.
+        $rows = array_values(array_filter(
+            $rows,
+            fn(array $row): bool => $this->storageGate->isFileAccessible(
+                $user,
+                self::toInt($row['storage'] ?? 0),
+                self::toStr($row['identifier'] ?? ''),
+            ),
+        ));
+
+        if ($rows === []) {
+            return 'No missing files in the accessible storages.';
+        }
+
+        // The storage-wide $total is only meaningful (and non-leaking) for an
+        // admin; a non-admin sees just the count of files within their mounts.
+        $lines = [($user !== null && $user->isAdmin())
+            ? sprintf('%d missing file%s (showing %d):', $total, $total === 1 ? '' : 's', count($rows))
+            : sprintf('%d missing file%s shown:', count($rows), count($rows) === 1 ? '' : 's')];
         foreach ($rows as $row) {
             $lines[] = sprintf(
                 '- [%d] %d:%s (last known size %d bytes)',

--- a/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
+++ b/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
@@ -33,6 +33,13 @@ final readonly class FindMissingFilesTool implements ToolInterface
 
     private const MAX_LIMIT = 50;
 
+    /**
+     * Non-admins are mount-filtered in PHP after the query; scan up to this
+     * many rows so an out-of-mount-heavy window does not starve the in-mount
+     * result set, then cap the accessible subset to the requested limit.
+     */
+    private const MOUNT_SCAN_CAP = 1000;
+
     public function __construct(
         private ConnectionPool $connectionPool,
         private FalStorageGate $storageGate,
@@ -80,6 +87,8 @@ final readonly class FindMissingFilesTool implements ToolInterface
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         $limit = max(1, min(self::MAX_LIMIT, $limit));
 
+        $isAdmin = $user !== null && $user->isAdmin();
+
         $countQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
         $countQuery->getRestrictions()->removeAll();
         $total = self::toInt($countQuery
@@ -113,21 +122,24 @@ final readonly class FindMissingFilesTool implements ToolInterface
             )
             ->orderBy('storage')
             ->addOrderBy('identifier')
-            ->setMaxResults($limit)
+            ->setMaxResults($isAdmin ? $limit : self::MOUNT_SCAN_CAP)
             ->executeQuery()
             ->fetchAllAssociative();
 
         // effectiveStorages() only gates the storage; drop identifiers outside
         // the acting user's file mounts so a subfolder-mounted non-admin does
-        // not learn missing-file paths elsewhere in the storage.
-        $rows = array_values(array_filter(
-            $rows,
-            fn(array $row): bool => $this->storageGate->isFileAccessible(
-                $user,
-                self::toInt($row['storage'] ?? 0),
-                self::toStr($row['identifier'] ?? ''),
-            ),
-        ));
+        // not learn missing-file paths elsewhere in the storage, then cap to the
+        // requested limit (the DB scanned a wider window above).
+        if (!$isAdmin) {
+            $rows = array_slice(array_values(array_filter(
+                $rows,
+                fn(array $row): bool => $this->storageGate->isFileAccessible(
+                    $user,
+                    self::toInt($row['storage'] ?? 0),
+                    self::toStr($row['identifier'] ?? ''),
+                ),
+            )), 0, $limit);
+        }
 
         if ($rows === []) {
             return 'No missing files in the accessible storages.';
@@ -135,7 +147,7 @@ final readonly class FindMissingFilesTool implements ToolInterface
 
         // The storage-wide $total is only meaningful (and non-leaking) for an
         // admin; a non-admin sees just the count of files within their mounts.
-        $lines = [($user !== null && $user->isAdmin())
+        $lines = [$isAdmin
             ? sprintf('%d missing file%s (showing %d):', $total, $total === 1 ? '' : 's', count($rows))
             : sprintf('%d missing file%s shown:', count($rows), count($rows) === 1 ? '' : 's')];
         foreach ($rows as $row) {

--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -80,13 +80,20 @@ final readonly class GetFalReferencesTool implements ToolInterface
         $fileQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
         $fileQuery->getRestrictions()->removeAll();
         $file = $fileQuery
-            ->select('storage', 'name')
+            ->select('storage', 'name', 'identifier')
             ->from('sys_file')
             ->where($fileQuery->expr()->eq('uid', $fileQuery->createNamedParameter($uid, Connection::PARAM_INT)))
             ->executeQuery()
             ->fetchAssociative();
 
-        if (!is_array($file) || !$this->storageGate->isAllowed($user, self::toInt($file['storage'] ?? 0))) {
+        // Gate at file-mount granularity, not just storage: a non-admin whose
+        // mount is a subfolder must not enumerate usages of a file elsewhere
+        // in the storage.
+        if (!is_array($file) || !$this->storageGate->isFileAccessible(
+            $user,
+            self::toInt($file['storage'] ?? 0),
+            self::toStr($file['identifier'] ?? ''),
+        )) {
             return self::NOT_PERMITTED;
         }
 

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -123,6 +123,18 @@ final readonly class SearchFalFilesTool implements ToolInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
+        // effectiveStorages() only gates the storage; a non-admin whose file
+        // mount is a subfolder would otherwise see file names/paths across the
+        // whole storage. Drop files outside the acting user's file mounts.
+        $rows = array_values(array_filter(
+            $rows,
+            fn(array $row): bool => $this->storageGate->isFileAccessible(
+                $user,
+                self::toInt($row['storage'] ?? 0),
+                self::toStr($row['identifier'] ?? ''),
+            ),
+        ));
+
         if ($rows === []) {
             return sprintf('No files match "%s" in the accessible storages.', $query);
         }

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -34,6 +34,14 @@ final readonly class SearchFalFilesTool implements ToolInterface
 
     private const MAX_LIMIT = 50;
 
+    /**
+     * Non-admins are mount-filtered in PHP after the query, so the DB limit
+     * must not be the result cap or an out-of-mount-heavy window could yield
+     * fewer (or zero) in-mount hits than exist. Scan up to this many matching
+     * rows, then cap the accessible subset to the requested limit.
+     */
+    private const MOUNT_SCAN_CAP = 1000;
+
     public function __construct(
         private ConnectionPool $connectionPool,
         private FalStorageGate $storageGate,
@@ -90,6 +98,8 @@ final readonly class SearchFalFilesTool implements ToolInterface
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         $limit = max(1, min(self::MAX_LIMIT, $limit));
 
+        $isAdmin = $user !== null && $user->isAdmin();
+
         // sys_file has no enable columns; metadata is language-pinned below
         // and the storage gate is the access boundary (cf. read_fal_asset_meta).
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file');
@@ -119,21 +129,24 @@ final readonly class SearchFalFilesTool implements ToolInterface
                 ),
             )
             ->orderBy('f.name')
-            ->setMaxResults($limit)
+            ->setMaxResults($isAdmin ? $limit : self::MOUNT_SCAN_CAP)
             ->executeQuery()
             ->fetchAllAssociative();
 
         // effectiveStorages() only gates the storage; a non-admin whose file
         // mount is a subfolder would otherwise see file names/paths across the
-        // whole storage. Drop files outside the acting user's file mounts.
-        $rows = array_values(array_filter(
-            $rows,
-            fn(array $row): bool => $this->storageGate->isFileAccessible(
-                $user,
-                self::toInt($row['storage'] ?? 0),
-                self::toStr($row['identifier'] ?? ''),
-            ),
-        ));
+        // whole storage. Drop files outside the acting user's file mounts, then
+        // cap to the requested limit (the DB scanned a wider window above).
+        if (!$isAdmin) {
+            $rows = array_slice(array_values(array_filter(
+                $rows,
+                fn(array $row): bool => $this->storageGate->isFileAccessible(
+                    $user,
+                    self::toInt($row['storage'] ?? 0),
+                    self::toStr($row['identifier'] ?? ''),
+                ),
+            )), 0, $limit);
+        }
 
         if ($rows === []) {
             return sprintf('No files match "%s" in the accessible storages.', $query);

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -103,9 +103,16 @@ final readonly class FalStorageGate
             if ($storage === null) {
                 return false;
             }
+            // findByUid returns a request-shared, cached storage; restore its
+            // prior evaluatePermissions so this check does not leak into other
+            // consumers of the same instance in the request.
+            $previous = $storage->getEvaluatePermissions();
             $storage->setEvaluatePermissions(true);
-
-            return $storage->checkFileActionPermission('read', $storage->getFile($identifier));
+            try {
+                return $storage->checkFileActionPermission('read', $storage->getFile($identifier));
+            } finally {
+                $storage->setEvaluatePermissions($previous);
+            }
         } catch (Throwable) {
             return false;
         }

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 /**
  * Shared storage gate of the FAL tools (ADR-047).
@@ -19,6 +21,12 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * through their file mounts ({@see BackendUserAuthentication::getFileStorages()}).
  * Fail-closed: no backend user means no storages, and an empty intersection
  * means every FAL tool answers with its neutral denial.
+ *
+ * {@see self::effectiveStorages()} gates at STORAGE granularity only. A
+ * non-admin whose file mount points at a subfolder still has the whole storage
+ * in that set, so tools that surface individual files must additionally gate
+ * each file with {@see self::isFileAccessible()}, which enforces the acting
+ * user's file-mount boundaries via the storage API.
  */
 final readonly class FalStorageGate
 {
@@ -27,6 +35,9 @@ final readonly class FalStorageGate
      */
     public function __construct(
         private array $allowedStorages = [1],
+        // Optional so the storage-set-only unit construction keeps working;
+        // autowired in production and required for isFileAccessible().
+        private ?StorageRepository $storageRepository = null,
     ) {}
 
     /**
@@ -58,5 +69,45 @@ final readonly class FalStorageGate
     public function isAllowed(?BackendUserAuthentication $user, int $storageUid): bool
     {
         return in_array($storageUid, $this->effectiveStorages($user), true);
+    }
+
+    /**
+     * Whether the acting user may actually reach one file, enforcing file-mount
+     * boundaries — not just the storage allow-list. {@see self::isAllowed()}
+     * only checks the storage; a non-admin with a subfolder file mount passes
+     * that for every file in the storage.
+     *
+     * The storage object is resolved inside the running backend request, where
+     * the core StoragePermissionsAspect has attached the acting user's file
+     * mounts; with evaluatePermissions on, checkFileActionPermission('read')
+     * then returns false for a file outside those mounts. NB getFile() alone
+     * does NOT assert — it only resolves the record — so the explicit
+     * permission check is load-bearing. Admins bypass mount checks.
+     */
+    public function isFileAccessible(?BackendUserAuthentication $user, int $storageUid, string $identifier): bool
+    {
+        if (!$this->isAllowed($user, $storageUid) || $user === null || $identifier === '') {
+            return false;
+        }
+
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        if ($this->storageRepository === null) {
+            return false;
+        }
+
+        try {
+            $storage = $this->storageRepository->findByUid($storageUid);
+            if ($storage === null) {
+                return false;
+            }
+            $storage->setEvaluatePermissions(true);
+
+            return $storage->checkFileActionPermission('read', $storage->getFile($identifier));
+        } catch (Throwable) {
+            return false;
+        }
     }
 }

--- a/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
+++ b/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
@@ -96,6 +96,10 @@ final class FalToolsFileMountTest extends AbstractFunctionalTestCase
 
     private function indexFile(Connection $connection, int $uid, string $identifier, string $name, int $missing): void
     {
+        // identifier_hash / folder_hash use TYPO3's own sha1 identifier-hash
+        // algorithm so getFile() resolves the index row exactly as core does.
+        // This is a test fixture, not a security context (SonarCloud's
+        // "weak hashing" flag here is a false positive).
         $connection->insert('sys_file', [
             'uid'             => $uid,
             'pid'             => 0,

--- a/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
+++ b/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * File-mount confinement of the sys_file-querying FAL tools for non-admins
+ * (ADR-047): search_fal_files, find_missing_files and get_fal_references gate
+ * only the STORAGE via {@see \Netresearch\NrLlm\Service\Tool\FalStorageGate};
+ * this test proves the added per-file mount check actually confines a
+ * subfolder-mounted editor to their mount.
+ *
+ * Mirrors BrowseFalFolderToolFileMountTest: the storage ROW is inserted
+ * directly so the ResourceStorage object is first built while the editor is
+ * logged in inside a backend request, when the core StoragePermissionsAspect
+ * attaches the user's file mounts — only then does checkFileActionPermission()
+ * enforce them.
+ */
+final class FalToolsFileMountTest extends AbstractFunctionalTestCase
+{
+    private const STORAGE_CONFIGURATION = '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3FlexForms>
+    <data>
+        <sheet index="sDEF">
+            <language index="lDEF">
+                <field index="basePath"><value index="vDEF">fileadmin/</value></field>
+                <field index="pathType"><value index="vDEF">relative</value></field>
+                <field index="caseSensitive"><value index="vDEF">1</value></field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/docs');
+        file_put_contents($this->instancePath . '/fileadmin/top-secret.txt', 'root file');
+        file_put_contents($this->instancePath . '/fileadmin/docs/manual.txt', 'The manual');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $storageConnection = $connectionPool->getConnectionForTable('sys_file_storage');
+        self::assertInstanceOf(Connection::class, $storageConnection);
+        // Row only — the ResourceStorage OBJECT must not exist before login.
+        $storageConnection->insert('sys_file_storage', [
+            'uid' => 1, 'pid' => 0, 'name' => 'Main storage', 'driver' => 'Local',
+            'configuration' => self::STORAGE_CONFIGURATION,
+            'is_online' => 1, 'is_browsable' => 1, 'is_public' => 1, 'is_writable' => 1,
+        ]);
+        $storageConnection->insert('sys_filemounts', [
+            'uid' => 1, 'pid' => 0, 'title' => 'Docs mount', 'identifier' => '1:/docs/',
+        ]);
+        $storageConnection->insert('be_groups', [
+            'uid' => 9, 'pid' => 0, 'title' => 'Doc readers', 'file_mountpoints' => '1',
+            'file_permissions' => 'readFolder,readFile',
+        ]);
+        // options=3: inherit db AND file mounts from groups.
+        $storageConnection->update('be_users', ['usergroup' => '9', 'options' => 3], ['uid' => 2]);
+
+        $fileConnection = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $fileConnection);
+        // In-mount (/docs/) and out-of-mount (root) indexed files.
+        $this->indexFile($fileConnection, 10, '/docs/manual.txt', 'manual.txt', 0);
+        $this->indexFile($fileConnection, 11, '/top-secret.txt', 'top-secret.txt', 0);
+        // Missing files, one per side of the mount boundary.
+        $this->indexFile($fileConnection, 12, '/docs/gone-inside.txt', 'gone-inside.txt', 1);
+        $this->indexFile($fileConnection, 13, '/gone-outside.txt', 'gone-outside.txt', 1);
+    }
+
+    protected function tearDown(): void
+    {
+        // The faked backend request must not leak into later tests.
+        unset($GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    private function indexFile(Connection $connection, int $uid, string $identifier, string $name, int $missing): void
+    {
+        $connection->insert('sys_file', [
+            'uid'             => $uid,
+            'pid'             => 0,
+            'storage'         => 1,
+            'identifier'      => $identifier,
+            'identifier_hash' => sha1($identifier),
+            'folder_hash'     => sha1(dirname($identifier)),
+            'name'            => $name,
+            'extension'       => 'txt',
+            'mime_type'       => 'text/plain',
+            'size'            => 10,
+            'missing'         => $missing,
+        ]);
+    }
+
+    private function loginEditorInBackendRequest(): void
+    {
+        $this->setUpBackendUser(2);
+        // The core StoragePermissionsAspect only attaches mounts/permissions
+        // when the storage object is created inside a BACKEND request.
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest('https://typo3-testing.local/typo3/'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+    }
+
+    private function tool(string $name): ToolInterface
+    {
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        $tool = $registry->get($name);
+        self::assertInstanceOf(ToolInterface::class, $tool);
+
+        return $tool;
+    }
+
+    #[Test]
+    public function searchFalFilesHidesFilesOutsideTheUsersMount(): void
+    {
+        $this->loginEditorInBackendRequest();
+
+        $output = $this->tool('search_fal_files')->execute(['query' => 'txt']);
+
+        self::assertStringContainsString('docs/manual.txt', $output);
+        self::assertStringNotContainsString('top-secret.txt', $output);
+    }
+
+    #[Test]
+    public function findMissingFilesHidesFilesOutsideTheUsersMount(): void
+    {
+        $this->loginEditorInBackendRequest();
+
+        $output = $this->tool('find_missing_files')->execute([]);
+
+        self::assertStringContainsString('docs/gone-inside.txt', $output);
+        self::assertStringNotContainsString('gone-outside.txt', $output);
+    }
+
+    #[Test]
+    public function getFalReferencesDeniesAFileOutsideTheUsersMount(): void
+    {
+        $this->loginEditorInBackendRequest();
+
+        // File 11 (root, out of the /docs/ mount) must not reveal its usages.
+        $output = $this->tool('get_fal_references')->execute(['uid' => 11]);
+
+        self::assertSame('Asset not found or not permitted.', $output);
+    }
+
+    #[Test]
+    public function getFalReferencesAllowsAFileInsideTheUsersMount(): void
+    {
+        $this->loginEditorInBackendRequest();
+
+        // File 10 (/docs/, in mount) is reachable — no references seeded, so the
+        // neutral "no references" answer (not the permission denial) is returned.
+        $output = $this->tool('get_fal_references')->execute(['uid' => 10]);
+
+        self::assertStringContainsString('No references to manual.txt', $output);
+    }
+}

--- a/Tests/Unit/Service/Tool/FalStorageGateTest.php
+++ b/Tests/Unit/Service/Tool/FalStorageGateTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 /**
  * The shared FAL storage gate (ADR-047) must stay fail-closed: no user
@@ -69,6 +70,59 @@ final class FalStorageGateTest extends AbstractUnitTestCase
         self::assertSame([], $gate->effectiveStorages($editor));
         self::assertFalse($gate->isAllowed($editor, 1));
         self::assertFalse($gate->isAllowed($editor, 7));
+    }
+
+    #[Test]
+    public function adminReachesAnyFileInAllowedStorageWithoutMountCheck(): void
+    {
+        $admin = $this->userWith(isAdmin: true, storageUids: []);
+        // No StorageRepository needed — admins bypass the mount resolution.
+        $gate = new FalStorageGate([1]);
+
+        self::assertTrue($gate->isFileAccessible($admin, 1, '/any/where/file.pdf'));
+        // Storage outside the allow-list is still denied.
+        self::assertFalse($gate->isFileAccessible($admin, 2, '/x.pdf'));
+    }
+
+    // The actual file-mount enforcement (getFile resolves, then
+    // checkFileActionPermission asserts against the acting user's mounts) is
+    // exercised end-to-end in FalToolsFileMountTest against a real storage +
+    // file mount — stubbing the storage here would only assert fabricated
+    // behaviour. The unit tests below cover the pre-resolution guard logic.
+
+    #[Test]
+    public function fileInDisallowedStorageIsDeniedBeforeResolution(): void
+    {
+        $editor = $this->userWith(isAdmin: false, storageUids: [7]); // no mount into storage 1
+        $gate   = new FalStorageGate([1], $this->storageRepositoryReturning(null));
+
+        self::assertFalse($gate->isFileAccessible($editor, 1, '/x.pdf'));
+    }
+
+    #[Test]
+    public function nonAdminIsDeniedWhenStorageRepositoryIsAbsent(): void
+    {
+        $editor = $this->userWith(isAdmin: false, storageUids: [1]);
+        $gate   = new FalStorageGate([1]); // no repository → fail-closed
+
+        self::assertFalse($gate->isFileAccessible($editor, 1, '/x.pdf'));
+    }
+
+    #[Test]
+    public function emptyIdentifierIsDenied(): void
+    {
+        $editor = $this->userWith(isAdmin: false, storageUids: [1]);
+        $gate   = new FalStorageGate([1], $this->storageRepositoryReturning(self::createStub(ResourceStorage::class)));
+
+        self::assertFalse($gate->isFileAccessible($editor, 1, ''));
+    }
+
+    private function storageRepositoryReturning(?ResourceStorage $storage): StorageRepository
+    {
+        $repository = self::createStub(StorageRepository::class);
+        $repository->method('findByUid')->willReturn($storage);
+
+        return $repository;
     }
 
     /**


### PR DESCRIPTION
From the ultracode tool-execution security audit: the FAL tools gate access at **storage** granularity only, not **file-mount**. `FalStorageGate::effectiveStorages()` returns the whole storage uid for a non-admin even when their file mount is just a subfolder, so `search_fal_files` / `find_missing_files` enumerated file names + storage-relative paths across the whole storage, and `get_fal_references` listed usages of any file in it. Tool results egress to the external LLM provider → a subfolder-mounted non-admin leaked cross-mount file metadata.

## Fix
Add `FalStorageGate::isFileAccessible(user, storageUid, identifier)`. The storage is resolved inside the running backend request, where the core `StoragePermissionsAspect` has attached the acting user's file mounts; with `setEvaluatePermissions(true)`, `checkFileActionPermission('read', $file)` returns false for a file outside those mounts. The three tools filter each result row (search/find) or gate the target file (references) through it; `find_missing_files` also stops exposing the storage-wide count to non-admins. Admins bypass.

**Note (why v2):** the first version used `$storage->getFile($identifier)` in a try/catch, assuming it throws out-of-mount. An adversarial security review correctly caught that `getFile()` does **not** assert permission — it only resolves the record — so `setEvaluatePermissions` had no effect and the gate was a no-op (and the unit test stubbed `getFile()`-throws, a fabricated behavior = false-green). This is reworked onto the asserting `checkFileActionPermission('read', …)` and verified end-to-end with a **real** file mount.

## Tests
- **`FalToolsFileMountTest`** (new): a real `Local` storage with a `/docs/` subfolder file mount (`sys_file_storage` row + `sys_filemounts` + `be_groups.file_mountpoints` + a BE request so `StoragePermissionsAspect` runs, mirroring `BrowseFalFolderToolFileMountTest`). A non-admin editor: `search_fal_files` shows `docs/manual.txt` but not `top-secret.txt`; `find_missing_files` shows the in-mount missing file but not the out-of-mount one; `get_fal_references` denies the out-of-mount file and allows the in-mount one.
- `FalStorageGate` unit tests cover the pre-resolution guard logic (admin bypass, disallowed storage, absent repository, empty identifier). The two earlier stub-based tests were removed — they asserted fabricated `getFile` behavior.
- The three tools' existing admin functional tests still pass (no regression).

## Gates
cgl, PHPStan level 10, unit (5279), Rector `-n`, fuzzy — green; FAL tool functional tests + the new file-mount test green locally. Full functional runs in CI.