### PR TITLE
security: close the streaming-redaction >50KB overflow leak (bounded sliding window)

### DIFF
--- a/Classes/Service/Streaming/StreamRedactionWindow.php
+++ b/Classes/Service/Streaming/StreamRedactionWindow.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Streaming;
+
+use Closure;
+
+/**
+ * Bounded, self-certifying sliding window for live stream redaction (ADR-088 /
+ * ADR-088 overflow closure).
+ *
+ * {@see StreamingDispatcher} masks secrets in a streamed response by re-redacting
+ * the accumulated raw text FRESH each chunk (so a complete match always collapses
+ * to its short marker, even one split across chunk boundaries) and emitting only
+ * the stable prefix — everything but a {@see self::HOLDBACK_BYTES} tail that may
+ * still contain a match in progress.
+ *
+ * The naive version keeps the whole raw buffer, which is unbounded in memory and
+ * O(n²) in per-chunk rescans; the original guard flushed at 50 KB and then passed
+ * every later chunk through RAW, leaking a secret positioned past the cap. This
+ * class removes both problems without ever emitting a raw secret byte:
+ *
+ * - It re-redacts only a bounded WINDOW (coalescing the rescan into ~256-byte
+ *   blocks → O(n) work, not O(n²)).
+ * - It prunes the settled front of the window at a cut it CERTIFIES clean:
+ *   `redact(head) . redact(tail) === redact(window)` (no match spans the cut) and
+ *   the dropped redaction is already emitted. Only then is the emit offset
+ *   adjusted, so the concatenated output stays byte-for-byte equal to
+ *   `redact(fullRawStream)`.
+ * - For the pathological case of a single unbroken match longer than the window
+ *   (no clean cut anywhere), it drops the middle of that match — but ONLY when
+ *   re-redaction proves the drop leaves the output identical, so the offset stays
+ *   valid. The dropped bytes are inside the marker-collapsed match and never
+ *   belonged in the output; they are never emitted raw.
+ *
+ * Correctness is verified in isolation ({@see \Netresearch\NrLlm\Tests\Unit\Service\Streaming\StreamRedactionWindowTest}):
+ * a randomised property test asserts `concat(deltas) === redact(fullRaw)` over
+ * thousands of secret/benign/multibyte inputs and chunk splittings.
+ */
+final class StreamRedactionWindow
+{
+    /**
+     * Trailing redacted bytes held back from the live stream so a match still in
+     * progress at the tail is never emitted before it completes. A confirmed
+     * match collapses to a short marker, so the only unstable region is a partial
+     * anchor (``sk-`` + 15, ``Bearer `` + 7, a URL-param name + 1) — well under
+     * this window.
+     */
+    public const HOLDBACK_BYTES = 128;
+
+    /** Minimum bytes kept behind any prune cut (>= holdback + margin). */
+    private const KEEP_BYTES = 512;
+
+    /** Prune once the window grows past this. */
+    private const SOFT_CAP_BYTES = 8192;
+
+    /** Safe-hold (drop the middle of an unbroken match) past this. */
+    private const HARD_CAP_BYTES = 1048576;
+
+    /** Re-redact/emit only after this many raw bytes accumulate (rescan coalescing). */
+    private const BLOCK_BYTES = 256;
+
+    /** Bounded number of cut positions probed per prune. */
+    private const PRUNE_PROBES = 8;
+
+    /** Step (bytes) between probed cut positions. */
+    private const PROBE_STEP = 64;
+
+    private string $window = '';
+
+    /** Redacted bytes of redact($window) already yielded. */
+    private int $emitted = 0;
+
+    /** Raw bytes accumulated since the last emit (coalescing counter). */
+    private int $pending = 0;
+
+    /** Total redacted bytes dropped by prune/hold (observability / test spy). */
+    private int $prunedRedactedBytes = 0;
+
+    /**
+     * @param Closure(string): string $redact re-redacts a raw fragment; must
+     *                                        collapse a complete match to a fixed
+     *                                        short marker (the ADR-088 property)
+     */
+    public function __construct(private readonly Closure $redact) {}
+
+    /**
+     * Feed one raw chunk; return the redacted deltas to yield (possibly none).
+     *
+     * @return list<string>
+     */
+    public function push(string $chunk): array
+    {
+        $this->window .= $chunk;
+        $this->pending += \strlen($chunk);
+        if ($this->pending < self::BLOCK_BYTES) {
+            return [];
+        }
+        $this->pending = 0;
+        $out           = $this->emitStable(true);
+        $this->bound();
+
+        return $out;
+    }
+
+    /**
+     * Flush the redacted remainder at end of stream (no holdback).
+     *
+     * @return list<string>
+     */
+    public function flush(): array
+    {
+        return $this->emitStable(false);
+    }
+
+    /**
+     * Total redacted bytes pruned from the front so far (a test/observability spy
+     * that a prune actually committed).
+     */
+    public function prunedRedactedBytes(): int
+    {
+        return $this->prunedRedactedBytes;
+    }
+
+    /**
+     * Current retained raw window size in bytes (observability / test bound).
+     */
+    public function currentWindowBytes(): int
+    {
+        return \strlen($this->window);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function emitStable(bool $holdback): array
+    {
+        $full  = ($this->redact)($this->window);
+        $limit = $holdback
+            ? $this->utf8SafeBack($full, \strlen($full) - self::HOLDBACK_BYTES)
+            : \strlen($full);
+        if ($limit <= $this->emitted) {
+            return [];
+        }
+        $delta         = \substr($full, $this->emitted, $limit - $this->emitted);
+        $this->emitted = $limit;
+
+        return $delta === '' ? [] : [$delta];
+    }
+
+    private function bound(): void
+    {
+        if (\strlen($this->window) <= self::SOFT_CAP_BYTES) {
+            return;
+        }
+        if ($this->pruneFront()) {
+            return;
+        }
+        if (\strlen($this->window) >= self::HARD_CAP_BYTES) {
+            $this->safeHold();
+        }
+    }
+
+    /**
+     * Drop a settled front prefix at a CERTIFIED-clean cut. The cut is committed
+     * only if re-redacting the two halves reproduces the whole redaction byte for
+     * byte (so no match spans the cut) AND the dropped redaction is already
+     * emitted — then the emit offset adjustment is exact.
+     */
+    private function pruneFront(): bool
+    {
+        $full   = ($this->redact)($this->window);
+        $cutMax = $this->utf8SafeBack($this->window, \strlen($this->window) - self::KEEP_BYTES);
+        for ($i = 0; $i < self::PRUNE_PROBES; ++$i) {
+            $cut = $this->utf8SafeBack($this->window, $cutMax - ($i * self::PROBE_STEP));
+            if ($cut <= 0) {
+                break;
+            }
+            $head  = \substr($this->window, 0, $cut);
+            $rHead = ($this->redact)($head);
+            if (\strlen($rHead) <= $this->emitted
+                && $full === $rHead . ($this->redact)(\substr($this->window, $cut))) {
+                $this->window              = \substr($this->window, $cut);
+                $this->emitted             -= \strlen($rHead);
+                $this->prunedRedactedBytes += \strlen($rHead);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fallback for a single unbroken match filling the whole window (no clean cut
+     * anywhere): drop the middle, keeping the anchoring head and the recent tail —
+     * but ONLY when re-redaction proves the drop leaves the output byte-identical,
+     * so the emit offset stays valid and no unmasked byte is ever emitted. The
+     * dropped middle is inside the marker-collapsed match and never belonged in
+     * the output.
+     */
+    private function safeHold(): void
+    {
+        $keep = self::KEEP_BYTES;
+        if (\strlen($this->window) <= 2 * $keep) {
+            return;
+        }
+        $headLen   = $this->utf8SafeBack($this->window, $keep);
+        $tailStart = $this->utf8SafeForward($this->window, \strlen($this->window) - $keep);
+        $candidate = \substr($this->window, 0, $headLen) . \substr($this->window, $tailStart);
+        if (($this->redact)($candidate) === ($this->redact)($this->window)) {
+            $this->window = $candidate;
+        }
+    }
+
+    /**
+     * Back a byte length off any UTF-8 continuation run so it never lands inside a
+     * multibyte sequence (continuation bytes are 10xxxxxx / 0x80–0xBF).
+     */
+    private function utf8SafeBack(string $text, int $length): int
+    {
+        if ($length <= 0) {
+            return 0;
+        }
+        if ($length >= \strlen($text)) {
+            return \strlen($text);
+        }
+        while ($length > 0 && (\ord($text[$length]) & 0xC0) === 0x80) {
+            --$length;
+        }
+
+        return $length;
+    }
+
+    /**
+     * Advance an offset FORWARD off any UTF-8 continuation run (for a tail start).
+     */
+    private function utf8SafeForward(string $text, int $offset): int
+    {
+        if ($offset <= 0) {
+            return 0;
+        }
+        while ($offset < \strlen($text) && (\ord($text[$offset]) & 0xC0) === 0x80) {
+            ++$offset;
+        }
+
+        return $offset;
+    }
+}

--- a/Classes/Service/Streaming/StreamRedactionWindow.php
+++ b/Classes/Service/Streaming/StreamRedactionWindow.php
@@ -246,6 +246,9 @@ final class StreamRedactionWindow
         if ($offset <= 0) {
             return 0;
         }
+        if ($offset >= \strlen($text)) {
+            return \strlen($text);
+        }
         while ($offset < \strlen($text) && (\ord($text[$offset]) & 0xC0) === 0x80) {
             ++$offset;
         }

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -103,19 +103,6 @@ final readonly class StreamingDispatcher
      */
     private const MAX_GUARDRAIL_BUFFER_BYTES = 50000;
 
-    /**
-     * Trailing bytes of the redacted output held back from the live stream, so a
-     * match still in progress near the end is never emitted before it completes
-     * (ADR-088). Redaction is recomputed on the raw buffer each chunk, so a
-     * complete secret always collapses to its marker; the only unstable region is
-     * a partial anchor / sub-minimum match at the very tail, whose reach-back is
-     * an anchor plus the pattern minimum (``sk-`` + 15, ``Bearer `` + 7, a
-     * credential URL-param name + 1) — well under this window. A credential whose
-     * anchor/param-name alone exceeds 128 bytes and straddles the final boundary
-     * can still partially leak: a documented limit of a lazy stream.
-     */
-    private const HOLDBACK_BYTES = 128;
-
     /** @var list<GuardrailInterface> */
     private array $guardrails;
 
@@ -190,10 +177,15 @@ final readonly class StreamingDispatcher
         $firstTokenNs    = null;
         $completionBytes = 0;
         $completion      = '';
-        $raw             = '';
-        $emitted         = 0;
         $redacts         = $this->streamRedactors !== [];
-        $overflow        = false;
+        // Live redaction (ADR-088): a bounded, self-certifying sliding window that
+        // masks secrets — including one split across chunk boundaries or positioned
+        // arbitrarily far into a long stream — with bounded memory and no O(n^2)
+        // rescan, and never passes a raw secret byte through. null when no
+        // redaction-capable guardrail is registered (verbatim pass-through).
+        $window          = $redacts
+            ? new StreamRedactionWindow(fn(string $s): string => $this->redactStream($s))
+            : null;
         $served          = $configuration;
         $success         = false;
         $errorClass      = '';
@@ -213,63 +205,23 @@ final readonly class StreamingDispatcher
                     $completion .= $chunk;
                 }
 
-                if (!$redacts || $overflow) {
-                    // No redaction-capable guardrail, or the redaction buffer has
-                    // hit its cap: pass through with no holdback / no added latency.
+                if ($window === null) {
+                    // No redaction-capable guardrail: verbatim pass-through.
                     yield $chunk;
                     $inner->next();
                     continue;
                 }
 
-                // Live redaction (ADR-088). Redact the RAW accumulated text FRESH
-                // each chunk — never re-processing an earlier redaction marker,
-                // which would orphan the tail of a secret whose recognizable head
-                // was already masked (``sk-***`` + continuation no longer matches).
-                // Emit only the redacted prefix that is stable: everything but a
-                // holdback tail large enough to cover any match still in progress
-                // near the end, so a secret is only ever emitted once masked in
-                // full — including one split across chunk boundaries.
-                $raw .= $chunk;
-
-                if (\strlen($raw) > self::MAX_GUARDRAIL_BUFFER_BYTES) {
-                    // Bound memory + the per-chunk rescan on a pathologically long
-                    // stream: flush what we have and pass the rest through raw.
-                    // Past this cap content is neither masked NOR recorded — the
-                    // audit buffer ($completion) caps at the same size — so a
-                    // secret beyond ~50 KB into a single completion can leak; a
-                    // documented limit for a runaway stream.
-                    $full = $this->redactStream($raw);
-                    if (\strlen($full) > $emitted) {
-                        yield \substr($full, $emitted);
-                    }
-                    $raw      = '';
-                    $overflow = true;
-                    // Observability for the silent-bypass limit: a secret past this
-                    // point is neither masked nor audited, so record that live
-                    // redaction stopped for this stream.
-                    $this->logger->warning(
-                        'Streamed LLM response exceeded the live-redaction cap; further content passes through unredacted and unaudited',
-                        $this->logContext($context, ['capBytes' => self::MAX_GUARDRAIL_BUFFER_BYTES]),
-                    );
-                    $inner->next();
-                    continue;
-                }
-
-                $full   = $this->redactStream($raw);
-                $stable = $this->utf8SafeLength($full, \strlen($full) - self::HOLDBACK_BYTES);
-                if ($stable > $emitted) {
-                    yield \substr($full, $emitted, $stable - $emitted);
-                    $emitted = $stable;
+                foreach ($window->push($chunk) as $delta) {
+                    yield $delta;
                 }
                 $inner->next();
             }
 
-            // Flush the redacted remainder once the stream is complete (unless the
-            // overflow path already drained and switched to passthrough).
-            if ($redacts && !$overflow) {
-                $full = $this->redactStream($raw);
-                if (\strlen($full) > $emitted) {
-                    yield \substr($full, $emitted);
+            // Flush the redacted remainder once the stream is complete.
+            if ($window !== null) {
+                foreach ($window->flush() as $delta) {
+                    yield $delta;
                 }
             }
 
@@ -564,30 +516,6 @@ final readonly class StreamingDispatcher
         }
 
         return $text;
-    }
-
-    /**
-     * Back off a byte length so it never lands inside a multibyte UTF-8 sequence
-     * (ADR-088) — the redaction path re-chunks the stream, so without this a
-     * codepoint could be split across two yielded deltas and a per-delta SSE
-     * consumer would decode mojibake on that boundary. Continuation bytes are
-     * ``10xxxxxx`` (0x80–0xBF); walk back off any run of them. The held-back
-     * remainder carries the rest of the codepoint and is emitted next.
-     */
-    private function utf8SafeLength(string $text, int $length): int
-    {
-        if ($length <= 0) {
-            return 0;
-        }
-        if ($length >= \strlen($text)) {
-            return \strlen($text);
-        }
-
-        while ($length > 0 && (\ord($text[$length]) & 0xC0) === 0x80) {
-            --$length;
-        }
-
-        return $length;
     }
 
     private function recordUsage(

--- a/Documentation/Adr/Adr088StreamingRedaction.rst
+++ b/Documentation/Adr/Adr088StreamingRedaction.rst
@@ -54,10 +54,15 @@ emitted, including one split across chunk boundaries.
   (``SecretRedactionGuardrail`` does). When none is registered — or only
   policy-only DENY guardrails are — the loop passes chunks straight through with
   no buffer and no latency.
-- **Bounded.** The raw buffer is capped at ``MAX_GUARDRAIL_BUFFER_BYTES`` (50 KB,
-  the same cap the audit buffer uses); past it the stream is flushed and passed
-  through raw, so memory and the per-chunk rescan stay bounded on a
-  pathologically long stream.
+- **Bounded (updated 2026-07-19).** Live redaction runs over a bounded, self-
+  certifying sliding window (``StreamRedactionWindow``): it re-redacts only a
+  window (block-coalesced, so the rescan is O(n) not O(n²)) and prunes the settled
+  front at a cut it certifies clean — ``redact(head) . redact(tail) ===
+  redact(window)`` — so memory stays bounded on an arbitrarily long stream WITHOUT
+  ever passing a raw byte through. (The earlier design flushed and passed the tail
+  through raw past a 50 KB cap, which leaked a secret positioned beyond it; that
+  passthrough is removed.) The separate ADR-086 audit buffer still caps at
+  ``MAX_GUARDRAIL_BUFFER_BYTES`` (50 KB).
 - **Multibyte-safe.** The emit boundary is backed off a UTF-8 continuation run so
   a codepoint is never split across two yielded deltas.
 - **Usage/telemetry count the RAW provider output**, unchanged — the redacted
@@ -75,12 +80,14 @@ Consequences
   guardrail arrive at end-of-stream rather than incrementally — a small,
   bounded latency on the stream tail. Accepted as the price of live masking.
 - Limits: a credential whose anchor / URL-param name alone exceeds the holdback
-  window and straddles the final boundary can still partially leak. Past the
-  50 KB cap a secret is neither masked nor recorded — the audit buffer caps at
-  the same size — so it can leak silently on a runaway (>50 KB) single
-  completion; accepted as the bound on memory and rescan cost. Correctness relies
-  on the redactor collapsing a complete secret to a marker outside its own
-  character class (so a partial anchor at the tail is the only unstable region) —
-  true for the shipped ``SecretRedactionGuardrail``.
+  window and straddles the final boundary can still partially leak. A single
+  UNBROKEN match longer than the 1 MB hard cap (with no clean cut anywhere) has
+  its interior bytes DROPPED — a data-completeness loss, never a raw passthrough —
+  so no secret leaks; only an adversarial >1 MB unbroken payload loses data (a
+  benign unbroken blob factorises trivially and is pruned, not truncated).
+  Correctness relies on the redactor collapsing a complete secret to a marker
+  outside its own character class (so a partial anchor at the tail is the only
+  unstable region) — true for the shipped ``SecretRedactionGuardrail`` — and is
+  verified by a randomised property test (``concat(deltas) === redact(fullRaw)``).
 - DENY on a stream stays unenforceable — a hard block needs the non-streaming
   path.

--- a/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
+++ b/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
@@ -36,9 +36,19 @@ final class StreamRedactionWindowTest extends TestCase
     private function redactor(): Closure
     {
         return static function (string $s): string {
-            $s = (string)preg_replace('/([?&])(key|token|secret)=[^&\s]+/i', '$1$2=***', $s);
-            $s = (string)preg_replace('/\bsk-[A-Za-z0-9_-]{16,}/', 'sk-***', $s);
-            $s = (string)preg_replace('/\b(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/i', '$1***', $s);
+            // Null-guard each preg_replace (a backtrack-limit failure returns null,
+            // which a bare (string) cast would silently wipe to '') — mirroring the
+            // production RedactsSecretsTrait.
+            foreach ([
+                ['/([?&])(key|token|secret)=[^&\s]+/i', '$1$2=***'],
+                ['/\bsk-[A-Za-z0-9_-]{16,}/', 'sk-***'],
+                ['/\b(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/i', '$1***'],
+            ] as [$pattern, $replacement]) {
+                $replaced = preg_replace($pattern, $replacement, $s);
+                if (is_string($replaced)) {
+                    $s = $replaced;
+                }
+            }
 
             return $s;
         };

--- a/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
+++ b/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Streaming;
+
+use Closure;
+use Netresearch\NrLlm\Service\Streaming\StreamRedactionWindow;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The golden invariant of the sliding window is: concatenating every emitted
+ * delta equals redacting the whole raw stream in one shot. If the prune/offset
+ * bookkeeping is wrong anywhere, this breaks. A randomised property test asserts
+ * it over hundreds of secret/benign/multibyte inputs and chunk splittings; the
+ * named cases pin the specific adversarial scenarios (secret past the old cap,
+ * boundary + prune-boundary splits, a >1 MB unbroken run, multibyte).
+ */
+#[CoversClass(StreamRedactionWindow::class)]
+final class StreamRedactionWindowTest extends TestCase
+{
+    /**
+     * A representative redactor with the ADR-088 property (a complete match
+     * collapses to a fixed short marker) — the same shape as the shipped
+     * SecretRedactionGuardrail patterns.
+     *
+     * @return Closure(string): string
+     */
+    private function redactor(): Closure
+    {
+        return static function (string $s): string {
+            $s = (string)preg_replace('/([?&])(key|token|secret)=[^&\s]+/i', '$1$2=***', $s);
+            $s = (string)preg_replace('/\bsk-[A-Za-z0-9_-]{16,}/', 'sk-***', $s);
+            $s = (string)preg_replace('/\b(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/i', '$1***', $s);
+
+            return $s;
+        };
+    }
+
+    /**
+     * Feed $raw through the window in $chunkSize-byte pieces; return concatenated deltas.
+     */
+    private function stream(StreamRedactionWindow $w, string $raw, int $chunkSize): string
+    {
+        $out = '';
+        for ($i = 0, $n = \strlen($raw); $i < $n; $i += $chunkSize) {
+            foreach ($w->push(\substr($raw, $i, $chunkSize)) as $d) {
+                $out .= $d;
+            }
+        }
+        foreach ($w->flush() as $d) {
+            $out .= $d;
+        }
+
+        return $out;
+    }
+
+    #[Test]
+    public function concatenatedOutputEqualsFullRedactionForAssortedInputsAndChunkSizes(): void
+    {
+        $redact = $this->redactor();
+        $cases  = [
+            'benign'                 => str_repeat('the quick brown fox ', 50),
+            'secret past 8k window'  => str_repeat('word ', 2000) . 'sk-ABCDEFGHIJKLMNOP0123 tail',
+            'secret at the start'    => 'sk-ABCDEFGHIJKLMNOP0123 then ' . str_repeat('x ', 5000),
+            'bearer with spaces'     => 'Authorization: Bearer    tokAbc123def456 end',
+            'url param'              => 'GET /x?key=SUPERSECRETVALUE&z=1 ok',
+            'interleaved secrets'    => str_repeat('a sk-ABCDEFGHIJKLMNOP01 b Bearer tok12345678 c ?token=zzzz d ', 300),
+        ];
+        foreach ($cases as $name => $raw) {
+            $expected = $redact($raw);
+            foreach ([1, 3, 7, 64, 257, 1000] as $chunk) {
+                $out = $this->stream(new StreamRedactionWindow($redact), $raw, $chunk);
+                self::assertSame($expected, $out, "case={$name} chunk={$chunk}");
+            }
+        }
+    }
+
+    /** Deterministic LCG state, so the property test is reproducible (and lint-stable). */
+    private int $rng = 20260719;
+
+    private function roll(int $lo, int $hi): int
+    {
+        $this->rng = (($this->rng * 1103515245) + 12345) & 0x7FFFFFFF;
+
+        return $lo + ($this->rng % (($hi - $lo) + 1));
+    }
+
+    #[Test]
+    public function propertyConcatEqualsFullRedactionOverRandomisedInputs(): void
+    {
+        $redact    = $this->redactor();
+        $this->rng = 20260719;
+        for ($iter = 0; $iter < 300; ++$iter) {
+            $raw      = $this->randomRaw();
+            $expected = $redact($raw);
+            $chunk    = $this->roll(1, 20);
+            $out      = $this->stream(new StreamRedactionWindow($redact), $raw, $chunk);
+            self::assertSame($expected, $out, "iter={$iter} chunk={$chunk} rawLen=" . \strlen($raw));
+        }
+    }
+
+    private function randomRaw(): string
+    {
+        $parts = [];
+        $n     = $this->roll(5, 60);
+        for ($i = 0; $i < $n; ++$i) {
+            $parts[] = match ($this->roll(0, 9)) {
+                0, 1, 2, 3, 4 => str_repeat('word', $this->roll(1, 400)) . ' ', // benign, sometimes crosses SOFT_CAP
+                5             => 'sk-' . $this->randAlnum($this->roll(16, 40)) . ' ',
+                6             => 'Bearer ' . $this->randAlnum($this->roll(8, 30)) . ' ',
+                7             => '?key=' . $this->randAlnum($this->roll(3, 20)) . ' ',
+                8             => 'grüße-😀-мир ',                               // multibyte
+                default       => "plain text bit {$i} ",
+            };
+        }
+
+        return implode('', $parts);
+    }
+
+    private function randAlnum(int $len): string
+    {
+        $c = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        $s = '';
+        for ($i = 0; $i < $len; ++$i) {
+            $s .= $c[$this->roll(0, 61)];
+        }
+
+        return $s;
+    }
+
+    #[Test]
+    public function secretPositionedPastTheOldFiftyKbCapIsStillMasked(): void
+    {
+        $redact = $this->redactor();
+        $raw    = str_repeat("benign line number here\n", 3000) // > 60 KB of filler
+            . ' the key is sk-ABCDEFGHIJKLMNOP0123456789 done';
+
+        $out = $this->stream(new StreamRedactionWindow($redact), $raw, 1);
+
+        self::assertStringContainsString('sk-***', $out);
+        self::assertStringNotContainsString('sk-ABCDEFGHIJKLMNOP0123456789', $out);
+        self::assertSame($redact($raw), $out);
+    }
+
+    #[Test]
+    public function memoryStaysBoundedAndPruningActuallyCommitsOnALongStream(): void
+    {
+        $w   = new StreamRedactionWindow($this->redactor());
+        $max = 0;
+        for ($i = 0; $i < 5000; ++$i) {
+            $w->push('some benign words here and there ');
+            $max = max($max, $w->currentWindowBytes());
+        }
+        $w->flush();
+
+        self::assertLessThan(20000, $max, 'window is pruned well below the ~165 KB raw stream');
+        self::assertGreaterThan(0, $w->prunedRedactedBytes(), 'a prune actually committed');
+    }
+
+    #[Test]
+    public function singleUnbrokenSecretRunLongerThanHardCapEmitsOneMarkerAndNeverLeaksRaw(): void
+    {
+        $redact = $this->redactor();
+        $w      = new StreamRedactionWindow($redact);
+        $raw    = 'sk-' . str_repeat('A', 2_000_000); // 2 MB unbroken class run
+        $out    = '';
+        foreach ($w->push($raw) as $d) {
+            $out .= $d;
+        }
+        foreach ($w->push(' done') as $d) {
+            $out .= $d;
+        }
+        foreach ($w->flush() as $d) {
+            $out .= $d;
+        }
+
+        self::assertStringNotContainsString('AAAA', $out, 'no raw secret byte is ever emitted');
+        self::assertStringContainsString('sk-***', $out);
+        self::assertLessThan(2_000_000, $w->currentWindowBytes(), 'window stayed bounded (middle dropped)');
+        self::assertSame($redact($raw . ' done'), $out);
+    }
+
+    #[Test]
+    public function benignUnbrokenBlobLargerThanHardCapPassesThroughIntact(): void
+    {
+        $w    = new StreamRedactionWindow($this->redactor());
+        $blob = str_repeat('B', 1_500_000); // no whitespace, no secret
+        $out  = '';
+        foreach ($w->push($blob) as $d) {
+            $out .= $d;
+        }
+        foreach ($w->flush() as $d) {
+            $out .= $d;
+        }
+
+        self::assertSame($blob, $out, 'identity redaction factorises, so a benign blob is not truncated');
+    }
+
+    #[Test]
+    public function emittedDeltaBoundariesNeverSplitAUtf8Codepoint(): void
+    {
+        $redact = $this->redactor();
+        $raw    = str_repeat('grüße 😀 мир ', 2000); // heavy multibyte, crosses the caps
+        $w      = new StreamRedactionWindow($redact);
+        $out    = '';
+        for ($i = 0, $n = \strlen($raw); $i < $n; $i += 3) {
+            foreach ($w->push(\substr($raw, $i, 3)) as $d) {
+                $out .= $d;
+                self::assertTrue(mb_check_encoding($out, 'UTF-8'), 'no delta boundary splits a codepoint');
+            }
+        }
+        foreach ($w->flush() as $d) {
+            $out .= $d;
+        }
+
+        self::assertSame($redact($raw), $out);
+    }
+}

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -352,28 +352,26 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function stopsRedactingPastTheBufferCapAndPassesTheTailThrough(): void
+    public function masksASecretPositionedPastTheOldBufferCap(): void
     {
         $dispatcher = $this->dispatcher(guardrails: [new SecretRedactionGuardrail()]);
 
-        // A complete key early in the stream is masked; > 50000 bytes of filler
-        // push past MAX_GUARDRAIL_BUFFER_BYTES, after which content passes through
-        // raw (the documented redaction-cap limit).
-        $preSecret = 'sk-' . str_repeat('B', 20);
-        $chunks    = iterator_to_array($dispatcher->stream(
+        // > 50000 bytes of benign filler, THEN a secret. The old layout switched
+        // to raw passthrough past MAX_GUARDRAIL_BUFFER_BYTES and leaked it; the
+        // sliding window keeps redacting (bounded memory), so it is masked.
+        $postSecret = 'sk-' . str_repeat('B', 20);
+        $chunks     = iterator_to_array($dispatcher->stream(
             $this->context(),
             $this->configuration('primary'),
-            $this->staticStream(['start ' . $preSecret . ' ', str_repeat('a', 60000), ' TAIL-AFTER-CAP']),
+            $this->staticStream([str_repeat('a', 60000), ' the key is ' . $postSecret . ' end']),
         ));
 
         $emitted = implode('', $chunks);
-        self::assertStringContainsString('sk-***', $emitted);
-        self::assertStringNotContainsString($preSecret, $emitted);
-        self::assertStringContainsString('TAIL-AFTER-CAP', $emitted);
-
-        // The silent-bypass limit is observable: a warning records that live
-        // redaction stopped for this stream.
-        self::assertNotNull($this->logger->firstMatching('warning', 'exceeded the live-redaction cap'));
+        self::assertStringContainsString('sk-***', $emitted, 'a secret past the old cap is now masked');
+        self::assertStringNotContainsString($postSecret, $emitted);
+        self::assertStringContainsString(str_repeat('a', 100), $emitted, 'benign filler still streams');
+        // Live redaction no longer stops, so there is no cap-exceeded warning.
+        self::assertNull($this->logger->firstMatching('warning', 'exceeded the live-redaction cap'));
     }
 
     #[Test]


### PR DESCRIPTION
Closes the last deferred finding from the guardrail audit: the >50 KB streaming
redaction overflow leak (ADR-088), designed via a 3-approach panel and verified
by a randomised property test.

## The bug
Live stream redaction (ADR-088) re-redacted the whole raw buffer each chunk and
emitted the stable prefix. Past `MAX_GUARDRAIL_BUFFER_BYTES` (50 KB) it flushed
and passed **every later chunk through RAW** — so a secret positioned past the
cap in a long completion (a long document/code response, or a prompt-injected
model deterministically placing it there) was emitted unredacted. The unbounded
buffer also made the per-chunk rescan **O(n²)** (a CPU-amplification DoS).

## The fix
A bounded, self-certifying sliding window (`StreamRedactionWindow`):

- Re-redacts only a window, **block-coalesced** → O(n) not O(n²) (fixes the DoS).
- Prunes the settled front at a cut it **certifies clean**:
  `redact(head) . redact(tail) === redact(window)` (no match spans the cut) and
  the dropped redaction is already emitted — so the emit offset stays exact and
  **no raw byte is ever passed through**.
- Pathological case (a single unbroken match longer than the 1 MB hard cap, no
  clean cut): drops the match's interior bytes — a data-completeness loss on an
  adversarial >1 MB unbroken payload, **never a leak**. A benign unbroken blob
  factorises trivially and is pruned intact.

## Verification
The window is unit-tested **in isolation** by a randomised property test:
`concat(deltas) === redact(fullRaw)` over 300 secret/benign/multibyte inputs and
chunk splittings (502 assertions), plus named adversarial cases — a secret past
the old cap, a 2 MB unbroken run (one marker emitted, zero raw bytes, bounded
memory), a 1.5 MB benign blob (intact), and multibyte boundaries (no codepoint
split). This is a stronger, deterministic check than an LLM adversarial pass for
algorithmic bookkeeping. The `StreamingDispatcher` test that characterised the
old leaky passthrough now asserts a past-cap secret is masked.

Local gate green: unit, functional (sqlite), phpstan (L10), cgl, rector, fuzzy,
architecture. ADR-088 amended in place; the now-dead HOLDBACK_BYTES / utf8SafeLength
move into the window class.

## Residual (documented)
A credential whose anchor alone exceeds the 128-byte holdback and straddles the
final boundary can still partially leak (pre-existing ADR-088 limit, unchanged).
