### PR TITLE
feat(agent): extract AgentRuntime as the public agent-run service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `AgentRuntimeInterface` (ADR-101): the agent-run lifecycle — begin, execute,
+  persist, suspend for approval, approve/deny, cancel, event polling, status —
+  as one public, fail-closed application service. The tool playground is now a
+  UI adapter over it; scheduler tasks, queue workers and downstream extensions
+  get the identical tested lifecycle instead of re-assembling loop + persister.
+  Operator decisions are persisted as a new `approval` event
+  (`AgentEventKind::APPROVAL`), a resume continues the event stream at
+  `MAX(sequence)+1` (refused fail-closed when the position is unavailable), a
+  failed re-suspension now fails the run on every path instead of promising an
+  impossible resume, and `status()` never exposes the raw suspended transcript.
+  Cancellation is now a real fence: a cancelled run can no longer be
+  resurrected into the approval queue by an in-flight suspension
+  (`suspendRun` became a guarded transition).
+  **Breaking:** `ToolPlaygroundController`'s constructor takes the runtime
+  instead of `ToolLoopService`/`AgentRunPersister`;
+  `AgentRunPersister::resumeHandle()` returns `?AgentRunHandle`;
+  `AgentRunRepositoryInterface` gained `maxEventSequence()` and
+  `suspendRun()` returns `bool`.
 - Specialized usage (images, characters, audio seconds) is now recorded by the
   pipeline through tagged `UsageMetricsExtractor`s instead of each service
   writing to the usage table itself (ADR-100). A service attaches a

--- a/Classes/Command/CancelAgentRunCommand.php
+++ b/Classes/Command/CancelAgentRunCommand.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
-use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,7 +37,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class CancelAgentRunCommand extends Command
 {
     public function __construct(
-        private readonly AgentRunPersister $agentRuns,
+        // The runtime is the single consumer surface for run lifecycle
+        // operations (ADR-101); cancel delegates to the same guarded
+        // transition it always did.
+        private readonly AgentRuntimeInterface $agentRuntime,
     ) {
         parent::__construct();
     }
@@ -58,7 +61,7 @@ final class CancelAgentRunCommand extends Command
             return Command::INVALID;
         }
 
-        if (!$this->agentRuns->cancel($uuid)) {
+        if (!$this->agentRuntime->cancel($uuid)) {
             $io->warning(sprintf('Run "%s" was not cancelled: it is unknown or already finished.', $uuid));
 
             return Command::FAILURE;

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -265,6 +265,15 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($result->error)], 500);
 
             case AgentRunOutcome::COMPLETED:
+                break;
+
+            default:
+                // A future outcome from a newer runtime (the enum may grow in
+                // minor releases) must not fall through to the completed
+                // payload.
+                $this->logger?->error('Unhandled agent run outcome', ['outcome' => $result->outcome->value]);
+
+                return $this->respondJson(['success' => false, 'error' => 'The run ended with an unhandled outcome.'], 500);
         }
 
         $loop = $result->loopResult;
@@ -435,6 +444,15 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 return;
 
             case AgentRunOutcome::COMPLETED:
+                break;
+
+            default:
+                // A future outcome from a newer runtime must not fall through
+                // to the done event.
+                $this->logger?->error('Unhandled agent run outcome', ['outcome' => $result->outcome->value]);
+                $emit(['event' => 'error', 'success' => false, 'error' => 'The run ended with an unhandled outcome.']);
+
+                return;
         }
 
         $loop = $result->loopResult;

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -11,9 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use Closure;
 use Netresearch\NrLlm\Controller\Backend\Response\PlaygroundRunResponse;
-use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
-use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -21,26 +19,27 @@ use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
-use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
-use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
-use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
+use Netresearch\NrLlm\Service\Agent\AgentRunResult;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
+use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
+use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
-use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
-use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
-use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
-use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
-use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use ReflectionClass;
-use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
@@ -53,11 +52,12 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 /**
  * Admin-only interactive tool playground backend module.
  *
- * The v1 consumer of the tool runtime (PR-A): an admin picks an LLM
- * configuration, types a prompt, and the agent loop runs each tool call and
- * the final answer. {@see listAction()} renders the Fluid shell (config
- * picker, prompt box, tools panel, output pane); the AJAX runAction (Task 2)
- * runs the loop and returns the trace as JSON.
+ * Since ADR-101 a pure UI adapter over {@see AgentRuntimeInterface}: it parses
+ * the request into an {@see AgentRunRequest} / {@see ApprovalDecision}, lets
+ * the runtime own the whole run lifecycle (begin, trace, persist, suspend,
+ * settle, resume-claim), and maps the returned {@see AgentRunResult} onto the
+ * module's JSON / NDJSON response shapes. {@see listAction()} renders the
+ * Fluid shell (config picker, prompt box, tools panel, output pane).
  *
  * Mirrors {@see SkillSourceController}: a `#[AsController]` Extbase
  * ActionController whose list action is the module entry point, gated to
@@ -73,13 +73,6 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     use DefensiveLocalizationTrait;
 
     /**
-     * Server-side ceiling on the per-run round count, matching the UI's
-     * max-rounds input. Guards against a crafted request driving an unbounded,
-     * cost-accruing agent loop.
-     */
-    private const MAX_ROUNDS = 20;
-
-    /**
      * Minimum byte length of each streamed NDJSON line. A TYPO3 backend AJAX
      * response is buffered by the reverse proxy until a chunk clears its flush
      * threshold; padding every event past ~4 KB makes it flush immediately, so
@@ -87,19 +80,20 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      */
     private const STREAM_MIN_LINE_BYTES = 4096;
 
+    /**
+     * The 500 body when a run required approval but its state could not be
+     * stored (fail-closed, ADR-092): no resume must be promised.
+     */
+    private const SUSPEND_FAILED_MESSAGE = 'The run required approval but its state could not be stored, so it cannot be resumed.';
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly LlmConfigurationRepository $configurationRepository,
         private readonly PageRenderer $pageRenderer,
-        private readonly ToolLoopService $toolLoopService,
+        private readonly AgentRuntimeInterface $agentRuntime,
         private readonly ToolAvailabilityServiceInterface $toolAvailability,
         private readonly SkillRepository $skillRepository,
         private readonly PromptSnippetRepository $promptSnippetRepository,
-        // Optional and last so the existing direct constructions in the
-        // functional tests keep compiling (they run with persistence off — a
-        // free characterization guard that the loop path is unchanged); the DI
-        // container autowires the real persister in production.
-        private readonly ?AgentRunPersister $agentRunPersister = null,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -123,18 +117,15 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * trace as JSON (design §4.6).
      *
      * Admin-gated via {@see denyNonAdmin()} FIRST: AJAX routes bypass the
-     * module's ``access => admin`` check (ADR-037). The configuration's vault
-     * key, model and pricing reach the call through
-     * {@see ToolLoopService::runLoop()} (it runs on
-     * `chatWithToolsForConfiguration`). The per-run allow-list comes from the
-     * tool checkboxes the operator ticked (defaulting to the globally-enabled
-     * set when none are sent); {@see ToolLoopService} still intersects it with
-     * the global gate, so a disabled tool can never be offered. Any unexpected
-     * provider/tool failure returns a JSON 500 carrying a SANITIZED diagnosis
-     * (exception class + message with secret-bearing URL params stripped via
-     * {@see ErrorMessageSanitizerTrait}, plus a truncated sanitized provider
-     * response body) — never the raw message verbatim — while the full detail is
-     * logged downstream.
+     * module's ``access => admin`` check (ADR-037). The run itself — loop
+     * execution, persistence, suspension, settling — is entirely the
+     * {@see AgentRuntimeInterface}'s; this action only builds the
+     * {@see AgentRunRequest} from the form and shapes the result. Any
+     * unexpected provider/tool failure returns a JSON 500 carrying a SANITIZED
+     * diagnosis (exception class + message with secret-bearing URL params
+     * stripped via {@see ErrorMessageSanitizerTrait}, plus a truncated
+     * sanitized provider response body) — never the raw message verbatim —
+     * while the full detail is logged downstream.
      */
     public function runAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -154,13 +145,13 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $captureRaw   = $this->boolFromBody($body, 'captureRaw');
         $dryRun       = $this->boolFromBody($body, 'dryRun');
         $systemPrompt = trim($this->stringFromBody($body, 'systemPrompt'));
-        // Cap the per-run round count server-side (matching the UI ceiling) so
-        // a crafted request cannot drive an unbounded, cost-accruing loop.
-        $maxRounds    = min($this->intFromBody($body, 'maxRounds'), self::MAX_ROUNDS);
+        // Cap the per-run round count at the UI ceiling; the runtime clamps to
+        // the same constant again server-side (single source of truth).
+        $maxRounds    = min($this->intFromBody($body, 'maxRounds'), AgentRuntime::MAX_ITERATIONS);
         $maxTokens    = $this->intFromBody($body, 'maxTokens');
         // Clamp to ChatOptions' valid range: an out-of-range value would throw
         // an InvalidArgumentException from the ToolOptions constructor below —
-        // which is outside the run try/catch — and 500 the request.
+        // before the runtime's ladder — and 500 the request.
         $temperature  = $this->floatFromBody($body, 'temperature');
         if ($temperature !== null) {
             $temperature = max(0.0, min(2.0, $temperature));
@@ -183,106 +174,42 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         // The checked tool boxes restrict this run; absent any selection, fall
         // back to the globally-enabled set. The runtime gate is authoritative
-        // regardless (a disabled tool stays off).
+        // regardless (a disabled tool stays off, ADR-093).
         $selected = $this->toolNamesFromBody($body) ?? $this->toolAvailability->enabledNames();
 
-        // The selection is a request, not a grant: the configuration's skill
-        // allow-list and allowed_tool_groups are applied inside the loop since
-        // ADR-093, so every consumer of ToolLoopServiceInterface gets the same
-        // gate — not just this controller.
-        $allowed = $selected;
-
-        $augmentation = new RunAugmentation(
-            forcedSkills: $this->resolveForcedSkills($this->uidListFromBody($body, 'forcedSkills')),
-            forcedSnippets: $this->promptSnippetRepository->findByUids($this->uidListFromBody($body, 'forcedSnippets')),
-            dryRun: $dryRun,
+        $agentRequest = new AgentRunRequest(
+            configuration: $config,
+            messages: [ChatMessage::user($prompt)],
+            allowedToolNames: $selected,
+            options: $options,
+            maxIterations: $maxRounds > 0 ? $maxRounds : null,
+            augmentation: new RunAugmentation(
+                forcedSkills: $this->resolveForcedSkills($this->uidListFromBody($body, 'forcedSkills')),
+                forcedSnippets: $this->promptSnippetRepository->findByUids($this->uidListFromBody($body, 'forcedSnippets')),
+                dryRun: $dryRun,
+            ),
+            captureRaw: $captureRaw,
+            beUserUid: $this->currentBackendUserUid(),
         );
-        $messages      = [ChatMessage::user($prompt)];
-        $maxIterations = $maxRounds > 0 ? $maxRounds : null;
-
-        // Persist the run (ADR-081): open a RUNNING row and get a handle to
-        // thread each recorded step through. Null when persistence is
-        // unavailable — the run then proceeds unpersisted, exactly as before.
-        $handle = $this->agentRunPersister?->begin($config, $this->currentBackendUserUid());
 
         // Live path: stream each recorded step to the browser as it happens.
         if ($this->boolFromBody($body, 'stream')) {
-            return $this->runStreamed($messages, $config, $allowed, $options, $maxIterations, $augmentation, $captureRaw, $handle);
+            return $this->runStreamed($agentRequest, $dryRun);
         }
 
         // Batch path: run the whole loop, then return the full trace as one JSON
         // document (the no-JS fallback and the shape the functional tests assert).
-        // The onRecord hook persists each step as it is recorded (ADR-081) —
-        // additive to the loop, which is unaware of it.
-        $trace = new RunTrace(
-            captureRaw: $captureRaw,
-            onRecord: $handle !== null
-                ? function (RunStep $step) use ($handle): void {
-                    $this->agentRunPersister?->recordStep($handle, $step);
-                }
-            : null,
-        );
-
-        try {
-            $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
-        } catch (ToolApprovalRequiredException $approval) {
-            // ADR-084: a called tool requires human approval. Persist the
-            // suspended state (transcript + pending calls) so a later resume can
-            // continue, and return an awaiting-approval response — caught BEFORE
-            // the generic Throwable below so a suspension is not a failed run.
-            $persister = $this->agentRunPersister;
-            if ($handle !== null && $persister !== null && !$persister->suspend($handle, $approval->state)) {
-                // Fail-closed: an approval-gated tool is side-effecting. Without
-                // stored state there is nothing to resume, so promising the
-                // client an approval flow would strand the run (ADR-092).
-                $persister->settleFailed($handle, $approval);
-                $this->logger?->error('Agent run could not be suspended for approval; the run was failed instead', ['run' => $handle->uuid]);
-
-                return $this->respondJson([
-                    'success' => false,
-                    'error'   => 'The run required approval but its state could not be stored, so it cannot be resumed.',
-                ], 500);
-            }
-
-            return $this->respondJson($this->awaitingApprovalPayload($handle !== null ? $handle->uuid : '', $approval, $trace));
-        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
-            return $this->handleGuardrailBlock($guardrail, $handle, $trace);
-        } catch (Throwable $e) {
-            if ($handle !== null) {
-                $this->agentRunPersister?->settleFailed($handle, $e);
-            }
-            $this->logger?->error('Tool playground run failed', ['exception' => $e]);
-
-            return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
-        }
-
-        if ($handle !== null) {
-            $this->agentRunPersister?->settleCompleted($handle, $result);
-        }
-
-        $response = new PlaygroundRunResponse(
-            finalContent: $result->finalContent,
-            iterations: $result->iterations,
-            truncated: $result->truncated,
-            dryRun: $dryRun,
-            steps: $trace->getSteps(),
-            promptTokens: $result->usage->promptTokens,
-            completionTokens: $result->usage->completionTokens,
-            totalTokens: $result->usage->totalTokens,
-            estimatedCost: $result->usage->estimatedCost,
-        );
-
-        return $this->respondJson($response->toArray());
+        return $this->respondToResult($this->agentRuntime->run($agentRequest), $dryRun);
     }
 
     /**
      * Resume a run suspended for human approval (ADR-084).
      *
-     * Admin-gated like {@see runAction()}. Loads the suspended run by uuid,
-     * rehydrates its state, executes (or, when not approved, refuses) the pending
-     * tool call(s) via {@see ToolLoopService::resume()}, and returns the continued
-     * run's result — which may itself suspend again on another approval-required
-     * tool.
+     * Admin-gated like {@see runAction()}. The load/validate/claim/resume
+     * lifecycle is {@see AgentRuntimeInterface::approve()}'s; this action maps
+     * its typed request-validation exceptions onto the module's HTTP statuses
+     * and the continued run's result — which may itself suspend again — onto
+     * the same payload shapes as a fresh run.
      */
     public function resumeAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -294,74 +221,71 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $runUuid  = trim($this->stringFromBody($body, 'runUuid'));
         $approved = $this->boolFromBody($body, 'approve');
 
-        $run = $this->agentRunPersister?->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
+        try {
+            $result = $this->agentRuntime->approve(
+                $runUuid,
+                new ApprovalDecision($approved, $this->currentBackendUserUid()),
+            );
+        } catch (RunNotAwaitingApprovalException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.notAwaitingApproval', 'No run is awaiting approval for that id.')], 400);
-        }
-
-        $config = $this->configurationRepository->findByUid($run->configurationUid);
-        if ($config === null) {
+        } catch (RunConfigurationGoneException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.configGone', 'The run configuration no longer exists.')], 400);
-        }
-
-        $decoded = json_decode($run->suspendedState, true);
-        if (!is_array($decoded)) {
+        } catch (CorruptSuspendedStateException|RunStateUnavailableException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.corruptState', 'The suspended run state could not be read.')], 500);
-        }
-        $state = SuspendedRunState::fromArray($decoded);
-
-        // Atomically claim the run before executing its pending (approval-gated,
-        // possibly destructive) tool calls, so two concurrent Approve requests
-        // — an admin double-click, a client retry — cannot both run them (ADR-084).
-        if ($this->agentRunPersister !== null && !$this->agentRunPersister->claimResume($run)) {
+        } catch (RunAlreadyResumingException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.alreadyResuming', 'This run is already being processed.')], 409);
         }
 
-        // Continue the SAME run: rebuild the handle so events keep ascending.
-        // The allow-list and options are restored from the suspended state inside
-        // resume() — the run keeps its original constraints (ADR-084).
-        $handle = $this->agentRunPersister?->resumeHandle($run);
-        $trace  = new RunTrace(
-            onRecord: $handle !== null
-                ? function (RunStep $step) use ($handle): void {
-                    $this->agentRunPersister?->recordStep($handle, $step);
-                }
-            : null,
-        );
+        return $this->respondToResult($result, false);
+    }
 
-        try {
-            $result = $this->toolLoopService->resume($state, $approved, $config, null, $trace, $this->currentBackendUserUid());
-        } catch (ToolApprovalRequiredException $approval) {
-            if ($handle !== null) {
-                $this->agentRunPersister?->suspend($handle, $approval->state);
-            }
+    /**
+     * Map a settled {@see AgentRunResult} onto the module's batch JSON shapes
+     * — the ADR-041 contract the functional tests assert.
+     */
+    private function respondToResult(AgentRunResult $result, bool $dryRun): ResponseInterface
+    {
+        switch ($result->outcome) {
+            case AgentRunOutcome::AWAITING_APPROVAL:
+                return $this->respondJson($this->awaitingApprovalPayload($result));
 
-            return $this->respondJson($this->awaitingApprovalPayload($run->uuid, $approval, $trace));
-        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
-            return $this->handleGuardrailBlock($guardrail, $handle, $trace);
-        } catch (Throwable $e) {
-            if ($handle !== null) {
-                $this->agentRunPersister?->settleFailed($handle, $e);
-            }
-            $this->logger?->error('Tool playground resume failed', ['exception' => $e]);
+            case AgentRunOutcome::SUSPEND_FAILED:
+                return $this->respondJson(['success' => false, 'error' => self::SUSPEND_FAILED_MESSAGE], 500);
 
-            return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($e)], 500);
+            case AgentRunOutcome::GUARDRAIL_BLOCKED:
+            case AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED:
+                // A guardrail DENY or REQUIRE_APPROVAL is a policy outcome, not
+                // a server error — the HTTP status stays 200 with success:false
+                // (ADR-086). The runtime already logged it with the run uuid.
+                return $this->respondJson($this->guardrailBlockedPayload($result));
+
+            case AgentRunOutcome::FAILED:
+                // Logged by the runtime; the controller only shapes the (admin-
+                // only, sanitized) diagnosis.
+                return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($result->error)], 500);
+
+            case AgentRunOutcome::COMPLETED:
         }
 
-        if ($handle !== null) {
-            $this->agentRunPersister?->settleCompleted($handle, $result);
+        $loop = $result->loopResult;
+        if ($loop === null) {
+            // Contract violation: a COMPLETED result always carries the loop
+            // result. Surface it as a failure instead of fabricating a payload.
+            $this->logger?->error('Completed agent run carried no loop result', ['run' => $result->runUuid]);
+
+            return $this->respondJson(['success' => false, 'error' => 'The run completed but produced no result.'], 500);
         }
 
         $response = new PlaygroundRunResponse(
-            finalContent: $result->finalContent,
-            iterations: $result->iterations,
-            truncated: $result->truncated,
-            dryRun: false,
-            steps: $trace->getSteps(),
-            promptTokens: $result->usage->promptTokens,
-            completionTokens: $result->usage->completionTokens,
-            totalTokens: $result->usage->totalTokens,
-            estimatedCost: $result->usage->estimatedCost,
+            finalContent: $loop->finalContent,
+            iterations: $loop->iterations,
+            truncated: $loop->truncated,
+            dryRun: $dryRun,
+            steps: $result->steps,
+            promptTokens: $loop->usage->promptTokens,
+            completionTokens: $loop->usage->completionTokens,
+            totalTokens: $loop->usage->totalTokens,
+            estimatedCost: $loop->usage->estimatedCost,
         );
 
         return $this->respondJson($response->toArray());
@@ -373,37 +297,26 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      *
      * @return array<string, mixed>
      */
-    private function awaitingApprovalPayload(string $runUuid, ToolApprovalRequiredException $approval, RunTrace $trace): array
+    private function awaitingApprovalPayload(AgentRunResult $result): array
     {
         return [
             'success'      => true,
             'status'       => 'awaiting_approval',
-            'runUuid'      => $runUuid,
-            'pendingTools' => array_map(
-                static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
-                $approval->state->toolCalls(),
-            ),
-            'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $trace->getSteps()),
+            'runUuid'      => $result->runUuid,
+            'pendingTools' => $this->pendingTools($result),
+            'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
         ];
     }
 
     /**
-     * Common handling for a guardrail verdict on a non-streamed run (ADR-086):
-     * record the run as blocked so it is not left RUNNING, then return the
-     * blocked payload. A guardrail DENY or REQUIRE_APPROVAL is a policy outcome,
-     * not a server error — the HTTP status stays 200 with ``success:false``.
+     * @return list<array{name: string, arguments: array<string, mixed>}>
      */
-    private function handleGuardrailBlock(
-        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
-        ?AgentRunHandle $handle,
-        RunTrace $trace,
-    ): ResponseInterface {
-        if ($handle !== null) {
-            $this->agentRunPersister?->settlePolicyStopped($handle, $guardrail, $this->guardrailTerminationReason($guardrail));
-        }
-        $this->logger?->warning('Tool playground run blocked by guardrail', ['exception' => $guardrail]);
-
-        return $this->respondJson($this->guardrailBlockedPayload($guardrail, $trace));
+    private function pendingTools(AgentRunResult $result): array
+    {
+        return array_map(
+            static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
+            $result->suspendedState?->toolCalls() ?? [],
+        );
     }
 
     /**
@@ -413,60 +326,15 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      *
      * @return array<string, mixed>
      */
-    private function guardrailBlockedPayload(
-        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
-        RunTrace $trace,
-    ): array {
+    private function guardrailBlockedPayload(AgentRunResult $result): array
+    {
         return [
             'success'   => false,
-            'status'    => $this->guardrailStatus($guardrail),
-            'guardrail' => $guardrail->guardrail,
-            'error'     => $guardrail->getMessage(),
-            'steps'     => array_map(static fn(RunStep $step): array => $step->toArray(), $trace->getSteps()),
+            'status'    => $result->outcome->value,
+            'guardrail' => $result->guardrailClass ?? '',
+            'error'     => $result->error?->getMessage() ?? '',
+            'steps'     => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
         ];
-    }
-
-    /**
-     * The terminal streamed event for a guardrail block (ADR-086): same status
-     * and reason as {@see self::guardrailBlockedPayload()}, shaped as a stream
-     * event rather than a full JSON response.
-     *
-     * @return array<string, mixed>
-     */
-    private function guardrailBlockedEvent(
-        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
-    ): array {
-        $status = $this->guardrailStatus($guardrail);
-
-        return [
-            'event'     => $status,
-            'success'   => false,
-            'status'    => $status,
-            'guardrail' => $guardrail->guardrail,
-            'error'     => $guardrail->getMessage(),
-        ];
-    }
-
-    private function guardrailStatus(
-        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
-    ): string {
-        return $guardrail instanceof GuardrailApprovalRequiredException
-            ? 'guardrail_approval_required'
-            : 'guardrail_blocked';
-    }
-
-    /**
-     * Why the run ended, for the persisted row (ADR-092). A guardrail stop is a
-     * policy outcome, so it is never recorded as a provider failure; an
-     * approval that was required and never obtained is recorded as such rather
-     * than as an outright denial.
-     */
-    private function guardrailTerminationReason(
-        GuardrailViolationException|GuardrailApprovalRequiredException $guardrail,
-    ): AgentRunTerminationReason {
-        return $guardrail instanceof GuardrailApprovalRequiredException
-            ? AgentRunTerminationReason::APPROVAL_DENIED
-            : AgentRunTerminationReason::POLICY_DENIED;
     }
 
     /**
@@ -476,22 +344,11 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * Output buffering and compression are disabled and each line is padded
      * (see {@see self::STREAM_MIN_LINE_BYTES}) so the reverse proxy flushes it
      * immediately; a {@see NullResponse} is returned so TYPO3 emits nothing
-     * further (it has already been sent). The step callback runs inside
-     * {@see RunTrace}, fired the moment each step is recorded.
-     *
-     * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param list<string>|null                      $allowed
+     * further (it has already been sent). The step callback runs inside the
+     * runtime's trace, fired the moment each step is recorded.
      */
-    private function runStreamed(
-        array $messages,
-        LlmConfiguration $config,
-        ?array $allowed,
-        ToolOptions $options,
-        ?int $maxIterations,
-        RunAugmentation $augmentation,
-        bool $captureRaw,
-        ?AgentRunHandle $handle = null,
-    ): ResponseInterface {
+    private function runStreamed(AgentRunRequest $request, bool $dryRun): ResponseInterface
+    {
         ini_set('zlib.output_compression', '0');
         ini_set('output_buffering', '0');
         ini_set('implicit_flush', '1');
@@ -508,14 +365,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             function (array $event): void {
                 $this->streamLine($event);
             },
-            $messages,
-            $config,
-            $allowed,
-            $options,
-            $maxIterations,
-            $augmentation,
-            $captureRaw,
-            $handle,
+            $request,
+            $dryRun,
         );
 
         return new NullResponse();
@@ -523,113 +374,93 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
     /**
      * Run the loop and emit the streamed protocol through {@see $emit}: one
-     * ``step`` event per recorded step (live, via the {@see RunTrace} callback),
-     * then a terminal ``done`` — or ``error`` on failure. Transport-agnostic (no
-     * output buffering, headers or flushing), so the event sequence can be
-     * asserted in isolation from the echo/flush plumbing in {@see runStreamed()}.
+     * ``step`` event per recorded step (live, via the runtime's step observer),
+     * then a terminal ``done`` — or ``error`` / ``awaiting_approval`` /
+     * guardrail event — mapped from the settled {@see AgentRunResult}.
+     * Transport-agnostic (no output buffering, headers or flushing), so the
+     * event sequence can be asserted in isolation from the echo/flush plumbing
+     * in {@see runStreamed()}.
      *
-     * @param Closure(array<string, mixed>): void    $emit
-     * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param list<string>|null                      $allowed
+     * @param Closure(array<string, mixed>): void $emit
      */
-    private function streamRun(
-        Closure $emit,
-        array $messages,
-        LlmConfiguration $config,
-        ?array $allowed,
-        ToolOptions $options,
-        ?int $maxIterations,
-        RunAugmentation $augmentation,
-        bool $captureRaw,
-        ?AgentRunHandle $handle = null,
-    ): void {
-        $trace = new RunTrace(
-            captureRaw: $captureRaw,
-            onRecord: function (RunStep $step) use ($emit, $handle): void {
+    private function streamRun(Closure $emit, AgentRunRequest $request, bool $dryRun): void
+    {
+        $result = $this->agentRuntime->run(
+            $request,
+            static function (RunStep $step) use ($emit): void {
                 $emit(['event' => 'step', 'step' => $step->toArray()]);
-                if ($handle !== null) {
-                    $this->agentRunPersister?->recordStep($handle, $step);
-                }
             },
         );
 
-        $settled = false;
-        try {
-            $result = $this->toolLoopService->runLoop($messages, $config, $allowed, $options, $maxIterations, $trace, $augmentation);
-            if ($handle !== null) {
-                $this->agentRunPersister?->settleCompleted($handle, $result);
-                $settled = true;
-            }
-            $emit([
-                'event'        => 'done',
-                'success'      => true,
-                'finalContent' => $result->finalContent,
-                'iterations'   => $result->iterations,
-                'truncated'    => $result->truncated,
-                'dryRun'       => $augmentation->dryRun,
-                'usage'        => [
-                    'promptTokens'     => $result->usage->promptTokens,
-                    'completionTokens' => $result->usage->completionTokens,
-                    'totalTokens'      => $result->usage->totalTokens,
-                    'estimatedCost'    => $result->usage->estimatedCost,
-                ],
-            ]);
-        } catch (ToolApprovalRequiredException $approval) {
-            // ADR-084: a called tool requires approval — suspend the run and emit
-            // an awaiting-approval event instead of failing.
-            $persister = $this->agentRunPersister;
-            if ($handle !== null && $persister !== null) {
-                $suspended = $persister->suspend($handle, $approval->state);
-                $settled   = true;
+        switch ($result->outcome) {
+            case AgentRunOutcome::AWAITING_APPROVAL:
+                // ADR-084: a called tool requires approval — the run suspended
+                // instead of failing.
+                $emit([
+                    'event'        => 'awaiting_approval',
+                    'success'      => true,
+                    'runUuid'      => $result->runUuid,
+                    'pendingTools' => $this->pendingTools($result),
+                ]);
 
-                if (!$suspended) {
-                    // Fail-closed, as in the batch path: no stored state means no
-                    // resume, so do not announce an approval flow (ADR-092).
-                    $persister->settleFailed($handle, $approval);
-                    $this->logger?->error('Agent run could not be suspended for approval; the run was failed instead', ['run' => $handle->uuid]);
-                    $emit([
-                        'event'   => 'error',
-                        'success' => false,
-                        'error'   => 'The run required approval but its state could not be stored, so it cannot be resumed.',
-                    ]);
+                return;
 
-                    return;
-                }
-            }
-            $emit([
-                'event'        => 'awaiting_approval',
-                'success'      => true,
-                'runUuid'      => $handle !== null ? $handle->uuid : '',
-                'pendingTools' => array_map(
-                    static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
-                    $approval->state->toolCalls(),
-                ),
-            ]);
-        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
-            // ADR-085/086: a guardrail verdict is a policy outcome, not a failure
-            // — settle the run as blocked and emit a distinct terminal event
-            // instead of a generic error.
-            if ($handle !== null) {
-                $this->agentRunPersister?->settlePolicyStopped($handle, $guardrail, $this->guardrailTerminationReason($guardrail));
-                $settled = true;
-            }
-            $this->logger?->warning('Tool playground stream blocked by guardrail', ['exception' => $guardrail]);
-            $emit($this->guardrailBlockedEvent($guardrail));
-        } catch (Throwable $e) {
-            if ($handle !== null) {
-                $this->agentRunPersister?->settleFailed($handle, $e);
-                $settled = true;
-            }
-            $this->logger?->error('Tool playground run failed', ['exception' => $e]);
-            $emit(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($e)]);
-        } finally {
-            // A client disconnect (or a fatal mid-stream) can abandon the run
-            // before either branch settles it; mark it failed so no run is left
-            // stuck RUNNING. Mirrors StreamingDispatcher's finally-block settle.
-            if ($handle !== null && !$settled) {
-                $this->agentRunPersister?->settleFailed($handle, new RuntimeException('Agent run did not complete'));
-            }
+            case AgentRunOutcome::SUSPEND_FAILED:
+                // Fail-closed, as in the batch path: no stored state means no
+                // resume, so do not announce an approval flow (ADR-092).
+                $emit(['event' => 'error', 'success' => false, 'error' => self::SUSPEND_FAILED_MESSAGE]);
+
+                return;
+
+            case AgentRunOutcome::GUARDRAIL_BLOCKED:
+            case AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED:
+                // ADR-085/086: a guardrail verdict is a policy outcome, not a
+                // failure — a distinct terminal event instead of a generic
+                // error. The runtime already logged it with the run uuid.
+                $emit([
+                    'event'     => $result->outcome->value,
+                    'success'   => false,
+                    'status'    => $result->outcome->value,
+                    'guardrail' => $result->guardrailClass ?? '',
+                    'error'     => $result->error?->getMessage() ?? '',
+                ]);
+
+                return;
+
+            case AgentRunOutcome::FAILED:
+                // Logged by the runtime; only the sanitized diagnosis is shaped
+                // here.
+                $emit(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($result->error)]);
+
+                return;
+
+            case AgentRunOutcome::COMPLETED:
         }
+
+        $loop = $result->loopResult;
+        if ($loop === null) {
+            // Contract violation: a COMPLETED result always carries the loop
+            // result. Emit an error line instead of fabricating a done event.
+            $this->logger?->error('Completed agent run carried no loop result', ['run' => $result->runUuid]);
+            $emit(['event' => 'error', 'success' => false, 'error' => 'The run completed but produced no result.']);
+
+            return;
+        }
+
+        $emit([
+            'event'        => 'done',
+            'success'      => true,
+            'finalContent' => $loop->finalContent,
+            'iterations'   => $loop->iterations,
+            'truncated'    => $loop->truncated,
+            'dryRun'       => $dryRun,
+            'usage'        => [
+                'promptTokens'     => $loop->usage->promptTokens,
+                'completionTokens' => $loop->usage->completionTokens,
+                'totalTokens'      => $loop->usage->totalTokens,
+                'estimatedCost'    => $loop->usage->estimatedCost,
+            ],
+        ]);
     }
 
     /**
@@ -676,8 +507,9 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     }
 
     /**
-     * Resolve the current backend user's uid for the budget pre-flight (0 when
-     * no real BE user is present — the budget check then treats it as anonymous).
+     * Resolve the current backend user's uid for run attribution and the budget
+     * pre-flight (0 when no real BE user is present — the budget check then
+     * treats it as anonymous).
      */
     private function currentBackendUserUid(): int
     {
@@ -853,8 +685,12 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      * status and a truncated, sanitised response-body snippet — instead of a
      * generic "Tool run failed". The full exception is still logged separately.
      */
-    private function diagnoseRunFailure(Throwable $e): string
+    private function diagnoseRunFailure(?Throwable $e): string
     {
+        if ($e === null) {
+            return 'Unknown error';
+        }
+
         $class   = (new ReflectionClass($e))->getShortName();
         $message = $this->sanitizeErrorMessage($e->getMessage());
         $detail  = sprintf('%s: %s', $class, $message);

--- a/Classes/Domain/Enum/AgentEventKind.php
+++ b/Classes/Domain/Enum/AgentEventKind.php
@@ -14,11 +14,14 @@ use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 /**
  * Kind of a persisted agent-run event (ADR-081).
  *
- * These map one-to-one onto the four {@see RunStep} kinds the tool loop emits
- * through {@see \Netresearch\NrLlm\Service\Tool\RunTrace}. The enum is
- * intentionally limited to what the loop actually produces today; richer kinds
- * (approval requests, artifacts, streamed text deltas) are added by the epics
- * that emit them, not speculatively here.
+ * REQUEST / LLM / TOOL / ASSEMBLED map one-to-one onto the four {@see RunStep}
+ * kinds the tool loop emits through
+ * {@see \Netresearch\NrLlm\Service\Tool\RunTrace}; their payload is the decoded
+ * {@see RunStep::toArray()} snapshot. APPROVAL (ADR-101) is emitted by the
+ * AgentRuntime when an operator decides a suspended run, with the payload
+ * ``{approved: bool, decidedBy: int}`` — it is NOT a RunStep kind. The enum
+ * stays limited to what is actually emitted; richer kinds (artifacts, streamed
+ * text deltas) are added by the epics that emit them, not speculatively here.
  */
 enum AgentEventKind: string
 {
@@ -26,6 +29,7 @@ enum AgentEventKind: string
     case LLM = 'llm';
     case TOOL = 'tool';
     case ASSEMBLED = 'assembled';
+    case APPROVAL = 'approval';
 
     /**
      * @return list<string>
@@ -43,10 +47,15 @@ enum AgentEventKind: string
     /**
      * Map a {@see RunStep} kind constant onto its event kind. Returns null for an
      * unknown value so a future RunStep kind cannot silently masquerade as a
-     * known one.
+     * known one. Deliberately restricted to the four RunStep kinds: APPROVAL is
+     * an AgentRuntime event, not a RunStep, so it must not resolve here even
+     * though it is a valid stored event kind (use {@see self::tryFrom()} to
+     * hydrate a stored kind).
      */
     public static function fromRunStepKind(string $kind): ?self
     {
-        return self::tryFrom($kind);
+        $case = self::tryFrom($kind);
+
+        return $case === self::APPROVAL ? null : $case;
     }
 }

--- a/Classes/Domain/Enum/AgentRunOutcome.php
+++ b/Classes/Domain/Enum/AgentRunOutcome.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * How a synchronous agent-run segment ended, as returned by the
+ * AgentRuntime (ADR-101).
+ *
+ * Distinct from {@see AgentRunStatus} (the persisted row's lifecycle state):
+ * an outcome describes what THIS run() / approve() call produced, including
+ * transient distinctions the row does not need — a guardrail denial vs. a
+ * guardrail approval requirement both persist as FAILED, and SUSPEND_FAILED
+ * persists as FAILED while telling the caller specifically that an approval
+ * was required but could not be stored (fail-closed, ADR-092), so no resume
+ * must be offered.
+ *
+ * More cases may be added in minor releases (the queue epic will add
+ * queue-related outcomes); consumers must not match exhaustively without a
+ * default arm.
+ */
+enum AgentRunOutcome: string
+{
+    case COMPLETED = 'completed';
+    case AWAITING_APPROVAL = 'awaiting_approval';
+    case SUSPEND_FAILED = 'suspend_failed';
+    case GUARDRAIL_BLOCKED = 'guardrail_blocked';
+    case GUARDRAIL_APPROVAL_REQUIRED = 'guardrail_approval_required';
+    case FAILED = 'failed';
+}

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -45,6 +45,37 @@ final readonly class AgentRun
     ) {}
 
     /**
+     * A copy without the suspended-state transcript, for status exposure
+     * (ADR-101). The suspended state is stored VERBATIM for resume — it bypasses
+     * the {@see \Netresearch\NrLlm\Service\Privacy\RunStepPrivacyFilter} that
+     * every persisted event goes through (ADR-064) — so a status projection
+     * handed to a runtime consumer must not carry it.
+     */
+    public function withoutSuspendedState(): self
+    {
+        return new self(
+            uid: $this->uid,
+            uuid: $this->uuid,
+            status: $this->status,
+            configurationUid: $this->configurationUid,
+            configurationIdentifier: $this->configurationIdentifier,
+            beUser: $this->beUser,
+            iterations: $this->iterations,
+            truncated: $this->truncated,
+            totalPromptTokens: $this->totalPromptTokens,
+            totalCompletionTokens: $this->totalCompletionTokens,
+            totalTokens: $this->totalTokens,
+            estimatedCost: $this->estimatedCost,
+            errorClass: $this->errorClass,
+            terminationReason: $this->terminationReason,
+            startedAt: $this->startedAt,
+            finishedAt: $this->finishedAt,
+            crdate: $this->crdate,
+            suspendedState: null,
+        );
+    }
+
+    /**
      * The status as a typed enum, or null when the stored string is unknown
      * (a forward-compatibility guard — an unrecognised status is not coerced).
      */

--- a/Classes/Domain/ValueObject/AgentRunEvent.php
+++ b/Classes/Domain/ValueObject/AgentRunEvent.php
@@ -15,15 +15,19 @@ use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
  * One persisted event of an agent run, read back from `tx_nrllm_agentrun_event`
  * (ADR-081).
  *
- * Each event is the durable form of a {@see RunStep}: the replayable stream a
- * consumer UI can render after the fact. The full step payload is preserved in
- * {@see self::$payload} (the {@see RunStep::toArray()} shape); the promoted
+ * Most events are the durable form of a {@see RunStep}: the replayable stream a
+ * consumer UI can render after the fact, with the full step payload preserved
+ * in {@see self::$payload} (the {@see RunStep::toArray()} shape). An
+ * {@see AgentEventKind::APPROVAL} event (ADR-101) instead carries the
+ * operator's decision as ``{approved: bool, decidedBy: int}`` — consumers must
+ * discriminate the payload shape by {@see self::kindEnum()}. The promoted
  * columns (kind, round, duration) exist for querying and ordering.
  */
 final readonly class AgentRunEvent
 {
     /**
-     * @param array<string, mixed> $payload The decoded {@see RunStep::toArray()} snapshot.
+     * @param array<string, mixed> $payload The decoded {@see RunStep::toArray()} snapshot,
+     *                                      or the approval-decision shape for an APPROVAL event.
      */
     public function __construct(
         public int $uid,
@@ -38,9 +42,12 @@ final readonly class AgentRunEvent
 
     /**
      * The kind as a typed enum, or null when the stored string is unknown.
+     * Hydrates every valid stored kind — including APPROVAL, which is not a
+     * RunStep kind and therefore not resolvable via
+     * {@see AgentEventKind::fromRunStepKind()}.
      */
     public function kindEnum(): ?AgentEventKind
     {
-        return AgentEventKind::fromRunStepKind($this->kind);
+        return AgentEventKind::tryFrom($this->kind);
     }
 }

--- a/Classes/Service/Agent/AgentRunRequest.php
+++ b/Classes/Service/Agent/AgentRunRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
+
+/**
+ * Everything the AgentRuntime needs to execute one agent run (ADR-101).
+ *
+ * Built by a UI adapter (the playground controller), a CLI command, or — once
+ * the queue epic lands — a worker rehydrating a queued request. Deliberately a
+ * plain value object so it can later be serialised for queued execution without
+ * changing the runtime interface.
+ */
+final readonly class AgentRunRequest
+{
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages         the initial transcript,
+     *                                                                 usually a single user message
+     * @param list<string>|null                      $allowedToolNames per-run allow-list; null offers
+     *                                                                 the globally-enabled set. The
+     *                                                                 loop's gate (ADR-093) is
+     *                                                                 authoritative either way.
+     * @param int|null                               $maxIterations    requested round cap; null uses the
+     *                                                                 loop default. The runtime clamps a
+     *                                                                 non-null value to its ceiling
+     *                                                                 ({@see AgentRuntime::MAX_ITERATIONS}).
+     * @param int                                    $beUserUid        the initiating backend user, recorded
+     *                                                                 on the run row and used for the budget
+     *                                                                 pre-flight (0 = anonymous)
+     */
+    public function __construct(
+        public LlmConfiguration $configuration,
+        public array $messages,
+        public ?array $allowedToolNames = null,
+        public ?ToolOptions $options = null,
+        public ?int $maxIterations = null,
+        public ?RunAugmentation $augmentation = null,
+        public bool $captureRaw = false,
+        public int $beUserUid = 0,
+    ) {}
+}

--- a/Classes/Service/Agent/AgentRunResult.php
+++ b/Classes/Service/Agent/AgentRunResult.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Throwable;
+
+/**
+ * The settled result of one AgentRuntime run() / approve() call (ADR-101).
+ *
+ * The runtime never throws for a run outcome — a consumer always receives a
+ * result whose persisted status already matches. Which optional fields are set
+ * depends on the outcome:
+ *
+ *  - COMPLETED:                    loopResult
+ *  - AWAITING_APPROVAL:            suspendedState (pending calls via toolCalls())
+ *  - SUSPEND_FAILED:               error (the approval exception; run settled
+ *                                  FAILED, no resume possible — fail-closed,
+ *                                  ADR-092)
+ *  - GUARDRAIL_BLOCKED /
+ *    GUARDRAIL_APPROVAL_REQUIRED:  guardrailClass + error (the guardrail
+ *                                  exception; message = reason)
+ *  - FAILED:                       error
+ *
+ * `steps` carries the trace recorded up to the end of the segment on every
+ * outcome. `runUuid` is '' when the run could not be persisted (the run still
+ * executed, unrecorded — the persister's fail-soft contract).
+ */
+final readonly class AgentRunResult
+{
+    /**
+     * @param list<RunStep> $steps
+     */
+    public function __construct(
+        public AgentRunOutcome $outcome,
+        public string $runUuid,
+        public array $steps,
+        public ?ToolLoopResult $loopResult = null,
+        public ?SuspendedRunState $suspendedState = null,
+        public ?string $guardrailClass = null,
+        public ?Throwable $error = null,
+    ) {}
+}

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -1,0 +1,331 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Closure;
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * The one place the agent-run lifecycle lives (ADR-101).
+ *
+ * Extracted from ToolPlaygroundController, which carried this orchestration —
+ * begin, trace, persist, the suspend/guardrail/failure/completion ladder, the
+ * resume claim — copied three times (batch, resume, stream). Here it exists
+ * once; the playground is a UI adapter mapping {@see AgentRunResult} to its
+ * response shapes, and any other consumer (CLI, scheduler, review queue) gets
+ * the identical fail-closed semantics.
+ *
+ * Catch order is a hard guarantee (ADR-084): {@see ToolApprovalRequiredException}
+ * is control flow, not failure, and MUST be caught before the guardrail pair
+ * and before the generic Throwable.
+ */
+final readonly class AgentRuntime implements AgentRuntimeInterface
+{
+    /**
+     * Server-side ceiling on the per-run round count — a cost-safety invariant:
+     * no consumer request may drive an unbounded, cost-accruing loop. Clamps
+     * only an explicit {@see AgentRunRequest::$maxIterations}; null passes
+     * through so the loop's own (lower) default applies.
+     */
+    public const MAX_ITERATIONS = 20;
+
+    public function __construct(
+        private ToolLoopServiceInterface $toolLoop,
+        private AgentRunPersister $persister,
+        private LlmConfigurationRepository $configurationRepository,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult
+    {
+        $maxIterations = $request->maxIterations !== null
+            ? min($request->maxIterations, self::MAX_ITERATIONS)
+            : null;
+
+        $handle = $this->persister->begin($request->configuration, $request->beUserUid);
+        $trace  = $this->trace($handle, $onStep, $request->captureRaw);
+
+        return $this->execute(
+            $handle,
+            $trace,
+            fn(): ToolLoopResult => $this->toolLoop->runLoop(
+                $request->messages,
+                $request->configuration,
+                $request->allowedToolNames,
+                $request->options,
+                $maxIterations,
+                $trace,
+                $request->augmentation,
+            ),
+        );
+    }
+
+    public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
+            throw RunNotAwaitingApprovalException::forRun($runUuid);
+        }
+
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw RunConfigurationGoneException::forRun($runUuid);
+        }
+
+        $decoded = json_decode($run->suspendedState, true);
+        if (!is_array($decoded)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Probe the event-stream position BEFORE the claim: a failure here
+        // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
+        // the approval can simply be retried (nothing was claimed or executed).
+        if ($this->persister->resumeHandle($run) === null) {
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // Atomically claim the run before executing its pending (approval-gated,
+        // possibly destructive) tool calls, so two concurrent Approve requests
+        // cannot both run them (ADR-084). Fail-closed on a store error too.
+        if (!$this->persister->claimResume($run)) {
+            throw RunAlreadyResumingException::forRun($runUuid);
+        }
+
+        // Re-resolve the position from a FRESH row snapshot AFTER winning the
+        // claim: a request that stalled between findRun and the claim may hold
+        // a stale position from before another approval's continuation
+        // appended events — writing there would duplicate sequences and
+        // interleave segments. The claim is won, so a failure now settles the
+        // run rather than stranding it RUNNING (fail-closed either way).
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $this->persister->settleFailed(
+                new AgentRunHandle($run->uid, $run->uuid),
+                new RuntimeException('The event-stream position could not be determined after the resume claim'),
+            );
+
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // The decision is part of the run's audit stream (best-effort, ADR-101):
+        // who approved or denied, before the continuation's own events.
+        $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
+
+        $trace = $this->trace($handle, $onStep, false);
+
+        return $this->execute(
+            $handle,
+            $trace,
+            fn(): ToolLoopResult => $this->toolLoop->resume(
+                $state,
+                $decision->approved,
+                $configuration,
+                null,
+                $trace,
+                $decision->decidedByBeUser,
+            ),
+        );
+    }
+
+    public function cancel(string $runUuid): bool
+    {
+        return $this->persister->cancel($runUuid);
+    }
+
+    public function events(string $runUuid, int $afterSequence = -1): array
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $this->persister->findEvents($run->uid),
+            static fn($event): bool => $event->sequence > $afterSequence,
+        ));
+    }
+
+    public function status(string $runUuid): ?AgentRun
+    {
+        // The raw suspended transcript bypasses the privacy filter (it must —
+        // resume needs it verbatim); the status surface must not expose it.
+        return $this->persister->findRun($runUuid)?->withoutSuspendedState();
+    }
+
+    /**
+     * The trace every segment runs under: each recorded step reaches the live
+     * observer FIRST (preserving the streaming path's emit-before-persist
+     * order — a step is shown even when its persist fails), then the persisted
+     * event stream.
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw): RunTrace
+    {
+        if ($handle === null && $onStep === null) {
+            return new RunTrace(captureRaw: $captureRaw);
+        }
+
+        return new RunTrace(
+            captureRaw: $captureRaw,
+            onRecord: function (RunStep $step) use ($handle, $onStep): void {
+                if ($onStep !== null) {
+                    $onStep($step);
+                }
+                if ($handle !== null) {
+                    $this->persister->recordStep($handle, $step);
+                }
+            },
+        );
+    }
+
+    /**
+     * The single lifecycle ladder (ADR-101; previously copied three times in
+     * the playground controller).
+     *
+     * Every branch both settles the persisted row and marks the run settled so
+     * the finally-guard cannot touch it — including a SUCCESSFUL suspension:
+     * WAITING_FOR_APPROVAL is non-terminal, so an unguarded finally-settle
+     * would flip a resumable run to FAILED and destroy its suspended state.
+     * The finally-guard exists for the abandoned-run case (a live-stream
+     * observer dying mid-run, mirroring StreamingDispatcher) and costs the
+     * settled paths nothing.
+     *
+     * @param Closure(): ToolLoopResult $loopCall
+     */
+    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall): AgentRunResult
+    {
+        $runUuid = $handle !== null ? $handle->uuid : '';
+        $settled = false;
+
+        try {
+            $result = $loopCall();
+
+            if ($handle !== null) {
+                $this->persister->settleCompleted($handle, $result);
+            }
+            $settled = true;
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::COMPLETED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                loopResult: $result,
+            );
+        } catch (ToolApprovalRequiredException $approval) {
+            // ADR-084: a called tool requires human approval — control flow,
+            // not failure. Persist the suspended state so a later approve()
+            // can continue. Both branches below settle the run's fate, so the
+            // finally-guard must not run either way.
+            $settled = true;
+
+            if ($handle !== null && $this->persister->suspend($handle, $approval->state)) {
+                return new AgentRunResult(
+                    outcome: AgentRunOutcome::AWAITING_APPROVAL,
+                    runUuid: $runUuid,
+                    steps: $trace->getSteps(),
+                    suspendedState: $approval->state,
+                );
+            }
+
+            // Fail-closed (ADR-092): an approval-gated tool is side-effecting.
+            // Without stored state — the store refused or errored, a concurrent
+            // cancel already terminated the row, or the run was never persisted
+            // at all (null handle) — there is nothing to resume, so promising
+            // an approval flow would strand the client. Applied on EVERY path
+            // since ADR-101 (the old code silently ignored a failed
+            // re-suspension AND announced awaiting-approval for unpersisted
+            // runs).
+            if ($handle !== null) {
+                $this->persister->settleFailed($handle, $approval);
+            }
+            $this->logger?->error('Agent run could not be suspended for approval; no resume is possible', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::SUSPEND_FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $approval,
+            );
+        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
+            // ADR-085/086: a guardrail verdict is a policy outcome, not a
+            // failure — and an approval that was required but never obtained
+            // is not recorded as an outright denial (ADR-092).
+            if ($handle !== null) {
+                $this->persister->settlePolicyStopped(
+                    $handle,
+                    $guardrail,
+                    $guardrail instanceof GuardrailApprovalRequiredException
+                        ? AgentRunTerminationReason::APPROVAL_DENIED
+                        : AgentRunTerminationReason::POLICY_DENIED,
+                );
+            }
+            $settled = true;
+            $this->logger?->warning('Agent run blocked by guardrail', ['exception' => $guardrail, 'run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: $guardrail instanceof GuardrailApprovalRequiredException
+                    ? AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED
+                    : AgentRunOutcome::GUARDRAIL_BLOCKED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                guardrailClass: $guardrail->guardrail,
+                error: $guardrail,
+            );
+        } catch (Throwable $e) {
+            if ($handle !== null) {
+                $this->persister->settleFailed($handle, $e);
+            }
+            $settled = true;
+            $this->logger?->error('Agent run failed', ['exception' => $e, 'run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $e,
+            );
+        } finally {
+            // A live-stream observer dying mid-run (client disconnect) can
+            // abandon the run before any branch settles it; mark it failed so
+            // no run is left stuck RUNNING. Mirrors StreamingDispatcher's
+            // finally-block settle. Guarded by $settled: a suspended run is
+            // WAITING_FOR_APPROVAL — non-terminal — and settling it here would
+            // destroy its resumable state.
+            if ($handle !== null && !$settled) {
+                $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'));
+            }
+        }
+    }
+}

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -170,10 +170,8 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             return [];
         }
 
-        return array_values(array_filter(
-            $this->persister->findEvents($run->uid),
-            static fn($event): bool => $event->sequence > $afterSequence,
-        ));
+        // Filtered in SQL — a poller pages without re-hydrating the history.
+        return $this->persister->findEvents($run->uid, $afterSequence);
     }
 
     public function status(string $runUuid): ?AgentRun

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Closure;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Service\Agent\Exception\AgentRuntimeException;
+
+/**
+ * The public application service for agent runs (ADR-101): begin, execute,
+ * persist, suspend for approval, resume, cancel and observe an agent run
+ * through one surface, so every consumer — the playground UI, CLI commands,
+ * and later scheduler/queue workers, editor actions and review queues — gets
+ * the identical, fail-closed lifecycle instead of re-assembling it from the
+ * loop and the persister.
+ *
+ * CONSUMER interface: call it, do not implement or decorate it outside
+ * nr_llm. Methods and {@see \Netresearch\NrLlm\Domain\Enum\AgentRunOutcome}
+ * cases may be added in minor releases (the queue epic will add asynchronous
+ * execution), so exhaustive matches need a default arm. The lower-level
+ * {@see \Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface} stays public
+ * for consumers that want the bare loop without persistence or approval; this
+ * runtime is the preferred surface.
+ */
+interface AgentRuntimeInterface
+{
+    /**
+     * Execute one agent run synchronously: open a persisted run, drive the tool
+     * loop, and settle the row to match the outcome. Never throws for a run
+     * outcome — the returned result is already settled (completion, suspension
+     * for approval, guardrail block, or failure).
+     *
+     * A non-null {@see AgentRunRequest::$maxIterations} is clamped to
+     * {@see AgentRuntime::MAX_ITERATIONS}; null keeps the loop's own default.
+     *
+     * @param (Closure(RunStep): void)|null $onStep fired for each step the moment it
+     *                                              is recorded (before it is persisted),
+     *                                              so a caller can stream steps live
+     */
+    public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult;
+
+    /**
+     * Decide a run suspended for human approval (ADR-084) and synchronously
+     * continue it: execute the pending tool calls when approved (refuse them
+     * into the transcript when not), then re-enter the loop. The continuation
+     * may itself suspend again, and — like {@see self::run()} — always comes
+     * back as a settled result.
+     *
+     * The decision is claimed atomically (two concurrent approvals cannot both
+     * execute the gated calls) and persisted as an APPROVAL event in the run's
+     * stream.
+     *
+     * @param (Closure(RunStep): void)|null $onStep as in {@see self::run()}
+     *
+     * @throws AgentRuntimeException when the request is invalid before any
+     *                               execution: RunNotAwaitingApproval,
+     *                               RunConfigurationGone, CorruptSuspendedState,
+     *                               RunStateUnavailable, RunAlreadyResuming
+     */
+    public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
+
+    /**
+     * Cancel a run that is still queued, running or awaiting a decision. True
+     * when this call cancelled it; false when the run is unknown or already
+     * terminal (the guarded transition decides, so two concurrent cancels
+     * cannot both win). Cancellation is a persistence-level fence: an
+     * in-flight loop is not interrupted, its late settle is discarded.
+     */
+    public function cancel(string $runUuid): bool;
+
+    /**
+     * The persisted event stream of a run, ordered by sequence ascending —
+     * only events with sequence > $afterSequence, so a poller can page.
+     * Empty for an unknown run (indistinguishable from a run with no events;
+     * use {@see self::status()} to tell the two apart).
+     *
+     * @return list<AgentRunEvent>
+     */
+    public function events(string $runUuid, int $afterSequence = -1): array;
+
+    /**
+     * The persisted run row, or null when unknown. The suspended-state
+     * transcript is stripped: it is stored verbatim for resume and bypasses
+     * the privacy filter every event goes through (ADR-064), so it is not
+     * part of the status surface.
+     */
+    public function status(string $runUuid): ?AgentRun;
+}

--- a/Classes/Service/Agent/ApprovalDecision.php
+++ b/Classes/Service/Agent/ApprovalDecision.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+/**
+ * An operator's decision on a run suspended for human approval (ADR-084 /
+ * ADR-101).
+ *
+ * One decision covers the whole pending tool-call turn (per-call verdicts are a
+ * later epic). The decision is persisted as an
+ * {@see \Netresearch\NrLlm\Domain\Enum\AgentEventKind::APPROVAL} event —
+ * best-effort, like every event write — so who approved or denied, and when, is
+ * part of the run's audit stream. Deliberately no free-text note: the event
+ * stream is privacy-filtered (ADR-064) and a prose field would bypass that.
+ */
+final readonly class ApprovalDecision
+{
+    public function __construct(
+        public bool $approved,
+        public int $decidedByBeUser,
+    ) {}
+}

--- a/Classes/Service/Agent/Exception/AgentRuntimeException.php
+++ b/Classes/Service/Agent/Exception/AgentRuntimeException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use RuntimeException;
+
+/**
+ * Base of the AgentRuntime request-validation exceptions (ADR-101).
+ *
+ * Thrown by {@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::approve()}
+ * BEFORE any execution when the request itself is invalid — an unknown or
+ * non-suspended run, a deleted configuration, unreadable state, or a lost
+ * concurrency claim. Run OUTCOMES (completion, suspension, guardrail block,
+ * failure) are never exceptions; they come back as a settled
+ * {@see \Netresearch\NrLlm\Service\Agent\AgentRunResult}.
+ */
+abstract class AgentRuntimeException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $runUuid,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/Classes/Service/Agent/Exception/CorruptSuspendedStateException.php
+++ b/Classes/Service/Agent/Exception/CorruptSuspendedStateException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The persisted suspended-run state could not be decoded.
+ *
+ * Thrown by approve(): the stored JSON is unreadable, so the pending tool calls cannot be reconstructed.
+ */
+final class CorruptSuspendedStateException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The persisted suspended-run state could not be decoded.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/Exception/RunAlreadyResumingException.php
+++ b/Classes/Service/Agent/Exception/RunAlreadyResumingException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The atomic resume claim was lost to a concurrent approval (or the store refused it).
+ *
+ * Thrown by approve(): fail-closed so the gated tool is never double-executed (ADR-084).
+ */
+final class RunAlreadyResumingException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The atomic resume claim was lost to a concurrent approval (or the store refused it).', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/Exception/RunConfigurationGoneException.php
+++ b/Classes/Service/Agent/Exception/RunConfigurationGoneException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The LlmConfiguration the suspended run was started with no longer exists.
+ *
+ * Thrown by approve(): the run cannot be resumed without its configuration.
+ */
+final class RunConfigurationGoneException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The LlmConfiguration the suspended run was started with no longer exists.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/Exception/RunNotAwaitingApprovalException.php
+++ b/Classes/Service/Agent/Exception/RunNotAwaitingApprovalException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The run is unknown, not suspended for approval, or carries no resumable state.
+ *
+ * Thrown by approve(): no run with this uuid is awaiting an approval decision.
+ */
+final class RunNotAwaitingApprovalException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The run is unknown, not suspended for approval, or carries no resumable state.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/Exception/RunStateUnavailableException.php
+++ b/Classes/Service/Agent/Exception/RunStateUnavailableException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The event-stream position for the resume could not be determined.
+ *
+ * Thrown by approve(): resuming anyway would corrupt the run's event sequence, so the resume is refused before the claim - the run stays suspended and the approval can be retried.
+ */
+final class RunStateUnavailableException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The event-stream position for the resume could not be determined.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
@@ -205,7 +207,14 @@ final readonly class AgentRunPersister
     {
         try {
             $stateJson = json_encode($state->toArray(), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR);
-            $this->repository->suspendRun($handle->runUid, $stateJson);
+            // Guarded transition (ADR-101): false when the run is no longer
+            // RUNNING — a concurrent cancel or settle won the row first, and the
+            // suspension must not resurrect it.
+            if (!$this->repository->suspendRun($handle->runUid, $stateJson)) {
+                $this->logger?->notice('AgentRun was no longer running when its suspension arrived; the suspension was discarded', ['run' => $handle->uuid]);
+
+                return false;
+            }
 
             return true;
         } catch (Throwable $exception) {
@@ -249,18 +258,72 @@ final readonly class AgentRunPersister
 
     /**
      * Rebuild a live handle for an existing (suspended) run so a resume continues
-     * its event stream at the right sequence.
+     * its event stream at the right sequence — MAX(sequence) + 1, so a gap in the
+     * stored stream can never produce a duplicate.
+     *
+     * Fail-closed exception to the fail-soft rule (like {@see self::suspend()}):
+     * null when the position cannot be determined. Restarting at 0 would insert
+     * duplicate sequence numbers and interleave the resumed segment into the
+     * middle of the stream — silently corrupting the event order the ADR-101
+     * `events()` API is defined by. The caller refuses the resume instead (the
+     * run stays suspended, the approval can be retried).
      */
-    public function resumeHandle(AgentRun $run): AgentRunHandle
+    public function resumeHandle(AgentRun $run): ?AgentRunHandle
     {
-        $handle = new AgentRunHandle($run->uid, $run->uuid);
         try {
-            $handle->sequence = count($this->repository->findEvents($run->uid));
-        } catch (Throwable $exception) {
-            $this->logger?->warning('AgentRun events could not be counted for resume; sequence restarts at 0', ['exception' => $exception]);
-        }
+            $handle           = new AgentRunHandle($run->uid, $run->uuid);
+            $handle->sequence = $this->repository->maxEventSequence($run->uid) + 1;
 
-        return $handle;
+            return $handle;
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun event position could not be determined; the resume is refused', ['exception' => $exception]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Persist an operator's approval decision as the next event in the run's
+     * stream (ADR-101): kind {@see AgentEventKind::APPROVAL}, payload
+     * ``{approved, decidedBy}``. Best-effort like every event write — a failure
+     * is logged, never blocks the decided continuation.
+     */
+    public function recordApproval(AgentRunHandle $handle, bool $approved, int $decidedByBeUser): void
+    {
+        try {
+            $payload = json_encode(
+                ['approved' => $approved, 'decidedBy' => $decidedByBeUser],
+                JSON_THROW_ON_ERROR,
+            );
+            $this->repository->recordEvent(
+                $handle->runUid,
+                $handle->sequence,
+                AgentEventKind::APPROVAL->value,
+                0,
+                0.0,
+                $payload,
+            );
+            ++$handle->sequence;
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun approval decision could not be persisted', ['exception' => $exception]);
+        }
+    }
+
+    /**
+     * The persisted event stream of a run, ordered by sequence — the read side
+     * of the ADR-101 `events()` API. Empty on error or for an unknown run.
+     *
+     * @return list<AgentRunEvent>
+     */
+    public function findEvents(int $runUid): array
+    {
+        try {
+            return $this->repository->findEvents($runUid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun events could not be loaded', ['exception' => $exception]);
+
+            return [];
+        }
     }
 
     private function finish(

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -311,14 +311,16 @@ final readonly class AgentRunPersister
 
     /**
      * The persisted event stream of a run, ordered by sequence — the read side
-     * of the ADR-101 `events()` API. Empty on error or for an unknown run.
+     * of the ADR-101 `events()` API. Only events with sequence > $afterSequence
+     * (filtered in SQL, so a poller pages cheaply). Empty on error or for an
+     * unknown run.
      *
      * @return list<AgentRunEvent>
      */
-    public function findEvents(int $runUid): array
+    public function findEvents(int $runUid, int $afterSequence = -1): array
     {
         try {
-            return $this->repository->findEvents($runUid);
+            return $this->repository->findEvents($runUid, $afterSequence);
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun events could not be loaded', ['exception' => $exception]);
 

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -196,7 +196,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return $this->hydrateRun($row);
     }
 
-    public function findEvents(int $runUid): array
+    public function findEvents(int $runUid, int $afterSequence = -1): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_EVENT);
         $queryBuilder->getRestrictions()->removeAll();
@@ -204,7 +204,10 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         $rows = $queryBuilder
             ->select('*')
             ->from(self::TABLE_EVENT)
-            ->where($queryBuilder->expr()->eq('run', $queryBuilder->createNamedParameter($runUid, Connection::PARAM_INT)))
+            ->where(
+                $queryBuilder->expr()->eq('run', $queryBuilder->createNamedParameter($runUid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->gt('sequence', $queryBuilder->createNamedParameter($afterSequence, Connection::PARAM_INT)),
+            )
             ->orderBy('sequence', 'ASC')
             ->executeQuery()
             ->fetchAllAssociative();

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -128,19 +128,28 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return $affected > 0;
     }
 
-    public function suspendRun(int $runUid, string $stateJson): void
+    public function suspendRun(int $runUid, string $stateJson): bool
     {
         // Non-terminal transition (ADR-084): store the resumable state and move
-        // the run to WAITING_FOR_APPROVAL without setting finished_at.
-        $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+        // the run to WAITING_FOR_APPROVAL without setting finished_at. Guarded
+        // on the run still being RUNNING (ADR-101): a concurrent cancel wins the
+        // terminal transition first, and an unguarded suspend would resurrect
+        // the CANCELLED row to WAITING_FOR_APPROVAL — offering an approval flow
+        // for a run the operator was told was stopped.
+        $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
             self::TABLE_RUN,
             [
                 'status'          => AgentRunStatus::WAITING_FOR_APPROVAL->value,
                 'suspended_state' => $stateJson,
                 'tstamp'          => time(),
             ],
-            ['uid' => $runUid],
+            [
+                'uid'    => $runUid,
+                'status' => AgentRunStatus::RUNNING->value,
+            ],
         );
+
+        return $affected === 1;
     }
 
     /**
@@ -201,6 +210,22 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ->fetchAllAssociative();
 
         return array_map($this->hydrateEvent(...), $rows);
+    }
+
+    public function maxEventSequence(int $runUid): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_EVENT);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $max = $queryBuilder
+            ->selectLiteral('MAX(sequence) AS max_sequence')
+            ->from(self::TABLE_EVENT)
+            ->where($queryBuilder->expr()->eq('run', $queryBuilder->createNamedParameter($runUid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+
+        // MAX() over zero rows is NULL — a run with no events yet.
+        return is_numeric($max) ? (int)$max : -1;
     }
 
     public function purgeOlderThan(int $timestamp): int

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -56,9 +56,12 @@ interface AgentRunRepositoryInterface
     /**
      * Suspend a run for human approval (ADR-084): persist its serialised state
      * and move it to WAITING_FOR_APPROVAL — a non-terminal transition, distinct
-     * from finishRun which sets a terminal status and finished_at.
+     * from finishRun which sets a terminal status and finished_at. Guarded on
+     * the run still being RUNNING (ADR-101): false when the transition was
+     * refused because a concurrent cancel (or settle) got there first, so a
+     * cancelled run is never resurrected into an approval queue.
      */
-    public function suspendRun(int $runUid, string $stateJson): void;
+    public function suspendRun(int $runUid, string $stateJson): bool;
 
     /**
      * Atomically claim a WAITING_FOR_APPROVAL run for resume (move it to RUNNING);
@@ -73,6 +76,13 @@ interface AgentRunRepositoryInterface
      * @return list<AgentRunEvent> Events for a run, ordered by sequence ascending.
      */
     public function findEvents(int $runUid): array;
+
+    /**
+     * The highest event sequence recorded for a run, or -1 when the run has no
+     * events yet. A resume continues the stream at max + 1 (ADR-101) —
+     * MAX-based, not count-based, so gaps can never cause a duplicate sequence.
+     */
+    public function maxEventSequence(int $runUid): int;
 
     /**
      * Delete FINISHED runs (and their events) created before the given

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -73,9 +73,14 @@ interface AgentRunRepositoryInterface
     public function findByUuid(string $uuid): ?AgentRun;
 
     /**
+     * @param int $afterSequence only events with sequence > this value; -1
+     *                           (the default) returns the full stream. Filtered
+     *                           in SQL so a poller does not re-hydrate the whole
+     *                           history on every page (ADR-101).
+     *
      * @return list<AgentRunEvent> Events for a run, ordered by sequence ascending.
      */
-    public function findEvents(int $runUid): array;
+    public function findEvents(int $runUid, int $afterSequence = -1): array;
 
     /**
      * The highest event sequence recorded for a run, or -1 when the run has no

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -22,6 +22,7 @@ services:
       - '../Classes/Provider/Exception/*'
       # Newable rank-fusion math (ADR-074): consumers construct it, no DI.
       - '../Classes/Service/Retrieval/ReciprocalRankFusion.php'
+      - '../Classes/Service/Agent/Exception/*'
       - '../Classes/Service/Rerank/Exception/*'
       # Scalar-argument constructor; built exclusively by RerankerFactory.
       - '../Classes/Service/Rerank/HttpReranker.php'
@@ -55,6 +56,15 @@ services:
 
   Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface:
     alias: Netresearch\NrLlm\Service\Tool\ToolLoopService
+    public: true
+
+  # The agent-run application service (ADR-101): run / approve / cancel /
+  # events / status through one fail-closed lifecycle. The preferred consumer
+  # surface — scheduler tasks, queue workers and downstream extensions use
+  # this; the bare ToolLoopServiceInterface above stays for consumers that
+  # want the loop without persistence or approval.
+  Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface:
+    alias: Netresearch\NrLlm\Service\Agent\AgentRuntime
     public: true
 
   # The composite tool gate (ADR-094): registered, enabled, permitted, within

--- a/Documentation/Adr/Adr101AgentRuntime.rst
+++ b/Documentation/Adr/Adr101AgentRuntime.rst
@@ -1,0 +1,138 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-101:
+
+============================================================================
+ADR-101: AgentRuntime — the agent-run lifecycle as a public service
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-101-context:
+
+Context
+=======
+
+Persistence (:ref:`ADR-081 <adr-081>`), human-in-the-loop approval
+(:ref:`ADR-084 <adr-084>`) and termination semantics (:ref:`ADR-092 <adr-092>`)
+work, but they were assembled inside ``ToolPlaygroundController``: it began the
+run, built the trace, persisted events, caught the suspension, settled the
+status and executed the resume. The lifecycle ladder — ``runLoop`` → catch
+suspension → catch guardrail → catch failure → settle completed — was copied
+three times (batch, resume, stream), and any new consumer (a scheduler task, a
+queue worker, an editor action) would have had to re-assemble it again, each
+copy a chance to get the fail-closed rules wrong.
+
+.. _adr-101-decision:
+
+Decision
+========
+
+``AgentRuntimeInterface`` (``Classes/Service/Agent/``) is the public
+application service for agent runs; ``AgentRuntime`` implements it and owns the
+ladder exactly once. The playground controller is now a UI adapter: it parses
+the request into an ``AgentRunRequest`` / ``ApprovalDecision`` and maps the
+returned ``AgentRunResult`` onto its JSON / NDJSON shapes, which are unchanged.
+
+.. code-block:: php
+
+   interface AgentRuntimeInterface
+   {
+       public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult;
+       public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
+       public function cancel(string $runUuid): bool;
+       /** @return list<AgentRunEvent> */
+       public function events(string $runUuid, int $afterSequence = -1): array;
+       public function status(string $runUuid): ?AgentRun;
+   }
+
+- ``run()`` / ``approve()`` **never throw for a run outcome** — the result is
+  already settled, discriminated by ``AgentRunOutcome`` (COMPLETED /
+  AWAITING_APPROVAL / SUSPEND_FAILED / GUARDRAIL_BLOCKED /
+  GUARDRAIL_APPROVAL_REQUIRED / FAILED). ``approve()`` throws typed
+  ``AgentRuntimeException``\ s only for an invalid request, before any
+  execution: not-awaiting-approval, configuration gone, corrupt state, event
+  position unavailable, claim lost.
+- ``onStep`` is a live observer fired for each recorded step **before** it is
+  persisted (preserving the streaming path's emit-before-persist order); the
+  NDJSON stream is built on it.
+- The roadmap sketched ``start(request): handle`` + ``run(handle)``. That split
+  is only real once the request payload is persisted so a *different process*
+  can execute it — the queue epic. Until then a handle would not be
+  rehydratable, so ``run()`` is synchronous begin-and-execute;
+  ``AgentRunRequest`` is a plain value object so the queue epic can serialise
+  it and add asynchronous execution without changing these signatures.
+
+Hardening folded in
+-------------------
+
+- **Suspension-safe finally-guard.** The abandoned-run settle (previously
+  stream-only) now guards every path, and every branch — including a
+  *successful* suspension — marks the run settled first. An unguarded
+  finally-settle would flip a just-suspended run (WAITING_FOR_APPROVAL is
+  non-terminal) to FAILED and destroy its resumable state.
+- **Fail-closed re-suspension.** The old resume path silently ignored a failed
+  re-suspension and still answered ``awaiting_approval`` — an unresumable
+  promise. The unified ladder applies :ref:`ADR-092 <adr-092>`'s fail-closed
+  rule everywhere; the distinct SUSPEND_FAILED outcome makes it visible.
+- **Iteration ceiling.** The per-run round cap (20) is a runtime invariant
+  (``AgentRuntime::MAX_ITERATIONS``), no longer a controller constant. Only an
+  explicit ``maxIterations`` is clamped; null keeps the loop's own lower
+  default.
+- **Deterministic event sequence.** A resume continues the stream at
+  ``MAX(sequence) + 1`` (was: a count that silently restarted at 0 on a query
+  failure, interleaving segments). The position is probed *before* the claim —
+  a failure refuses the resume while the run is still suspended, so the
+  approval can simply be retried — and resolved *again* after winning it, so a
+  request that stalled across another approval's continuation can never write
+  duplicate sequences. (The narrower pre-existing window that such a stale
+  request resumes the earlier suspension's *state* is unchanged from the
+  previous controller code and bounded by the claim fence.)
+- **Cancel is a real fence.** ``suspendRun`` is now a guarded transition
+  (suspends only a run still RUNNING). Previously an in-flight loop's late
+  suspension could resurrect a just-CANCELLED row to WAITING_FOR_APPROVAL,
+  offering an approval flow — and an executable gated tool — for a run the
+  operator was told was stopped. A refused suspension takes the fail-closed
+  SUSPEND_FAILED path; the terminal-status guard then discards its settle, so
+  the run stays CANCELLED.
+- **No fail-open unpersisted suspension.** A run whose persistence was down at
+  begin (null handle) that then hits an approval-gated tool is SUSPEND_FAILED,
+  not AWAITING_APPROVAL: nothing was stored, so ``approve('')`` could only
+  ever fail — the old code announced an approval flow that did not exist.
+- **Single-sourced logging.** The runtime logs each failure / guardrail block /
+  refused suspension once, with the run uuid; the controller no longer re-logs
+  the same event (the old per-channel messages, including "Tool playground
+  resume failed", are replaced by the runtime's).
+- **Audited decisions.** The operator's decision is persisted as a new
+  ``AgentEventKind::APPROVAL`` event (payload ``{approved, decidedBy}``,
+  best-effort like every event write). ``fromRunStepKind()`` deliberately does
+  not resolve it — it is not a ``RunStep`` kind; stored kinds hydrate via
+  ``tryFrom()``. No free-text note: the event stream is privacy-filtered
+  (:ref:`ADR-064 <adr-064>`) and prose would bypass that.
+- **Privacy-safe status.** ``status()`` strips the suspended-state transcript:
+  it is stored verbatim for resume and bypasses the privacy filter, so it is
+  not part of the status surface.
+
+.. _adr-101-consequences:
+
+Consequences
+============
+
+- ``AgentRuntimeInterface`` is a **public DI alias** (Category B), raising the
+  audited public-service count from 34 to **35**. This ADR supersedes ADR-094
+  as the count authority. It is a *consumer* interface: call it, do not
+  implement or decorate it outside nr_llm — methods and ``AgentRunOutcome``
+  cases may be added in minor releases (the queue epic will), so exhaustive
+  matches need a default arm. ``ToolLoopServiceInterface`` stays public for
+  consumers that want the bare loop; the runtime is the preferred surface.
+- ``nrllm:agent:cancel`` goes through the runtime; the playground controller
+  lost its ``ToolLoopService`` / ``AgentRunPersister`` dependencies.
+- **Breaking:** ``AgentRunPersister::resumeHandle()`` now returns
+  ``?AgentRunHandle`` (null = refuse the resume), and
+  ``AgentRunRepositoryInterface`` gained ``maxEventSequence()``.
+- Now possible without touching the playground: scheduler and messenger
+  workers, consumer extensions, batch runs, review queues, editor actions and
+  status polling (``events()`` pages by sequence) — the run lifecycle they get
+  is the tested one.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -398,3 +398,4 @@ Tools
    Adr098SpecializedInputGuardrailScreening
    Adr099SpecializedFailClosedDispatch
    Adr100SpecializedUsageExtractors
+   Adr101AgentRuntime

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -26,13 +26,14 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
-use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
@@ -102,14 +103,10 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $promptSnippetRepository = $this->get(PromptSnippetRepository::class);
         self::assertInstanceOf(PromptSnippetRepository::class, $promptSnippetRepository);
 
-        $controller = new ToolPlaygroundController(
-            $moduleTemplateFactory,
+        $controller = $this->makeController(
             $configurationRepository,
-            $pageRenderer,
+            $toolRegistry,
             new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), $availability),
-            $availability,
-            $skillRepository,
-            $promptSnippetRepository,
         );
         $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
 
@@ -520,12 +517,12 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $method->invoke(
             $controller,
             $emit,
-            [ChatMessage::user('analyse the logs')],
-            $config,
-            ['fetch_logs'],
-            new ToolOptions(),
-            null,
-            new RunAugmentation(),
+            new AgentRunRequest(
+                configuration: $config,
+                messages: [ChatMessage::user('analyse the logs')],
+                allowedToolNames: ['fetch_logs'],
+                options: new ToolOptions(),
+            ),
             false,
         );
 
@@ -631,12 +628,12 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $method->invoke(
             $controller,
             $emit,
-            [ChatMessage::user('do it')],
-            $config,
-            ['fetch_logs'],
-            new ToolOptions(),
-            null,
-            new RunAugmentation(),
+            new AgentRunRequest(
+                configuration: $config,
+                messages: [ChatMessage::user('do it')],
+                allowedToolNames: ['fetch_logs'],
+                options: new ToolOptions(),
+            ),
             false,
         );
 
@@ -806,15 +803,25 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $promptSnippetRepository = $this->get(PromptSnippetRepository::class);
         self::assertInstanceOf(PromptSnippetRepository::class, $promptSnippetRepository);
 
+        // Since ADR-101 the controller is a UI adapter over the runtime; the
+        // runtime is wired here from the same real collaborators the container
+        // would inject (real DB-backed persister unless a test supplies one),
+        // so every behavioural assertion still exercises the full path.
+        $agentRuntime = new AgentRuntime(
+            $toolLoopService,
+            $agentRunPersister ?? new AgentRunPersister(new AgentRunRepository($this->toolConnectionPool()), FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger()),
+            $configurationRepository,
+            new NullLogger(),
+        );
+
         return new ToolPlaygroundController(
             $moduleTemplateFactory,
             $configurationRepository,
             $pageRenderer,
-            $toolLoopService,
+            $agentRuntime,
             $this->availabilityFor($toolRegistry),
             $skillRepository,
             $promptSnippetRepository,
-            $agentRunPersister,
         );
     }
 

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -78,8 +78,11 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertIsArray($decoded);
         self::assertSame(1, $decoded['iterations']);
 
-        // resumeHandle continues the event stream after the two recorded events.
+        // resumeHandle continues the event stream after the two recorded events
+        // (MAX(sequence) + 1 since ADR-101; null only when the position cannot
+        // be determined).
         $resumed = $this->persister->resumeHandle($run);
+        self::assertNotNull($resumed);
         self::assertSame($handle->runUid, $resumed->runUid);
         self::assertSame(2, $resumed->sequence);
 
@@ -89,6 +92,27 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertNotNull($settled);
         self::assertSame('completed', $settled->status);
         self::assertNull($settled->suspendedState);
+    }
+
+    #[Test]
+    public function aSuspensionArrivingAfterACancelIsDiscarded(): void
+    {
+        // ADR-101: the guarded suspend transition suspends only a run that is
+        // still RUNNING. A concurrent cancel that already terminated the row
+        // must not be resurrected to WAITING_FOR_APPROVAL by the in-flight
+        // loop's late suspension — that would offer an approval flow (and an
+        // executable gated tool) for a run the operator was told was stopped.
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->cancel($handle->uuid));
+
+        $state = new SuspendedRunState([['role' => 'user', 'content' => 'delete it']], [], 1, 0, 0);
+        self::assertFalse($this->persister->suspend($handle, $state));
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('cancelled', $run->status);
+        self::assertNull($run->suspendedState);
     }
 
     #[Test]

--- a/Tests/Unit/Command/CancelAgentRunCommandTest.php
+++ b/Tests/Unit/Command/CancelAgentRunCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\CancelAgentRunCommand;
+use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(CancelAgentRunCommand::class)]
+final class CancelAgentRunCommandTest extends TestCase
+{
+    #[Test]
+    public function cancelsARunThroughTheRuntimeAndReportsSuccess(): void
+    {
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->expects(self::once())->method('cancel')->with('run-uuid-1')->willReturn(true);
+
+        $tester = new CommandTester(new CancelAgentRunCommand($runtime));
+        $exit   = $tester->execute(['uuid' => 'run-uuid-1']);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('was cancelled', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsFailureForAnUnknownOrAlreadyFinishedRun(): void
+    {
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->method('cancel')->willReturn(false);
+
+        $tester = new CommandTester(new CancelAgentRunCommand($runtime));
+        $exit   = $tester->execute(['uuid' => 'gone']);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('unknown or already finished', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function rejectsAMissingUuidWithoutTouchingTheRuntime(): void
+    {
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->expects(self::never())->method('cancel');
+
+        $tester = new CommandTester(new CancelAgentRunCommand($runtime));
+        $exit   = $tester->execute(['uuid' => '']);
+
+        self::assertSame(Command::INVALID, $exit);
+    }
+}

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -54,9 +54,10 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
-    public function suspendRun(int $runUid, string $stateJson): void
+    public function suspendRun(int $runUid, string $stateJson): bool
     {
         // Not needed by the command tests.
+        return true;
     }
 
     public function claimForResume(int $runUid): bool
@@ -72,6 +73,11 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
     public function findEvents(int $runUid): array
     {
         return [];
+    }
+
+    public function maxEventSequence(int $runUid): int
+    {
+        return -1;
     }
 
     public function purgeOlderThan(int $timestamp): int

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -70,7 +70,7 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return null;
     }
 
-    public function findEvents(int $runUid): array
+    public function findEvents(int $runUid, int $afterSequence = -1): array
     {
         return [];
     }

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -59,7 +59,10 @@ final class PublicServicesPolicyTest extends TestCase
      *   ToolLoopServiceInterface (ADR-084 tool loop, injected by downstream
      *   extensions running the agent loop), ToolCallPolicyInterface (ADR-094:
      *   the composite tool gate, asked by the backend module why a tool is
-     *   missing from a run).
+     *   missing from a run), AgentRuntimeInterface (ADR-101: the agent-run
+     *   application service — begin/approve/cancel/events/status — the
+     *   preferred consumer surface over the bare tool loop). That makes
+     *   Category B 8 since ADR-101.
      * - Category C (Concrete-only documented surface): 1 —
      *   PromptSnippetComposer (ADR-031, no interface).
      * - Category D (Specialized standalone consumer API): 5 —
@@ -68,15 +71,15 @@ final class PublicServicesPolicyTest extends TestCase
      *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 19 + 7 + 1 + 5 + 2 = **34**.
+     * Total: 19 + 8 + 1 + 5 + 2 = **35**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in
-     * `Documentation/Adr/Adr094ToolDataClassTrustZone.rst` (the current
-     * count authority, superseding ADR-084's count) in the same PR — the
-     * diff is the audit trail.
+     * `Documentation/Adr/Adr101AgentRuntime.rst` (the current count
+     * authority, superseding ADR-094's count) in the same PR — the diff is
+     * the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 34;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 35;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Domain/Enum/AgentEventKindTest.php
+++ b/Tests/Unit/Domain/Enum/AgentEventKindTest.php
@@ -21,14 +21,16 @@ final class AgentEventKindTest extends TestCase
     #[Test]
     public function valuesListsAllBackingStrings(): void
     {
-        self::assertSame(['request', 'llm', 'tool', 'assembled'], AgentEventKind::values());
+        self::assertSame(['request', 'llm', 'tool', 'assembled', 'approval'], AgentEventKind::values());
     }
 
     #[Test]
     public function isValidIsTrueForKnownAndFalseForUnknown(): void
     {
         self::assertTrue(AgentEventKind::isValid('llm'));
-        self::assertFalse(AgentEventKind::isValid('approval'));
+        // The operator-decision event emitted by the AgentRuntime (ADR-101).
+        self::assertTrue(AgentEventKind::isValid('approval'));
+        self::assertFalse(AgentEventKind::isValid('artifact'));
     }
 
     #[Test]
@@ -41,8 +43,11 @@ final class AgentEventKindTest extends TestCase
     }
 
     #[Test]
-    public function fromRunStepKindReturnsNullForUnknown(): void
+    public function fromRunStepKindReturnsNullForNonRunStepKinds(): void
     {
+        // 'approval' is a valid EVENT kind (ADR-101) but not a RunStep kind —
+        // it must not masquerade as one; hydrate stored kinds via tryFrom().
         self::assertNull(AgentEventKind::fromRunStepKind('approval'));
+        self::assertNull(AgentEventKind::fromRunStepKind('artifact'));
     }
 }

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -1,0 +1,550 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
+use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Throwable;
+
+#[CoversClass(AgentRuntime::class)]
+final class AgentRuntimeTest extends AbstractUnitTestCase
+{
+    private RecordingAgentRunRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new RecordingAgentRunRepository();
+    }
+
+    #[Test]
+    public function aCompletedRunSettlesCompletedAndCarriesTheLoopResult(): void
+    {
+        $loopResult = $this->loopResult('done');
+        $runtime    = $this->runtime($this->loopReturning($loopResult));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertSame($loopResult, $result->loopResult);
+        self::assertNotSame('', $result->runUuid);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::COMPLETED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function aSuspendedRunIsPersistedAndReturnedAsAwaitingApproval(): void
+    {
+        $state   = $this->suspendedState();
+        $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($state)));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::AWAITING_APPROVAL, $result->outcome);
+        self::assertSame($state, $result->suspendedState);
+        self::assertNotNull($this->repository->suspended);
+        // The run stays WAITING_FOR_APPROVAL: the finally-guard must NOT settle
+        // a successfully-suspended run into FAILED — that would destroy the
+        // resumable state (the run-destroying case the design review flagged).
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function aFailedSuspensionFailsClosedAsSuspendFailed(): void
+    {
+        $this->repository->throwOnSuspend = true;
+        $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($this->suspendedState())));
+
+        $result = $runtime->run($this->request());
+
+        // ADR-092: no stored state means no resume — the run is failed, never
+        // announced as awaiting approval.
+        self::assertSame(AgentRunOutcome::SUSPEND_FAILED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function aSuspensionArrivingAfterACancelIsDiscardedAndFailsClosed(): void
+    {
+        // The guarded suspendRun refuses because the run is no longer RUNNING
+        // (a concurrent cancel won the row): the suspension must not resurrect
+        // the cancelled run into an approval queue (ADR-101).
+        $this->repository->refuseSuspend = true;
+        $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($this->suspendedState())));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::SUSPEND_FAILED, $result->outcome);
+        self::assertNull($this->repository->suspended);
+    }
+
+    #[Test]
+    public function anUnpersistedRunThatSuspendsFailsClosed(): void
+    {
+        // No handle (persistence down at begin) means no stored state and no
+        // resume — announcing awaiting-approval would strand the client behind
+        // an approve() that can only ever 400 (ADR-092).
+        $this->repository->throwOnStart = true;
+        $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($this->suspendedState())));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::SUSPEND_FAILED, $result->outcome);
+        self::assertSame('', $result->runUuid);
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function aGuardrailDenialSettlesPolicyStopped(): void
+    {
+        $runtime = $this->runtime($this->loopThrowing(new GuardrailViolationException('GuardrailFqcn', 'blocked')));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::GUARDRAIL_BLOCKED, $result->outcome);
+        self::assertSame('GuardrailFqcn', $result->guardrailClass);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunTerminationReason::POLICY_DENIED->value, $this->repository->finished['terminationReason']);
+    }
+
+    #[Test]
+    public function aGuardrailApprovalRequirementIsDistinctFromADenial(): void
+    {
+        $runtime = $this->runtime($this->loopThrowing(new GuardrailApprovalRequiredException('GuardrailFqcn', 'needs a human')));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+        // ADR-092: required-but-never-obtained is not recorded as a denial.
+        self::assertSame(AgentRunTerminationReason::APPROVAL_DENIED->value, $this->repository->finished['terminationReason']);
+    }
+
+    #[Test]
+    public function anUnexpectedThrowableSettlesFailedAndIsReturnedNotRethrown(): void
+    {
+        $error   = new RuntimeException('provider exploded', 1784700001);
+        $runtime = $this->runtime($this->loopThrowing($error));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertSame($error, $result->error);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function stepsReachTheObserverBeforePersistenceAndTheResult(): void
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('ok');
+            },
+        );
+
+        $observed = [];
+        $runtime  = $this->runtime($loop);
+        $result   = $runtime->run($this->request(), function (RunStep $s) use (&$observed): void {
+            $observed[] = $s->kind;
+        });
+
+        self::assertSame([RunStep::KIND_REQUEST], $observed);
+        self::assertCount(1, $result->steps);
+        // The same step also reached the persisted event stream.
+        self::assertCount(1, $this->repository->events);
+        self::assertSame(RunStep::KIND_REQUEST, $this->repository->events[0]['kind']);
+    }
+
+    #[Test]
+    public function anObserverThrowMidRunSettlesTheRunFailed(): void
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                // A recorded step reaches the observer, which dies (client
+                // disconnect on the stream) — the throw propagates through the
+                // loop into the ladder.
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('never reached');
+            },
+        );
+
+        $runtime = $this->runtime($loop);
+        $result  = $runtime->run($this->request(), static function (): void {
+            throw new RuntimeException('client gone', 1784700002);
+        });
+
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function anExplicitIterationCapIsClampedToTheCeilingButNullPassesThrough(): void
+    {
+        $seen = [];
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max) use (&$seen): ToolLoopResult {
+                $seen[] = $max;
+
+                return $this->loopResult('ok');
+            },
+        );
+        $runtime = $this->runtime($loop);
+
+        $runtime->run($this->request(maxIterations: 50));
+        $runtime->run($this->request(maxIterations: 3));
+        // null must NOT be coerced to the ceiling: the loop's own (lower)
+        // default applies — a naive clamp would quadruple the default cost.
+        $runtime->run($this->request());
+
+        self::assertSame([AgentRuntime::MAX_ITERATIONS, 3, null], $seen);
+    }
+
+    #[Test]
+    public function approveClaimsRecordsTheDecisionAndResumes(): void
+    {
+        $this->repository->findResult  = $this->suspendedRun();
+        $this->repository->maxSequence = 4;
+        $loopResult = $this->loopResult('continued');
+
+        $seenBeUser = null;
+        $loop       = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(
+            function (SuspendedRunState $state, bool $approved, LlmConfiguration $config, ?int $max, ?RunTrace $trace, ?int $beUserUid) use (&$seenBeUser, $loopResult): ToolLoopResult {
+                $seenBeUser = $beUserUid;
+
+                return $loopResult;
+            },
+        );
+
+        $result = $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(true, 42));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertSame($loopResult, $result->loopResult);
+        // The approver's uid budget-checks the continuation (ADR-084).
+        self::assertSame(42, $seenBeUser);
+        // The decision is the first event of the resumed segment, at the next
+        // sequence after the stored stream (MAX 4 -> 5).
+        self::assertNotSame([], $this->repository->events);
+        $approval = $this->repository->events[0];
+        self::assertSame('approval', $approval['kind']);
+        self::assertSame(5, $approval['sequence']);
+        $payload = json_decode($approval['payloadJson'], true);
+        self::assertSame(['approved' => true, 'decidedBy' => 42], $payload);
+    }
+
+    #[Test]
+    public function approveResolvesTheEventPositionAgainAfterWinningTheClaim(): void
+    {
+        // A request that stalled between its pre-claim probe and the claim may
+        // hold a stale position from before another approval's continuation
+        // appended events; the post-claim resolve must win so sequences are
+        // never duplicated (ADR-101). Probe sees MAX 4; after the claim the
+        // stream has grown to MAX 9 — the approval event lands at 10.
+        $this->repository->findResult         = $this->suspendedRun();
+        $this->repository->maxSequenceReturns = [4, 9];
+
+        $this->runtime($this->loopReturning($this->loopResult('continued')))
+            ->approve('run-uuid-1', new ApprovalDecision(true, 1));
+
+        self::assertNotSame([], $this->repository->events);
+        self::assertSame(10, $this->repository->events[0]['sequence']);
+    }
+
+    #[Test]
+    public function approveThrowsWhenNoRunIsAwaitingApproval(): void
+    {
+        $this->repository->findResult = null;
+
+        $this->expectException(RunNotAwaitingApprovalException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('unknown', new ApprovalDecision(true, 1));
+    }
+
+    #[Test]
+    public function approveThrowsWhenTheRunIsNotSuspended(): void
+    {
+        $this->repository->findResult = $this->suspendedRun(status: 'completed');
+
+        $this->expectException(RunNotAwaitingApprovalException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+    }
+
+    #[Test]
+    public function approveThrowsWhenTheConfigurationIsGone(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+
+        $this->expectException(RunConfigurationGoneException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->approve('run-uuid-1', new ApprovalDecision(true, 1));
+    }
+
+    #[Test]
+    public function approveThrowsOnCorruptSuspendedState(): void
+    {
+        $this->repository->findResult = $this->suspendedRun(stateJson: 'not-json{');
+
+        $this->expectException(CorruptSuspendedStateException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+    }
+
+    #[Test]
+    public function approveRefusesBeforeClaimingWhenTheEventPositionIsUnavailable(): void
+    {
+        $this->repository->findResult         = $this->suspendedRun();
+        $this->repository->throwOnMaxSequence = true;
+
+        try {
+            $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+            self::fail('Expected RunStateUnavailableException');
+        } catch (RunStateUnavailableException) {
+            // Fail-closed BEFORE the claim: the run is still suspended, so the
+            // approval can simply be retried — nothing was claimed or executed.
+            self::assertSame(0, $this->repository->claimsGranted);
+        }
+    }
+
+    #[Test]
+    public function approveThrowsWhenTheClaimIsLostToAConcurrentApproval(): void
+    {
+        $this->repository->findResult    = $this->suspendedRun();
+        $this->repository->claimsGranted = 1; // the next claim loses
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        // The gated tool must never execute on the losing request.
+        $loop->method('resume')->willReturnCallback(static function (): ToolLoopResult {
+            throw new RuntimeException('resume must not be reached', 1784700003);
+        });
+
+        $this->expectException(RunAlreadyResumingException::class);
+        $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(true, 1));
+    }
+
+    #[Test]
+    public function aDeniedApprovalStillResumesWithApprovedFalse(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+
+        $seenApproved = null;
+        $loop         = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(
+            function (SuspendedRunState $state, bool $approved) use (&$seenApproved): ToolLoopResult {
+                $seenApproved = $approved;
+
+                return $this->loopResult('refused and continued');
+            },
+        );
+
+        $result = $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(false, 7));
+
+        // A denial does not terminate the run: the loop continues from the
+        // refusal message (ADR-084) — and the denial is on the audit stream.
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertFalse($seenApproved);
+        $payload = json_decode($this->repository->events[0]['payloadJson'], true);
+        self::assertSame(['approved' => false, 'decidedBy' => 7], $payload);
+    }
+
+    #[Test]
+    public function aResumedRunMaySuspendAgain(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+        $again = $this->suspendedState();
+
+        $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($again), onResume: true));
+        $result  = $runtime->approve('run-uuid-1', new ApprovalDecision(true, 1));
+
+        self::assertSame(AgentRunOutcome::AWAITING_APPROVAL, $result->outcome);
+        self::assertSame($again, $result->suspendedState);
+        self::assertNotNull($this->repository->suspended);
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function cancelDelegatesToTheGuardedTransition(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+
+        self::assertTrue($this->runtime($this->loopReturning($this->loopResult('x')))->cancel('run-uuid-1'));
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::CANCELLED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function eventsFiltersBySequenceAndIsEmptyForAnUnknownRun(): void
+    {
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        self::assertSame([], $runtime->events('unknown'));
+
+        $this->repository->findResult     = $this->suspendedRun();
+        $this->repository->eventsToReturn = [
+            new AgentRunEvent(1, 1, 0, 'request', 1, 0.0, [], 0),
+            new AgentRunEvent(2, 1, 1, 'llm', 1, 0.0, [], 0),
+            new AgentRunEvent(3, 1, 2, 'tool', 1, 0.0, [], 0),
+        ];
+
+        self::assertCount(3, $runtime->events('run-uuid-1'));
+        $paged = $runtime->events('run-uuid-1', 0);
+        self::assertCount(2, $paged);
+        self::assertSame(1, $paged[0]->sequence);
+    }
+
+    #[Test]
+    public function statusStripsTheSuspendedStateTranscript(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+        $runtime                      = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        $status = $runtime->status('run-uuid-1');
+
+        self::assertNotNull($status);
+        self::assertSame('run-uuid-1', $status->uuid);
+        // The raw transcript bypasses the privacy filter — never on the status
+        // surface (design-review MAJOR 1).
+        self::assertNull($status->suspendedState);
+    }
+
+    #[Test]
+    public function anUnpersistedRunStillExecutesWithAnEmptyRunUuid(): void
+    {
+        $this->repository->throwOnStart = true;
+        $loopResult = $this->loopResult('ran without persistence');
+
+        $result = $this->runtime($this->loopReturning($loopResult))->run($this->request());
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertSame('', $result->runUuid);
+        self::assertSame($loopResult, $result->loopResult);
+        self::assertNull($this->repository->finished);
+    }
+
+    // ------------------------------------------------------------------ //
+
+    private function runtime(ToolLoopServiceInterface $loop, ?LlmConfiguration $configuration = new LlmConfiguration()): AgentRuntime
+    {
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($configuration);
+
+        return new AgentRuntime(
+            $loop,
+            new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL)),
+            $configurationRepository,
+        );
+    }
+
+    private function request(?int $maxIterations = null): AgentRunRequest
+    {
+        return new AgentRunRequest(
+            configuration: new LlmConfiguration(),
+            messages: [ChatMessage::user('go')],
+            maxIterations: $maxIterations,
+            beUserUid: 9,
+        );
+    }
+
+    private function loopResult(string $content): ToolLoopResult
+    {
+        return new ToolLoopResult($content, [], 1, false, UsageStatistics::fromTokens(3, 2));
+    }
+
+    private function loopReturning(ToolLoopResult $result): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturn($result);
+        $loop->method('resume')->willReturn($result);
+
+        return $loop;
+    }
+
+    private function loopThrowing(Throwable $throwable, bool $onResume = false): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method($onResume ? 'resume' : 'runLoop')->willThrowException($throwable);
+
+        return $loop;
+    }
+
+    private function suspendedState(): SuspendedRunState
+    {
+        return new SuspendedRunState(
+            [['role' => 'user', 'content' => 'delete it']],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            1,
+            5,
+            2,
+        );
+    }
+
+    private function suspendedRun(string $status = 'waiting_for_approval', ?string $stateJson = null): AgentRun
+    {
+        $encoded = $stateJson ?? json_encode($this->suspendedState()->toArray());
+        \assert(is_string($encoded));
+
+        return new AgentRun(
+            uid: 1,
+            uuid: 'run-uuid-1',
+            status: $status,
+            configurationUid: 1,
+            configurationIdentifier: 'cfg',
+            beUser: 9,
+            iterations: 1,
+            truncated: false,
+            totalPromptTokens: 5,
+            totalCompletionTokens: 2,
+            totalTokens: 7,
+            estimatedCost: 0.0,
+            errorClass: '',
+            terminationReason: '',
+            startedAt: 0,
+            finishedAt: 0,
+            crdate: 0,
+            suspendedState: $status === 'waiting_for_approval' ? $encoded : null,
+        );
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
 
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
 use RuntimeException;
 
@@ -109,12 +110,20 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
 
     public bool $throwOnSuspend = false;
 
-    public function suspendRun(int $runUid, string $stateJson): void
+    /** Simulates a run no longer RUNNING (cancelled/settled), so the guarded suspend matches no row. */
+    public bool $refuseSuspend = false;
+
+    public function suspendRun(int $runUid, string $stateJson): bool
     {
         if ($this->throwOnSuspend) {
             throw new RuntimeException('suspendRun failed', 1784600401);
         }
+        if ($this->refuseSuspend) {
+            return false;
+        }
         $this->suspended = ['runUid' => $runUid, 'stateJson' => $stateJson];
+
+        return true;
     }
 
     public bool $throwOnClaim = false;
@@ -144,9 +153,38 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return $this->findResult;
     }
 
+    /** @var list<AgentRunEvent> */
+    public array $eventsToReturn = [];
+
     public function findEvents(int $runUid): array
     {
-        return [];
+        return $this->eventsToReturn;
+    }
+
+    public bool $throwOnMaxSequence = false;
+
+    /** Highest stored event sequence reported to resumeHandle() (-1 = none). */
+    public int $maxSequence = -1;
+
+    /**
+     * When non-empty, each maxEventSequence() call shifts the next value —
+     * models a stream that grows between two position resolutions (the
+     * probe-before-claim vs. resolve-after-claim ordering, ADR-101).
+     *
+     * @var list<int>
+     */
+    public array $maxSequenceReturns = [];
+
+    public function maxEventSequence(int $runUid): int
+    {
+        if ($this->throwOnMaxSequence) {
+            throw new RuntimeException('maxEventSequence failed', 1784600403);
+        }
+        if ($this->maxSequenceReturns !== []) {
+            return array_shift($this->maxSequenceReturns);
+        }
+
+        return $this->maxSequence;
     }
 
     public function purgeOlderThan(int $timestamp): int

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -156,9 +156,13 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
     /** @var list<AgentRunEvent> */
     public array $eventsToReturn = [];
 
-    public function findEvents(int $runUid): array
+    public function findEvents(int $runUid, int $afterSequence = -1): array
     {
-        return $this->eventsToReturn;
+        // Mirrors the SQL predicate: only events past the requested position.
+        return array_values(array_filter(
+            $this->eventsToReturn,
+            static fn(AgentRunEvent $event): bool => $event->sequence > $afterSequence,
+        ));
     }
 
     public bool $throwOnMaxSequence = false;


### PR DESCRIPTION
## What

P1 #7: the agent-run lifecycle — begin, trace, persist, suspend for approval, approve/deny, cancel, event polling, status — moves out of `ToolPlaygroundController` (which carried the `runLoop → catch(suspend) → catch(guardrail) → catch(Throwable) → settle` ladder **three times**: batch, resume, stream) into a public application service ([ADR-101](Documentation/Adr/Adr101AgentRuntime.rst)). The playground is now a UI adapter with **unchanged JSON/NDJSON shapes**; `nrllm:agent:cancel` goes through the runtime.

```php
interface AgentRuntimeInterface {
    public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult;
    public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
    public function cancel(string $runUuid): bool;
    public function events(string $runUuid, int $afterSequence = -1): array;
    public function status(string $runUuid): ?AgentRun;
}
```

`run()`/`approve()` never throw for a run outcome — the result is settled, discriminated by `AgentRunOutcome` (COMPLETED / AWAITING_APPROVAL / SUSPEND_FAILED / GUARDRAIL_BLOCKED / GUARDRAIL_APPROVAL_REQUIRED / FAILED). `approve()` throws typed exceptions only for invalid requests, before any execution (→ the controller's 400/400/500/409). The roadmap's `start()/run()` split is deferred to the queue epic — a handle is only rehydratable once the request payload is persisted; `AgentRunRequest` is serialisation-ready so that epic changes no signatures.

## Hardening folded in (design + implementation each adversarially reviewed; every item pinned by a test)

- **Suspension-safe finally-guard**: the abandoned-run settle now covers every path *without* double-settling a successful suspension — an unguarded finally would flip a WAITING_FOR_APPROVAL run to FAILED and destroy its resumable state.
- **Fail-closed everywhere**: a failed re-suspension fails the run (was: resume silently answered `awaiting_approval` for an unresumable run); an *unpersisted* run that suspends is SUSPEND_FAILED (was: fail-open `awaiting_approval` with an empty uuid whose approve could only ever 400).
- **Cancel is a real fence**: `suspendRun` is now a guarded transition (only a RUNNING row suspends). Previously an in-flight loop's late suspension could resurrect a just-CANCELLED run into the approval queue — offering an executable gated tool for a run the operator was told was stopped.
- **Deterministic event sequence**: resume continues at `MAX(sequence)+1` (was: a count that restarted at 0 on a query failure), probed before the claim (retryable refusal, run stays suspended) and re-resolved from a fresh snapshot after winning it (a stale concurrent request can no longer write duplicate sequences).
- **Audited decisions**: the operator's approve/deny is persisted as a new `AgentEventKind::APPROVAL` event (`{approved, decidedBy}`; no free-text — the stream is privacy-filtered per ADR-064). `fromRunStepKind('approval')` stays null (not a RunStep kind); stored kinds hydrate via `tryFrom()`.
- **Privacy-safe `status()`**: strips the suspended-state transcript (stored verbatim for resume; bypasses the privacy filter).
- **Iteration ceiling** in the runtime: explicit values clamped to 20, `null` keeps the loop's lower default (a naive clamp would have quadrupled default cost).
- **Single-sourced logging**: runtime logs once, with the run uuid (controller no longer re-logs).

## Breaking

- `ToolPlaygroundController` ctor takes `AgentRuntimeInterface` instead of `ToolLoopService`/`?AgentRunPersister`.
- `AgentRunPersister::resumeHandle(): ?AgentRunHandle`; `AgentRunRepositoryInterface` gained `maxEventSequence()`; `suspendRun(): bool`.
- Audited public-service count 34 → **35** (`AgentRuntimeInterface`, Category B; ADR-101 supersedes ADR-094 as count authority — `PublicServicesPolicyTest` updated in the same PR). `ToolLoopServiceInterface` stays public for bare-loop consumers.

## Tests

New `AgentRuntimeTest` (21 tests: all six outcomes, the suspension-not-double-settled pin, cancel-fence, unpersisted-suspension fail-closed, claim race, post-claim re-resolve, ceiling clamp incl. null pass-through, observer ordering + observer-throw, approval-event payload/sequence, the 5 typed approve() validations, events paging, status stripping); a functional cancel-then-suspend-discarded test on the real DB; `CancelAgentRunCommandTest` (previous coverage gap); `AgentEventKindTest` pins updated (with `fromRunStepKind('approval') === null` kept). The functional playground test is rewired to a real `AgentRuntime` (real loop + DB persister) — **all behavioural assertions unchanged**.

Full local gate green: cgl, phpstan (level 10), unit, functional (sqlite — the 7 pre-existing `KeSearchBackendTest` risky tests are unrelated baseline), rector, fuzzy.

## Now possible without touching the playground

Scheduler/messenger workers, consumer extensions, batch runs, review queues, editor actions, status polling (`events()` pages by sequence) — next P1 step: queue/cancel (#8) on top of this surface.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
