### PR TITLE
chore: release v0.23.1

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,7 +11,7 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.23"
+        version="0.23.1"
         release="0.23.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.23.0"
-        release="0.23.0"
+        version="0.23"
+        release="0.23.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.23.0",
+            "version": "0.23.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.23.0',
+    'version' => '0.23.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Patch release shipping the unified v14 3-color icon family (v13 legacy tiles) and the backend dark-mode fixes for Playground/SetupWizard/Analytics ([#488](https://github.com/netresearch/t3x-nr-llm/pull/488)). Additive/non-breaking.