### PR TITLE
fix: count one usage request per translation (#473)

### DIFF
--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -83,6 +83,16 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_TASK_UID = 'task_uid';
 
+    /**
+     * Pipeline-metadata key: when set to `true`, this call records its metrics
+     * (tokens/cost) but does NOT increment the request counter. LlmServiceManager
+     * sets it from `ChatOptions::getSuppressRequestCount()` for provider sub-calls
+     * that belong to a higher-level operation which records its own single request
+     * row (e.g. the language-detection step of a translation), preventing the
+     * "one translation counted as two requests" double-count.
+     */
+    public const METADATA_SKIP_REQUEST_COUNT = 'skip_request_count';
+
     public function __construct(
         private UsageTrackerServiceInterface $usageTracker,
         private LoggerInterface $logger,
@@ -174,6 +184,11 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             ? $context->metadata[BudgetMiddleware::METADATA_BE_USER_UID]
             : null;
 
+        // A sub-call flagged by the manager (e.g. a translation's language
+        // detection) still records its tokens/cost here, but the request is
+        // counted only once — on the parent operation's own row.
+        $countsAsRequest = ($context->metadata[self::METADATA_SKIP_REQUEST_COUNT] ?? null) !== true;
+
         $this->usageTracker->trackUsage(
             serviceType: $context->operation->value,
             provider: $provider !== '' ? $provider : 'unknown',
@@ -183,6 +198,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             modelId: $modelId,
             taskUid: $taskUid,
             beUserUid: $beUserUid,
+            countsAsRequest: $countsAsRequest,
         );
     }
 

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -241,20 +241,37 @@ final readonly class TranslationService implements TranslationServiceInterface
      */
     public function detectLanguage(string $text, ?TranslationOptions $options = null): string
     {
-        $options ??= new TranslationOptions();
+        // Standalone detection is a request in its own right, so it counts.
+        return $this->runLanguageDetection($text, $options ?? new TranslationOptions(), true);
+    }
+
+    /**
+     * Shared language-detection implementation.
+     *
+     * @param bool $countsAsRequest false when detection runs as the internal
+     *                              first step of a translate() call — the
+     *                              translation records the single request-of-
+     *                              record, so the detection sub-call must not
+     *                              increment the request counter too (issue #473
+     *                              double-count). true for a standalone call.
+     *
+     * @return string Language code (ISO 639-1)
+     */
+    private function runLanguageDetection(string $text, TranslationOptions $options, bool $countsAsRequest): string
+    {
         $messages = [
             ChatMessage::system('You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.'),
             ChatMessage::user("Detect the language of this text:\n\n" . $text),
         ];
 
-        $chatOptions = new ChatOptions(
+        $chatOptions = (new ChatOptions(
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
             model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
-        );
+        ))->withSuppressRequestCount(!$countsAsRequest);
 
         $response = $this->llmManager->chat($messages, $chatOptions);
 
@@ -513,9 +530,11 @@ final readonly class TranslationService implements TranslationServiceInterface
 
         $this->validateLanguageCode($targetLanguage);
 
-        // Auto-detect source language if not provided
+        // Auto-detect source language if not provided. This detection is an
+        // internal step of the translation, so it records its tokens/cost but
+        // does not count as a separate request (issue #473 double-count).
         if ($sourceLanguage === null) {
-            $sourceLanguage = $this->detectLanguage($text, $options);
+            $sourceLanguage = $this->runLanguageDetection($text, $options, false);
         } else {
             $this->validateLanguageCode($sourceLanguage);
         }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -220,7 +221,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             return $this->chatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
-                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
+                $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()) + $this->requestCountMetadata($options),
                 $optionsArray,
             );
         }
@@ -234,7 +235,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
             fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->applyAndScreenSystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
-            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()),
+            $this->buildBudgetMetadata($options->getBeUserUid(), $options->getPlannedCost()) + $this->idempotencyMetadata($options->getIdempotencyKey()) + $this->requestCountMetadata($options),
         );
     }
 
@@ -1016,6 +1017,21 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         }
 
         return [IdempotencyMiddleware::METADATA_IDEMPOTENCY_KEY => $idempotencyKey];
+    }
+
+    /**
+     * Pipeline metadata that tells UsageMiddleware to record the call's metrics
+     * without incrementing the request counter. Set for chat sub-calls that
+     * belong to a higher-level operation recording its own request row (e.g. a
+     * translation's language-detection step, or the LLM translator's chat call).
+     *
+     * @return array<string, bool>
+     */
+    private function requestCountMetadata(ChatOptions $options): array
+    {
+        return $options->getSuppressRequestCount()
+            ? [UsageMiddleware::METADATA_SKIP_REQUEST_COUNT => true]
+            : [];
     }
 
     /**

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -43,6 +43,11 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         $this->validate();
     }
 
+    // Set via withSuppressRequestCount() rather than the constructor: ChatOptions
+    // is @phpstan-consistent-constructor and ToolOptions extends it, so a new
+    // constructor parameter would collide with the subclass's own parameters.
+    private ?bool $suppressRequestCount = null;
+
     // ========================================
     // Factory Presets
     // ========================================
@@ -197,6 +202,18 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         return $clone;
     }
 
+    /**
+     * Mark the call as a sub-call of a larger operation: it still records its
+     * tokens/cost but is not counted as a separate request.
+     * See {@see self::getSuppressRequestCount()}.
+     */
+    public function withSuppressRequestCount(bool $suppressRequestCount): static
+    {
+        $clone = clone $this;
+        $clone->suppressRequestCount = $suppressRequestCount;
+        return $clone;
+    }
+
     // Budget pre-flight setters (`withBeUserUid()`, `withPlannedCost()`)
     // are provided by `BudgetFieldsTrait`. See REC #4 for the full
     // contract — `0` is "anonymous / skip the check"; positive uid =
@@ -218,6 +235,22 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
     public function getThink(): ?bool
     {
         return $this->think;
+    }
+
+    /**
+     * Whether the underlying provider call should be recorded WITHOUT
+     * incrementing the request counter. Set on the sub-calls of a larger
+     * operation (a translation's language detection, the LLM translator's
+     * chat call) so that operation is counted as a single request rather
+     * than once per internal provider call.
+     *
+     * Metadata-only: deliberately excluded from toArray() so it never reaches
+     * the provider payload — LlmServiceManager reads it and forwards it as
+     * pipeline metadata, exactly like beUserUid / plannedCost.
+     */
+    public function getSuppressRequestCount(): bool
+    {
+        return $this->suppressRequestCount === true;
     }
 
     public function getMaxTokens(): ?int

--- a/Classes/Service/UsageTrackerService.php
+++ b/Classes/Service/UsageTrackerService.php
@@ -53,6 +53,12 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
      * @param int|null $beUserUid        Backend user to attribute the usage to; null falls
      *                                   back to the ambient `backend.user` context aspect
      *                                   (0 when no backend user is authenticated)
+     * @param bool     $countsAsRequest  Whether this call increments the request counter.
+     *                                   Pass false for a provider sub-call that belongs to
+     *                                   a higher-level operation which records its own
+     *                                   request row (e.g. the language-detection step of a
+     *                                   translation), so the metrics (tokens/cost) are still
+     *                                   aggregated but the request is counted only once.
      */
     public function trackUsage(
         string $serviceType,
@@ -63,10 +69,15 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
         string $modelId = '',
         int $taskUid = 0,
         ?int $beUserUid = null,
+        bool $countsAsRequest = true,
     ): void {
         $beUser = $beUserUid ?? $this->getCurrentBackendUserId();
         $today = strtotime('today');
         $now = time();
+        // Sub-calls of a larger operation (e.g. a translation's language-detection
+        // step) still record their tokens/cost but must not inflate the request
+        // counter — the parent operation records the single request-of-record.
+        $requestIncrement = $countsAsRequest ? 1 : 0;
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
@@ -99,7 +110,7 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
             // Update existing record with incremental values
             $connection->executeStatement(
                 'UPDATE ' . self::TABLE . ' SET
-                    request_count = request_count + 1,
+                    request_count = request_count + :requestIncrement,
                     tokens_used = tokens_used + :tokens,
                     prompt_tokens = prompt_tokens + :promptTokens,
                     completion_tokens = completion_tokens + :completionTokens,
@@ -110,6 +121,7 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
                     tstamp = :tstamp
                 WHERE uid = :uid',
                 [
+                    'requestIncrement' => $requestIncrement,
                     'tokens' => $metrics['tokens'] ?? 0,
                     'promptTokens' => $metrics['promptTokens'] ?? 0,
                     'completionTokens' => $metrics['completionTokens'] ?? 0,
@@ -132,7 +144,7 @@ final readonly class UsageTrackerService implements UsageTrackerServiceInterface
                 'model_id' => $modelId,
                 'task_uid' => $taskUid,
                 'be_user' => $beUser,
-                'request_count' => 1,
+                'request_count' => $requestIncrement,
                 'tokens_used' => $metrics['tokens'] ?? 0,
                 'prompt_tokens' => $metrics['promptTokens'] ?? 0,
                 'completion_tokens' => $metrics['completionTokens'] ?? 0,

--- a/Classes/Service/UsageTrackerServiceInterface.php
+++ b/Classes/Service/UsageTrackerServiceInterface.php
@@ -39,6 +39,12 @@ interface UsageTrackerServiceInterface
      * @param int|null $beUserUid        Backend user to attribute the usage to; null falls
      *                                   back to the ambient `backend.user` context aspect
      *                                   (0 when no backend user is authenticated)
+     * @param bool     $countsAsRequest  Whether this call increments the request counter.
+     *                                   Pass false for a provider sub-call that belongs to
+     *                                   a higher-level operation which records its own
+     *                                   request row (e.g. the language-detection step of a
+     *                                   translation), so the metrics (tokens/cost) are still
+     *                                   aggregated but the request is counted only once.
      */
     public function trackUsage(
         string $serviceType,
@@ -49,6 +55,7 @@ interface UsageTrackerServiceInterface
         string $modelId = '',
         int $taskUid = 0,
         ?int $beUserUid = null,
+        bool $countsAsRequest = true,
     ): void;
 
     /**

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -81,9 +81,11 @@ final readonly class LlmTranslator implements TranslatorInterface
         // middleware pipeline) and the translation-level tracking row alike.
         $beUserUid = $this->extractBeUserUid($options);
 
-        // Detect source language if not provided
+        // Detect source language if not provided. As an internal step of the
+        // translation it must not count as a separate request (#473) — the
+        // 'translation' row below is the single request of record.
         if ($sourceLanguage === null) {
-            $sourceLanguage = $this->detectLanguageAttributed($text, $beUserUid);
+            $sourceLanguage = $this->detectLanguageAttributed($text, $beUserUid, false);
         }
 
         // Build translation prompt
@@ -182,17 +184,24 @@ final readonly class LlmTranslator implements TranslatorInterface
     {
         // Public TranslatorInterface signature carries no options, so a
         // direct call stays ambient; translate() routes through
-        // detectLanguageAttributed() with the caller's uid instead.
-        return $this->detectLanguageAttributed($text, null);
+        // detectLanguageAttributed() with the caller's uid instead. A
+        // standalone detection is a request in its own right, so it counts.
+        return $this->detectLanguageAttributed($text, null, true);
     }
 
     /**
      * Detect the language of a text, attributing the underlying chat call
-     * to the given backend user (ADR-052). The detection call is billed
-     * like any other chat request — without the uid it lands in the
-     * ambient bucket even when the translation itself is attributed.
+     * to the given backend user (ADR-052).
+     *
+     * @param bool $countsAsRequest false when detection runs as the internal
+     *                              first step of translate() — the translation
+     *                              records the single request-of-record, so the
+     *                              detection sub-call must not increment the
+     *                              request counter too (#473). true for a
+     *                              standalone detectLanguage() call, which is a
+     *                              request in its own right.
      */
-    private function detectLanguageAttributed(string $text, ?int $beUserUid): string
+    private function detectLanguageAttributed(string $text, ?int $beUserUid, bool $countsAsRequest): string
     {
         $messages = [
             [
@@ -205,13 +214,13 @@ final readonly class LlmTranslator implements TranslatorInterface
             ],
         ];
 
-        // Language detection is a sub-step of the translation, not a separate
-        // request (issue #473 double-count).
+        // Suppress the request count only when detection is a sub-step of a
+        // translation; a standalone detectLanguage() call counts (#473).
         $chatOptions = (new ChatOptions(
             temperature: 0.1,
             maxTokens: 10,
             beUserUid: $beUserUid,
-        ))->withSuppressRequestCount(true);
+        ))->withSuppressRequestCount(!$countsAsRequest);
 
         $response = $this->llmManager->chat($messages, $chatOptions);
 

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -107,13 +107,16 @@ final readonly class LlmTranslator implements TranslatorInterface
         // BudgetMiddleware enforces the caller's budget and UsageMiddleware
         // attributes the chat row to the same be_user as the translation row
         // (previously the chat row always landed in the ambient bucket).
-        $chatOptions = new ChatOptions(
+        // The 'translation' row below is the single request-of-record; the
+        // underlying chat row keeps its tokens/cost but must not also count as
+        // a request (issue #473 double-count).
+        $chatOptions = (new ChatOptions(
             temperature: $temperature,
             maxTokens: $maxTokens,
             provider: $provider,
             model: $model,
             beUserUid: $beUserUid,
-        );
+        ))->withSuppressRequestCount(true);
 
         $response = $this->llmManager->chat($prompt['messages'], $chatOptions);
 
@@ -202,11 +205,13 @@ final readonly class LlmTranslator implements TranslatorInterface
             ],
         ];
 
-        $chatOptions = new ChatOptions(
+        // Language detection is a sub-step of the translation, not a separate
+        // request (issue #473 double-count).
+        $chatOptions = (new ChatOptions(
             temperature: 0.1,
             maxTokens: 10,
             beUserUid: $beUserUid,
-        );
+        ))->withSuppressRequestCount(true);
 
         $response = $this->llmManager->chat($messages, $chatOptions);
 

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -104,6 +104,58 @@ final class UsageTrackerServiceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function trackUsageWithCountsAsRequestFalseRecordsMetricsWithoutCountingRequest(): void
+    {
+        // #473: a provider sub-call (e.g. a translation's language detection)
+        // records its tokens/cost but must not increment the request counter.
+        $this->service->trackUsage(
+            'chat',
+            'openai',
+            ['tokens' => 150, 'promptTokens' => 100, 'completionTokens' => 50, 'cost' => 0.01],
+            modelId: 'gpt-4o-mini',
+            countsAsRequest: false,
+        );
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(
+            ['request_count', 'tokens_used', 'estimated_cost'],
+            self::TABLE,
+            ['service_type' => 'chat', 'service_provider' => 'openai'],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertIsNumeric($row['request_count']);
+        self::assertIsNumeric($row['tokens_used']);
+        self::assertIsNumeric($row['estimated_cost']);
+        self::assertSame(0, (int)$row['request_count']);
+        self::assertSame(150, (int)$row['tokens_used']);
+        self::assertEqualsWithDelta(0.01, (float)$row['estimated_cost'], 0.0001);
+    }
+
+    #[Test]
+    public function trackUsageWithCountsAsRequestFalseDoesNotIncrementExistingRequestCount(): void
+    {
+        // A counting call establishes the daily row; a following non-counting
+        // sub-call aggregates its tokens but leaves request_count at 1 — one
+        // logical operation is a single request of record (#473).
+        $this->service->trackUsage('chat', 'openai', ['tokens' => 10], modelId: 'gpt-4o-mini');
+        $this->service->trackUsage('chat', 'openai', ['tokens' => 150], modelId: 'gpt-4o-mini', countsAsRequest: false);
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = $connection->select(
+            ['request_count', 'tokens_used'],
+            self::TABLE,
+            ['service_type' => 'chat', 'service_provider' => 'openai'],
+        )->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertIsNumeric($row['request_count']);
+        self::assertIsNumeric($row['tokens_used']);
+        self::assertSame(1, (int)$row['request_count']);
+        self::assertSame(160, (int)$row['tokens_used']);
+    }
+
+    #[Test]
     public function trackUsageKeepsSeparateRecordsForDifferentModelIds(): void
     {
         // Specialized calls carry model_uid=0 and only a model_id string — two

--- a/Tests/Unit/Fixture/RecordingUsageTracker.php
+++ b/Tests/Unit/Fixture/RecordingUsageTracker.php
@@ -31,6 +31,7 @@ final class RecordingUsageTracker implements UsageTrackerServiceInterface
      *     modelId: string,
      *     taskUid: int,
      *     beUserUid: ?int,
+     *     countsAsRequest: bool,
      * }>
      */
     public array $calls = [];
@@ -44,6 +45,7 @@ final class RecordingUsageTracker implements UsageTrackerServiceInterface
         string $modelId = '',
         int $taskUid = 0,
         ?int $beUserUid = null,
+        bool $countsAsRequest = true,
     ): void {
         $this->calls[] = [
             'serviceType'      => $serviceType,
@@ -54,6 +56,7 @@ final class RecordingUsageTracker implements UsageTrackerServiceInterface
             'modelId'          => $modelId,
             'taskUid'          => $taskUid,
             'beUserUid'        => $beUserUid,
+            'countsAsRequest'  => $countsAsRequest,
         ];
     }
 

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -76,6 +76,75 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function skipRequestCountMetadataRecordsMetricsButNotTheRequest(): void
+    {
+        // #473: when the manager flags a sub-call via METADATA_SKIP_REQUEST_COUNT,
+        // the metrics are still recorded but trackUsage() is told not to count the
+        // request (countsAsRequest = false, the 9th argument).
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                false,
+            );
+
+        $response = new CompletionResponse(
+            content: 'hi',
+            model: 'gpt-4o-mini',
+            usage: new UsageStatistics(100, 50, 150, 0.0012),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::forConfiguration(
+                ProviderOperation::Chat,
+                $this->configuration(uid: 7),
+                [UsageMiddleware::METADATA_SKIP_REQUEST_COUNT => true],
+            ),
+            terminal: static fn(): CompletionResponse => $response,
+        );
+    }
+
+    #[Test]
+    public function requestIsCountedByDefaultWithoutSkipMetadata(): void
+    {
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                true,
+            );
+
+        $response = new CompletionResponse(
+            content: 'hi',
+            model: 'gpt-4o-mini',
+            usage: new UsageStatistics(100, 50, 150, 0.0012),
+            finishReason: 'stop',
+            provider: 'openai',
+        );
+
+        $this->pipeline()->run(
+            context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration(uid: 7)),
+            terminal: static fn(): CompletionResponse => $response,
+        );
+    }
+
+    #[Test]
     public function tracksEmbeddingResponseWithOperationAsServiceType(): void
     {
         $this->tracker->expects(self::once())

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -139,6 +139,85 @@ class TranslationServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function translateSuppressesRequestCountOnTheAutoDetectionSubCall(): void
+    {
+        // Regression for #473: a translate() without a source language makes two
+        // provider calls (detect + translate). Counting both inflated the backend
+        // "requests" KPI to 2 per translation. The detection sub-call must not
+        // count; the translation itself is the single request of record.
+        $capturedOptions = [];
+        $responses = [
+            $this->createChatResponse('en'),     // language detection
+            $this->createChatResponse('Hallo'),  // translation
+        ];
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock
+            ->expects(self::exactly(2))
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ?ChatOptions $options = null) use (&$capturedOptions, &$responses): CompletionResponse {
+                    $capturedOptions[] = $options;
+                    $next = array_shift($responses);
+                    self::assertInstanceOf(CompletionResponse::class, $next);
+
+                    return $next;
+                },
+            );
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            new TranslationPromptBuilder(),
+        );
+
+        $subject->translate('Hello', 'de');
+
+        self::assertCount(2, $capturedOptions);
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions[0]);
+        self::assertTrue(
+            $capturedOptions[0]->getSuppressRequestCount(),
+            'The language-detection sub-call must not be counted as a request.',
+        );
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions[1]);
+        self::assertFalse(
+            $capturedOptions[1]->getSuppressRequestCount(),
+            'The translation itself is the single request of record.',
+        );
+    }
+
+    #[Test]
+    public function detectLanguageStandaloneCountsAsARequest(): void
+    {
+        // Standalone detection is a request in its own right and still counts.
+        $captured = null;
+
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ?ChatOptions $options = null) use (&$captured): CompletionResponse {
+                    $captured = $options;
+
+                    return $this->createChatResponse('en');
+                },
+            );
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            new TranslationPromptBuilder(),
+        );
+
+        $subject->detectLanguage('Hello World');
+
+        self::assertInstanceOf(ChatOptions::class, $captured);
+        self::assertFalse($captured->getSuppressRequestCount());
+    }
+
+    #[Test]
     public function translateCalculatesConfidenceFromFinishReason(): void
     {
         $this->llmManagerStub

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -40,6 +40,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
@@ -1683,6 +1684,54 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // coexists with the budget keys.
         self::assertArrayHasKey(CacheMiddleware::METADATA_CACHE_KEY, $metadata);
         self::assertSame(86400, $metadata[CacheMiddleware::METADATA_CACHE_TTL]);
+    }
+
+    #[Test]
+    public function chatThreadsSuppressRequestCountIntoPipelineMetadata(): void
+    {
+        // #473: ChatOptions::suppressRequestCount must reach the pipeline as the
+        // UsageMiddleware skip-request-count metadata key, so a sub-call's request
+        // is recorded (tokens/cost) without being counted.
+        $spy = new RecordingMiddleware();
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            new MiddlewarePipeline([$spy]),
+            self::createStub(CacheManagerInterface::class),
+        );
+        $manager->registerProvider(new TestableProvider());
+
+        $manager->chat(
+            [['role' => 'user', 'content' => 'Hi']],
+            (new ChatOptions(provider: 'openai'))->withSuppressRequestCount(true),
+        );
+
+        self::assertCount(1, $spy->calls);
+        self::assertArrayHasKey(UsageMiddleware::METADATA_SKIP_REQUEST_COUNT, $spy->calls[0]['metadata']);
+        self::assertTrue($spy->calls[0]['metadata'][UsageMiddleware::METADATA_SKIP_REQUEST_COUNT]);
+    }
+
+    #[Test]
+    public function chatOmitsSkipRequestCountMetadataByDefault(): void
+    {
+        $spy = new RecordingMiddleware();
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            new MiddlewarePipeline([$spy]),
+            self::createStub(CacheManagerInterface::class),
+        );
+        $manager->registerProvider(new TestableProvider());
+
+        $manager->chat(
+            [['role' => 'user', 'content' => 'Hi']],
+            new ChatOptions(provider: 'openai'),
+        );
+
+        self::assertCount(1, $spy->calls);
+        self::assertArrayNotHasKey(UsageMiddleware::METADATA_SKIP_REQUEST_COUNT, $spy->calls[0]['metadata']);
     }
 
     #[Test]

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -167,6 +167,89 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function detectLanguageStandaloneDoesNotSuppressRequestCount(): void
+    {
+        // #473 review: a standalone LlmTranslator::detectLanguage() is a request
+        // in its own right and must count — the translator records no separate
+        // 'translation' row for it, unlike the detection sub-step of translate().
+        $captured = [];
+
+        $managerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $managerMock
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ?ChatOptions $options = null) use (&$captured): CompletionResponse {
+                    $captured[] = $options;
+
+                    return new CompletionResponse(
+                        content: 'en',
+                        model: 'gpt-5.2',
+                        usage: new UsageStatistics(100, 50, 150),
+                        finishReason: 'stop',
+                        provider: 'openai',
+                    );
+                },
+            );
+
+        $translator = new LlmTranslator(
+            $managerMock,
+            self::createStub(UsageTrackerServiceInterface::class),
+        );
+
+        $translator->detectLanguage('Hello World');
+
+        self::assertNotEmpty($captured);
+        self::assertInstanceOf(ChatOptions::class, $captured[0]);
+        self::assertFalse(
+            $captured[0]->getSuppressRequestCount(),
+            'Standalone language detection must count as a request.',
+        );
+    }
+
+    #[Test]
+    public function translateWithAutoDetectionSuppressesBothChatCalls(): void
+    {
+        // #473: an auto-detected translation makes two chat calls (detect +
+        // translate); both must be suppressed so only the 'translation' row
+        // counts, giving exactly one request.
+        $captured = [];
+
+        $managerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $managerMock
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ?ChatOptions $options = null) use (&$captured): CompletionResponse {
+                    $captured[] = $options;
+
+                    return new CompletionResponse(
+                        content: 'en',
+                        model: 'gpt-5.2',
+                        usage: new UsageStatistics(100, 50, 150),
+                        finishReason: 'stop',
+                        provider: 'openai',
+                    );
+                },
+            );
+
+        $translator = new LlmTranslator(
+            $managerMock,
+            self::createStub(UsageTrackerServiceInterface::class),
+        );
+
+        // No source language → auto-detection runs before the translation.
+        $translator->translate('Hello', 'de', null, ['provider' => 'openai']);
+
+        self::assertCount(2, $captured);
+        foreach ($captured as $options) {
+            self::assertInstanceOf(ChatOptions::class, $options);
+            self::assertTrue(
+                $options->getSuppressRequestCount(),
+                'Both the detection and translation chat calls must be suppressed.',
+            );
+        }
+    }
+
+    #[Test]
     public function isAvailableReturnsTrueWhenProviderAvailable(): void
     {
         self::assertTrue($this->subject->isAvailable());

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -126,6 +126,47 @@ class LlmTranslatorTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function translateSuppressesRequestCountOnTheUnderlyingChatCall(): void
+    {
+        // Regression for #473: the translator records its own 'translation' request
+        // row, so the underlying chat call must not be counted as a second request.
+        $capturedOptions = [];
+
+        $managerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $managerMock
+            ->method('chat')
+            ->willReturnCallback(
+                function (array $messages, ?ChatOptions $options = null) use (&$capturedOptions): CompletionResponse {
+                    $capturedOptions[] = $options;
+
+                    return new CompletionResponse(
+                        content: 'Hallo',
+                        model: 'gpt-5.2',
+                        usage: new UsageStatistics(100, 50, 150),
+                        finishReason: 'stop',
+                        provider: 'openai',
+                    );
+                },
+            );
+
+        $translator = new LlmTranslator(
+            $managerMock,
+            self::createStub(UsageTrackerServiceInterface::class),
+        );
+
+        // Explicit source language avoids the auto-detection sub-call, isolating
+        // the translation chat call under assertion.
+        $translator->translate('Hello', 'de', 'en', ['provider' => 'openai']);
+
+        self::assertNotEmpty($capturedOptions);
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions[0]);
+        self::assertTrue(
+            $capturedOptions[0]->getSuppressRequestCount(),
+            'The underlying chat call of a translation must not be counted as a request.',
+        );
+    }
+
+    #[Test]
     public function isAvailableReturnsTrueWhenProviderAvailable(): void
     {
         self::assertTrue($this->subject->isAvailable());


### PR DESCRIPTION
## Problem

Each LLM translation increments the backend **"requests"** KPI by **2** (or **3** when the source language is auto-detected) instead of 1. `LlmServiceManager->complete()` correctly increments by 1. Reported in #473.

## Root cause

`UsageAnalyticsService::getKpiTotals()` sums `request_count` across **all** usage rows with no `service_type` filter, and every `UsageTrackerService::trackUsage()` call increments `request_count` by one. A single translation produced several rows:

- `TranslationService::translate()` / `translateForConfiguration()` run a **separate language-detection `chat()`** when no source language is supplied (`prepareTranslation()` → `detectLanguage()`). That detection recorded its own `chat` request row — this is the path the reporter hit.
- The specialized `LlmTranslator` records its own `translation` row **and** its underlying `chat()` recorded a second `chat` row (plus a third for its internal auto-detection).

Tokens/cost were never double-counted (that split was deliberate) — only `request_count` doubled.

## Fix

A translation is one logical operation and should count as one request; its internal provider sub-calls should still record tokens/cost but not the request.

- `UsageTrackerService::trackUsage()` gains an optional `bool $countsAsRequest = true`. Default `true`, so **every existing caller is byte-for-byte unchanged**; when `false`, the row records its metrics but does not increment `request_count`.
- `ChatOptions::withSuppressRequestCount()` (metadata-only, excluded from `toArray()`, never sent to the provider — same discipline as `beUserUid`/`plannedCost`).
- `LlmServiceManager::chat()` forwards the flag to the pipeline as `UsageMiddleware::METADATA_SKIP_REQUEST_COUNT`; `UsageMiddleware` passes `countsAsRequest: false` when present.
- The detection sub-call (`TranslationService`) and both `LlmTranslator` chat calls set the flag. The translation stays the single request of record. **Standalone `detectLanguage()` still counts** as its own request.

## Tests

- Functional (`UsageTrackerServiceTest`): `countsAsRequest: false` records tokens/cost without incrementing `request_count`, on both the INSERT and UPDATE paths.
- Unit (`UsageMiddlewareTest`): the metadata key maps to `countsAsRequest: false`; default counts.
- Unit (`LlmServiceManagerTest`): `chat()` threads `suppressRequestCount` into pipeline metadata; omits it by default.
- Unit (`TranslationServiceTest`): auto-detect suppresses the detection sub-call and counts the translation; standalone `detectLanguage()` counts.
- Unit (`LlmTranslatorTest`): the translator's underlying chat call is suppressed.

Local: unit (5400), the changed functional file (27), rector, fuzzy, cgl all green; PHPStan adds no errors over the base tree.

Fixes #473
