### PR TITLE
fix(tool): enforce backend language access in read tools

### DIFF
--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -103,6 +103,12 @@ final readonly class GetPageContentTool implements ToolInterface
 
         $isAdmin = $user->isAdmin();
 
+        // Non-admins may only read content in languages they are permitted;
+        // otherwise a language restriction is a no-op against this tool.
+        if (!$isAdmin && !$user->checkLanguageAccess($language)) {
+            return self::NOT_PERMITTED;
+        }
+
         // Non-admins must hold PAGE_SHOW on the page itself; a missing page and
         // a denied page are indistinguishable in the reply (fail-closed).
         if (!$isAdmin) {

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -148,15 +148,26 @@ final readonly class ReadRecordsTool implements ToolInterface
         $offset = self::toInt($arguments['offset'] ?? 0);
         $offset = max(0, min($offset, self::MAX_OFFSET));
 
-        $rows = $this->fetchRows($table, $fields, $filters, $limit, $offset);
+        // For a non-admin on a language-aware table, fetch the language column
+        // too (even if not displayed) so rows in a forbidden language can be
+        // dropped below — an unfiltered read must not leak them to the provider.
+        $languageField = $this->languageField($table);
+        $queryFields   = $fields;
+        if (!$user->isAdmin() && $languageField !== null && !in_array($languageField, $queryFields, true)) {
+            $queryFields[] = $languageField;
+        }
 
-        // Non-admins only see rows on pages they may show (fail-closed).
+        $rows = $this->fetchRows($table, $queryFields, $filters, $limit, $offset);
+
+        // Non-admins only see rows on pages they may show and in languages they
+        // may access (fail-closed).
         if (!$user->isAdmin()) {
             $permsClause = self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
             $pidAccess   = [];
             $rows        = array_values(array_filter(
                 $rows,
-                fn(array $row): bool => $this->pageIsReadable($table, $row, $permsClause, $pidAccess),
+                fn(array $row): bool => $this->pageIsReadable($table, $row, $permsClause, $pidAccess)
+                    && ($languageField === null || $user->checkLanguageAccess(self::toInt($row[$languageField] ?? 0))),
             ));
         }
 
@@ -188,6 +199,20 @@ final readonly class ReadRecordsTool implements ToolInterface
     {
         // Usable by non-admins; execute() self-enforces the acting user's TYPO3 permissions.
         return false;
+    }
+
+    /**
+     * The table's TCA language field (ctrl.languageField), or null when the
+     * table is not language-aware.
+     */
+    private function languageField(string $table): ?string
+    {
+        $tca        = is_array($GLOBALS['TCA'] ?? null) ? $GLOBALS['TCA'] : [];
+        $definition = $tca[$table] ?? null;
+        $ctrl       = is_array($definition) ? ($definition['ctrl'] ?? null) : null;
+        $field      = is_array($ctrl) ? ($ctrl['languageField'] ?? null) : null;
+
+        return is_string($field) && $field !== '' ? $field : null;
     }
 
     /**

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -130,6 +130,15 @@ final readonly class ReadRecordsTool implements ToolInterface
             return 'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.';
         }
 
+        // A non-admin explicitly filtering by a language they may not access
+        // gets nothing — the backend language restriction applies here too.
+        if (!$user->isAdmin()
+            && isset($filters['sys_language_uid'])
+            && !$user->checkLanguageAccess((int)$filters['sys_language_uid'])
+        ) {
+            return self::NOT_PERMITTED;
+        }
+
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         if ($limit < 1) {
             $limit = self::DEFAULT_LIMIT;

--- a/Tests/Functional/Service/Tool/GetPageContentToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageContentToolTest.php
@@ -13,8 +13,10 @@ use Netresearch\NrLlm\Service\Tool\Builtin\GetPageContentTool;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
  * Functional tests for GetPageContentTool (ADR-042).
@@ -125,5 +127,37 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
         $output = $this->tool->execute(['uid' => 999]);
 
         self::assertSame('Page not found or not permitted.', $output);
+    }
+
+    #[Test]
+    public function nonAdminWithoutLanguageAccessIsDenied(): void
+    {
+        $pages = $this->get(ConnectionPool::class)->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        // A root-level page the editor can fully reach (own rootline, everybody
+        // perms, in web mount below) so the language gate is the only variable.
+        $pages->insert('pages', [
+            'uid' => 5, 'pid' => 0, 'title' => 'Public', 'doktype' => 1, 'slug' => '/public',
+            'sorting' => 5, 'perms_everybody' => Permission::ALL,
+        ]);
+
+        $this->setUpBackendUser(2); // editor (non-admin)
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        self::assertInstanceOf(BackendUserAuthentication::class, $beUser);
+        // Web mount covers page 5 (readPageAccess requires isInWebMount); the
+        // acting user is restricted to the default language only.
+        $beUser->groupData['webmounts']         = '5';
+        $beUser->groupData['allowed_languages'] = '0';
+
+        // Language 0 is permitted -> the page resolves past the language gate.
+        self::assertStringContainsString(
+            'Page [5] Public',
+            $this->tool->execute(['uid' => 5, 'language' => 0]),
+        );
+        // Language 1 is not permitted -> neutral denial at the language gate.
+        self::assertSame(
+            'Page not found or not permitted.',
+            $this->tool->execute(['uid' => 5, 'language' => 1]),
+        );
     }
 }

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -122,6 +123,26 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
         $this->setUpBackendUser(2); // editor without any group rights
 
         $output = $this->tool->execute(['table' => 'tt_content']);
+
+        self::assertSame('Table not found or not permitted.', $output);
+    }
+
+    #[Test]
+    public function nonAdminFilteringByForbiddenLanguageIsDenied(): void
+    {
+        $this->setUpBackendUser(2); // editor
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        self::assertInstanceOf(BackendUserAuthentication::class, $beUser);
+        // Grant table read but restrict to the default language only.
+        $beUser->groupData['tables_select']     = 'tt_content';
+        $beUser->groupData['allowed_languages'] = '0';
+
+        // Explicitly filtering by the forbidden language 1 -> neutral denial,
+        // before any row is fetched.
+        $output = $this->tool->execute([
+            'table'        => 'tt_content',
+            'where_equals' => ['sys_language_uid' => 1],
+        ]);
 
         self::assertSame('Table not found or not permitted.', $output);
     }

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
 /**
  * Functional tests for ReadRecordsTool (ADR-042).
@@ -145,5 +146,44 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
         ]);
 
         self::assertSame('Table not found or not permitted.', $output);
+    }
+
+    #[Test]
+    public function nonAdminNeverSeesForbiddenLanguageRowsEvenWithoutAFilter(): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        $pages = $connectionPool->getConnectionForTable('pages');
+        self::assertInstanceOf(Connection::class, $pages);
+        // A page the editor can reach (root page, everybody-show, in web mount).
+        $pages->insert('pages', [
+            'uid' => 7, 'pid' => 0, 'title' => 'Public', 'doktype' => 1,
+            'sorting' => 7, 'perms_everybody' => Permission::PAGE_SHOW,
+        ]);
+        $content = $connectionPool->getConnectionForTable('tt_content');
+        self::assertInstanceOf(Connection::class, $content);
+        $content->insert('tt_content', [
+            'uid' => 40, 'pid' => 7, 'colPos' => 0, 'sorting' => 1,
+            'CType' => 'text', 'header' => 'LangZeroRow', 'sys_language_uid' => 0,
+        ]);
+        $content->insert('tt_content', [
+            'uid' => 41, 'pid' => 7, 'colPos' => 0, 'sorting' => 2,
+            'CType' => 'text', 'header' => 'LangOneRow', 'sys_language_uid' => 1,
+        ]);
+
+        $this->setUpBackendUser(2);
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        self::assertInstanceOf(BackendUserAuthentication::class, $beUser);
+        $beUser->groupData['tables_select']     = 'tt_content';
+        $beUser->groupData['webmounts']         = '7';
+        $beUser->groupData['allowed_languages'] = '0';
+
+        // No language filter given: the language-0 row is returned, the
+        // language-1 row (on the same, accessible page) is dropped and its
+        // content never egresses.
+        $output = $this->tool->execute(['table' => 'tt_content', 'where_equals' => ['pid' => 7]]);
+
+        self::assertStringContainsString('tt_content:40', $output);
+        self::assertStringNotContainsString('tt_content:41', $output);
+        self::assertStringNotContainsString('LangOneRow', $output);
     }
 }


### PR DESCRIPTION
From the ultracode tool-execution security audit: `get_page_content` and `read_records` never call `$user->checkLanguageAccess()`, so a non-admin restricted to certain backend languages could read content in languages they are not permitted. Since tool results egress to the external LLM provider, the language restriction was a silent no-op against these tools.

## Fix
- `get_page_content`: a non-admin querying a language they may not access gets the neutral denial (before the page/content is read).
- `read_records`: a non-admin whose `where_equals` explicitly filters by a forbidden `sys_language_uid` gets the neutral denial (before any row is fetched).

Admins are unaffected (`checkLanguageAccess` returns true for them).

## Tests
Both gated with a real backend user restricted to `allowed_languages='0'`:
- `get_page_content`: language 0 resolves the page; language 1 → neutral denial. The page is a root page in the editor's web mount with everybody-perms, so the language gate is the only variable (isolating it from the page-permission and web-mount checks).
- `read_records`: the editor is granted `tables_select` on `tt_content` but restricted to language 0; a `sys_language_uid=1` filter → the language-gate denial string (distinct from the "No records" path, proving the gate fired rather than an empty result).

## Gates
cgl, PHPStan level 10, unit (5287), Rector `-n`, fuzzy — green; the two tool functional files green locally (11 tests). Full functional runs in CI.