### PR TITLE
ci(phpstan): ignore nullsafe.neverNull flagged only by a newer PHPStan than CI pins

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -38,7 +38,7 @@ parameters:
     # no-op on the version that does not emit it, and a safety net for when CI
     # bumps to the version that does.
     -
-      message: '#Using nullsafe method call on non-nullable type#'
+      message: '#Using nullsafe (method call|property access) on non-nullable type#'
       reportUnmatched: false
     -
       message: '#Only booleans are allowed in#'

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -30,6 +30,16 @@ parameters:
 
   ignoreErrors:
     # --- phpstan-strict-rules ---
+    # A newer PHPStan than the CI matrix pins narrows some `?->` receivers to
+    # never-null (e.g. an enum resolved from a hard-coded set, or a property
+    # already proven non-null by an outer `if ($x !== null)`), then reports the
+    # nullsafe operator as redundant. The CI PHPStan cannot prove those and needs
+    # the `?->`, so the code must keep it. reportUnmatched:false makes this a
+    # no-op on the version that does not emit it, and a safety net for when CI
+    # bumps to the version that does.
+    -
+      message: '#Using nullsafe method call on non-nullable type#'
+      reportUnmatched: false
     -
       message: '#Only booleans are allowed in#'
       reportUnmatched: false


### PR DESCRIPTION
A PHPStan newer than the CI matrix resolves flags 9 `?->` calls as `nullsafe.neverNull` (redundant nullsafe on a proven-non-null receiver). The CI PHPStan cannot prove those and needs the `?->`, so a `?->`→`->` swap would break the pinned build. This ignores the rule with `reportUnmatched:false` — a no-op on the CI version, a safety net when CI bumps PHPStan. Local `runTests.sh -s phpstan` now reports no errors.

Follows the existing strict-rules ignore idiom in `Build/phpstan/phpstan.neon`.