### PR TITLE
feat(specialized): fail closed on a provider dispatch outside runLifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The specialized HTTP egress fails closed (ADR-099): a provider call that
+  dispatches without wrapping in `runLifecycle()` now throws a `LogicException`
+  instead of silently spending against the provider with no telemetry, circuit
+  breaker or usage. DeepL's `detectLanguage()` (a billable translate call) now
+  routes through the pipeline too, and its `getUsage()` / `getGlossaries()`
+  metadata lookups run under the new `ProviderOperation::Metadata` — observable
+  and circuit-breaker guarded, labelled honestly rather than as a translation.
 - The specialized services now screen their prompt through the input guardrails
   before it leaves the process (ADR-098): DALL·E (`generate` /
   `generateMultiple` / `edit`), FAL (`generate` / `generateMultiple`), TTS

--- a/Classes/Provider/Middleware/ProviderOperation.php
+++ b/Classes/Provider/Middleware/ProviderOperation.php
@@ -35,4 +35,10 @@ enum ProviderOperation: string
     case Transcription = 'transcribe';
     case SpeechSynthesis = 'speech';
     case Translation = 'translate';
+
+    // A provider metadata / status call that is not itself an AI generation —
+    // DeepL usage and glossary lookups. Routed through the pipeline so it is
+    // observable and guarded by the circuit breaker like any provider HTTP call,
+    // but labelled honestly rather than as a translation.
+    case Metadata = 'metadata';
 }

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Specialized;
 
 use JsonException;
+use LogicException;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
@@ -89,6 +90,14 @@ abstract class AbstractSpecializedService
      */
     private ?ClientInterface $configuredHttpClient = null;
 
+    /**
+     * True only while a {@see runLifecycle()} dispatch is executing. The HTTP
+     * egress ({@see assertWithinLifecycle()}) fails closed when it is false, so a
+     * provider call that forgets to wrap its dispatch in the pipeline throws
+     * rather than silently spending unmetered and unobserved (ADR-099).
+     */
+    private bool $withinLifecycle = false;
+
     public function __construct(
         protected readonly VaultServiceInterface $vault,
         protected readonly RequestFactoryInterface $requestFactory,
@@ -135,7 +144,35 @@ abstract class AbstractSpecializedService
      */
     protected function runLifecycle(ProviderCallContext $context, callable $call): mixed
     {
-        return $this->pipeline->run($context, static fn(ProviderCallContext $context): mixed => $call());
+        return $this->pipeline->run($context, function (ProviderCallContext $context) use ($call): mixed {
+            $previous = $this->withinLifecycle;
+            $this->withinLifecycle = true;
+            try {
+                return $call();
+            } finally {
+                $this->withinLifecycle = $previous;
+            }
+        });
+    }
+
+    /**
+     * Guard the HTTP egress: a specialized provider call must run inside a
+     * {@see runLifecycle()} dispatch so it gets a telemetry row, a correlation id
+     * and the circuit breaker (ADR-099). Called before every provider request;
+     * throwing here means a service method dispatched without wrapping — a
+     * programmer error, not a runtime fault, hence {@see \LogicException}.
+     *
+     * @throws LogicException when no lifecycle dispatch is active
+     */
+    protected function assertWithinLifecycle(): void
+    {
+        if (!$this->withinLifecycle) {
+            throw new LogicException(sprintf(
+                '%s attempted a provider HTTP request outside runLifecycle(): the call would bypass telemetry, '
+                . 'the circuit breaker and usage. Wrap the dispatch in runLifecycle().',
+                static::class,
+            ));
+        }
     }
 
     /**
@@ -700,6 +737,10 @@ abstract class AbstractSpecializedService
      */
     protected function executeRequest(RequestInterface $request): array
     {
+        // Fail closed before the try so the guard is not masked by the
+        // Throwable->ServiceUnavailableException wrapping below (ADR-099).
+        $this->assertWithinLifecycle();
+
         try {
             $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -461,6 +461,9 @@ final class TextToSpeechService extends AbstractSpecializedService
             $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)),
         );
 
+        // Fail closed before the try (see AbstractSpecializedService, ADR-099).
+        $this->assertWithinLifecycle();
+
         try {
             $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -398,6 +398,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         }
         $request = $request->withBody($this->streamFactory->createStream($body));
 
+        // Fail closed before the try (see AbstractSpecializedService, ADR-099).
+        $this->assertWithinLifecycle();
+
         try {
             $response = $this->getSecureClient()->sendRequest($request);
             $statusCode = $response->getStatusCode();

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -279,7 +279,10 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
             'target_lang' => 'EN',
         ];
 
-        $response = $this->sendDeeplRequest('translate', $payload);
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), ''),
+            fn(): array => $this->sendDeeplRequest('translate', $payload),
+        );
 
         /** @var array<int, array{text: string, detected_source_language?: string}> $translations */
         $translations = $response['translations'] ?? [];
@@ -322,7 +325,10 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
     {
         $this->ensureAvailable();
 
-        $response = $this->sendDeeplRequest('usage', [], 'GET');
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Metadata, $this->getServiceProvider(), ''),
+            fn(): array => $this->sendDeeplRequest('usage', [], 'GET'),
+        );
 
         $characterCount = $response['character_count'] ?? 0;
         $characterLimit = $response['character_limit'] ?? 0;
@@ -342,7 +348,10 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
     {
         $this->ensureAvailable();
 
-        $response = $this->sendDeeplRequest('glossaries', [], 'GET');
+        $response = $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Metadata, $this->getServiceProvider(), ''),
+            fn(): array => $this->sendDeeplRequest('glossaries', [], 'GET'),
+        );
 
         /** @var array<int, array{glossary_id: string, name: string, source_lang: string, target_lang: string}> $glossaries */
         $glossaries = $response['glossaries'] ?? [];

--- a/Documentation/Adr/Adr099SpecializedFailClosedDispatch.rst
+++ b/Documentation/Adr/Adr099SpecializedFailClosedDispatch.rst
@@ -1,0 +1,72 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-099:
+
+============================================================================
+ADR-099: Fail-closed HTTP egress for the specialized services
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-099-context:
+
+Context
+=======
+
+:ref:`ADR-097 <adr-097>` routed every specialized dispatch through the pipeline
+via ``runLifecycle()``, so an image / speech / translation call now gets the same
+telemetry row, correlation id and circuit breaker as a chat call. But the
+wrapping is a convention: a new service method — or a refactor — that builds a
+request and sends it without calling ``runLifecycle()`` would compile, pass, and
+silently spend against the provider with no telemetry, no circuit breaker and no
+usage. Nothing enforced the convention.
+
+.. _adr-099-decision:
+
+Decision
+========
+
+The HTTP egress fails closed. ``AbstractSpecializedService`` tracks a private
+``$withinLifecycle`` flag, set only while a ``runLifecycle()`` dispatch is
+executing (saved/restored around the terminal, so nesting is safe).
+``assertWithinLifecycle()`` throws a ``\LogicException`` when the flag is false,
+and it is called at every HTTP-egress point — ``executeRequest()`` and the two
+binary/multipart senders in ``TextToSpeechService`` and
+``WhisperTranscriptionService`` — **before** their ``try`` block, so the guard is
+not swallowed by the ``Throwable -> ServiceUnavailableException`` mapping.
+
+A ``\LogicException`` (not a service exception) is deliberate: dispatching
+outside a lifecycle is a programmer error, not a runtime fault, and must not be
+retried or mapped to a transient failure.
+
+Enabling the guard required routing the last unwrapped provider calls through
+``runLifecycle()``. DeepL's ``detectLanguage()`` is a billable translate call and
+now runs as ``ProviderOperation::Translation`` — closing a real telemetry gap.
+Its ``getUsage()`` and ``getGlossaries()`` are free metadata lookups; they run as
+the new ``ProviderOperation::Metadata`` so they are observable and circuit-breaker
+guarded like any provider HTTP call, but labelled honestly rather than as a
+translation.
+
+.. _adr-099-consequences:
+
+Consequences
+============
+
+- A specialized service method that reaches the provider without
+  ``runLifecycle()`` now throws immediately instead of spending unobserved. The
+  guard is the single invariant behind ADR-097's promise.
+- ``ProviderOperation`` gained a ``Metadata`` case for provider status /
+  metadata calls that are not themselves an AI generation.
+- DeepL ``detectLanguage`` / ``getUsage`` / ``getGlossaries`` now emit a
+  telemetry row and are subject to the provider circuit breaker. They record no
+  usage and enforce no budget (they are not billable generations, apart from the
+  translate call ``detectLanguage`` already made), so cost accounting is
+  unchanged.
+- Test doubles that exercise the low-level HTTP helpers must dispatch inside a
+  lifecycle — the ``TestableSpecializedService`` delegate wraps its call in
+  ``runLifecycle()``, mirroring production. A deliberately unwrapped delegate
+  asserts the guard throws.
+- Still deferred: folding the per-service usage recording into a tagged pipeline
+  extractor read by the usage middleware.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -396,3 +396,4 @@ Tools
    Adr096PipelineCallContext
    Adr097SpecializedServicesOnPipeline
    Adr098SpecializedInputGuardrailScreening
+   Adr099SpecializedFailClosedDispatch

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -19,6 +19,8 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
@@ -89,6 +91,17 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $this->expectException(GuardrailViolationException::class);
         $subject->callScreenPrompt('anything');
+    }
+
+    #[Test]
+    public function aProviderRequestOutsideALifecycleFailsClosed(): void
+    {
+        // ADR-099: an HTTP dispatch that skips runLifecycle() would bypass
+        // telemetry, the circuit breaker and usage, so it throws instead.
+        $subject = $this->createSubject();
+
+        $this->expectException(LogicException::class);
+        $subject->callSendJsonRequestWithoutLifecycle('endpoint', []);
     }
 
     #[Test]
@@ -1332,7 +1345,25 @@ final class TestableSpecializedService extends AbstractSpecializedService
      */
     public function callSendJsonRequest(string $endpoint, array $payload, string $method = 'POST'): array
     {
-        return $this->sendJsonRequest($endpoint, $payload, $method);
+        // Mirror production: the HTTP dispatch runs inside a lifecycle so the
+        // fail-closed egress guard (ADR-099) is satisfied.
+        return $this->runLifecycle(
+            ProviderCallContext::forService(ProviderOperation::Chat, 'test-provider', 'test-model'),
+            fn(): array => $this->sendJsonRequest($endpoint, $payload, $method),
+        );
+    }
+
+    /**
+     * Dispatch WITHOUT a lifecycle — used only to assert the fail-closed egress
+     * guard throws (ADR-099).
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function callSendJsonRequestWithoutLifecycle(string $endpoint, array $payload): array
+    {
+        return $this->sendJsonRequest($endpoint, $payload);
     }
 
     /**


### PR DESCRIPTION
## What

[ADR-097](Documentation/Adr/Adr097SpecializedServicesOnPipeline.rst) routed every specialized dispatch through the pipeline, but the wrapping was a **convention**: a service method that built a request and sent it without `runLifecycle()` would compile, pass, and silently spend against the provider with no telemetry, no circuit breaker, no usage. This makes it fail closed ([ADR-099](Documentation/Adr/Adr099SpecializedFailClosedDispatch.rst)).

## How

- `AbstractSpecializedService` tracks a private `$withinLifecycle` flag, set only while a `runLifecycle()` dispatch executes (saved/restored around the terminal → nesting-safe).
- `assertWithinLifecycle()` throws a `LogicException` when the flag is false, called at **every** HTTP egress — `executeRequest()` and the TTS / Whisper binary senders — **before** the `try`, so it is not swallowed by the `Throwable → ServiceUnavailableException` mapping.
- `LogicException`, not a service exception: dispatching unwrapped is a programmer error, never retried or mapped to a transient failure.

## Closing the last gaps

Enabling the guard required routing the last unwrapped provider calls (DeepL) through `runLifecycle()`:

| Method | Was | Now |
|--------|-----|-----|
| `detectLanguage()` | unwrapped translate call (billable, no telemetry) | `ProviderOperation::Translation` — closes a real gap |
| `getUsage()`, `getGlossaries()` | unwrapped metadata GETs | new `ProviderOperation::Metadata` — observable + breaker-guarded, labelled honestly |

These record no usage and enforce no budget (not billable generations), so cost accounting is unchanged; they now emit a telemetry row and respect the provider circuit breaker.

## Tests

A negative test asserts an unwrapped dispatch throws `LogicException`; the `TestableSpecializedService` low-level delegate wraps its call in `runLifecycle()`, mirroring production (the existing plumbing tests — JSON decode, error mapping, timeout, vault auth — now exercise the lifecycle path). Full local gate green: cgl, phpstan (level 10), unit, rector, fuzzy. Functional: the 7 pre-existing `KeSearchBackendTest` risky tests are unrelated baseline; no new failures.

## Still deferred

Folding the per-service usage recording into a tagged pipeline extractor read by the usage middleware (the last specialized-lifecycle step).

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
