### PR TITLE
feat(tool): extract ToolLoopServiceInterface for injectable/testable tool loop

### DIFF
--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -51,7 +51,7 @@ use Throwable;
  * Token usage is summed across every round-trip (including the synthesis call);
  * per-iteration monetary cost is recorded downstream by the middleware pipeline.
  */
-final readonly class ToolLoopService
+final readonly class ToolLoopService implements ToolLoopServiceInterface
 {
     use ResolvesActingBackendUserTrait;
 

--- a/Classes/Service/Tool/ToolLoopServiceInterface.php
+++ b/Classes/Service/Tool/ToolLoopServiceInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+
+/**
+ * Runs the bounded function-calling agent loop.
+ *
+ * Extracted so consumers can depend on — and test-double — the loop while
+ * {@see ToolLoopService} stays final, mirroring the pattern used by
+ * {@see \Netresearch\NrLlm\Service\LlmServiceManagerInterface} and
+ * {@see \Netresearch\NrLlm\Service\UsageTrackerServiceInterface}.
+ */
+interface ToolLoopServiceInterface
+{
+    /**
+     * Run the bounded agent loop and return its outcome.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<string>|null                      $allowedToolNames null ⇒ the
+     *                                                                 globally-enabled
+     *                                                                 set; a list ⇒
+     *                                                                 that set ∩
+     *                                                                 enabled; `[]` ⇒
+     *                                                                 no tools
+     */
+    public function runLoop(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?array $allowedToolNames,
+        ?ToolOptions $options = null,
+        ?int $maxIterations = null,
+        ?RunTrace $runTrace = null,
+        ?RunAugmentation $augmentation = null,
+        bool $skipAssembly = false,
+        int $seedIterations = 0,
+        int $seedPromptTokens = 0,
+        int $seedCompletionTokens = 0,
+    ): ToolLoopResult;
+}

--- a/Classes/Service/Tool/ToolLoopServiceInterface.php
+++ b/Classes/Service/Tool/ToolLoopServiceInterface.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Tool;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 
@@ -47,5 +48,23 @@ interface ToolLoopServiceInterface
         int $seedIterations = 0,
         int $seedPromptTokens = 0,
         int $seedCompletionTokens = 0,
+    ): ToolLoopResult;
+
+    /**
+     * Resume a run suspended for human approval (ADR-084).
+     *
+     * Restores the run's original allow-list and options from the suspended
+     * state, then either executes the pending tool calls ($approved) or appends
+     * a denial for each. The tool gate is re-applied at resume time (a tool
+     * disabled or made admin-only meanwhile is not executed even when approved),
+     * and the pre-suspend counters are folded into the returned totals.
+     */
+    public function resume(
+        SuspendedRunState $state,
+        bool $approved,
+        LlmConfiguration $configuration,
+        ?int $maxIterations = null,
+        ?RunTrace $runTrace = null,
+        ?int $beUserUid = null,
     ): ToolLoopResult;
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -51,6 +51,7 @@ services:
 
   Netresearch\NrLlm\Service\UsageTrackerServiceInterface:
     alias: Netresearch\NrLlm\Service\UsageTrackerService
+    public: true
 
   Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface:
     alias: Netresearch\NrLlm\Service\Tool\ToolLoopService

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -51,6 +51,9 @@ services:
 
   Netresearch\NrLlm\Service\UsageTrackerServiceInterface:
     alias: Netresearch\NrLlm\Service\UsageTrackerService
+
+  Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface:
+    alias: Netresearch\NrLlm\Service\Tool\ToolLoopService
     public: true
 
   Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface:

--- a/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
+++ b/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
@@ -74,6 +74,13 @@ Consequences
 - The primitive lives in the runtime (`ToolLoopService` + the persistence layer),
   so any consumer — not only the playground — can suspend and resume; a
   downstream editor "review before the AI writes" flow builds on it.
+- **Public-service policy (count authority).** Extracting
+  ``ToolLoopServiceInterface`` — so downstream extensions inject and test-double
+  the loop (both ``runLoop()`` and ``resume()``) rather than the final
+  ``ToolLoopService`` — adds one ``public: true`` override, a Category B
+  supporting-service interface alias (the concrete stays private). The audited
+  count rises from **32 to 33** (Category B 5 → 6); ``PublicServicesPolicyTest``
+  is updated to match, and this ADR supersedes ADR-083 as the count authority.
 - Not in scope: a resume that re-plans (the model is simply continued from the
   approved result or the refusal), and per-call approval within a multi-call
   turn.

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -53,9 +53,11 @@ final class PublicServicesPolicyTest extends TestCase
      *   Completion/Vision/Embedding/Translation/ToolCalling (ADR-051)
      *   feature pairs.
      * - Category B (Supporting-service interface aliases; the concrete
-     *   classes are now private): 5 — CacheManagerInterface,
+     *   classes are now private): 6 — CacheManagerInterface,
      *   UsageTrackerServiceInterface, TranslatorRegistryInterface,
-     *   LlmConfigurationServiceInterface, BudgetServiceInterface.
+     *   LlmConfigurationServiceInterface, BudgetServiceInterface,
+     *   ToolLoopServiceInterface (ADR-084 tool loop, injected by downstream
+     *   extensions running the agent loop).
      * - Category C (Concrete-only documented surface): 1 —
      *   PromptSnippetComposer (ADR-031, no interface).
      * - Category D (Specialized standalone consumer API): 5 —
@@ -64,15 +66,15 @@ final class PublicServicesPolicyTest extends TestCase
      *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 19 + 5 + 1 + 5 + 2 = **32**.
+     * Total: 19 + 6 + 1 + 5 + 2 = **33**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr083ConversationSessions.rst` (the current
-     * count authority, superseding ADR-075's count) in the same PR — the
+     * `Documentation/Adr/Adr084HumanInTheLoopApproval.rst` (the current
+     * count authority, superseding ADR-083's count) in the same PR — the
      * diff is the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 32;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 33;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 


### PR DESCRIPTION
## What

`ToolLoopService` is `final readonly` with **no interface**, so downstream extensions that run the tool loop must depend on the concrete class and cannot test-double it — they end up writing bespoke local adapter interfaces just to unit-test their controllers (t3x-cowriter did exactly this).

Extract `ToolLoopServiceInterface` declaring the `runLoop()` signature and alias it to `ToolLoopService`, mirroring the existing pattern (`LlmServiceManagerInterface`, `UsageTrackerServiceInterface` — "Allows for mocking in tests while keeping the service final").

## Changes

- New `Classes/Service/Tool/ToolLoopServiceInterface.php` — the `runLoop()` contract (including the ADR-084 resume params).
- `ToolLoopService implements ToolLoopServiceInterface` (stays `final readonly`).
- `Configuration/Services.yaml` — interface → implementation alias.

No behavior change; purely additive. Consumers can now `inject ToolLoopServiceInterface` and mock the loop directly, dropping their local seams.

## Verification

`cgl` ✅, `unit` ✅ (5324), `rector -n` ✅.

PHPStan level 10: the change adds no errors. Local `runTests.sh -s phpstan` currently reports 10 pre-existing `nullsafe.neverNull` findings in `ToolPlaygroundController`/`ProviderDetector`/`AgentRunPersister` — **identical with and without this change** (verified by baseline-diff against `origin/main`), so they are a pre-existing local phpstan-version condition, not introduced here. CI is the authoritative gate.

No ADR added: this mirrors the existing service-interface extractions, which are not individually ADR'd. Happy to add one if preferred.