### PR TITLE
feat(agent): queued agent runs over the TYPO3 message bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Queued agent runs (ADR-102): `AgentRuntimeInterface::enqueue()` persists a
+  QUEUED run carrying its serialised request and dispatches a wake-up message
+  on the TYPO3 message bus; `runQueued()` — behind the new
+  `AgentRunQueuedMessage` handler — atomically claims the row (exactly one
+  worker wins; a run cancelled while queued is unclaimable), rehydrates the
+  request and drives the same fail-closed lifecycle as `run()`. On the default
+  synchronous transport the run executes in-process; routing the message to the
+  core doctrine transport plus `messenger:consume` makes it genuinely
+  asynchronous — batch runs, review queues and scheduled agent work poll via
+  `status()`/`events()`. Fail-closed on every seam: no orphaned QUEUED rows
+  (a failed dispatch settles the row), no stranded RUNNING rows (rehydration
+  failures settle the claimed run). Schema: `queued_request` (privacy-stripped
+  from `status()` like the suspended state), `claimed_by`, `lease_expires`
+  (worker lease, groundwork for the stale-run reaper).
+  `AgentRunRepositoryInterface` gained `enqueueRun()` and `claimQueued()`.
 - `AgentRuntimeInterface` (ADR-101): the agent-run lifecycle — begin, execute,
   persist, suspend for approval, approve/deny, cancel, event polling, status —
   as one public, fail-closed application service. The tool playground is now a

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -42,14 +42,23 @@ final readonly class AgentRun
         // Serialised SuspendedRunState JSON while status = waiting_for_approval
         // (ADR-084); null once the run is running or terminal.
         public ?string $suspendedState = null,
+        // Serialised AgentRunRequest JSON from enqueue() (ADR-102); kept while
+        // the run is queued or executing (a requeue can reuse it) and cleared
+        // by the guarded terminal settle, like suspended_state.
+        public ?string $queuedRequest = null,
+        // Worker lease (ADR-102): who claimed the queued run and until when the
+        // claim is presumed live; ''/0 = not claimed.
+        public string $claimedBy = '',
+        public int $leaseExpires = 0,
     ) {}
 
     /**
-     * A copy without the suspended-state transcript, for status exposure
-     * (ADR-101). The suspended state is stored VERBATIM for resume — it bypasses
-     * the {@see \Netresearch\NrLlm\Service\Privacy\RunStepPrivacyFilter} that
-     * every persisted event goes through (ADR-064) — so a status projection
-     * handed to a runtime consumer must not carry it.
+     * A copy without the raw payload carriers, for status exposure (ADR-101).
+     * The suspended state and the queued request are stored VERBATIM for
+     * resume/execution — they bypass the
+     * {@see \Netresearch\NrLlm\Service\Privacy\RunStepPrivacyFilter} that every
+     * persisted event goes through (ADR-064) — so a status projection handed to
+     * a runtime consumer must not carry them.
      */
     public function withoutSuspendedState(): self
     {
@@ -72,6 +81,9 @@ final readonly class AgentRun
             finishedAt: $this->finishedAt,
             crdate: $this->crdate,
             suspendedState: null,
+            queuedRequest: null,
+            claimedBy: $this->claimedBy,
+            leaseExpires: $this->leaseExpires,
         );
     }
 

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -13,8 +13,13 @@ use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
@@ -23,15 +28,20 @@ use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Throwable;
 
 /**
@@ -58,21 +68,124 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      */
     public const MAX_ITERATIONS = 20;
 
+    /**
+     * How long a worker's claim on a queued run is presumed live (ADR-102).
+     * Written at claim time; the stale-run reaper epic acts on expiry —
+     * until then the lease is diagnostic.
+     */
+    public const LEASE_SECONDS = 900;
+
     public function __construct(
         private ToolLoopServiceInterface $toolLoop,
         private AgentRunPersister $persister,
         private LlmConfigurationRepository $configurationRepository,
         private ?LoggerInterface $logger = null,
+        private ?MessageBusInterface $messageBus = null,
+        private ?SkillRepository $skillRepository = null,
+        private ?PromptSnippetRepository $promptSnippetRepository = null,
     ) {}
 
     public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult
+    {
+        $handle = $this->persister->begin($request->configuration, $request->beUserUid);
+
+        return $this->executeRequest($request, $handle, $onStep);
+    }
+
+    public function enqueue(AgentRunRequest $request): string
+    {
+        if ($this->messageBus === null) {
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        try {
+            $requestJson = json_encode(
+                $this->dehydrateRequest($request),
+                JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
+            );
+        } catch (Throwable $e) {
+            // A non-encodable payload value (INF/NAN in a raw message array)
+            // must surface as the interface's documented failure type, not a
+            // bare JsonException. Nothing was stored yet — no cleanup needed.
+            $this->logger?->error('Agent run request could not be serialised for the queue', ['exception' => $e]);
+
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        // Fail-closed, unlike run(): a live run can proceed unpersisted, but a
+        // queued run without a stored row simply does not exist.
+        $handle = $this->persister->enqueue($request->configuration, $request->beUserUid, $requestJson);
+        if ($handle === null) {
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        try {
+            // The wake-up call. On the default SyncTransport the run executes
+            // right here; routed to the doctrine transport it executes in
+            // messenger:consume. The claim makes a duplicate dispatch harmless.
+            $this->messageBus->dispatch(new AgentRunQueuedMessage($handle->uuid));
+        } catch (Throwable $e) {
+            // On an async transport a failed dispatch would strand the row
+            // QUEUED forever (no message will ever arrive) — settle it failed
+            // so no orphan is left behind. On the sync transport a handler
+            // failure never reaches here (runQueued() settles outcomes itself
+            // and does not throw), so this is genuinely the transport failing.
+            $this->persister->settleFailed($handle, $e);
+            $this->logger?->error('Queued agent run could not be dispatched; the run was failed', ['run' => $handle->uuid, 'exception' => $e]);
+
+            throw RunEnqueueFailedException::forRun($handle->uuid);
+        }
+
+        return $handle->uuid;
+    }
+
+    public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::QUEUED || $run->queuedRequest === null) {
+            return null;
+        }
+
+        // Exactly one worker wins the guarded QUEUED -> RUNNING transition; a
+        // run cancelled while waiting is terminal and unclaimable (ADR-102).
+        if (!$this->persister->claimQueued($run, $this->workerIdentity(), time() + self::LEASE_SECONDS)) {
+            return null;
+        }
+
+        // The claim is won: from here every failure settles the run rather
+        // than leaving it stuck RUNNING.
+        $handle = new AgentRunHandle($run->uid, $run->uuid);
+
+        try {
+            $request = $this->rehydrateRequest($run);
+        } catch (Throwable $e) {
+            $this->persister->settleFailed($handle, $e);
+            $this->logger?->error('Queued agent run could not be rehydrated; the run was failed', ['run' => $runUuid, 'exception' => $e]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: [],
+                error: $e,
+            );
+        }
+
+        return $this->executeRequest($request, $handle, $onStep);
+    }
+
+    /**
+     * The shared execution path behind {@see run()} and {@see runQueued()}:
+     * clamp the round cap, build the trace, drive the ladder.
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    private function executeRequest(AgentRunRequest $request, ?AgentRunHandle $handle, ?Closure $onStep): AgentRunResult
     {
         $maxIterations = $request->maxIterations !== null
             ? min($request->maxIterations, self::MAX_ITERATIONS)
             : null;
 
-        $handle = $this->persister->begin($request->configuration, $request->beUserUid);
-        $trace  = $this->trace($handle, $onStep, $request->captureRaw);
+        $trace = $this->trace($handle, $onStep, $request->captureRaw);
 
         return $this->execute(
             $handle,
@@ -87,6 +200,203 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 $request->augmentation,
             ),
         );
+    }
+
+    /**
+     * Serialise a request for the queued row (ADR-102). Entities travel as
+     * uids (the rehydrator re-loads them — the same identity-over-snapshot
+     * choice approve() makes for the configuration); messages and options use
+     * their established array forms (the SuspendedRunState precedent).
+     *
+     * @return array<string, mixed>
+     */
+    private function dehydrateRequest(AgentRunRequest $request): array
+    {
+        $augmentation = $request->augmentation;
+
+        return [
+            'messages'         => array_map(
+                static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m,
+                $request->messages,
+            ),
+            'allowedToolNames' => $request->allowedToolNames,
+            'options'          => $request->options?->toArray(),
+            // ToolOptions::toArray() deliberately excludes the budget fields and
+            // the idempotency key (they are not provider API fields), but a
+            // queued run's budget PRE-FLIGHT has not happened yet — unlike the
+            // ADR-084 resume case that exclusion was designed for. Carry them
+            // out-of-band so run() and enqueue()+runQueued() of the same
+            // request hit the identical budget gate and dedup.
+            'plannedCost'      => $request->options?->getPlannedCost(),
+            'idempotencyKey'   => $request->options?->getIdempotencyKey(),
+            'maxIterations'    => $request->maxIterations,
+            'captureRaw'       => $request->captureRaw,
+            // null stays null: a non-null augmentation makes the loop bake the
+            // effective system prompt into the transcript (ADR-060 assembly),
+            // which a null-augmentation run() would not do — losing the
+            // distinction would silently change the prompt composition.
+            'augmentation'     => $augmentation === null ? null : [
+                'forcedSkillUids'   => array_values(array_filter(array_map(
+                    static fn(Skill $skill): int => $skill->getUid() ?? 0,
+                    $augmentation->forcedSkills,
+                ))),
+                'forcedSnippetUids' => array_values(array_filter(array_map(
+                    static fn(PromptSnippet $snippet): int => $snippet->getUid() ?? 0,
+                    $augmentation->forcedSnippets,
+                ))),
+                'dryRun'            => $augmentation->dryRun,
+            ],
+        ];
+    }
+
+    /**
+     * Rebuild the request from a claimed queued row (ADR-102). The
+     * configuration and the forced skills/snippets are re-loaded by uid — a
+     * configuration deleted while the run was queued fails the run, and a
+     * skill/snippet deleted meanwhile is simply no longer forced (the same
+     * live-resolution semantics the interactive path has).
+     */
+    private function rehydrateRequest(AgentRun $run): AgentRunRequest
+    {
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw new RuntimeException(sprintf('The configuration (uid %d) of queued run %s no longer exists', $run->configurationUid, $run->uuid), 2040727569);
+        }
+
+        $data = json_decode($run->queuedRequest ?? '', true);
+        if (!is_array($data)) {
+            throw new RuntimeException(sprintf('The stored request of queued run %s could not be decoded', $run->uuid), 2826462004);
+        }
+
+        $messages = [];
+        foreach (is_array($data['messages'] ?? null) ? $data['messages'] : [] as $message) {
+            if (is_array($message)) {
+                /** @var array<string, mixed> $message */
+                $messages[] = $message;
+            }
+        }
+
+        $allowed = null;
+        if (is_array($data['allowedToolNames'] ?? null)) {
+            $allowed = array_values(array_filter($data['allowedToolNames'], is_string(...)));
+        }
+
+        $options = null;
+        if (is_array($data['options'] ?? null)) {
+            /** @var array<string, mixed> $optionsData */
+            $optionsData = $data['options'];
+            // The initiator on the run row attributes the budget pre-flight,
+            // exactly as the interactive path does.
+            $options = ToolOptions::fromArray($optionsData, $run->beUser !== 0 ? $run->beUser : null);
+            // Re-inject the out-of-band budget/idempotency fields (see
+            // dehydrateRequest()): a queued run's budget pre-flight must be as
+            // strict as the direct path's, and its provider calls as
+            // deduplicatable.
+            $plannedCost = $data['plannedCost'] ?? null;
+            if (is_float($plannedCost) || is_int($plannedCost)) {
+                $options = $options->withPlannedCost((float)$plannedCost);
+            }
+            $idempotencyKey = $data['idempotencyKey'] ?? null;
+            if (is_string($idempotencyKey) && $idempotencyKey !== '') {
+                $options = $options->withIdempotencyKey($idempotencyKey);
+            }
+        }
+
+        $augmentation = null;
+        if (is_array($data['augmentation'] ?? null)) {
+            $augmentationData = $data['augmentation'];
+            $augmentation     = new RunAugmentation(
+                forcedSkills: $this->skillsByUids($this->uidList($augmentationData['forcedSkillUids'] ?? null)),
+                forcedSnippets: $this->snippetsByUids($this->uidList($augmentationData['forcedSnippetUids'] ?? null)),
+                dryRun: ($augmentationData['dryRun'] ?? false) === true,
+            );
+        }
+
+        return new AgentRunRequest(
+            configuration: $configuration,
+            messages: $messages,
+            allowedToolNames: $allowed,
+            options: $options,
+            maxIterations: is_int($data['maxIterations'] ?? null) ? $data['maxIterations'] : null,
+            augmentation: $augmentation,
+            captureRaw: ($data['captureRaw'] ?? false) === true,
+            beUserUid: $run->beUser,
+        );
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function uidList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $uids = [];
+        foreach ($value as $uid) {
+            if (is_int($uid) && $uid > 0) {
+                $uids[] = $uid;
+            }
+        }
+
+        return $uids;
+    }
+
+    /**
+     * Forced skills by uid, preserving order. Resolved without the enabled
+     * filter — forcing a skill overrides its global toggle, the same semantics
+     * the playground's force-inject control has.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<Skill>
+     */
+    private function skillsByUids(array $uids): array
+    {
+        if ($uids === [] || $this->skillRepository === null) {
+            return [];
+        }
+
+        $byUid = [];
+        foreach ($this->skillRepository->findAll() as $skill) {
+            if ($skill instanceof Skill && $skill->getUid() !== null) {
+                $byUid[$skill->getUid()] = $skill;
+            }
+        }
+
+        $skills = [];
+        foreach ($uids as $uid) {
+            if (isset($byUid[$uid])) {
+                $skills[] = $byUid[$uid];
+            }
+        }
+
+        return $skills;
+    }
+
+    /**
+     * @param list<int> $uids
+     *
+     * @return list<PromptSnippet>
+     */
+    private function snippetsByUids(array $uids): array
+    {
+        if ($uids === [] || $this->promptSnippetRepository === null) {
+            return [];
+        }
+
+        return $this->promptSnippetRepository->findByUids($uids);
+    }
+
+    /**
+     * Which worker claimed a queued run — host + pid, for lease diagnostics.
+     */
+    private function workerIdentity(): string
+    {
+        $host = gethostname();
+
+        return substr(($host !== false ? $host : 'unknown') . ':' . getmypid(), 0, 64);
     }
 
     public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -258,9 +258,12 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      */
     private function rehydrateRequest(AgentRun $run): AgentRunRequest
     {
+        // The same typed absence approve() reports — here it is caught by
+        // runQueued()'s rehydration guard, which settles the run FAILED with a
+        // meaningful error class instead of letting it escape.
         $configuration = $this->configurationRepository->findByUid($run->configurationUid);
         if ($configuration === null) {
-            throw new RuntimeException(sprintf('The configuration (uid %d) of queued run %s no longer exists', $run->configurationUid, $run->uuid), 2040727569);
+            throw RunConfigurationGoneException::forRun($run->uuid);
         }
 
         $data = json_decode($run->queuedRequest ?? '', true);

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -49,6 +49,36 @@ interface AgentRuntimeInterface
     public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult;
 
     /**
+     * Enqueue an agent run for asynchronous execution (ADR-102): persist a
+     * QUEUED row carrying the serialised request, then dispatch a wake-up
+     * message on the message bus. Returns the run uuid for status polling
+     * ({@see self::status()} / {@see self::events()}).
+     *
+     * Transport is the operator's choice (TYPO3 messenger routing): on the
+     * default synchronous transport the run executes in-process before this
+     * method returns; routed to the doctrine transport it executes inside
+     * ``messenger:consume``. Fail-closed: when the row cannot be stored or the
+     * message cannot be dispatched, no QUEUED run is left behind.
+     *
+     * @throws Exception\RunEnqueueFailedException
+     */
+    public function enqueue(AgentRunRequest $request): string;
+
+    /**
+     * Claim and execute a queued run (ADR-102) — the worker entry point behind
+     * {@see Queue\AgentRunQueuedHandler}. Atomically claims the QUEUED row
+     * (exactly one worker wins; a cancelled or already-claimed run returns
+     * null), rehydrates the stored request and drives the same fail-closed
+     * lifecycle as {@see self::run()}. Never throws for a run outcome; a
+     * rehydration failure settles the run FAILED and is returned as such.
+     *
+     * @param (Closure(RunStep): void)|null $onStep as in {@see self::run()}
+     *
+     * @return AgentRunResult|null null when the run was not claimable
+     */
+    public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult;
+
+    /**
      * Decide a run suspended for human approval (ADR-084) and synchronously
      * continue it: execute the pending tool calls when approved (refuse them
      * into the transcript when not), then re-enter the loop. The continuation

--- a/Classes/Service/Agent/Exception/RunEnqueueFailedException.php
+++ b/Classes/Service/Agent/Exception/RunEnqueueFailedException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The run could not be enqueued: the queued row could not be stored, or the
+ * message could not be dispatched (the stored row is then settled failed, so
+ * no orphaned QUEUED run is left behind).
+ *
+ * Thrown by enqueue(): a queued run without a persisted row and a dispatched
+ * wake-up simply does not exist — fail closed rather than promising an
+ * execution that will never happen (ADR-102).
+ */
+final class RunEnqueueFailedException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf(
+            'The run could not be enqueued (run %s).',
+            $runUuid !== '' ? $runUuid : 'unpersisted',
+        ));
+    }
+}

--- a/Classes/Service/Agent/Queue/AgentRunQueuedHandler.php
+++ b/Classes/Service/Agent/Queue/AgentRunQueuedHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Queue;
+
+use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Executes a queued agent run when its message arrives (ADR-102).
+ *
+ * On the default SyncTransport this runs in-process during enqueue(); with the
+ * doctrine transport routed by the operator it runs inside
+ * ``bin/typo3 messenger:consume``. Either way the handler is a thin adapter:
+ * {@see AgentRuntimeInterface::runQueued()} owns the atomic claim, the
+ * rehydration and the whole fail-closed lifecycle, and never throws for a run
+ * outcome — so a handled message is never redelivered for a run that merely
+ * failed (the run row carries the outcome). A null result (claim lost: another
+ * worker won, or the run was cancelled while queued) is a non-event.
+ */
+#[AsMessageHandler]
+final readonly class AgentRunQueuedHandler
+{
+    public function __construct(
+        private AgentRuntimeInterface $agentRuntime,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function __invoke(AgentRunQueuedMessage $message): void
+    {
+        if ($this->agentRuntime->runQueued($message->runUuid) === null) {
+            $this->logger?->info('Queued agent run was not claimable (already claimed, cancelled, or unknown)', [
+                'run' => $message->runUuid,
+            ]);
+        }
+    }
+}

--- a/Classes/Service/Agent/Queue/AgentRunQueuedMessage.php
+++ b/Classes/Service/Agent/Queue/AgentRunQueuedMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Queue;
+
+/**
+ * "A queued agent run is ready to execute" (ADR-102).
+ *
+ * Deliberately carries only the run uuid: the full request payload lives on
+ * the run row (`queued_request`), where the atomic claim, cancellation and a
+ * later requeue can all see it. The message is a wake-up call, not the state —
+ * a duplicate or stale message is harmless because the claim decides. Plain
+ * scalars only: TYPO3's messenger uses PHP serialization for the doctrine
+ * transport, so the message must never hold services or entities.
+ */
+final readonly class AgentRunQueuedMessage
+{
+    public function __construct(
+        public string $runUuid,
+    ) {}
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -79,6 +79,49 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * Open a new run in the QUEUED state, carrying its serialised request for a
+     * worker to claim and execute (ADR-102). Returns null when the row could
+     * not be stored — the caller must fail closed: unlike a live run, a queued
+     * run without a persisted row simply does not exist.
+     */
+    public function enqueue(?LlmConfiguration $configuration, int $beUser, string $requestJson): ?AgentRunHandle
+    {
+        try {
+            $uuid   = Uuid::v4()->toRfc4122();
+            $runUid = $this->repository->enqueueRun(
+                $uuid,
+                $configuration?->getUid() ?? 0,
+                $configuration?->getIdentifier() ?? '',
+                $beUser,
+                $requestJson,
+            );
+
+            return new AgentRunHandle($runUid, $uuid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be enqueued', ['exception' => $exception]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Atomically claim a queued run for execution (ADR-102). Fail-closed like
+     * {@see self::claimResume()}: false — refusing the claim — when it is lost
+     * to another worker, the run was cancelled while queued, or the store
+     * errors, so a queued run is never executed twice.
+     */
+    public function claimQueued(AgentRun $run, string $claimedBy, int $leaseExpires): bool
+    {
+        try {
+            return $this->repository->claimQueued($run->uid, $claimedBy, $leaseExpires);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be claimed for execution', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
      * Persist one recorded step as the next event in the run's stream.
      */
     public function recordStep(AgentRunHandle $handle, RunStep $step): void

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -68,6 +68,64 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return (int)$connection->lastInsertId();
     }
 
+    public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int
+    {
+        $now        = time();
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $connection->insert(self::TABLE_RUN, [
+            'pid'                      => 0,
+            'uuid'                     => $uuid,
+            // QUEUED, not RUNNING: the run waits for a worker's atomic claim
+            // (ADR-102). started_at stays 0 until the claim.
+            'status'                   => AgentRunStatus::QUEUED->value,
+            'configuration_uid'        => $configurationUid,
+            'configuration_identifier' => $configurationIdentifier,
+            'be_user'                  => $beUser,
+            'iterations'               => 0,
+            'truncated'                => 0,
+            'total_prompt_tokens'      => 0,
+            'total_completion_tokens'  => 0,
+            'total_tokens'             => 0,
+            'estimated_cost'           => 0.0,
+            'error_class'              => '',
+            'termination_reason'       => '',
+            'queued_request'           => $requestJson,
+            'started_at'               => 0,
+            'finished_at'              => 0,
+            'tstamp'                   => $now,
+            'crdate'                   => $now,
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    /**
+     * Atomically claim a queued run for execution (ADR-102): move it off QUEUED
+     * to RUNNING only if it is still queued, in a single conditional UPDATE —
+     * the same optimistic idiom as {@see claimForResume()}. Returns true for
+     * the worker that won; false when another worker already claimed it or the
+     * run was cancelled while waiting.
+     */
+    public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'status'        => AgentRunStatus::RUNNING->value,
+                'claimed_by'    => $claimedBy,
+                'lease_expires' => $leaseExpires,
+                'started_at'    => time(),
+                'tstamp'        => time(),
+            ],
+            [
+                'uid'    => $runUid,
+                'status' => AgentRunStatus::QUEUED->value,
+            ],
+        );
+
+        return $affected === 1;
+    }
+
     public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
     {
         $this->connectionPool->getConnectionForTable(self::TABLE_EVENT)->insert(self::TABLE_EVENT, [
@@ -112,8 +170,11 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ->set('estimated_cost', $builder->createNamedParameter((string)$estimatedCost, Connection::PARAM_STR), false)
             ->set('error_class', $errorClass)
             ->set('termination_reason', $terminationReason)
-            // A terminal run is no longer suspended.
+            // A terminal run is no longer suspended, queued or leased.
             ->set('suspended_state', '')
+            ->set('queued_request', '')
+            ->set('claimed_by', '')
+            ->set('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT), false)
             ->set('finished_at', $builder->createNamedParameter($now, Connection::PARAM_INT), false)
             ->set('tstamp', $builder->createNamedParameter($now, Connection::PARAM_INT), false)
             ->where(
@@ -141,6 +202,11 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             [
                 'status'          => AgentRunStatus::WAITING_FOR_APPROVAL->value,
                 'suspended_state' => $stateJson,
+                // A suspended run has no live worker claim (ADR-102): the lease
+                // means "presumed executing until", which a run waiting on a
+                // human is not.
+                'claimed_by'      => '',
+                'lease_expires'   => 0,
                 'tstamp'          => time(),
             ],
             [
@@ -164,8 +230,13 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
             self::TABLE_RUN,
             [
-                'status' => AgentRunStatus::RUNNING->value,
-                'tstamp' => time(),
+                'status'        => AgentRunStatus::RUNNING->value,
+                // The resume executes in the approving process, not under a
+                // queue worker's lease — never leave a dead worker's identity
+                // on the row (ADR-102).
+                'claimed_by'    => '',
+                'lease_expires' => 0,
+                'tstamp'        => time(),
             ],
             [
                 'uid'    => $runUid,
@@ -319,12 +390,15 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             finishedAt: self::toInt($row['finished_at'] ?? 0),
             crdate: self::toInt($row['crdate'] ?? 0),
             suspendedState: $this->suspendedStateOf($row['suspended_state'] ?? null),
+            queuedRequest: $this->suspendedStateOf($row['queued_request'] ?? null),
+            claimedBy: self::toStr($row['claimed_by'] ?? ''),
+            leaseExpires: self::toInt($row['lease_expires'] ?? 0),
         );
     }
 
     /**
-     * The stored suspended-state JSON, or null when the run is not suspended
-     * (empty column) — distinct from a genuine payload.
+     * The stored payload JSON (suspended state / queued request), or null when
+     * the column is empty — distinct from a genuine payload.
      */
     private function suspendedStateOf(mixed $value): ?string
     {

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -70,6 +70,23 @@ interface AgentRunRepositoryInterface
      */
     public function claimForResume(int $runUid): bool;
 
+    /**
+     * Insert a QUEUED run carrying its serialised request, so a worker in
+     * another process can claim, rehydrate and execute it (ADR-102).
+     * started_at stays 0 until the claim.
+     *
+     * @return int The new run's uid.
+     */
+    public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int;
+
+    /**
+     * Atomically claim a QUEUED run for execution (move it to RUNNING, stamp
+     * started_at and the worker lease); true for the winning worker, false when
+     * another worker already claimed it or the run was cancelled while queued
+     * (ADR-102).
+     */
+    public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool;
+
     public function findByUuid(string $uuid): ?AgentRun;
 
     /**

--- a/Documentation/Adr/Adr102QueuedAgentRuns.rst
+++ b/Documentation/Adr/Adr102QueuedAgentRuns.rst
@@ -1,0 +1,129 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-102:
+
+============================================================================
+ADR-102: Queued agent runs over the TYPO3 message bus
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-102-context:
+
+Context
+=======
+
+``AgentRunStatus::QUEUED`` has been reserved vocabulary since ADR-081, and
+:ref:`ADR-101 <adr-101>` deliberately deferred asynchronous execution: a
+``start()/run()`` split is only real once the request payload is persisted so a
+*different process* can execute it. Every consumer that wants batch runs,
+review queues or scheduled agent work needs exactly that — enqueue now, execute
+in a worker, poll status.
+
+TYPO3 core (v13.4 and v14.3 identically) ships Symfony Messenger as the
+message bus: ``MessageBusInterface`` is autowireable, handlers register via
+``#[AsMessageHandler]``, the default routing sends every message to the
+synchronous transport, and an installation opts into asynchronous execution by
+routing messages to the core-provided doctrine transport and running
+``bin/typo3 messenger:consume``. No composer change is needed.
+
+.. _adr-102-decision:
+
+Decision
+========
+
+``AgentRuntimeInterface`` (consumer contract: methods may be added in minor
+releases, ADR-101) gains the queued half of its lifecycle:
+
+.. code-block:: php
+
+   public function enqueue(AgentRunRequest $request): string;                 // returns run uuid
+   public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult;
+
+**The run row is the state; the message is only a wake-up call.**
+``enqueue()`` serialises the request into a new ``queued_request`` column on a
+QUEUED ``tx_nrllm_agentrun`` row (entities travel as uids and are re-loaded at
+execution time — the same identity-over-snapshot choice ``approve()`` makes;
+messages and options use their established array forms, the ADR-084
+``SuspendedRunState`` precedent). Two round-trip details are load-bearing:
+``plannedCost`` and the idempotency key are deliberately excluded from
+``ToolOptions::toArray()`` (sound for the ADR-084 resume, whose pre-flight
+already ran) but a *queued* run's budget pre-flight has not happened yet, so
+they travel out-of-band in the payload and are re-injected at rehydration —
+``run()`` and ``enqueue()`` of the same request hit the identical budget gate
+and dedup. And a null ``RunAugmentation`` stays null: fabricating an empty one
+would flip the loop into its prompt-baking assembly branch and silently change
+the prompt composition versus the identical direct run. ``enqueue()`` then
+dispatches an ``AgentRunQueuedMessage``
+carrying nothing but the uuid. ``AgentRunQueuedHandler``
+(``#[AsMessageHandler]``) calls ``runQueued()``, which atomically claims the
+row — a guarded ``QUEUED → RUNNING`` UPDATE in the ``claimForResume()`` idiom,
+stamping ``started_at`` plus a worker lease (``claimed_by``,
+``lease_expires``) — rehydrates the request and drives the identical
+fail-closed ladder as ``run()``.
+
+Consequences of that split:
+
+- **Duplicate or stale messages are harmless** — the claim decides; the loser
+  sees ``null`` and the handler treats it as a non-event (no redelivery).
+- **Cancel-while-queued works with zero new code**: the guarded terminal
+  transition already covers QUEUED, and a cancelled run is unclaimable.
+- **Fail-closed enqueue**: a row that cannot be stored throws
+  ``RunEnqueueFailedException``; a dispatch failure settles the just-stored
+  row FAILED first — no orphaned QUEUED run that no message will ever wake.
+- **Fail-closed execution**: the claim comes first; a rehydration failure
+  (corrupt payload, configuration deleted while queued) settles the claimed
+  run FAILED instead of stranding it. A skill or snippet deleted while queued
+  is simply no longer forced — live resolution, like the interactive path.
+- ``run()`` and ``runQueued()`` share one execution path, so the iteration
+  ceiling, the trace wiring and the outcome taxonomy cannot drift.
+- The handler never throws for run outcomes, so under ``messenger:consume`` a
+  failed *run* is a handled message (the row carries the outcome) — messenger
+  retry/dead-letter machinery, which TYPO3 wires none of, is not relied upon.
+
+Operations
+----------
+
+Default (no configuration): the SyncTransport executes the run in-process
+during ``enqueue()`` — semantically identical to ``run()``, just addressed by
+uuid. For genuinely asynchronous execution the installation routes the message
+to the doctrine transport and runs a consumer:
+
+.. code-block:: php
+
+   // settings.php / additional.php
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['messenger']['routing']
+       [\Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage::class] = 'doctrine';
+
+.. code-block:: bash
+
+   bin/typo3 messenger:consume doctrine
+
+Schema: ``queued_request mediumtext`` (cleared by the guarded terminal settle,
+like ``suspended_state`` — and stripped from ``status()`` for the same ADR-064
+privacy reason), ``claimed_by varchar(64)`` and ``lease_expires int`` with
+fail-safe ``''``/``0`` defaults. The lease (15 min) is written at claim time
+and is diagnostic for now — the stale-run reaper, heartbeat, per-failure-class
+retry and ``WAITING_FOR_INPUT`` are the remaining slices of the queue epic,
+each its own step on top of this substrate.
+
+.. _adr-102-consequences:
+
+Consequences
+============
+
+- Batch runs, review queues, scheduled agent work and editor actions can
+  enqueue through the public runtime and poll via ``status()`` / ``events()``
+  — no playground involvement, no bespoke lifecycle.
+- ``AgentRunRepositoryInterface`` gained ``enqueueRun()`` and ``claimQueued()``
+  (**breaking** for out-of-tree implementors — the interface is in-repo plus
+  test doubles by design).
+- ``AgentRuntime`` gained optional ``MessageBusInterface`` /
+  ``SkillRepository`` / ``PromptSnippetRepository`` dependencies (autowired in
+  production); with no bus wired, ``enqueue()`` fails closed.
+- A run FAILED by a dispatch or rehydration failure records
+  ``PROVIDER_FAILED`` as its termination reason — acceptable coarseness until
+  the retry epic introduces per-failure-class classification at the run level
+  (ADR-095 groundwork exists).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -399,3 +399,4 @@ Tools
    Adr099SpecializedFailClosedDispatch
    Adr100SpecializedUsageExtractors
    Adr101AgentRuntime
+   Adr102QueuedAgentRuns

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -116,6 +116,84 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function aQueuedRunIsClaimedExactlyOnceAndSettlingClearsTheQueueFields(): void
+    {
+        // ADR-102: enqueue stores the serialised request on a QUEUED row;
+        // exactly one worker wins the guarded QUEUED -> RUNNING claim; the
+        // terminal settle clears the request payload and the worker lease.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('queued', $run->status);
+        self::assertSame('{"messages":[]}', $run->queuedRequest);
+        self::assertSame(0, $run->startedAt);
+
+        // First worker wins, second loses — the same optimistic idiom as the
+        // approval claim.
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+        self::assertFalse($this->persister->claimQueued($run, 'worker-b:2', time() + 60));
+
+        $claimed = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($claimed);
+        self::assertSame('running', $claimed->status);
+        self::assertSame('worker-a:1', $claimed->claimedBy);
+        self::assertGreaterThan(0, $claimed->leaseExpires);
+        self::assertGreaterThan(0, $claimed->startedAt);
+
+        $this->persister->settleCompleted($handle, new ToolLoopResult('done', [], 1, false, UsageStatistics::fromTokens(3, 2)));
+        $settled = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($settled);
+        self::assertSame('completed', $settled->status);
+        self::assertNull($settled->queuedRequest);
+        self::assertSame('', $settled->claimedBy);
+        self::assertSame(0, $settled->leaseExpires);
+    }
+
+    #[Test]
+    public function aSuspensionClearsTheWorkerLease(): void
+    {
+        // ADR-102: the lease means "presumed executing until" — a run suspended
+        // for a human decision has no live worker claim, and the later resume
+        // executes in the approving process, so a dead worker's identity must
+        // never linger on a non-terminal row (it would mislead the reaper).
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        $state = new SuspendedRunState([['role' => 'user', 'content' => 'x']], [], 1, 0, 0);
+        self::assertTrue($this->persister->suspend($handle, $state));
+
+        $suspended = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($suspended);
+        self::assertSame('waiting_for_approval', $suspended->status);
+        self::assertSame('', $suspended->claimedBy);
+        self::assertSame(0, $suspended->leaseExpires);
+    }
+
+    #[Test]
+    public function aCancelledQueuedRunCannotBeClaimed(): void
+    {
+        // Cancel-while-queued (ADR-102): the guarded terminal transition wins
+        // and the later claim finds no QUEUED row to move.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->cancel($handle->uuid));
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertFalse($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+        self::assertSame('cancelled', $run->status);
+        // The request payload is already gone with the cancel.
+        $cancelled = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($cancelled);
+        self::assertNull($cancelled->queuedRequest);
+    }
+
+    #[Test]
     public function aSettledRunCannotBeSettledAgain(): void
     {
         $handle = $this->persister->begin(null, 0);

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -60,6 +60,18 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int
+    {
+        // Not needed by the command tests.
+        return 0;
+    }
+
+    public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        // Not needed by the command tests.
+        return false;
+    }
+
     public function claimForResume(int $runUid): bool
     {
         return false;

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -30,8 +30,11 @@ use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
@@ -42,6 +45,8 @@ use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunReposito
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Throwable;
 
 #[CoversClass(AgentRuntime::class)]
@@ -406,6 +411,176 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function enqueuePersistsAQueuedRowAndDispatchesTheWakeUpMessage(): void
+    {
+        $dispatched = [];
+        $runtime    = $this->runtime($this->loopReturning($this->loopResult('x')), bus: $this->recordingBus($dispatched));
+
+        $uuid = $runtime->enqueue($this->request(maxIterations: 7));
+
+        self::assertNotSame('', $uuid);
+        self::assertCount(1, $this->repository->enqueuedRuns);
+        $row = $this->repository->enqueuedRuns[0];
+        self::assertSame($uuid, $row['uuid']);
+        self::assertSame(9, $row['beUser']);
+        $payload = json_decode($row['requestJson'], true);
+        self::assertIsArray($payload);
+        self::assertSame(7, $payload['maxIterations']);
+        self::assertCount(1, $dispatched);
+        self::assertInstanceOf(AgentRunQueuedMessage::class, $dispatched[0]);
+        self::assertSame($uuid, $dispatched[0]->runUuid);
+    }
+
+    #[Test]
+    public function enqueueFailsClosedWhenTheRowCannotBeStored(): void
+    {
+        $this->repository->throwOnEnqueue = true;
+        $dispatched = [];
+        $runtime    = $this->runtime($this->loopReturning($this->loopResult('x')), bus: $this->recordingBus($dispatched));
+
+        try {
+            $runtime->enqueue($this->request());
+            self::fail('Expected RunEnqueueFailedException');
+        } catch (RunEnqueueFailedException) {
+            // No row, and crucially no wake-up for a run that does not exist.
+            self::assertSame([], $dispatched);
+        }
+    }
+
+    #[Test]
+    public function enqueueSettlesTheRowFailedWhenTheDispatchFails(): void
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willThrowException(new RuntimeException('transport down', 1784700020));
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')), bus: $bus);
+
+        try {
+            $runtime->enqueue($this->request());
+            self::fail('Expected RunEnqueueFailedException');
+        } catch (RunEnqueueFailedException) {
+            // The stored row must not stay QUEUED forever with no message ever
+            // arriving — it is settled failed (fail-closed, no orphan).
+            self::assertNotNull($this->repository->finished);
+            self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+        }
+    }
+
+    #[Test]
+    public function enqueueFailsClosedWithoutAMessageBus(): void
+    {
+        $this->expectException(RunEnqueueFailedException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))->enqueue($this->request());
+    }
+
+    #[Test]
+    public function runQueuedClaimsRehydratesAndExecutesTheStoredRequest(): void
+    {
+        // Full round-trip: enqueue() serialises the request, runQueued() claims
+        // the row and rehydrates — the loop must receive equivalent inputs.
+        $dispatched = [];
+        $runtime0   = $this->runtime($this->loopReturning($this->loopResult('x')), bus: $this->recordingBus($dispatched));
+        $uuid       = $runtime0->enqueue(new AgentRunRequest(
+            configuration: new LlmConfiguration(),
+            messages: [ChatMessage::user('do the queued thing')],
+            allowedToolNames: ['fetch_logs'],
+            options: (new ToolOptions(temperature: 0.5, plannedCost: 1.25))->withIdempotencyKey('idem-1'),
+            maxIterations: 50,
+            captureRaw: true,
+            beUserUid: 9,
+        ));
+
+        $this->repository->findResult = $this->queuedRun($uuid, $this->repository->enqueuedRuns[0]['requestJson']);
+
+        $seen = [];
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, mixed $trace, mixed $augmentation) use (&$seen): ToolLoopResult {
+                $seen = ['messages' => $messages, 'allowed' => $allowed, 'options' => $options, 'max' => $max, 'augmentation' => $augmentation];
+
+                return $this->loopResult('queued done');
+            },
+        );
+
+        $result = $this->runtime($loop)->runQueued($uuid);
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        // The claim was atomic and stamped the worker lease.
+        self::assertNotNull($this->repository->queuedClaim);
+        self::assertNotSame('', $this->repository->queuedClaim['claimedBy']);
+        self::assertGreaterThan(time(), $this->repository->queuedClaim['leaseExpires']);
+        // Rehydrated inputs reached the loop: the message content, the
+        // allow-list, the ceiling-clamped round cap, the initiator's budget uid.
+        self::assertSame('do the queued thing', $seen['messages'][0]['content'] ?? null);
+        self::assertSame(['fetch_logs'], $seen['allowed']);
+        self::assertSame(AgentRuntime::MAX_ITERATIONS, $seen['max']);
+        self::assertInstanceOf(ToolOptions::class, $seen['options']);
+        self::assertSame(0.5, $seen['options']->getTemperature());
+        self::assertSame(9, $seen['options']->getBeUserUid());
+        // The out-of-band budget/idempotency fields survive the round-trip: a
+        // queued run's budget pre-flight is as strict as the direct path's.
+        self::assertSame(1.25, $seen['options']->getPlannedCost());
+        self::assertSame('idem-1', $seen['options']->getIdempotencyKey());
+        // A null augmentation stays null — a fabricated empty RunAugmentation
+        // would flip the loop into its prompt-baking assembly branch and
+        // silently change the prompt composition vs. the identical run().
+        self::assertNull($seen['augmentation']);
+        // And the run settled completed.
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::COMPLETED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function runQueuedReturnsNullForAnUnknownOrNonQueuedRun(): void
+    {
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        self::assertNull($runtime->runQueued('unknown'));
+
+        $this->repository->findResult = $this->suspendedRun();
+        self::assertNull($runtime->runQueued('run-uuid-1'));
+    }
+
+    #[Test]
+    public function runQueuedReturnsNullWhenTheClaimIsLost(): void
+    {
+        $this->repository->findResult        = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+        $this->repository->refuseClaimQueued = true;
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(static function (): ToolLoopResult {
+            throw new RuntimeException('the loop must not run on the losing worker', 1784700021);
+        });
+
+        self::assertNull($this->runtime($loop)->runQueued('run-uuid-q'));
+    }
+
+    #[Test]
+    public function runQueuedSettlesTheRunFailedWhenTheStoredRequestIsCorrupt(): void
+    {
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', 'not-json{');
+
+        $result = $this->runtime($this->loopReturning($this->loopResult('x')))->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function runQueuedSettlesTheRunFailedWhenTheConfigurationIsGone(): void
+    {
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $result = $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+    }
+
+    #[Test]
     public function cancelDelegatesToTheGuardedTransition(): void
     {
         $this->repository->findResult = $this->suspendedRun();
@@ -466,8 +641,11 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
 
     // ------------------------------------------------------------------ //
 
-    private function runtime(ToolLoopServiceInterface $loop, ?LlmConfiguration $configuration = new LlmConfiguration()): AgentRuntime
-    {
+    private function runtime(
+        ToolLoopServiceInterface $loop,
+        ?LlmConfiguration $configuration = new LlmConfiguration(),
+        ?MessageBusInterface $bus = null,
+    ): AgentRuntime {
         $configurationRepository = self::createStub(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($configuration);
 
@@ -475,6 +653,52 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             $loop,
             new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL)),
             $configurationRepository,
+            null,
+            $bus,
+        );
+    }
+
+    /**
+     * A bus double recording every dispatched message into $sink.
+     *
+     * @param list<object> $sink
+     */
+    private function recordingBus(array &$sink): MessageBusInterface
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(
+            static function (object $message) use (&$sink): Envelope {
+                $sink[] = $message;
+
+                return new Envelope($message);
+            },
+        );
+
+        return $bus;
+    }
+
+    private function queuedRun(string $uuid, string $requestJson): AgentRun
+    {
+        return new AgentRun(
+            uid: 1,
+            uuid: $uuid,
+            status: 'queued',
+            configurationUid: 1,
+            configurationIdentifier: 'cfg',
+            beUser: 9,
+            iterations: 0,
+            truncated: false,
+            totalPromptTokens: 0,
+            totalCompletionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: 0.0,
+            errorClass: '',
+            terminationReason: '',
+            startedAt: 0,
+            finishedAt: 0,
+            crdate: 0,
+            suspendedState: null,
+            queuedRequest: $requestJson,
         );
     }
 

--- a/Tests/Unit/Service/Agent/Queue/AgentRunQueuedHandlerTest.php
+++ b/Tests/Unit/Service/Agent/Queue/AgentRunQueuedHandlerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Agent\Queue;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Service\Agent\AgentRunResult;
+use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedHandler;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(AgentRunQueuedHandler::class)]
+final class AgentRunQueuedHandlerTest extends TestCase
+{
+    #[Test]
+    public function executesTheQueuedRunThroughTheRuntime(): void
+    {
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->expects(self::once())
+            ->method('runQueued')
+            ->with('run-uuid-1')
+            ->willReturn(new AgentRunResult(AgentRunOutcome::COMPLETED, 'run-uuid-1', []));
+
+        (new AgentRunQueuedHandler($runtime, new NullLogger()))(new AgentRunQueuedMessage('run-uuid-1'));
+    }
+
+    #[Test]
+    public function anUnclaimableRunIsANonEventNotAFailure(): void
+    {
+        // Another worker won the claim (or the run was cancelled while queued):
+        // the handler must complete normally so the message is not redelivered.
+        $runtime = self::createStub(AgentRuntimeInterface::class);
+        $runtime->method('runQueued')->willReturn(null);
+
+        (new AgentRunQueuedHandler($runtime, new NullLogger()))(new AgentRunQueuedMessage('run-uuid-1'));
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -126,6 +126,48 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    public bool $throwOnEnqueue = false;
+
+    /** @var list<array{uuid: string, configurationUid: int, configurationIdentifier: string, beUser: int, requestJson: string}> */
+    public array $enqueuedRuns = [];
+
+    public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int
+    {
+        if ($this->throwOnEnqueue) {
+            throw new RuntimeException('enqueueRun failed', 1784700010);
+        }
+        $this->enqueuedRuns[] = [
+            'uuid'                    => $uuid,
+            'configurationUid'        => $configurationUid,
+            'configurationIdentifier' => $configurationIdentifier,
+            'beUser'                  => $beUser,
+            'requestJson'             => $requestJson,
+        ];
+
+        return $this->nextUid++;
+    }
+
+    public bool $throwOnClaimQueued = false;
+
+    /** Simulates a queued run already claimed by another worker (or cancelled). */
+    public bool $refuseClaimQueued = false;
+
+    /** @var array{runUid: int, claimedBy: string, leaseExpires: int}|null */
+    public ?array $queuedClaim = null;
+
+    public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        if ($this->throwOnClaimQueued) {
+            throw new RuntimeException('claimQueued failed', 1784700011);
+        }
+        if ($this->refuseClaimQueued) {
+            return false;
+        }
+        $this->queuedClaim = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'leaseExpires' => $leaseExpires];
+
+        return true;
+    }
+
     public bool $throwOnClaim = false;
 
     /** Number of resume claims that were granted; false is returned after the first. */

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -687,6 +687,18 @@ CREATE TABLE tx_nrllm_agentrun (
     -- status = waiting_for_approval; empty otherwise.
     suspended_state mediumtext,
 
+    -- Queued execution (ADR-102): the serialised AgentRunRequest while
+    -- status = queued, so a worker in another process can rehydrate and run it.
+    -- Cleared by the guarded terminal settle, like suspended_state.
+    queued_request mediumtext,
+
+    -- Worker lease (ADR-102): who claimed the queued run and until when the
+    -- claim is presumed live. ''/0 = not claimed — the fail-safe default, so an
+    -- un-migrated row can never look leased. Written by the atomic
+    -- QUEUED -> RUNNING claim; the stale-run reaper epic reads lease_expires.
+    claimed_by varchar(64) DEFAULT '' NOT NULL,
+    lease_expires int(11) unsigned DEFAULT '0' NOT NULL,
+
     -- Time tracking
     started_at int(11) unsigned DEFAULT '0' NOT NULL,
     finished_at int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## What

P1 #8, slice 1 of the queue epic ([ADR-102](Documentation/Adr/Adr102QueuedAgentRuns.rst)): `QUEUED` stops being reserved vocabulary. `AgentRuntimeInterface` gains the queued half of its lifecycle:

```php
public function enqueue(AgentRunRequest $request): string;                 // returns run uuid
public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult;
```

**The run row is the state; the message is only a wake-up call.** `enqueue()` serialises the request into a new `queued_request` column on a QUEUED row and dispatches `AgentRunQueuedMessage` (uuid only) on the TYPO3 message bus — which ships with core on both supported majors, no composer change. `AgentRunQueuedHandler` (`#[AsMessageHandler]`) calls `runQueued()`: atomic claim (guarded `QUEUED → RUNNING` in the `claimForResume` idiom, stamping `started_at` + worker lease), rehydrate, then the identical fail-closed ladder as `run()` (shared execution path — ceiling, trace, outcome taxonomy cannot drift).

## Semantics that fall out of the design

- **Duplicate/stale messages harmless** — the claim decides; the losing worker is a non-event, never a redelivery.
- **Cancel-while-queued: zero new code** — the guarded terminal transition already covers QUEUED; a cancelled run is unclaimable (functional-pinned).
- **Fail-closed on every seam**: unstorable row / unserialisable payload / failed dispatch → `RunEnqueueFailedException`, with the stored row settled first (no orphaned QUEUED run a message will never wake); rehydration failure (corrupt payload, configuration deleted while queued) settles the *claimed* run instead of stranding it RUNNING.

## Round-trip fidelity (each caught by the adversarial review, each test-pinned)

- `plannedCost` + idempotency key travel **out-of-band**: `ToolOptions::toArray()` excludes them (sound for the ADR-084 resume, whose pre-flight already ran) — but a queued run's budget pre-flight hasn't happened yet. Without this, a request `run()` rejects on budget would execute and spend via `enqueue()`.
- A null `RunAugmentation` **stays null** — fabricating an empty one flips the loop into its prompt-baking assembly branch and silently changes prompt composition vs. the identical direct run.
- Suspension and the approval-claim **clear the worker lease** (`claimed_by`/`lease_expires`) — it means "presumed executing until", which a run waiting on a human is not; a dead worker's identity must not mislead the future reaper.

## Operations

Default (no config): SyncTransport executes the run in-process during `enqueue()`. Genuinely async:

```php
$GLOBALS['TYPO3_CONF_VARS']['SYS']['messenger']['routing']
    [\Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage::class] = 'doctrine';
```
```bash
bin/typo3 messenger:consume doctrine
```

## Breaking / schema

`AgentRunRepositoryInterface` gained `enqueueRun()` + `claimQueued()` (in-repo + test doubles by design). Schema: `queued_request` (privacy-stripped from `status()` like the suspended state), `claimed_by`, `lease_expires` — fail-safe defaults, plain ext_tables.sql (no wizard needed). `AgentRuntime` gained optional autowired `MessageBusInterface`/`SkillRepository`/`PromptSnippetRepository`; without a bus, `enqueue()` fails closed. No new `public: true` (count stays 35).

## Tests

9 new runtime unit tests (enqueue happy/persist-fail/dispatch-fail-settles/no-bus, full enqueue→runQueued round-trip incl. plannedCost/idempotency/null-augmentation/clamp/lease, claim-lost, corrupt payload, config gone), handler tests, 3 functional DB tests (claim-once + terminal cleanup, cancel-unclaimable, suspension-clears-lease). Full local gate green: cgl, phpstan (L10), unit, functional (sqlite; 7 pre-existing KeSearch risky = baseline), rector, fuzzy.

## Remaining queue-epic slices (each its own PR)

Stale-run reaper + heartbeat (lease groundwork laid), per-failure-class retry + dead-letter (ADR-095 classifier gap for `FallbackChainExhaustedException` documented), cooperative cancel between loop steps, `WAITING_FOR_INPUT`.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
