### PR TITLE
feat(specialized)!: route DALL-E through the shared pipeline (telemetry + circuit breaker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The DALL·E image service dispatches through the shared middleware pipeline
+  (ADR-097): image generation/variation/edit now writes a telemetry row with a
+  correlation id and is guarded by the provider circuit breaker, like a chat
+  call. `AbstractSpecializedService` gained a required `MiddlewarePipeline`
+  constructor parameter (**breaking** for a subclass or manual construction).
+  Budget enforcement and usage recording are unchanged. FAL/Whisper/TTS/DeepL
+  follow in later steps.
+
 - The middleware pipeline's configuration moved from a separate parameter onto
   the call context: `MiddlewarePipeline::run(context, terminal)` and
   `ProviderMiddlewareInterface::handle(context, next)` no longer take a separate

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -98,11 +100,37 @@ abstract class AbstractSpecializedService
         // silently disappears when a caller forgets to wire it is a fail-open
         // control on money (ADR-078 shipped it optional; that was wrong).
         protected readonly BudgetServiceInterface $budgetService,
+        // The cross-cutting lifecycle every AI call shares (ADR-097): routing the
+        // HTTP dispatch through the pipeline gives a specialized call the same
+        // telemetry row, correlation id and circuit breaker as a chat call.
+        // Required — a lifecycle that silently disappears is not a lifecycle.
+        protected readonly MiddlewarePipeline $pipeline,
         protected readonly ?ModelRepository $modelRepository = null,
         protected readonly ?LlmConfigurationRepository $configurationRepository = null,
     ) {
         $this->timeout = $this->getDefaultTimeout();
         $this->loadConfiguration();
+    }
+
+    /**
+     * Run one dispatch through the shared middleware pipeline (ADR-097).
+     *
+     * The call is described by a {@see ProviderCallContext} carrying the
+     * operation and the provider/model strings — no {@see LlmConfiguration}
+     * entity, so the fallback, cache and idempotency middleware self-disable and
+     * the budget middleware is inert (the per-call budget is still enforced by
+     * {@see self::enforceBudget()} before dispatch). What the pipeline adds is a
+     * telemetry row with a correlation id and the provider circuit breaker.
+     *
+     * @template T
+     *
+     * @param callable(): T $call the actual HTTP dispatch
+     *
+     * @return T
+     */
+    protected function runLifecycle(ProviderCallContext $context, callable $call): mixed
+    {
+        return $this->pipeline->run($context, static fn(): mixed => $call());
     }
 
     /**

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -130,7 +130,7 @@ abstract class AbstractSpecializedService
      */
     protected function runLifecycle(ProviderCallContext $context, callable $call): mixed
     {
-        return $this->pipeline->run($context, static fn(): mixed => $call());
+        return $this->pipeline->run($context, static fn(ProviderCallContext $context): mixed => $call());
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Image;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
@@ -101,8 +103,14 @@ final class DallEImageService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
-        $this->setAuditContext(sprintf('%s, generate', $model));
-        $response = $this->sendJsonRequest('generations', $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            function () use ($payload, $model): array {
+                $this->setAuditContext(sprintf('%s, generate', $model));
+
+                return $this->sendJsonRequest('generations', $payload);
+            },
+        );
 
         /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
@@ -171,8 +179,14 @@ final class DallEImageService extends AbstractSpecializedService
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $payload['n'] = $count;
 
-        $this->setAuditContext(sprintf('%s, generate', $model));
-        $response = $this->sendJsonRequest('generations', $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            function () use ($payload, $model): array {
+                $this->setAuditContext(sprintf('%s, generate', $model));
+
+                return $this->sendJsonRequest('generations', $payload);
+            },
+        );
 
         $results = [];
         /** @var array<int, mixed> $responseData */
@@ -227,12 +241,18 @@ final class DallEImageService extends AbstractSpecializedService
 
         $count = min(max($count, 1), 10);
 
-        $this->setAuditContext('dall-e-2, variations');
-        $response = $this->sendImageMultipart('variations', $imagePath, null, [
-            'n' => (string)$count,
-            'size' => $size,
-            'response_format' => 'url',
-        ]);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageVariation, $this->getServiceProvider(), 'dall-e-2'),
+            function () use ($imagePath, $count, $size): array {
+                $this->setAuditContext('dall-e-2, variations');
+
+                return $this->sendImageMultipart('variations', $imagePath, null, [
+                    'n' => (string)$count,
+                    'size' => $size,
+                    'response_format' => 'url',
+                ]);
+            },
+        );
 
         $results = [];
         /** @var array<int, mixed> $responseData */
@@ -287,12 +307,18 @@ final class DallEImageService extends AbstractSpecializedService
         }
         $this->enforceBudget($beUserUid, null, null);
 
-        $this->setAuditContext('dall-e-2, edit');
-        $response = $this->sendImageMultipart('edits', $imagePath, $maskPath, [
-            'prompt' => $prompt,
-            'size' => $size,
-            'response_format' => 'url',
-        ]);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageEdit, $this->getServiceProvider(), 'dall-e-2'),
+            function () use ($imagePath, $maskPath, $prompt, $size): array {
+                $this->setAuditContext('dall-e-2, edit');
+
+                return $this->sendImageMultipart('edits', $imagePath, $maskPath, [
+                    'prompt' => $prompt,
+                    'size' => $size,
+                    'response_format' => 'url',
+                ]);
+            },
+        );
 
         /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];

--- a/Documentation/Adr/Adr097SpecializedServicesOnPipeline.rst
+++ b/Documentation/Adr/Adr097SpecializedServicesOnPipeline.rst
@@ -1,0 +1,72 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-097:
+
+============================================================================
+ADR-097: Specialized services dispatch through the shared pipeline
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-20
+:Authors: Netresearch DTT GmbH
+
+.. _adr-097-context:
+
+Context
+=======
+
+The specialized services — DALL·E, FAL, Whisper, TTS, DeepL — dispatch HTTP
+directly and bypass the middleware pipeline, so they get none of what a chat
+call gets: no telemetry row, no correlation id, no circuit breaker, no uniform
+error classification. :ref:`ADR-096 <adr-096>` made that reachable by moving the
+configuration onto the call context, so a caller without an ``LlmConfiguration``
+entity can now drive the pipeline through a ``forService()`` context.
+
+.. _adr-097-decision:
+
+Decision
+========
+
+``AbstractSpecializedService`` takes the ``MiddlewarePipeline`` as a required
+dependency and exposes ``runLifecycle(ProviderCallContext $context, callable
+$call)``, which runs the actual HTTP dispatch as the pipeline terminal. Each
+service builds a ``ProviderCallContext::forService(operation, provider, model)``
+and wraps its dispatch in ``runLifecycle()``.
+
+For a service context (no configuration entity, no budget metadata) most
+middleware self-disable: fallback has no chain, cache and idempotency have no
+key, the guardrail passes a non-completion result through, and the budget
+middleware is inert because the per-call budget is still enforced by
+``enforceBudget()`` before dispatch. What the pipeline adds is a **telemetry row
+with a correlation id** and the **provider circuit breaker** — a flapping image
+or speech endpoint now trips and fails fast like a chat provider.
+
+This ADR migrates the first service, **DALL·E** (all four entry points:
+generate, generate-multiple, variations, edit). The other four follow the same
+shape.
+
+.. _adr-097-consequences:
+
+Consequences
+============
+
+- **Breaking:** ``AbstractSpecializedService`` gained a required
+  ``MiddlewarePipeline`` constructor parameter (after ``budgetService``). A
+  subclass or manual construction must pass it; an empty ``MiddlewarePipeline([])``
+  is a valid pass-through for tests that do not exercise the lifecycle.
+- DALL·E calls now write a telemetry row (operation ``image``, the provider and
+  model, a correlation id) and are guarded by the circuit breaker. No other
+  behaviour changes: usage is still recorded by the service's own
+  ``trackImageUsage()`` (unifying that into a pipeline extractor is a later
+  step), and the budget is still enforced by ``enforceBudget()`` before
+  dispatch — the budget middleware stays inert for a service context, so there
+  is no double check.
+- ``Classes/Specialized`` now depends on ``Classes/Provider/Middleware``. That is
+  the point — the specialized services join the shared lifecycle rather than
+  reimplementing it.
+- Deferred, each its own step: migrating FAL / Whisper / TTS / DeepL; applying
+  input-guardrail screening to the specialized prompts; the fail-closed dispatch
+  seam that makes a forgotten lifecycle wrapper throw rather than spend
+  unmetered (it can only be switched on once all five services route through
+  ``runLifecycle()``); and folding the per-service usage recording into a tagged
+  pipeline extractor.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -394,3 +394,4 @@ Tools
    Adr094ToolDataClassTrustZone
    Adr095FailureTaxonomy
    Adr096PipelineCallContext
+   Adr097SpecializedServicesOnPipeline

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
@@ -311,6 +312,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
+            pipeline: new MiddlewarePipeline([]),
         );
 
         $subject->callSendJsonRequest('endpoint', []);
@@ -557,6 +559,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
+            pipeline: new MiddlewarePipeline([]),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -628,6 +631,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
+            pipeline: new MiddlewarePipeline([]),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -1155,6 +1159,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: $budgetService ?? new AllowingBudgetService(),
+            pipeline: new MiddlewarePipeline([]),
             modelRepository: $modelRepository,
             configurationRepository: $configurationRepository,
         );
@@ -1215,6 +1220,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             logger: self::createStub(LoggerInterface::class),
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
+            pipeline: new MiddlewarePipeline([]),
         );
     }
 

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
+use Closure;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
@@ -92,15 +93,17 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     public function aGenerationIsRoutedThroughThePipelineWithAnImageServiceContext(): void
     {
         $captured   = null;
-        $middleware = new class ($captured) implements ProviderMiddlewareInterface {
+        $middleware = new class (static function (ProviderCallContext $context) use (&$captured): void {
+            $captured = $context;
+        }) implements ProviderMiddlewareInterface {
             /**
-             * @param ProviderCallContext|null $captured
+             * @param Closure(ProviderCallContext): void $onHandle
              */
-            public function __construct(private mixed &$captured) {}
+            public function __construct(private readonly Closure $onHandle) {}
 
             public function handle(ProviderCallContext $context, callable $next): mixed
             {
-                $this->captured = $context;
+                ($this->onHandle)($context);
 
                 return $next($context);
             }
@@ -133,6 +136,9 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         self::assertNotSame('', $captured->correlationId);
     }
 
+    /**
+     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null, budget?: BudgetServiceInterface|null, pipeline?: MiddlewarePipeline} $repositories
+     */
     private function buildService(
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -15,6 +15,10 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -83,9 +87,52 @@ class DallEImageServiceTest extends AbstractUnitTestCase
      * Build a DallEImageService wired to the vault mock, then inject the given
      * plain HTTP client through the test seam (bypasses the vault secure client
      * so request/response assertions can read the request the service built).
-     *
-     * @param array{model?: ModelRepository|null, configuration?: LlmConfigurationRepository|null, budget?: BudgetServiceInterface|null} $repositories
      */
+    #[Test]
+    public function aGenerationIsRoutedThroughThePipelineWithAnImageServiceContext(): void
+    {
+        $captured   = null;
+        $middleware = new class ($captured) implements ProviderMiddlewareInterface {
+            /**
+             * @param ProviderCallContext|null $captured
+             */
+            public function __construct(private mixed &$captured) {}
+
+            public function handle(ProviderCallContext $context, callable $next): mixed
+            {
+                $this->captured = $context;
+
+                return $next($context);
+            }
+        };
+
+        $config = [
+            'providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']],
+        ];
+        $this->extensionConfigMock->expects(self::once())->method('get')->with('nr_llm')->willReturn($config);
+
+        $service = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+            ['pipeline' => new MiddlewarePipeline([$middleware])],
+        );
+        $this->setupSuccessfulRequest(['data' => [['url' => 'https://example.org/i.png']]]);
+
+        $service->generate('a cat', ['model' => 'dall-e-3']);
+
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        // The dispatch now carries the shared lifecycle: a labelled operation,
+        // the provider and model for telemetry, and a correlation id (ADR-097).
+        self::assertSame(ProviderOperation::ImageGeneration, $captured->operation);
+        self::assertSame('dall-e', $captured->telemetryProvider());
+        self::assertSame('dall-e-3', $captured->telemetryModel());
+        self::assertNotSame('', $captured->correlationId);
+    }
+
     private function buildService(
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
@@ -104,6 +151,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             $repositories['budget'] ?? new AllowingBudgetService(),
+            $repositories['pipeline'] ?? new MiddlewarePipeline([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -96,6 +97,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             $logger,
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $service->setHttpClient($httpClient);
 
@@ -127,6 +129,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             $this->loggerStub,
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
             $modelRepository,
         );
 

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -100,6 +101,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -127,6 +128,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
@@ -120,6 +121,7 @@ final class DeepLTranslatorBudgetTest extends TestCase
             new NullLogger(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             $budgetService,
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClient);
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Exception;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -68,6 +69,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -95,6 +97,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -482,6 +485,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClientMock);
 
@@ -733,6 +737,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($this->createHttpClientMock());
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
@@ -51,6 +52,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -84,6 +86,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -532,6 +535,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClientMock);
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use LogicException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -87,6 +88,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -110,6 +112,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -142,6 +145,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -278,6 +282,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
 
         $reflection = new ReflectionClass($translator);
@@ -494,6 +499,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -540,6 +546,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -585,6 +592,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -961,6 +969,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -1137,6 +1146,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
+            new MiddlewarePipeline([]),
         );
         $subject->setHttpClient($httpClientStub);
 


### PR DESCRIPTION
## Description

First specialized service to join the shared middleware lifecycle (ADR-097). The specialized services dispatch HTTP directly and bypass the pipeline, so they get no telemetry, no correlation id, no circuit breaker. [ADR-096](../blob/main/Documentation/Adr/Adr096PipelineCallContext.rst) made that reachable by putting the config on the call context.

- `AbstractSpecializedService` takes `MiddlewarePipeline` (required) and exposes `runLifecycle(context, call)` running the HTTP dispatch as the pipeline terminal.
- DALL-E's four entry points build `ProviderCallContext::forService(image-op, provider, model)` and wrap dispatch in `runLifecycle()`.

For a service context most middleware self-disable (no chain, no cache/idempotency key, non-completion result); the budget middleware is inert because `enforceBudget()` still runs before dispatch. What the pipeline adds: a **telemetry row with a correlation id** and the **provider circuit breaker** — a flapping image endpoint now trips and fails fast.

Budget and usage unchanged. FAL/Whisper/TTS/DeepL, input-guardrail screening, and the fail-closed dispatch seam follow.

## Type of Change

- [x] New feature
- [x] Breaking change

**Breaking:** `AbstractSpecializedService` gained a required `MiddlewarePipeline` constructor parameter after `budgetService`; an empty `MiddlewarePipeline([])` is a valid pass-through for tests.

## Checklist

- [x] Local suite green (unit, functional, phpstan, cgl, rector, fuzzy); functional shows only the pre-existing `KeSearchBackendTest` risky tests
- [x] New test asserts a DALL-E generation routes through the pipeline with an ImageGeneration context (provider/model/correlation id); all 10 specialized test files updated for the constructor
- [x] ADR-097 added

No version bump; changelog under `[Unreleased]`.