### PR TITLE
security: close tool secret-egress denylist gaps (vault table, FAL config, legacy config file, encryptionKey, DSN)

### DIFF
--- a/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
+++ b/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
@@ -32,7 +32,14 @@ trait RendersTypoScriptTreeTrait
      * last path segment, per camelCase/underscore word.
      */
     private const SECRET_KEY_PATTERN
-        = '/(password|passwd|pwd|secret|token|credential|apikey|api_key|privatekey|private_key|authorization)/i';
+        = '/(password|passwd|pwd|secret|token|credential|apikey|api_key|accesskey|access_key|encryptionkey|encryption_key|licensekey|privatekey|private_key|authorization|salt|dsn)/i';
+
+    /**
+     * Credentials embedded in a connection-string value (scheme://user:pass@host)
+     * are masked regardless of the key name — a DSN under a benign key (e.g.
+     * `settings.dsn`) would otherwise egress its inline password.
+     */
+    private const SECRET_URL_PATTERN = '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s]+@~i';
 
     /** Maximum rendered lines per reply. */
     private const MAX_LINES = 300;
@@ -147,10 +154,15 @@ trait RendersTypoScriptTreeTrait
      */
     private function redactSecretValue(string $key, string $value): string
     {
-        if ($value !== '' && preg_match(self::SECRET_KEY_PATTERN, $key) === 1) {
+        if ($value === '') {
+            return $value;
+        }
+        if (preg_match(self::SECRET_KEY_PATTERN, $key) === 1) {
             return '[redacted]';
         }
+        // Mask an inline connection-string password even under a benign key name.
+        $masked = preg_replace(self::SECRET_URL_PATTERN, '$1:***@', $value);
 
-        return $value;
+        return is_string($masked) ? $masked : $value;
     }
 }

--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -44,13 +44,16 @@ final readonly class SourcePathGuard
 
     private const DENIED_EXTENSIONS = ['key', 'pem', 'crt', 'p12', 'pfx'];
 
-    // settings/additional.php hold TYPO3 secrets; auth.json holds Composer
-    // registry/OAuth credentials (deploy tokens) — none may be read by read_source.
-    private const DENIED_BASENAME_PATTERN = '/^(?:settings|additional)\.php$|^auth\.json$/i';
+    // settings/additional.php (modern config/system) AND the legacy
+    // LocalConfiguration.php / AdditionalConfiguration.php (typo3conf, still valid
+    // on upgraded/non-composer v13.4 instances) hold TYPO3 secrets; auth.json
+    // holds Composer registry/OAuth credentials — none may be read by read_source.
+    private const DENIED_BASENAME_PATTERN
+        = '/^(?:settings|additional)\.php$|^(?:local|additional)configuration\.php$|^auth\.json$/i';
 
     /** Lines whose key looks credential-bearing get their value replaced. */
     private const SECRET_LINE_PATTERN
-        = '/^(?<lead>.*?(?:password|passwd|pwd|secret|token|salt|api[_-]?key|credential|private[_-]?key)[\'"\s\]]*\s*(?:=>?|:)\s*)(?<value>.+)$/i';
+        = '/^(?<lead>.*?(?:password|passwd|pwd|secret|token|salt|api[_-]?key|encryption[_-]?key|credential|private[_-]?key)[\'"\s\]]*\s*(?:=>?|:)\s*)(?<value>.+)$/i';
 
     public function __construct(
         private ?string $projectPath = null,

--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -53,7 +53,7 @@ final readonly class SourcePathGuard
 
     /** Lines whose key looks credential-bearing get their value replaced. */
     private const SECRET_LINE_PATTERN
-        = '/^(?<lead>.*?(?:password|passwd|pwd|secret|token|salt|api[_-]?key|encryption[_-]?key|credential|private[_-]?key)[\'"\s\]]*\s*(?:=>?|:)\s*)(?<value>.+)$/i';
+        = '/^(?<lead>.*?(?:password|passwd|pwd|secret|token|salt|api[_-]?key|access[_-]?key|encryption[_-]?key|license[_-]?key|credential|private[_-]?key|authorization|dsn)[\'"\s\]]*\s*(?:=>?|:)\s*)(?<value>.+)$/i';
 
     public function __construct(
         private ?string $projectPath = null,

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -44,13 +44,18 @@ final readonly class TableReadAccessService
         'sys_refindex',
         'sys_http_report',
         'sys_lockedrecords',
+        // The FAL storage `configuration` FlexForm carries remote-driver
+        // credentials (S3/FTP/WebDAV keys) and the server base path; storages are
+        // exposed only through the FAL tools' redacted view (ADR-049).
+        'sys_file_storage',
     ];
 
     /**
      * Table-name prefixes treated like {@see self::SENSITIVE_TABLES} — the
-     * nr_llm tables store provider endpoints and vault key references.
+     * nr_llm tables store provider endpoints and vault key references, and the
+     * nr_vault tables ARE the secret store (identifiers, ACLs, ciphertext).
      */
-    private const SENSITIVE_TABLE_PREFIXES = ['tx_nrllm'];
+    private const SENSITIVE_TABLE_PREFIXES = ['tx_nrllm', 'tx_nrvault'];
 
     /**
      * Credential-ish field-name segments whose values must never egress.
@@ -60,7 +65,7 @@ final readonly class TableReadAccessService
      * without listing each one.
      */
     private const SENSITIVE_FIELD_PATTERN
-        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa)(\d+)?($|_)/i';
+        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa|dsn|authorization)(\d+)?($|_)/i';
 
     /**
      * Unambiguous credential nouns matched boundary-free, catching concatenated

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -65,7 +65,7 @@ final readonly class TableReadAccessService
      * without listing each one.
      */
     private const SENSITIVE_FIELD_PATTERN
-        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa|dsn|authorization)(\d+)?($|_)/i';
+        = '/(^|_)(password|passwd|pwd|secret|token|salt|hash|credential|key|mfa|dsn|authorization|accesskey|licensekey|encryptionkey)(\d+)?($|_)/i';
 
     /**
      * Unambiguous credential nouns matched boundary-free, catching concatenated

--- a/Tests/Unit/Service/Tool/Builtin/RendersTypoScriptTreeTraitTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/RendersTypoScriptTreeTraitTest.php
@@ -108,7 +108,23 @@ final class RendersTypoScriptTreeTraitTest extends TestCase
         self::assertSame('[redacted]', $this->renderer->redact('apiKey', 'x'));
         self::assertSame('[redacted]', $this->renderer->redact('password', 'x'));
         self::assertSame('[redacted]', $this->renderer->redact('authorization', 'x'));
+        // Keys aligned with the record denylist (previously leaked):
+        self::assertSame('[redacted]', $this->renderer->redact('accessKey', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('encryptionKey', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('licenseKey', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('dsn', 'x'));
+        self::assertSame('[redacted]', $this->renderer->redact('salt', 'x'));
         self::assertSame('kept', $this->renderer->redact('title', 'kept'));
         self::assertSame('kept', $this->renderer->redact('monkeys', 'kept'));
+    }
+
+    #[Test]
+    public function masksAnInlineConnectionStringPasswordUnderABenignKey(): void
+    {
+        // A DSN under a non-credential key would otherwise egress its inline password.
+        $out = $this->renderer->redact('endpoint', 'mysql://dbuser:dbpass@127.0.0.1/app');
+
+        self::assertStringNotContainsString('dbpass', $out);
+        self::assertStringContainsString('mysql://dbuser:***@127.0.0.1/app', $out);
     }
 }

--- a/Tests/Unit/Service/Tool/SourcePathGuardTest.php
+++ b/Tests/Unit/Service/Tool/SourcePathGuardTest.php
@@ -123,6 +123,27 @@ final class SourcePathGuardTest extends TestCase
     }
 
     #[Test]
+    public function deniesLegacyTypo3confCredentialFiles(): void
+    {
+        // typo3conf/LocalConfiguration.php + AdditionalConfiguration.php hold the
+        // DB credentials + encryptionKey on upgraded/non-composer v13.4 instances.
+        self::assertTrue($this->guard->isDeniedRelativePath('public/typo3conf/LocalConfiguration.php'));
+        self::assertTrue($this->guard->isDeniedRelativePath('typo3conf/AdditionalConfiguration.php'));
+        self::assertTrue($this->guard->isDeniedRelativePath('LocalConfiguration.php'));
+        // An ordinary *Configuration.php class file is still readable.
+        self::assertFalse($this->guard->isDeniedRelativePath('Classes/Configuration/MyConfiguration.php'));
+    }
+
+    #[Test]
+    public function redactsAnEncryptionKeyLine(): void
+    {
+        $redacted = $this->guard->redactSecretLine("    'encryptionKey' => 'abc123def456ghi789jkl',");
+
+        self::assertStringContainsString('[redacted]', $redacted);
+        self::assertStringNotContainsString('abc123def456ghi789jkl', $redacted);
+    }
+
+    #[Test]
     public function readLinesIsRangedNumberedAndSecretRedacted(): void
     {
         $read = $this->guard->readLines('Classes/Service.php', 2, 2);

--- a/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
+++ b/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
@@ -113,6 +113,8 @@ final class TableReadAccessServiceTest extends TestCase
             'ses_token'         => ['ses_token', true],
             'mfa'               => ['mfa', true],
             'salt'              => ['salt', true],
+            'dsn'               => ['dsn', true],
+            'authorization'     => ['authorization', true],
             // Concatenated / camelCase / digit-suffixed forms the segment
             // pattern misses, caught by the substring pattern:
             'apikey'            => ['apikey', true],
@@ -150,5 +152,17 @@ final class TableReadAccessServiceTest extends TestCase
         $fields = $this->service->filterSensitiveFields(['uid', 'title', 'password', 'api_key', 'author']);
 
         self::assertSame(['uid', 'title', 'author'], $fields);
+    }
+
+    #[Test]
+    public function nrVaultAndFalStorageTablesAreSensitive(): void
+    {
+        // The nr_vault tables ARE the secret store (identifiers, ACLs, ciphertext).
+        self::assertTrue($this->service->isSensitiveTable('tx_nrvault_secret'));
+        self::assertTrue($this->service->isSensitiveTable('tx_nrvault_audit_log'));
+        // sys_file_storage.configuration carries remote-driver credentials.
+        self::assertTrue($this->service->isSensitiveTable('sys_file_storage'));
+        // An ordinary content table is still readable.
+        self::assertFalse($this->service->isSensitiveTable('pages'));
     }
 }

--- a/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
+++ b/Tests/Unit/Service/Tool/TableReadAccessServiceTest.php
@@ -115,6 +115,11 @@ final class TableReadAccessServiceTest extends TestCase
             'salt'              => ['salt', true],
             'dsn'               => ['dsn', true],
             'authorization'     => ['authorization', true],
+            // camelCase concatenated credential columns (no underscore boundary):
+            'accesskey'         => ['accesskey', true],
+            'accessKey camel'   => ['accessKey', true],
+            'licensekey'        => ['licensekey', true],
+            'encryptionKey'     => ['encryptionKey', true],
             // Concatenated / camelCase / digit-suffixed forms the segment
             // pattern misses, caught by the substring pattern:
             'apikey'            => ['apikey', true],


### PR DESCRIPTION
From an adversarial data-exfiltration audit of the read-only tools (SSRF / path
traversal / DB-RBAC / secret-egress). The tool protections are name-based
denylists (the #463 era); this closes the next layer of gaps a read tool could
use to exfiltrate secrets to the external LLM provider. Each was verified against
the code.

## Closed (verified)
- **nr_vault secret store was readable.** `TableReadAccessService` denylisted the
  `tx_nrllm` prefix but **not `tx_nrvault`** — so `read_records` / `search_records`
  / `get_table_schema` / `get_record_history` streamed the whole `tx_nrvault_secret`
  inventory (identifiers, ACL groups, adapter, metadata). Added the prefix.
- **`sys_file_storage.configuration`** (remote FAL-driver credentials + server base
  path) was readable via the generic record reader under a benign column name,
  bypassing the FAL tools' redacted view. Denylisted the table.
- **Legacy TYPO3 config files.** `SourcePathGuard` blocked `config/system/settings.php`
  but not `typo3conf/LocalConfiguration.php` / `AdditionalConfiguration.php` (valid on
  upgraded/non-composer v13.4) — which hold the DB credentials **and `encryptionKey`**.
  Denied those basenames; added `encryptionKey` to the line-redaction pattern.
- **TypoScript / TSconfig readers** used a weaker secret pattern than the record
  denylist (missed `dsn`, `accessKey`, `encryptionKey`, `licenseKey`, `salt`) and
  redacted only by key name — a DSN with an inline password under a benign key
  leaked. Aligned the key pattern **and** mask `scheme://user:pass@` credentials in
  the VALUE regardless of key name.
- Extended the record field denylist with `dsn` / `authorization`.

Tests: unit cases for each (denylisted tables, denied config basenames, redacted
`encryptionKey` line, credential keys + DSN value masking). Local gate green:
unit, functional (sqlite), phpstan (L10), cgl, rector, fuzzy, architecture.

## Found, deferred (lower severity / more involved — follow-ups)
- `probe_url` egress allowlist trusts ALL site `baseVariants`, incl. inactive
  internal/staging hosts (low SSRF-widening).
- `var/log` is readable and the line redaction is keyword+assignment-shaped, so
  token-shaped secrets (Bearer/JSON headers) in logs egress (low).
- `get_site_config` redaction is casing-dependent (camelCase-only normalization).

