### PR TITLE
feat(agent): stop a cancelled run cooperatively at the next step boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Cooperative cancellation (ADR-103): `nrllm:agent:cancel` (and any
+  `AgentRuntimeInterface::cancel()` caller) now also stops an in-flight loop at
+  its next step boundary — after the current provider response or tool
+  execution, before the next one — instead of letting it run to completion
+  with a discarded outcome. The boundary step stays on the audit stream; the
+  run surfaces as the new `AgentRunOutcome::CANCELLED` (playground:
+  `status: 'cancelled'` / `cancelled` stream event). The tool loop itself
+  stays persistence-unaware; the probe lives in the runtime's trace hook.
 - Queued agent runs (ADR-102): `AgentRuntimeInterface::enqueue()` persists a
   QUEUED run carrying its serialised request and dispatches a wake-up message
   on the TYPO3 message bus; `runQueued()` — behind the new

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -264,6 +264,16 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 // only, sanitized) diagnosis.
                 return $this->respondJson(['success' => false, 'error' => $this->diagnoseRunFailure($result->error)], 500);
 
+            case AgentRunOutcome::CANCELLED:
+                // ADR-103: an operator cancelled the run mid-flight and the
+                // loop stopped cooperatively — a decision, not a server error.
+                return $this->respondJson([
+                    'success' => false,
+                    'status'  => 'cancelled',
+                    'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.cancelled', 'The run was cancelled.'),
+                    'steps'   => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
+                ]);
+
             case AgentRunOutcome::COMPLETED:
                 break;
 
@@ -440,6 +450,18 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 // Logged by the runtime; only the sanitized diagnosis is shaped
                 // here.
                 $emit(['event' => 'error', 'success' => false, 'error' => $this->diagnoseRunFailure($result->error)]);
+
+                return;
+
+            case AgentRunOutcome::CANCELLED:
+                // ADR-103: a distinct terminal event — the operator stopped the
+                // run; not a failure.
+                $emit([
+                    'event'   => 'cancelled',
+                    'success' => false,
+                    'status'  => 'cancelled',
+                    'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.cancelled', 'The run was cancelled.'),
+                ]);
 
                 return;
 

--- a/Classes/Domain/Enum/AgentRunOutcome.php
+++ b/Classes/Domain/Enum/AgentRunOutcome.php
@@ -33,4 +33,10 @@ enum AgentRunOutcome: string
     case GUARDRAIL_BLOCKED = 'guardrail_blocked';
     case GUARDRAIL_APPROVAL_REQUIRED = 'guardrail_approval_required';
     case FAILED = 'failed';
+
+    // The run was cancelled while executing and the loop stopped
+    // cooperatively at the next step boundary (ADR-103). The row is already
+    // terminal CANCELLED (the cancel won the guarded transition); this outcome
+    // tells the caller their in-flight call ended because of it.
+    case CANCELLED = 'cancelled';
 }

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
@@ -498,7 +499,17 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      * The trace every segment runs under: each recorded step reaches the live
      * observer FIRST (preserving the streaming path's emit-before-persist
      * order — a step is shown even when its persist fails), then the persisted
-     * event stream.
+     * event stream — and then the cancellation probe runs (ADR-103).
+     *
+     * The probe is what makes {@see cancel()} cooperative: the loop itself
+     * stays persistence-unaware (ADR-081), but every step boundary — after a
+     * provider response, after each tool execution, before the next round —
+     * records a step, and the probe checks the run row there. A run cancelled
+     * mid-flight therefore stops before the NEXT provider call or tool
+     * execution instead of running to completion with its outcome discarded.
+     * The step that just happened is still emitted and persisted: the audit
+     * stream stays complete up to the abort point. One indexed row read per
+     * step; steps are provider-call-slow, so the cost is negligible.
      *
      * @param (Closure(RunStep): void)|null $onStep
      */
@@ -516,6 +527,12 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 }
                 if ($handle !== null) {
                     $this->persister->recordStep($handle, $step);
+
+                    // findRun is fail-soft (null on a store hiccup), so a read
+                    // failure can never fabricate a cancellation.
+                    if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
+                        throw RunCancellationRequestedException::forRun($handle->uuid);
+                    }
                 }
             },
         );
@@ -553,6 +570,20 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 runUuid: $runUuid,
                 steps: $trace->getSteps(),
                 loopResult: $result,
+            );
+        } catch (RunCancellationRequestedException $cancelled) {
+            // ADR-103: the operator's cancel already won the guarded terminal
+            // transition — the row IS CANCELLED and its late settle would be
+            // discarded anyway, so none is attempted. Control flow, not
+            // failure: the loop stopped cooperatively at a step boundary.
+            $settled = true;
+            $this->logger?->info('Agent run stopped cooperatively after being cancelled', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::CANCELLED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $cancelled,
             );
         } catch (ToolApprovalRequiredException $approval) {
             // ADR-084: a called tool requires human approval — control flow,

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -102,8 +102,13 @@ interface AgentRuntimeInterface
      * Cancel a run that is still queued, running or awaiting a decision. True
      * when this call cancelled it; false when the run is unknown or already
      * terminal (the guarded transition decides, so two concurrent cancels
-     * cannot both win). Cancellation is a persistence-level fence: an
-     * in-flight loop is not interrupted, its late settle is discarded.
+     * cannot both win). Cancellation is a persistence-level fence — a late
+     * settle from an in-flight loop is discarded — AND cooperative (ADR-103):
+     * a loop running under this runtime notices the cancelled row at its next
+     * step boundary and stops before the next provider call or tool execution,
+     * surfacing {@see \Netresearch\NrLlm\Domain\Enum\AgentRunOutcome::CANCELLED}
+     * to whoever drove the run. A step already in flight (a provider call, a
+     * tool) runs to its boundary — cancellation is not a signal.
      */
     public function cancel(string $runUuid): bool;
 

--- a/Classes/Service/Agent/Exception/RunCancellationRequestedException.php
+++ b/Classes/Service/Agent/Exception/RunCancellationRequestedException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use RuntimeException;
+
+/**
+ * Internal control-flow signal for cooperative cancellation (ADR-103).
+ *
+ * Thrown by the AgentRuntime's cancellation probe (inside the trace hook, at a
+ * step boundary) when the run row turned CANCELLED while the loop was
+ * executing. Deliberately NOT an {@see AgentRuntimeException}: it is not a
+ * caller error — it is caught by the runtime's own ladder, mapped to
+ * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunOutcome::CANCELLED}, and never
+ * escapes the runtime.
+ */
+final class RunCancellationRequestedException extends RuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self(sprintf('Run %s was cancelled; the loop stops at this step boundary.', $runUuid), 1784800001);
+    }
+}

--- a/Documentation/Adr/Adr103CooperativeCancellation.rst
+++ b/Documentation/Adr/Adr103CooperativeCancellation.rst
@@ -1,0 +1,69 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-103:
+
+============================================================================
+ADR-103: Cooperative cancellation at step boundaries
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-103-context:
+
+Context
+=======
+
+Cancellation has been a persistence-level fence since :ref:`ADR-092 <adr-092>`:
+the guarded terminal transition wins the row and a late settle is discarded —
+but the in-flight loop itself kept running to completion, spending provider
+calls and executing tools whose outcome was then thrown away. With queued runs
+(:ref:`ADR-102 <adr-102>`) that gap grows: a worker run can be long, and
+``nrllm:agent:cancel`` is the only brake an operator has. The P1 roadmap asks
+for exactly this: check the cancel flag *between* model and tool steps.
+
+.. _adr-103-decision:
+
+Decision
+========
+
+The AgentRuntime's trace hook gains a **cancellation probe**. Every step
+boundary — after a provider response, after each tool execution, before the
+next round — already records a step through the runtime's ``onRecord`` closure;
+the probe re-reads the run row there and, when it is CANCELLED, throws the
+internal ``RunCancellationRequestedException``. The ladder catches it as
+control flow (before the generic Throwable), attempts **no** settle (the
+cancel already won the terminal transition; a late settle would be discarded
+anyway) and returns the new ``AgentRunOutcome::CANCELLED``.
+
+Properties:
+
+- **The loop stays persistence-unaware** (ADR-081): the probe lives entirely
+  in the runtime's trace closure; ``ToolLoopServiceInterface`` is untouched.
+- **A step in flight runs to its boundary** — cancellation is a cooperative
+  check, not a signal. The boundary step itself is still emitted and
+  persisted, so the audit stream is complete up to the abort point.
+- **No further spend after the boundary**: the next provider call and the
+  pending tool executions of the following round never start.
+- **Fail-soft probe**: the row read goes through the fail-soft persister — a
+  store hiccup yields null, never a fabricated cancellation. One indexed row
+  read per step; steps are provider-call-slow, so the cost is noise.
+- Works identically for interactive (``run()``), resumed (``approve()``) and
+  queued (``runQueued()``) segments — they share the one trace builder.
+
+.. _adr-103-consequences:
+
+Consequences
+============
+
+- ``AgentRunOutcome`` gained ``CANCELLED`` (the documented minor-release
+  growth path; consumers match with a default arm). The playground maps it to
+  a ``status: 'cancelled'`` payload / ``cancelled`` stream event — a decision,
+  not an error.
+- ``AgentRuntimeInterface::cancel()``'s contract is upgraded from "fence only"
+  to "fence + cooperative stop at the next step boundary".
+- A cancelled run's in-flight segment now ends within one step instead of
+  running to completion — the remaining latency is bounded by the longest
+  single step (one provider call or one tool execution), which the future
+  heartbeat/lease epic can further constrain.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -400,3 +400,4 @@ Tools
    Adr100SpecializedUsageExtractors
    Adr101AgentRuntime
    Adr102QueuedAgentRuns
+   Adr103CooperativeCancellation

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -139,6 +139,59 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aCancelledRunStopsCooperativelyAtTheNextStepBoundary(): void
+    {
+        // ADR-103: the operator cancelled while the loop was executing (the row
+        // is already terminal CANCELLED). The probe at the step boundary stops
+        // the loop BEFORE any further provider call or tool execution.
+        $this->repository->findResult = $this->suspendedRun(status: 'cancelled');
+
+        $reachedSecondRound = false;
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace) use (&$reachedSecondRound): ToolLoopResult {
+                // First step boundary: the probe fires here and aborts.
+                $trace?->recordRequest(1, [], []);
+                // Anything after the boundary must never run for a cancelled run.
+                $reachedSecondRound = true;
+
+                return $this->loopResult('must not complete');
+            },
+        );
+
+        $result = $this->runtime($loop)->run($this->request());
+
+        self::assertSame(AgentRunOutcome::CANCELLED, $result->outcome);
+        self::assertFalse($reachedSecondRound);
+        // The boundary step itself is still on the audit stream…
+        self::assertCount(1, $this->repository->events);
+        // …and the already-terminal row is NOT settled again (no discarded
+        // double settle, no FAILED overwrite attempt).
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function aRunningRunIsNotDisturbedByTheCancellationProbe(): void
+    {
+        // The probe reads the row at every step boundary; a run that is simply
+        // RUNNING must complete normally.
+        $this->repository->findResult = $this->suspendedRun(status: 'running');
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop)->run($this->request());
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    #[Test]
     public function aGuardrailDenialSettlesPolicyStopped(): void
     {
         $runtime = $this->runtime($this->loopThrowing(new GuardrailViolationException('GuardrailFqcn', 'blocked')));

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -781,7 +781,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         // Called twice now: once by the budget pre-flight, once for the usage
         // row's configuration link. The count is not what this test is about.
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::atLeastOnce())->method('findOneByIdentifier')
             ->with('alt-text-images')
             ->willReturn($configuration);
 

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -698,7 +698,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         // Called twice now: once by the budget pre-flight, once for the usage
         // row's configuration link. The count is not what this test is about.
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::atLeastOnce())->method('findOneByIdentifier')
             ->with('podcast-narration')
             ->willReturn($configuration);
 

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -486,7 +486,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         // Called twice now: once by the budget pre-flight, once for the usage
         // row's configuration link. The count is not what this test is about.
-        $configurationRepository->method('findOneByIdentifier')
+        $configurationRepository->expects(self::atLeastOnce())->method('findOneByIdentifier')
             ->with('meeting-minutes')
             ->willReturn($configuration);
 


### PR DESCRIPTION
## What

P1 #8, slice 2 ("Cancel Flag zwischen Modell- und Tool-Schritten prüfen", [ADR-103](Documentation/Adr/Adr103CooperativeCancellation.rst)): cancellation stops being fence-only. Since ADR-092 the guarded terminal transition won the row, but the in-flight loop ran to completion — spending provider calls and executing tools whose outcome was then discarded. With queued worker runs (ADR-102) that gap grows; `nrllm:agent:cancel` is the only brake an operator has.

## How

The AgentRuntime's trace hook gains a **cancellation probe**: every step boundary — after a provider response, after each tool execution, before the next round — already records a step through the runtime's `onRecord` closure; the probe re-reads the run row there and, when it turned CANCELLED, throws the internal `RunCancellationRequestedException`. The ladder catches it as control flow, attempts **no** settle (the cancel already won; a late settle would be discarded anyway) and returns the new `AgentRunOutcome::CANCELLED`.

- **Loop stays persistence-unaware** (ADR-081) — `ToolLoopServiceInterface` untouched; the probe lives entirely in the runtime's trace closure.
- **A step in flight runs to its boundary** (cooperative check, not a signal); the boundary step stays on the audit stream. Nothing further starts after it.
- **Fail-soft probe**: a store hiccup reads null, never a fabricated cancellation. One indexed row read per step; steps are provider-call-slow.
- Identical behavior for `run()`, `approve()` continuations and `runQueued()` (shared trace builder).
- Playground maps it to `status: 'cancelled'` / `cancelled` stream event — a decision, not an error. `cancel()`'s interface contract upgraded to "fence + cooperative stop".

## Also in this PR (own commit)

`fix(tests)`: a fresh dependency resolve now installs **PHPUnit 13.1**, which removed `with()` from the stubbing API — three `*LinksUsageRowToConfigurationUid` tests used `createMock()->method()->with()` without `expects()` and fail PHPStan + runtime under 13. Fixed with `expects(atLeastOnce())` (expectation API keeps `with()` on 11/12/13, count matches the documented "called twice" comment). `composer.lock` is deliberately uncommitted, so every fresh CI resolve would have hit this independently of this branch.

## Tests

`aCancelledRunStopsCooperativelyAtTheNextStepBoundary` (probe aborts before further work; boundary step persisted; **no** double settle of the already-terminal row) + `aRunningRunIsNotDisturbedByTheCancellationProbe`. Full local gate green **under PHPUnit 13.1** (stricter than the previous local resolve): cgl, phpstan (L10), unit, functional (sqlite, 1244 tests), rector, fuzzy.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
