### PR TITLE
refactor(provider)!: move the pipeline configuration onto the call context (enables non-chat callers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The middleware pipeline's configuration moved from a separate parameter onto
+  the call context: `MiddlewarePipeline::run(context, terminal)` and
+  `ProviderMiddlewareInterface::handle(context, next)` no longer take a separate
+  `LlmConfiguration`; it travels on `ProviderCallContext`, which gained a
+  nullable `configuration` plus `provider`/`model`/`configurationIdentifier`
+  strings and `for()`/`forConfiguration()`/`forService()` factories. This lets a
+  caller without an `LlmConfiguration` entity (a specialized image/speech/
+  translation service) drive the same pipeline. No behaviour change on the chat
+  path. `ProviderOperation` gained the specialized cases. **Breaking** for a
+  downstream custom middleware or a direct `run()` caller (ADR-096).
+
 - A provider 5xx now triggers fallback to the next configuration and counts
   towards opening the provider's circuit breaker (ADR-095). Previously only a
   connection error and a 429 did, so a provider returning 500 repeatedly neither

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -82,25 +81,26 @@ final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      *
      * @throws BudgetExceededException when the pre-flight check denies the call
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
         $beUserUid   = $this->readInt($context, self::METADATA_BE_USER_UID);
         $plannedCost = $this->readFloat($context, self::METADATA_PLANNED_COST);
 
-        $result = $this->budgetService->check($beUserUid, $plannedCost, $configuration);
+        // check() accepts a null configuration (per-user cap only); a call with
+        // no configuration entity — a specialized service — is still gated (ADR-096).
+        $result = $this->budgetService->check($beUserUid, $plannedCost, $context->configuration);
 
         if (!$result->allowed) {
             throw new BudgetExceededException($result);
         }
 
-        return $next($configuration);
+        return $next($context);
     }
 
     private function readInt(ProviderCallContext $context, string $key): int

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -86,16 +85,15 @@ final readonly class CacheMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
         $key = $this->readKey($context);
         if ($key === null) {
-            return $next($configuration);
+            return $next($context);
         }
 
         $cached = $this->cache->get($key);
@@ -108,7 +106,7 @@ final readonly class CacheMiddleware implements ProviderMiddlewareInterface
             return $cached;
         }
 
-        $result = $next($configuration);
+        $result = $next($context);
 
         if (\is_array($result)) {
             /** @var array<string, mixed> $result */

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerConfig;
 use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface;
 use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
@@ -45,7 +44,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  *  1. INSIDE FallbackMiddleware. An open circuit throws
  *     {@see CircuitOpenException}, which FallbackMiddleware treats as retryable.
  *     Because the circuit sits *inside* the fallback loop, that exception is
- *     raised from within `$next($configuration)` on each attempt, so Fallback
+ *     raised from within `$next($context)` on each attempt, so Fallback
  *     catches it and advances to the next configuration/provider. Placing the
  *     breaker OUTSIDE Fallback (e.g. between Budget and Fallback) would instead
  *     make an open primary circuit abort the whole call before Fallback ever
@@ -86,24 +85,23 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      *
      * @throws CircuitOpenException when the provider's circuit is open
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
         $config = $this->config();
         if (!$config->enabled) {
-            return $next($configuration);
+            return $next($context);
         }
 
-        $provider = $this->circuitKey($configuration);
+        $provider = $this->circuitKey($context);
         if ($provider === '') {
             // Nothing stable to key a circuit on — do not guard.
-            return $next($configuration);
+            return $next($context);
         }
 
         $cooldown = $config->cooldownSeconds;
@@ -129,7 +127,7 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
         }
 
         try {
-            $result = $next($configuration);
+            $result = $next($context);
         } catch (Throwable $e) {
             if ($this->isTrippingFailure($e)) {
                 $this->recordFailure($provider, $state, $now, $config);
@@ -200,11 +198,13 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
      * configurations on the same provider share one circuit — the provider is
      * what is unhealthy, not the configuration.
      */
-    private function circuitKey(LlmConfiguration $configuration): string
+    private function circuitKey(ProviderCallContext $context): string
     {
-        $provider = $configuration->getProviderType();
+        // The provider the call reaches, whether it comes from a configuration
+        // entity or the context's own provider string (a specialized service).
+        $provider = $context->telemetryProvider();
 
-        return $provider !== '' ? $provider : $configuration->getIdentifier();
+        return $provider !== '' ? $provider : $context->telemetryConfigurationIdentifier();
     }
 
     /**

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
@@ -57,25 +56,28 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      *
      * @throws FallbackChainExhaustedException when primary and all fallbacks fail
      * @throws Throwable                       on the first non-retryable failure
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
-        if ($configuration->getFallbackChainDTO()->isEmpty()) {
-            return $next($configuration);
+        // A call with no configuration entity (a specialized service) has no
+        // fallback chain — there is nothing to swap to, so pass it straight
+        // through, exactly as an empty chain does.
+        $configuration = $context->configuration;
+        if ($configuration === null || $configuration->getFallbackChainDTO()->isEmpty()) {
+            return $next($context);
         }
 
         /** @var list<array{configuration: string, error: Throwable}> $attempts */
         $attempts = [];
 
         try {
-            return $next($configuration);
+            return $next($context);
         } catch (Throwable $e) {
             if (!$this->isRetryable($e)) {
                 throw $e;
@@ -151,7 +153,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
             $context->telemetrySignals->recordFallbackAttempt();
 
             try {
-                $result = $next($fallback);
+                $result = $next($context->withConfiguration($fallback));
                 $this->logger->info(
                     'LLM fallback configuration succeeded',
                     [

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
@@ -63,12 +62,11 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
-        $result = $next($configuration);
+        $result = $next($context);
         if ($result instanceof CompletionResponse) {
-            return $this->screen($result, $configuration, $next, false);
+            return $this->screen($result, $context, $next, false);
         }
         if ($result instanceof VisionResponse) {
             return $this->screenVision($result);
@@ -126,11 +124,11 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
     }
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     private function screen(
         CompletionResponse $response,
-        LlmConfiguration $configuration,
+        ProviderCallContext $context,
         callable $next,
         bool $retried,
     ): CompletionResponse {
@@ -141,7 +139,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             // RETRY short-circuits the loop (it re-runs the pipeline and re-screens
             // the fresh response from scratch), so it is handled before the match.
             if ($verdict === GuardrailVerdict::RETRY) {
-                return $this->retryOnce($response, $configuration, $next, $retried, $guardrail, $result);
+                return $this->retryOnce($response, $context, $next, $retried, $guardrail, $result);
             }
 
             // match (no default) is exhaustive over the remaining verdicts: a new
@@ -169,11 +167,11 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
     }
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     private function retryOnce(
         CompletionResponse $response,
-        LlmConfiguration $configuration,
+        ProviderCallContext $context,
         callable $next,
         bool $retried,
         GuardrailInterface $guardrail,
@@ -190,12 +188,12 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         // retry genuinely re-runs the provider rather than replaying an
         // idempotency-cached response. Still capped at one retry; no shipped
         // guardrail returns RETRY.
-        $fresh = $next($configuration);
+        $fresh = $next($context);
         if (!$fresh instanceof CompletionResponse) {
             return $response;
         }
 
-        return $this->screen($fresh, $configuration, $next, true);
+        return $this->screen($fresh, $context, $next, true);
     }
 
     private function withContent(CompletionResponse $response, string $content, ?string $thinking): CompletionResponse

--- a/Classes/Provider/Middleware/IdempotencyMiddleware.php
+++ b/Classes/Provider/Middleware/IdempotencyMiddleware.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Generator;
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Throwable;
 use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
@@ -87,16 +86,15 @@ final class IdempotencyMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
         $key = $this->readKey($context);
         if ($key === null) {
-            return $next($configuration);
+            return $next($context);
         }
 
         $entryId = $this->entryIdentifier($key);
@@ -106,7 +104,7 @@ final class IdempotencyMiddleware implements ProviderMiddlewareInterface
             return $stored;
         }
 
-        $result = $next($configuration);
+        $result = $next($context);
 
         if ($this->isStorable($result)) {
             $this->safeSet($entryId, $result);

--- a/Classes/Provider/Middleware/MiddlewarePipeline.php
+++ b/Classes/Provider/Middleware/MiddlewarePipeline.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
@@ -23,9 +22,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  *
  * The pipeline is side-effect-free on its own; every behavioural decision
  * (retry on rate-limit, skip cache, record usage, ...) lives in a concrete
- * middleware. Consumers call `run()` with the immutable call context, the
- * primary configuration, and the terminal callable that performs the actual
- * provider invocation.
+ * middleware. Consumers call `run()` with the immutable call context (which carries the
+ * configuration) and the terminal callable that performs the actual provider
+ * invocation.
  */
 final readonly class MiddlewarePipeline
 {
@@ -47,25 +46,26 @@ final readonly class MiddlewarePipeline
     /**
      * @template T
      *
-     * @param callable(LlmConfiguration): T $terminal the actual provider call,
-     *                                                typically a closure over
-     *                                                messages / options /
-     *                                                adapter resolution
+     * @param callable(ProviderCallContext): T $terminal the actual provider
+     *                                                   call, typically a closure
+     *                                                   over messages / options /
+     *                                                   adapter resolution that
+     *                                                   reads the configuration
+     *                                                   from the context
      *
      * @return T
      */
     public function run(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $terminal,
     ): mixed {
         $next = $terminal;
         foreach (\array_reverse($this->middleware) as $middleware) {
             $captured = $next;
-            $next = static fn(LlmConfiguration $config): mixed
-                => $middleware->handle($context, $config, $captured);
+            $next = static fn(ProviderCallContext $ctx): mixed
+                => $middleware->handle($ctx, $captured);
         }
 
-        return $next($configuration);
+        return $next($context);
     }
 }

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -151,7 +151,12 @@ final readonly class ProviderCallContext
      */
     public function telemetryProvider(): string
     {
-        return $this->configuration?->getProviderType() ?? $this->provider;
+        // A configuration entity can carry an empty provider (a transient/ad-hoc
+        // config), so fall through to the context string when it is empty, not
+        // only when the whole entity is absent.
+        $fromConfiguration = $this->configuration?->getProviderType() ?? '';
+
+        return $fromConfiguration !== '' ? $fromConfiguration : $this->provider;
     }
 
     /**
@@ -160,7 +165,9 @@ final readonly class ProviderCallContext
      */
     public function telemetryModel(): string
     {
-        return $this->configuration?->getModelId() ?? $this->model;
+        $fromConfiguration = $this->configuration?->getModelId() ?? '';
+
+        return $fromConfiguration !== '' ? $fromConfiguration : $this->model;
     }
 
     /**
@@ -169,6 +176,8 @@ final readonly class ProviderCallContext
      */
     public function telemetryConfigurationIdentifier(): string
     {
-        return $this->configuration?->getIdentifier() ?? $this->configurationIdentifier;
+        $fromConfiguration = $this->configuration?->getIdentifier() ?? '';
+
+        return $fromConfiguration !== '' ? $fromConfiguration : $this->configurationIdentifier;
     }
 }

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -9,45 +9,48 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Symfony\Component\Uid\Uuid;
 
 /**
  * Immutable context threaded through a MiddlewarePipeline invocation.
  *
  * Carries what every middleware needs to know about the call without leaking
- * the operation-specific payload (messages, embeddings input, tool specs).
- * The payload stays captured in the terminal callable, which lets each
- * feature service keep its typed signature.
+ * the operation-specific payload (messages, embeddings input, tool specs). The
+ * payload stays captured in the terminal callable, which lets each feature
+ * service keep its typed signature (ADR-026).
+ *
+ * The configuration it runs against lives on the context, not as a separate
+ * pipeline parameter, so a caller that has no {@see LlmConfiguration} entity —
+ * an image or speech service identified only by provider/model strings — can
+ * still drive the same pipeline (ADR-096). When the configuration is null those
+ * string fields are the source of truth for telemetry; when it is present they
+ * are ignored and the entity wins. {@see FallbackMiddleware} swaps the
+ * configuration on a retryable failure via {@see self::withConfiguration()}.
  */
 final readonly class ProviderCallContext
 {
     /**
-     * @param array<string, mixed> $metadata         additional cross-cutting data
-     *                                               (e.g. user id for budget checks,
-     *                                               cache-key inputs, trace tags)
-     * @param TelemetrySignals     $telemetrySignals mutable scratchpad an inner
-     *                                               middleware uses to signal the
-     *                                               outer TelemetryMiddleware within
-     *                                               this run (cache hit, fallback
-     *                                               attempts). Default-constructed
-     *                                               per call so every pipeline run
-     *                                               has its own; the `new` default
-     *                                               is evaluated fresh on each call,
-     *                                               never shared across contexts.
+     * @param string               $provider                provider identifier for telemetry when no configuration entity is present
+     * @param string               $model                   model identifier for telemetry when no configuration entity is present
+     * @param string               $configurationIdentifier configuration identifier for telemetry when no configuration entity is present
+     * @param array<string, mixed> $metadata                additional cross-cutting data (user id for budget checks, cache-key inputs, trace tags)
+     * @param TelemetrySignals     $telemetrySignals        mutable scratchpad an inner middleware uses to signal the outer TelemetryMiddleware within this run (cache hit, fallback attempts). Default-constructed per call, never shared across contexts.
      */
     public function __construct(
         public ProviderOperation $operation,
         public string $correlationId,
+        public ?LlmConfiguration $configuration = null,
+        public string $provider = '',
+        public string $model = '',
+        public string $configurationIdentifier = '',
         public array $metadata = [],
         public TelemetrySignals $telemetrySignals = new TelemetrySignals(),
     ) {}
 
     /**
-     * Create a context with an auto-generated UUID v4 correlation id.
-     *
-     * Callers that already hold a correlation id (e.g. propagated from an
-     * upstream trace / request id) should use the regular constructor instead
-     * of this factory so the incoming id survives end-to-end.
+     * A context for a generic call with an auto-generated correlation id and no
+     * configuration entity yet (the pipeline resolves or the caller sets one).
      *
      * @param array<string, mixed> $metadata
      */
@@ -61,10 +64,70 @@ final readonly class ProviderCallContext
     }
 
     /**
-     * Return a new context with the given metadata merged on top of the current
-     * map. Useful for middleware that wants to annotate downstream handlers
-     * (cache hit/miss, budget remaining, retry attempt counter, etc.) without
-     * mutating state.
+     * A context bound to a configuration entity (the chat/embedding/vision
+     * path). The provider/model/identifier strings are left empty — the entity
+     * is the source of truth while it is present.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public static function forConfiguration(ProviderOperation $operation, LlmConfiguration $configuration, array $metadata = []): self
+    {
+        return new self(
+            operation: $operation,
+            correlationId: Uuid::v4()->toRfc4122(),
+            configuration: $configuration,
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * A context for a service call identified only by provider/model strings —
+     * an image, speech or translation service with no {@see LlmConfiguration}
+     * entity. Telemetry reads these strings.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public static function forService(
+        ProviderOperation $operation,
+        string $provider,
+        string $model,
+        string $configurationIdentifier = '',
+        array $metadata = [],
+    ): self {
+        return new self(
+            operation: $operation,
+            correlationId: Uuid::v4()->toRfc4122(),
+            provider: $provider,
+            model: $model,
+            configurationIdentifier: $configurationIdentifier,
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * Return a copy bound to a different configuration — used by
+     * {@see FallbackMiddleware} to route the call to a sibling configuration
+     * while keeping the correlation id and the accumulated telemetry signals.
+     */
+    public function withConfiguration(?LlmConfiguration $configuration): self
+    {
+        return new self(
+            operation: $this->operation,
+            correlationId: $this->correlationId,
+            configuration: $configuration,
+            provider: $this->provider,
+            model: $this->model,
+            configurationIdentifier: $this->configurationIdentifier,
+            metadata: $this->metadata,
+            telemetrySignals: $this->telemetrySignals,
+        );
+    }
+
+    /**
+     * Return a copy with the given metadata merged on top of the current map,
+     * carrying the SAME telemetry-signal sink forward so a context re-derived
+     * mid-run does not drop the cache-hit / fallback signals collected against
+     * the original.
      *
      * @param array<string, mixed> $metadata
      */
@@ -73,11 +136,39 @@ final readonly class ProviderCallContext
         return new self(
             operation: $this->operation,
             correlationId: $this->correlationId,
+            configuration: $this->configuration,
+            provider: $this->provider,
+            model: $this->model,
+            configurationIdentifier: $this->configurationIdentifier,
             metadata: [...$this->metadata, ...$metadata],
-            // Carry the SAME signal sink forward: a context re-derived mid-run
-            // (e.g. to annotate downstream metadata) must not silently drop the
-            // cache-hit / fallback signals collected against the original.
             telemetrySignals: $this->telemetrySignals,
         );
+    }
+
+    /**
+     * The provider identifier for telemetry: the configuration entity's when
+     * present, else the string carried on the context.
+     */
+    public function telemetryProvider(): string
+    {
+        return $this->configuration?->getProviderType() ?? $this->provider;
+    }
+
+    /**
+     * The model identifier for telemetry: the configuration entity's when
+     * present, else the string carried on the context.
+     */
+    public function telemetryModel(): string
+    {
+        return $this->configuration?->getModelId() ?? $this->model;
+    }
+
+    /**
+     * The configuration identifier for telemetry: the configuration entity's
+     * when present, else the string carried on the context.
+     */
+    public function telemetryConfigurationIdentifier(): string
+    {
+        return $this->configuration?->getIdentifier() ?? $this->configurationIdentifier;
     }
 }

--- a/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
+++ b/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
@@ -42,11 +42,15 @@ interface ProviderMiddlewareInterface
     public const TAG_NAME = 'nr_llm.provider_middleware';
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * Handle one call, delegating to `$next` to run the inner layers (ADR-096).
+     * The configuration, when present, lives on `$context->configuration`; a
+     * middleware that swaps it re-derives the context via
+     * {@see ProviderCallContext::withConfiguration()} before calling `$next`.
+     *
+     * @param callable(ProviderCallContext): mixed $next
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed;
 }

--- a/Classes/Provider/Middleware/ProviderOperation.php
+++ b/Classes/Provider/Middleware/ProviderOperation.php
@@ -24,4 +24,15 @@ enum ProviderOperation: string
     case Vision = 'vision';
     case Tools = 'tools';
     case Stream = 'stream';
+
+    // Specialized-service operations (ADR-096): image, speech and translation
+    // calls that reach the pipeline through a service context rather than an
+    // LlmConfiguration entity. Kept in the same enum so telemetry, usage and the
+    // failure classifier label every AI call from one vocabulary.
+    case ImageGeneration = 'image';
+    case ImageEdit = 'image_edit';
+    case ImageVariation = 'image_variation';
+    case Transcription = 'transcribe';
+    case SpeechSynthesis = 'speech';
+    case Translation = 'translate';
 }

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Exception\GuardrailPolicyException;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
@@ -81,15 +80,14 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
         if (!$this->isEnabled()) {
-            return $next($configuration);
+            return $next($context);
         }
 
         $start      = hrtime(true);
@@ -97,7 +95,7 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
         $errorClass = '';
 
         try {
-            $result  = $next($configuration);
+            $result  = $next($context);
             $success = true;
 
             return $result;
@@ -115,7 +113,7 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
 
             throw $e;
         } finally {
-            $this->safeRecord($context, $configuration, $success, $errorClass, $this->elapsedMs($start));
+            $this->safeRecord($context, $success, $errorClass, $this->elapsedMs($start));
         }
     }
 
@@ -130,7 +128,6 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
 
     private function safeRecord(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         bool $success,
         string $errorClass,
         int $latencyMs,
@@ -139,9 +136,9 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
             $this->repository->record(new TelemetryRecord(
                 correlationId: $context->correlationId,
                 operation: $context->operation->value,
-                provider: $configuration->getProviderType(),
-                model: $configuration->getModelId(),
-                configurationIdentifier: $configuration->getIdentifier(),
+                provider: $context->telemetryProvider(),
+                model: $context->telemetryModel(),
+                configurationIdentifier: $context->telemetryConfigurationIdentifier(),
                 beUser: $this->resolveBeUser($context),
                 success: $success,
                 errorClass: $errorClass,

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -89,14 +89,13 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
     ) {}
 
     /**
-     * @param callable(LlmConfiguration): mixed $next
+     * @param callable(ProviderCallContext): mixed $next
      */
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
-        $result = $next($configuration);
+        $result = $next($context);
 
         // Usage recording is post-flight bookkeeping. A tracker/DB failure here
         // must not fail an already-successful provider call, nor propagate out to
@@ -104,7 +103,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         // provider failure (success=false, the DB exception FQCN) and re-throw to
         // the caller. Fail soft, like every other accounting sink in the pipeline.
         try {
-            $this->track($context, $configuration, $result);
+            $this->track($context, $result);
         } catch (Throwable $e) {
             $this->logger->warning(
                 'Usage tracking failed after a successful provider call; the call result is unaffected.',
@@ -117,7 +116,6 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
 
     private function track(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         mixed $result,
     ): void {
         [$usage, $provider, $responseModel] = $this->extractUsage($result);
@@ -125,13 +123,17 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             return;
         }
 
-        $model    = $configuration->getLlmModel();
-        $modelUid = $model?->getUid() ?? 0;
+        // A call with no configuration entity (a specialized service) carries no
+        // model entity: the model id and cost then come from the response and
+        // the context, not from a pricing lookup.
+        $configuration = $context->configuration;
+        $model         = $configuration?->getLlmModel();
+        $modelUid      = $model?->getUid() ?? 0;
         // Ad-hoc/transient configurations (e.g. the embeddings path) carry no
         // model, so getModelId() is ''. Fall back to the model the provider
         // actually reported on the response so per-model analytics attribute
         // the usage instead of dropping it into an empty-model bucket.
-        $modelId  = $configuration->getModelId();
+        $modelId = $configuration?->getModelId() ?? $context->model;
         if ($modelId === '' && $responseModel !== '') {
             $modelId = $responseModel;
         }
@@ -153,7 +155,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             $metrics['cost'] = $cost;
         }
 
-        $configUid = $configuration->getUid();
+        $configUid = $configuration?->getUid();
         $uid       = ($configUid !== null && $configUid > 0) ? $configUid : null;
 
         $taskUid = isset($context->metadata[self::METADATA_TASK_UID]) && is_int($context->metadata[self::METADATA_TASK_UID])

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -133,7 +133,10 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         // model, so getModelId() is ''. Fall back to the model the provider
         // actually reported on the response so per-model analytics attribute
         // the usage instead of dropping it into an empty-model bucket.
-        $modelId = $configuration?->getModelId() ?? $context->model;
+        // An empty model id on a present config (a transient/ad-hoc config) must
+        // still fall through to the context's model string, then to the model the
+        // provider reported — `?:` treats '' and null alike.
+        $modelId = ($configuration?->getModelId() ?: $context->model);
         if ($modelId === '' && $responseModel !== '') {
             $modelId = $responseModel;
         }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -296,8 +296,11 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // persists `array<string, mixed>`) can round-trip through the TYPO3
         // cache frontend. The typed response is reconstructed at this layer.
         $raw = $this->pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Embedding, $metadata),
-            $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
+            ProviderCallContext::forConfiguration(
+                ProviderOperation::Embedding,
+                $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
+                $metadata,
+            ),
             function () use ($input, $optionsArray, $providerKey): array {
                 $provider = $this->getProvider($providerKey);
                 if (!$provider->supportsFeature('embeddings')) {
@@ -521,7 +524,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Tools,
-            function (LlmConfiguration $config) use ($normalisedMessages, $normalisedTools, $optionOverrides): CompletionResponse {
+            function (ProviderCallContext $ctx) use ($normalisedMessages, $normalisedTools, $optionOverrides): CompletionResponse {
+                $config   = $this->requireConfiguration($ctx);
                 $llmModel = $this->resolveModelForConfiguration($config);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter instanceof ToolCapableInterface) {
@@ -608,9 +612,9 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // persists `array<string, mixed>`) can round-trip through the TYPO3
         // cache frontend. The typed response is reconstructed at this layer.
         $raw = $this->pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Embedding, $metadata),
-            $configuration,
-            function (LlmConfiguration $config) use ($input, $optionOverrides): array {
+            ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $configuration, $metadata),
+            function (ProviderCallContext $ctx) use ($input, $optionOverrides): array {
+                $config   = $this->requireConfiguration($ctx);
                 $llmModel = $this->resolveModelForConfiguration($config);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter->supportsFeature('embeddings')) {
@@ -776,7 +780,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Chat,
-            function (LlmConfiguration $config) use ($normalisedMessages, $optionOverrides): CompletionResponse {
+            function (ProviderCallContext $ctx) use ($normalisedMessages, $optionOverrides): CompletionResponse {
+                $config   = $this->requireConfiguration($ctx);
                 $llmModel = $this->resolveModelForConfiguration($config);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
@@ -801,7 +806,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->runThroughPipeline(
             $configuration,
             ProviderOperation::Completion,
-            function (LlmConfiguration $config) use ($prompt, $optionOverrides): CompletionResponse {
+            function (ProviderCallContext $ctx) use ($prompt, $optionOverrides): CompletionResponse {
+                $config   = $this->requireConfiguration($ctx);
                 $llmModel = $this->resolveModelForConfiguration($config);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 $options  = $this->buildCallOptions($config, $llmModel, $optionOverrides);
@@ -890,10 +896,26 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         array $metadata = [],
     ): mixed {
         return $this->pipeline->run(
-            ProviderCallContext::for($operation, $metadata),
-            $configuration,
+            ProviderCallContext::forConfiguration($operation, $configuration, $metadata),
             $terminal,
         );
+    }
+
+    /**
+     * The configuration the pipeline threaded onto the context — never null on
+     * the configuration-driven paths, which always enter through
+     * {@see ProviderCallContext::forConfiguration()} and whose fallback swaps
+     * carry a non-null sibling. The guard makes that invariant explicit for the
+     * type checker; it never fires in practice.
+     */
+    private function requireConfiguration(ProviderCallContext $context): LlmConfiguration
+    {
+        $configuration = $context->configuration;
+        if ($configuration === null) {
+            throw new ProviderException('The pipeline context carried no configuration on a configuration-driven call.', 1784600700);
+        }
+
+        return $configuration;
     }
 
     /**

--- a/Documentation/Adr/Adr096PipelineCallContext.rst
+++ b/Documentation/Adr/Adr096PipelineCallContext.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-096:
+
+============================================================================
+ADR-096: The pipeline configuration lives on the call context
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-20
+:Authors: Netresearch DTT GmbH
+
+.. _adr-096-context:
+
+Context
+=======
+
+The middleware pipeline that wraps every chat/embedding/vision call —
+budget, telemetry, cache, idempotency, guardrail, fallback, usage, circuit
+breaker — took the ``LlmConfiguration`` as a **separate positional parameter**
+of ``MiddlewarePipeline::run()`` and of every ``ProviderMiddlewareInterface::handle()``.
+Six of the eight middleware merely forwarded it; it existed as its own parameter
+only so ``FallbackMiddleware`` could substitute a sibling configuration on a
+retryable failure.
+
+That shape hard-wires the pipeline to callers that *have* an ``LlmConfiguration``
+entity. The specialized services — DALL·E, FAL, Whisper, TTS, DeepL — do not:
+they are identified by provider and model strings and dispatch HTTP directly,
+which is exactly why they bypass the pipeline and, with it, telemetry,
+correlation ids, the circuit breaker and input guardrails.
+
+.. _adr-096-decision:
+
+Decision
+========
+
+**The configuration moves onto the context.** ``ProviderCallContext`` gains a
+nullable ``configuration`` plus ``provider`` / ``model`` /
+``configurationIdentifier`` strings. ``MiddlewarePipeline::run(context, terminal)``
+and ``ProviderMiddlewareInterface::handle(context, next)`` drop the separate
+configuration parameter; ``$next`` and the terminal now receive the context.
+``FallbackMiddleware`` swaps the configuration through
+``ProviderCallContext::withConfiguration()``.
+
+When the configuration entity is present it is the source of truth; when it is
+null the string fields are — ``telemetryProvider()`` / ``telemetryModel()`` /
+``telemetryConfigurationIdentifier()`` encode that fallback in one place, so
+telemetry, usage and the circuit key work whether the call came from a
+configuration entity or a bare service descriptor. Three factories name the
+intent: ``for()`` (generic), ``forConfiguration()`` (an entity), ``forService()``
+(provider/model strings, no entity).
+
+``ProviderOperation`` gains the specialized cases — image generation/edit/
+variation, transcription, speech synthesis, translation — so every AI call is
+labelled from one vocabulary.
+
+The class names keep the ``Provider`` prefix for now. Renaming
+``ProviderCallContext`` → ``AiCallContext`` and the sibling types is a pure
+cosmetic follow-up (~40 references) and is deliberately not bundled into this
+behaviour-preserving change.
+
+.. _adr-096-consequences:
+
+Consequences
+============
+
+- **No behaviour change.** This is a structural refactor: the chat path builds a
+  context via ``forConfiguration()`` and every existing test passes unchanged in
+  intent. ``TelemetryMiddleware`` reads provider/model/identifier from the
+  context helpers rather than the entity, which also means the "requested
+  primary configuration" survives a fallback swap for free.
+- **Breaking for downstream pipeline callers.** ``MiddlewarePipeline::run()`` and
+  ``ProviderMiddlewareInterface::handle()`` changed signature, and a custom
+  middleware or a direct ``run()`` caller must move the configuration onto the
+  context. In-tree this was a mechanical migration across the middleware tests.
+- ``UsageMiddleware`` and ``CircuitBreakerMiddleware`` now tolerate a null
+  configuration (a specialized call): usage attributes by the context's model
+  string and the circuit keys off the context's provider.
+- This is the enabling step. It delivers no user-visible change on its own — the
+  specialized services do not yet route through the pipeline. Adding the
+  fail-closed dispatch seam and migrating those five services onto it is the
+  following step, at which point they gain telemetry, correlation ids, the
+  circuit breaker and input guardrails.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -393,3 +393,4 @@ Tools
    Adr093ToolGateChokepoint
    Adr094ToolDataClassTrustZone
    Adr095FailureTaxonomy
+   Adr096PipelineCallContext

--- a/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
@@ -65,12 +65,14 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         $terminalRan = false;
         $result = $this->pipeline()->run(
-            context: $this->contextFor(plannedCost: 0.5),
-            configuration: $this->configuration(),
-            terminal: static function (LlmConfiguration $config) use (&$terminalRan): string {
+            context: $this->contextFor(plannedCost: 0.5)->withConfiguration($this->configuration()),
+            terminal: static function (ProviderCallContext $ctx) use (&$terminalRan): string {
                 $terminalRan = true;
 
                 // The middleware must forward the SAME configuration untouched.
+                $config = $ctx->configuration;
+                self::assertInstanceOf(LlmConfiguration::class, $config);
+
                 return $config->getIdentifier();
             },
         );
@@ -91,8 +93,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         try {
             $this->pipeline()->run(
-                context: $this->contextFor(plannedCost: 0.5),
-                configuration: $this->configuration(),
+                context: $this->contextFor(plannedCost: 0.5)->withConfiguration($this->configuration()),
                 terminal: static function () use (&$terminalRan): string {
                     $terminalRan = true;
 
@@ -119,8 +120,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
         // must reach the terminal even with a non-trivial planned cost.
         $terminalRan = false;
         $this->pipeline()->run(
-            context: $this->contextFor(plannedCost: 99.0),
-            configuration: $this->configuration(),
+            context: $this->contextFor(plannedCost: 99.0)->withConfiguration($this->configuration()),
             terminal: static function () use (&$terminalRan): string {
                 $terminalRan = true;
 
@@ -143,8 +143,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         try {
             $this->pipeline()->run(
-                context: $this->contextFor(plannedCost: 0.5),
-                configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+                context: $this->contextFor(plannedCost: 0.5)->withConfiguration($this->configuration(uid: 5, maxCostPerDay: 1.0)),
                 terminal: static function () use (&$terminalRan): string {
                     $terminalRan = true;
 
@@ -169,8 +168,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         $terminalRan = false;
         $this->pipeline()->run(
-            context: $this->contextFor(plannedCost: 0.5),
-            configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+            context: $this->contextFor(plannedCost: 0.5)->withConfiguration($this->configuration(uid: 5, maxCostPerDay: 1.0)),
             terminal: static function () use (&$terminalRan): string {
                 $terminalRan = true;
 
@@ -190,8 +188,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         $terminalRan = false;
         $this->pipeline()->run(
-            context: $this->contextFor(plannedCost: 0.5),
-            configuration: $this->configuration(uid: 5, maxCostPerDay: 1.0),
+            context: $this->contextFor(plannedCost: 0.5)->withConfiguration($this->configuration(uid: 5, maxCostPerDay: 1.0)),
             terminal: static function () use (&$terminalRan): string {
                 $terminalRan = true;
 

--- a/Tests/Functional/Provider/Middleware/GuardrailIdempotencyLeakTest.php
+++ b/Tests/Functional/Provider/Middleware/GuardrailIdempotencyLeakTest.php
@@ -60,13 +60,12 @@ final class GuardrailIdempotencyLeakTest extends AbstractFunctionalTestCase
         $context = new ProviderCallContext(
             ProviderOperation::Chat,
             'corr-leak',
-            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
+            metadata: [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
         );
 
         $result = $pipeline->run(
-            $context,
-            new LlmConfiguration(),
-            static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+            $context->withConfiguration(new LlmConfiguration()),
+            static fn(): CompletionResponse => new CompletionResponse(
                 content: 'your token is ' . $secret . ' keep it safe',
                 model: 'test-model',
                 usage: UsageStatistics::fromTokens(1, 1),

--- a/Tests/Functional/Provider/Middleware/IdempotencyMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/IdempotencyMiddlewarePipelineTest.php
@@ -47,7 +47,7 @@ final class IdempotencyMiddlewarePipelineTest extends AbstractFunctionalTestCase
         $context  = new ProviderCallContext(
             ProviderOperation::Chat,
             'corr',
-            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => 'checkout-99'],
+            metadata: [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => 'checkout-99'],
         );
         $response = new CompletionResponse(
             content: 'idempotent answer',
@@ -58,18 +58,16 @@ final class IdempotencyMiddlewarePipelineTest extends AbstractFunctionalTestCase
 
         // First call computes and stores.
         $first = $this->middleware->handle(
-            $context,
-            new LlmConfiguration(),
-            static fn(LlmConfiguration $c): CompletionResponse => $response,
+            $context->withConfiguration(new LlmConfiguration()),
+            static fn(): CompletionResponse => $response,
         );
         self::assertInstanceOf(CompletionResponse::class, $first);
 
         // Second call with the same key must NOT reach the provider — a throwing
         // terminal proves the replay is served entirely from the store.
         $replay = $this->middleware->handle(
-            $context,
-            new LlmConfiguration(),
-            static fn(LlmConfiguration $c): CompletionResponse => throw new RuntimeException('provider must not be called', 1),
+            $context->withConfiguration(new LlmConfiguration()),
+            static fn(): CompletionResponse => throw new RuntimeException('provider must not be called', 1),
         );
 
         self::assertInstanceOf(CompletionResponse::class, $replay);

--- a/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
@@ -68,7 +68,7 @@ final class StreamingDispatcherTest extends AbstractFunctionalTestCase
         $context = new ProviderCallContext(
             ProviderOperation::Stream,
             'func-stream-corr',
-            [
+            metadata: [
                 BudgetMiddleware::METADATA_BE_USER_UID     => 5,
                 StreamingDispatcher::METADATA_PROVIDER      => 'openai',
                 StreamingDispatcher::METADATA_PROMPT_CHARS  => 8,

--- a/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/BudgetMiddlewareTest.php
@@ -44,8 +44,8 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
 
         $called = false;
         $result = $this->pipeline()->run(
-            context: $this->contextFor(beUserUid: 42, plannedCost: 0.5),
-            configuration: $this->configuration(),
+            context: $this->contextFor(beUserUid: 42, plannedCost: 0.5)
+                ->withConfiguration($this->configuration()),
             terminal: static function () use (&$called): string {
                 $called = true;
 
@@ -71,8 +71,8 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->pipeline()->run(
-                context: $this->contextFor(beUserUid: 42, plannedCost: 1.0),
-                configuration: $this->configuration(),
+                context: $this->contextFor(beUserUid: 42, plannedCost: 1.0)
+                    ->withConfiguration($this->configuration()),
                 terminal: static function () use (&$terminalWasCalled): string {
                     $terminalWasCalled = true;
 
@@ -98,9 +98,9 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $configuration,
-            terminal: static fn(LlmConfiguration $c): string => 'ok',
+            context: ProviderCallContext::for(ProviderOperation::Chat)
+                ->withConfiguration($configuration),
+            terminal: static fn(): string => 'ok',
         );
     }
 
@@ -114,9 +114,9 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
-            context: $this->contextFor(beUserUid: 7, plannedCost: 3), // int, not float
-            configuration: $configuration,
-            terminal: static fn(LlmConfiguration $c): string => 'ok',
+            context: $this->contextFor(beUserUid: 7, plannedCost: 3) // int, not float
+                ->withConfiguration($configuration),
+            terminal: static fn(): string => 'ok',
         );
     }
 
@@ -141,9 +141,8 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: $context,
-            configuration: $configuration,
-            terminal: static fn(LlmConfiguration $c): string => 'ok',
+            context: $context->withConfiguration($configuration),
+            terminal: static fn(): string => 'ok',
         );
     }
 
@@ -161,9 +160,9 @@ final class BudgetMiddlewareTest extends AbstractUnitTestCase
             ->willReturn(BudgetCheckResult::allowed());
 
         $this->pipeline()->run(
-            context: $this->contextFor(beUserUid: -1, plannedCost: 0.0),
-            configuration: $configuration,
-            terminal: static fn(LlmConfiguration $c): string => 'ok',
+            context: $this->contextFor(beUserUid: -1, plannedCost: 0.0)
+                ->withConfiguration($configuration),
+            terminal: static fn(): string => 'ok',
         );
     }
 

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -39,9 +39,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         $this->cache->expects(self::never())->method('set');
 
         $result = $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): string => 'ran',
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),
+            terminal: static fn(): string => 'ran',
         );
 
         self::assertSame('ran', $result);
@@ -54,9 +53,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         $this->cache->expects(self::never())->method('set');
 
         $result = $this->pipeline()->run(
-            context: $this->context(key: ''),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): string => 'ran',
+            context: $this->context(key: '')->withConfiguration($this->configuration()),
+            terminal: static fn(): string => 'ran',
         );
 
         self::assertSame('ran', $result);
@@ -74,9 +72,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['stored' => false],
+            context: $context->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['stored' => false],
         );
     }
 
@@ -92,8 +89,7 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
 
         $terminalCalled = false;
         $result         = $this->pipeline()->run(
-            context: $this->context(key: 'embed:abc'),
-            configuration: $this->configuration(),
+            context: $this->context(key: 'embed:abc')->withConfiguration($this->configuration()),
             terminal: static function () use (&$terminalCalled): array {
                 $terminalCalled = true;
 
@@ -112,9 +108,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
 
         $context = $this->context(key: 'embed:abc');
         $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['vector' => [0.9]],
+            context: $context->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['vector' => [0.9]],
         );
 
         self::assertTrue($context->telemetrySignals->cacheHit, 'A cache hit must be flagged for TelemetryMiddleware.');
@@ -127,9 +122,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
 
         $context = $this->context(key: 'embed:new');
         $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+            context: $context->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['x' => 1],
         );
 
         self::assertFalse($context->telemetrySignals->cacheHit);
@@ -149,9 +143,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
             ->with('embed:new', $produced, 3600, []);
 
         $result = $this->pipeline()->run(
-            context: $this->context(key: 'embed:new'),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => $produced,
+            context: $this->context(key: 'embed:new')->withConfiguration($this->configuration()),
+            terminal: static fn(): array => $produced,
         );
 
         self::assertSame($produced, $result);
@@ -166,9 +159,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
             ->with('key', ['x' => 1], 86400, []);
 
         $this->pipeline()->run(
-            context: $this->context(key: 'key', ttl: 86400),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+            context: $this->context(key: 'key', ttl: 86400)->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['x' => 1],
         );
     }
 
@@ -215,9 +207,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+            context: $context->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['x' => 1],
         );
     }
 
@@ -230,9 +221,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
             ->with('key', ['x' => 1], 3600, ['nr_llm_embed', 'user_42']);
 
         $this->pipeline()->run(
-            context: $this->context(key: 'key', tags: ['nr_llm_embed', 'user_42']),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+            context: $this->context(key: 'key', tags: ['nr_llm_embed', 'user_42'])->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['x' => 1],
         );
     }
 
@@ -254,9 +244,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: $context,
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => ['x' => 1],
+            context: $context->withConfiguration($this->configuration()),
+            terminal: static fn(): array => ['x' => 1],
         );
     }
 
@@ -267,9 +256,8 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         $this->cache->expects(self::never())->method('set');
 
         $result = $this->pipeline()->run(
-            context: $this->context(key: 'key'),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): string => 'not-an-array',
+            context: $this->context(key: 'key')->withConfiguration($this->configuration()),
+            terminal: static fn(): string => 'not-an-array',
         );
 
         self::assertSame('not-an-array', $result);

--- a/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
@@ -39,9 +39,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $store->seed(self::PROVIDER, new CircuitState(9, time()));
 
         $result = $this->middleware($store, enabled: false)->handle(
-            $this->context(),
-            $this->config(self::PROVIDER),
-            static fn(LlmConfiguration $c): string => 'ok',
+            $this->context()->withConfiguration($this->config(self::PROVIDER)),
+            static fn(): string => 'ok',
         );
 
         self::assertSame('ok', $result);
@@ -55,9 +54,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $called = false;
 
         $result = $this->middleware($store)->handle(
-            $this->context(),
-            new LlmConfiguration(), // no identifier, no model → empty key
-            static function (LlmConfiguration $c) use (&$called): string {
+            $this->context()->withConfiguration(new LlmConfiguration()), // no identifier, no model → empty key
+            static function () use (&$called): string {
                 $called = true;
 
                 return 'ok';
@@ -75,9 +73,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $store = new InMemoryCircuitBreakerStore();
 
         $result = $this->middleware($store)->handle(
-            $this->context(),
-            $this->config(self::PROVIDER),
-            static fn(LlmConfiguration $c): string => 'ok',
+            $this->context()->withConfiguration($this->config(self::PROVIDER)),
+            static fn(): string => 'ok',
         );
 
         self::assertSame('ok', $result);
@@ -94,9 +91,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         for ($i = 0; $i < 3; $i++) {
             try {
                 $middleware->handle(
-                    $this->context(),
-                    $this->config(self::PROVIDER),
-                    static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('down', 0),
+                    $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                    static fn(): never => throw new ProviderConnectionException('down', 0),
                 );
                 self::fail('Expected the connection failure to propagate');
             } catch (ProviderConnectionException) {
@@ -120,9 +116,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, threshold: 3)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('down', 0),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new ProviderConnectionException('down', 0),
             );
         } catch (ProviderConnectionException) {
         }
@@ -142,9 +137,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, threshold: 3)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('boom', 500),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new ProviderResponseException('boom', 500),
             );
         } catch (ProviderResponseException) {
         }
@@ -160,9 +154,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, threshold: 3)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('bad request', 400),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new ProviderResponseException('bad request', 400),
             );
         } catch (ProviderResponseException) {
         }
@@ -179,9 +172,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, cooldown: 30)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static function (LlmConfiguration $c) use (&$called): string {
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static function () use (&$called): string {
                     $called = true;
 
                     return 'ok';
@@ -205,9 +197,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $called = false;
 
         $result = $this->middleware($store, cooldown: 30)->handle(
-            $this->context(),
-            $this->config(self::PROVIDER),
-            static function (LlmConfiguration $c) use (&$called): string {
+            $this->context()->withConfiguration($this->config(self::PROVIDER)),
+            static function () use (&$called): string {
                 $called = true;
 
                 return 'recovered';
@@ -230,9 +221,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, cooldown: 30)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new ProviderConnectionException('still down', 0),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new ProviderConnectionException('still down', 0),
             );
         } catch (ProviderConnectionException) {
         }
@@ -253,10 +243,9 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, cooldown: 30)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
                 // 401: the provider responded, so it is not a health signal.
-                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('unauthorized', 401),
+                static fn(): never => throw new ProviderResponseException('unauthorized', 401),
             );
             self::fail('Expected the response exception to propagate');
         } catch (ProviderResponseException) {
@@ -280,9 +269,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $store->seed(self::PROVIDER, new CircuitState(2, null)); // closed, counting
 
         $this->middleware($store)->handle(
-            $this->context(),
-            $this->config(self::PROVIDER),
-            static fn(LlmConfiguration $c): string => 'ok',
+            $this->context()->withConfiguration($this->config(self::PROVIDER)),
+            static fn(): string => 'ok',
         );
 
         $state = $store->load(self::PROVIDER);
@@ -298,11 +286,10 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
                 // 401 is a client error: the provider answered, so it is not a
                 // health signal — neither trip nor reset.
-                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('unauthorized', 401),
+                static fn(): never => throw new ProviderResponseException('unauthorized', 401),
             );
             self::fail('Expected the response exception to propagate');
         } catch (ProviderResponseException $e) {
@@ -320,9 +307,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, threshold: 1)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new ProviderResponseException('slow down', 429),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new ProviderResponseException('slow down', 429),
             );
         } catch (ProviderResponseException) {
         }
@@ -339,9 +325,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
 
         try {
             $this->middleware($store, threshold: 1)->handle(
-                $this->context(),
-                $this->config(self::PROVIDER),
-                static fn(LlmConfiguration $c): never => throw new RuntimeException('bug', 1),
+                $this->context()->withConfiguration($this->config(self::PROVIDER)),
+                static fn(): never => throw new RuntimeException('bug', 1),
             );
         } catch (RuntimeException) {
         }

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -56,9 +56,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
 
                 return 'ok';
@@ -79,8 +80,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $caught = $this->captureException(
             ProviderConnectionException::class,
             fn() => $pipeline->run(
-                ProviderCallContext::for(ProviderOperation::Chat),
-                $primary,
+                ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                 static function () use ($err): never {
                     throw $err;
                 },
@@ -102,9 +102,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderConnectionException('down', 0);
@@ -132,9 +133,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls    = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'primary') {
                     throw new CircuitOpenException('openai', 12);
@@ -162,13 +164,14 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ['alt2', $alt2],
         ]);
 
-        $context  = ProviderCallContext::for(ProviderOperation::Chat);
+        $context  = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary);
         $pipeline = $this->makePipeline();
 
         $result = $pipeline->run(
             $context,
-            $primary,
-            static function (LlmConfiguration $config): string {
+            static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 if ($config->getIdentifier() !== 'alt2') {
                     throw new ProviderConnectionException('down', 0);
                 }
@@ -186,13 +189,12 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
     public function recordsNoFallbackAttemptWhenPrimarySucceeds(): void
     {
         $primary  = $this->makeConfig('primary', new FallbackChain(['alt']));
-        $context  = ProviderCallContext::for(ProviderOperation::Chat);
+        $context  = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary);
         $pipeline = $this->makePipeline();
 
         $pipeline->run(
             $context,
-            $primary,
-            static fn(LlmConfiguration $config): string => 'ok',
+            static fn(): string => 'ok',
         );
 
         self::assertSame(0, $context->telemetrySignals->fallbackAttempts);
@@ -209,9 +211,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $pipeline = $this->makePipeline();
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            static function (LlmConfiguration $config): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderResponseException('rate limited', 429);
                 }
@@ -233,9 +236,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $this->repositoryStub->method('findOneByIdentifier')->willReturn($alt);
 
         $result = $this->makePipeline()->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            static function (LlmConfiguration $config): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderResponseException('internal error', 500);
                 }
@@ -262,9 +266,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderResponseException::class,
             function () use ($pipeline, $primary, $err, &$calls): never {
                 $pipeline->run(
-                    ProviderCallContext::for(ProviderOperation::Chat),
-                    $primary,
-                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                    ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                    static function (ProviderCallContext $ctx) use (&$calls, $err): never {
+                        $config = $ctx->configuration;
+                        assert($config !== null);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -289,9 +294,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             UnsupportedFeatureException::class,
             function () use ($pipeline, $primary, $err, &$calls): never {
                 $pipeline->run(
-                    ProviderCallContext::for(ProviderOperation::Chat),
-                    $primary,
-                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                    ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                    static function (ProviderCallContext $ctx) use (&$calls, $err): never {
+                        $config = $ctx->configuration;
+                        assert($config !== null);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -316,9 +322,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderConfigurationException::class,
             function () use ($pipeline, $primary, $err, &$calls): never {
                 $pipeline->run(
-                    ProviderCallContext::for(ProviderOperation::Chat),
-                    $primary,
-                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                    ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                    static function (ProviderCallContext $ctx) use (&$calls, $err): never {
+                        $config = $ctx->configuration;
+                        assert($config !== null);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -350,9 +357,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if (\in_array($config->getIdentifier(), ['p', 'a', 'b'], true)) {
                     throw new ProviderConnectionException('down', 0);
@@ -384,8 +392,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $exhausted = $this->captureException(
             FallbackChainExhaustedException::class,
             fn() => $pipeline->run(
-                ProviderCallContext::for(ProviderOperation::Chat),
-                $primary,
+                ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                 static function (): never {
                     throw new ProviderConnectionException('down', 0);
                 },
@@ -413,9 +420,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -446,9 +454,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -474,9 +483,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderConnectionException::class,
             function () use ($pipeline, $primary, $err, &$calls): never {
                 $pipeline->run(
-                    ProviderCallContext::for(ProviderOperation::Chat),
-                    $primary,
-                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                    ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                    static function (ProviderCallContext $ctx) use (&$calls, $err): never {
+                        $config = $ctx->configuration;
+                        assert($config !== null);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -505,9 +515,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $calls      = [];
 
         $result = $pipeline->run(
-            ProviderCallContext::for(ProviderOperation::Chat),
-            $primary,
-            function (LlmConfiguration $config) use (&$calls): string {
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+            function (ProviderCallContext $ctx) use (&$calls): string {
+                $config = $ctx->configuration;
+                assert($config !== null);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -533,9 +544,10 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             RuntimeException::class,
             function () use ($pipeline, $primary, $err, &$calls): never {
                 $pipeline->run(
-                    ProviderCallContext::for(ProviderOperation::Chat),
-                    $primary,
-                    static function (LlmConfiguration $config) use (&$calls, $err): never {
+                    ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                    static function (ProviderCallContext $ctx) use (&$calls, $err): never {
+                        $config = $ctx->configuration;
+                        assert($config !== null);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -206,7 +206,7 @@ final class GuardrailMiddlewareTest extends TestCase
      */
     private function screen(GuardrailMiddleware $middleware, callable $terminal): mixed
     {
-        return $middleware->handle(ProviderCallContext::for(ProviderOperation::Chat), new LlmConfiguration(), $terminal);
+        return $middleware->handle(ProviderCallContext::forConfiguration(ProviderOperation::Chat, new LlmConfiguration()), $terminal);
     }
 
     private function guardrail(GuardrailResult $result): GuardrailInterface

--- a/Tests/Unit/Provider/Middleware/IdempotencyMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/IdempotencyMiddlewareTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
 use Generator;
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -33,8 +32,7 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
 
         $result = $middleware->handle(
             new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            new LlmConfiguration(),
-            function (LlmConfiguration $c) use (&$calls): string {
+            function () use (&$calls): string {
                 $calls++;
 
                 return 'fresh';
@@ -54,14 +52,14 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
         $response->answer = 'generated once';
 
         $calls = 0;
-        $next  = function (LlmConfiguration $c) use (&$calls, $response): stdClass {
+        $next  = function () use (&$calls, $response): stdClass {
             $calls++;
 
             return $response;
         };
 
-        $first  = $middleware->handle($context, new LlmConfiguration(), $next);
-        $second = $middleware->handle($context, new LlmConfiguration(), $next);
+        $first  = $middleware->handle($context, $next);
+        $second = $middleware->handle($context, $next);
 
         self::assertSame($response, $first);
         self::assertSame($response, $second, 'The repeat must return the stored result');
@@ -74,14 +72,14 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
         $middleware = $this->middleware();
 
         $calls = 0;
-        $next  = function (LlmConfiguration $c) use (&$calls): string {
+        $next  = function () use (&$calls): string {
             $calls++;
 
             return 'result-' . $calls;
         };
 
-        $middleware->handle($this->contextWithKey('key-a'), new LlmConfiguration(), $next);
-        $middleware->handle($this->contextWithKey('key-b'), new LlmConfiguration(), $next);
+        $middleware->handle($this->contextWithKey('key-a'), $next);
+        $middleware->handle($this->contextWithKey('key-b'), $next);
 
         self::assertSame(2, $calls, 'A different key is a miss and must reach the provider');
     }
@@ -99,14 +97,14 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
             yield 'chunk';
         };
         $calls = 0;
-        $next  = function (LlmConfiguration $c) use (&$calls, $makeGenerator): Generator {
+        $next  = function () use (&$calls, $makeGenerator): Generator {
             $calls++;
 
             return $makeGenerator();
         };
 
-        $middleware->handle($context, new LlmConfiguration(), $next);
-        $middleware->handle($context, new LlmConfiguration(), $next);
+        $middleware->handle($context, $next);
+        $middleware->handle($context, $next);
 
         // A generator cannot be stored, so the second call is a miss and re-runs.
         self::assertSame(2, $calls);
@@ -119,7 +117,7 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
         $context    = $this->contextWithKey('will-fail');
 
         $calls = 0;
-        $next  = function (LlmConfiguration $c) use (&$calls): never {
+        $next  = function () use (&$calls): never {
             $calls++;
 
             throw new RuntimeException('boom', 1);
@@ -127,7 +125,7 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
 
         for ($i = 0; $i < 2; $i++) {
             try {
-                $middleware->handle($context, new LlmConfiguration(), $next);
+                $middleware->handle($context, $next);
                 self::fail('Expected the failure to propagate');
             } catch (RuntimeException) {
                 // expected
@@ -152,7 +150,7 @@ final class IdempotencyMiddlewareTest extends AbstractUnitTestCase
         return new ProviderCallContext(
             ProviderOperation::Chat,
             'corr',
-            [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
+            metadata: [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $key],
         );
     }
 

--- a/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
+++ b/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
@@ -29,9 +29,13 @@ final class MiddlewarePipelineTest extends TestCase
         $config   = $this->configuration('primary');
 
         $result = $pipeline->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $config,
-            terminal: static fn(LlmConfiguration $c): string => 'terminal:' . $c->getIdentifier(),
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config),
+            terminal: static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                \assert($config !== null);
+
+                return 'terminal:' . $config->getIdentifier();
+            },
         );
 
         self::assertSame('terminal:primary', $result);
@@ -44,9 +48,13 @@ final class MiddlewarePipelineTest extends TestCase
         $pipeline   = new MiddlewarePipeline([$middleware]);
 
         $result = $pipeline->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration('primary'),
-            terminal: static fn(LlmConfiguration $c): string => 'terminal:' . $c->getIdentifier(),
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration('primary')),
+            terminal: static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                \assert($config !== null);
+
+                return 'terminal:' . $config->getIdentifier();
+            },
         );
 
         self::assertSame('A(terminal:primary)', $result);
@@ -62,9 +70,13 @@ final class MiddlewarePipelineTest extends TestCase
         ]);
 
         $result = $pipeline->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration('primary'),
-            terminal: static fn(LlmConfiguration $c): string => 'T(' . $c->getIdentifier() . ')',
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('primary')),
+            terminal: static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                \assert($config !== null);
+
+                return 'T(' . $config->getIdentifier() . ')';
+            },
         );
 
         // First-registered is outermost: outer(middle(inner(T)))
@@ -77,7 +89,6 @@ final class MiddlewarePipelineTest extends TestCase
         $shortCircuit = new class implements ProviderMiddlewareInterface {
             public function handle(
                 ProviderCallContext $context,
-                LlmConfiguration $configuration,
                 callable $next,
             ): string {
                 return 'short-circuit';
@@ -89,7 +100,6 @@ final class MiddlewarePipelineTest extends TestCase
 
         $result = $pipeline->run(
             context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration('primary'),
             terminal: static function () use (&$terminalWasCalled): string {
                 $terminalWasCalled = true;
 
@@ -109,19 +119,22 @@ final class MiddlewarePipelineTest extends TestCase
 
             public function handle(
                 ProviderCallContext $context,
-                LlmConfiguration $configuration,
                 callable $next,
             ): mixed {
-                return $next($this->replacement);
+                return $next($context->withConfiguration($this->replacement));
             }
         };
 
         $pipeline = new MiddlewarePipeline([$swap]);
 
         $result = $pipeline->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration('primary'),
-            terminal: static fn(LlmConfiguration $c): string => $c->getIdentifier(),
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('primary')),
+            terminal: static function (ProviderCallContext $ctx): string {
+                $config = $ctx->configuration;
+                \assert($config !== null);
+
+                return $config->getIdentifier();
+            },
         );
 
         self::assertSame('fallback', $result);
@@ -145,8 +158,7 @@ final class MiddlewarePipelineTest extends TestCase
 
         $pipeline->run(
             context: $context,
-            configuration: $this->configuration('primary'),
-            terminal: static fn(LlmConfiguration $c): string => 'done',
+            terminal: static fn(): string => 'done',
         );
 
         self::assertSame(
@@ -167,8 +179,7 @@ final class MiddlewarePipelineTest extends TestCase
 
         $result = $pipeline->run(
             context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration('primary'),
-            terminal: static fn(LlmConfiguration $c): string => 'T',
+            terminal: static fn(): string => 'T',
         );
 
         self::assertSame('A(B(T))', $result);
@@ -198,10 +209,9 @@ final class MiddlewarePipelineTest extends TestCase
 
             public function handle(
                 ProviderCallContext $context,
-                LlmConfiguration $configuration,
                 callable $next,
             ): string {
-                $downstream = $next($configuration);
+                $downstream = $next($context);
                 \assert(\is_string($downstream));
 
                 return $this->label . '(' . $downstream . ')';
@@ -230,12 +240,11 @@ final class MiddlewarePipelineTest extends TestCase
 
             public function handle(
                 ProviderCallContext $context,
-                LlmConfiguration $configuration,
                 callable $next,
             ): mixed {
                 ($this->record)($this->label . ':' . $context->correlationId);
 
-                return $next($configuration);
+                return $next($context);
             }
         };
     }

--- a/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
+++ b/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\Middleware\TelemetrySignals;
@@ -73,5 +74,51 @@ final class ProviderCallContextTest extends TestCase
         self::assertInstanceOf(TelemetrySignals::class, $context->telemetrySignals);
         self::assertFalse($context->telemetrySignals->cacheHit);
         self::assertSame(0, $context->telemetrySignals->fallbackAttempts);
+    }
+
+    #[Test]
+    public function forConfigurationBindsTheEntityAndTelemetryReadsItOverTheStrings(): void
+    {
+        $config = new LlmConfiguration();
+        $config->setIdentifier('editorial');
+
+        $context = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config);
+
+        self::assertSame($config, $context->configuration);
+        // The entity is the source of truth for telemetry while it is present.
+        self::assertSame('editorial', $context->telemetryConfigurationIdentifier());
+    }
+
+    #[Test]
+    public function forServiceCarriesProviderModelStringsForACallWithoutAConfigurationEntity(): void
+    {
+        // The enabling case (ADR-096): an image/speech/translation call with no
+        // LlmConfiguration entity still populates telemetry from the strings.
+        $context = ProviderCallContext::forService(ProviderOperation::ImageGeneration, 'dall-e', 'gpt-image-2', 'image-default');
+
+        self::assertNull($context->configuration);
+        self::assertSame('dall-e', $context->telemetryProvider());
+        self::assertSame('gpt-image-2', $context->telemetryModel());
+        self::assertSame('image-default', $context->telemetryConfigurationIdentifier());
+    }
+
+    #[Test]
+    public function withConfigurationSwapsTheEntityButKeepsCorrelationAndSignals(): void
+    {
+        $primary  = (new LlmConfiguration());
+        $primary->setIdentifier('primary');
+        $fallback = (new LlmConfiguration());
+        $fallback->setIdentifier('fallback');
+
+        $base = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary);
+        $base->telemetrySignals->recordFallbackAttempt();
+
+        $swapped = $base->withConfiguration($fallback);
+
+        self::assertSame($fallback, $swapped->configuration);
+        self::assertSame($base->correlationId, $swapped->correlationId);
+        // Fallback substitution mid-run must keep the accumulated signals.
+        self::assertSame($base->telemetrySignals, $swapped->telemetrySignals);
+        self::assertSame(1, $swapped->telemetrySignals->fallbackAttempts);
     }
 }

--- a/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
+++ b/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
@@ -121,4 +121,25 @@ final class ProviderCallContextTest extends TestCase
         self::assertSame($base->telemetrySignals, $swapped->telemetrySignals);
         self::assertSame(1, $swapped->telemetrySignals->fallbackAttempts);
     }
+
+    #[Test]
+    public function telemetryFallsThroughToTheContextStringWhenTheConfigurationsValueIsEmpty(): void
+    {
+        // A transient/ad-hoc configuration can carry empty provider/model/id.
+        // The context strings must then win, not the empty entity values.
+        $emptyConfig = new LlmConfiguration();
+
+        $context = new ProviderCallContext(
+            ProviderOperation::ImageGeneration,
+            'corr',
+            configuration: $emptyConfig,
+            provider: 'ctx-provider',
+            model: 'ctx-model',
+            configurationIdentifier: 'ctx-id',
+        );
+
+        self::assertSame('ctx-provider', $context->telemetryProvider());
+        self::assertSame('ctx-model', $context->telemetryModel());
+        self::assertSame('ctx-id', $context->telemetryConfigurationIdentifier());
+    }
 }

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -42,9 +42,8 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
 
         $context = new ProviderCallContext(ProviderOperation::Chat, 'corr-success');
         $result  = $this->pipeline($repository)->run(
-            $context,
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'answer',
+            $context->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'answer',
         );
 
         self::assertSame('answer', $result);
@@ -75,9 +74,8 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         $caught = false;
         try {
             $this->pipeline($repository)->run(
-                $context,
-                $this->configuration('primary'),
-                static function (LlmConfiguration $c): string {
+                $context->withConfiguration($this->configuration('primary')),
+                static function (): string {
                     throw new RuntimeException('boom', 1495872184);
                 },
             );
@@ -109,9 +107,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         $caught = false;
         try {
             $this->pipeline($repository)->run(
-                new ProviderCallContext(ProviderOperation::Chat, 'corr-guardrail'),
-                $this->configuration('primary'),
-                static fn(LlmConfiguration $c): string => throw new GuardrailViolationException('Some\\Guardrail', 'blocked'),
+                (new ProviderCallContext(ProviderOperation::Chat, 'corr-guardrail'))
+                    ->withConfiguration($this->configuration('primary')),
+                static fn(): string => throw new GuardrailViolationException('Some\\Guardrail', 'blocked'),
             );
         } catch (GuardrailViolationException) {
             $caught = true;
@@ -131,9 +129,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         $caught = false;
         try {
             $this->pipeline($repository)->run(
-                new ProviderCallContext(ProviderOperation::Chat, 'corr-approval'),
-                $this->configuration('primary'),
-                static fn(LlmConfiguration $c): string => throw new GuardrailApprovalRequiredException('Some\\Guardrail', 'needs approval'),
+                (new ProviderCallContext(ProviderOperation::Chat, 'corr-approval'))
+                    ->withConfiguration($this->configuration('primary')),
+                static fn(): string => throw new GuardrailApprovalRequiredException('Some\\Guardrail', 'needs approval'),
             );
         } catch (GuardrailApprovalRequiredException) {
             $caught = true;
@@ -150,13 +148,13 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
     {
         $repository = $this->recordingRepository();
 
-        $context = new ProviderCallContext(ProviderOperation::Embedding, 'corr');
+        $context = (new ProviderCallContext(ProviderOperation::Embedding, 'corr'))
+            ->withConfiguration($this->configuration('primary'));
         $context->telemetrySignals->recordCacheHit();
 
         $this->pipeline($repository)->run(
             $context,
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'x',
+            static fn(): string => 'x',
         );
 
         self::assertTrue($repository->records[0]->cacheHit);
@@ -167,14 +165,14 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
     {
         $repository = $this->recordingRepository();
 
-        $context = new ProviderCallContext(ProviderOperation::Chat, 'corr');
+        $context = (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+            ->withConfiguration($this->configuration('primary'));
         $context->telemetrySignals->recordFallbackAttempt();
         $context->telemetrySignals->recordFallbackAttempt();
 
         $this->pipeline($repository)->run(
             $context,
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'x',
+            static fn(): string => 'x',
         );
 
         self::assertSame(2, $repository->records[0]->fallbackAttempts);
@@ -186,9 +184,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         $repository = $this->recordingRepository();
 
         $result = $this->pipeline($repository, enabled: false)->run(
-            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'answer',
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'answer',
         );
 
         self::assertSame('answer', $result, 'The terminal must still run when telemetry is disabled.');
@@ -212,9 +210,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         );
 
         $result = (new MiddlewarePipeline([$middleware]))->run(
-            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'answer',
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'answer',
         );
 
         self::assertSame('answer', $result);
@@ -241,9 +239,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         );
 
         $result = (new MiddlewarePipeline([$middleware]))->run(
-            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'answer',
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'answer',
         );
 
         self::assertSame('answer', $result);
@@ -257,13 +255,12 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         $context = new ProviderCallContext(
             ProviderOperation::Chat,
             'corr',
-            [BudgetMiddleware::METADATA_BE_USER_UID => 42],
+            metadata: [BudgetMiddleware::METADATA_BE_USER_UID => 42],
         );
 
         $this->pipeline($repository)->run(
-            $context,
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'x',
+            $context->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
         );
 
         self::assertSame(42, $repository->records[0]->beUser);
@@ -282,9 +279,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         );
 
         (new MiddlewarePipeline([$middleware]))->run(
-            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'x',
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
         );
 
         self::assertSame(7, $repository->records[0]->beUser);
@@ -306,9 +303,9 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         );
 
         (new MiddlewarePipeline([$middleware]))->run(
-            new ProviderCallContext(ProviderOperation::Chat, 'corr'),
-            $this->configuration('primary'),
-            static fn(LlmConfiguration $c): string => 'x',
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
         );
 
         self::assertSame(0, $repository->records[0]->beUser);

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -68,9 +68,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $result = $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(uid: 7),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration(uid: 7)),
+            terminal: static fn(): CompletionResponse => $response,
         );
 
         self::assertSame($response, $result);
@@ -99,9 +98,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration(), // uid = null (not persisted)
-            terminal: static fn(LlmConfiguration $c): EmbeddingResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration()), // uid = null (not persisted)
+            terminal: static fn(): EmbeddingResponse => $response,
         );
     }
 
@@ -128,9 +126,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Vision),
-            configuration: $this->configuration(uid: 12),
-            terminal: static fn(LlmConfiguration $c): VisionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Vision, $this->configuration(uid: 12)),
+            terminal: static fn(): VisionResponse => $response,
         );
     }
 
@@ -157,9 +154,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),
+            terminal: static fn(): CompletionResponse => $response,
         );
     }
 
@@ -169,9 +165,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->tracker->expects(self::never())->method('trackUsage');
 
         $result = $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): string => 'raw-string-response',
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),
+            terminal: static fn(): string => 'raw-string-response',
         );
 
         self::assertSame('raw-string-response', $result);
@@ -186,8 +181,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->expectExceptionMessage('boom');
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),
             terminal: static function (): never {
                 throw new LogicException('boom', 1504818594);
             },
@@ -216,9 +210,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->setUid($config, 0);
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $config,
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config),
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
                 content: 'x',
                 model: 'm',
                 usage: new UsageStatistics(1, 1, 2),
@@ -261,9 +254,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         ];
 
         $result = $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => $payload,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration()),
+            terminal: static fn(): array => $payload,
         );
 
         self::assertSame($payload, $result);
@@ -285,9 +277,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => [
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration()),
+            terminal: static fn(): array => [
                 'provider' => '',
                 'usage'    => ['totalTokens' => 5],
             ],
@@ -300,9 +291,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->tracker->expects(self::never())->method('trackUsage');
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => [
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration()),
+            terminal: static fn(): array => [
                 'embeddings' => [[0.1]],
                 'provider'   => 'openai',
                 // no 'usage' key — nothing reliable to record
@@ -316,9 +306,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->tracker->expects(self::never())->method('trackUsage');
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Embedding),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): array => [
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration()),
+            terminal: static fn(): array => [
                 'provider' => ['not', 'a', 'string'],
                 'usage'    => ['totalTokens' => 5],
             ],
@@ -358,9 +347,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configurationWithModel($model, uid: 7),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configurationWithModel($model, uid: 7)),
+            terminal: static fn(): CompletionResponse => $response,
         );
     }
 
@@ -395,9 +383,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configurationWithModel($model, uid: 7),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configurationWithModel($model, uid: 7)),
+            terminal: static fn(): CompletionResponse => $response,
         );
     }
 
@@ -417,9 +404,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat, [UsageMiddleware::METADATA_TASK_UID => 42]),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration(), [UsageMiddleware::METADATA_TASK_UID => 42]),
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
                 content: 'x',
                 model: 'm',
                 usage: new UsageStatistics(5, 5, 10),
@@ -445,9 +431,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat, [BudgetMiddleware::METADATA_BE_USER_UID => 99]),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration(), [BudgetMiddleware::METADATA_BE_USER_UID => 99]),
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
                 content: 'x',
                 model: 'm',
                 usage: new UsageStatistics(5, 5, 10),
@@ -476,9 +461,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             );
 
         $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => new CompletionResponse(
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
                 content: 'x',
                 model: 'm',
                 usage: new UsageStatistics(5, 5, 10),
@@ -510,9 +494,8 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->logger->expects(self::once())->method('warning');
 
         $result = $this->pipeline()->run(
-            context: ProviderCallContext::for(ProviderOperation::Chat),
-            configuration: $this->configuration(uid: 7),
-            terminal: static fn(LlmConfiguration $c): CompletionResponse => $response,
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration(uid: 7)),
+            terminal: static fn(): CompletionResponse => $response,
         );
 
         self::assertSame($response, $result);

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -2649,9 +2649,11 @@ final class RecordingMiddleware implements ProviderMiddlewareInterface
 
     public function handle(
         ProviderCallContext $context,
-        LlmConfiguration $configuration,
         callable $next,
     ): mixed {
+        $configuration = $context->configuration;
+        assert($configuration !== null);
+
         $this->calls[] = [
             'operation'          => $context->operation,
             'identifier'         => $configuration->getIdentifier(),
@@ -2660,7 +2662,7 @@ final class RecordingMiddleware implements ProviderMiddlewareInterface
             'metadata'           => $context->metadata,
         ];
 
-        return $next($configuration);
+        return $next($context);
     }
 }
 

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -1023,7 +1023,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
      */
     private function context(array $metadata = []): ProviderCallContext
     {
-        return new ProviderCallContext(ProviderOperation::Stream, 'corr-1', $metadata);
+        return new ProviderCallContext(ProviderOperation::Stream, 'corr-1', metadata: $metadata);
     }
 
     /**


### PR DESCRIPTION
## Description

The middleware pipeline (budget, telemetry, cache, idempotency, guardrail, fallback, usage, circuit breaker) took the `LlmConfiguration` as a **separate positional parameter** of `MiddlewarePipeline::run()` and every `ProviderMiddlewareInterface::handle()`. Six of eight middleware merely forwarded it; it existed as its own parameter only so `FallbackMiddleware` could substitute a sibling. That hard-wires the pipeline to callers with an `LlmConfiguration` entity — which the specialized image/speech/translation services do not have, the reason they bypass the pipeline and its telemetry / correlation ids / circuit breaker / input guardrails.

- `ProviderCallContext` gains a nullable `configuration` + `provider`/`model`/`configurationIdentifier` strings + `for()`/`forConfiguration()`/`forService()` factories. Entity is the source of truth when present; the strings when null (`telemetryProvider()` etc.).
- `run(context, terminal)` and `handle(context, next)` drop the separate config param; `$next` and the terminal receive the context. `FallbackMiddleware` swaps via `withConfiguration()`.
- `UsageMiddleware`/`CircuitBreakerMiddleware` tolerate a null configuration. `ProviderOperation` gains the specialized cases.

**No behaviour change** — the chat path builds a context via `forConfiguration()` and every existing test passes unchanged in intent. Class names keep the `Provider` prefix; the `AiCallContext` rename is a cosmetic follow-up. This is the **enabling** step; the specialized services are migrated onto the pipeline (with a fail-closed dispatch seam) next.

## Type of Change

- [x] Refactoring (behaviour-preserving)
- [x] Breaking change

**Breaking:** `MiddlewarePipeline::run()` and `ProviderMiddlewareInterface::handle()` changed signature — a downstream custom middleware or direct `run()` caller must move the configuration onto the context.

## Checklist

- [x] Local suite green (unit, functional, phpstan, cgl, rector, fuzzy); functional shows only the pre-existing `KeSearchBackendTest` risky tests that also fail on main
- [x] The ~26 middleware/pipeline test files migrated to the new API; new `ProviderCallContext` factory + telemetry-fallback tests added
- [x] ADR-096 added

No version bump; changelog under `[Unreleased]`.