### PR TITLE
feat(agent): worker heartbeat, stale-run reaper, retry and dead-letter (ADR-104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Worker heartbeat, stale-run reaper, retry and dead-letter (ADR-104): a queue
+  worker now renews its lease at every step boundary; if the renewal fails
+  (the run was reclaimed) it stops without settling — the run belongs to its
+  new owner (`AgentRunOutcome::LEASE_LOST`). The new schedulable
+  `nrllm:agent:reap` command finds RUNNING runs whose lease has expired (a
+  dead worker) and either requeues them for another worker or, once the requeue
+  budget is spent, dead-letters them; both mutations re-check staleness inside
+  the UPDATE so a merely slow worker is left alone. A queued run that fails is
+  classified through the `FailureClassifier` (extended so an exhausted fallback
+  chain classifies by its most recent attempt): a non-retryable class
+  dead-letters immediately (`AgentRunTerminationReason::NOT_RETRYABLE`), a
+  retryable one is requeued with an exponential backoff `DelayStamp`
+  (`AgentRunOutcome::REQUEUED`) until the budget is spent
+  (`RETRIES_EXHAUSTED`). Dead-lettering stays on the existing FAILED status +
+  reason axis — no new status, purge/retention untouched. Real backoff needs
+  the doctrine transport (which honours the delay); the sync transport retries
+  in-process, bounded by `AgentRuntime::MAX_REQUEUES` (3). Schema:
+  `requeue_count`. `AgentRunRepositoryInterface` gained `renewLease()`,
+  `requeue()`, `findStaleRunning()`, `requeueStale()` and `deadLetterStale()`.
 - Cooperative cancellation (ADR-103): `nrllm:agent:cancel` (and any
   `AgentRuntimeInterface::cancel()` caller) now also stops an in-flight loop at
   its next step boundary — after the current provider response or tool

--- a/Classes/Command/ReapStaleAgentRunsCommand.php
+++ b/Classes/Command/ReapStaleAgentRunsCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
+
+/**
+ * Reclaims queued agent runs abandoned by a dead worker (ADR-104).
+ *
+ * A worker that claims a queued run stamps a lease and renews it at every step
+ * boundary while it runs (the heartbeat). If the worker dies — the PHP process
+ * is killed, the container is recycled, the machine reboots — the run stays
+ * RUNNING with a lease nobody renews. This command finds those runs (lease
+ * expired) and either puts them back on the queue for another worker or, once
+ * the requeue budget is spent, dead-letters them so they stop occupying the
+ * RUNNING set forever.
+ *
+ * Interactive run()/approve() runs never take a lease, so the reaper never
+ * touches them; a foreground run abandoned by a dying client is reaped by the
+ * separate age-based retention path ({@see PurgePrivacyDataCommand}).
+ *
+ * Every mutation is staleness-guarded in the repository: a run whose lease was
+ * renewed between this command's read and its write is skipped, so a worker
+ * that was merely slow (not dead) is never disturbed. Schedulable from
+ * EXT:scheduler or cron.
+ */
+#[AsCommand(
+    name: 'nrllm:agent:reap',
+    description: 'Reclaim or dead-letter queued agent runs whose worker lease has expired.',
+)]
+final class ReapStaleAgentRunsCommand extends Command
+{
+    /** Default upper bound on runs handled per invocation, so one tick is bounded. */
+    private const DEFAULT_LIMIT = 50;
+
+    public function __construct(
+        private readonly AgentRunPersister $persister,
+        private readonly ?MessageBusInterface $messageBus = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'limit',
+            'l',
+            InputOption::VALUE_REQUIRED,
+            'Maximum number of stale runs to handle in this run.',
+            (string)self::DEFAULT_LIMIT,
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($this->messageBus === null) {
+            $io->error('No message bus is available; queued runs cannot be reclaimed.');
+
+            return Command::FAILURE;
+        }
+
+        $limitOption = $input->getOption('limit');
+        $limit       = is_numeric($limitOption) ? (int)$limitOption : 0;
+        if ($limit < 1) {
+            $io->error('The --limit option must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $now        = time();
+        $staleRuns  = $this->persister->findStaleRunning($now, $limit);
+        $requeued   = 0;
+        $deadLetter = 0;
+        $skipped    = 0;
+
+        foreach ($staleRuns as $run) {
+            // Budget spent -> dead-letter; otherwise reclaim onto the queue. Both
+            // writes re-check staleness in the repository, so a heartbeat renewal
+            // between findStaleRunning() and here wins and the run is skipped.
+            if ($run->requeueCount >= AgentRuntime::MAX_REQUEUES) {
+                if ($this->persister->settleDeadLetteredStale($run, $now, AgentRunTerminationReason::RETRIES_EXHAUSTED)) {
+                    ++$deadLetter;
+                } else {
+                    ++$skipped;
+                }
+
+                continue;
+            }
+
+            if (!$this->persister->requeueStale($run, $now)) {
+                ++$skipped;
+
+                continue;
+            }
+
+            // The row is QUEUED again: wake a worker. A dispatch failure leaves a
+            // QUEUED row a later tick (or a still-live consumer) picks up, so it
+            // is counted as reclaimed, logged, and not treated as fatal.
+            try {
+                $this->messageBus->dispatch(new AgentRunQueuedMessage($run->uuid));
+            } catch (Throwable $exception) {
+                $io->warning(sprintf('Run "%s" was reclaimed but its wake-up could not be dispatched: %s', $run->uuid, $exception->getMessage()));
+            }
+            ++$requeued;
+        }
+
+        $io->success(sprintf(
+            'Reaped %d stale run(s): %d requeued, %d dead-lettered, %d skipped (renewed or already moved on).',
+            count($staleRuns),
+            $requeued,
+            $deadLetter,
+            $skipped,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Domain/Enum/AgentRunOutcome.php
+++ b/Classes/Domain/Enum/AgentRunOutcome.php
@@ -39,4 +39,14 @@ enum AgentRunOutcome: string
     // terminal CANCELLED (the cancel won the guarded transition); this outcome
     // tells the caller their in-flight call ended because of it.
     case CANCELLED = 'cancelled';
+
+    // A queued run failed with a retryable provider error and was put back on
+    // the queue for another attempt within its requeue budget (ADR-104). The
+    // row is QUEUED again; a delayed message will re-execute it.
+    case REQUEUED = 'requeued';
+
+    // A worker executing a queued run lost its lease — the stale-run reaper
+    // reclaimed it and another worker owns it now (ADR-104). This worker stops
+    // WITHOUT settling; the run belongs to the new owner.
+    case LEASE_LOST = 'lease_lost';
 }

--- a/Classes/Domain/Enum/AgentRunTerminationReason.php
+++ b/Classes/Domain/Enum/AgentRunTerminationReason.php
@@ -57,6 +57,23 @@ enum AgentRunTerminationReason: string
     case CANCELLED = 'cancelled';
 
     /**
+     * A queued run failed with a retryable provider error, was requeued the
+     * maximum number of times, and still did not succeed (ADR-104). The failure
+     * class was transient in principle, but the requeue budget is spent — this
+     * is the dead-letter terminus for a run that could be retried but no longer
+     * may be.
+     */
+    case RETRIES_EXHAUSTED = 'retries_exhausted';
+
+    /**
+     * A queued run failed with a failure class that retrying cannot fix
+     * (authentication, configuration, a 4xx client error, ADR-104). No requeue
+     * is attempted; the run dead-letters immediately. Distinct from
+     * PROVIDER_FAILED, whose isRetryable() is true.
+     */
+    case NOT_RETRYABLE = 'not_retryable';
+
+    /**
      * @return list<string>
      */
     public static function values(): array

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -50,6 +50,10 @@ final readonly class AgentRun
         // claim is presumed live; ''/0 = not claimed.
         public string $claimedBy = '',
         public int $leaseExpires = 0,
+        // How many times the run has been requeued (ADR-104), by either a
+        // retryable-failure retry or a stale-lease reclaim; capped by
+        // AgentRuntime::MAX_REQUEUES so a deterministic crash cannot loop.
+        public int $requeueCount = 0,
     ) {}
 
     /**
@@ -84,6 +88,7 @@ final readonly class AgentRun
             queuedRequest: null,
             claimedBy: $this->claimedBy,
             leaseExpires: $this->leaseExpires,
+            requeueCount: $this->requeueCount,
         );
     }
 

--- a/Classes/Provider/Middleware/FailureClassifier.php
+++ b/Classes/Provider/Middleware/FailureClassifier.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Enum\FailureClass;
 use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
@@ -36,12 +37,38 @@ final readonly class FailureClassifier
     {
         return match (true) {
             $e instanceof CircuitOpenException => FailureClass::CIRCUIT_OPEN,
+            $e instanceof FallbackChainExhaustedException => self::fromChain($e),
             $e instanceof ProviderConnectionException,
             $e instanceof NetworkExceptionInterface => FailureClass::CONNECTION,
             $e instanceof ProviderConfigurationException => FailureClass::CONFIGURATION,
             $e instanceof ProviderResponseException => self::fromStatus($e->getCode()),
             default => FailureClass::UNKNOWN,
         };
+    }
+
+    /**
+     * A fallback chain only wraps retryable per-attempt errors (ADR-026), so the
+     * wrapper itself is retryable. Classify it by its most recent attempt — the
+     * freshest provider condition — so a queue retry (ADR-104) reacts to what
+     * actually failed last rather than to the opaque wrapper (which alone would
+     * classify UNKNOWN, i.e. not retryable). An empty attempt list cannot occur
+     * for a real chain but is treated conservatively as UNKNOWN.
+     */
+    private static function fromChain(FallbackChainExhaustedException $e): FailureClass
+    {
+        $attempts = $e->getAttemptErrors();
+        if ($attempts === []) {
+            return FailureClass::UNKNOWN;
+        }
+
+        $lastError = $attempts[array_key_last($attempts)]['error'];
+
+        // Guard against a pathological nested wrapper: recurse, never loop.
+        if ($lastError instanceof FallbackChainExhaustedException) {
+            return self::fromChain($lastError);
+        }
+
+        return self::classify($lastError);
     }
 
     private static function fromStatus(int $status): FailureClass

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -25,11 +25,13 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunLeaseLostException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
@@ -43,6 +45,7 @@ use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Throwable;
 
 /**
@@ -71,10 +74,31 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
     /**
      * How long a worker's claim on a queued run is presumed live (ADR-102).
-     * Written at claim time; the stale-run reaper epic acts on expiry —
-     * until then the lease is diagnostic.
+     * Written at claim time and renewed at every step boundary while the worker
+     * runs (ADR-104 heartbeat); the stale-run reaper reclaims a run whose lease
+     * has expired.
      */
     public const LEASE_SECONDS = 900;
+
+    /**
+     * How many times a queued run may be requeued before it dead-letters
+     * (ADR-104). A shared budget for both requeue sources — a retryable failure
+     * and a stale-lease reclaim — so a deterministically crashing run cannot
+     * loop forever through the queue.
+     */
+    public const MAX_REQUEUES = 3;
+
+    /**
+     * Base backoff before a requeued run is retried, in milliseconds (ADR-104).
+     * The delay grows exponentially with the requeue count, capped by
+     * {@see self::REQUEUE_BACKOFF_CAP_MS}. Honoured by the doctrine transport
+     * (available_at); the sync transport ignores it and retries in-process,
+     * bounded by {@see self::MAX_REQUEUES}.
+     */
+    public const REQUEUE_BACKOFF_MS = 30_000;
+
+    /** Ceiling on the exponential requeue backoff, in milliseconds (ADR-104). */
+    public const REQUEUE_BACKOFF_CAP_MS = 600_000;
 
     public function __construct(
         private ToolLoopServiceInterface $toolLoop,
@@ -149,13 +173,34 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
         // Exactly one worker wins the guarded QUEUED -> RUNNING transition; a
         // run cancelled while waiting is terminal and unclaimable (ADR-102).
-        if (!$this->persister->claimQueued($run, $this->workerIdentity(), time() + self::LEASE_SECONDS)) {
+        $workerIdentity = $this->workerIdentity();
+        if (!$this->persister->claimQueued($run, $workerIdentity, time() + self::LEASE_SECONDS)) {
             return null;
         }
 
-        // The claim is won: from here every failure settles the run rather
-        // than leaving it stuck RUNNING.
-        $handle = new AgentRunHandle($run->uid, $run->uuid);
+        // Resolve the event-stream position from a FRESH row AFTER the claim.
+        // A first execution has no events (MAX = -1 -> sequence 0, identical to
+        // before ADR-104); a REQUEUED run carries the prior attempt's events, so
+        // starting at 0 would reuse sequences and corrupt the stream. Fail-closed
+        // like approve(): a null position settles the run FAILED rather than
+        // stranding it RUNNING (the claim is already won).
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $fallback = new AgentRunHandle($run->uid, $run->uuid);
+            $this->persister->settleFailed(
+                $fallback,
+                new RuntimeException(sprintf('The event-stream position of queued run %s could not be determined after the claim', $runUuid), 1784900002),
+            );
+            $this->logger?->error('Queued agent run position could not be resolved after the claim; the run was failed', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: [],
+                error: new RuntimeException('The event-stream position could not be determined after the queue claim', 1784900002),
+            );
+        }
 
         try {
             $request = $this->rehydrateRequest($run);
@@ -171,22 +216,121 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             );
         }
 
-        return $this->executeRequest($request, $handle, $onStep);
+        // The heartbeat renews the lease under this worker's identity, and the
+        // recover closure decides retry-vs-dead-letter for a failure (ADR-104).
+        $recover = fn(Throwable $e, array $steps): AgentRunResult
+            => $this->recoverQueuedFailure($handle, $runUuid, $workerIdentity, $e, $steps);
+
+        return $this->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
+    }
+
+    /**
+     * Decide the fate of a FAILED queued run (ADR-104), invoked from the ladder
+     * BEFORE the default settleFailed. Returns the outcome that replaces the
+     * generic FAILED — for a queued run every branch settles the row itself, so
+     * the ladder never falls through to PROVIDER_FAILED. Fully fail-soft: it
+     * must never throw — {@see runQueued()} does not throw once the claim is
+     * won — so a failure of the recovery machinery itself dead-letters the run.
+     *
+     * @param list<RunStep> $steps
+     */
+    private function recoverQueuedFailure(AgentRunHandle $handle, string $runUuid, string $workerIdentity, Throwable $e, array $steps): AgentRunResult
+    {
+        try {
+            $class = FailureClassifier::classify($e);
+
+            // A class retrying cannot fix (auth, config, a 4xx client error):
+            // dead-letter immediately, distinct from PROVIDER_FAILED so it never
+            // reads as retryable.
+            if (!$class->isRetryable()) {
+                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE);
+                $this->logger?->warning('Queued agent run failed with a non-retryable error; dead-lettered', ['run' => $runUuid, 'class' => $class->value]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // Retryable in principle — but is the requeue budget spent? Re-read
+            // the row; a null read (-1) forces the fail-closed dead-letter.
+            $currentRun = $this->persister->findRun($runUuid);
+            $count      = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
+            if ($count < 0 || $count >= self::MAX_REQUEUES) {
+                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED);
+                $this->logger?->warning('Queued agent run exhausted its retry budget; dead-lettered', ['run' => $runUuid, 'requeueCount' => $count]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // Requeue under an ownership guard. false => this worker no longer
+            // owns the run (the reaper reclaimed it, another worker holds it, or
+            // a concurrent cancel won). Do NOT settle: the row belongs to its
+            // current owner and settling it would destroy that owner's state.
+            if (!$this->persister->requeue($handle, $workerIdentity)) {
+                $this->logger?->notice('Queued agent run could not be requeued (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // The row is QUEUED again: wake a worker for the retry, backing off.
+            // A dispatch failure would strand the QUEUED row (async transport),
+            // so the outer catch dead-letters it (finishRun's guard covers
+            // QUEUED). The sync transport ignores the delay and re-executes
+            // in-process, bounded by MAX_REQUEUES.
+            $this->dispatchRequeue($handle->uuid, $count);
+
+            return new AgentRunResult(outcome: AgentRunOutcome::REQUEUED, runUuid: $runUuid, steps: $steps, error: $e);
+        } catch (Throwable $internal) {
+            $this->logger?->error('Queued agent run recovery failed; dead-lettering', ['run' => $runUuid, 'exception' => $internal]);
+            try {
+                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED);
+            } catch (Throwable) {
+                // The persister is itself fail-soft; nothing more can be done.
+            }
+
+            return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+        }
+    }
+
+    /**
+     * Dispatch a delayed wake-up for a requeued run (ADR-104). Throws when no
+     * bus is wired — unreachable in practice (a queued run only exists when
+     * enqueue() dispatched, which requires the bus) but surfaced so the caller
+     * dead-letters rather than stranding a QUEUED row.
+     */
+    private function dispatchRequeue(string $uuid, int $priorRequeueCount): void
+    {
+        if ($this->messageBus === null) {
+            throw RunEnqueueFailedException::forRun($uuid);
+        }
+
+        $delayMs = min(self::REQUEUE_BACKOFF_MS * (2 ** $priorRequeueCount), self::REQUEUE_BACKOFF_CAP_MS);
+        $this->messageBus->dispatch(new AgentRunQueuedMessage($uuid), [new DelayStamp($delayMs)]);
     }
 
     /**
      * The shared execution path behind {@see run()} and {@see runQueued()}:
      * clamp the round cap, build the trace, drive the ladder.
      *
-     * @param (Closure(RunStep): void)|null $onStep
+     * A queued run passes its worker identity as $leaseOwner (so each step
+     * boundary renews the lease and detects a reaper reclaim, ADR-104) and a
+     * $recover closure that decides retry-vs-dead-letter for a failure. An
+     * interactive run() passes neither: it holds no lease and surfaces failures
+     * to its caller unchanged.
+     *
+     * @param (Closure(RunStep): void)|null                             $onStep
+     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
      */
-    private function executeRequest(AgentRunRequest $request, ?AgentRunHandle $handle, ?Closure $onStep): AgentRunResult
-    {
+    private function executeRequest(
+        AgentRunRequest $request,
+        ?AgentRunHandle $handle,
+        ?Closure $onStep,
+        ?string $leaseOwner = null,
+        ?Closure $recover = null,
+    ): AgentRunResult {
         $maxIterations = $request->maxIterations !== null
             ? min($request->maxIterations, self::MAX_ITERATIONS)
             : null;
 
-        $trace = $this->trace($handle, $onStep, $request->captureRaw);
+        $trace = $this->trace($handle, $onStep, $request->captureRaw, $leaseOwner);
 
         return $this->execute(
             $handle,
@@ -200,6 +344,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 $trace,
                 $request->augmentation,
             ),
+            $recover,
         );
     }
 
@@ -511,9 +656,17 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      * stream stays complete up to the abort point. One indexed row read per
      * step; steps are provider-call-slow, so the cost is negligible.
      *
+     * For a queued run $leaseOwner is this worker's identity (ADR-104): after
+     * the cancellation check, the lease is renewed under an ownership guard
+     * BEFORE the step is persisted. If the renewal affects no row the worker no
+     * longer owns the run — the reaper reclaimed it and another worker may hold
+     * it now — so it stops WITHOUT writing the step, which would otherwise
+     * collide with the new owner's stream. Interactive runs pass null and never
+     * renew (they hold no lease).
+     *
      * @param (Closure(RunStep): void)|null $onStep
      */
-    private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw): RunTrace
+    private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw, ?string $leaseOwner = null): RunTrace
     {
         if ($handle === null && $onStep === null) {
             return new RunTrace(captureRaw: $captureRaw);
@@ -521,19 +674,40 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
         return new RunTrace(
             captureRaw: $captureRaw,
-            onRecord: function (RunStep $step) use ($handle, $onStep): void {
+            onRecord: function (RunStep $step) use ($handle, $onStep, $leaseOwner): void {
+                // The live observer sees the step FIRST (emit-before-persist),
+                // so a step is shown even when its persistence or the checks
+                // below abort the loop.
                 if ($onStep !== null) {
                     $onStep($step);
                 }
-                if ($handle !== null) {
+                if ($handle === null) {
+                    return;
+                }
+
+                // A single indexed read drives the cancellation probe (ADR-103).
+                // findRun is fail-soft (null on a store hiccup), so a read
+                // failure can never fabricate a cancellation.
+                if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
+                    // Persist the step that already happened, then stop: the
+                    // audit stream stays complete up to the abort point.
                     $this->persister->recordStep($handle, $step);
 
-                    // findRun is fail-soft (null on a store hiccup), so a read
-                    // failure can never fabricate a cancellation.
-                    if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
-                        throw RunCancellationRequestedException::forRun($handle->uuid);
-                    }
+                    throw RunCancellationRequestedException::forRun($handle->uuid);
                 }
+
+                // Heartbeat + lease-lost guard for a worker run (ADR-104). The
+                // renewal's ownership guard is the atomic check: 0 rows means
+                // the run was reclaimed/re-claimed/terminated — stop WITHOUT
+                // recording the step, so a zombie worker cannot append an event
+                // whose sequence collides with the new owner's stream.
+                if ($leaseOwner !== null
+                    && !$this->persister->renewLease($handle, $leaseOwner, time() + self::LEASE_SECONDS)
+                ) {
+                    throw RunLeaseLostException::forRun($handle->uuid);
+                }
+
+                $this->persister->recordStep($handle, $step);
             },
         );
     }
@@ -550,9 +724,14 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      * observer dying mid-run, mirroring StreamingDispatcher) and costs the
      * settled paths nothing.
      *
-     * @param Closure(): ToolLoopResult $loopCall
+     * A queued run passes a $recover closure (ADR-104): in the generic failure
+     * arm, before the default settleFailed, it decides retry-vs-dead-letter and,
+     * when it handles the failure, returns the outcome that replaces FAILED.
+     *
+     * @param Closure(): ToolLoopResult                                 $loopCall
+     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
      */
-    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall): AgentRunResult
+    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null): AgentRunResult
     {
         $runUuid = $handle !== null ? $handle->uuid : '';
         $settled = false;
@@ -645,7 +824,34 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 guardrailClass: $guardrail->guardrail,
                 error: $guardrail,
             );
+        } catch (RunLeaseLostException $leaseLost) {
+            // ADR-104: the reaper reclaimed this run (or a cancel/settle won) and
+            // it belongs to another worker now. Stop WITHOUT settling — any
+            // settle here could destroy the new owner's in-flight state. Not a
+            // failure of the run; a loss of ownership by this worker.
+            $settled = true;
+            $this->logger?->info('Agent run worker lost its lease; stopping without settling', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::LEASE_LOST,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $leaseLost,
+            );
         } catch (Throwable $e) {
+            // A queued run's recover closure decides retry-vs-dead-letter and,
+            // when it handles the failure, settles the row itself and returns
+            // the replacement outcome. Only an interactive run (no recover) or a
+            // recover that declines (null) falls through to the default settle.
+            if ($recover !== null) {
+                $recovery = $recover($e, $trace->getSteps());
+                if ($recovery instanceof AgentRunResult) {
+                    $settled = true;
+
+                    return $recovery;
+                }
+            }
+
             if ($handle !== null) {
                 $this->persister->settleFailed($handle, $e);
             }

--- a/Classes/Service/Agent/Exception/RunLeaseLostException.php
+++ b/Classes/Service/Agent/Exception/RunLeaseLostException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use RuntimeException;
+
+/**
+ * Internal control-flow signal that a queue worker has lost its lease (ADR-104).
+ *
+ * Thrown by the AgentRuntime's heartbeat (inside the trace hook, at a step
+ * boundary) when the lease renewal affects no row — the stale-run reaper
+ * reclaimed the run, another worker already re-claimed it, or a cancel/settle
+ * terminated it. Like {@see RunCancellationRequestedException} it is control
+ * flow, not a caller error: it is caught by the runtime's own ladder, mapped to
+ * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunOutcome::LEASE_LOST}, and never
+ * escapes the runtime. The ladder does NOT settle the run — the row belongs to
+ * its new owner, and settling it would destroy that owner's in-flight state.
+ */
+final class RunLeaseLostException extends RuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self(sprintf('Run %s lease was lost; this worker stops at the step boundary.', $runUuid), 1784900001);
+    }
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -122,6 +122,41 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * Extend the lease on a running run this worker owns (ADR-104 heartbeat).
+     * Fail-closed, unlike most methods here: a store error returns false — the
+     * worker treats it as a lost lease and stops. Better a run stalls and is
+     * reaped later than a worker keeps executing on a lease it can no longer
+     * prove it holds, risking a double-execution once the reaper reclaims it.
+     */
+    public function renewLease(AgentRunHandle $handle, string $claimedBy, int $leaseExpires): bool
+    {
+        try {
+            return $this->repository->renewLease($handle->runUid, $claimedBy, $leaseExpires);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun lease could not be renewed; the worker will treat it as lost', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Put a running run this worker owns back on the queue for a retry (ADR-104).
+     * Ownership-guarded in the repository; false when the worker no longer owned
+     * the run (reclaimed/cancelled) or the store errored — the caller must then
+     * NOT settle it as failed, since the row may belong to another worker now.
+     */
+    public function requeue(AgentRunHandle $handle, string $claimedBy): bool
+    {
+        try {
+            return $this->repository->requeue($handle->runUid, $claimedBy);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be requeued for retry', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
      * Persist one recorded step as the next event in the run's stream.
      */
     public function recordStep(AgentRunHandle $handle, RunStep $step): void
@@ -186,6 +221,18 @@ final readonly class AgentRunPersister
      * read as a denial.
      */
     public function settlePolicyStopped(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason): void
+    {
+        $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason);
+    }
+
+    /**
+     * Dead-letter a queued run that will not be retried (ADR-104): FAILED, with
+     * a reason that says why retrying stopped — RETRIES_EXHAUSTED (the requeue
+     * budget is spent) or NOT_RETRYABLE (the failure class cannot be fixed by
+     * retrying). Distinct from {@see self::settleFailed()}, whose PROVIDER_FAILED
+     * reason is retryable; a dead-letter terminus must not read as retryable.
+     */
+    public function settleDeadLettered(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason): void
     {
         $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason);
     }
@@ -368,6 +415,55 @@ final readonly class AgentRunPersister
             $this->logger?->warning('AgentRun events could not be loaded', ['exception' => $exception]);
 
             return [];
+        }
+    }
+
+    /**
+     * Running runs whose lease has expired (ADR-104 reaper). Fail-soft: an empty
+     * list on error, so a reaper tick simply does nothing that pass.
+     *
+     * @return list<AgentRun>
+     */
+    public function findStaleRunning(int $now, int $limit = 50): array
+    {
+        try {
+            return $this->repository->findStaleRunning($now, $limit);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('Stale agent runs could not be loaded', ['exception' => $exception]);
+
+            return [];
+        }
+    }
+
+    /**
+     * Reclaim a stale running run onto the queue (ADR-104 reaper). Fail-soft:
+     * false on error or when the run was renewed between select and update, so
+     * the reaper skips it and no dispatch follows.
+     */
+    public function requeueStale(AgentRun $run, int $now): bool
+    {
+        try {
+            return $this->repository->requeueStale($run->uid, $now);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('Stale agent run could not be requeued', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Dead-letter a stale running run whose retry budget is spent (ADR-104
+     * reaper): staleness-guarded in the repository so a heartbeat renewal wins.
+     * Fail-soft: false on error or when the run was no longer stale.
+     */
+    public function settleDeadLetteredStale(AgentRun $run, int $now, AgentRunTerminationReason $reason): bool
+    {
+        try {
+            return $this->repository->deadLetterStale($run->uid, $now, $reason->value);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('Stale agent run could not be dead-lettered', ['exception' => $exception]);
+
+            return false;
         }
     }
 

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
@@ -247,6 +248,157 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return $affected === 1;
     }
 
+    /**
+     * Extend the lease on a running run this worker owns (ADR-104 heartbeat).
+     * Guarded on both status = running AND claimed_by = the caller: a run the
+     * reaper reclaimed (claimed_by cleared, or another worker's identity) or a
+     * cancel/settle terminated updates zero rows, which is the worker's signal
+     * that it has lost ownership and must stop before executing further.
+     */
+    public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'lease_expires' => $leaseExpires,
+                'tstamp'        => time(),
+            ],
+            [
+                'uid'        => $runUid,
+                'status'     => AgentRunStatus::RUNNING->value,
+                'claimed_by' => $claimedBy,
+            ],
+        );
+
+        return $affected === 1;
+    }
+
+    /**
+     * Put a running run this worker owns back on the queue for a retry (ADR-104
+     * failure retry). Ownership-guarded (status = running AND claimed_by = the
+     * caller) so a zombie worker cannot requeue — and thereby double-execute — a
+     * run another worker already owns. Increments requeue_count, clears the
+     * claim and lease; queued_request stays on the row for re-execution. Returns
+     * true when this worker still owned the run and the requeue took effect.
+     */
+    public function requeue(int $runUid, string $claimedBy): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $builder    = $connection->createQueryBuilder();
+
+        $affected = $this
+            ->applyRequeueSet($builder)
+            ->where(
+                $builder->expr()->eq('uid', $builder->createNamedParameter($runUid, Connection::PARAM_INT)),
+                $builder->expr()->eq('status', $builder->createNamedParameter(AgentRunStatus::RUNNING->value)),
+                $builder->expr()->eq('claimed_by', $builder->createNamedParameter($claimedBy)),
+            )
+            ->executeStatement();
+
+        return $affected > 0;
+    }
+
+    /**
+     * Running runs whose lease has expired (ADR-104 stale-run reaper). The
+     * lease_expires > 0 predicate excludes interactive run()/approve() runs,
+     * which never take a lease (claimed_by/lease stay empty) — the reaper only
+     * reclaims abandoned queue workers, never a live foreground call.
+     *
+     * @return list<AgentRun>
+     */
+    public function findStaleRunning(int $now, int $limit = 50): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_RUN)
+            ->where(
+                $queryBuilder->expr()->eq('status', $queryBuilder->createNamedParameter(AgentRunStatus::RUNNING->value)),
+                $queryBuilder->expr()->gt('lease_expires', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->lt('lease_expires', $queryBuilder->createNamedParameter($now, Connection::PARAM_INT)),
+            )
+            ->orderBy('lease_expires', 'ASC')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrateRun(...), $rows);
+    }
+
+    /**
+     * Reclaim a stale running run back onto the queue (ADR-104 reaper). Unlike
+     * {@see requeue()} this is not ownership-guarded — the reaper reclaims on
+     * behalf of no worker — but it re-checks staleness inside the UPDATE
+     * (lease_expires still > 0 and < now): a heartbeat renewal that lands
+     * between the reaper's SELECT and this UPDATE moves lease_expires forward,
+     * the predicate no longer matches, zero rows change and the reaper skips it.
+     * Increments requeue_count, clears the claim and lease.
+     */
+    public function requeueStale(int $runUid, int $now): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $builder    = $connection->createQueryBuilder();
+
+        $affected = $this
+            ->applyRequeueSet($builder)
+            ->where(...$this->stalePredicates($builder, $runUid, $now))
+            ->executeStatement();
+
+        return $affected > 0;
+    }
+
+    /**
+     * Dead-letter a stale running run whose requeue budget is spent (ADR-104
+     * reaper): a terminal FAILED with the given reason. Staleness-guarded like
+     * {@see requeueStale()} — the same lease_expires re-check inside the UPDATE,
+     * so a heartbeat renewal that lands between the reaper's SELECT and this
+     * write moves the lease forward, the predicate no longer matches, and a
+     * still-live run is never flipped to FAILED. Totals are zeroed, matching the
+     * failure convention of {@see finishRun()}.
+     */
+    public function deadLetterStale(int $runUid, int $now, string $terminationReason): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
+        $builder    = $connection->createQueryBuilder();
+        $timestamp  = time();
+
+        $affected = $builder
+            ->update(self::TABLE_RUN)
+            ->set('status', $builder->createNamedParameter(AgentRunStatus::FAILED->value), false)
+            ->set('termination_reason', $builder->createNamedParameter($terminationReason), false)
+            ->set('error_class', $builder->createNamedParameter(''), false)
+            ->set('suspended_state', $builder->createNamedParameter(''), false)
+            ->set('queued_request', $builder->createNamedParameter(''), false)
+            ->set('claimed_by', $builder->createNamedParameter(''), false)
+            ->set('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT), false)
+            ->set('finished_at', $builder->createNamedParameter($timestamp, Connection::PARAM_INT), false)
+            ->set('tstamp', $builder->createNamedParameter($timestamp, Connection::PARAM_INT), false)
+            ->where(...$this->stalePredicates($builder, $runUid, $now))
+            ->executeStatement();
+
+        return $affected > 0;
+    }
+
+    /**
+     * The WHERE guard both reaper mutations share (ADR-104): a specific run that
+     * is RUNNING and whose lease has expired (lease_expires > 0 excludes
+     * interactive runs, < now is the staleness re-check). Returned as an
+     * expression list so the caller spreads it into ->where().
+     *
+     * @return list<string>
+     */
+    private function stalePredicates(QueryBuilder $builder, int $runUid, int $now): array
+    {
+        return [
+            $builder->expr()->eq('uid', $builder->createNamedParameter($runUid, Connection::PARAM_INT)),
+            $builder->expr()->eq('status', $builder->createNamedParameter(AgentRunStatus::RUNNING->value)),
+            $builder->expr()->gt('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT)),
+            $builder->expr()->lt('lease_expires', $builder->createNamedParameter($now, Connection::PARAM_INT)),
+        ];
+    }
+
     public function findByUuid(string $uuid): ?AgentRun
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
@@ -367,6 +519,27 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
     }
 
     /**
+     * The SET clause shared by both requeue paths (ADR-104): back to QUEUED,
+     * requeue_count incremented, claim and lease cleared, tstamp bumped. The
+     * caller adds the WHERE guard that distinguishes an ownership requeue
+     * ({@see requeue()}) from a staleness reclaim ({@see requeueStale()}).
+     * queued_request is deliberately left untouched — the stored request is what
+     * the re-dispatched worker re-executes.
+     */
+    private function applyRequeueSet(QueryBuilder $builder): QueryBuilder
+    {
+        $now = time();
+
+        return $builder
+            ->update(self::TABLE_RUN)
+            ->set('status', $builder->createNamedParameter(AgentRunStatus::QUEUED->value), false)
+            ->set('requeue_count', 'requeue_count + 1', false)
+            ->set('claimed_by', $builder->createNamedParameter(''), false)
+            ->set('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT), false)
+            ->set('tstamp', $builder->createNamedParameter($now, Connection::PARAM_INT), false);
+    }
+
+    /**
      * @param array<string, mixed> $row
      */
     private function hydrateRun(array $row): AgentRun
@@ -393,6 +566,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             queuedRequest: $this->suspendedStateOf($row['queued_request'] ?? null),
             claimedBy: self::toStr($row['claimed_by'] ?? ''),
             leaseExpires: self::toInt($row['lease_expires'] ?? 0),
+            requeueCount: self::toInt($row['requeue_count'] ?? 0),
         );
     }
 

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -87,6 +87,46 @@ interface AgentRunRepositoryInterface
      */
     public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool;
 
+    /**
+     * Extend the lease on a running run this worker owns (ADR-104 heartbeat).
+     * Guarded on status = running AND claimed_by = the caller; false means the
+     * worker no longer owns the run (reaped, cancelled or settled) and must
+     * stop before doing further work.
+     */
+    public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool;
+
+    /**
+     * Put a running run this worker owns back on the queue for a retry (ADR-104
+     * failure retry): ownership-guarded (status = running AND claimed_by = the
+     * caller), increments requeue_count, clears claim and lease, keeps
+     * queued_request. False when the worker no longer owned the run.
+     */
+    public function requeue(int $runUid, string $claimedBy): bool;
+
+    /**
+     * Running runs whose lease has expired at $now (ADR-104 reaper). Excludes
+     * interactive runs, which never take a lease.
+     *
+     * @return list<AgentRun>
+     */
+    public function findStaleRunning(int $now, int $limit = 50): array;
+
+    /**
+     * Reclaim a stale running run onto the queue (ADR-104 reaper): re-checks
+     * staleness inside the UPDATE so a concurrent heartbeat renewal wins,
+     * increments requeue_count, clears claim and lease. False when the run was
+     * no longer stale (renewed) or already moved on.
+     */
+    public function requeueStale(int $runUid, int $now): bool;
+
+    /**
+     * Dead-letter a stale running run whose requeue budget is spent (ADR-104
+     * reaper): terminal FAILED with the given reason, staleness-guarded like
+     * {@see requeueStale()} so a heartbeat renewal wins and a live run is never
+     * failed. False when the run was no longer stale or already terminal.
+     */
+    public function deadLetterStale(int $runUid, int $now, string $terminationReason): bool;
+
     public function findByUuid(string $uuid): ?AgentRun;
 
     /**

--- a/Documentation/Adr/Adr104StaleRunReaperAndRetry.rst
+++ b/Documentation/Adr/Adr104StaleRunReaperAndRetry.rst
@@ -1,0 +1,101 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-104:
+
+============================================================================
+ADR-104: Worker heartbeat, stale-run reaper, retry and dead-letter
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-21
+:Authors: Netresearch DTT GmbH
+
+.. _adr-104-context:
+
+Context
+=======
+
+Queued runs (:ref:`ADR-102 <adr-102>`) claim a row with a **lease**
+(``claimed_by`` + ``lease_expires``), but until now nothing renewed or acted on
+it — the lease was diagnostic only. Two gaps remained:
+
+- **A dead worker strands its run forever.** If the PHP process is killed, the
+  container recycled or the machine rebooted mid-loop, the run stays RUNNING
+  with a lease nobody renews. No other worker can take it (the claim is
+  optimistic on QUEUED), so it never finishes.
+- **A transient provider failure is terminal.** A queued run that hit a 5xx, a
+  rate limit or an exhausted fallback chain settled FAILED immediately — no
+  retry, even though a different worker moments later might have succeeded.
+
+The P1 roadmap asks for a heartbeat, a stale-run reaper, retry-per-failure-class
+and a dead-letter terminus.
+
+.. _adr-104-decision:
+
+Decision
+========
+
+**Heartbeat.** The runtime's trace hook (the same step-boundary closure the
+cancellation probe uses, :ref:`ADR-103 <adr-103>`) renews the lease on every
+step for a worker run — an ownership-guarded UPDATE
+(``WHERE status='running' AND claimed_by = :me``). A renewal that affects **no
+row** means the worker lost the run (reaped, re-claimed or terminated); it
+throws the internal ``RunLeaseLostException``, caught by a dedicated ladder arm
+that stops **without settling** (the row belongs to its new owner now) and
+returns ``AgentRunOutcome::LEASE_LOST``. Interactive ``run()``/``approve()``
+segments hold no lease and never renew — the heartbeat is worker-only. To avoid
+a zombie worker appending an event whose sequence collides with the new owner's
+stream, the boundary step is persisted **after** the renewal check, not before.
+
+**Reaper.** ``nrllm:agent:reap`` (schedulable) finds RUNNING runs whose lease
+has expired (``lease_expires > 0 AND lease_expires < now`` — the ``> 0`` excludes
+interactive runs) and either requeues them (budget permitting) or dead-letters
+them. Both mutations re-check staleness **inside** the UPDATE, so a heartbeat
+renewal that lands between the reaper's SELECT and its write wins and the merely
+slow (not dead) worker is left alone.
+
+**Retry.** A queued run's failure runs through a recovery hook in the ladder,
+before the default settle. The failure is classified through the existing
+:ref:`FailureClassifier <adr-095>` (extended so a ``FallbackChainExhausted``
+wrapper classifies by its most recent attempt rather than as UNKNOWN):
+
+- **Not retryable** (auth, configuration, 4xx) → dead-letter now with reason
+  ``NOT_RETRYABLE``.
+- **Retryable but the requeue budget is spent** → dead-letter with
+  ``RETRIES_EXHAUSTED``.
+- **Retryable and under budget** → ownership-guarded requeue (bumping
+  ``requeue_count``) and a re-dispatch with an exponential ``DelayStamp``
+  backoff, returning ``AgentRunOutcome::REQUEUED``.
+
+Interactive runs pass no recovery hook and surface failures unchanged.
+
+**Budget.** A new ``requeue_count`` column, shared by both requeue sources
+(failure retry and stale reclaim), capped by ``AgentRuntime::MAX_REQUEUES`` (3),
+so a deterministically crashing or hanging run cannot loop forever.
+
+**Dead-letter = FAILED + reason axis.** No new status is introduced (the status
+model stays stable, and purge/retention are untouched). Dead-lettering is
+expressed on the :ref:`ADR-092 <adr-092>` reason axis via the two new
+non-retryable reasons above.
+
+.. _adr-104-consequences:
+
+Consequences
+============
+
+- ``AgentRunOutcome`` gained ``REQUEUED`` and ``LEASE_LOST``;
+  ``AgentRunTerminationReason`` gained ``RETRIES_EXHAUSTED`` and
+  ``NOT_RETRYABLE`` (both ``isRetryable() === false``). All are the documented
+  minor-release growth path — consumers match with a default arm, and the
+  playground never sees the new outcomes (they arise only on the worker path).
+- ``tx_nrllm_agentrun`` gained ``requeue_count``.
+- Real exponential backoff requires the doctrine transport (which honours the
+  ``DelayStamp``); the default SyncTransport ignores the delay and retries
+  in-process, bounded by ``MAX_REQUEUES`` — the same requirement ADR-102 already
+  places on async execution.
+- A worker that renews its lease adds one guarded UPDATE per step boundary
+  (alongside the ADR-103 read); steps are provider-call-slow, so the cost is
+  noise.
+- The reaper only reclaims abandoned **queue** workers. An interactive run
+  abandoned by a dying client keeps no lease and is still reaped by the
+  age-based retention path (``nrllm:privacy:purge``).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -401,3 +401,4 @@ Tools
    Adr101AgentRuntime
    Adr102QueuedAgentRuns
    Adr103CooperativeCancellation
+   Adr104StaleRunReaperAndRetry

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -353,4 +353,153 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertNull($this->repository->findByUuid($handle->uuid));
         self::assertSame([], $this->repository->findEvents($handle->runUid));
     }
+
+    #[Test]
+    public function renewLeaseIsGuardedByWorkerOwnership(): void
+    {
+        // ADR-104 heartbeat: only the worker that holds the claim can extend the
+        // lease; a stranger's renewal (a zombie worker after a reaper reclaim)
+        // matches no row.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        self::assertFalse($this->persister->renewLease($handle, 'worker-b:2', time() + 999));
+        self::assertTrue($this->persister->renewLease($handle, 'worker-a:1', time() + 999));
+
+        $renewed = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($renewed);
+        self::assertGreaterThan(time() + 900, $renewed->leaseExpires);
+    }
+
+    #[Test]
+    public function requeueIsOwnershipGuardedIncrementsTheCountAndKeepsTheRequest(): void
+    {
+        // ADR-104 failure retry (review MAJOR): a zombie worker cannot requeue a
+        // run another worker owns; the owner's requeue bumps requeue_count,
+        // clears the claim/lease and preserves the stored request.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        self::assertFalse($this->persister->requeue($handle, 'worker-b:2'));
+        self::assertTrue($this->persister->requeue($handle, 'worker-a:1'));
+
+        $requeued = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($requeued);
+        self::assertSame('queued', $requeued->status);
+        self::assertSame(1, $requeued->requeueCount);
+        self::assertSame('', $requeued->claimedBy);
+        self::assertSame(0, $requeued->leaseExpires);
+        self::assertSame('{"messages":[]}', $requeued->queuedRequest);
+    }
+
+    #[Test]
+    public function aReclaimedRunResumesItsEventStreamAtMaxSequencePlusOne(): void
+    {
+        // ADR-104 D3: a requeued run carries its prior attempt's events, so the
+        // next claim continues the stream at MAX(sequence) + 1, never 0.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 1.0, content: 'a'));
+        $this->persister->recordStep($handle, new RunStep(kind: RunStep::KIND_LLM, round: 1, durationMs: 1.0, content: 'b'));
+        self::assertSame(1, $this->repository->maxEventSequence($handle->runUid));
+
+        self::assertTrue($this->persister->requeue($handle, 'worker-a:1'));
+        $reclaimed = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($reclaimed);
+
+        $resumed = $this->persister->resumeHandle($reclaimed);
+        self::assertNotNull($resumed);
+        self::assertSame(2, $resumed->sequence);
+    }
+
+    #[Test]
+    public function findStaleRunningReturnsExpiredWorkerLeasesOnly(): void
+    {
+        // A worker run with an expired lease is stale; a fresh lease and an
+        // interactive run (no lease) are not.
+        $stale = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        $fresh = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($stale);
+        self::assertNotNull($fresh);
+        $staleRun = $this->repository->findByUuid($stale->uuid);
+        $freshRun = $this->repository->findByUuid($fresh->uuid);
+        self::assertNotNull($staleRun);
+        self::assertNotNull($freshRun);
+        self::assertTrue($this->persister->claimQueued($staleRun, 'worker-a:1', time() - 100));
+        self::assertTrue($this->persister->claimQueued($freshRun, 'worker-b:2', time() + 600));
+
+        // An interactive run is RUNNING with no lease — never reaped.
+        $interactive = $this->persister->begin(null, 7);
+        self::assertNotNull($interactive);
+
+        $found = $this->repository->findStaleRunning(time());
+
+        $uuids = array_map(static fn($r): string => $r->uuid, $found);
+        self::assertContains($stale->uuid, $uuids);
+        self::assertNotContains($fresh->uuid, $uuids);
+        self::assertNotContains($interactive->uuid, $uuids);
+    }
+
+    #[Test]
+    public function requeueStaleReclaimsAnExpiredRunButLosesToAHeartbeatRenewal(): void
+    {
+        // ADR-104 reaper: the staleness re-check inside the UPDATE means a lease
+        // that was renewed after the reaper's SELECT is not reclaimed.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() - 100));
+
+        // A concurrent heartbeat renews the lease into the future.
+        self::assertTrue($this->persister->renewLease($handle, 'worker-a:1', time() + 600));
+        self::assertFalse($this->repository->requeueStale($handle->runUid, time()));
+
+        // Once the (renewed) lease expires again, the reclaim succeeds.
+        self::assertTrue($this->persister->renewLease($handle, 'worker-a:1', time() - 5));
+        self::assertTrue($this->repository->requeueStale($handle->runUid, time()));
+
+        $requeued = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($requeued);
+        self::assertSame('queued', $requeued->status);
+        self::assertSame(1, $requeued->requeueCount);
+    }
+
+    #[Test]
+    public function deadLetterStaleFailsAnExpiredRunButSparesAFreshOne(): void
+    {
+        // ADR-104 reaper dead-letter: staleness-guarded like requeueStale — a
+        // still-live (freshly leased) run is never flipped to FAILED.
+        $fresh = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($fresh);
+        $freshRun = $this->repository->findByUuid($fresh->uuid);
+        self::assertNotNull($freshRun);
+        self::assertTrue($this->persister->claimQueued($freshRun, 'worker-a:1', time() + 600));
+        self::assertFalse($this->repository->deadLetterStale($fresh->runUid, time(), AgentRunTerminationReason::RETRIES_EXHAUSTED->value));
+
+        $stale = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($stale);
+        $staleRun = $this->repository->findByUuid($stale->uuid);
+        self::assertNotNull($staleRun);
+        self::assertTrue($this->persister->claimQueued($staleRun, 'worker-b:2', time() - 100));
+        self::assertTrue($this->repository->deadLetterStale($stale->runUid, time(), AgentRunTerminationReason::RETRIES_EXHAUSTED->value));
+
+        $failed = $this->repository->findByUuid($stale->uuid);
+        self::assertNotNull($failed);
+        self::assertSame('failed', $failed->status);
+        self::assertSame(AgentRunTerminationReason::RETRIES_EXHAUSTED->value, $failed->terminationReason);
+        self::assertSame('', $failed->claimedBy);
+        self::assertSame(0, $failed->leaseExpires);
+        self::assertNull($failed->queuedRequest);
+    }
 }

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -77,6 +77,58 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return false;
     }
 
+    public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        // Not needed by the command tests.
+        return true;
+    }
+
+    public function requeue(int $runUid, string $claimedBy): bool
+    {
+        // Not needed by the command tests.
+        return true;
+    }
+
+    /** @var list<AgentRun> Stale runs the reaper command will iterate. */
+    public array $staleRunning = [];
+
+    /** @var list<array{runUid: int, now: int}> requeueStale() calls the reaper made. */
+    public array $staleRequeues = [];
+
+    /** uids for which requeueStale() reports the run was already renewed/moved on. */
+    public bool $refuseRequeueStale = false;
+
+    public function findStaleRunning(int $now, int $limit = 50): array
+    {
+        return $this->staleRunning;
+    }
+
+    public function requeueStale(int $runUid, int $now): bool
+    {
+        if ($this->refuseRequeueStale) {
+            return false;
+        }
+        $this->staleRequeues[] = ['runUid' => $runUid, 'now' => $now];
+
+        return true;
+    }
+
+    /** @var list<array{runUid: int, now: int, reason: string}> deadLetterStale() calls the reaper made. */
+    public array $staleDeadLetters = [];
+
+    /** requeueStale/deadLetterStale report the run was already renewed/moved on. */
+    public bool $refuseDeadLetterStale = false;
+
+    public function deadLetterStale(int $runUid, int $now, string $terminationReason): bool
+    {
+        if ($this->refuseDeadLetterStale) {
+            return false;
+        }
+        $this->staleDeadLetters[] = ['runUid' => $runUid, 'now' => $now, 'reason' => $terminationReason];
+
+        return true;
+    }
+
     public function findByUuid(string $uuid): ?AgentRun
     {
         return null;

--- a/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
+++ b/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\ReapStaleAgentRunsCommand;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAgentRunRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(ReapStaleAgentRunsCommand::class)]
+final class ReapStaleAgentRunsCommandTest extends TestCase
+{
+    private InMemoryAgentRunRepository $repository;
+
+    /** @var list<object> */
+    private array $dispatched = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new InMemoryAgentRunRepository();
+        $this->dispatched = [];
+    }
+
+    #[Test]
+    public function reclaimsAStaleRunUnderBudgetAndDispatchesAWakeUp(): void
+    {
+        $this->repository->staleRunning = [$this->staleRun('run-a', requeueCount: 0)];
+
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertCount(1, $this->repository->staleRequeues);
+        self::assertSame([], $this->repository->staleDeadLetters);
+        self::assertCount(1, $this->dispatched);
+        self::assertInstanceOf(AgentRunQueuedMessage::class, $this->dispatched[0]);
+        self::assertStringContainsString('1 requeued', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function deadLettersAStaleRunWhoseBudgetIsSpent(): void
+    {
+        $this->repository->staleRunning = [$this->staleRun('run-b', requeueCount: AgentRuntime::MAX_REQUEUES)];
+
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame([], $this->repository->staleRequeues);
+        self::assertCount(1, $this->repository->staleDeadLetters);
+        self::assertSame(AgentRunTerminationReason::RETRIES_EXHAUSTED->value, $this->repository->staleDeadLetters[0]['reason']);
+        // A dead-letter is terminal — no wake-up is dispatched.
+        self::assertCount(0, $this->dispatched);
+        self::assertStringContainsString('1 dead-lettered', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function skipsARunRenewedBetweenSelectAndUpdate(): void
+    {
+        // The repository's staleness re-check fails (a heartbeat renewed the
+        // lease after the reaper's SELECT), so requeueStale returns false.
+        $this->repository->staleRunning     = [$this->staleRun('run-c', requeueCount: 0)];
+        $this->repository->refuseRequeueStale = true;
+
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertCount(0, $this->dispatched);
+        self::assertStringContainsString('1 skipped', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function rejectsANonPositiveLimit(): void
+    {
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute(['--limit' => '0']);
+
+        self::assertSame(Command::INVALID, $exit);
+    }
+
+    #[Test]
+    public function failsWhenNoMessageBusIsAvailable(): void
+    {
+        $persister = new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
+        $tester    = new CommandTester(new ReapStaleAgentRunsCommand($persister, null));
+
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exit);
+    }
+
+    private function command(): ReapStaleAgentRunsCommand
+    {
+        $persister = new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
+
+        return new ReapStaleAgentRunsCommand($persister, $this->recordingBus());
+    }
+
+    private function recordingBus(): MessageBusInterface
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(
+            function (object $message, array $stamps = []): Envelope {
+                $this->dispatched[] = $message;
+
+                return new Envelope($message, $stamps);
+            },
+        );
+
+        return $bus;
+    }
+
+    private function staleRun(string $uuid, int $requeueCount): AgentRun
+    {
+        return new AgentRun(
+            uid: 1,
+            uuid: $uuid,
+            status: 'running',
+            configurationUid: 1,
+            configurationIdentifier: 'cfg',
+            beUser: 9,
+            iterations: 1,
+            truncated: false,
+            totalPromptTokens: 0,
+            totalCompletionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: 0.0,
+            errorClass: '',
+            terminationReason: '',
+            startedAt: 0,
+            finishedAt: 0,
+            crdate: 0,
+            suspendedState: null,
+            queuedRequest: '{"messages":[]}',
+            claimedBy: 'dead-worker:1',
+            leaseExpires: 1,
+            requeueCount: $requeueCount,
+        );
+    }
+}

--- a/Tests/Unit/Provider/Middleware/FailureClassifierTest.php
+++ b/Tests/Unit/Provider/Middleware/FailureClassifierTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Enum\FailureClass;
 use Netresearch\NrLlm\Provider\Exception\CircuitOpenException;
+use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Provider\Exception\ProviderAuthenticationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
@@ -68,5 +69,31 @@ final class FailureClassifierTest extends TestCase
         self::assertSame(FailureClass::UNKNOWN, $class);
         self::assertFalse($class->isRetryable());
         self::assertFalse($class->tripsCircuit());
+    }
+
+    #[Test]
+    public function classifiesAFallbackChainByItsMostRecentAttempt(): void
+    {
+        // The wrapper alone would classify UNKNOWN (not retryable); the queue
+        // retry (ADR-104) must react to the freshest provider condition, so the
+        // chain classifies by its LAST attempt's error — here a 503.
+        $chain = FallbackChainExhaustedException::fromAttempts([
+            ['configuration' => 'primary', 'error' => new ProviderConnectionException('down')],
+            ['configuration' => 'fallback', 'error' => new ProviderResponseException('gateway', 503)],
+        ]);
+
+        $class = FailureClassifier::classify($chain);
+
+        self::assertSame(FailureClass::SERVER_ERROR, $class);
+        self::assertTrue($class->isRetryable());
+    }
+
+    #[Test]
+    public function anEmptyFallbackChainIsConservativelyUnknown(): void
+    {
+        $class = FailureClassifier::classify(FallbackChainExhaustedException::fromAttempts([]));
+
+        self::assertSame(FailureClass::UNKNOWN, $class);
+        self::assertFalse($class->isRetryable());
     }
 }

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
@@ -47,6 +48,7 @@ use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Throwable;
 
 #[CoversClass(AgentRuntime::class)]
@@ -634,6 +636,192 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aQueuedRunRenewsItsLeaseAtEachStepBoundary(): void
+    {
+        // ADR-104 heartbeat: a worker-claimed run renews its lease at every step
+        // boundary, under its own worker identity.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertCount(1, $this->repository->leaseRenewals);
+        self::assertSame($this->repository->queuedClaim['claimedBy'] ?? null, $this->repository->leaseRenewals[0]['claimedBy']);
+        self::assertGreaterThan(time(), $this->repository->leaseRenewals[0]['leaseExpires']);
+    }
+
+    #[Test]
+    public function aQueuedRunThatLosesItsLeaseStopsWithoutSettling(): void
+    {
+        // ADR-104: the reaper reclaimed the run (renewLease affects no row). The
+        // worker stops at the step boundary WITHOUT recording the step and
+        // WITHOUT settling — the row belongs to its new owner.
+        $this->repository->findResult        = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+        $this->repository->refuseRenewLease = true;
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('must not complete');
+            },
+        );
+
+        $result = $this->runtime($loop)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::LEASE_LOST, $result->outcome);
+        // No settle: the run is not this worker's to terminate.
+        self::assertNull($this->repository->finished);
+        // The step was NOT persisted — the abort precedes the recordStep.
+        self::assertCount(0, $this->repository->events);
+    }
+
+    #[Test]
+    public function aQueuedRunFailingRetryablyIsRequeuedAndReDispatchedWithBackoff(): void
+    {
+        // ADR-104 failure retry: a retryable provider error requeues the run
+        // (ownership-guarded) and re-dispatches it with an exponential backoff.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $dispatched = [];
+        $runtime    = $this->runtime(
+            $this->loopRecordingThenThrowing(new ProviderConnectionException('provider unreachable', 1784900010)),
+            bus: $this->stampRecordingBus($dispatched),
+        );
+
+        $result = $runtime->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::REQUEUED, $result->outcome);
+        // Requeued under this worker's identity, not settled.
+        self::assertCount(1, $this->repository->requeues);
+        self::assertSame($this->repository->queuedClaim['claimedBy'] ?? null, $this->repository->requeues[0]['claimedBy']);
+        self::assertNull($this->repository->finished);
+        // Re-dispatched with a DelayStamp of the base backoff (2^0).
+        self::assertCount(1, $dispatched);
+        self::assertInstanceOf(AgentRunQueuedMessage::class, $dispatched[0]['message']);
+        self::assertCount(1, $dispatched[0]['stamps']);
+        self::assertInstanceOf(DelayStamp::class, $dispatched[0]['stamps'][0]);
+        self::assertSame(AgentRuntime::REQUEUE_BACKOFF_MS, $dispatched[0]['stamps'][0]->getDelay());
+    }
+
+    #[Test]
+    public function aQueuedRunFailingNonRetryablyIsDeadLetteredAsNotRetryable(): void
+    {
+        // ADR-104: a failure class retrying cannot fix (here UNKNOWN, from a
+        // plain error) dead-letters immediately with NOT_RETRYABLE — never the
+        // retryable PROVIDER_FAILED reason.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $result = $this->runtime(
+            $this->loopRecordingThenThrowing(new RuntimeException('deterministic bug', 1784900011)),
+            bus: $this->discardingBus(),
+        )->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertNull($this->repository->requeues[0] ?? null);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+        self::assertSame(AgentRunTerminationReason::NOT_RETRYABLE->value, $this->repository->finished['terminationReason']);
+    }
+
+    #[Test]
+    public function aQueuedRunOutOfRetryBudgetIsDeadLetteredAsRetriesExhausted(): void
+    {
+        // ADR-104: retryable in principle, but the requeue budget is spent — the
+        // run dead-letters with RETRIES_EXHAUSTED and is NOT requeued again.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}', AgentRuntime::MAX_REQUEUES);
+
+        $result = $this->runtime(
+            $this->loopRecordingThenThrowing(new ProviderConnectionException('still failing', 1784900012)),
+            bus: $this->discardingBus(),
+        )->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome);
+        self::assertNull($this->repository->requeues[0] ?? null);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunTerminationReason::RETRIES_EXHAUSTED->value, $this->repository->finished['terminationReason']);
+    }
+
+    #[Test]
+    public function aQueuedRunLosingOwnershipDuringRequeueIsNotSettled(): void
+    {
+        // ADR-104 (review MAJOR): requeue returns false — a concurrent reaper
+        // reclaim or cancel won. The worker must NOT settle the run: it may
+        // belong to another worker now.
+        $this->repository->findResult   = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+        $this->repository->refuseRequeue = true;
+
+        $result = $this->runtime(
+            $this->loopRecordingThenThrowing(new ProviderConnectionException('provider unreachable', 1784900013)),
+            bus: $this->discardingBus(),
+        )->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::LEASE_LOST, $result->outcome);
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function aRequeuedRunResumesItsEventStreamAtMaxSequencePlusOne(): void
+    {
+        // ADR-104 D3: a requeued run carries the prior attempt's events, so the
+        // claim resolves the stream position to MAX(sequence) + 1 rather than 0.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}', 1);
+        $this->repository->maxSequence = 5;
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertCount(1, $this->repository->events);
+        self::assertSame(6, $this->repository->events[0]['sequence']);
+    }
+
+    #[Test]
+    public function anInteractiveRunNeverRenewsALease(): void
+    {
+        // ADR-104: run()/approve() hold no lease (leaseOwner is null), so the
+        // heartbeat never fires — only queue workers renew.
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop)->run($this->request());
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertCount(0, $this->repository->leaseRenewals);
+    }
+
+    #[Test]
     public function cancelDelegatesToTheGuardedTransition(): void
     {
         $this->repository->findResult = $this->suspendedRun();
@@ -730,7 +918,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         return $bus;
     }
 
-    private function queuedRun(string $uuid, string $requestJson): AgentRun
+    private function queuedRun(string $uuid, string $requestJson, int $requeueCount = 0): AgentRun
     {
         return new AgentRun(
             uid: 1,
@@ -752,7 +940,58 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             crdate: 0,
             suspendedState: null,
             queuedRequest: $requestJson,
+            requeueCount: $requeueCount,
         );
+    }
+
+    /**
+     * A bus double recording each dispatched message and its stamps into $sink.
+     *
+     * @param list<array{message: object, stamps: list<object>}> $sink
+     */
+    private function stampRecordingBus(array &$sink): MessageBusInterface
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(
+            static function (object $message, array $stamps = []) use (&$sink): Envelope {
+                $sink[] = ['message' => $message, 'stamps' => array_values($stamps)];
+
+                return new Envelope($message, $stamps);
+            },
+        );
+
+        return $bus;
+    }
+
+    /**
+     * A bus double that accepts any dispatch and records nothing.
+     */
+    private function discardingBus(): MessageBusInterface
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(
+            static fn(object $message, array $stamps = []): Envelope => new Envelope($message, $stamps),
+        );
+
+        return $bus;
+    }
+
+    /**
+     * A loop that drives one step boundary (so the heartbeat/cancellation probe
+     * fires) and then throws — the queued-run failure path.
+     */
+    private function loopRecordingThenThrowing(Throwable $throwable): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            static function (array $messages, LlmConfiguration $config, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace) use ($throwable): ToolLoopResult {
+                $trace?->recordRequest(1, [], []);
+
+                throw $throwable;
+            },
+        );
+
+        return $loop;
     }
 
     private function request(?int $maxIterations = null): AgentRunRequest

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -233,6 +233,87 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return $this->maxSequence;
     }
 
+    public bool $throwOnRenewLease = false;
+
+    /** Simulates a lost lease (reaped/cancelled/settled): renewLease matches no row. */
+    public bool $refuseRenewLease = false;
+
+    /** @var list<array{runUid: int, claimedBy: string, leaseExpires: int}> */
+    public array $leaseRenewals = [];
+
+    public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        if ($this->throwOnRenewLease) {
+            throw new RuntimeException('renewLease failed', 1784700020);
+        }
+        if ($this->refuseRenewLease) {
+            return false;
+        }
+        $this->leaseRenewals[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'leaseExpires' => $leaseExpires];
+
+        return true;
+    }
+
+    public bool $throwOnRequeue = false;
+
+    /** Simulates a run this worker no longer owns: requeue matches no row. */
+    public bool $refuseRequeue = false;
+
+    /** @var list<array{runUid: int, claimedBy: string}> */
+    public array $requeues = [];
+
+    public function requeue(int $runUid, string $claimedBy): bool
+    {
+        if ($this->throwOnRequeue) {
+            throw new RuntimeException('requeue failed', 1784700021);
+        }
+        if ($this->refuseRequeue) {
+            return false;
+        }
+        $this->requeues[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy];
+
+        return true;
+    }
+
+    /** @var list<AgentRun> */
+    public array $staleRunning = [];
+
+    public function findStaleRunning(int $now, int $limit = 50): array
+    {
+        return $this->staleRunning;
+    }
+
+    /** Simulates a run reclaimed by a heartbeat between SELECT and UPDATE. */
+    public bool $refuseRequeueStale = false;
+
+    /** @var list<array{runUid: int, now: int}> */
+    public array $staleRequeues = [];
+
+    public function requeueStale(int $runUid, int $now): bool
+    {
+        if ($this->refuseRequeueStale) {
+            return false;
+        }
+        $this->staleRequeues[] = ['runUid' => $runUid, 'now' => $now];
+
+        return true;
+    }
+
+    /** @var list<array{runUid: int, now: int, reason: string}> */
+    public array $staleDeadLetters = [];
+
+    public bool $refuseDeadLetterStale = false;
+
+    public function deadLetterStale(int $runUid, int $now, string $terminationReason): bool
+    {
+        if ($this->refuseDeadLetterStale) {
+            return false;
+        }
+        $this->staleDeadLetters[] = ['runUid' => $runUid, 'now' => $now, 'reason' => $terminationReason];
+
+        return true;
+    }
+
     public function purgeOlderThan(int $timestamp): int
     {
         return 0;

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -699,6 +699,11 @@ CREATE TABLE tx_nrllm_agentrun (
     claimed_by varchar(64) DEFAULT '' NOT NULL,
     lease_expires int(11) unsigned DEFAULT '0' NOT NULL,
 
+    -- Requeue budget (ADR-104): how many times this run was requeued for a
+    -- retryable failure or a stale-lease reclaim. Capped so a deterministically
+    -- failing run cannot loop forever; 0 = never requeued.
+    requeue_count int(11) unsigned DEFAULT '0' NOT NULL,
+
     -- Time tracking
     started_at int(11) unsigned DEFAULT '0' NOT NULL,
     finished_at int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## What

Completes P1 #8 (queue epic) slices 3+4 — **ADR-104**: a worker heartbeat, a stale-run reaper, retry-per-failure-class, and a dead-letter terminus for queued agent runs. Closes the two gaps ADR-102 left open:

- **A dead worker stranded its run RUNNING forever** — the lease existed but nothing renewed or acted on it.
- **A transient provider failure was terminal** — no retry, even for a 5xx / rate-limit / exhausted fallback chain.

## How

- **Heartbeat** — the runtime's step-boundary trace hook (shared with the ADR-103 cancellation probe) renews a worker run's lease under an ownership guard (`WHERE status='running' AND claimed_by = :me`). A renewal affecting no row means the run was reclaimed → the worker stops **without settling** (`AgentRunOutcome::LEASE_LOST`); the row belongs to its new owner. The boundary step is persisted **after** the renewal check so a zombie worker cannot append a colliding event sequence. Interactive `run()`/`approve()` hold no lease and never renew.
- **Reaper** — schedulable `nrllm:agent:reap` reclaims RUNNING runs whose lease has expired, requeuing them while budget remains or dead-lettering them once spent. Both mutations re-check staleness **inside** the UPDATE, so a heartbeat renewal that lands between the reaper's SELECT and its write wins and a merely-slow worker is left alone.
- **Retry** — a queued run's failure is classified through the `FailureClassifier` (extended so an exhausted fallback chain classifies by its most recent attempt, not UNKNOWN). Non-retryable class → dead-letter now (`NOT_RETRYABLE`); retryable → ownership-guarded requeue + exponential backoff `DelayStamp` (`REQUEUED`) until the shared `requeue_count` budget is spent (`RETRIES_EXHAUSTED`, capped by `AgentRuntime::MAX_REQUEUES` = 3). Interactive runs surface failures unchanged.
- **Dead-letter** stays on the existing FAILED status + ADR-092 reason axis — no new status; purge/retention untouched.

Real backoff needs the doctrine transport (which honours the delay); the default sync transport retries in-process, bounded by `MAX_REQUEUES` — the same requirement ADR-102 already places on async execution.

## API / schema

- `AgentRunOutcome` += `REQUEUED`, `LEASE_LOST`
- `AgentRunTerminationReason` += `RETRIES_EXHAUSTED`, `NOT_RETRYABLE` (both `isRetryable() === false`)
- `AgentRunRepositoryInterface` += `renewLease()`, `requeue()`, `findStaleRunning()`, `requeueStale()`, `deadLetterStale()`
- `tx_nrllm_agentrun` += `requeue_count`
- New command `nrllm:agent:reap`; new internal `RunLeaseLostException`

## Tests

Local gate green: PHP-CS-Fixer, PHPStan L10, unit (5485), functional/sqlite (1250), Rector, fuzzy (79). New coverage: heartbeat renewal, lease-lost-no-settle, requeue/dead-letter classification and budget, ownership-guarded requeue, MAX+1 stream resume, reaper command paths, staleness-guarded reaper mutations, `FallbackChainExhausted` classification.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
