### PR TITLE
security: close remaining tool egress follow-ups (probe_url baseVariants, var/log tokens, site-config DSN)

### DIFF
--- a/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
@@ -138,13 +138,15 @@ final readonly class GetSiteConfigTool implements ToolInterface
 
             // Normalize camelCase (apiKey → api_Key) AND acronym→word boundaries
             // (APIKey → API_Key) first — the credential pattern is snake_case-segment
-            // based, site settings are often camelCase.
-            $normalizedKey = (string)preg_replace(
+            // based, site settings are often camelCase. Null-guard the split so a
+            // preg failure falls back to the raw key (still checked) rather than an
+            // empty string, which would bypass the credential check.
+            $normalizedKey = preg_replace(
                 ['/(?<=[a-z0-9])(?=[A-Z])/', '/(?<=[A-Z])(?=[A-Z][a-z])/'],
                 '_',
                 $keyName,
             );
-            if ($this->tableAccess->isSensitiveField($normalizedKey)) {
+            if ($this->tableAccess->isSensitiveField(is_string($normalizedKey) ? $normalizedKey : $keyName)) {
                 $lines[] = sprintf('%s: %s', $path, self::REDACTED);
                 continue;
             }

--- a/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
@@ -136,10 +136,14 @@ final readonly class GetSiteConfigTool implements ToolInterface
             $keyName = (string)$key;
             $path    = $prefix === '' ? $keyName : $prefix . '.' . $keyName;
 
-            // Normalize camelCase (apiKey → api_Key) first — the credential
-            // pattern is snake_case-segment based, site settings are often
-            // camelCase.
-            $normalizedKey = (string)preg_replace('/(?<=[a-z0-9])(?=[A-Z])/', '_', $keyName);
+            // Normalize camelCase (apiKey → api_Key) AND acronym→word boundaries
+            // (APIKey → API_Key) first — the credential pattern is snake_case-segment
+            // based, site settings are often camelCase.
+            $normalizedKey = (string)preg_replace(
+                ['/(?<=[a-z0-9])(?=[A-Z])/', '/(?<=[A-Z])(?=[A-Z][a-z])/'],
+                '_',
+                $keyName,
+            );
             if ($this->tableAccess->isSensitiveField($normalizedKey)) {
                 $lines[] = sprintf('%s: %s', $path, self::REDACTED);
                 continue;
@@ -168,6 +172,12 @@ final readonly class GetSiteConfigTool implements ToolInterface
         }
 
         $text = trim((string)preg_replace('/\s+/', ' ', self::toStr($value)));
+        // Mask an inline connection-string password even under a benign key name
+        // (e.g. a DSN whose key spelling escapes the credential-name match).
+        $masked = preg_replace('~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s]+@~i', '$1:***@', $text);
+        if (is_string($masked)) {
+            $text = $masked;
+        }
 
         return mb_strimwidth($text, 0, self::VALUE_WIDTH, '…');
     }

--- a/Classes/Service/Tool/EgressPolicyService.php
+++ b/Classes/Service/Tool/EgressPolicyService.php
@@ -12,7 +12,6 @@ namespace Netresearch\NrLlm\Service\Tool;
 use Netresearch\NrLlm\Domain\Enum\ToolEgressScope;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Psr\Http\Message\UriInterface;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 
@@ -145,18 +144,12 @@ final readonly class EgressPolicyService
      */
     private function siteBases(Site $site): array
     {
-        $bases = [$site->getBase()];
-
-        $variants = $site->getConfiguration()['baseVariants'] ?? null;
-        if (is_array($variants)) {
-            foreach ($variants as $variant) {
-                if (is_array($variant) && is_string($variant['base'] ?? null)) {
-                    $bases[] = new Uri($variant['base']);
-                }
-            }
-        }
-
-        return $bases;
+        // Only the site's ACTIVE resolved base is a legitimate probe_url target.
+        // baseVariants are context/condition-resolved (a local/staging variant may
+        // point at an internal host, e.g. http://web:80); folding them all into the
+        // egress allowlist unconditionally would widen it to hosts the instance
+        // does not actually serve.
+        return [$site->getBase()];
     }
 
     private function firstSiteBase(): ?string

--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -165,7 +165,23 @@ final readonly class SourcePathGuard
      */
     public function redactSecretLine(string $line): string
     {
-        return (string)preg_replace(self::SECRET_LINE_PATTERN, '$1[redacted]', $line);
+        $out  = preg_replace(self::SECRET_LINE_PATTERN, '$1[redacted]', $line);
+        $line = is_string($out) ? $out : $line;
+        // Also mask token-shaped secrets that carry NO credential key — the shape
+        // logs emit (var/log is readable): JSON `"Authorization":"Bearer …"`
+        // headers, bearer / sk- tokens, and connection-string URLs in free-form or
+        // structured lines that the key-based pattern above never matches.
+        $out = preg_replace(
+            [
+                '/\bBearer\s+[A-Za-z0-9._~+\/\-]+=*/i',
+                '/\bsk-[A-Za-z0-9_\-]{16,}/',
+                '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s]+@~i',
+            ],
+            ['Bearer [redacted]', 'sk-[redacted]', '$1:***@'],
+            $line,
+        );
+
+        return is_string($out) ? $out : $line;
     }
 
     /**

--- a/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
+++ b/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
@@ -42,6 +42,9 @@ final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
               maps:
                 apiKey: 'super-secret-value-123'
                 zoom: 12
+              cache:
+                endpoint: 'redis://user:s3cr3tpw@cache.internal:6379/0'
+                accesskey: 'lowercase-key-secret'
             languages:
               - languageId: 0
                 title: English
@@ -76,6 +79,12 @@ final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('settings.maps.apiKey: [redacted]', $output);
         self::assertStringNotContainsString('super-secret-value-123', $output);
         self::assertStringContainsString('settings.maps.zoom: 12', $output);
+        // A lowercase credential key is redacted too (aligned field pattern).
+        self::assertStringContainsString('settings.cache.accesskey: [redacted]', $output);
+        self::assertStringNotContainsString('lowercase-key-secret', $output);
+        // A DSN password under a benign key is masked by value, not by key name.
+        self::assertStringNotContainsString('s3cr3tpw', $output);
+        self::assertStringContainsString('redis://user:***@cache.internal', $output);
     }
 
     #[Test]

--- a/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
@@ -46,6 +46,9 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
         file_put_contents($siteDir . '/config.yaml', <<<YAML
             rootPageId: 1
             base: 'http://localhost:59999/'
+            baseVariants:
+              - base: 'http://staging.internal:8080/'
+                condition: 'applicationContext == "Production/Staging"'
             languages:
               - languageId: 0
                 title: English
@@ -83,6 +86,17 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     {
         self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'file:///etc/passwd']));
         self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'gopher://localhost:59999/x']));
+    }
+
+    #[Test]
+    public function deniesAnInactiveBaseVariantHost(): void
+    {
+        // The site declares a staging baseVariant on an internal host; its
+        // condition is inactive in the test context, so it is NOT the served
+        // base — probe_url must not reach it (only the active base is trusted).
+        $output = $this->tool->execute(['url' => 'http://staging.internal:8080/']);
+
+        self::assertStringContainsString('Denied', $output);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/SourcePathGuardTest.php
+++ b/Tests/Unit/Service/Tool/SourcePathGuardTest.php
@@ -144,6 +144,21 @@ final class SourcePathGuardTest extends TestCase
     }
 
     #[Test]
+    public function redactsTokenShapedSecretsWithNoCredentialKey(): void
+    {
+        // Token shapes with NO credential key (the key-based pattern never fires):
+        // a bare bearer / sk- token and a connection-string URL in a log line.
+        $line = 'app.INFO retrieved Bearer sk-proj-ABCDEFGHIJKLMNOP123 then mysql://u:p4ssw0rd@db/x';
+
+        $out = $this->guard->redactSecretLine($line);
+
+        self::assertStringNotContainsString('sk-proj-ABCDEFGHIJKLMNOP123', $out);
+        self::assertStringContainsString('Bearer [redacted]', $out);
+        self::assertStringNotContainsString(':p4ssw0rd@', $out);
+        self::assertStringContainsString('mysql://u:***@db/x', $out);
+    }
+
+    #[Test]
     public function readLinesIsRangedNumberedAndSecretRedacted(): void
     {
         $read = $this->guard->readLines('Classes/Service.php', 2, 2);


### PR DESCRIPTION
The three follow-ups deferred from the tool data-exfiltration audit (#467). Each
verified against the code, with a regression test.

- **probe_url — inactive baseVariants no longer trusted.** `EgressPolicyService`
  folded EVERY site `baseVariants[*].base` into the egress allowlist
  unconditionally, so an inactive local/staging variant on an internal host
  (`http://web:80`, `staging.internal:8080`) became a `probe_url` target. It now
  trusts only the site's ACTIVE resolved base. Functional test asserts an
  inactive variant host is denied.
- **var/log — token-shaped secrets redacted.** `var/log` is readable but
  `SourcePathGuard::redactSecretLine` only masked assignment-shaped credential
  keys, so token shapes in log lines (JSON `"Authorization":"Bearer …"` headers,
  bare `Bearer`/`sk-` tokens, connection-string URLs) egressed. Added
  key-independent token redaction (and null-guarded the pass).
- **get_site_config — casing + value.** Redaction was camelCase-only key
  normalization and key-name-only. Added an acronym→word normalization boundary
  and a value-based `scheme://user:pass@` mask, so a DSN under a benign key no
  longer leaks its inline password, and a lowercase credential key is redacted.

Local gate green: unit, functional (sqlite), phpstan (L10), cgl, rector, fuzzy,
architecture.

Residual (documented): a pure ALLCAPS-concatenated key (`SECRETKEY`, no word
boundary) relies on the value scrub rather than the key match.
