### PR TITLE
feat(specialized): route FAL, Whisper, TTS and DeepL through the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,13 +62,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- The DALL·E image service dispatches through the shared middleware pipeline
-  (ADR-097): image generation/variation/edit now writes a telemetry row with a
-  correlation id and is guarded by the provider circuit breaker, like a chat
-  call. `AbstractSpecializedService` gained a required `MiddlewarePipeline`
-  constructor parameter (**breaking** for a subclass or manual construction).
-  Budget enforcement and usage recording are unchanged. FAL/Whisper/TTS/DeepL
-  follow in later steps.
+- All five specialized services — DALL·E, FAL, Whisper, TTS, DeepL — dispatch
+  through the shared middleware pipeline (ADR-097): each call now writes a
+  telemetry row with a correlation id and is guarded by the provider circuit
+  breaker, like a chat call. `AbstractSpecializedService` gained a required
+  `MiddlewarePipeline` constructor parameter (**breaking** for a subclass or
+  manual construction). Budget enforcement and usage recording are unchanged.
 
 - The middleware pipeline's configuration moved from a separate parameter onto
   the call context: `MiddlewarePipeline::run(context, terminal)` and

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -95,21 +95,7 @@ final class FalImageService extends AbstractSpecializedService
             $this->extractConfigurationIdentifier($options),
         );
 
-        $modelEndpoint = $this->resolveModelEndpoint($model);
-
-        $payload = $this->buildGeneratePayload($prompt, $options);
-
-        $usesQueue = $this->modelUsesQueue($model);
-        $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
-            function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
-                $this->setAuditContext(sprintf('%s, generate', $model));
-
-                return $usesQueue
-                    ? $this->sendQueueRequest($modelEndpoint, $payload)
-                    : $this->sendJsonRequest($modelEndpoint, $payload);
-            },
-        );
+        $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $images = $response['images'] ?? [];
         /** @var array<string, mixed> $image */
@@ -167,20 +153,7 @@ final class FalImageService extends AbstractSpecializedService
             $this->extractConfigurationIdentifier($options),
         );
 
-        $modelEndpoint = $this->resolveModelEndpoint($model);
-        $payload = $this->buildGeneratePayload($prompt, $options);
-
-        $usesQueue = $this->modelUsesQueue($model);
-        $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
-            function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
-                $this->setAuditContext(sprintf('%s, generate', $model));
-
-                return $usesQueue
-                    ? $this->sendQueueRequest($modelEndpoint, $payload)
-                    : $this->sendJsonRequest($modelEndpoint, $payload);
-            },
-        );
+        $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $results = [];
         $responseImages = $response['images'] ?? [];
@@ -413,6 +386,33 @@ final class FalImageService extends AbstractSpecializedService
             );
         }
         return parent::mapErrorStatus($statusCode, $errorMessage);
+    }
+
+    /**
+     * Resolve the endpoint, build the payload and dispatch a generation request
+     * through the middleware pipeline. Shared by {@see generate()} and
+     * {@see generateMultiple()} so the pipeline wiring lives in one place.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed> the decoded FAL response
+     */
+    private function dispatchGeneration(string $prompt, string $model, array $options): array
+    {
+        $modelEndpoint = $this->resolveModelEndpoint($model);
+        $payload       = $this->buildGeneratePayload($prompt, $options);
+        $usesQueue     = $this->modelUsesQueue($model);
+
+        return $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
+                $this->setAuditContext(sprintf('%s, generate', $model));
+
+                return $usesQueue
+                    ? $this->sendQueueRequest($modelEndpoint, $payload)
+                    : $this->sendJsonRequest($modelEndpoint, $payload);
+            },
+        );
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Image;
 
 use JsonException;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -97,11 +99,17 @@ final class FalImageService extends AbstractSpecializedService
 
         $payload = $this->buildGeneratePayload($prompt, $options);
 
-        $this->setAuditContext(sprintf('%s, generate', $model));
         $usesQueue = $this->modelUsesQueue($model);
-        $response = $usesQueue
-            ? $this->sendQueueRequest($modelEndpoint, $payload)
-            : $this->sendJsonRequest($modelEndpoint, $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
+                $this->setAuditContext(sprintf('%s, generate', $model));
+
+                return $usesQueue
+                    ? $this->sendQueueRequest($modelEndpoint, $payload)
+                    : $this->sendJsonRequest($modelEndpoint, $payload);
+            },
+        );
 
         $images = $response['images'] ?? [];
         /** @var array<string, mixed> $image */
@@ -162,11 +170,17 @@ final class FalImageService extends AbstractSpecializedService
         $modelEndpoint = $this->resolveModelEndpoint($model);
         $payload = $this->buildGeneratePayload($prompt, $options);
 
-        $this->setAuditContext(sprintf('%s, generate', $model));
         $usesQueue = $this->modelUsesQueue($model);
-        $response = $usesQueue
-            ? $this->sendQueueRequest($modelEndpoint, $payload)
-            : $this->sendJsonRequest($modelEndpoint, $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
+                $this->setAuditContext(sprintf('%s, generate', $model));
+
+                return $usesQueue
+                    ? $this->sendQueueRequest($modelEndpoint, $payload)
+                    : $this->sendJsonRequest($modelEndpoint, $payload);
+            },
+        );
 
         $results = [];
         $responseImages = $response['images'] ?? [];

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Speech;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
@@ -102,8 +104,14 @@ final class TextToSpeechService extends AbstractSpecializedService
             'speed' => $speed,
         ];
 
-        $this->setAuditContext(sprintf('%s, voice %s', $model, $voice));
-        $audioContent = $this->sendBinaryRequest($payload);
+        $audioContent = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::SpeechSynthesis, $this->getServiceProvider(), $model),
+            function () use ($model, $voice, $payload): string {
+                $this->setAuditContext(sprintf('%s, voice %s', $model, $voice));
+
+                return $this->sendBinaryRequest($payload);
+            },
+        );
 
         $characterCount = mb_strlen($text);
         $this->usageTracker->trackUsage(

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -84,7 +84,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
             fn(): array|string => $this->sendTranscriptionRequest($audioPath, $options),
         );
 
@@ -126,7 +126,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
             fn(): array|string => $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options),
         );
 
@@ -158,7 +158,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
             fn(): array|string => $this->sendTranslationRequest($audioPath, $options),
         );
 

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Speech;
 
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -81,7 +83,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->validateAudioFile($audioPath);
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
-        $response = $this->sendTranscriptionRequest($audioPath, $options);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            fn(): array|string => $this->sendTranscriptionRequest($audioPath, $options),
+        );
 
         return $this->parseTranscriptionResponse($response, $options);
     }
@@ -120,7 +125,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
 
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
-        $response = $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            fn(): array|string => $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options),
+        );
 
         return $this->parseTranscriptionResponse($response, $options);
     }
@@ -149,7 +157,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->validateAudioFile($audioPath);
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
-        $response = $this->sendTranslationRequest($audioPath, $options);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), 'whisper-1'),
+            fn(): array|string => $this->sendTranslationRequest($audioPath, $options),
+        );
 
         // Usage is recorded once inside dispatchMultipart() — no extra
         // tracking here, a second call would double-count the request.

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized\Translation;
 
 use Netresearch\NrLlm\Attribute\AsTranslator;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -115,7 +117,10 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $payload = $this->buildTranslatePayload($text, $targetLanguage, $sourceLanguage, $options);
 
-        $response = $this->sendDeeplRequest('translate', $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), ''),
+            fn(): array => $this->sendDeeplRequest('translate', $payload),
+        );
 
         $translations = $response['translations'] ?? [];
         if (!is_array($translations) || $translations === []) {
@@ -171,7 +176,10 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $payload = $this->buildBatchPayload($texts, $targetLanguage, $sourceLanguage, $options);
 
-        $response = $this->sendDeeplRequest('translate', $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), ''),
+            fn(): array => $this->sendDeeplRequest('translate', $payload),
+        );
 
         $translations = $response['translations'] ?? [];
         if (!is_array($translations)) {

--- a/Documentation/Adr/Adr097SpecializedServicesOnPipeline.rst
+++ b/Documentation/Adr/Adr097SpecializedServicesOnPipeline.rst
@@ -41,9 +41,13 @@ middleware is inert because the per-call budget is still enforced by
 with a correlation id** and the **provider circuit breaker** — a flapping image
 or speech endpoint now trips and fails fast like a chat provider.
 
-This ADR migrates the first service, **DALL·E** (all four entry points:
-generate, generate-multiple, variations, edit). The other four follow the same
-shape.
+All five services are migrated: **DALL·E** (generate/generate-multiple/
+variations/edit), **FAL** (generate/generate-multiple), **Whisper**
+(transcribe/transcribe-from-content/translate-to-English), **TTS** (synthesize)
+and **DeepL** (translate/translate-batch). Each wraps its dispatch in
+``runLifecycle()`` with a ``forService()`` context labelled by its operation
+(``ProviderOperation::ImageGeneration`` / ``Transcription`` / ``SpeechSynthesis``
+/ ``Translation``).
 
 .. _adr-097-consequences:
 
@@ -64,8 +68,8 @@ Consequences
 - ``Classes/Specialized`` now depends on ``Classes/Provider/Middleware``. That is
   the point — the specialized services join the shared lifecycle rather than
   reimplementing it.
-- Deferred, each its own step: migrating FAL / Whisper / TTS / DeepL; applying
-  input-guardrail screening to the specialized prompts; the fail-closed dispatch
+- Deferred, each its own step: applying input-guardrail screening to the
+  specialized prompts; the fail-closed dispatch
   seam that makes a forgotten lifecycle wrapper throw rather than spend
   unmetered (it can only be switched on once all five services route through
   ``runLifecycle()``); and folding the per-service usage recording into a tagged

--- a/Tests/Fixture/CapturingMiddleware.php
+++ b/Tests/Fixture/CapturingMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixture;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+
+/**
+ * A pipeline middleware that records the last context it saw, for asserting
+ * that a call was routed through the pipeline with the expected operation and
+ * provider/model (ADR-097). Add it to a MiddlewarePipeline in a test, run the
+ * call, then read {@see self::$captured}.
+ */
+final class CapturingMiddleware implements ProviderMiddlewareInterface
+{
+    public ?ProviderCallContext $captured = null;
+
+    public function handle(ProviderCallContext $context, callable $next): mixed
+    {
+        $this->captured = $context;
+
+        return $next($context);
+    }
+}

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -12,7 +12,6 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
-use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
@@ -25,6 +24,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -51,6 +51,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(FalImageService::class)]
 class FalImageServiceTest extends AbstractUnitTestCase
 {
+    use PipelineRoutingAssertionTrait;
+
     private ClientInterface&Stub $httpClientStub;
     private RequestFactoryInterface&Stub $requestFactoryStub;
     private StreamFactoryInterface&Stub $streamFactoryStub;
@@ -615,11 +617,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
 
         $service->generate('a sunset', 'flux-schnell');
 
-        $captured = $capture->captured;
-        self::assertInstanceOf(ProviderCallContext::class, $captured);
-        self::assertSame(ProviderOperation::ImageGeneration, $captured->operation);
-        self::assertNotSame('', $captured->telemetryProvider());
-        self::assertNotSame('', $captured->correlationId);
+        $this->assertRoutedThroughPipeline($capture, ProviderOperation::ImageGeneration);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Image;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -21,6 +23,7 @@ use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -87,6 +90,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         ExtensionConfiguration $extensionConfiguration,
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
+        ?MiddlewarePipeline $pipeline = null,
     ): FalImageService {
         $service = new FalImageService(
             $this->vaultStub,
@@ -97,7 +101,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             $logger,
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([]),
         );
         $service->setHttpClient($httpClient);
 
@@ -578,6 +582,44 @@ class FalImageServiceTest extends AbstractUnitTestCase
         self::assertEquals('flux-schnell', $result->model);
         self::assertEquals('1024x1024', $result->size);
         self::assertEquals('fal', $result->provider);
+    }
+
+    #[Test]
+    public function aCallIsRoutedThroughThePipelineWithAServiceContext(): void
+    {
+        $capture = new CapturingMiddleware();
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'image' => [
+                    'fal' => [
+                        'apiKeyIdentifier' => 'test-api-key',
+                    ],
+                ],
+            ]);
+
+        $service = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+            new MiddlewarePipeline([$capture]),
+        );
+        $this->setupSuccessfulRequest([
+            'images' => [['url' => 'https://fal.media/files/image.png']],
+        ]);
+
+        $service->generate('a sunset', 'flux-schnell');
+
+        $captured = $capture->captured;
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        self::assertSame(ProviderOperation::ImageGeneration, $captured->operation);
+        self::assertNotSame('', $captured->telemetryProvider());
+        self::assertNotSame('', $captured->correlationId);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/PipelineRoutingAssertionTrait.php
+++ b/Tests/Unit/Specialized/PipelineRoutingAssertionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
+
+/**
+ * Shared assertion for the specialized-service pipeline-routing tests (ADR-097).
+ *
+ * Every specialized service (DALL·E, FAL, Whisper, TTS, DeepL) wraps its HTTP
+ * dispatch in a MiddlewarePipeline run with a service-scoped
+ * {@see ProviderCallContext}. Each service test drives one such call through a
+ * {@see CapturingMiddleware} and asserts the captured context here, so the
+ * identical five-line expectation lives once instead of per test file.
+ */
+trait PipelineRoutingAssertionTrait
+{
+    private function assertRoutedThroughPipeline(
+        CapturingMiddleware $capture,
+        ProviderOperation $expectedOperation,
+    ): void {
+        $captured = $capture->captured;
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        self::assertSame($expectedOperation, $captured->operation);
+        self::assertNotSame('', $captured->telemetryProvider());
+        self::assertNotSame('', $captured->correlationId);
+    }
+}

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -24,6 +26,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\SpeechSynthesisResult;
 use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -91,6 +94,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
         array $repositories = [],
+        ?MiddlewarePipeline $pipeline = null,
     ): TextToSpeechService {
         $service = new TextToSpeechService(
             $this->vaultStub,
@@ -101,7 +105,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );
@@ -356,6 +360,39 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         self::assertEquals('mp3', $result->format);
         self::assertEquals('tts-1', $result->model);
         self::assertEquals('alloy', $result->voice);
+    }
+
+    #[Test]
+    public function aCallIsRoutedThroughThePipelineWithAServiceContext(): void
+    {
+        // ADR-097: the HTTP dispatch runs through the shared MiddlewarePipeline
+        // with a service-scoped ProviderCallContext (SpeechSynthesis operation).
+        $capture = new CapturingMiddleware();
+
+        $this->setupSuccessfulRequest();
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn(['providers' => ['openai' => ['apiKeyIdentifier' => 'test-api-key']]]);
+
+        $subject = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+            [],
+            new MiddlewarePipeline([$capture]),
+        );
+
+        $subject->synthesize('hello world');
+
+        $captured = $capture->captured;
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        self::assertSame(ProviderOperation::SpeechSynthesis, $captured->operation);
+        self::assertNotSame('', $captured->telemetryProvider());
+        self::assertNotSame('', $captured->correlationId);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -14,7 +14,6 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
-use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -28,6 +27,7 @@ use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -51,6 +51,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(TextToSpeechService::class)]
 class TextToSpeechServiceTest extends AbstractUnitTestCase
 {
+    use PipelineRoutingAssertionTrait;
+
     private ClientInterface&Stub $httpClientStub;
     private RequestFactoryInterface&Stub $requestFactoryStub;
     private StreamFactoryInterface&Stub $streamFactoryStub;
@@ -388,11 +390,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
 
         $subject->synthesize('hello world');
 
-        $captured = $capture->captured;
-        self::assertInstanceOf(ProviderCallContext::class, $captured);
-        self::assertSame(ProviderOperation::SpeechSynthesis, $captured->operation);
-        self::assertNotSame('', $captured->telemetryProvider());
-        self::assertNotSame('', $captured->correlationId);
+        $this->assertRoutedThroughPipeline($capture, ProviderOperation::SpeechSynthesis);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -14,7 +14,6 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
-use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -29,6 +28,7 @@ use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -51,6 +51,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 #[CoversClass(WhisperTranscriptionService::class)]
 class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 {
+    use PipelineRoutingAssertionTrait;
+
     private ClientInterface&Stub $httpClientStub;
     private RequestFactoryInterface&Stub $requestFactoryStub;
     private StreamFactoryInterface&Stub $streamFactoryStub;
@@ -1530,10 +1532,6 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
         $service->transcribe($audioFile);
 
-        $captured = $capture->captured;
-        self::assertInstanceOf(ProviderCallContext::class, $captured);
-        self::assertSame(ProviderOperation::Transcription, $captured->operation);
-        self::assertNotSame('', $captured->telemetryProvider());
-        self::assertNotSame('', $captured->correlationId);
+        $this->assertRoutedThroughPipeline($capture, ProviderOperation::Transcription);
     }
 }

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -25,6 +27,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\TranscriptionResult;
 use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -118,6 +121,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         UsageTrackerServiceInterface $usageTracker,
         LoggerInterface $logger,
         array $repositories = [],
+        ?MiddlewarePipeline $pipeline = null,
     ): WhisperTranscriptionService {
         $service = new WhisperTranscriptionService(
             $this->vaultStub,
@@ -128,7 +132,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );
@@ -1490,5 +1494,46 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         self::assertNotNull($result->metadata);
         self::assertSame('verbose_json', $result->metadata['format'] ?? null);
         self::assertSame('transcribe', $result->metadata['task'] ?? null);
+    }
+
+    #[Test]
+    public function aCallIsRoutedThroughThePipelineWithAServiceContext(): void
+    {
+        // ADR-097: the HTTP dispatch runs through the shared MiddlewarePipeline
+        // with a service ProviderCallContext (Transcription operation), so a
+        // capturing middleware observes the context the service built.
+        $capture = new CapturingMiddleware();
+        $audioFile = $this->createTestAudioFile();
+        $this->setupSuccessfulRequest((string)json_encode(['text' => 'Hello']));
+
+        $this->extensionConfigMock
+            ->expects(self::once())->method('get')
+            ->with('nr_llm')
+            ->willReturn([
+                'providers' => [
+                    'openai' => [
+                        'apiKeyIdentifier' => 'test-api-key',
+                    ],
+                ],
+            ]);
+
+        $service = $this->buildService(
+            $this->httpClientStub,
+            $this->requestFactoryStub,
+            $this->streamFactoryStub,
+            $this->extensionConfigMock,
+            $this->usageTrackerStub,
+            $this->loggerStub,
+            [],
+            new MiddlewarePipeline([$capture]),
+        );
+
+        $service->transcribe($audioFile);
+
+        $captured = $capture->captured;
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        self::assertSame(ProviderOperation::Transcription, $captured->operation);
+        self::assertNotSame('', $captured->telemetryProvider());
+        self::assertNotSame('', $captured->correlationId);
     }
 }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use LogicException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -19,6 +21,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
@@ -73,8 +76,10 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
      * The translator is wired to a vault mock and the response client is
      * injected through the test seam (bypassing the vault secure client).
      */
-    private function createSubjectWithResponse(ResponseInterface $response): DeepLTranslator
-    {
+    private function createSubjectWithResponse(
+        ResponseInterface $response,
+        ?MiddlewarePipeline $pipeline = null,
+    ): DeepLTranslator {
         /** @var ClientInterface&MockObject $httpClientStub */
         $httpClientStub = self::createStub(ClientInterface::class);
         $httpClientStub->method('sendRequest')->willReturn($response);
@@ -88,7 +93,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([]),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -1323,5 +1328,32 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         );
 
         self::assertFalse($translator->isAvailable());
+    }
+
+    /**
+     * ADR-097: the HTTP dispatch is routed through the shared MiddlewarePipeline
+     * via runLifecycle(), building a service-scoped ProviderCallContext so a
+     * middleware observes the Translation operation and a non-empty telemetry
+     * provider / correlation id.
+     */
+    #[Test]
+    public function aCallIsRoutedThroughThePipelineWithAServiceContext(): void
+    {
+        $capture = new CapturingMiddleware();
+
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock([
+                'translations' => [['text' => 'Hello', 'detected_source_language' => 'DE']],
+            ]),
+            new MiddlewarePipeline([$capture]),
+        );
+
+        $subject->translate('Hallo', 'en');
+
+        $captured = $capture->captured;
+        self::assertInstanceOf(ProviderCallContext::class, $captured);
+        self::assertSame(ProviderOperation::Translation, $captured->operation);
+        self::assertNotSame('', $captured->telemetryProvider());
+        self::assertNotSame('', $captured->correlationId);
     }
 }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use LogicException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
-use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -23,6 +22,7 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -41,6 +41,8 @@ use ReflectionClass;
 #[CoversClass(DeepLTranslator::class)]
 class DeepLTranslatorTest extends AbstractUnitTestCase
 {
+    use PipelineRoutingAssertionTrait;
+
     private DeepLTranslator $subject;
     private UsageTrackerServiceInterface $usageTrackerStub;
 
@@ -1350,10 +1352,6 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
 
         $subject->translate('Hallo', 'en');
 
-        $captured = $capture->captured;
-        self::assertInstanceOf(ProviderCallContext::class, $captured);
-        self::assertSame(ProviderOperation::Translation, $captured->operation);
-        self::assertNotSame('', $captured->telemetryProvider());
-        self::assertNotSame('', $captured->correlationId);
+        $this->assertRoutedThroughPipeline($capture, ProviderOperation::Translation);
     }
 }


### PR DESCRIPTION
## What

Completes the specialized-service pipeline migration begun with DALL·E (ADR-097). The remaining four services now wrap their HTTP dispatch in `runLifecycle()` with a `forService()` context, so **every** specialized AI call writes a telemetry row with a correlation id and is guarded by the provider circuit breaker — the same treatment a chat call gets.

| Service | Entry points | Operation |
|---------|--------------|-----------|
| FAL | generate, generate-multiple | `ImageGeneration` |
| Whisper | transcribe, transcribe-from-content, translate-to-English | `Transcription` |
| TTS | synthesize | `SpeechSynthesis` |
| DeepL | translate, translate-batch | `Translation` |

## Not changed

Budget and usage stay exactly as with DALL·E: `enforceBudget()` still runs before dispatch and `BudgetMiddleware` stays inert for a service context (no budget metadata), and each service keeps its own usage recording. No double budget check.

## Tests

`CapturingMiddleware` fixture + one routing test per service asserting the call reaches the pipeline with the correct `ProviderOperation` and a non-empty telemetry provider / correlation id. Full local gate green: cgl, phpstan (level 10), unit, functional (sqlite), rector, fuzzy.

## Still deferred (own steps)

- Input-guardrail screening on specialized prompts.
- Fail-closed dispatch seam (now switchable since all five route through `runLifecycle`).
- Folding per-service usage recording into a tagged pipeline extractor.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
