### PR TITLE
feat(agent): typed user-input suspension — WAITING_FOR_INPUT (ADR-105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Typed user-input suspension (ADR-105): a tool may implement the new
+  `RequiresInputInterface` marker to declare an input schema and suspend the
+  agent run WAITING_FOR_INPUT until the user supplies typed data — the input
+  sibling of the ADR-084 approval flow. `AgentRuntimeInterface::submitInput()`
+  validates the submission against the tool's schema BEFORE claiming the run
+  (an invalid submission is rejected without consuming the claim, so it stays
+  resubmittable), records an `INPUT` audit event, overlays the validated values
+  onto the target tool's arguments (bounded to the schema-declared keys so
+  neither the model nor the user can smuggle a value into the other's field),
+  and resumes the loop. The playground exposes it at
+  `POST /nrllm/tool/submit-input` (admin-gated; invalid input → 422 while
+  re-signalling `awaiting_input`). Fail-closed throughout: a degenerate schema
+  is treated as corruption (never "accept anything"), a tool may not be both
+  approval- and input-gated (rejected at registration), and an unstorable
+  suspension fails as `SUSPEND_FAILED`. `AgentRunOutcome` gained
+  `AWAITING_INPUT`, `AgentEventKind` gained `INPUT`,
+  `AgentRunRepositoryInterface` gained `suspendRunForInput()` and
+  `claimForResumeFromInput()`, and `ToolLoopServiceInterface` gained
+  `resumeWithInput()`. No schema change — the input schema rides inside the
+  existing `suspended_state`.
 - Worker heartbeat, stale-run reaper, retry and dead-letter (ADR-104): a queue
   worker now renews its lease at every step boundary; if the renewal fails
   (the run was reclaimed) it stops without settling — the run belongs to its

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -27,10 +27,13 @@ use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\InputSubmission;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
@@ -240,6 +243,51 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     }
 
     /**
+     * Submit typed input for a run suspended WAITING_FOR_INPUT (ADR-105) and
+     * continue it. The input sibling of {@see resumeAction()}: admin-gated (the
+     * injection mitigation for the untrusted submitted values), it maps
+     * {@see AgentRuntimeInterface::submitInput()}'s typed request-validation
+     * exceptions onto the module's HTTP statuses. An invalid submission returns
+     * 422 while re-signalling ``awaiting_input`` so the client keeps the form
+     * open for a resubmission (the run is untouched, nothing was claimed).
+     */
+    public function submitInputAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body    = $request->getParsedBody();
+        $runUuid = trim($this->stringFromBody($body, 'runUuid'));
+
+        try {
+            $result = $this->agentRuntime->submitInput(
+                $runUuid,
+                new InputSubmission($this->inputDataFromBody($body), $this->currentBackendUserUid()),
+            );
+        } catch (RunNotAwaitingInputException) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.notAwaitingInput', 'No run is awaiting input for that id.')], 400);
+        } catch (RunConfigurationGoneException) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.configGone', 'The run configuration no longer exists.')], 400);
+        } catch (InvalidInputSubmissionException) {
+            // Retryable: the run stays WAITING_FOR_INPUT, nothing was claimed.
+            // Re-signal awaiting_input so the client keeps the form open.
+            return $this->respondJson([
+                'success' => false,
+                'status'  => 'awaiting_input',
+                'runUuid' => $runUuid,
+                'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.inputSchemaMismatch', 'The submitted input did not match the required schema.'),
+            ], 422);
+        } catch (CorruptSuspendedStateException|RunStateUnavailableException) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.corruptState', 'The suspended run state could not be read.')], 500);
+        } catch (RunAlreadyResumingException) {
+            return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.alreadyResuming', 'This run is already being processed.')], 409);
+        }
+
+        return $this->respondToResult($result, false);
+    }
+
+    /**
      * Map a settled {@see AgentRunResult} onto the module's batch JSON shapes
      * — the ADR-041 contract the functional tests assert.
      */
@@ -248,6 +296,9 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         switch ($result->outcome) {
             case AgentRunOutcome::AWAITING_APPROVAL:
                 return $this->respondJson($this->awaitingApprovalPayload($result));
+
+            case AgentRunOutcome::AWAITING_INPUT:
+                return $this->respondJson($this->awaitingInputPayload($result));
 
             case AgentRunOutcome::SUSPEND_FAILED:
                 return $this->respondJson(['success' => false, 'error' => self::SUSPEND_FAILED_MESSAGE], 500);
@@ -339,6 +390,50 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     }
 
     /**
+     * The JSON body for a run that suspended for typed input (ADR-105): the
+     * target tool and its declared input schema the client renders a form from,
+     * plus the steps recorded up to the pause.
+     *
+     * @return array<string, mixed>
+     */
+    private function awaitingInputPayload(AgentRunResult $result): array
+    {
+        $state = $result->suspendedState;
+
+        return [
+            'success'      => true,
+            'status'       => 'awaiting_input',
+            'runUuid'      => $result->runUuid,
+            'inputRequest' => [
+                'tool'   => $state !== null ? ($state->inputToolName ?? '') : '',
+                'schema' => $state !== null ? $state->inputSchema : [],
+            ],
+            'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
+        ];
+    }
+
+    /**
+     * Read the submitted input object (the `input` body field) as a
+     * string-keyed map. Non-object payloads degrade to an empty map, which the
+     * schema validation then rejects — never trusted through.
+     *
+     * @return array<string, mixed>
+     */
+    private function inputDataFromBody(mixed $body): array
+    {
+        if (!is_array($body) || !isset($body['input']) || !is_array($body['input'])) {
+            return [];
+        }
+
+        $data = [];
+        foreach ($body['input'] as $key => $value) {
+            $data[(string)$key] = $value;
+        }
+
+        return $data;
+    }
+
+    /**
      * The JSON body for a run a guardrail blocked (ADR-086): the status
      * (denied vs flagged for approval), the deciding guardrail FQCN and its
      * reason, plus the steps recorded up to the block.
@@ -420,6 +515,22 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                     'success'      => true,
                     'runUuid'      => $result->runUuid,
                     'pendingTools' => $this->pendingTools($result),
+                ]);
+
+                return;
+
+            case AgentRunOutcome::AWAITING_INPUT:
+                // ADR-105: a called tool requires typed input — the run
+                // suspended for a submitInput() instead of failing.
+                $inputState = $result->suspendedState;
+                $emit([
+                    'event'        => 'awaiting_input',
+                    'success'      => true,
+                    'runUuid'      => $result->runUuid,
+                    'inputRequest' => [
+                        'tool'   => $inputState !== null ? ($inputState->inputToolName ?? '') : '',
+                        'schema' => $inputState !== null ? $inputState->inputSchema : [],
+                    ],
                 ]);
 
                 return;

--- a/Classes/Domain/Enum/AgentEventKind.php
+++ b/Classes/Domain/Enum/AgentEventKind.php
@@ -30,6 +30,11 @@ enum AgentEventKind: string
     case TOOL = 'tool';
     case ASSEMBLED = 'assembled';
     case APPROVAL = 'approval';
+    // Emitted by the AgentRuntime when an operator submits typed input for a run
+    // suspended WAITING_FOR_INPUT (ADR-105), payload ``{submittedBy: int}`` — the
+    // who/when, never the submitted values (ADR-064). Like APPROVAL it is NOT a
+    // RunStep kind.
+    case INPUT = 'input';
 
     /**
      * @return list<string>
@@ -50,12 +55,12 @@ enum AgentEventKind: string
      * known one. Deliberately restricted to the four RunStep kinds: APPROVAL is
      * an AgentRuntime event, not a RunStep, so it must not resolve here even
      * though it is a valid stored event kind (use {@see self::tryFrom()} to
-     * hydrate a stored kind).
+     * hydrate a stored kind). INPUT (ADR-105) is excluded for the same reason.
      */
     public static function fromRunStepKind(string $kind): ?self
     {
         $case = self::tryFrom($kind);
 
-        return $case === self::APPROVAL ? null : $case;
+        return in_array($case, [self::APPROVAL, self::INPUT], true) ? null : $case;
     }
 }

--- a/Classes/Domain/Enum/AgentRunOutcome.php
+++ b/Classes/Domain/Enum/AgentRunOutcome.php
@@ -29,6 +29,11 @@ enum AgentRunOutcome: string
 {
     case COMPLETED = 'completed';
     case AWAITING_APPROVAL = 'awaiting_approval';
+    // A called tool suspended the run to request TYPED INPUT from the user
+    // (ADR-105). The row is WAITING_FOR_INPUT carrying the declared input schema;
+    // a later submitInput() validates the submission and resumes. Distinct from
+    // AWAITING_APPROVAL (approve/deny) — this collects data, not a verdict.
+    case AWAITING_INPUT = 'awaiting_input';
     case SUSPEND_FAILED = 'suspend_failed';
     case GUARDRAIL_BLOCKED = 'guardrail_blocked';
     case GUARDRAIL_APPROVAL_REQUIRED = 'guardrail_approval_required';

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -11,14 +11,16 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 
 /**
  * The serialisable state of a tool-loop run suspended for human approval
- * (ADR-084).
+ * (ADR-084) or typed user input (ADR-105).
  *
  * Captured the moment {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}
- * reaches an approval-required tool call: the full message transcript up to and
- * including the assistant's tool-call turn, the pending calls of that turn (the
- * whole turn is held so a multi-call turn stays consistent), and the
- * iteration/token counters accumulated so far. Stored as JSON on the AgentRun
- * and rehydrated on resume.
+ * reaches an approval-required OR input-required tool call: the full message
+ * transcript up to and including the assistant's tool-call turn, the pending
+ * calls of that turn (the whole turn is held so a multi-call turn stays
+ * consistent), and the iteration/token counters accumulated so far. Stored as
+ * JSON on the AgentRun and rehydrated on resume. On an input pause it also
+ * carries the target tool name and its declared input schema; on an approval
+ * pause both stay at their null/empty defaults.
  *
  * Messages and calls are held in their already-serialised
  * ({@see ChatMessage::toArray()} / {@see ToolCall::toArray()}) form so the state
@@ -32,6 +34,8 @@ final readonly class SuspendedRunState
      * @param list<array<string, mixed>> $pendingCalls     serialised ToolCall list of the suspended turn
      * @param list<string>|null          $allowedToolNames the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
      * @param array<string, mixed>       $options          the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
+     * @param string|null                $inputToolName    on an input pause (ADR-105) the tool whose typed input the user must supply; null on an approval pause
+     * @param array<string, mixed>       $inputSchema      on an input pause the tool's declared input schema (a JSON-Schema subset); `[]` on an approval pause
      */
     public function __construct(
         public array $messages,
@@ -41,10 +45,12 @@ final readonly class SuspendedRunState
         public int $completionTokens,
         public ?array $allowedToolNames = null,
         public array $options = [],
+        public ?string $inputToolName = null,
+        public array $inputSchema = [],
     ) {}
 
     /**
-     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>}
+     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>, inputToolName: string|null, inputSchema: array<string, mixed>}
      */
     public function toArray(): array
     {
@@ -56,6 +62,8 @@ final readonly class SuspendedRunState
             'completionTokens' => $this->completionTokens,
             'allowedToolNames' => $this->allowedToolNames,
             'options'          => $this->options,
+            'inputToolName'    => $this->inputToolName,
+            'inputSchema'      => $this->inputSchema,
         ];
     }
 
@@ -71,6 +79,16 @@ final readonly class SuspendedRunState
         /** @var array<string, mixed> $options */
         $options = is_array($options) ? $options : [];
 
+        // Back-compat: an approval-era row has neither key. The degradation to
+        // null/[] is intentional; the fail-open risk an empty schema would
+        // otherwise create is closed by AgentRuntime's well-formedness gate
+        // before validation (ADR-105 M2), never here.
+        $inputToolName = is_string($data['inputToolName'] ?? null) ? $data['inputToolName'] : null;
+
+        $inputSchema = $data['inputSchema'] ?? null;
+        /** @var array<string, mixed> $inputSchema */
+        $inputSchema = is_array($inputSchema) ? $inputSchema : [];
+
         return new self(
             self::listOfArrays($data['messages'] ?? null),
             self::listOfArrays($data['pendingCalls'] ?? null),
@@ -79,6 +97,8 @@ final readonly class SuspendedRunState
             is_numeric($data['completionTokens'] ?? null) ? (int)$data['completionTokens'] : 0,
             $allowedToolNames,
             $options,
+            $inputToolName,
+            $inputSchema,
         );
     }
 

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -27,18 +27,23 @@ use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunLeaseLostException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
+use Netresearch\NrLlm\Service\Tool\InputSchema;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
@@ -108,6 +113,11 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         private ?MessageBusInterface $messageBus = null,
         private ?SkillRepository $skillRepository = null,
         private ?PromptSnippetRepository $promptSnippetRepository = null,
+        // Validates a submitted input against a tool's declared schema (ADR-105).
+        // Optional in the ctor only so the lean test wiring and the positional
+        // construction sites keep working; submitInput() always validates,
+        // falling back to a fresh stateless validator when none was injected.
+        private ?JsonSchemaValidator $schemaValidator = null,
     ) {}
 
     public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult
@@ -617,6 +627,81 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         );
     }
 
+    public function submitInput(string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
+            throw RunNotAwaitingInputException::forRun($runUuid);
+        }
+
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw RunConfigurationGoneException::forRun($runUuid);
+        }
+
+        $decoded = json_decode($run->suspendedState, true);
+        if (!is_array($decoded)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Well-formedness gate (ADR-105 M2): an input suspension with no target
+        // tool or a degenerate schema is corruption, never "accept anything".
+        // validate($data, []) returns true, so this path must be unreachable
+        // before the validation below — a corrupt row is a 500, not resumable.
+        if ($state->inputToolName === null || $state->inputToolName === '' || !InputSchema::isUsable($state->inputSchema)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+
+        // DIVERGENCE from approve() (ADR-105): validate the submission BEFORE
+        // probing or claiming. A rejection leaves the run WAITING_FOR_INPUT with
+        // nothing claimed and no event recorded, so the user can simply resubmit.
+        $validator = $this->schemaValidator ?? new JsonSchemaValidator();
+        if (!$validator->validate($submission->data, $state->inputSchema)) {
+            throw InvalidInputSubmissionException::forRun($runUuid);
+        }
+
+        // From here the flow is identical to approve(): probe-before-claim,
+        // atomic claim, re-resolve the stream position from a fresh row.
+        if ($this->persister->resumeHandle($run) === null) {
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        if (!$this->persister->claimResumeFromInput($run)) {
+            throw RunAlreadyResumingException::forRun($runUuid);
+        }
+
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $this->persister->settleFailed(
+                new AgentRunHandle($run->uid, $run->uuid),
+                new RuntimeException('The event-stream position could not be determined after the resume claim'),
+            );
+
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // The submission is part of the run's audit stream (best-effort): who
+        // submitted, before the continuation's own events — never the values.
+        $this->persister->recordInput($handle, $submission->submittedByBeUser);
+
+        $trace = $this->trace($handle, $onStep, false);
+
+        return $this->execute(
+            $handle,
+            $trace,
+            fn(): ToolLoopResult => $this->toolLoop->resumeWithInput(
+                $state,
+                $submission->data,
+                $configuration,
+                null,
+                $trace,
+                $submission->submittedByBeUser,
+            ),
+        );
+    }
+
     public function cancel(string $runUuid): bool
     {
         return $this->persister->cancel($runUuid);
@@ -799,6 +884,40 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 steps: $trace->getSteps(),
                 error: $approval,
             );
+        } catch (ToolInputRequiredException $input) {
+            // ADR-105: a called tool requires typed user input — control flow,
+            // not failure (the input sibling of the approval arm above). Must be
+            // caught before the guardrail pair and the generic Throwable so a
+            // suspension is never recorded as a failed run. Both branches settle
+            // the run's fate, so $settled=true keeps the finally-guard off — a
+            // successfully-suspended WAITING_FOR_INPUT row is non-terminal and
+            // must not be flipped to FAILED.
+            $settled = true;
+
+            if ($handle !== null && $this->persister->suspendForInput($handle, $input->state)) {
+                return new AgentRunResult(
+                    outcome: AgentRunOutcome::AWAITING_INPUT,
+                    runUuid: $runUuid,
+                    steps: $trace->getSteps(),
+                    suspendedState: $input->state,
+                );
+            }
+
+            // Fail-closed (ADR-092/105): without stored state — the store
+            // refused or errored, a concurrent cancel terminated the row, or the
+            // run was never persisted (null handle) — there is nothing to resume,
+            // so promising an input flow would strand the client.
+            if ($handle !== null) {
+                $this->persister->settleFailed($handle, $input);
+            }
+            $this->logger?->error('Agent run could not be suspended for input; no resume is possible', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::SUSPEND_FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $input,
+            );
         } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
             // ADR-085/086: a guardrail verdict is a policy outcome, not a
             // failure — and an approval that was required but never obtained
@@ -869,8 +988,8 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // abandon the run before any branch settles it; mark it failed so
             // no run is left stuck RUNNING. Mirrors StreamingDispatcher's
             // finally-block settle. Guarded by $settled: a suspended run is
-            // WAITING_FOR_APPROVAL — non-terminal — and settling it here would
-            // destroy its resumable state.
+            // WAITING_FOR_APPROVAL or WAITING_FOR_INPUT — both non-terminal — and
+            // settling it here would destroy its resumable state.
             if ($handle !== null && !$settled) {
                 $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'));
             }

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -99,6 +99,32 @@ interface AgentRuntimeInterface
     public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
 
     /**
+     * Submit typed input for a run suspended WAITING_FOR_INPUT (ADR-105) and
+     * synchronously continue it. The input sibling of {@see self::approve()}:
+     * the submission is validated against the tool's declared schema BEFORE the
+     * run is claimed, so an invalid submission is rejected without consuming the
+     * claim and the user can resubmit while the run stays WAITING_FOR_INPUT.
+     * A valid submission is claimed atomically (two concurrent submissions
+     * cannot both resume), persisted as an INPUT event, overlaid onto the target
+     * tool's arguments (bounded to the schema-declared keys), and the loop
+     * re-entered — coming back as a settled result like {@see self::run()}.
+     *
+     * Trust boundary: the submitted values are UNTRUSTED content that flow into
+     * the tool's arguments and back into the model context; the submit entry
+     * point is admin-gated, which is the injection mitigation (structure-only
+     * schema validation does not sanitise content).
+     *
+     * @param (Closure(RunStep): void)|null $onStep as in {@see self::run()}
+     *
+     * @throws AgentRuntimeException when the request is invalid before any
+     *                               execution: RunNotAwaitingInput,
+     *                               RunConfigurationGone, CorruptSuspendedState,
+     *                               InvalidInputSubmission, RunStateUnavailable,
+     *                               RunAlreadyResuming
+     */
+    public function submitInput(string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult;
+
+    /**
      * Cancel a run that is still queued, running or awaiting a decision. True
      * when this call cancelled it; false when the run is unknown or already
      * terminal (the guarded transition decides, so two concurrent cancels

--- a/Classes/Service/Agent/Exception/InvalidInputSubmissionException.php
+++ b/Classes/Service/Agent/Exception/InvalidInputSubmissionException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The submitted input did not match the tool's declared schema (ADR-105).
+ *
+ * Thrown by submitInput() BEFORE the run is claimed, so the run stays
+ * WAITING_FOR_INPUT and the user can resubmit — nothing was consumed.
+ */
+final class InvalidInputSubmissionException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The submitted input did not match the required schema.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/Exception/RunNotAwaitingInputException.php
+++ b/Classes/Service/Agent/Exception/RunNotAwaitingInputException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The run is unknown, not suspended for input, or carries no resumable state.
+ *
+ * Thrown by submitInput(): no run with this uuid is awaiting typed input (ADR-105).
+ */
+final class RunNotAwaitingInputException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf('%s (run %s)', 'The run is unknown, not suspended for input, or carries no resumable state.', $runUuid !== '' ? $runUuid : 'unknown'));
+    }
+}

--- a/Classes/Service/Agent/InputSubmission.php
+++ b/Classes/Service/Agent/InputSubmission.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+/**
+ * The typed input a user submits for a run suspended WAITING_FOR_INPUT (ADR-105).
+ *
+ * The sibling of {@see ApprovalDecision}: where that carries a verdict as data
+ * (approve/deny), this carries a payload that must pass the tool's declared
+ * input schema BEFORE the run is claimed and resumed — an invalid submission is
+ * rejected without consuming the claim, so the user can resubmit. The submitted
+ * values are UNTRUSTED content that flow into the tool's arguments and back into
+ * the model context; admin-gating the submit path is the injection mitigation
+ * (structure-only schema validation does not sanitise content).
+ *
+ * Persisted only as an {@see \Netresearch\NrLlm\Domain\Enum\AgentEventKind::INPUT}
+ * event recording ``{submittedBy: int}`` — never the values (ADR-064).
+ */
+final readonly class InputSubmission
+{
+    /**
+     * @param array<string, mixed> $data the user-supplied input, validated against the tool's schema before use
+     */
+    public function __construct(
+        public array $data,
+        public int $submittedByBeUser,
+    ) {}
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -315,6 +315,32 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * Suspend a run for typed user input (ADR-105): the input sibling of
+     * {@see self::suspend()}. Persists the transcript, pending calls and the
+     * tool's declared input schema (all inside $state) and moves the run to
+     * WAITING_FOR_INPUT. Fail-closed like suspend(): false when the state could
+     * not be stored (store error or a concurrent cancel won) — the caller then
+     * settles the run failed rather than promising a resume that cannot happen.
+     */
+    public function suspendForInput(AgentRunHandle $handle, SuspendedRunState $state): bool
+    {
+        try {
+            $stateJson = json_encode($state->toArray(), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR);
+            if (!$this->repository->suspendRunForInput($handle->runUid, $stateJson)) {
+                $this->logger?->notice('AgentRun was no longer running when its input suspension arrived; it was discarded', ['run' => $handle->uuid]);
+
+                return false;
+            }
+
+            return true;
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be suspended for input', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
      * Load a persisted run by uuid. Exposed on the persister (a service) so a
      * controller can reach a run without depending on the repository directly
      * (the layered-architecture rule). Null when unknown or unavailable.
@@ -341,6 +367,23 @@ final readonly class AgentRunPersister
             return $this->repository->claimForResume($run->uid);
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun could not be claimed for resume', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Atomically claim a WAITING_FOR_INPUT run before resuming it (ADR-105): the
+     * input sibling of {@see self::claimResume()}. Fail-closed — false if the
+     * claim is lost to a concurrent submission or the store errors — so the
+     * pending turn is never executed twice.
+     */
+    public function claimResumeFromInput(AgentRun $run): bool
+    {
+        try {
+            return $this->repository->claimForResumeFromInput($run->uid);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun could not be claimed for input resume', ['exception' => $exception]);
 
             return false;
         }
@@ -396,6 +439,34 @@ final readonly class AgentRunPersister
             ++$handle->sequence;
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun approval decision could not be persisted', ['exception' => $exception]);
+        }
+    }
+
+    /**
+     * Persist a user's input submission as the next event in the run's stream
+     * (ADR-105): kind {@see AgentEventKind::INPUT}, payload ``{submittedBy}``
+     * ONLY — never the submitted values, which are privacy-filtered content
+     * (ADR-064), mirroring {@see self::recordApproval()}'s who/when-not-what
+     * rule. Best-effort — a failure is logged, never blocks the continuation.
+     */
+    public function recordInput(AgentRunHandle $handle, int $submittedByBeUser): void
+    {
+        try {
+            $payload = json_encode(
+                ['submittedBy' => $submittedByBeUser],
+                JSON_THROW_ON_ERROR,
+            );
+            $this->repository->recordEvent(
+                $handle->runUid,
+                $handle->sequence,
+                AgentEventKind::INPUT->value,
+                0,
+                0.0,
+                $payload,
+            );
+            ++$handle->sequence;
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun input submission could not be persisted', ['exception' => $exception]);
         }
     }
 

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -192,20 +192,48 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
 
     public function suspendRun(int $runUid, string $stateJson): bool
     {
-        // Non-terminal transition (ADR-084): store the resumable state and move
-        // the run to WAITING_FOR_APPROVAL without setting finished_at. Guarded
-        // on the run still being RUNNING (ADR-101): a concurrent cancel wins the
-        // terminal transition first, and an unguarded suspend would resurrect
-        // the CANCELLED row to WAITING_FOR_APPROVAL — offering an approval flow
-        // for a run the operator was told was stopped.
+        return $this->conditionalSuspend($runUid, $stateJson, AgentRunStatus::WAITING_FOR_APPROVAL);
+    }
+
+    public function suspendRunForInput(int $runUid, string $stateJson): bool
+    {
+        return $this->conditionalSuspend($runUid, $stateJson, AgentRunStatus::WAITING_FOR_INPUT);
+    }
+
+    /**
+     * Atomically claim a suspended run for resume (ADR-084): move it off
+     * WAITING_FOR_APPROVAL to RUNNING only if it is still awaiting approval, in a
+     * single conditional UPDATE. Returns true for the caller that won the claim,
+     * false if another resume already claimed it — so two concurrent Approve
+     * requests cannot both execute the gated (destructive) tool.
+     */
+    public function claimForResume(int $runUid): bool
+    {
+        return $this->conditionalClaim($runUid, AgentRunStatus::WAITING_FOR_APPROVAL);
+    }
+
+    public function claimForResumeFromInput(int $runUid): bool
+    {
+        return $this->conditionalClaim($runUid, AgentRunStatus::WAITING_FOR_INPUT);
+    }
+
+    /**
+     * Shared body for the suspend transitions (ADR-084 approval / ADR-105 input):
+     * store the resumable state and move the run RUNNING -> $target without
+     * setting finished_at. Guarded on the run still being RUNNING (ADR-101): a
+     * concurrent cancel wins the terminal transition first, and an unguarded
+     * suspend would resurrect the CANCELLED row into a waiting state — offering a
+     * resume for a run the operator was told was stopped. The lease is cleared:
+     * a run waiting on a human is not "presumed executing" (ADR-102), so the
+     * reaper must not see it.
+     */
+    private function conditionalSuspend(int $runUid, string $stateJson, AgentRunStatus $target): bool
+    {
         $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
             self::TABLE_RUN,
             [
-                'status'          => AgentRunStatus::WAITING_FOR_APPROVAL->value,
+                'status'          => $target->value,
                 'suspended_state' => $stateJson,
-                // A suspended run has no live worker claim (ADR-102): the lease
-                // means "presumed executing until", which a run waiting on a
-                // human is not.
                 'claimed_by'      => '',
                 'lease_expires'   => 0,
                 'tstamp'          => time(),
@@ -220,28 +248,25 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
     }
 
     /**
-     * Atomically claim a suspended run for resume (ADR-084): move it off
-     * WAITING_FOR_APPROVAL to RUNNING only if it is still awaiting approval, in a
-     * single conditional UPDATE. Returns true for the caller that won the claim,
-     * false if another resume already claimed it — so two concurrent Approve
-     * requests cannot both execute the gated (destructive) tool.
+     * Shared body for the resume claims (ADR-084 approval / ADR-105 input): move
+     * the run $from -> RUNNING only if it is still in $from, in a single
+     * conditional UPDATE — the atomic mutual-exclusion gate so two concurrent
+     * resume requests cannot both execute the pending turn. The lease is left
+     * clear: the resume runs in the acting process, not under a worker lease.
      */
-    public function claimForResume(int $runUid): bool
+    private function conditionalClaim(int $runUid, AgentRunStatus $from): bool
     {
         $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
             self::TABLE_RUN,
             [
                 'status'        => AgentRunStatus::RUNNING->value,
-                // The resume executes in the approving process, not under a
-                // queue worker's lease — never leave a dead worker's identity
-                // on the row (ADR-102).
                 'claimed_by'    => '',
                 'lease_expires' => 0,
                 'tstamp'        => time(),
             ],
             [
                 'uid'    => $runUid,
-                'status' => AgentRunStatus::WAITING_FOR_APPROVAL->value,
+                'status' => $from->value,
             ],
         );
 

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -64,11 +64,27 @@ interface AgentRunRepositoryInterface
     public function suspendRun(int $runUid, string $stateJson): bool;
 
     /**
+     * Suspend a run for typed user input (ADR-105): the input sibling of
+     * {@see suspendRun()} — persist the serialised state (carrying the tool's
+     * declared input schema) and move RUNNING -> WAITING_FOR_INPUT, same
+     * anti-resurrection guard. False when a concurrent cancel/settle won first.
+     */
+    public function suspendRunForInput(int $runUid, string $stateJson): bool;
+
+    /**
      * Atomically claim a WAITING_FOR_APPROVAL run for resume (move it to RUNNING);
      * true for the winner, false if already claimed. Prevents two concurrent
      * approvals from double-executing the gated tool (ADR-084).
      */
     public function claimForResume(int $runUid): bool;
+
+    /**
+     * Atomically claim a WAITING_FOR_INPUT run for resume (ADR-105): the input
+     * sibling of {@see claimForResume()}. True for the winner, false if another
+     * submitInput already claimed it — so two concurrent submissions cannot both
+     * resume the run.
+     */
+    public function claimForResumeFromInput(int $runUid): bool;
 
     /**
      * Insert a QUEUED run carrying its serialised request, so a worker in

--- a/Classes/Service/Tool/Exception/ToolInputRequiredException.php
+++ b/Classes/Service/Tool/Exception/ToolInputRequiredException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use RuntimeException;
+
+/**
+ * Thrown by {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService::runLoop()}
+ * when the model calls a tool that requires typed user input (ADR-105).
+ *
+ * The sibling of {@see ToolApprovalRequiredException}: a control-flow signal,
+ * not a failure. It carries the {@see SuspendedRunState} — whose $inputToolName
+ * and $inputSchema name the target tool and the shape the user must supply — the
+ * caller persists to suspend the run WAITING_FOR_INPUT. The caller MUST catch it
+ * before any generic `catch (Throwable)` so a suspension is not mistaken for a
+ * failed run.
+ */
+final class ToolInputRequiredException extends RuntimeException
+{
+    public function __construct(
+        public readonly SuspendedRunState $state,
+    ) {
+        parent::__construct('Tool loop suspended: a called tool requires user input.', 1784600101);
+    }
+
+    public static function fromState(SuspendedRunState $state): self
+    {
+        return new self($state);
+    }
+}

--- a/Classes/Service/Tool/InputSchema.php
+++ b/Classes/Service/Tool/InputSchema.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * The single authority on whether a tool's declared input schema (ADR-105) is
+ * usable — one predicate shared by the tool loop's capture-time gate and the
+ * AgentRuntime's rehydrate gate, so the two can never drift.
+ *
+ * A degenerate schema (empty, or with no declared shape) is a programming error,
+ * NOT "accept anything": validating a submission against `[]` would return true
+ * and let unvalidated user input flow into a tool. Both gates reject a
+ * non-usable schema fail-closed (capture -> LogicException; rehydrate ->
+ * CorruptSuspendedStateException).
+ */
+final class InputSchema
+{
+    /**
+     * A schema is usable only if it declares a real shape: a `type`, or at least
+     * one `properties` entry.
+     *
+     * @param array<string, mixed> $schema
+     */
+    public static function isUsable(array $schema): bool
+    {
+        if ($schema === []) {
+            return false;
+        }
+
+        if (isset($schema['type'])) {
+            return true;
+        }
+
+        return isset($schema['properties'])
+            && is_array($schema['properties'])
+            && $schema['properties'] !== [];
+    }
+}

--- a/Classes/Service/Tool/RequiresInputInterface.php
+++ b/Classes/Service/Tool/RequiresInputInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Opt-in marker: a {@see ToolInterface} that also implements this suspends the
+ * agent loop to collect TYPED INPUT from the user before it executes (ADR-105).
+ *
+ * The sibling of {@see RequiresApprovalInterface}: approval collects a verdict,
+ * input collects data. A marker (not a method on {@see ToolInterface}) so the
+ * existing read-only tools are untouched — the loop only pauses for a tool that
+ * opts in. When the model calls such a tool, {@see ToolLoopService} suspends the
+ * run WAITING_FOR_INPUT carrying {@see self::getInputSchema()}; a later
+ * submitInput() validates the user's submission against that schema and resumes.
+ *
+ * A tool MUST NOT implement BOTH this and {@see RequiresApprovalInterface}: a
+ * combined approval+input pause is unsupported and rejected at registration
+ * ({@see ToolRegistry}), because the approval-resume path carries no input and
+ * would silently drop the mandatory data.
+ */
+interface RequiresInputInterface
+{
+    /**
+     * A JSON-Schema subset (``type`` / ``required`` / ``properties``) describing
+     * the input the user must supply before this tool executes. Uses the same
+     * unbounded ``array<string, mixed>`` convention as tool parameter specs
+     * (ADR-082) — no typed schema DTO by design.
+     *
+     * MUST declare a real shape (a ``type`` or at least one property); a tool
+     * with nothing to collect must not implement this interface. A degenerate
+     * schema is treated as a programming error at the loop's capture-time gate
+     * (ADR-105), never as "accept anything".
+     *
+     * @return array<string, mixed>
+     */
+    public function getInputSchema(): array;
+}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use LogicException;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
@@ -23,9 +24,11 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesActingBackendUserTrait;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -83,6 +86,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // absent it the loop falls back to the gates it applied before, which
         // is what the lean unit-test wiring exercises.
         private ?ToolCallPolicyInterface $toolPolicy = null,
+        // Validates a user's typed input against a tool's declared schema
+        // (ADR-105). Optional for the lean test wiring; production always wires
+        // it. Absent it, resumeWithInput() skips its defence-in-depth
+        // re-validation (the runtime already validated before the claim).
+        private ?JsonSchemaValidator $schemaValidator = null,
     ) {}
 
     /**
@@ -227,6 +235,39 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                     }
                 }
 
+                // Typed-input-in-the-loop (ADR-105): the input sibling of the
+                // approval scan above. Approval keeps strict precedence (its
+                // scan runs first); both suspend BEFORE any of the turn's calls
+                // execute, so a multi-call turn stays consistent. Fail-closed
+                // like the approval scan: only an OFFERED input tool pauses.
+                foreach ($resp->toolCalls ?? [] as $call) {
+                    $inputTool = $this->registry->get($call->name);
+                    if (in_array($call->name, $allowedNames, true)
+                        && $inputTool instanceof RequiresInputInterface) {
+                        $schema = $inputTool->getInputSchema();
+                        // Capture-time gate (ADR-105 M2): a RequiresInputInterface
+                        // tool with a degenerate schema is a programming error;
+                        // never persist a suspend that would rehydrate fail-open.
+                        if (!InputSchema::isUsable($schema)) {
+                            throw new LogicException(
+                                sprintf('Tool "%s" implements RequiresInputInterface but returned a degenerate input schema.', $call->name),
+                                1784600105,
+                            );
+                        }
+                        throw ToolInputRequiredException::fromState(new SuspendedRunState(
+                            array_map(static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m, $messages),
+                            array_map(static fn(ToolCall $c): array => $c->toArray(), $resp->toolCalls ?? []),
+                            $iterations,
+                            $promptTokens,
+                            $completionTokens,
+                            $allowedToolNames,
+                            $options?->toArray() ?? [],
+                            inputToolName: $call->name,
+                            inputSchema: $schema,
+                        ));
+                    }
+                }
+
                 foreach ($resp->toolCalls ?? [] as $call) {
                     $tt0                = hrtime(true);
                     [$result, $isError] = $this->invoke($call, $allowedNames);
@@ -325,6 +366,16 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             } elseif (!in_array($call->name, $offered, true)) {
                 $result = sprintf('Error: tool "%s" is no longer permitted and was not executed.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
+                // ADR-105 M1 defence in depth: the approval-resume path carries no
+                // user input. An input-requiring pending call must NOT fail-open
+                // execute here without its data — refuse it, forcing the model to
+                // re-request via a fresh turn, which then hits the input scan and
+                // suspends for a proper submitInput(). (The dual approval+input
+                // marker is already banned at registration; this guards the case
+                // regardless.)
+                $result = sprintf('Error: tool "%s" requires user input that was not provided.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
                 $tt0                = hrtime(true);
                 [$result, $isError] = $this->invoke($call, $offered);
@@ -349,6 +400,102 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             $state->promptTokens,
             $state->completionTokens,
         );
+    }
+
+    /**
+     * Resume a run suspended for typed user input (ADR-105) — the input sibling
+     * of {@see self::resume()}.
+     *
+     * Restores the run's allow-list and options, then executes the pending
+     * turn's calls: the input-requiring target ($state->inputToolName) runs with
+     * the human's validated data overlaid onto its arguments; a sibling call
+     * that has since been disabled is refused; a SECOND input-requiring call in
+     * the same turn is fail-closed-refused (one submission cannot satisfy two);
+     * any other (read-only) call runs normally. Then re-enters
+     * {@see self::runLoop()} with assembly skipped and the pre-suspend counters
+     * seeded, exactly as approval resume does — so multi-suspend cycles
+     * accumulate their totals.
+     *
+     * $inputData is validated by the caller (AgentRuntime, before the claim);
+     * it is re-validated here as defence in depth when a validator is wired.
+     *
+     * @param array<string, mixed> $inputData
+     */
+    public function resumeWithInput(
+        SuspendedRunState $state,
+        array $inputData,
+        LlmConfiguration $configuration,
+        ?int $maxIterations = null,
+        ?RunTrace $runTrace = null,
+        ?int $beUserUid = null,
+    ): ToolLoopResult {
+        // Defence in depth: do not trust the caller's "already validated" claim.
+        if ($this->schemaValidator !== null && !$this->schemaValidator->validate($inputData, $state->inputSchema)) {
+            throw new LogicException('resumeWithInput received input that does not match the declared schema.', 1784600106);
+        }
+
+        $messages     = $state->messages;
+        $pendingCalls = $state->toolCalls();
+        $options      = ToolOptions::fromArray($state->options, $beUserUid);
+        $offered      = $this->resolveOfferedNames($state->allowedToolNames, $configuration);
+
+        foreach ($pendingCalls as $call) {
+            if (!in_array($call->name, $offered, true)) {
+                $result = sprintf('Error: tool "%s" is no longer permitted and was not executed.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } elseif ($call->name === $state->inputToolName) {
+                $tt0                = hrtime(true);
+                [$result, $isError] = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered);
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+            } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
+                // A second input-requiring call in the same turn got no data —
+                // one submission satisfies one tool. Fail-closed refusal.
+                $result = sprintf('Error: tool "%s" requires input that was not provided.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } else {
+                $tt0                = hrtime(true);
+                [$result, $isError] = $this->invoke($call, $offered);
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+            }
+            $messages[] = ChatMessage::toolResult($call->id, $result);
+        }
+
+        return $this->runLoop(
+            $messages,
+            $configuration,
+            $state->allowedToolNames,
+            $options,
+            $maxIterations,
+            $runTrace,
+            null,
+            true,
+            $state->iterations,
+            $state->promptTokens,
+            $state->completionTokens,
+        );
+    }
+
+    /**
+     * Overlay the user's validated input onto the target tool call's arguments,
+     * bounded to the schema-declared keys (ADR-105 security): the model's own
+     * values for human-controlled keys are stripped, then ONLY schema-declared
+     * keys from the human are merged in. The model cannot smuggle a value into a
+     * human-controlled field, and the human cannot smuggle an undeclared
+     * argument into the call.
+     *
+     * @param array<string, mixed> $schema
+     * @param array<string, mixed> $inputData
+     */
+    private function withInput(ToolCall $call, array $schema, array $inputData): ToolCall
+    {
+        $properties = $schema['properties'] ?? [];
+        $declared   = is_array($properties) ? array_keys($properties) : [];
+        $keyMap     = array_flip(array_map(static fn(int|string $k): string => (string)$k, $declared));
+
+        $base  = array_diff_key($call->arguments, $keyMap);
+        $human = array_intersect_key($inputData, $keyMap);
+
+        return new ToolCall($call->id, $call->name, [...$base, ...$human], $call->type);
     }
 
     /**

--- a/Classes/Service/Tool/ToolLoopServiceInterface.php
+++ b/Classes/Service/Tool/ToolLoopServiceInterface.php
@@ -67,4 +67,25 @@ interface ToolLoopServiceInterface
         ?RunTrace $runTrace = null,
         ?int $beUserUid = null,
     ): ToolLoopResult;
+
+    /**
+     * Resume a run suspended for typed user input (ADR-105) — the input sibling
+     * of {@see self::resume()}.
+     *
+     * Executes the pending turn's calls with the user's validated $inputData
+     * overlaid (bounded to the schema-declared keys) onto the input-requiring
+     * target; refuses a disabled sibling and any second input-requiring call.
+     * The gate is re-applied at resume time and the pre-suspend counters are
+     * folded into the returned totals, as approval resume does.
+     *
+     * @param array<string, mixed> $inputData validated against the tool's schema before this call
+     */
+    public function resumeWithInput(
+        SuspendedRunState $state,
+        array $inputData,
+        LlmConfiguration $configuration,
+        ?int $maxIterations = null,
+        ?RunTrace $runTrace = null,
+        ?int $beUserUid = null,
+    ): ToolLoopResult;
 }

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -46,6 +46,19 @@ final class ToolRegistry
                     1782700001,
                 );
             }
+            // ADR-105 M1: a tool may not be both approval- and input-gated. The
+            // approval-resume path carries no user input and would silently drop
+            // the mandatory data; the combination is unsupported, so reject it
+            // at registration rather than fail open at resume.
+            if ($tool instanceof RequiresApprovalInterface && $tool instanceof RequiresInputInterface) {
+                throw new LogicException(
+                    sprintf(
+                        'Tool "%s" may not implement both RequiresApprovalInterface and RequiresInputInterface; combined approval+input pauses are unsupported (ADR-105).',
+                        $name,
+                    ),
+                    1784600104,
+                );
+            }
             $this->byName[$name] = $tool;
         }
     }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -172,6 +172,11 @@ return [
         'path' => '/nrllm/tool/resume',
         'target' => ToolPlaygroundController::class . '::resumeAction',
     ],
+    // Submit typed input for a run suspended WAITING_FOR_INPUT (ADR-105)
+    'nrllm_tool_submit_input' => [
+        'path' => '/nrllm/tool/submit-input',
+        'target' => ToolPlaygroundController::class . '::submitInputAction',
+    ],
     // Tool management route (global enable/disable)
     'nrllm_tool_toggle' => [
         'path' => '/nrllm/tool/toggle',

--- a/Documentation/Adr/Adr105TypedInputSuspension.rst
+++ b/Documentation/Adr/Adr105TypedInputSuspension.rst
@@ -1,0 +1,101 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-105:
+
+============================================================================
+ADR-105: Typed user-input suspension (WAITING_FOR_INPUT)
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-22
+:Authors: Netresearch DTT GmbH
+
+.. _adr-105-context:
+
+Context
+=======
+
+Human-in-the-loop so far means *approval* (:ref:`ADR-084 <adr-084>`): a tool
+opts into a verdict, the run suspends WAITING_FOR_APPROVAL, and ``approve()``
+continues it with approve/deny. But some tools need the human to supply
+**typed data**, not a verdict — a target the model cannot know, a value only a
+person can decide. The P1 roadmap's final queue-epic slice asks for exactly
+this: a tool that suspends the run to collect schema-validated input and
+resumes with it fed back into the tool's arguments.
+
+.. _adr-105-decision:
+
+Decision
+========
+
+A new suspend kind, routed by the persisted status discriminator:
+WAITING_FOR_APPROVAL → ``approve()``, **WAITING_FOR_INPUT → ``submitInput()``**.
+The two never share a code path after the row is loaded, so the persisted state
+needs no "kind" field.
+
+- **Tool signal.** A tool opts in with the ``RequiresInputInterface`` marker
+  (the sibling of ``RequiresApprovalInterface``), declaring an input schema via
+  ``getInputSchema()``. When the model calls an *offered* such tool, the loop
+  throws ``ToolInputRequiredException`` carrying a ``SuspendedRunState`` whose
+  new ``inputToolName``/``inputSchema`` fields name the target and its schema.
+  The runtime's ladder catches it right after the approval arm (before the
+  guardrail pair and the generic ``Throwable``) and persists WAITING_FOR_INPUT.
+- **Reuse.** The status is stored in the existing ``suspended_state`` column
+  (no new column), the guarded suspend/claim transitions mirror ADR-084
+  (``suspendRunForInput`` / ``claimForResumeFromInput``), the lease is cleared
+  so the reaper (:ref:`ADR-104 <adr-104>`) ignores a waiting run, and the
+  MAX(sequence)+1 resume-position resolution is unchanged.
+- **Divergence — validate before claim.** ``submitInput()`` validates the
+  submission against the declared schema (via the existing structure-only
+  ``JsonSchemaValidator``, :ref:`ADR-082 <adr-082>`) **before** probing or
+  claiming the run. An invalid submission is rejected without consuming the
+  claim, so the run stays WAITING_FOR_INPUT and the user can resubmit — a flow
+  approve/deny has no analogue for.
+- **Overlay.** On resume, the human's validated values are overlaid onto the
+  target call's arguments **bounded to the schema-declared keys**: the model's
+  own values for those keys are stripped and only declared keys from the human
+  are merged, so neither side can smuggle a value into the other's field.
+
+.. _adr-105-fail-closed:
+
+Fail-closed rules
+=================
+
+- **A degenerate schema is corruption, never accept-all.** An empty/shapeless
+  ``inputSchema`` (against which ``validate()`` returns true for anything) is
+  rejected at both the capture-time gate (``LogicException``) and the rehydrate
+  gate (``CorruptSuspendedStateException``) — one shared predicate
+  (``InputSchema::isUsable()``) is the single authority.
+- **A tool may not be both approval- and input-gated.** The approval-resume
+  path carries no input and would silently drop the mandatory data; the
+  combination is rejected at tool registration, and — defence in depth —
+  ``resume()`` refuses an input-requiring pending call rather than fail-open
+  executing it.
+- **An unstorable suspension fails closed** as ``SUSPEND_FAILED`` (as approval
+  does): promising an input flow that cannot be resumed would strand the client.
+- **Submitted values are untrusted content** entering the model context; the
+  submit entry point is admin-gated, which is the injection mitigation
+  (structure-only validation does not sanitise content).
+
+.. _adr-105-consequences:
+
+Consequences
+============
+
+- ``AgentRunOutcome`` gained ``AWAITING_INPUT``; ``AgentEventKind`` gained
+  ``INPUT`` (payload ``{submittedBy}`` only, never the values, ADR-064);
+  ``AgentRunStatus::WAITING_FOR_INPUT`` already existed and needed no change.
+  All are the documented minor-release growth path — consumers match with a
+  default arm.
+- ``AgentRuntimeInterface`` gained ``submitInput()`` (an interface method, not a
+  new public service — the audited public-service count is unchanged);
+  ``AgentRunRepositoryInterface`` gained ``suspendRunForInput()`` and
+  ``claimForResumeFromInput()``; ``ToolLoopServiceInterface`` gained
+  ``resumeWithInput()``.
+- Accepted limitations: validation is structure-only (no min/max/enum/pattern —
+  a tool needing those re-checks in ``execute()``, as ``completeStructured``
+  does); a single turn requesting two tool inputs is fail-closed-refused on the
+  second, not collected; the schema is delivered in the suspend response, not
+  via ``status()`` (which strips ``suspended_state``), so a client reloading
+  mid-wait loses the form — matching the existing approval ``pendingTools``
+  limitation.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -402,3 +402,4 @@ Tools
    Adr102QueuedAgentRuns
    Adr103CooperativeCancellation
    Adr104StaleRunReaperAndRetry
+   Adr105TypedInputSuspension

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -698,6 +698,95 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertFalse($payload['success']);
     }
 
+    #[Test]
+    public function submitInputActionRejectsInvalidInputWith422AndKeepsTheRunWaiting(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // A run waiting for input whose tool requires a 'city'; the submission
+        // omits it → validation fails BEFORE any claim, so the provider is never
+        // touched and the client is told to resubmit (ADR-105).
+        $schema  = ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']];
+        $state   = new SuspendedRunState([['role' => 'user', 'content' => 'weather?']], [], 1, 5, 2, ['ask_user'], [], 'ask_user', $schema);
+        $encoded = json_encode($state->toArray());
+        self::assertIsString($encoded);
+        $run = new AgentRun(1, 'run-uuid-1', 'waiting_for_input', 1, 'cfg', 1, 1, false, 5, 2, 7, 0.0, '', '', 0, 0, 0, $encoded);
+
+        $repo             = new RecordingAgentRunRepository();
+        $repo->findResult = $run;
+        $persister        = new AgentRunPersister($repo, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg');
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        $manager = $this->createMock(LlmServiceManagerInterface::class);
+        $manager->expects(self::never())->method('chatWithToolsForConfiguration');
+        $manager->expects(self::never())->method('chatWithConfiguration');
+
+        $registry        = new ToolRegistry([new FakeTool('ask_user')]);
+        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
+
+        $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/submit-input'))
+            ->withParsedBody(['runUuid' => 'run-uuid-1', 'input' => []]);
+        $response = $controller->submitInputAction($request);
+
+        self::assertSame(422, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        // Re-signals awaiting_input so the client keeps the form open.
+        self::assertSame('awaiting_input', $payload['status']);
+        // The claim was never consumed — the run is still resubmittable.
+        self::assertSame(0, $repo->inputClaimsGranted);
+    }
+
+    #[Test]
+    public function submitInputActionRejectsASecondConcurrentSubmission(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // Valid input, but the atomic claim is LOST to a concurrent submission:
+        // findByUuid still returns it WAITING, claimForResumeFromInput returns
+        // false → 409, and the provider is never reached.
+        $schema  = ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']];
+        $state   = new SuspendedRunState([['role' => 'user', 'content' => 'weather?']], [], 1, 5, 2, ['ask_user'], [], 'ask_user', $schema);
+        $encoded = json_encode($state->toArray());
+        self::assertIsString($encoded);
+        $run = new AgentRun(1, 'run-uuid-1', 'waiting_for_input', 1, 'cfg', 1, 1, false, 5, 2, 7, 0.0, '', '', 0, 0, 0, $encoded);
+
+        $repo                     = new RecordingAgentRunRepository();
+        $repo->findResult         = $run;
+        $repo->inputClaimsGranted = 1; // the next input claim loses
+        $persister                = new AgentRunPersister($repo, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg');
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        $manager = $this->createMock(LlmServiceManagerInterface::class);
+        $manager->expects(self::never())->method('chatWithToolsForConfiguration');
+        $manager->expects(self::never())->method('chatWithConfiguration');
+
+        $registry        = new ToolRegistry([new FakeTool('ask_user')]);
+        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
+
+        $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/submit-input'))
+            ->withParsedBody(['runUuid' => 'run-uuid-1', 'input' => ['city' => 'Berlin']]);
+        $response = $controller->submitInputAction($request);
+
+        self::assertSame(409, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+    }
+
     /**
      * Build a controller wired to the scripted tool adapter (one tool call, then
      * a plain answer) over an in-memory configuration.

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -60,6 +60,12 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    public function suspendRunForInput(int $runUid, string $stateJson): bool
+    {
+        // Not needed by the command tests.
+        return true;
+    }
+
     public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int
     {
         // Not needed by the command tests.
@@ -73,6 +79,11 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
     }
 
     public function claimForResume(int $runUid): bool
+    {
+        return false;
+    }
+
+    public function claimForResumeFromInput(int $runUid): bool
     {
         return false;
     }

--- a/Tests/Unit/Domain/Enum/AgentEventKindTest.php
+++ b/Tests/Unit/Domain/Enum/AgentEventKindTest.php
@@ -21,7 +21,7 @@ final class AgentEventKindTest extends TestCase
     #[Test]
     public function valuesListsAllBackingStrings(): void
     {
-        self::assertSame(['request', 'llm', 'tool', 'assembled', 'approval'], AgentEventKind::values());
+        self::assertSame(['request', 'llm', 'tool', 'assembled', 'approval', 'input'], AgentEventKind::values());
     }
 
     #[Test]
@@ -45,9 +45,11 @@ final class AgentEventKindTest extends TestCase
     #[Test]
     public function fromRunStepKindReturnsNullForNonRunStepKinds(): void
     {
-        // 'approval' is a valid EVENT kind (ADR-101) but not a RunStep kind —
-        // it must not masquerade as one; hydrate stored kinds via tryFrom().
+        // 'approval' (ADR-101) and 'input' (ADR-105) are valid EVENT kinds but
+        // not RunStep kinds — they must not masquerade as one; hydrate stored
+        // kinds via tryFrom().
         self::assertNull(AgentEventKind::fromRunStepKind('approval'));
+        self::assertNull(AgentEventKind::fromRunStepKind('input'));
         self::assertNull(AgentEventKind::fromRunStepKind('artifact'));
     }
 }

--- a/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
+++ b/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SuspendedRunState::class)]
+final class SuspendedRunStateTest extends TestCase
+{
+    #[Test]
+    public function anInputPauseRoundTripsItsToolNameAndSchema(): void
+    {
+        $state = new SuspendedRunState(
+            messages: [['role' => 'user', 'content' => 'go']],
+            pendingCalls: [['id' => 'call_1', 'name' => 'ask_user', 'arguments' => []]],
+            iterations: 2,
+            promptTokens: 5,
+            completionTokens: 3,
+            allowedToolNames: ['ask_user'],
+            options: ['temperature' => 0.4],
+            inputToolName: 'ask_user',
+            inputSchema: ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+        );
+
+        $restored = SuspendedRunState::fromArray($state->toArray());
+
+        self::assertSame('ask_user', $restored->inputToolName);
+        self::assertSame(['type' => 'object', 'properties' => ['city' => ['type' => 'string']]], $restored->inputSchema);
+        self::assertSame(2, $restored->iterations);
+        self::assertSame(['ask_user'], $restored->allowedToolNames);
+    }
+
+    #[Test]
+    public function anApprovalEraRowWithoutInputKeysDefaultsToNullAndEmpty(): void
+    {
+        // Back-compat: a row persisted before ADR-105 carries neither key.
+        $legacy = [
+            'messages'         => [['role' => 'user', 'content' => 'go']],
+            'pendingCalls'     => [],
+            'iterations'       => 1,
+            'promptTokens'     => 0,
+            'completionTokens' => 0,
+            'allowedToolNames' => null,
+            'options'          => [],
+        ];
+
+        $restored = SuspendedRunState::fromArray($legacy);
+
+        self::assertNull($restored->inputToolName);
+        self::assertSame([], $restored->inputSchema);
+    }
+
+    #[Test]
+    public function malformedInputKeysDegradeDefensively(): void
+    {
+        $restored = SuspendedRunState::fromArray([
+            'messages'      => [],
+            'pendingCalls'  => [],
+            'inputToolName' => 42,          // not a string
+            'inputSchema'   => 'not-an-array',
+        ]);
+
+        self::assertNull($restored->inputToolName);
+        self::assertSame([], $restored->inputSchema);
+    }
+}

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -29,15 +29,19 @@ use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\InputSubmission;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
@@ -822,6 +826,114 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aToolRequiringInputSuspendsTheRunAsAwaitingInput(): void
+    {
+        // ADR-105: a called tool raised ToolInputRequiredException — the run
+        // suspends WAITING_FOR_INPUT carrying the declared schema, not FAILED.
+        $runtime = $this->runtime($this->loopThrowing(ToolInputRequiredException::fromState($this->inputState())));
+
+        $result = $runtime->run($this->request());
+
+        self::assertSame(AgentRunOutcome::AWAITING_INPUT, $result->outcome);
+        self::assertSame('ask_user', $result->suspendedState?->inputToolName);
+        self::assertNotNull($this->repository->suspendedForInput);
+        // A successful input suspension is non-terminal: the finally-guard must
+        // NOT flip it to FAILED.
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function aFailedInputSuspensionFailsClosedAsSuspendFailed(): void
+    {
+        $this->repository->refuseSuspendForInput = true;
+        $runtime = $this->runtime($this->loopThrowing(ToolInputRequiredException::fromState($this->inputState())));
+
+        $result = $runtime->run($this->request());
+
+        // No stored state means no resume — fail closed, never announce awaiting.
+        self::assertSame(AgentRunOutcome::SUSPEND_FAILED, $result->outcome);
+        self::assertNotNull($this->repository->finished);
+        self::assertSame(AgentRunStatus::FAILED->value, $this->repository->finished['status']);
+    }
+
+    #[Test]
+    public function submitInputValidatesClaimsRecordsAndResumes(): void
+    {
+        $this->repository->findResult = $this->inputRun();
+
+        $result = $this->runtime($this->loopReturning($this->loopResult('answered')))
+            ->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        // The claim was consumed exactly once and an INPUT audit event recorded.
+        self::assertSame(1, $this->repository->inputClaimsGranted);
+        self::assertSame('input', $this->repository->events[0]['kind'] ?? null);
+        self::assertNotNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function submitInputRejectsInvalidInputWithoutConsumingTheClaim(): void
+    {
+        // The required 'city' is missing → schema validation fails BEFORE the
+        // claim, so the run stays WAITING_FOR_INPUT and can be resubmitted.
+        $this->repository->findResult = $this->inputRun();
+
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        try {
+            $runtime->submitInput('run-uuid-i', new InputSubmission([], 7));
+            self::fail('Expected InvalidInputSubmissionException');
+        } catch (InvalidInputSubmissionException) {
+            // expected
+        }
+
+        self::assertSame(0, $this->repository->inputClaimsGranted);
+        self::assertSame([], $this->repository->events);
+        self::assertNull($this->repository->finished);
+    }
+
+    #[Test]
+    public function submitInputThrowsWhenTheRunIsNotAwaitingInput(): void
+    {
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        // Unknown run.
+        $this->expectException(RunNotAwaitingInputException::class);
+        $runtime->submitInput('unknown', new InputSubmission(['city' => 'Berlin'], 7));
+    }
+
+    #[Test]
+    public function submitInputThrowsCorruptStateForADegenerateSchema(): void
+    {
+        // A rehydrated input state with an empty schema must NOT validate against
+        // [] (accept-all) — it is corruption, fail closed (ADR-105 M2).
+        $state = new SuspendedRunState([['role' => 'user', 'content' => 'x']], [], 1, 0, 0, ['ask_user'], [], 'ask_user', []);
+        $encoded = json_encode($state->toArray());
+        \assert(is_string($encoded));
+        $this->repository->findResult = $this->inputRun($encoded);
+
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
+
+        $this->expectException(CorruptSuspendedStateException::class);
+        $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+    }
+
+    #[Test]
+    public function aSecondConcurrentSubmitInputLosesTheClaim(): void
+    {
+        $this->repository->findResult = $this->inputRun();
+        $runtime = $this->runtime($this->loopReturning($this->loopResult('answered')));
+
+        // First submission wins the atomic claim and resumes.
+        $first = $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+        self::assertSame(AgentRunOutcome::COMPLETED, $first->outcome);
+
+        // A second submission (the fixture grants only the first claim) is refused.
+        $this->expectException(RunAlreadyResumingException::class);
+        $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Hamburg'], 7));
+    }
+
+    #[Test]
     public function cancelDelegatesToTheGuardedTransition(): void
     {
         $this->repository->findResult = $this->suspendedRun();
@@ -1014,6 +1126,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $loop = self::createStub(ToolLoopServiceInterface::class);
         $loop->method('runLoop')->willReturn($result);
         $loop->method('resume')->willReturn($result);
+        $loop->method('resumeWithInput')->willReturn($result);
 
         return $loop;
     }
@@ -1034,6 +1147,56 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             1,
             5,
             2,
+        );
+    }
+
+    /**
+     * @return array<string, mixed> the input schema used by the input-pause fixtures
+     */
+    private function inputSchema(): array
+    {
+        return ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']];
+    }
+
+    private function inputState(): SuspendedRunState
+    {
+        return new SuspendedRunState(
+            [['role' => 'user', 'content' => 'weather?']],
+            [['id' => 'call_1', 'name' => 'ask_user', 'arguments' => []]],
+            1,
+            5,
+            2,
+            ['ask_user'],
+            [],
+            'ask_user',
+            $this->inputSchema(),
+        );
+    }
+
+    private function inputRun(?string $stateJson = null): AgentRun
+    {
+        $encoded = $stateJson ?? json_encode($this->inputState()->toArray());
+        \assert(is_string($encoded));
+
+        return new AgentRun(
+            uid: 1,
+            uuid: 'run-uuid-i',
+            status: 'waiting_for_input',
+            configurationUid: 1,
+            configurationIdentifier: 'cfg',
+            beUser: 9,
+            iterations: 1,
+            truncated: false,
+            totalPromptTokens: 5,
+            totalCompletionTokens: 2,
+            totalTokens: 7,
+            estimatedCost: 0.0,
+            errorClass: '',
+            terminationReason: '',
+            startedAt: 0,
+            finishedAt: 0,
+            crdate: 0,
+            suspendedState: $encoded,
         );
     }
 

--- a/Tests/Unit/Service/Tool/Fixtures/FakeInputTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeInputTool.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+
+/**
+ * A tool that opts into typed user input (ADR-105), for the tool-loop tests.
+ *
+ * Captures the arguments it was executed with so a test can assert the
+ * human-input overlay ({@see \Netresearch\NrLlm\Service\Tool\ToolLoopService::resumeWithInput()})
+ * merged the submitted values and stripped the model's own for declared keys.
+ */
+final class FakeInputTool implements ToolInterface, RequiresInputInterface
+{
+    /** @var array<string, mixed>|null the arguments execute() last received */
+    public ?array $capturedArguments = null;
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    public function __construct(
+        private readonly string $name = 'ask_user',
+        private readonly array $schema = ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function($this->name, 'asks the user for input', ['type' => 'object', 'properties' => []]);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments): string
+    {
+        $this->capturedArguments = $arguments;
+
+        return 'input-tool ran';
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'test';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getInputSchema(): array
+    {
+        return $this->schema;
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -126,6 +126,27 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    /** @var array{runUid: int, stateJson: string}|null */
+    public ?array $suspendedForInput = null;
+
+    public bool $throwOnSuspendForInput = false;
+
+    /** Simulates a run no longer RUNNING, so the guarded input-suspend matches no row. */
+    public bool $refuseSuspendForInput = false;
+
+    public function suspendRunForInput(int $runUid, string $stateJson): bool
+    {
+        if ($this->throwOnSuspendForInput) {
+            throw new RuntimeException('suspendRunForInput failed', 1784600402);
+        }
+        if ($this->refuseSuspendForInput) {
+            return false;
+        }
+        $this->suspendedForInput = ['runUid' => $runUid, 'stateJson' => $stateJson];
+
+        return true;
+    }
+
     public bool $throwOnEnqueue = false;
 
     /** @var list<array{uuid: string, configurationUid: int, configurationIdentifier: string, beUser: int, requestJson: string}> */
@@ -183,6 +204,24 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
             return false;
         }
         ++$this->claimsGranted;
+
+        return true;
+    }
+
+    public bool $throwOnClaimInput = false;
+
+    /** Number of input-resume claims granted; false after the first (double-submit loses). */
+    public int $inputClaimsGranted = 0;
+
+    public function claimForResumeFromInput(int $runUid): bool
+    {
+        if ($this->throwOnClaimInput) {
+            throw new RuntimeException('claimForResumeFromInput failed', 1784600403);
+        }
+        if ($this->inputClaimsGranted > 0) {
+            return false;
+        }
+        ++$this->inputClaimsGranted;
 
         return true;
     }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
+use LogicException;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
@@ -23,15 +24,18 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -908,6 +912,185 @@ final class ToolLoopServiceTest extends TestCase
         $service->runLoop([$this->userTurn('go')], $configuration, ['content_tool', 'system_tool']);
 
         self::assertSame(['content_tool'], $captured, 'A tool outside the configuration\'s groups must never be offered.');
+    }
+
+    #[Test]
+    public function suspendsForInputWhenAnOfferedInputToolIsCalled(): void
+    {
+        // ADR-105: the model called an input-requiring tool — the loop suspends
+        // carrying that tool's name and its declared schema.
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'ask_user', [])]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeInputTool('ask_user')]));
+
+        $state = null;
+        try {
+            $service->runLoop([$this->userTurn('weather?')], new LlmConfiguration(), ['ask_user']);
+            self::fail('Expected the run to suspend for input.');
+        } catch (ToolInputRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertSame('ask_user', $state->inputToolName);
+        self::assertArrayHasKey('properties', $state->inputSchema);
+    }
+
+    #[Test]
+    public function aDegenerateInputSchemaThrowsAtCaptureTime(): void
+    {
+        // ADR-105 M2: a RequiresInputInterface tool with an empty schema is a
+        // programming error — never persist a suspend that would rehydrate
+        // fail-open (validating against []).
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'ask_user', [])]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeInputTool('ask_user', [])]));
+
+        $this->expectException(LogicException::class);
+        $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['ask_user']);
+    }
+
+    #[Test]
+    public function doesNotSuspendForARegisteredInputToolThatIsNotOffered(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_1', 'ask_user', [])]),
+            $this->response('handled'),
+        ]));
+        $service = $this->service($mgr, new ToolRegistry([new FakeInputTool('ask_user'), new FakeTool('safe_tool')]));
+
+        // ask_user is registered but NOT offered: a model naming it is refused by
+        // the gate, not turned into a spurious input suspension.
+        $result = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ['safe_tool']);
+
+        self::assertSame('handled', $result->finalContent);
+        self::assertTrue($result->trace[0]->isError);
+    }
+
+    #[Test]
+    public function resumeWithInputOverlaysHumanDataBoundedToDeclaredKeys(): void
+    {
+        $tool = new FakeInputTool('ask_user');
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        // After the pending call runs, the follow-up turn has no tool calls.
+        $mgr->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+        $service = $this->service($mgr, new ToolRegistry([$tool]));
+
+        // The model guessed 'city' AND passed an undeclared 'note'.
+        $state = new SuspendedRunState(
+            [$this->userTurn('weather?'), ['role' => 'assistant', 'content' => '', 'tool_calls' => [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{"city":"ModelGuess","note":"keep"}']]]]],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{"city":"ModelGuess","note":"keep"}']]],
+            1,
+            5,
+            2,
+            ['ask_user'],
+            [],
+            'ask_user',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+        );
+
+        // The human supplies the declared 'city' and an undeclared 'evil'.
+        $service->resumeWithInput($state, ['city' => 'Berlin', 'evil' => 'x'], new LlmConfiguration());
+
+        // 'city' comes from the human (model's guess stripped); 'note' (model,
+        // undeclared) is kept; 'evil' (human, undeclared) is dropped.
+        self::assertSame(['note' => 'keep', 'city' => 'Berlin'], $tool->capturedArguments);
+    }
+
+    #[Test]
+    public function resumeWithInputRefusesASecondInputToolInTheSameTurn(): void
+    {
+        $first  = new FakeInputTool('ask_user');
+        $second = new FakeInputTool('ask_more');
+        $mgr    = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+        $service = $this->service($mgr, new ToolRegistry([$first, $second]));
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('go')],
+            [
+                ['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{}']],
+                ['id' => 'call_2', 'type' => 'function', 'function' => ['name' => 'ask_more', 'arguments' => '{}']],
+            ],
+            1,
+            0,
+            0,
+            ['ask_user', 'ask_more'],
+            [],
+            'ask_user',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+        );
+
+        $trace = new RunTrace();
+        $service->resumeWithInput($state, ['city' => 'Berlin'], new LlmConfiguration(), null, $trace);
+
+        // The second input tool got no data — fail-closed refusal, never executed.
+        self::assertNull($second->capturedArguments);
+        $refused = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL && $s->toolIsError));
+        self::assertNotSame([], $refused);
+    }
+
+    #[Test]
+    public function approvalResumeRefusesAnInputRequiringPendingCall(): void
+    {
+        // ADR-105 M1 defence in depth: the approval-resume path carries no input;
+        // an input-requiring pending call must be refused, never fail-open run.
+        $tool = new FakeInputTool('ask_user');
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+        $service = $this->service($mgr, new ToolRegistry([$tool]));
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('go')],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{}']]],
+            1,
+            0,
+            0,
+            ['ask_user'],
+            [],
+        );
+
+        $service->resume($state, true, new LlmConfiguration());
+
+        self::assertNull($tool->capturedArguments);
+    }
+
+    #[Test]
+    public function resumeWithInputRejectsCallerUnvalidatedData(): void
+    {
+        // Defence in depth: with a validator wired, resumeWithInput re-checks the
+        // input and refuses data that does not match the declared schema.
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $service = new ToolLoopService(
+            $mgr,
+            new ToolRegistry([new FakeInputTool('ask_user')]),
+            new FakeToolAvailability(['ask_user']),
+            null,
+            5,
+            null,
+            null,
+            null,
+            null,
+            new JsonSchemaValidator(),
+        );
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('go')],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{}']]],
+            1,
+            0,
+            0,
+            ['ask_user'],
+            [],
+            'ask_user',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+        );
+
+        $this->expectException(LogicException::class);
+        // Missing the required 'city'.
+        $service->resumeWithInput($state, [], new LlmConfiguration());
     }
 
     private function service(

--- a/Tests/Unit/Service/Tool/ToolRegistryTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryTest.php
@@ -11,6 +11,9 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
 use LogicException;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
+use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,5 +51,52 @@ final class ToolRegistryTest extends TestCase
     {
         $this->expectException(LogicException::class);
         self::assertInstanceOf(ToolRegistry::class, new ToolRegistry([new FakeTool('dup'), new FakeTool('dup')]));
+    }
+
+    #[Test]
+    public function aToolThatIsBothApprovalAndInputGatedIsRejected(): void
+    {
+        // ADR-105 M1: the combination is unsupported — the approval-resume path
+        // carries no user input and would silently drop the mandatory data.
+        $dualMarker = new class implements ToolInterface, RequiresApprovalInterface, RequiresInputInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('dual', 'both markers', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments): string
+            {
+                return 'ok';
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function getInputSchema(): array
+            {
+                return ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]];
+            }
+        };
+
+        $this->expectException(LogicException::class);
+        self::assertInstanceOf(ToolRegistry::class, new ToolRegistry([$dualMarker]));
     }
 }


### PR DESCRIPTION
## What

Completes the final P1 #8 (queue epic) slice — **ADR-105**: a tool can suspend an agent run to collect **schema-validated typed input** from the user, the input sibling of the ADR-084 approval flow. Where approval collects a *verdict*, input collects *data*.

The persisted status routes the resume path: `WAITING_FOR_APPROVAL` → `approve()`, **`WAITING_FOR_INPUT` → `submitInput()`**.

## How

- **Tool signal** — a tool opts in with the new `RequiresInputInterface` marker and declares an input schema via `getInputSchema()`. When the model calls an *offered* such tool, the loop throws `ToolInputRequiredException` carrying the transcript plus the target tool name and schema (new `SuspendedRunState` fields). The runtime ladder catches it right after the approval arm (before the guardrail pair and generic `Throwable`) and persists `WAITING_FOR_INPUT`. **No schema change** — the input schema rides inside the existing `suspended_state` column.
- **Validate before claim** (the deliberate divergence from `approve()`) — `submitInput()` validates the submission against the declared schema (structure-only `JsonSchemaValidator`, ADR-082) **before** probing or claiming the run. An invalid submission is rejected without consuming the claim, so the run stays `WAITING_FOR_INPUT` and the user can resubmit.
- **Bounded overlay** — the validated values are overlaid onto the target call's arguments *bounded to the schema-declared keys*: the model's own values for those keys are stripped and only declared keys from the human merge in. Neither side can smuggle a value into the other's field.
- **Reuse** — guarded suspend/claim transitions mirror ADR-084 (`suspendRunForInput` / `claimForResumeFromInput`), the lease is cleared so the ADR-104 reaper ignores a waiting run, the `MAX(sequence)+1` resume position is unchanged, and an `INPUT` audit event records *who* submitted (never the values, ADR-064).

## Fail-closed rules

- A **degenerate/empty schema is corruption, never accept-all** — one shared `InputSchema::isUsable()` predicate gates both capture-time (`LogicException`) and rehydrate (`CorruptSuspendedStateException`), so `validate($data, [])` (which returns true for anything) is unreachable.
- A tool **may not be both approval- and input-gated** — rejected at registration; `resume()` additionally refuses an input-requiring pending call in depth.
- An **unstorable suspension fails as `SUSPEND_FAILED`**; the submit entry point is **admin-gated** (the injection mitigation for the untrusted submitted values).

## API / surface

- `AgentRunOutcome` += `AWAITING_INPUT`; `AgentEventKind` += `INPUT` (`AgentRunStatus::WAITING_FOR_INPUT` already existed)
- `AgentRuntimeInterface` += `submitInput()` (interface method — public-service count unchanged)
- `AgentRunRepositoryInterface` += `suspendRunForInput()`, `claimForResumeFromInput()`; `ToolLoopServiceInterface` += `resumeWithInput()`
- New `RequiresInputInterface`, `ToolInputRequiredException`, `InputSubmission`, `InputSchema`, and `RunNotAwaitingInput`/`InvalidInputSubmission` runtime exceptions
- Playground: `POST /nrllm/tool/submit-input` (admin-gated; invalid input → 422 re-signalling `awaiting_input`; lost claim → 409)

## Tests

Local gate green: PHP-CS-Fixer, PHPStan L10, unit (5503), functional/sqlite (1252), Rector, fuzzy (79). New coverage: input suspend, capture-time degenerate-schema rejection, `submitInput` validate/claim/record/resume, invalid-input-no-claim-consumed, corrupt/degenerate-state 500, concurrent-submit 409, bounded overlay (model-key strip + undeclared-key drop), second-input-tool refusal, `resume()` input-call refusal, dual-marker registration ban, controller 422/409 mapping, `SuspendedRunState` round-trip + back-compat.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
