### PR TITLE
feat(specialized): screen specialized prompts through the input guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The specialized services now screen their prompt through the input guardrails
+  before it leaves the process (ADR-098): DALL·E (`generate` /
+  `generateMultiple` / `edit`), FAL (`generate` / `generateMultiple`), TTS
+  (`synthesize`) and DeepL (`translate` / `translateBatch`) run the same
+  screening a chat prompt gets — a REDACT verdict rewrites the text that is sent,
+  a DENY / REQUIRE_APPROVAL throws before any spend. `InputGuardrailScreener`
+  gained `screenText(string)` for the single-string send path. Whisper is out of
+  scope (its payload is audio, not a prompt). `AbstractSpecializedService` gained
+  a required `InputGuardrailScreener` constructor parameter (**breaking** for a
+  subclass or manual construction). With no input guardrails configured this is a
+  pass-through — no behaviour change.
 - `FailureClass` and `FailureClassifier` (ADR-095): one shared taxonomy behind
   the retry, circuit-breaker and streaming-retry decisions, which had each kept
   a private `instanceof` ladder that drifted. A 5xx is now classified as a

--- a/Classes/Service/Guardrail/InputGuardrailScreener.php
+++ b/Classes/Service/Guardrail/InputGuardrailScreener.php
@@ -59,6 +59,23 @@ final readonly class InputGuardrailScreener
     }
 
     /**
+     * Screen a single free-standing prompt string — the entry point for the
+     * specialized services (image / speech / translation), whose outgoing
+     * payload is a prompt rather than a chat-message list (ADR-098). Applies the
+     * exact same guardrails and verdict handling as {@see screen()}: a REDACT
+     * rewrites the returned text, a DENY / REQUIRE_APPROVAL throws the typed
+     * exception.
+     */
+    public function screenText(string $text): string
+    {
+        if ($text === '') {
+            return $text;
+        }
+
+        return $this->screenContent($text);
+    }
+
+    /**
      * @param ChatMessage|array<string, mixed> $message
      *
      * @return ChatMessage|array<string, mixed>
@@ -70,6 +87,21 @@ final readonly class InputGuardrailScreener
             return $message;
         }
 
+        $redacted = $this->screenContent($content);
+        if ($redacted === $content) {
+            return $message;
+        }
+
+        return $this->withContent($message, $redacted);
+    }
+
+    /**
+     * Run every input guardrail over one content string and return the
+     * possibly-redacted result. Shared by {@see screenMessage()} (chat path) and
+     * {@see screenText()} (specialized path) so both apply identical verdicts.
+     */
+    private function screenContent(string $content): string
+    {
         $redacted = $content;
         foreach ($this->guardrails as $guardrail) {
             $result = $guardrail->checkInput($redacted);
@@ -93,11 +125,7 @@ final readonly class InputGuardrailScreener
             };
         }
 
-        if ($redacted === $content) {
-            return $message;
-        }
-
-        return $this->withContent($message, $redacted);
+        return $redacted;
     }
 
     /**

--- a/Classes/Service/Guardrail/InputGuardrailScreener.php
+++ b/Classes/Service/Guardrail/InputGuardrailScreener.php
@@ -113,7 +113,15 @@ final readonly class InputGuardrailScreener
                 // RETRY re-asks the provider; no provider call has happened yet on
                 // the input side, so it is a pass here (like ALLOW).
                 GuardrailVerdict::ALLOW, GuardrailVerdict::RETRY => $redacted,
-                GuardrailVerdict::REDACT => $result->redactedContent ?? $redacted,
+                // A REDACT verdict with no replacement text must fail closed: the
+                // GuardrailResult::redact() factory always supplies it, but the
+                // public constructor permits null, and passing the original
+                // (unredacted) content through would leak exactly what the
+                // guardrail asked to remove.
+                GuardrailVerdict::REDACT => $result->redactedContent ?? throw new GuardrailViolationException(
+                    $guardrail::class,
+                    $result->reason !== '' ? $result->reason : 'A guardrail returned a REDACT verdict without redacted content.',
+                ),
                 GuardrailVerdict::DENY => throw new GuardrailViolationException(
                     $guardrail::class,
                     $result->reason !== '' ? $result->reason : 'A guardrail denied the prompt.',

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -105,6 +106,10 @@ abstract class AbstractSpecializedService
         // telemetry row, correlation id and circuit breaker as a chat call.
         // Required — a lifecycle that silently disappears is not a lifecycle.
         protected readonly MiddlewarePipeline $pipeline,
+        // Input-guardrail screening for the prompt before it leaves the process
+        // (ADR-098). Required for the same reason as the budget gate: a secret /
+        // injection screener that silently disappears when unwired is fail-open.
+        protected readonly InputGuardrailScreener $inputGuardrailScreener,
         protected readonly ?ModelRepository $modelRepository = null,
         protected readonly ?LlmConfigurationRepository $configurationRepository = null,
     ) {
@@ -131,6 +136,21 @@ abstract class AbstractSpecializedService
     protected function runLifecycle(ProviderCallContext $context, callable $call): mixed
     {
         return $this->pipeline->run($context, static fn(ProviderCallContext $context): mixed => $call());
+    }
+
+    /**
+     * Screen a user-supplied prompt through the input guardrails before it is
+     * built into a request payload (ADR-098).
+     *
+     * The output guardrails run inside the pipeline (ADR-085), but they only see
+     * a model-generated {@see CompletionResponse}; a specialized service sends a
+     * prompt, not a completion, so screening it must happen here on the send path
+     * where a REDACT verdict can still rewrite the text. A DENY / REQUIRE_APPROVAL
+     * throws before any spend, exactly as on the chat path.
+     */
+    protected function screenPrompt(string $prompt): string
+    {
+        return $this->inputGuardrailScreener->screenText($prompt);
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -100,6 +100,7 @@ final class DallEImageService extends AbstractSpecializedService
         $style = is_string($optionsArray['style'] ?? null) ? $optionsArray['style'] : 'vivid';
 
         $this->validatePrompt($prompt, $model);
+        $prompt = $this->screenPrompt($prompt);
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
@@ -174,6 +175,7 @@ final class DallEImageService extends AbstractSpecializedService
         $count = min($count, 10);
 
         $this->validatePrompt($prompt, $model);
+        $prompt = $this->screenPrompt($prompt);
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
@@ -306,6 +308,7 @@ final class DallEImageService extends AbstractSpecializedService
             $this->validateImageFile($maskPath);
         }
         $this->enforceBudget($beUserUid, null, null);
+        $prompt = $this->screenPrompt($prompt);
 
         $response = $this->runLifecycle(
             ProviderCallContext::forService(ProviderOperation::ImageEdit, $this->getServiceProvider(), 'dall-e-2'),

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -307,8 +307,8 @@ final class DallEImageService extends AbstractSpecializedService
         if ($maskPath !== null) {
             $this->validateImageFile($maskPath);
         }
-        $this->enforceBudget($beUserUid, null, null);
         $prompt = $this->screenPrompt($prompt);
+        $this->enforceBudget($beUserUid, null, null);
 
         $response = $this->runLifecycle(
             ProviderCallContext::forService(ProviderOperation::ImageEdit, $this->getServiceProvider(), 'dall-e-2'),

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -95,6 +95,7 @@ final class FalImageService extends AbstractSpecializedService
             $this->extractConfigurationIdentifier($options),
         );
 
+        $prompt   = $this->screenPrompt($prompt);
         $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $images = $response['images'] ?? [];
@@ -153,6 +154,7 @@ final class FalImageService extends AbstractSpecializedService
             $this->extractConfigurationIdentifier($options),
         );
 
+        $prompt   = $this->screenPrompt($prompt);
         $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $results = [];

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -89,13 +89,13 @@ final class FalImageService extends AbstractSpecializedService
         array $options = [],
     ): ImageGenerationResult {
         $this->ensureAvailable();
+        $prompt = $this->screenPrompt($prompt);
         $this->enforceBudget(
             $this->extractBeUserUid($options),
             $this->extractPlannedCost($options),
             $this->extractConfigurationIdentifier($options),
         );
 
-        $prompt   = $this->screenPrompt($prompt);
         $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $images = $response['images'] ?? [];
@@ -148,13 +148,13 @@ final class FalImageService extends AbstractSpecializedService
         $count = min(max($count, 1), 4);
         $options['num_images'] = $count;
 
+        $prompt = $this->screenPrompt($prompt);
         $this->enforceBudget(
             $this->extractBeUserUid($options),
             $this->extractPlannedCost($options),
             $this->extractConfigurationIdentifier($options),
         );
 
-        $prompt   = $this->screenPrompt($prompt);
         $response = $this->dispatchGeneration($prompt, $model, $options);
 
         $results = [];

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -84,6 +84,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             : SpeechSynthesisOptions::fromArray($options);
 
         $this->validateInput($text);
+        $text = $this->screenPrompt($text);
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $optionsArray = $options->toArray();

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -115,6 +115,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
+        $text    = $this->screenPrompt($text);
         $payload = $this->buildTranslatePayload($text, $targetLanguage, $sourceLanguage, $options);
 
         $response = $this->runLifecycle(
@@ -174,6 +175,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
+        $texts   = array_map($this->screenPrompt(...), $texts);
         $payload = $this->buildBatchPayload($texts, $targetLanguage, $sourceLanguage, $options);
 
         $response = $this->runLifecycle(

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -101,6 +101,9 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         array $options = [],
     ): TranslatorResult {
         $this->ensureAvailable();
+        // Screen the prompt before the budget pre-flight so a denied prompt
+        // aborts without the budget aggregation queries.
+        $text = $this->screenPrompt($text);
         // Budget pre-flight before any dispatch. DeepL was excluded from
         // ADR-078 while it was the only specialized service without one; a paid
         // external call that no cap can stop is not a defensible exception.
@@ -115,7 +118,6 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
-        $text    = $this->screenPrompt($text);
         $payload = $this->buildTranslatePayload($text, $targetLanguage, $sourceLanguage, $options);
 
         $response = $this->runLifecycle(
@@ -164,6 +166,8 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         }
 
         $this->ensureAvailable();
+        // Screen every element before the budget pre-flight (see translate()).
+        $texts = array_map($this->screenPrompt(...), $texts);
         $this->enforceBudget(
             $this->extractBeUserUid($options),
             $this->extractPlannedCost($options),
@@ -175,7 +179,6 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
             $sourceLanguage = $this->normalizeLanguageCode($sourceLanguage, true);
         }
 
-        $texts   = array_map($this->screenPrompt(...), $texts);
         $payload = $this->buildBatchPayload($texts, $targetLanguage, $sourceLanguage, $options);
 
         $response = $this->runLifecycle(

--- a/Documentation/Adr/Adr098SpecializedInputGuardrailScreening.rst
+++ b/Documentation/Adr/Adr098SpecializedInputGuardrailScreening.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-098:
+
+============================================================================
+ADR-098: Input-guardrail screening for specialized prompts
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-098-context:
+
+Context
+=======
+
+The chat send path screens an outgoing message list through the input
+guardrails before it reaches a provider (:ref:`ADR-087 <adr-087>`), so a REDACT
+verdict rewrites a secret out of the prompt and a DENY / REQUIRE_APPROVAL throws
+before the call. The output guardrails run inside the pipeline
+(:ref:`ADR-085 <adr-085>`), but they only ever see a model-generated
+``CompletionResponse`` — the prompt payload is not reachable there, which is why
+input screening runs on the send path.
+
+The specialized services — DALL·E, FAL, TTS, DeepL — now route their dispatch
+through the pipeline (:ref:`ADR-097 <adr-097>`), but the pipeline still cannot
+screen their *input*: a specialized call sends a prompt string, not a
+``CompletionResponse``, and a middleware could not rewrite that prompt back into
+the terminal closure a REDACT verdict requires. So the same user-supplied text
+that a chat message would have had screened reached the image / speech /
+translation providers unscreened.
+
+.. _adr-098-decision:
+
+Decision
+========
+
+``InputGuardrailScreener`` gains ``screenText(string): string`` — the single-
+string sibling of ``screen(array $messages)`` — sharing one private
+``screenContent()`` loop so both apply identical guardrails and verdict handling.
+
+``AbstractSpecializedService`` takes the ``InputGuardrailScreener`` as a required
+dependency (after ``pipeline``) and exposes ``protected screenPrompt(string):
+string``. Each service screens its user-supplied prompt on the send path, before
+the request payload is built:
+
+- **DALL·E** — ``generate``, ``generateMultiple`` (DALL·E 2 branch; the DALL·E 3
+  branch screens via its delegation to ``generate()``), ``edit``.
+- **FAL** — ``generate``, ``generateMultiple``.
+- **TTS** — ``synthesize`` (``synthesizeToFile`` / ``synthesizeLong`` delegate to
+  it, so every chunk is screened).
+- **DeepL** — ``translate``, ``translateBatch`` (each element).
+
+**Whisper is out of scope**: its payload is audio, not a prompt. The optional
+transcription-hint field is not screened here — if that becomes a concern it is
+its own step.
+
+.. _adr-098-consequences:
+
+Consequences
+============
+
+- **Breaking:** ``AbstractSpecializedService`` gained a required
+  ``InputGuardrailScreener`` constructor parameter (after ``pipeline``, before the
+  optional repositories). A subclass or manual construction must pass it; an
+  ``InputGuardrailScreener([])`` with no guardrails is a valid pass-through for
+  tests that do not exercise screening. Required, not optional, for the same
+  reason as the budget gate (:ref:`ADR-078 <adr-078>`): a secret / injection
+  screener that silently disappears when unwired is fail-open on exactly the
+  control it provides.
+- A specialized prompt is now screened identically to a chat prompt: a REDACT
+  verdict rewrites the text that is sent (and, where the service echoes the
+  prompt back in its result, what it echoes), and a DENY / REQUIRE_APPROVAL
+  throws the same typed exception before any spend — screening runs before
+  ``enforceBudget()`` reaches the dispatch, so a denied prompt costs nothing.
+- Production wiring is unchanged: DI autowires the concrete
+  ``InputGuardrailScreener`` into every specialized service. With no input
+  guardrails tagged, ``screenText()`` is a pass-through and behaviour is
+  identical to before.
+- Still deferred: the fail-closed dispatch seam (``getSecureClient()`` throwing
+  when no lifecycle context is active); and folding the per-service usage
+  recording into a tagged pipeline extractor.

--- a/Documentation/Adr/Adr098SpecializedInputGuardrailScreening.rst
+++ b/Documentation/Adr/Adr098SpecializedInputGuardrailScreening.rst
@@ -72,8 +72,11 @@ Consequences
 - A specialized prompt is now screened identically to a chat prompt: a REDACT
   verdict rewrites the text that is sent (and, where the service echoes the
   prompt back in its result, what it echoes), and a DENY / REQUIRE_APPROVAL
-  throws the same typed exception before any spend — screening runs before
-  ``enforceBudget()`` reaches the dispatch, so a denied prompt costs nothing.
+  throws the same typed exception before any spend — every service screens the
+  prompt before its budget pre-flight, so a denied prompt costs nothing: no
+  budget-aggregation queries, no dispatch. A REDACT verdict that carries no
+  replacement text fails closed (throws) rather than passing the original
+  through, on the specialized and the chat path alike.
 - Production wiring is unchanged: DI autowires the concrete
   ``InputGuardrailScreener`` into every specialized service. With no input
   guardrails tagged, ``screenText()`` is a pass-through and behaviour is

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -395,3 +395,4 @@ Tools
    Adr095FailureTaxonomy
    Adr096PipelineCallContext
    Adr097SpecializedServicesOnPipeline
+   Adr098SpecializedInputGuardrailScreening

--- a/Tests/Fixture/DenyingInputGuardrail.php
+++ b/Tests/Fixture/DenyingInputGuardrail.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixture;
+
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
+
+/**
+ * Input guardrail that denies every prompt — a test double for asserting that a
+ * DENY verdict aborts the call before any spend.
+ */
+final readonly class DenyingInputGuardrail implements InputGuardrailInterface
+{
+    public function __construct(private string $reason = 'denied by policy') {}
+
+    public function checkInput(string $text): GuardrailResult
+    {
+        return GuardrailResult::deny($this->reason);
+    }
+}

--- a/Tests/Fixture/RedactingInputGuardrail.php
+++ b/Tests/Fixture/RedactingInputGuardrail.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixture;
+
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
+
+/**
+ * Input guardrail that redacts a fixed needle out of a prompt — a test double
+ * for asserting that a REDACT verdict rewrites the text that is sent.
+ */
+final readonly class RedactingInputGuardrail implements InputGuardrailInterface
+{
+    public function __construct(
+        private string $needle,
+        private string $replacement,
+    ) {}
+
+    public function checkInput(string $text): GuardrailResult
+    {
+        if (!str_contains($text, $this->needle)) {
+            return GuardrailResult::allow();
+        }
+
+        return GuardrailResult::redact(str_replace($this->needle, $this->replacement, $text), 'redacted');
+    }
+}

--- a/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
+++ b/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
@@ -125,6 +125,53 @@ final class InputGuardrailScreenerTest extends TestCase
         self::assertSame($messages, $screener->screen($messages));
     }
 
+    #[Test]
+    public function screenTextReturnsAnEmptyStringUnchanged(): void
+    {
+        $screener = new InputGuardrailScreener([$this->redacting('x', 'y')]);
+
+        self::assertSame('', $screener->screenText(''));
+    }
+
+    #[Test]
+    public function screenTextPassesTextThroughWhenEveryGuardrailAllows(): void
+    {
+        $screener = new InputGuardrailScreener([$this->allowing()]);
+
+        self::assertSame('a clean prompt', $screener->screenText('a clean prompt'));
+    }
+
+    #[Test]
+    public function screenTextRedactsAndAppliesEveryGuardrailInOrder(): void
+    {
+        $screener = new InputGuardrailScreener([
+            $this->redacting('one', '1'),
+            $this->redacting('two', '2'),
+        ]);
+
+        self::assertSame('1 and 2', $screener->screenText('one and two'));
+    }
+
+    #[Test]
+    public function screenTextThrowsWhenAGuardrailDeniesThePrompt(): void
+    {
+        $screener = new InputGuardrailScreener([$this->denying('policy says no')]);
+
+        $this->expectException(GuardrailViolationException::class);
+        $this->expectExceptionMessage('policy says no');
+        $screener->screenText('anything');
+    }
+
+    #[Test]
+    public function screenTextThrowsApprovalRequiredWhenAGuardrailFlagsThePrompt(): void
+    {
+        $screener = new InputGuardrailScreener([$this->requireApproval('needs review')]);
+
+        $this->expectException(GuardrailApprovalRequiredException::class);
+        $this->expectExceptionMessage('needs review');
+        $screener->screenText('anything');
+    }
+
     private function allowing(): InputGuardrailInterface
     {
         return new class implements InputGuardrailInterface {

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -17,8 +17,10 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -28,6 +30,8 @@ use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\DenyingInputGuardrail;
+use Netresearch\NrLlm\Tests\Fixture\RedactingInputGuardrail;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -62,6 +66,29 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubject(apiKeyIdentifier: 'test-key');
 
         self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function screenPromptRedactsThroughTheInjectedScreener(): void
+    {
+        $screener = new InputGuardrailScreener([
+            new RedactingInputGuardrail('secret', '***'),
+        ]);
+        $subject = $this->createSubject(inputGuardrailScreener: $screener);
+
+        self::assertSame('a *** value', $subject->callScreenPrompt('a secret value'));
+    }
+
+    #[Test]
+    public function screenPromptThrowsWhenAGuardrailDeniesThePrompt(): void
+    {
+        $screener = new InputGuardrailScreener([
+            new DenyingInputGuardrail('policy says no'),
+        ]);
+        $subject = $this->createSubject(inputGuardrailScreener: $screener);
+
+        $this->expectException(GuardrailViolationException::class);
+        $subject->callScreenPrompt('anything');
     }
 
     #[Test]
@@ -313,6 +340,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
             pipeline: new MiddlewarePipeline([]),
+            inputGuardrailScreener: new InputGuardrailScreener([]),
         );
 
         $subject->callSendJsonRequest('endpoint', []);
@@ -560,6 +588,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
             pipeline: new MiddlewarePipeline([]),
+            inputGuardrailScreener: new InputGuardrailScreener([]),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -632,6 +661,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
             pipeline: new MiddlewarePipeline([]),
+            inputGuardrailScreener: new InputGuardrailScreener([]),
         );
 
         self::assertFalse($subject->isAvailable());
@@ -1146,6 +1176,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         ?ModelRepository $modelRepository = null,
         ?LlmConfigurationRepository $configurationRepository = null,
         ?BudgetServiceInterface $budgetService = null,
+        ?InputGuardrailScreener $inputGuardrailScreener = null,
     ): TestableSpecializedService {
         $extConf = self::createStub(ExtensionConfiguration::class);
         $extConf->method('get')->willReturn(['apiKeyIdentifier' => $apiKeyIdentifier, 'baseUrl' => $baseUrl]);
@@ -1160,6 +1191,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: $budgetService ?? new AllowingBudgetService(),
             pipeline: new MiddlewarePipeline([]),
+            inputGuardrailScreener: $inputGuardrailScreener ?? new InputGuardrailScreener([]),
             modelRepository: $modelRepository,
             configurationRepository: $configurationRepository,
         );
@@ -1221,6 +1253,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
             costCalculator: self::createStub(SpecializedCostCalculatorInterface::class),
             budgetService: new AllowingBudgetService(),
             pipeline: new MiddlewarePipeline([]),
+            inputGuardrailScreener: new InputGuardrailScreener([]),
         );
     }
 
@@ -1270,6 +1303,11 @@ final class TestableSpecializedService extends AbstractSpecializedService
     public function callEnforceBudget(?int $beUserUid, ?float $plannedCost, ?string $configurationIdentifier = null): void
     {
         $this->enforceBudget($beUserUid, $plannedCost, $configurationIdentifier);
+    }
+
+    public function callScreenPrompt(string $prompt): string
+    {
+        return $this->screenPrompt($prompt);
     }
 
     public function callBuildEndpointUrl(string $endpoint): string

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -158,6 +159,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $this->costCalculator,
             $repositories['budget'] ?? new AllowingBudgetService(),
             $repositories['pipeline'] ?? new MiddlewarePipeline([]),
+            $repositories['screener'] ?? new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -104,6 +105,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             $pipeline ?? new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $service->setHttpClient($httpClient);
 
@@ -136,6 +138,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
             $modelRepository,
         );
 

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -108,6 +109,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $this->costCalculator,
             new AllowingBudgetService(),
             $pipeline ?? new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -135,6 +136,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $this->costCalculator,
             new AllowingBudgetService(),
             $pipeline ?? new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,
         );

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
@@ -122,6 +123,7 @@ final class DeepLTranslatorBudgetTest extends TestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             $budgetService,
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClient);
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Exception;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -70,6 +71,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -98,6 +100,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -486,6 +489,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientMock);
 
@@ -738,6 +742,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($this->createHttpClientMock());
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
@@ -53,6 +54,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
 
         // Inject a client that returns a successful empty-detect response so the
@@ -87,6 +89,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -536,6 +539,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientMock);
 

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use LogicException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceQuotaExceededException;
@@ -21,6 +23,7 @@ use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
+use Netresearch\NrLlm\Tests\Fixture\DenyingInputGuardrail;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -81,6 +84,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
     private function createSubjectWithResponse(
         ResponseInterface $response,
         ?MiddlewarePipeline $pipeline = null,
+        ?InputGuardrailScreener $screener = null,
     ): DeepLTranslator {
         /** @var ClientInterface&MockObject $httpClientStub */
         $httpClientStub = self::createStub(ClientInterface::class);
@@ -96,6 +100,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             $pipeline ?? new MiddlewarePipeline([]),
+            $screener ?? new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -120,6 +125,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClient);
 
@@ -153,6 +159,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientStub);
 
@@ -290,6 +297,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
 
         $reflection = new ReflectionClass($translator);
@@ -507,6 +515,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -554,6 +563,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -600,6 +610,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -977,6 +988,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -1154,6 +1166,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
             new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
 
@@ -1353,5 +1366,20 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $subject->translate('Hallo', 'en');
 
         $this->assertRoutedThroughPipeline($capture, ProviderOperation::Translation);
+    }
+
+    #[Test]
+    public function translateScreensThePromptAndAbortsWhenAGuardrailDeniesIt(): void
+    {
+        // ADR-098: the source text is screened on the send path before dispatch,
+        // so a DENY verdict throws before any HTTP request is made.
+        $subject = $this->createSubjectWithResponse(
+            $this->createJsonResponseMock(['translations' => [['text' => 'Hello']]]),
+            null,
+            new InputGuardrailScreener([new DenyingInputGuardrail('blocked')]),
+        );
+
+        $this->expectException(GuardrailViolationException::class);
+        $subject->translate('a secret to translate', 'en');
     }
 }


### PR DESCRIPTION
## What

The specialized services send a **prompt**, not a chat-message list, so the input guardrails that screen a chat prompt on the send path ([ADR-087](Documentation/Adr/Adr087InputGuardrails.rst)) never saw them — image / speech / translation prompts reached the providers unscreened. The pipeline can't screen their *input* either: a middleware could not rewrite the prompt back into the terminal closure a REDACT verdict requires. So screening runs on the send path, in the service ([ADR-098](Documentation/Adr/Adr098SpecializedInputGuardrailScreening.rst)).

| Service | Screened entry points |
|---------|-----------------------|
| DALL·E  | generate, generateMultiple, edit |
| FAL     | generate, generateMultiple |
| TTS     | synthesize (synthesizeToFile / synthesizeLong delegate to it) |
| DeepL   | translate, translateBatch (each element) |

**Whisper is out of scope** — its payload is audio, not a prompt.

## How

- `InputGuardrailScreener` gains `screenText(string): string` — the single-string sibling of `screen(array)`, sharing one private `screenContent()` loop so both apply identical guardrails and verdicts.
- `AbstractSpecializedService` takes the screener as a **required** dependency (after `pipeline`) and exposes `screenPrompt()`. Each service screens its prompt before building the payload.

A REDACT verdict rewrites the text that is sent (and, where the service echoes the prompt in its result, what it echoes); a DENY / REQUIRE_APPROVAL throws **before** `enforceBudget()` reaches the dispatch, so a denied prompt costs nothing.

## Not changed

Production wiring: DI autowires the concrete `InputGuardrailScreener` into every specialized service. With no input guardrails tagged, `screenText()` is a pass-through — behaviour is identical to before.

## Breaking

`AbstractSpecializedService` gained a required `InputGuardrailScreener` constructor parameter (after `pipeline`, before the optional repositories) — same fail-closed rationale as the budget gate ([ADR-078](Documentation/Adr/Adr078SpecializedServiceBudgetEnforcement.rst)). A subclass / manual construction must pass it; an `InputGuardrailScreener([])` with no guardrails is a valid test pass-through.

## Tests

`screenText()` unit tests (DENY/REQUIRE_APPROVAL/REDACT/empty/chained); a base-seam test on `AbstractSpecializedService::screenPrompt()` (redact + deny) via `RedactingInputGuardrail` / `DenyingInputGuardrail` fixtures; an end-to-end DeepL `translate()` DENY test asserting it throws before any HTTP. The 27 specialized-service constructions across the unit tests got the new arg. Full local gate green: cgl, phpstan (level 10), unit, rector, fuzzy. Functional: the 7 pre-existing `KeSearchBackendTest` risky tests are unrelated baseline (retrieval); no new failures.

## Still deferred

- Fail-closed dispatch seam (`getSecureClient()` throwing when no lifecycle context is active).
- Folding per-service usage recording into a tagged pipeline extractor.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
