### PR TITLE
feat(specialized): record usage through tagged pipeline extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Specialized usage (images, characters, audio seconds) is now recorded by the
+  pipeline through tagged `UsageMetricsExtractor`s instead of each service
+  writing to the usage table itself (ADR-100). A service attaches a
+  `SpecializedUsageIntent` before dispatch; the matching extractor (one per
+  service, matched on operation and provider) reads it with the raw response and
+  `UsageMiddleware` writes the row — one recorder for every AI call. The recorded
+  rows are unchanged. DeepL's language-detection sub-call and the metadata calls
+  set no intent and so record nothing (the double-count guard is now structural).
 - The specialized HTTP egress fails closed (ADR-099): a provider call that
   dispatches without wrapping in `runLifecycle()` now throws a `LogicException`
   instead of silently spending against the provider with no telemetry, circuit

--- a/Classes/Provider/Middleware/Usage/ProviderUsageRecord.php
+++ b/Classes/Provider/Middleware/Usage/ProviderUsageRecord.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware\Usage;
+
+/**
+ * A ready-to-record usage row produced by a {@see UsageMetricsExtractorInterface}
+ * and written by {@see \Netresearch\NrLlm\Provider\Middleware\UsageMiddleware}
+ * (ADR-100).
+ *
+ * It carries exactly the arguments of
+ * {@see \Netresearch\NrLlm\Service\UsageTrackerServiceInterface::trackUsage()},
+ * so the middleware forwards it verbatim — the extractor owns the operation-
+ * specific accounting (image count, characters, audio seconds, cost), the
+ * middleware owns the single write.
+ */
+final readonly class ProviderUsageRecord
+{
+    /**
+     * @param array{tokens?: int, promptTokens?: int, completionTokens?: int, characters?: int, audioSeconds?: int, images?: int, batch_size?: int, cost?: float} $metrics
+     */
+    public function __construct(
+        public string $serviceType,
+        public string $provider,
+        public array $metrics,
+        public ?int $configurationUid = null,
+        public int $modelUid = 0,
+        public string $modelId = '',
+        public int $taskUid = 0,
+        public ?int $beUserUid = null,
+        public bool $countsAsRequest = true,
+    ) {}
+}

--- a/Classes/Provider/Middleware/Usage/SpecializedUsageIntent.php
+++ b/Classes/Provider/Middleware/Usage/SpecializedUsageIntent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+
+/**
+ * The stable, dispatch-independent inputs a specialized service knows before it
+ * calls the provider: which model, who to attribute the usage to, and the
+ * operation-specific counters it can measure up front (ADR-100).
+ *
+ * The service builds one and attaches it to the {@see ProviderCallContext}
+ * metadata under {@see METADATA_KEY}; the matching
+ * {@see UsageMetricsExtractorInterface} reads it back and combines it with the
+ * raw response (which supplies the rest — provider token usage, audio duration,
+ * the number of images actually returned) to compute the cost and the final
+ * usage row.
+ */
+final readonly class SpecializedUsageIntent
+{
+    /** Metadata key under which the intent travels on the call context. */
+    public const METADATA_KEY = 'nrllm.usage_intent';
+
+    public function __construct(
+        public string $modelId,
+        public int $modelUid = 0,
+        public ?int $configurationUid = null,
+        public ?int $beUserUid = null,
+        public ?string $size = null,
+        public ?string $quality = null,
+        public ?int $characters = null,
+        public ?int $batchSize = null,
+    ) {}
+
+    /**
+     * Read the intent off a call context, or null when none was attached
+     * (an internal sub-call or metadata lookup that records no usage).
+     */
+    public static function fromContext(ProviderCallContext $context): ?self
+    {
+        $intent = $context->metadata[self::METADATA_KEY] ?? null;
+
+        return $intent instanceof self ? $intent : null;
+    }
+}

--- a/Classes/Provider/Middleware/Usage/UsageMetricsExtractorInterface.php
+++ b/Classes/Provider/Middleware/Usage/UsageMetricsExtractorInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Middleware\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+
+/**
+ * Turns a specialized provider call (image / speech / translation) into a usage
+ * row (ADR-100).
+ *
+ * The token-shaped responses (chat / embedding / vision) are recorded by
+ * {@see \Netresearch\NrLlm\Provider\Middleware\UsageMiddleware} directly. A
+ * specialized service instead returns a raw provider payload and measures usage
+ * in its own unit (images, characters, audio seconds). Rather than each service
+ * writing to the usage table itself, it stashes a {@see SpecializedUsageIntent}
+ * in the call-context metadata before dispatch; the matching extractor reads that
+ * intent together with the raw response and returns a {@see ProviderUsageRecord}
+ * the middleware writes.
+ *
+ * A service that sets no intent (an internal sub-call such as DeepL language
+ * detection, or a metadata lookup) yields no record — {@see supports()} or
+ * {@see extract()} returns false / null — so nothing is recorded, exactly as
+ * before.
+ */
+interface UsageMetricsExtractorInterface
+{
+    public const TAG_NAME = 'nr_llm.usage_metrics_extractor';
+
+    /**
+     * Whether this extractor handles the given call (matched on operation and
+     * provider, so DALL·E and FAL — both image generation — do not collide).
+     */
+    public function supports(ProviderCallContext $context): bool;
+
+    /**
+     * Build the usage row from the call context (which carries the intent) and
+     * the raw provider response, or null when there is nothing to record.
+     */
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord;
+}

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -14,9 +14,11 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Throwable;
 
 /**
@@ -93,9 +95,17 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
      */
     public const METADATA_SKIP_REQUEST_COUNT = 'skip_request_count';
 
+    /**
+     * @param iterable<UsageMetricsExtractorInterface> $extractors extractors for the
+     *                                                             specialized operations whose
+     *                                                             responses are not token-shaped
+     *                                                             (image / speech / translation)
+     */
     public function __construct(
         private UsageTrackerServiceInterface $usageTracker,
         private LoggerInterface $logger,
+        #[AutowireIterator(UsageMetricsExtractorInterface::TAG_NAME)]
+        private iterable $extractors = [],
     ) {}
 
     /**
@@ -130,6 +140,11 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
     ): void {
         [$usage, $provider, $responseModel] = $this->extractUsage($result);
         if ($usage === null) {
+            // Not a token-shaped response — a specialized operation (image /
+            // speech / translation) records through its tagged extractor instead
+            // (ADR-100).
+            $this->trackSpecialized($context, $result);
+
             return;
         }
 
@@ -200,6 +215,39 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             beUserUid: $beUserUid,
             countsAsRequest: $countsAsRequest,
         );
+    }
+
+    /**
+     * Record a specialized operation whose response is not token-shaped, by
+     * asking the first matching tagged extractor for a usage row (ADR-100). A
+     * matched extractor that returns null (an internal sub-call that records
+     * nothing) still stops the search — the call was recognised, there is simply
+     * nothing to write.
+     */
+    private function trackSpecialized(ProviderCallContext $context, mixed $result): void
+    {
+        foreach ($this->extractors as $extractor) {
+            if (!$extractor->supports($context)) {
+                continue;
+            }
+
+            $record = $extractor->extract($context, $result);
+            if ($record !== null) {
+                $this->usageTracker->trackUsage(
+                    serviceType: $record->serviceType,
+                    provider: $record->provider !== '' ? $record->provider : 'unknown',
+                    metrics: $record->metrics,
+                    configurationUid: $record->configurationUid,
+                    modelUid: $record->modelUid,
+                    modelId: $record->modelId,
+                    taskUid: $record->taskUid,
+                    beUserUid: $record->beUserUid,
+                    countsAsRequest: $record->countsAsRequest,
+                );
+            }
+
+            return;
+        }
     }
 
     /**

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Specialized\Image;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\MultipartBodyBuilderTrait;
@@ -105,7 +106,7 @@ final class DallEImageService extends AbstractSpecializedService
 
         $payload = $this->buildGeneratePayload($prompt, $optionsArray);
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            $this->imageDispatchContext(ProviderOperation::ImageGeneration, $model, $size, $quality, $options->configuration, $options->getBeUserUid()),
             function () use ($payload, $model): array {
                 $this->setAuditContext(sprintf('%s, generate', $model));
 
@@ -116,8 +117,6 @@ final class DallEImageService extends AbstractSpecializedService
         /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? null;
-
-        $this->trackImageUsage($model, $size, $quality, 1, $response, $options->configuration, $options->getBeUserUid());
 
         return new ImageGenerationResult(
             url: $this->imageString($data, 'url') ?? '',
@@ -182,7 +181,7 @@ final class DallEImageService extends AbstractSpecializedService
         $payload['n'] = $count;
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            $this->imageDispatchContext(ProviderOperation::ImageGeneration, $model, $size, $quality, $options->configuration, $options->getBeUserUid()),
             function () use ($payload, $model): array {
                 $this->setAuditContext(sprintf('%s, generate', $model));
 
@@ -208,8 +207,6 @@ final class DallEImageService extends AbstractSpecializedService
                 ],
             );
         }
-
-        $this->trackImageUsage($model, $size, $quality, count($results), $response, $options->configuration, $options->getBeUserUid());
 
         return $results;
     }
@@ -244,7 +241,7 @@ final class DallEImageService extends AbstractSpecializedService
         $count = min(max($count, 1), 10);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageVariation, $this->getServiceProvider(), 'dall-e-2'),
+            $this->imageDispatchContext(ProviderOperation::ImageVariation, 'dall-e-2', $size, 'standard', null, $beUserUid),
             function () use ($imagePath, $count, $size): array {
                 $this->setAuditContext('dall-e-2, variations');
 
@@ -271,8 +268,6 @@ final class DallEImageService extends AbstractSpecializedService
                 metadata: ['type' => 'variation'],
             );
         }
-
-        $this->trackImageUsage('dall-e-2', $size, 'standard', count($results), $response, beUserUid: $beUserUid);
 
         return $results;
     }
@@ -311,7 +306,7 @@ final class DallEImageService extends AbstractSpecializedService
         $this->enforceBudget($beUserUid, null, null);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageEdit, $this->getServiceProvider(), 'dall-e-2'),
+            $this->imageDispatchContext(ProviderOperation::ImageEdit, 'dall-e-2', $size, 'standard', null, $beUserUid),
             function () use ($imagePath, $maskPath, $prompt, $size): array {
                 $this->setAuditContext('dall-e-2, edit');
 
@@ -326,8 +321,6 @@ final class DallEImageService extends AbstractSpecializedService
         /** @var array<int, mixed> $responseData */
         $responseData = is_array($response['data'] ?? null) ? $response['data'] : [];
         $data = $responseData[0] ?? null;
-
-        $this->trackImageUsage('dall-e-2', $size, 'standard', 1, $response, beUserUid: $beUserUid);
 
         return new ImageGenerationResult(
             url: $this->imageString($data, 'url') ?? '',
@@ -478,60 +471,30 @@ final class DallEImageService extends AbstractSpecializedService
      * When the options carried an LlmConfiguration identifier, the usage
      * row additionally links to that configuration record (resolved
      * fail-soft) so Analytics can aggregate spend per configuration.
-     *
-     * @param array<string, mixed> $response decoded API response
      */
-    private function trackImageUsage(
+    /**
+     * Build the dispatch context carrying the usage intent (ADR-100): the model,
+     * size, quality and attribution the DallEUsageExtractor needs to record the
+     * image usage once the pipeline has run. The image count and any token usage
+     * come from the response the extractor reads.
+     */
+    private function imageDispatchContext(
+        ProviderOperation $operation,
         string $model,
         string $size,
         string $quality,
-        int $imageCount,
-        array $response,
-        ?string $configuration = null,
-        ?int $beUserUid = null,
-    ): void {
-        // gpt-image-* responses include a `usage` token object;
-        // dall-e-2/3 never send one — token metrics are omitted then
-        // (all-zero counts) so the cost falls back to the per-image
-        // catalog instead of a fabricated token price.
-        $usage = $response['usage'] ?? null;
-        $input = $output = $total = $imageInput = 0;
-        if (is_array($usage)) {
-            $input = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
-            $output = is_numeric($usage['output_tokens'] ?? null) ? (int)$usage['output_tokens'] : 0;
-            $total = is_numeric($usage['total_tokens'] ?? null) ? (int)$usage['total_tokens'] : $input + $output;
-            $details = $usage['input_tokens_details'] ?? null;
-            $imageInput = is_array($details) && is_numeric($details['image_tokens'] ?? null)
-                ? (int)$details['image_tokens']
-                : 0;
-        }
-
-        $metrics = ['images' => $imageCount];
-        if ($input > 0 || $output > 0 || $total > 0) {
-            $metrics['tokens'] = $total;
-            $metrics['promptTokens'] = $input;
-            $metrics['completionTokens'] = $output;
-        }
-
-        $metrics['cost'] = $this->costCalculator->estimateImageCost(
-            $model,
-            $quality,
-            $size,
-            $imageCount,
-            $input,
-            $output,
-            $imageInput,
-        );
-
-        $this->usageTracker->trackUsage(
-            'image',
-            $this->getServiceProvider(),
-            $metrics,
-            configurationUid: $this->resolveConfigurationUid($configuration),
-            modelUid: $this->resolveModelUid($model),
-            modelId: $model,
-            beUserUid: $beUserUid,
-        );
+        ?string $configuration,
+        ?int $beUserUid,
+    ): ProviderCallContext {
+        return ProviderCallContext::forService($operation, $this->getServiceProvider(), $model)
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: $model,
+                modelUid: $this->resolveModelUid($model),
+                configurationUid: $this->resolveConfigurationUid($configuration),
+                beUserUid: $beUserUid,
+                size: $size,
+                quality: $quality,
+            )]);
     }
 
     /**

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -13,6 +13,7 @@ use JsonException;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -102,13 +103,6 @@ final class FalImageService extends AbstractSpecializedService
         /** @var array<string, mixed> $image */
         $image = is_array($images) && isset($images[0]) && is_array($images[0]) ? $images[0] : [];
 
-        // FAL publishes no static price list (billing varies per hosted
-        // model), so no cost is recorded — never guess (see
-        // SpecializedCostCalculatorInterface).
-        $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
-            'images' => 1,
-        ], modelUid: $this->resolveModelUid($model), modelId: $model, beUserUid: $this->extractBeUserUid($options));
-
         $imageUrl = isset($image['url']) && is_string($image['url']) ? $image['url'] : '';
 
         return new ImageGenerationResult(
@@ -180,10 +174,6 @@ final class FalImageService extends AbstractSpecializedService
                 );
             }
         }
-
-        $this->usageTracker->trackUsage('image', $this->getServiceProvider(), [
-            'images' => count($results),
-        ], modelUid: $this->resolveModelUid($model), modelId: $model, beUserUid: $this->extractBeUserUid($options));
 
         return $results;
     }
@@ -405,8 +395,17 @@ final class FalImageService extends AbstractSpecializedService
         $payload       = $this->buildGeneratePayload($prompt, $options);
         $usesQueue     = $this->modelUsesQueue($model);
 
+        // ADR-100: carry the usage intent so FalUsageExtractor records the image
+        // count from the response once the pipeline has run.
+        $context = ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model)
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: $model,
+                modelUid: $this->resolveModelUid($model),
+                beUserUid: $this->extractBeUserUid($options),
+            )]);
+
         return $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::ImageGeneration, $this->getServiceProvider(), $model),
+            $context,
             function () use ($model, $usesQueue, $modelEndpoint, $payload): array {
                 $this->setAuditContext(sprintf('%s, generate', $model));
 

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Specialized\Speech;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Exception\SpecializedServiceException;
@@ -105,27 +106,25 @@ final class TextToSpeechService extends AbstractSpecializedService
             'speed' => $speed,
         ];
 
+        // ADR-100: the input character count is the billed unit — carry it on the
+        // usage intent so TextToSpeechUsageExtractor records it once the pipeline
+        // has run.
+        $context = ProviderCallContext::forService(ProviderOperation::SpeechSynthesis, $this->getServiceProvider(), $model)
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: $model,
+                modelUid: $this->resolveModelUid($model),
+                configurationUid: $this->resolveConfigurationUid($options->configuration),
+                beUserUid: $options->getBeUserUid(),
+                characters: mb_strlen($text),
+            )]);
+
         $audioContent = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::SpeechSynthesis, $this->getServiceProvider(), $model),
+            $context,
             function () use ($model, $voice, $payload): string {
                 $this->setAuditContext(sprintf('%s, voice %s', $model, $voice));
 
                 return $this->sendBinaryRequest($payload);
             },
-        );
-
-        $characterCount = mb_strlen($text);
-        $this->usageTracker->trackUsage(
-            'speech',
-            $this->getServiceProvider(),
-            [
-                'characters' => $characterCount,
-                'cost' => $this->costCalculator->estimateSpeechSynthesisCost($model, $characterCount),
-            ],
-            configurationUid: $this->resolveConfigurationUid($options->configuration),
-            modelUid: $this->resolveModelUid($model),
-            modelId: $model,
-            beUserUid: $options->getBeUserUid(),
         );
 
         return new SpeechSynthesisResult(

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Specialized\Speech;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -84,7 +85,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
+            $this->transcriptionContext($options),
             fn(): array|string => $this->sendTranscriptionRequest($audioPath, $options),
         );
 
@@ -126,7 +127,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
+            $this->transcriptionContext($options),
             fn(): array|string => $this->sendTranscriptionRequestFromContent($audioContent, $filename, $options),
         );
 
@@ -158,12 +159,10 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         $this->enforceBudget($options->getBeUserUid(), $options->getPlannedCost(), $options->configuration);
 
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $options->model ?? self::DEFAULT_MODEL),
+            $this->transcriptionContext($options),
             fn(): array|string => $this->sendTranslationRequest($audioPath, $options),
         );
 
-        // Usage is recorded once inside dispatchMultipart() — no extra
-        // tracking here, a second call would double-count the request.
         return $this->parseTranscriptionResponse($response, $options);
     }
 
@@ -407,26 +406,18 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
             $responseBody = (string)$response->getBody();
 
             if ($statusCode >= 200 && $statusCode < 300) {
-                $model = $options->model ?? self::DEFAULT_MODEL;
-
                 $format = $options->format ?? 'json';
                 if (in_array($format, ['text', 'srt', 'vtt'], true)) {
-                    // Raw-string formats expose no duration — record the
-                    // request without audio seconds (cost stays 0 rather
-                    // than guessed).
-                    $this->trackTranscriptionUsage($model, null, $options->configuration, $options->getBeUserUid());
+                    // Raw-string formats expose no duration; WhisperUsageExtractor
+                    // records the request with no audio seconds (ADR-100).
                     return $responseBody;
                 }
 
+                // `verbose_json` reports the audio duration the extractor bills;
+                // plain `json` does not — the extractor reads what the response
+                // exposes.
                 /** @var array<string, mixed> $decoded */
                 $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
-
-                // `verbose_json` reports the audio duration in seconds;
-                // plain `json` does not — track what the response exposes.
-                $duration = isset($decoded['duration']) && is_numeric($decoded['duration'])
-                    ? (float)$decoded['duration']
-                    : null;
-                $this->trackTranscriptionUsage($model, $duration, $options->configuration, $options->getBeUserUid());
 
                 return $decoded;
             }
@@ -461,36 +452,22 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     }
 
     /**
-     * Record a transcription/translation request with real units: the
-     * audio duration (when the response format exposes it), an estimated
-     * cost, and the model identifier. When the options carried an
-     * LlmConfiguration identifier, the usage row additionally links to
-     * that configuration record (resolved fail-soft) so Analytics can
-     * aggregate spend per configuration.
+     * Build the dispatch context carrying the usage intent (ADR-100): the model
+     * and attribution WhisperUsageExtractor needs. The audio duration and cost
+     * come from the response the extractor reads; a request whose format exposes
+     * no duration records no audio seconds, exactly as before.
      */
-    private function trackTranscriptionUsage(
-        string $model,
-        ?float $duration,
-        ?string $configuration,
-        ?int $beUserUid = null,
-    ): void {
-        $metrics = [];
-        if ($duration !== null && $duration > 0.0) {
-            // Floor of 1: a sub-half-second clip must not round to 0 seconds while
-            // carrying a positive cost — units and cost stay consistent in analytics.
-            $metrics['audioSeconds'] = max(1, (int)round($duration));
-            $metrics['cost'] = $this->costCalculator->estimateTranscriptionCost($model, $duration);
-        }
+    private function transcriptionContext(TranscriptionOptions $options): ProviderCallContext
+    {
+        $model = $options->model ?? self::DEFAULT_MODEL;
 
-        $this->usageTracker->trackUsage(
-            'speech',
-            $this->getServiceProvider(),
-            $metrics,
-            configurationUid: $this->resolveConfigurationUid($configuration),
-            modelUid: $this->resolveModelUid($model),
-            modelId: $model,
-            beUserUid: $beUserUid,
-        );
+        return ProviderCallContext::forService(ProviderOperation::Transcription, $this->getServiceProvider(), $model)
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: $model,
+                modelUid: $this->resolveModelUid($model),
+                configurationUid: $this->resolveConfigurationUid($options->configuration),
+                beUserUid: $options->getBeUserUid(),
+            )]);
     }
 
     /**

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Specialized\Translation;
 use Netresearch\NrLlm\Attribute\AsTranslator;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
@@ -120,8 +121,17 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $payload = $this->buildTranslatePayload($text, $targetLanguage, $sourceLanguage, $options);
 
+        // ADR-100: the input character count is the billed unit — DeepLUsageExtractor
+        // records it from the intent once the pipeline has run.
+        $context = ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), '')
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: '',
+                beUserUid: $this->extractBeUserUid($options),
+                characters: mb_strlen($text),
+            )]);
+
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), ''),
+            $context,
             fn(): array => $this->sendDeeplRequest('translate', $payload),
         );
 
@@ -137,10 +147,6 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         $translation = $translations[0];
         $translatedText = $this->extractTranslatedText($translation);
         $detectedSourceLanguage = $this->extractDetectedSourceLanguage($translation, $sourceLanguage);
-
-        $this->usageTracker->trackUsage('translation', 'deepl', [
-            'characters' => mb_strlen($text),
-        ], beUserUid: $this->extractBeUserUid($options));
 
         return new TranslatorResult(
             translatedText: $translatedText,
@@ -181,8 +187,18 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
 
         $payload = $this->buildBatchPayload($texts, $targetLanguage, $sourceLanguage, $options);
 
+        // ADR-100: total input characters plus the batch size are the billed
+        // units — carried on the intent for DeepLUsageExtractor.
+        $context = ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), '')
+            ->withMetadata([SpecializedUsageIntent::METADATA_KEY => new SpecializedUsageIntent(
+                modelId: '',
+                beUserUid: $this->extractBeUserUid($options),
+                characters: array_sum(array_map(mb_strlen(...), $texts)),
+                batchSize: count($texts),
+            )]);
+
         $response = $this->runLifecycle(
-            ProviderCallContext::forService(ProviderOperation::Translation, $this->getServiceProvider(), ''),
+            $context,
             fn(): array => $this->sendDeeplRequest('translate', $payload),
         );
 
@@ -212,12 +228,6 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
                 ],
             );
         }
-
-        $totalCharacters = array_sum(array_map(mb_strlen(...), $texts));
-        $this->usageTracker->trackUsage('translation', 'deepl', [
-            'characters' => $totalCharacters,
-            'batch_size' => count($texts),
-        ], beUserUid: $this->extractBeUserUid($options));
 
         return $results;
     }

--- a/Classes/Specialized/Usage/DallEUsageExtractor.php
+++ b/Classes/Specialized/Usage/DallEUsageExtractor.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Records DALL·E image usage from the pipeline (ADR-100), replacing the
+ * service's former direct ``trackImageUsage()`` call.
+ *
+ * The image count and the model / size / quality come from the
+ * {@see SpecializedUsageIntent} the service attached before dispatch; the
+ * gpt-image token object (dall-e-2/3 send none) comes from the raw response.
+ * Cost is the per-image catalog price plus any token price, exactly as before.
+ */
+#[AutoconfigureTag(name: UsageMetricsExtractorInterface::TAG_NAME)]
+final readonly class DallEUsageExtractor implements UsageMetricsExtractorInterface
+{
+    private const PROVIDER = 'dall-e';
+
+    public function __construct(
+        private SpecializedCostCalculatorInterface $costCalculator,
+    ) {}
+
+    public function supports(ProviderCallContext $context): bool
+    {
+        return $context->telemetryProvider() === self::PROVIDER
+            && in_array($context->operation, [
+                ProviderOperation::ImageGeneration,
+                ProviderOperation::ImageEdit,
+                ProviderOperation::ImageVariation,
+            ], true);
+    }
+
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+    {
+        $intent = SpecializedUsageIntent::fromContext($context);
+        if ($intent === null) {
+            return null;
+        }
+
+        // The number of images actually returned, matching the former
+        // count($results): generate / edit responses carry one entry, the batch
+        // and variation endpoints carry the n requested.
+        $data       = is_array($result) && is_array($result['data'] ?? null) ? $result['data'] : [];
+        $imageCount = count($data);
+
+        // gpt-image-* responses include a `usage` token object; dall-e-2/3 never
+        // send one — token metrics are omitted then (all-zero) so the cost falls
+        // back to the per-image catalog instead of a fabricated token price.
+        $input = $output = $total = $imageInput = 0;
+        $usage = is_array($result) ? ($result['usage'] ?? null) : null;
+        if (is_array($usage)) {
+            $input  = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
+            $output = is_numeric($usage['output_tokens'] ?? null) ? (int)$usage['output_tokens'] : 0;
+            $total  = is_numeric($usage['total_tokens'] ?? null) ? (int)$usage['total_tokens'] : $input + $output;
+            $details = $usage['input_tokens_details'] ?? null;
+            $imageInput = is_array($details) && is_numeric($details['image_tokens'] ?? null)
+                ? (int)$details['image_tokens']
+                : 0;
+        }
+
+        /** @var array{tokens?: int, promptTokens?: int, completionTokens?: int, images: int, cost: float} $metrics */
+        $metrics = ['images' => $imageCount];
+        if ($input > 0 || $output > 0 || $total > 0) {
+            $metrics['tokens']           = $total;
+            $metrics['promptTokens']     = $input;
+            $metrics['completionTokens'] = $output;
+        }
+        $metrics['cost'] = $this->costCalculator->estimateImageCost(
+            $intent->modelId,
+            $intent->quality ?? 'standard',
+            $intent->size ?? '',
+            $imageCount,
+            $input,
+            $output,
+            $imageInput,
+        );
+
+        return new ProviderUsageRecord(
+            serviceType: 'image',
+            provider: self::PROVIDER,
+            metrics: $metrics,
+            configurationUid: $intent->configurationUid,
+            modelUid: $intent->modelUid,
+            modelId: $intent->modelId,
+            beUserUid: $intent->beUserUid,
+        );
+    }
+}

--- a/Classes/Specialized/Usage/DeepLUsageExtractor.php
+++ b/Classes/Specialized/Usage/DeepLUsageExtractor.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Records DeepL translation usage from the pipeline (ADR-100). The billed unit is
+ * the input character count (a batch also records its size); DeepL cost is not
+ * computed here. An intent is set only by translate() / translateBatch(), so the
+ * internal language-detection sub-call (also a Translation operation) records
+ * nothing.
+ */
+#[AutoconfigureTag(name: UsageMetricsExtractorInterface::TAG_NAME)]
+final readonly class DeepLUsageExtractor implements UsageMetricsExtractorInterface
+{
+    private const PROVIDER = 'deepl';
+
+    public function supports(ProviderCallContext $context): bool
+    {
+        return $context->telemetryProvider() === self::PROVIDER
+            && $context->operation === ProviderOperation::Translation;
+    }
+
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+    {
+        $intent = SpecializedUsageIntent::fromContext($context);
+        if ($intent === null) {
+            return null;
+        }
+
+        /** @var array{characters: int, batch_size?: int} $metrics */
+        $metrics = ['characters' => $intent->characters ?? 0];
+        if ($intent->batchSize !== null) {
+            $metrics['batch_size'] = $intent->batchSize;
+        }
+
+        return new ProviderUsageRecord(
+            serviceType: 'translation',
+            provider: self::PROVIDER,
+            metrics: $metrics,
+            beUserUid: $intent->beUserUid,
+        );
+    }
+}

--- a/Classes/Specialized/Usage/FalUsageExtractor.php
+++ b/Classes/Specialized/Usage/FalUsageExtractor.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Records FAL image usage from the pipeline (ADR-100). FAL publishes no static
+ * price list (billing varies per hosted model), so no cost is recorded — only
+ * the number of images returned.
+ */
+#[AutoconfigureTag(name: UsageMetricsExtractorInterface::TAG_NAME)]
+final readonly class FalUsageExtractor implements UsageMetricsExtractorInterface
+{
+    private const PROVIDER = 'fal';
+
+    public function supports(ProviderCallContext $context): bool
+    {
+        return $context->telemetryProvider() === self::PROVIDER
+            && $context->operation === ProviderOperation::ImageGeneration;
+    }
+
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+    {
+        $intent = SpecializedUsageIntent::fromContext($context);
+        if ($intent === null) {
+            return null;
+        }
+
+        $images = is_array($result) && is_array($result['images'] ?? null) ? $result['images'] : [];
+
+        return new ProviderUsageRecord(
+            serviceType: 'image',
+            provider: self::PROVIDER,
+            metrics: ['images' => count($images)],
+            modelUid: $intent->modelUid,
+            modelId: $intent->modelId,
+            beUserUid: $intent->beUserUid,
+        );
+    }
+}

--- a/Classes/Specialized/Usage/TextToSpeechUsageExtractor.php
+++ b/Classes/Specialized/Usage/TextToSpeechUsageExtractor.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Records text-to-speech usage from the pipeline (ADR-100). The billed unit is
+ * the input character count, which the service knows up front and carries on the
+ * {@see SpecializedUsageIntent}; the response (audio bytes) contributes nothing.
+ */
+#[AutoconfigureTag(name: UsageMetricsExtractorInterface::TAG_NAME)]
+final readonly class TextToSpeechUsageExtractor implements UsageMetricsExtractorInterface
+{
+    private const PROVIDER = 'tts';
+
+    public function __construct(
+        private SpecializedCostCalculatorInterface $costCalculator,
+    ) {}
+
+    public function supports(ProviderCallContext $context): bool
+    {
+        return $context->telemetryProvider() === self::PROVIDER
+            && $context->operation === ProviderOperation::SpeechSynthesis;
+    }
+
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+    {
+        $intent = SpecializedUsageIntent::fromContext($context);
+        if ($intent === null) {
+            return null;
+        }
+
+        $characters = $intent->characters ?? 0;
+
+        return new ProviderUsageRecord(
+            serviceType: 'speech',
+            provider: self::PROVIDER,
+            metrics: [
+                'characters' => $characters,
+                'cost'       => $this->costCalculator->estimateSpeechSynthesisCost($intent->modelId, $characters),
+            ],
+            configurationUid: $intent->configurationUid,
+            modelUid: $intent->modelUid,
+            modelId: $intent->modelId,
+            beUserUid: $intent->beUserUid,
+        );
+    }
+}

--- a/Classes/Specialized/Usage/WhisperUsageExtractor.php
+++ b/Classes/Specialized/Usage/WhisperUsageExtractor.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\SpecializedUsageIntent;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Records Whisper transcription usage from the pipeline (ADR-100). The billed
+ * unit is audio duration in seconds, which only the `verbose_json` response
+ * format reports — a raw-string / plain-json response records the request with no
+ * duration or cost, exactly as before.
+ */
+#[AutoconfigureTag(name: UsageMetricsExtractorInterface::TAG_NAME)]
+final readonly class WhisperUsageExtractor implements UsageMetricsExtractorInterface
+{
+    private const PROVIDER = 'whisper';
+
+    public function __construct(
+        private SpecializedCostCalculatorInterface $costCalculator,
+    ) {}
+
+    public function supports(ProviderCallContext $context): bool
+    {
+        return $context->telemetryProvider() === self::PROVIDER
+            && $context->operation === ProviderOperation::Transcription;
+    }
+
+    public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+    {
+        $intent = SpecializedUsageIntent::fromContext($context);
+        if ($intent === null) {
+            return null;
+        }
+
+        $duration = is_array($result) && is_numeric($result['duration'] ?? null)
+            ? (float)$result['duration']
+            : null;
+
+        /** @var array{audioSeconds?: int, cost?: float} $metrics */
+        $metrics = [];
+        if ($duration !== null && $duration > 0.0) {
+            // Floor of 1: a sub-half-second clip must not round to 0 seconds while
+            // carrying a positive cost — units and cost stay consistent.
+            $metrics['audioSeconds'] = max(1, (int)round($duration));
+            $metrics['cost']         = $this->costCalculator->estimateTranscriptionCost($intent->modelId, $duration);
+        }
+
+        return new ProviderUsageRecord(
+            serviceType: 'speech',
+            provider: self::PROVIDER,
+            metrics: $metrics,
+            configurationUid: $intent->configurationUid,
+            modelUid: $intent->modelUid,
+            modelId: $intent->modelId,
+            beUserUid: $intent->beUserUid,
+        );
+    }
+}

--- a/Documentation/Adr/Adr100SpecializedUsageExtractors.rst
+++ b/Documentation/Adr/Adr100SpecializedUsageExtractors.rst
@@ -1,0 +1,71 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-100:
+
+============================================================================
+ADR-100: Specialized usage recorded by tagged extractors in the pipeline
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-100-context:
+
+Context
+=======
+
+:ref:`ADR-097 <adr-097>` routed the specialized dispatches through the pipeline,
+but each service still recorded its own usage by calling
+``UsageTrackerServiceInterface::trackUsage()`` directly after the dispatch — a
+second write path alongside :ref:`UsageMiddleware <adr-058>`, which records the
+token-shaped chat / embedding / vision responses. The specialized responses are
+not token-shaped (they measure images, characters, audio seconds), so
+``UsageMiddleware`` skipped them and the service filled the gap itself. Two
+recorders, two places to keep the request-count and attribution rules
+consistent.
+
+.. _adr-100-decision:
+
+Decision
+========
+
+A specialized service no longer writes usage. Before dispatch it attaches a
+``SpecializedUsageIntent`` — the stable, dispatch-independent inputs it knows
+(model, resolved model / configuration uid, attribution uid, and the input-
+derived counters: characters, size, quality, batch size) — to the call-context
+metadata. A tagged ``UsageMetricsExtractorInterface`` (one per service, matched on
+operation **and** provider so DALL·E and FAL do not collide) reads that intent
+together with the raw response and returns a ``ProviderUsageRecord``.
+``UsageMiddleware`` writes it, as the single recorder, after the token path finds
+nothing.
+
+The response supplies what the service could not know up front: DALL·E's
+gpt-image token object and the number of images returned, Whisper's audio
+duration (``verbose_json`` only). Cost is computed in the extractor from the
+``SpecializedCostCalculator`` exactly as the service did.
+
+A service records usage **iff** it set an intent. DeepL's language-detection
+sub-call and the ``getUsage()`` / ``getGlossaries()`` metadata calls
+(:ref:`ADR-099 <adr-099>`) set none, so the extractor returns null and nothing is
+recorded — the former double-count guard is now structural.
+
+.. _adr-100-consequences:
+
+Consequences
+============
+
+- One write path for every AI call: ``UsageMiddleware`` records both the token-
+  shaped responses and the specialized operations. The services drop their direct
+  ``trackUsage()`` calls (and ``DallEImageService::trackImageUsage()`` /
+  ``WhisperTranscriptionService::trackTranscriptionUsage()`` are gone).
+- ``UsageMiddleware`` gained an autowired iterator of extractors; with none
+  tagged its behaviour is unchanged. ``ProviderOperation::Metadata`` records
+  nothing (no extractor claims it).
+- The recorded rows are unchanged — same service type, provider, metrics, cost,
+  model / configuration uid and attribution — verified end-to-end: the service
+  tests now drive a real ``UsageMiddleware`` + the service's extractor and assert
+  the same rows they asserted before.
+- Adding a specialized provider means adding one extractor tagged
+  ``nr_llm.usage_metrics_extractor`` and setting an intent before dispatch; no
+  service touches the usage table.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -397,3 +397,4 @@ Tools
    Adr097SpecializedServicesOnPipeline
    Adr098SpecializedInputGuardrailScreening
    Adr099SpecializedFailClosedDispatch
+   Adr100SpecializedUsageExtractors

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -73,6 +75,54 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         );
 
         self::assertSame($response, $result);
+    }
+
+    #[Test]
+    public function recordsASpecializedOperationThroughItsMatchingExtractor(): void
+    {
+        // A non-token response (a raw image array) is recorded via the tagged
+        // extractor for its operation (ADR-100).
+        $this->tracker->expects(self::once())
+            ->method('trackUsage')
+            ->with('image', 'fal', ['images' => 2], null, 0, 'flux-schnell', 0, 5, true);
+
+        $record = new ProviderUsageRecord(
+            serviceType: 'image',
+            provider: 'fal',
+            metrics: ['images' => 2],
+            modelUid: 0,
+            modelId: 'flux-schnell',
+            beUserUid: 5,
+        );
+
+        $this->pipeline([$this->extractor(ProviderOperation::ImageGeneration, $record)])->run(
+            context: ProviderCallContext::forService(ProviderOperation::ImageGeneration, 'fal', 'flux-schnell'),
+            terminal: static fn(): array => ['images' => [[], []]],
+        );
+    }
+
+    #[Test]
+    public function recordsNothingWhenTheMatchingExtractorReturnsNull(): void
+    {
+        // A matched extractor that yields null models an internal sub-call
+        // (e.g. DeepL language detection) — recognised, but nothing to write.
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $this->pipeline([$this->extractor(ProviderOperation::Translation, null)])->run(
+            context: ProviderCallContext::forService(ProviderOperation::Translation, 'deepl', ''),
+            terminal: static fn(): array => ['translations' => [['text' => 'x']]],
+        );
+    }
+
+    #[Test]
+    public function recordsNothingWhenNoExtractorMatches(): void
+    {
+        $this->tracker->expects(self::never())->method('trackUsage');
+
+        $this->pipeline([$this->extractor(ProviderOperation::SpeechSynthesis, null)])->run(
+            context: ProviderCallContext::forService(ProviderOperation::Translation, 'deepl', ''),
+            terminal: static fn(): array => ['translations' => []],
+        );
     }
 
     #[Test]
@@ -570,9 +620,36 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         self::assertSame($response, $result);
     }
 
-    private function pipeline(): MiddlewarePipeline
+    /**
+     * @param list<UsageMetricsExtractorInterface> $extractors
+     */
+    private function pipeline(array $extractors = []): MiddlewarePipeline
     {
-        return new MiddlewarePipeline([new UsageMiddleware($this->tracker, $this->logger)]);
+        return new MiddlewarePipeline([new UsageMiddleware($this->tracker, $this->logger, $extractors)]);
+    }
+
+    /**
+     * A stand-in extractor that reports it handles the operation and returns the
+     * given record (or null to model an internal sub-call that records nothing).
+     */
+    private function extractor(ProviderOperation $operation, ?ProviderUsageRecord $record): UsageMetricsExtractorInterface
+    {
+        return new class ($operation, $record) implements UsageMetricsExtractorInterface {
+            public function __construct(
+                private readonly ProviderOperation $operation,
+                private readonly ?ProviderUsageRecord $record,
+            ) {}
+
+            public function supports(ProviderCallContext $context): bool
+            {
+                return $context->operation === $this->operation;
+            }
+
+            public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
+            {
+                return $this->record;
+            }
+        };
     }
 
     private function configuration(?int $uid = null): LlmConfiguration

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
@@ -31,6 +32,7 @@ use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Option\ImageGenerationOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Netresearch\NrLlm\Specialized\Usage\DallEUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
@@ -158,7 +160,9 @@ class DallEImageServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             $repositories['budget'] ?? new AllowingBudgetService(),
-            $repositories['pipeline'] ?? new MiddlewarePipeline([]),
+            $repositories['pipeline'] ?? new MiddlewarePipeline([
+                new UsageMiddleware($usageTracker, $logger, [new DallEUsageExtractor($this->costCalculator)]),
+            ]),
             $repositories['screener'] ?? new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\AbstractSpecializedService;
@@ -22,6 +23,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\FalImageService;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Netresearch\NrLlm\Specialized\Usage\FalUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -104,7 +106,9 @@ class FalImageServiceTest extends AbstractUnitTestCase
             $logger,
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            $pipeline ?? new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([
+                new UsageMiddleware($usageTracker, $logger, [new FalUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $service->setHttpClient($httpClient);

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -25,6 +26,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\SpeechSynthesisResult;
 use Netresearch\NrLlm\Specialized\Speech\TextToSpeechService;
+use Netresearch\NrLlm\Specialized\Usage\TextToSpeechUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -108,7 +110,9 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
-            $pipeline ?? new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([
+                new UsageMiddleware($usageTracker, $logger, [new TextToSpeechUsageExtractor($this->costCalculator)]),
+            ]),
             new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -26,6 +27,7 @@ use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculator;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Speech\TranscriptionResult;
 use Netresearch\NrLlm\Specialized\Speech\WhisperTranscriptionService;
+use Netresearch\NrLlm\Specialized\Usage\WhisperUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -135,7 +137,9 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             $logger,
             $this->costCalculator,
             new AllowingBudgetService(),
-            $pipeline ?? new MiddlewarePipeline([]),
+            $pipeline ?? new MiddlewarePipeline([
+                new UsageMiddleware($usageTracker, $logger, [new WhisperUsageExtractor($this->costCalculator)]),
+            ]),
             new InputGuardrailScreener([]),
             $repositories['model'] ?? null,
             $repositories['configuration'] ?? null,

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Exception;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -18,6 +19,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
+use Netresearch\NrLlm\Specialized\Usage\DeepLUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -488,7 +490,9 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientMock);

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Specialized\Translation;
 
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Option\DeepLOptions;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
+use Netresearch\NrLlm\Specialized\Usage\DeepLUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -538,7 +540,9 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $translator->setHttpClient($httpClientMock);

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -13,6 +13,7 @@ use LogicException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
@@ -21,6 +22,7 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
+use Netresearch\NrLlm\Specialized\Usage\DeepLUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Fixture\CapturingMiddleware;
 use Netresearch\NrLlm\Tests\Fixture\DenyingInputGuardrail;
@@ -474,6 +476,41 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function detectLanguageRecordsNoUsage(): void
+    {
+        // ADR-100: detectLanguage() is an internal sub-call — it sets no usage
+        // intent, so DeepLUsageExtractor records nothing and the language check
+        // is not double-counted as a translation.
+        $httpClientStub = self::createStub(ClientInterface::class);
+        $httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock([
+                'translations' => [['text' => 'Hello', 'detected_source_language' => 'DE']],
+            ]));
+
+        $usageTrackerMock = $this->createMock(UsageTrackerServiceInterface::class);
+        $usageTrackerMock->expects(self::never())->method('trackUsage');
+
+        $subject = new DeepLTranslator(
+            $this->createVaultServiceMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createExtensionConfigurationMock($this->defaultConfig),
+            $usageTrackerMock,
+            $this->createLoggerMock(),
+            self::createStub(SpecializedCostCalculatorInterface::class),
+            new AllowingBudgetService(),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
+            new InputGuardrailScreener([]),
+        );
+        $subject->setHttpClient($httpClientStub);
+
+        self::assertSame('de', $subject->detectLanguage('Hallo'));
+    }
+
+    #[Test]
     public function translateTracksUsage(): void
     {
         $text = 'Hello World';
@@ -514,7 +551,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
@@ -562,7 +601,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
@@ -609,7 +650,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
@@ -987,7 +1030,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);
@@ -1165,7 +1210,9 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             $this->createLoggerMock(),
             self::createStub(SpecializedCostCalculatorInterface::class),
             new AllowingBudgetService(),
-            new MiddlewarePipeline([]),
+            new MiddlewarePipeline([
+                new UsageMiddleware($usageTrackerMock, $this->createLoggerMock(), [new DeepLUsageExtractor()]),
+            ]),
             new InputGuardrailScreener([]),
         );
         $subject->setHttpClient($httpClientStub);

--- a/Tests/Unit/Specialized/Usage/UsageExtractorSupportTest.php
+++ b/Tests/Unit/Specialized/Usage/UsageExtractorSupportTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Specialized\Usage;
+
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Netresearch\NrLlm\Specialized\Usage\DallEUsageExtractor;
+use Netresearch\NrLlm\Specialized\Usage\DeepLUsageExtractor;
+use Netresearch\NrLlm\Specialized\Usage\FalUsageExtractor;
+use Netresearch\NrLlm\Specialized\Usage\TextToSpeechUsageExtractor;
+use Netresearch\NrLlm\Specialized\Usage\WhisperUsageExtractor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The extractors match on operation AND provider, so the two image extractors
+ * (DALL·E and FAL share ImageGeneration) never both claim the same call, and a
+ * speech extractor never claims a translation (ADR-100).
+ */
+#[CoversClass(DallEUsageExtractor::class)]
+#[CoversClass(FalUsageExtractor::class)]
+#[CoversClass(TextToSpeechUsageExtractor::class)]
+#[CoversClass(WhisperUsageExtractor::class)]
+#[CoversClass(DeepLUsageExtractor::class)]
+final class UsageExtractorSupportTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{UsageMetricsExtractorInterface, ProviderOperation, string, bool}>
+     */
+    public static function supportMatrix(): iterable
+    {
+        $cost  = self::createStub(SpecializedCostCalculatorInterface::class);
+        $dalle = new DallEUsageExtractor($cost);
+        $fal   = new FalUsageExtractor();
+        $tts   = new TextToSpeechUsageExtractor($cost);
+        $whisper = new WhisperUsageExtractor($cost);
+        $deepl = new DeepLUsageExtractor();
+
+        yield 'dall-e claims its own image call' => [$dalle, ProviderOperation::ImageGeneration, 'dall-e', true];
+        yield 'dall-e ignores a FAL image call' => [$dalle, ProviderOperation::ImageGeneration, 'fal', false];
+        yield 'fal claims its own image call' => [$fal, ProviderOperation::ImageGeneration, 'fal', true];
+        yield 'fal ignores a DALL-E image call' => [$fal, ProviderOperation::ImageGeneration, 'dall-e', false];
+        yield 'tts claims speech synthesis' => [$tts, ProviderOperation::SpeechSynthesis, 'tts', true];
+        yield 'tts ignores transcription' => [$tts, ProviderOperation::Transcription, 'tts', false];
+        yield 'whisper claims transcription' => [$whisper, ProviderOperation::Transcription, 'whisper', true];
+        yield 'whisper ignores speech synthesis' => [$whisper, ProviderOperation::SpeechSynthesis, 'whisper', false];
+        yield 'deepl claims translation' => [$deepl, ProviderOperation::Translation, 'deepl', true];
+        yield 'deepl ignores its metadata sub-call' => [$deepl, ProviderOperation::Metadata, 'deepl', false];
+    }
+
+    #[Test]
+    #[DataProvider('supportMatrix')]
+    public function supportsMatchesOnOperationAndProvider(
+        UsageMetricsExtractorInterface $extractor,
+        ProviderOperation $operation,
+        string $provider,
+        bool $expected,
+    ): void {
+        $context = ProviderCallContext::forService($operation, $provider, 'model');
+
+        self::assertSame($expected, $extractor->supports($context));
+    }
+}


### PR DESCRIPTION
## What

Each specialized service recorded its own usage by calling `trackUsage()` directly after dispatch — a second write path beside `UsageMiddleware`, which records the token-shaped chat/embedding/vision responses but skipped the specialized ones (images, characters, audio seconds). This folds them into one recorder ([ADR-100](Documentation/Adr/Adr100SpecializedUsageExtractors.rst)), the **last** specialized-lifecycle step.

## How

- A service attaches a typed `SpecializedUsageIntent` (model, resolved model/configuration uid, attribution uid, and the input-derived counters: characters, size, quality, batch size) to the call-context metadata **before** dispatch.
- A tagged `UsageMetricsExtractorInterface` — one per service, matched on **operation AND provider** so DALL·E and FAL (both `ImageGeneration`) don't collide — reads that intent together with the raw response (which supplies what the service couldn't know up front: the gpt-image token object, the images returned, Whisper's `verbose_json` duration), computes cost via the `SpecializedCostCalculator`, and returns a `ProviderUsageRecord`.
- `UsageMiddleware` writes it, as the single recorder, after its token path finds nothing.

## Key property

A service records **iff** it set an intent. DeepL's language-detection sub-call and the `getUsage()` / `getGlossaries()` metadata calls set none → the extractor returns null → nothing recorded. The former double-count guard is now **structural**.

## Not changed

The recorded rows — service type, provider, metrics, cost, model/configuration uid, attribution — are identical. Verified **end-to-end**: the service tests now drive a real `UsageMiddleware` + the service's extractor and assert the same rows they asserted before (Whisper against a real cost calculator). `trackImageUsage()` / `trackTranscriptionUsage()` and every direct `trackUsage()` in the specialized services are gone.

## Tests

Extractor support-matrix (provider isolation), `UsageMiddleware` extractor dispatch (matched→record, null-intent→skip, no-match→nothing), a DeepL `detectLanguage` records-no-usage regression, plus the 22 existing per-service usage assertions now running through the pipeline. Full local gate green: cgl, phpstan (level 10), unit, rector, fuzzy. Functional: the 7 pre-existing `KeSearchBackendTest` risky tests are unrelated baseline; no new failures.

This completes the specialized-service lifecycle arc (ADR-097 → ADR-100): dispatch, input screening, fail-closed egress, and now unified usage.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
