### PR TITLE
feat(provider)!: shared failure taxonomy — 5xx now fails over and trips the breaker; 429 typed on specialized path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `FailureClass` and `FailureClassifier` (ADR-095): one shared taxonomy behind
+  the retry, circuit-breaker and streaming-retry decisions, which had each kept
+  a private `instanceof` ladder that drifted. A 5xx is now classified as a
+  provider-side fault.
+- `SpecializedServiceException::getStatusCode()` exposes the upstream HTTP
+  status the error carries (0 for a transport failure), so the specialized
+  failures can be classified once they reach the shared pipeline.
+
 - Tool egress is governed by a data classification instead of denylists alone:
   every tool has a `ToolDataClass` (from `publicContent` up to
   `secretAdjacent`), every provider declares a `TrustZone` (`local`,
@@ -53,6 +61,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`Documentation/Administration/DataRetention.rst`).
 
 ### Changed
+
+- A provider 5xx now triggers fallback to the next configuration and counts
+  towards opening the provider's circuit breaker (ADR-095). Previously only a
+  connection error and a 429 did, so a provider returning 500 repeatedly neither
+  failed over nor tripped — the two "this provider is unhealthy" mechanisms both
+  ignored the signal.
+- **Breaking:** the specialized image/speech/translation services throw
+  `ServiceQuotaExceededException` on HTTP 429 instead of the generic
+  `ServiceUnavailableException`, so a rate limit is distinguishable from an
+  outage. Both extend `SpecializedServiceException`; a catch on the base class is
+  unaffected (ADR-095).
 
 - **Breaking (tool contract):** the per-configuration tool gate — the skills'
   declared allow-list intersected with `allowed_tool_groups` — is applied inside

--- a/Classes/Domain/Enum/FailureClass.php
+++ b/Classes/Domain/Enum/FailureClass.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * How an AI provider call failed, in terms the retry and circuit-breaker logic
+ * can act on (ADR-095).
+ *
+ * The retry/fallback middleware, the circuit breaker and the streaming
+ * dispatcher each carried their own `instanceof` ladder deciding "is this worth
+ * retrying". They had drifted apart — one retried on a 5xx, another did not.
+ * This enum is the single vocabulary; {@see \Netresearch\NrLlm\Provider\Middleware\FailureClassifier}
+ * maps a throwable onto it, and the two questions below are answered once.
+ */
+enum FailureClass: string
+{
+    /**
+     * The request never reached the provider (DNS, TCP, TLS, timeout).
+     */
+    case CONNECTION = 'connection';
+
+    /**
+     * HTTP 429 — throttled; a different provider may not be.
+     */
+    case RATE_LIMIT = 'rateLimit';
+
+    /**
+     * HTTP 401/403 — bad or missing credentials. Retrying the same call cannot help.
+     */
+    case AUTH = 'auth';
+
+    /**
+     * The provider is misconfigured (missing endpoint, unusable model).
+     */
+    case CONFIGURATION = 'configuration';
+
+    /**
+     * HTTP 4xx other than auth/429 — the request itself is wrong.
+     */
+    case CLIENT_ERROR = 'clientError';
+
+    /**
+     * HTTP 5xx — the provider failed; another one might not.
+     */
+    case SERVER_ERROR = 'serverError';
+
+    /**
+     * The breaker is open for this provider — it just failed repeatedly.
+     */
+    case CIRCUIT_OPEN = 'circuitOpen';
+
+    /**
+     * Nothing recognisable — treated conservatively (not retried, does not trip).
+     */
+    case UNKNOWN = 'unknown';
+
+    /**
+     * Whether re-running the call — against a fallback provider — could
+     * plausibly succeed. A throttled, unreachable or 5xx-ing provider may have a
+     * healthy sibling; an open circuit is exactly the signal to route onward.
+     * A bad credential, a malformed request or a misconfiguration will fail the
+     * same way everywhere.
+     */
+    public function isRetryable(): bool
+    {
+        return match ($this) {
+            self::CONNECTION, self::RATE_LIMIT, self::SERVER_ERROR, self::CIRCUIT_OPEN => true,
+            self::AUTH, self::CONFIGURATION, self::CLIENT_ERROR, self::UNKNOWN => false,
+        };
+    }
+
+    /**
+     * Whether this failure should count towards opening the circuit for the
+     * provider. A provider-side fault — unreachable, throttled, 5xx — is
+     * evidence the provider is unhealthy. An already-open circuit must NOT
+     * re-trip (that would be counting the breaker's own refusal as a new
+     * fault), and a client/auth/config error is our fault, not the provider's.
+     */
+    public function tripsCircuit(): bool
+    {
+        return match ($this) {
+            self::CONNECTION, self::RATE_LIMIT, self::SERVER_ERROR => true,
+            self::AUTH, self::CONFIGURATION, self::CLIENT_ERROR, self::CIRCUIT_OPEN, self::UNKNOWN => false,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+}

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -186,14 +186,11 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
      */
     private function isTrippingFailure(Throwable $e): bool
     {
-        if ($e instanceof ProviderConnectionException) {
-            return true;
-        }
-        if ($e instanceof ProviderResponseException) {
-            return $e->getCode() === 429;
-        }
-
-        return false;
+        // Provider-side faults (connection, rate-limit, 5xx) count towards
+        // opening the circuit; our-side faults (auth, client, config) and an
+        // already-open circuit do not (ADR-095). Previously only connection and
+        // 429 tripped it, so a provider returning 500 repeatedly never opened.
+        return FailureClassifier::classify($e)->tripsCircuit();
     }
 
     /**

--- a/Classes/Provider/Middleware/FailureClassifier.php
+++ b/Classes/Provider/Middleware/FailureClassifier.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Enum\FailureClass;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Throwable;
+
+/**
+ * Maps a thrown failure onto a {@see FailureClass} (ADR-095).
+ *
+ * The one place that decides what kind of failure a throwable represents, so
+ * the retry/fallback middleware, the circuit breaker and the streaming
+ * dispatcher no longer each keep a private `instanceof` ladder that can drift.
+ * Pure and stateless — a static call, deterministic, unit-tested directly.
+ *
+ * Scope note: this recognises the provider exception family (ADR-080) and the
+ * PSR-18 network contract. The specialized-service exceptions travel a path
+ * that does not (yet) reach these middleware, so classifying them is deferred
+ * to the lifecycle migration that routes those calls through the pipeline.
+ */
+final readonly class FailureClassifier
+{
+    public static function classify(Throwable $e): FailureClass
+    {
+        return match (true) {
+            $e instanceof CircuitOpenException => FailureClass::CIRCUIT_OPEN,
+            $e instanceof ProviderConnectionException,
+            $e instanceof NetworkExceptionInterface => FailureClass::CONNECTION,
+            $e instanceof ProviderConfigurationException => FailureClass::CONFIGURATION,
+            $e instanceof ProviderResponseException => self::fromStatus($e->getCode()),
+            default => FailureClass::UNKNOWN,
+        };
+    }
+
+    private static function fromStatus(int $status): FailureClass
+    {
+        return match (true) {
+            $status === 401, $status === 403 => FailureClass::AUTH,
+            $status === 429 => FailureClass::RATE_LIMIT,
+            $status >= 500 && $status <= 599 => FailureClass::SERVER_ERROR,
+            $status >= 400 && $status <= 499 => FailureClass::CLIENT_ERROR,
+            default => FailureClass::UNKNOWN,
+        };
+    }
+}

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -11,10 +11,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
-use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
-use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
-use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -23,12 +20,11 @@ use Throwable;
 /**
  * Walks the primary configuration's fallback chain on retryable failure.
  *
- * Retryable = the request might succeed against a different provider:
- *  - ProviderConnectionException (network / timeout / 5xx / retries exhausted)
- *  - ProviderResponseException with HTTP code 429 (rate-limited here)
- *
- * Non-retryable errors bubble up immediately (misconfiguration, unsupported
- * feature, client-side 4xx, etc.) — fallback won't fix those.
+ * Retryable is decided by the shared {@see FailureClassifier} (ADR-095): a
+ * connection failure, a 429 rate limit, a 5xx server error or an open circuit
+ * routes to the next configuration. Non-retryable errors bubble up immediately
+ * (auth, misconfiguration, unsupported feature, client-side 4xx) — fallback
+ * won't fix those.
  *
  * Streaming calls (Generator returning) should not be routed through this
  * middleware: once chunks have been emitted to the caller, we cannot swap
@@ -194,20 +190,10 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
 
     private function isRetryable(Throwable $e): bool
     {
-        if ($e instanceof ProviderConnectionException) {
-            return true;
-        }
-        if ($e instanceof CircuitOpenException) {
-            // An open circuit (ADR-063) means the provider just failed
-            // repeatedly and is being skipped; routing to the next configuration
-            // is exactly what tripping fast is for.
-            return true;
-        }
-        if ($e instanceof ProviderResponseException) {
-            // Rate limit: a different provider might not be throttled
-            return $e->getCode() === 429;
-        }
-
-        return false;
+        // One shared taxonomy (ADR-095): connection, rate-limit, 5xx and an open
+        // circuit route to the next configuration; auth, client and config
+        // errors would fail the same way everywhere. Previously an inline ladder
+        // here retried only connection/429/circuit and never a 5xx.
+        return FailureClassifier::classify($e)->isRetryable();
     }
 }

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -17,8 +17,8 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
-use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
@@ -341,15 +341,10 @@ final readonly class StreamingDispatcher
 
     private function isRetryable(Throwable $e): bool
     {
-        if ($e instanceof ProviderConnectionException) {
-            return true;
-        }
-        if ($e instanceof ProviderResponseException) {
-            // Rate limit: a different provider might not be throttled.
-            return $e->getCode() === 429;
-        }
-
-        return false;
+        // Shared taxonomy (ADR-095) — the same decision the fallback middleware
+        // and the circuit breaker make, so the streaming path cannot drift from
+        // them. Previously this retried only connection and 429.
+        return FailureClassifier::classify($e)->isRetryable();
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -19,7 +19,9 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -113,12 +115,10 @@ abstract class AbstractSpecializedService
      * per-user and per-configuration check, and throw before any spend when a
      * limit is exceeded.
      *
-     * Fail-open by construction: when no BudgetServiceInterface is wired (the
-     * constructor param is optional, so unconfigured deployments and unit tests
-     * that omit it are unaffected) the gate is a no-op. When wired, the shared
-     * BudgetService still short-circuits to "allowed" for calls without a backend
-     * user or without configured limits, so nothing changes until an operator
-     * actually sets a cap.
+     * The budget service is a required dependency (a gate that disappears when
+     * unwired is fail-open). It still short-circuits to "allowed" for calls
+     * without a backend user or without configured limits, so nothing changes
+     * until an operator actually sets a cap.
      *
      * @throws BudgetExceededException when the pre-flight check denies the call
      */
@@ -678,7 +678,11 @@ abstract class AbstractSpecializedService
             ]);
 
             throw $this->mapErrorStatus($statusCode, $errorMessage);
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
+        } catch (SpecializedServiceException $e) {
+            // Any already-typed failure (config, rate limit, unavailable) passes
+            // through unchanged — re-wrapping a 429 as a connection error below
+            // would erase its classification (ADR-095). Catch the base class so a
+            // new subclass is covered by construction.
             throw $e;
         } catch (Throwable $e) {
             $this->logger->error(sprintf('%s API connection error', $this->getProviderLabel()), [
@@ -688,7 +692,8 @@ abstract class AbstractSpecializedService
             throw new ServiceUnavailableException(
                 sprintf('Failed to connect to %s API: %s', $this->getProviderLabel(), $e->getMessage()),
                 $this->getServiceDomain(),
-                ['provider' => $this->getServiceProvider()],
+                // A transport failure never reached the provider: status 0.
+                ['provider' => $this->getServiceProvider(), 'statusCode' => 0],
                 0,
                 $e,
             );
@@ -745,20 +750,22 @@ abstract class AbstractSpecializedService
      */
     protected function mapErrorStatus(int $statusCode, string $errorMessage): Throwable
     {
+        $context = ['provider' => $this->getServiceProvider(), 'statusCode' => $statusCode];
+
         return match ($statusCode) {
             401, 403 => ServiceConfigurationException::invalidApiKey(
                 $this->getServiceDomain(),
                 $this->getServiceProvider(),
             ),
-            429 => new ServiceUnavailableException(
-                sprintf('%s API rate limit exceeded', $this->getProviderLabel()),
-                $this->getServiceDomain(),
-                ['provider' => $this->getServiceProvider()],
-            ),
+            // 429 gets its own type (ADR-095): a rate limit is transient and
+            // distinguishable from an outage, so the failure classifier and any
+            // retry logic can tell them apart. This wires the previously-dead
+            // ServiceQuotaExceededException::rateLimitExceeded().
+            429 => ServiceQuotaExceededException::rateLimitExceeded($this->getServiceDomain()),
             default => new ServiceUnavailableException(
                 sprintf('%s API error: %s', $this->getProviderLabel(), $errorMessage),
                 $this->getServiceDomain(),
-                ['provider' => $this->getServiceProvider()],
+                $context,
             ),
         };
     }

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -756,6 +756,7 @@ abstract class AbstractSpecializedService
             401, 403 => ServiceConfigurationException::invalidApiKey(
                 $this->getServiceDomain(),
                 $this->getServiceProvider(),
+                $statusCode,
             ),
             // 429 gets its own type (ADR-095): a rate limit is transient and
             // distinguishable from an outage, so the failure classifier and any

--- a/Classes/Specialized/Exception/ServiceConfigurationException.php
+++ b/Classes/Specialized/Exception/ServiceConfigurationException.php
@@ -26,15 +26,17 @@ final class ServiceConfigurationException extends SpecializedServiceException
      * @param string $service  The service identifier
      * @param string $provider The provider name
      */
-    public static function invalidApiKey(string $service, string $provider): self
+    public static function invalidApiKey(string $service, string $provider, ?int $statusCode = null): self
     {
+        $context = ['reason' => 'invalid_api_key', 'provider' => $provider];
+        if ($statusCode !== null) {
+            $context['statusCode'] = $statusCode;
+        }
+
         return new self(
             sprintf('%s API authentication failed - please verify your API key', ucfirst($provider)),
             $service,
-            [
-                'reason' => 'invalid_api_key',
-                'provider' => $provider,
-            ],
+            $context,
         );
     }
 

--- a/Classes/Specialized/Exception/ServiceQuotaExceededException.php
+++ b/Classes/Specialized/Exception/ServiceQuotaExceededException.php
@@ -38,6 +38,7 @@ final class ServiceQuotaExceededException extends SpecializedServiceException
             [
                 'type' => 'rate_limit',
                 'retry_after' => $retryAfterSeconds,
+                'statusCode' => 429,
             ],
         );
     }

--- a/Classes/Specialized/Exception/SpecializedServiceException.php
+++ b/Classes/Specialized/Exception/SpecializedServiceException.php
@@ -38,6 +38,22 @@ abstract class SpecializedServiceException extends RuntimeException
     }
 
     /**
+     * The upstream HTTP status this failure carries, when the mapper recorded
+     * one under the `statusCode` context key (0 for a transport failure that
+     * never reached the provider); null when unknown (ADR-095).
+     *
+     * Lets a failure classifier tell a rate limit from an outage from a
+     * client error on the specialized path, the way the provider exceptions
+     * expose it through `getCode()`.
+     */
+    public function getStatusCode(): ?int
+    {
+        $status = $this->context['statusCode'] ?? null;
+
+        return is_int($status) ? $status : null;
+    }
+
+    /**
      * Get a formatted error message including service context.
      */
     public function getDetailedMessage(): string

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -11,8 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Speech;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
-use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
 use Netresearch\NrLlm\Specialized\Option\SpeechSynthesisOptions;
 use Throwable;
 
@@ -468,7 +468,10 @@ final class TextToSpeechService extends AbstractSpecializedService
             ]);
 
             throw $this->mapErrorStatus($statusCode, $errorMessage);
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
+        } catch (SpecializedServiceException $e) {
+            // Pass any already-typed failure through unchanged — re-wrapping a 429
+            // (ServiceQuotaExceededException) as a connection error below would
+            // erase its classification (ADR-095).
             throw $e;
         } catch (Throwable $e) {
             // Log the full Throwable server-side (the chained cause below carries

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
 use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Option\TranscriptionOptions;
@@ -424,7 +425,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             ]);
 
             throw $this->mapErrorStatus($statusCode, $errorMessage);
-        } catch (ServiceUnavailableException|ServiceConfigurationException $e) {
+        } catch (SpecializedServiceException $e) {
+            // Pass any already-typed failure through unchanged — re-wrapping a 429
+            // (ServiceQuotaExceededException) as a connection error below would
+            // erase its classification (ADR-095).
             throw $e;
         } catch (Throwable $e) {
             // Log the full Throwable server-side (the chained cause below carries

--- a/Documentation/Adr/Adr095FailureTaxonomy.rst
+++ b/Documentation/Adr/Adr095FailureTaxonomy.rst
@@ -1,0 +1,86 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-095:
+
+============================================================================
+ADR-095: One failure taxonomy for retry and circuit-breaker decisions
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-20
+:Authors: Netresearch DTT GmbH
+
+.. _adr-095-context:
+
+Context
+=======
+
+Three places decided "is this failure worth retrying against another provider":
+``FallbackMiddleware::isRetryable()``, ``CircuitBreakerMiddleware::isTrippingFailure()``
+and ``StreamingDispatcher::isRetryable()``. Each kept its own ``instanceof``
+ladder, and they had drifted:
+
+- the fallback middleware retried a connection error, a 429 and an open circuit;
+- the circuit breaker tripped on a connection error and a 429, but not an open
+  circuit (correctly) — and **not** on a 5xx;
+- the streaming dispatcher retried a connection error and a 429 only.
+
+None of them retried a **5xx**. A provider returning HTTP 500 repeatedly would
+neither fail over to a healthy sibling nor open its circuit — the two mechanisms
+built exactly for "this provider is unhealthy" both ignored the most common
+signal that it is.
+
+The specialized services had a related defect: ``mapErrorStatus()`` collapsed a
+429 into the same ``ServiceUnavailableException`` as every other error, so a
+rate limit was indistinguishable from an outage. ``ServiceQuotaExceededException``
+existed for exactly this but was dead code, referenced only from tests.
+
+.. _adr-095-decision:
+
+Decision
+========
+
+**One vocabulary.** ``FailureClass`` (``connection``, ``rateLimit``, ``auth``,
+``configuration``, ``clientError``, ``serverError``, ``circuitOpen``,
+``unknown``) answers the two questions once: ``isRetryable()`` and
+``tripsCircuit()``. ``FailureClassifier`` maps a throwable onto it — a pure,
+static, directly-tested function recognising the provider exception family
+(ADR-080) and the PSR-18 network contract. The three call sites delegate to it
+and can no longer drift.
+
+**A 5xx is now a provider-side fault.** ``serverError`` is retryable and
+circuit-tripping, so a 500-ing provider both fails over and counts towards
+opening its circuit. An ``auth``, ``clientError`` or ``configuration`` failure
+is our fault, not the provider's, so neither retries nor trips. An already-open
+circuit never re-trips itself.
+
+**429 gets its own type on the specialized path.** ``mapErrorStatus()`` throws
+``ServiceQuotaExceededException`` for a 429 — wiring the dead factory — and
+records the upstream status under a ``statusCode`` context key that
+``SpecializedServiceException::getStatusCode()`` exposes. The per-service error
+paths (Whisper, TTS) and the base ``executeRequest()`` catch the base
+``SpecializedServiceException`` when re-throwing, so a typed 429 is no longer
+re-wrapped into a connection error one layer up.
+
+.. _adr-095-consequences:
+
+Consequences
+============
+
+- **Behaviour change:** a 5xx from a provider now triggers fallback and counts
+  towards its circuit breaker, where before it bubbled up. This is the intended
+  correction — the mechanisms exist for exactly this failure — and is covered by
+  new tests in both middleware.
+- **Breaking:** the specialized services throw ``ServiceQuotaExceededException``
+  on HTTP 429 where they previously threw ``ServiceUnavailableException``. Both
+  extend ``SpecializedServiceException``, so a catch on the base class is
+  unaffected; a catch specifically on ``ServiceUnavailableException`` for rate
+  limits must be widened.
+- ``FailureClassifier`` deliberately does not yet classify the specialized
+  exception family: those calls do not reach the retry/breaker middleware until
+  the pipeline that routes them is generalised. ``getStatusCode()`` is the seam
+  that will let it, and is added now so the data is recorded from this change on.
+- This is the first step of unifying the specialized-service lifecycle with the
+  chat middleware pipeline; the pipeline generalisation (moving the call context
+  off "provider" specifics so image/speech/translation calls can run through it)
+  is tracked as the following step.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -392,3 +392,4 @@ Tools
    Adr092AgentRunTerminationReason
    Adr093ToolGateChokepoint
    Adr094ToolDataClassTrustZone
+   Adr095FailureTaxonomy

--- a/Tests/Unit/Domain/Enum/FailureClassTest.php
+++ b/Tests/Unit/Domain/Enum/FailureClassTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\FailureClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class FailureClassTest extends TestCase
+{
+    #[Test]
+    public function retryableCoversProviderSideFaultsAndAnOpenCircuit(): void
+    {
+        $retryable = array_values(array_filter(FailureClass::cases(), static fn(FailureClass $c): bool => $c->isRetryable()));
+
+        self::assertEqualsCanonicalizing(
+            [FailureClass::CONNECTION, FailureClass::RATE_LIMIT, FailureClass::SERVER_ERROR, FailureClass::CIRCUIT_OPEN],
+            $retryable,
+        );
+    }
+
+    #[Test]
+    public function ourSideFaultsAreNotRetryable(): void
+    {
+        self::assertFalse(FailureClass::AUTH->isRetryable());
+        self::assertFalse(FailureClass::CONFIGURATION->isRetryable());
+        self::assertFalse(FailureClass::CLIENT_ERROR->isRetryable());
+        self::assertFalse(FailureClass::UNKNOWN->isRetryable());
+    }
+
+    #[Test]
+    public function trippingCoversProviderSideFaultsButNotAnAlreadyOpenCircuit(): void
+    {
+        $tripping = array_values(array_filter(FailureClass::cases(), static fn(FailureClass $c): bool => $c->tripsCircuit()));
+
+        self::assertEqualsCanonicalizing(
+            [FailureClass::CONNECTION, FailureClass::RATE_LIMIT, FailureClass::SERVER_ERROR],
+            $tripping,
+        );
+
+        // An open circuit must not re-trip: that would count the breaker's own
+        // refusal as a fresh provider fault.
+        self::assertFalse(FailureClass::CIRCUIT_OPEN->tripsCircuit());
+    }
+}

--- a/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
@@ -133,6 +133,44 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aServerErrorCountsTowardsTripping(): void
+    {
+        // New with ADR-095: a 5xx is a provider-side fault and now counts
+        // towards opening the circuit. Before, only connection and 429 did, so
+        // a provider returning 500 repeatedly never tripped.
+        $store = new InMemoryCircuitBreakerStore();
+
+        try {
+            $this->middleware($store, threshold: 3)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('boom', 500),
+            );
+        } catch (ProviderResponseException) {
+        }
+
+        self::assertSame(1, $store->load(self::PROVIDER)->consecutiveFailures);
+    }
+
+    #[Test]
+    public function aClientErrorDoesNotCountTowardsTripping(): void
+    {
+        // A 4xx is our fault, not the provider's — it must not open the circuit.
+        $store = new InMemoryCircuitBreakerStore();
+
+        try {
+            $this->middleware($store, threshold: 3)->handle(
+                $this->context(),
+                $this->config(self::PROVIDER),
+                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('bad request', 400),
+            );
+        } catch (ProviderResponseException) {
+        }
+
+        self::assertSame(0, $store->load(self::PROVIDER)->consecutiveFailures);
+    }
+
+    #[Test]
     public function openCircuitFailsFastWithoutCallingProvider(): void
     {
         $store = new InMemoryCircuitBreakerStore();

--- a/Tests/Unit/Provider/Middleware/FailureClassifierTest.php
+++ b/Tests/Unit/Provider/Middleware/FailureClassifierTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Domain\Enum\FailureClass;
+use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
+use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use RuntimeException;
+
+#[CoversClass(FailureClassifier::class)]
+final class FailureClassifierTest extends TestCase
+{
+    #[Test]
+    public function classifiesTheProviderExceptionFamily(): void
+    {
+        self::assertSame(FailureClass::CIRCUIT_OPEN, FailureClassifier::classify(new CircuitOpenException('openai', 30)));
+        self::assertSame(FailureClass::CONNECTION, FailureClassifier::classify(new ProviderConnectionException('down')));
+        self::assertSame(FailureClass::CONFIGURATION, FailureClassifier::classify(new ProviderConfigurationException('misconfigured')));
+        self::assertSame(FailureClass::AUTH, FailureClassifier::classify(new ProviderAuthenticationException('nope', 401)));
+        self::assertSame(FailureClass::RATE_LIMIT, FailureClassifier::classify(new ProviderRateLimitException('slow down', 429)));
+    }
+
+    #[Test]
+    public function classifiesAResponseExceptionByItsStatusCode(): void
+    {
+        self::assertSame(FailureClass::AUTH, FailureClassifier::classify(new ProviderResponseException('forbidden', 403)));
+        self::assertSame(FailureClass::RATE_LIMIT, FailureClassifier::classify(new ProviderResponseException('throttled', 429)));
+        self::assertSame(FailureClass::CLIENT_ERROR, FailureClassifier::classify(new ProviderResponseException('bad request', 400)));
+        self::assertSame(FailureClass::SERVER_ERROR, FailureClassifier::classify(new ProviderResponseException('boom', 500)));
+        self::assertSame(FailureClass::SERVER_ERROR, FailureClassifier::classify(new ProviderResponseException('gateway', 503)));
+    }
+
+    #[Test]
+    public function treatsAPsr18NetworkExceptionAsAConnectionFailure(): void
+    {
+        $networkError = new class ('offline') extends RuntimeException implements NetworkExceptionInterface {
+            public function getRequest(): RequestInterface
+            {
+                throw new RuntimeException('not needed for the test', 1);
+            }
+        };
+
+        self::assertSame(FailureClass::CONNECTION, FailureClassifier::classify($networkError));
+    }
+
+    #[Test]
+    public function anUnrecognisedThrowableIsUnknownAndConservativelyHandled(): void
+    {
+        $class = FailureClassifier::classify(new RuntimeException('who knows', 1));
+
+        self::assertSame(FailureClass::UNKNOWN, $class);
+        self::assertFalse($class->isRetryable());
+        self::assertFalse($class->tripsCircuit());
+    }
+}

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -224,6 +224,30 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function retriesOnServerError(): void
+    {
+        // New with ADR-095: a 5xx used to bubble up (only connection and 429
+        // were retried). A provider that 500s may have a healthy sibling.
+        $primary = $this->makeConfig('primary', new FallbackChain(['alt']));
+        $alt     = $this->makeConfig('alt');
+        $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
+
+        $result = $this->makePipeline()->run(
+            ProviderCallContext::for(ProviderOperation::Chat),
+            $primary,
+            static function (LlmConfiguration $config): string {
+                if ($config->getIdentifier() === 'primary') {
+                    throw new ProviderResponseException('internal error', 500);
+                }
+
+                return 'ok';
+            },
+        );
+
+        self::assertSame('ok', $result);
+    }
+
+    #[Test]
     public function doesNotRetryOn4xxResponseOtherThan429(): void
     {
         $primary = $this->makeConfig('primary', new FallbackChain(['alt']));

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
@@ -450,9 +451,11 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         try {
             $subject->callSendJsonRequest('endpoint', []);
-            self::fail('Expected ServiceUnavailableException');
-        } catch (ServiceUnavailableException $e) {
-            self::assertStringContainsString('rate limit', $e->getMessage());
+            self::fail('Expected ServiceQuotaExceededException');
+        } catch (ServiceQuotaExceededException $e) {
+            // 429 now maps to its own typed exception (ADR-095), not the generic
+            // unavailable one, so a rate limit is distinguishable from an outage.
+            self::assertStringContainsStringIgnoringCase('rate limit', $e->getMessage());
         }
     }
 

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
@@ -437,6 +438,27 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $this->expectException(ServiceConfigurationException::class);
 
         $subject->callSendJsonRequest('endpoint', []);
+    }
+
+    #[Test]
+    public function theMappedExceptionCarriesTheUpstreamStatusCodeForEveryBranch(): void
+    {
+        // getStatusCode() must work for the typed 401/403 and 429 exceptions,
+        // not only the generic 5xx one — that is the seam a failure classifier
+        // reads on the specialized path (ADR-095).
+        foreach ([401 => 401, 403 => 403, 429 => 429, 503 => 503] as $status => $expected) {
+            $httpClient = $this->createMock(ClientInterface::class);
+            $httpClient->method('sendRequest')
+                ->willReturn($this->createJsonResponseMock(['error' => ['message' => 'x']], $status));
+            $subject = $this->createSubject(apiKeyIdentifier: 'k', baseUrl: 'https://api.test', httpClient: $httpClient);
+
+            try {
+                $subject->callSendJsonRequest('endpoint', []);
+                self::fail(sprintf('Expected a SpecializedServiceException for status %d', $status));
+            } catch (SpecializedServiceException $e) {
+                self::assertSame($expected, $e->getStatusCode(), sprintf('status %d', $status));
+            }
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\DallEImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
@@ -1238,7 +1239,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
         $this->setupFailedRequest(429, 'Rate limit exceeded');
 
-        $this->expectException(ServiceUnavailableException::class);
+        $this->expectException(ServiceQuotaExceededException::class);
 
         $subject->generate('A cat');
     }

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
@@ -927,7 +928,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
         $this->setupFailedRequest(429, 'Rate limit exceeded');
 
-        $this->expectException(ServiceUnavailableException::class);
+        $this->expectException(ServiceQuotaExceededException::class);
 
         $subject->generate('A sunset');
     }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\SpeechSynthesisOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
@@ -917,7 +918,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject();
         $this->setupFailedRequest(429, 'Rate limit exceeded');
 
-        $this->expectException(ServiceUnavailableException::class);
+        $this->expectException(ServiceQuotaExceededException::class);
 
         $subject->synthesize('Hello world');
     }
@@ -1093,8 +1094,8 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->method('sendRequest')
             ->willReturn($responseStub);
 
-        $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('rate limit exceeded');
+        $this->expectException(ServiceQuotaExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
 
         $subject->synthesize('Test text');
     }

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
 use Netresearch\NrLlm\Specialized\Option\TranscriptionOptions;
@@ -917,7 +918,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $audioFile = $this->createTestAudioFile();
         $this->setupFailedRequest(429, 'Rate limit exceeded');
 
-        $this->expectException(ServiceUnavailableException::class);
+        $this->expectException(ServiceQuotaExceededException::class);
 
         $subject->transcribe($audioFile);
     }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 use LogicException;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
+use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
@@ -772,8 +773,8 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createJsonResponseMock(['message' => 'Rate limit exceeded'], 429),
         );
 
-        $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('rate limit');
+        $this->expectException(ServiceQuotaExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
 
         $subject->translate('Hello', 'de');
     }


### PR DESCRIPTION
## Description

Three places decided "is this failure worth retrying against another provider" — `FallbackMiddleware`, `CircuitBreakerMiddleware` and `StreamingDispatcher` — each with its own `instanceof` ladder. They had drifted, and **none retried a 5xx**: a provider returning 500 repeatedly neither failed over nor opened its circuit.

- `FailureClass` + `FailureClassifier` (ADR-095): one shared vocabulary answering `isRetryable()` / `tripsCircuit()`; the three call sites delegate to it. Pure, static, tested directly.
- A 5xx is now a provider-side fault (retryable + circuit-tripping); auth/client/config errors are not; an open circuit never re-trips.
- Specialized path: `mapErrorStatus()` throws `ServiceQuotaExceededException` on 429 (wiring the dead factory) and records the status under a `statusCode` context key exposed by `SpecializedServiceException::getStatusCode()`. Whisper/TTS/base `executeRequest()` catch the base class when re-throwing so a typed 429 isn't re-wrapped into a connection error.

First step of unifying the specialized-service lifecycle with the chat pipeline; the pipeline generalisation is the next step.

## Type of Change

- [x] New feature
- [x] Breaking change
- [x] Refactoring

**Breaking:** a provider 5xx now triggers fallback and counts towards its circuit breaker (was: bubbled up). The specialized services throw `ServiceQuotaExceededException` on HTTP 429 instead of `ServiceUnavailableException` — both extend `SpecializedServiceException`, so a base-class catch is unaffected.

## Checklist

- [x] Local suite green (unit, functional, phpstan, cgl, rector, fuzzy); functional shows only the pre-existing `KeSearchBackendTest` risky tests that also fail on main
- [x] New tests: `FailureClassTest`, `FailureClassifierTest`, 5xx fallback + circuit-breaker behaviour, updated specialized 429 tests
- [x] ADR-095 added

No version bump; changelog under `[Unreleased]`.