### PR TITLE
feat(guardrail): per-configuration guardrail policies (ADR-106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,33 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** — Per-configuration guardrail policies (ADR-106): `GuardrailInterface`
+  and `InputGuardrailInterface` (the public `nr_llm.guardrail` /
+  `nr_llm.input_guardrail` extension points) gained two methods via a shared
+  `GuardrailIdentity` parent — `getIdentifier()` (a stable slug) and
+  `isMandatory()`. An out-of-tree guardrail must implement both; input and
+  output classes sharing a concept must return the same identifier and the same
+  `isMandatory()` value (the container fails closed on disagreement). See the
+  ADR-106 *Upgrading* note.
+
 ### Added
+
+- Per-configuration guardrail policies (ADR-106): an `LlmConfiguration` can now
+  select which OPTIONAL guardrails apply via a new `allowed_guardrails` field;
+  MANDATORY guardrails (secret redaction) always run and are never selectable.
+  The selection is honoured consistently on the output (`GuardrailMiddleware`),
+  input (`InputGuardrailScreener`) and streaming (`StreamingDispatcher` — live
+  redaction and end-of-stream audit) paths. Default-secure: an untouched
+  configuration (empty selection) runs all guardrails exactly as before, and no
+  selection value — empty, partial, unknown, or all-unknown — can drop a
+  mandatory guardrail on any axis. The `provider-content-filter` guardrail is
+  optional (it enforces the provider's own policy block, not secret leakage);
+  secret redaction is mandatory. The TCA picker lists only optional guardrails,
+  discovered from the registry. Schema: `allowed_guardrails` (additive,
+  defaulted). New `GuardrailIdentity`, `GuardrailRegistry` (public, fail-closed
+  on cross-side mandatory disagreement) and `GuardrailPolicyResolver`.
 
 - Typed user-input suspension (ADR-105): a tool may implement the new
   `RequiresInputInterface` marker to declare an input schema and suspend the

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -66,6 +66,14 @@ class LlmConfiguration extends AbstractEntity
      * See {@see getAllowedToolGroupsList()} and AllowedToolsResolver.
      */
     protected string $allowedToolGroups = '';
+
+    /**
+     * Comma list of enabled OPTIONAL guardrail identifiers (ADR-106); empty =
+     * all applicable guardrails run. Mandatory guardrails (secret redaction)
+     * always run and are never represented here.
+     * See {@see getAllowedGuardrailsList()} and GuardrailPolicyResolver.
+     */
+    protected string $allowedGuardrails = '';
     protected int $maxRequestsPerDay = 0;
     protected int $maxTokensPerDay = 0;
     protected float $maxCostPerDay = 0.0;
@@ -789,6 +797,45 @@ class LlmConfiguration extends AbstractEntity
             $group = trim($group);
             if ($group !== '') {
                 $list[] = $group;
+            }
+        }
+
+        return $list;
+    }
+
+    public function getAllowedGuardrails(): string
+    {
+        return $this->allowedGuardrails;
+    }
+
+    public function setAllowedGuardrails(string $allowedGuardrails): void
+    {
+        $this->allowedGuardrails = $allowedGuardrails;
+    }
+
+    /**
+     * The enabled OPTIONAL guardrail identifiers as a trimmed list; empty list =
+     * no restriction (all applicable guardrails run). Mandatory guardrails run
+     * regardless and are never represented here.
+     *
+     * A non-empty selection is an allow-list over OPTIONAL guardrails only: any
+     * optional guardrail not named — including when every token is an unknown id
+     * (e.g. a stale '0') — is not run; mandatory guardrails always run. This is
+     * the same restrictive semantics as {@see getAllowedToolGroupsList()}.
+     *
+     * @return list<string>
+     */
+    public function getAllowedGuardrailsList(): array
+    {
+        if (trim($this->allowedGuardrails) === '') {
+            return [];
+        }
+
+        $list = [];
+        foreach (explode(',', $this->allowedGuardrails) as $id) {
+            $id = trim($id);
+            if ($id !== '') {
+                $list[] = $id;
             }
         }
 

--- a/Classes/Form/Tca/GuardrailItems.php
+++ b/Classes/Form/Tca/GuardrailItems.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Form\Tca;
+
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TCA itemsProcFunc listing the SELECTABLE (optional-only) guardrails for the
+ * `allowed_guardrails` select on tx_nrllm_configuration (ADR-106).
+ *
+ * The list is derived from {@see GuardrailRegistry::selectableIdentifiers()}
+ * (not hardcoded) so third-party guardrails appear automatically. Mandatory
+ * guardrails (secret redaction) are never listed — they always run and cannot
+ * be un-selected. Values already stored on the record but no longer known (an
+ * uninstalled extension's guardrail) are appended so the stored selection stays
+ * visible and editable rather than silently dropped.
+ */
+final class GuardrailItems
+{
+    /**
+     * @param array{items: array<int, array{label: string, value: string}>, row?: array<string, mixed>} $params
+     */
+    public function addItems(array &$params): void
+    {
+        $registry = GeneralUtility::makeInstance(GuardrailRegistry::class);
+
+        $ids = [];
+        foreach ($registry->selectableIdentifiers() as $id) {
+            $ids[$id] = true;
+        }
+
+        // Keep already-stored but currently unknown identifiers selectable.
+        $row    = is_array($params['row'] ?? null) ? $params['row'] : [];
+        $stored = $row['allowed_guardrails'] ?? '';
+        if (is_array($stored)) {
+            $stored = implode(',', array_map(
+                static fn(mixed $value): string => is_scalar($value) ? (string)$value : '',
+                $stored,
+            ));
+        } elseif (!is_scalar($stored)) {
+            $stored = '';
+        } else {
+            $stored = (string)$stored;
+        }
+        foreach (GeneralUtility::trimExplode(',', $stored, true) as $known) {
+            $ids[$known] ??= true;
+        }
+
+        foreach (array_keys($ids) as $id) {
+            $params['items'][] = ['label' => $id, 'value' => $id];
+        }
+    }
+}

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailPolicyResolver;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
@@ -58,6 +60,10 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
     public function __construct(
         #[AutowireIterator(GuardrailInterface::TAG_NAME)]
         private iterable $guardrails,
+        // Autowired in production; the no-op default keeps the lean test wiring
+        // working (a null/empty selection runs all guardrails, unchanged from
+        // before ADR-106).
+        private GuardrailPolicyResolver $policyResolver = new GuardrailPolicyResolver(new GuardrailRegistry([], [])),
     ) {}
 
     public function handle(
@@ -65,11 +71,15 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         callable $next,
     ): mixed {
         $result = $next($context);
+        // Narrow the global collection to the configuration's policy ONCE per
+        // call (ADR-106); the mandatory floor is preserved regardless. The
+        // configuration already rides on the context (ADR-096) — no re-plumbing.
+        $guardrails = $this->policyResolver->filter($this->guardrails, $context->configuration);
         if ($result instanceof CompletionResponse) {
-            return $this->screen($result, $context, $next, false);
+            return $this->screen($result, $context, $next, false, $guardrails);
         }
         if ($result instanceof VisionResponse) {
-            return $this->screenVision($result);
+            return $this->screenVision($result, $guardrails);
         }
 
         return $result;
@@ -82,10 +92,13 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
      * through the pipeline, so a RETRY (the response was deemed deficient) fails
      * CLOSED — throwing rather than silently returning the unscreened response.
      */
-    private function screenVision(VisionResponse $vision): VisionResponse
+    /**
+     * @param list<GuardrailInterface> $guardrails the config-filtered output guardrails
+     */
+    private function screenVision(VisionResponse $vision, array $guardrails): VisionResponse
     {
         $screened = $vision->description;
-        foreach ($this->guardrails as $guardrail) {
+        foreach ($guardrails as $guardrail) {
             $result  = $guardrail->checkOutput(new CompletionResponse($screened, $vision->model, $vision->usage, provider: $vision->provider));
             $verdict = $result->verdict;
             if ($verdict === GuardrailVerdict::RETRY) {
@@ -125,21 +138,23 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 
     /**
      * @param callable(ProviderCallContext): mixed $next
+     * @param list<GuardrailInterface>             $guardrails the config-filtered output guardrails
      */
     private function screen(
         CompletionResponse $response,
         ProviderCallContext $context,
         callable $next,
         bool $retried,
+        array $guardrails,
     ): CompletionResponse {
-        foreach ($this->guardrails as $guardrail) {
+        foreach ($guardrails as $guardrail) {
             $result  = $guardrail->checkOutput($response);
             $verdict = $result->verdict;
 
             // RETRY short-circuits the loop (it re-runs the pipeline and re-screens
             // the fresh response from scratch), so it is handled before the match.
             if ($verdict === GuardrailVerdict::RETRY) {
-                return $this->retryOnce($response, $context, $next, $retried, $guardrail, $result);
+                return $this->retryOnce($response, $context, $next, $retried, $guardrail, $result, $guardrails);
             }
 
             // match (no default) is exhaustive over the remaining verdicts: a new
@@ -168,6 +183,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 
     /**
      * @param callable(ProviderCallContext): mixed $next
+     * @param list<GuardrailInterface>             $guardrails the config-filtered output guardrails
      */
     private function retryOnce(
         CompletionResponse $response,
@@ -176,6 +192,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         bool $retried,
         GuardrailInterface $guardrail,
         GuardrailResult $result,
+        array $guardrails,
     ): CompletionResponse {
         if ($retried) {
             throw new GuardrailViolationException(
@@ -193,7 +210,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             return $response;
         }
 
-        return $this->screen($fresh, $context, $next, true);
+        return $this->screen($fresh, $context, $next, true, $guardrails);
     }
 
     private function withContent(CompletionResponse $response, string $content, ?string $thinking): CompletionResponse

--- a/Classes/Service/Guardrail/GuardrailIdentity.php
+++ b/Classes/Service/Guardrail/GuardrailIdentity.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+/**
+ * Stable identity and policy classification shared by both guardrail sides
+ * (ADR-106).
+ *
+ * A per-configuration guardrail policy references a guardrail by a stable
+ * identifier — NOT its FQCN — and that identifier is SHARED across the input and
+ * output sides: the input and output secret-redaction classes report the same
+ * ``secret-redaction`` identifier, so a configuration governs the concept, not a
+ * single class.
+ *
+ * {@see self::isMandatory()} is the per-class AUTHORING signal. The
+ * authoritative, security-load-bearing verdict is computed PER IDENTIFIER by
+ * {@see GuardrailRegistry}, which fails closed on cross-side disagreement — the
+ * {@see GuardrailPolicyResolver} reads the registry's identifier-level verdict,
+ * never a raw per-instance flag, so no selection can drop a mandatory guardrail
+ * on any axis.
+ */
+interface GuardrailIdentity
+{
+    /**
+     * A stable kebab-case slug, unique per logical guardrail and shared across
+     * the input and output sides (e.g. ``secret-redaction``). It is API: a
+     * rename silently drops the guardrail for configurations that stored the old
+     * value, so identifiers are immutable (introduce a new guardrail instead).
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * Whether this guardrail is security-critical and always-on (true, e.g.
+     * secret redaction) or a selectable policy/advisory guardrail (false). A
+     * conscious, PHPStan-checked decision every implementer must declare; a
+     * configuration can never switch off a mandatory guardrail.
+     */
+    public function isMandatory(): bool;
+}

--- a/Classes/Service/Guardrail/GuardrailInterface.php
+++ b/Classes/Service/Guardrail/GuardrailInterface.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * pipeline is entered (ADR-087).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
-interface GuardrailInterface
+interface GuardrailInterface extends GuardrailIdentity
 {
     public const TAG_NAME = 'nr_llm.guardrail';
 

--- a/Classes/Service/Guardrail/GuardrailPolicyResolver.php
+++ b/Classes/Service/Guardrail/GuardrailPolicyResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Traversable;
+
+/**
+ * Narrows a guardrail collection to what a configuration permits (ADR-106) —
+ * the single filter used by the output, input and streaming application points,
+ * so all three honour the same policy and the same mandatory floor.
+ *
+ * The rule, once: DROP a guardrail only if the configuration has a NON-empty
+ * selection AND the guardrail's identifier is not registry-mandatory AND the
+ * identifier is not in the selection. Consequences: a null configuration or an
+ * empty selection means "no restriction" (all run, unchanged from before this
+ * feature); a mandatory guardrail is kept unconditionally against ANY selection
+ * value; an unknown selected id is ignored.
+ */
+final readonly class GuardrailPolicyResolver
+{
+    public function __construct(
+        private GuardrailRegistry $registry,
+    ) {}
+
+    /**
+     * @template T of GuardrailIdentity
+     *
+     * @param iterable<T> $guardrails
+     *
+     * @return list<T>
+     */
+    public function filter(iterable $guardrails, ?LlmConfiguration $configuration): array
+    {
+        $all = $guardrails instanceof Traversable ? iterator_to_array($guardrails, false) : array_values($guardrails);
+
+        if ($configuration === null) {
+            return $all;
+        }
+
+        $selection = $configuration->getAllowedGuardrailsList();
+        if ($selection === []) {
+            return $all;
+        }
+
+        // The KEEP predicate's first term is the registry's identifier-level
+        // verdict, so no selection value — empty, partial, hostile, unknown, or
+        // all-unknown — can drop a mandatory guardrail on any axis.
+        return array_values(array_filter(
+            $all,
+            fn(GuardrailIdentity $guardrail): bool => $this->registry->isMandatoryIdentifier($guardrail->getIdentifier())
+                || in_array($guardrail->getIdentifier(), $selection, true),
+        ));
+    }
+}

--- a/Classes/Service/Guardrail/GuardrailRegistry.php
+++ b/Classes/Service/Guardrail/GuardrailRegistry.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Guardrail;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Traversable;
+
+/**
+ * The identifier-level authority on guardrail policy (ADR-106).
+ *
+ * Collects both tagged guardrail iterators, and for each logical identifier
+ * (shared across the input and output sides) computes the canonical
+ * mandatory-ness verdict the {@see GuardrailPolicyResolver} consumes. It fails
+ * closed: if one side declares an identifier mandatory and another declares it
+ * optional, the build throws — a copy-paste error that flips one secret-redaction
+ * class to optional fails the container rather than shipping a one-sided leak.
+ *
+ * Public because the TCA itemsProcFunc reaches it via GeneralUtility::makeInstance
+ * to list the selectable (optional-only) guardrails.
+ */
+final class GuardrailRegistry
+{
+    /** @var array<string, bool>|null identifier => true (mandatory); memoised */
+    private ?array $mandatory = null;
+
+    /** @var list<string>|null optional-only identifiers, sorted; memoised */
+    private ?array $selectable = null;
+
+    /**
+     * @param iterable<GuardrailInterface>      $outputGuardrails
+     * @param iterable<InputGuardrailInterface> $inputGuardrails
+     */
+    public function __construct(
+        #[AutowireIterator(GuardrailInterface::TAG_NAME)]
+        private readonly iterable $outputGuardrails,
+        #[AutowireIterator(InputGuardrailInterface::TAG_NAME)]
+        private readonly iterable $inputGuardrails,
+    ) {}
+
+    /**
+     * The authoritative per-identifier verdict. True for a mandatory guardrail
+     * that no configuration may disable.
+     */
+    public function isMandatoryIdentifier(string $identifier): bool
+    {
+        $this->build();
+
+        return isset($this->mandatory[$identifier]);
+    }
+
+    /**
+     * The optional-only identifiers, deduplicated and sorted — the source for
+     * the per-configuration selection picker. A mandatory identifier is never
+     * listed (it cannot be un-selected, so offering it would mislead).
+     *
+     * @return list<string>
+     */
+    public function selectableIdentifiers(): array
+    {
+        $this->build();
+
+        return $this->selectable ?? [];
+    }
+
+    private function build(): void
+    {
+        if ($this->mandatory !== null) {
+            return;
+        }
+
+        /** @var array<string, array{hasMandatory: bool, hasOptional: bool}> $flags */
+        $flags = [];
+        foreach ([$this->toList($this->outputGuardrails), $this->toList($this->inputGuardrails)] as $set) {
+            foreach ($set as $guardrail) {
+                $id           = $guardrail->getIdentifier();
+                $flags[$id] ??= ['hasMandatory' => false, 'hasOptional' => false];
+                if ($guardrail->isMandatory()) {
+                    $flags[$id]['hasMandatory'] = true;
+                } else {
+                    $flags[$id]['hasOptional'] = true;
+                }
+            }
+        }
+
+        $mandatory  = [];
+        $selectable = [];
+        foreach ($flags as $id => $flag) {
+            if ($flag['hasMandatory'] && $flag['hasOptional']) {
+                // Fail closed: a mixed-mandatory identifier must never ship — it
+                // would let a config disable one side of a security guardrail.
+                throw new LogicException(sprintf(
+                    'Guardrail identifier "%s" is declared mandatory on one side and optional on another. '
+                    . 'Mandatory-ness is a property of the identifier; set isMandatory() consistently on every '
+                    . 'class sharing this slug.',
+                    $id,
+                ), 1752000000);
+            }
+            if ($flag['hasMandatory']) {
+                $mandatory[$id] = true;
+            } else {
+                $selectable[] = $id;
+            }
+        }
+        sort($selectable);
+
+        $this->mandatory  = $mandatory;
+        $this->selectable = $selectable;
+    }
+
+    /**
+     * @template T of GuardrailIdentity
+     *
+     * @param iterable<T> $guardrails
+     *
+     * @return list<T>
+     */
+    private function toList(iterable $guardrails): array
+    {
+        return $guardrails instanceof Traversable ? iterator_to_array($guardrails, false) : array_values($guardrails);
+    }
+}

--- a/Classes/Service/Guardrail/InputGuardrailInterface.php
+++ b/Classes/Service/Guardrail/InputGuardrailInterface.php
@@ -30,7 +30,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * before a provider call and is ignored.
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
-interface InputGuardrailInterface
+interface InputGuardrailInterface extends GuardrailIdentity
 {
     public const TAG_NAME = 'nr_llm.input_guardrail';
 

--- a/Classes/Service/Guardrail/InputGuardrailScreener.php
+++ b/Classes/Service/Guardrail/InputGuardrailScreener.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Guardrail;
 
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
@@ -41,6 +42,10 @@ final readonly class InputGuardrailScreener
     public function __construct(
         #[AutowireIterator(InputGuardrailInterface::TAG_NAME)]
         private iterable $guardrails,
+        // Autowired in production; the no-op default keeps the lean test wiring
+        // and the LlmServiceManager fallback screener working (a null/empty
+        // selection runs all guardrails, unchanged from before ADR-106).
+        private GuardrailPolicyResolver $policyResolver = new GuardrailPolicyResolver(new GuardrailRegistry([], [])),
     ) {}
 
     /**
@@ -48,11 +53,17 @@ final readonly class InputGuardrailScreener
      *
      * @return list<ChatMessage|array<string, mixed>>
      */
-    public function screen(array $messages): array
+    public function screen(array $messages, ?LlmConfiguration $configuration = null): array
     {
+        // Filter to the configuration's policy ONCE per call (ADR-106) and
+        // thread the pre-filtered list down — not per message, which would
+        // rebuild it O(messages) times. A null configuration or empty selection
+        // runs all guardrails; the mandatory floor is preserved regardless.
+        $guardrails = $this->policyResolver->filter($this->guardrails, $configuration);
+
         $screened = [];
         foreach ($messages as $message) {
-            $screened[] = $this->screenMessage($message);
+            $screened[] = $this->screenMessage($message, $guardrails);
         }
 
         return $screened;
@@ -66,28 +77,29 @@ final readonly class InputGuardrailScreener
      * rewrites the returned text, a DENY / REQUIRE_APPROVAL throws the typed
      * exception.
      */
-    public function screenText(string $text): string
+    public function screenText(string $text, ?LlmConfiguration $configuration = null): string
     {
         if ($text === '') {
             return $text;
         }
 
-        return $this->screenContent($text);
+        return $this->screenContent($text, $this->policyResolver->filter($this->guardrails, $configuration));
     }
 
     /**
      * @param ChatMessage|array<string, mixed> $message
+     * @param list<InputGuardrailInterface>    $guardrails the config-filtered input guardrails
      *
      * @return ChatMessage|array<string, mixed>
      */
-    private function screenMessage(ChatMessage|array $message): ChatMessage|array
+    private function screenMessage(ChatMessage|array $message, array $guardrails): ChatMessage|array
     {
         $content = $this->contentOf($message);
         if ($content === '') {
             return $message;
         }
 
-        $redacted = $this->screenContent($content);
+        $redacted = $this->screenContent($content, $guardrails);
         if ($redacted === $content) {
             return $message;
         }
@@ -96,14 +108,16 @@ final readonly class InputGuardrailScreener
     }
 
     /**
-     * Run every input guardrail over one content string and return the
+     * Run the given input guardrails over one content string and return the
      * possibly-redacted result. Shared by {@see screenMessage()} (chat path) and
      * {@see screenText()} (specialized path) so both apply identical verdicts.
+     *
+     * @param list<InputGuardrailInterface> $guardrails the config-filtered input guardrails
      */
-    private function screenContent(string $content): string
+    private function screenContent(string $content, array $guardrails): string
     {
         $redacted = $content;
-        foreach ($this->guardrails as $guardrail) {
+        foreach ($guardrails as $guardrail) {
             $result = $guardrail->checkInput($redacted);
             // match (no default) is exhaustive over GuardrailVerdict: adding a new
             // verdict without handling it here is a compile-time PHPStan error and

--- a/Classes/Service/Guardrail/ProviderContentFilterGuardrail.php
+++ b/Classes/Service/Guardrail/ProviderContentFilterGuardrail.php
@@ -24,6 +24,19 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
  */
 final readonly class ProviderContentFilterGuardrail implements GuardrailInterface
 {
+    public function getIdentifier(): string
+    {
+        return 'provider-content-filter';
+    }
+
+    // Optional (ADR-106): this enforces the provider's own policy block
+    // (finishReason=content_filter -> DENY), not secret leakage, so a
+    // configuration may select it out. Secret redaction stays mandatory.
+    public function isMandatory(): bool
+    {
+        return false;
+    }
+
     public function checkOutput(CompletionResponse $response): GuardrailResult
     {
         if ($response->wasFiltered()) {

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -26,6 +26,18 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 final readonly class SecretRedactionGuardrail implements GuardrailInterface, StreamRedactableInterface
 {
     use RedactsSecretsTrait;
+    public function getIdentifier(): string
+    {
+        return 'secret-redaction';
+    }
+
+    // Security-critical: no configuration may switch off secret redaction
+    // (ADR-106). The input twin must agree — GuardrailRegistry fails closed if
+    // they disagree.
+    public function isMandatory(): bool
+    {
+        return true;
+    }
 
     public function checkOutput(CompletionResponse $response): GuardrailResult
     {

--- a/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
@@ -25,6 +25,18 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 final readonly class SecretRedactionInputGuardrail implements InputGuardrailInterface
 {
     use RedactsSecretsTrait;
+    public function getIdentifier(): string
+    {
+        return 'secret-redaction';
+    }
+
+    // Security-critical and shares the output side's identifier: a per-config
+    // policy governs the concept, not one class, and can never disable it
+    // (ADR-106).
+    public function isMandatory(): bool
+    {
+        return true;
+    }
 
     public function checkInput(string $text): GuardrailResult
     {

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -23,6 +23,8 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailPolicyResolver;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
 use Netresearch\NrLlm\Service\Guardrail\StreamRedactableInterface;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
@@ -103,15 +105,15 @@ final readonly class StreamingDispatcher
      */
     private const MAX_GUARDRAIL_BUFFER_BYTES = 50000;
 
-    /** @var list<GuardrailInterface> */
-    private array $guardrails;
-
     /**
-     * The subset of guardrails that opt into live-stream redaction (ADR-088).
+     * The unfiltered baseline (ADR-106): the per-call filtered live-redactor and
+     * audit lists are derived as locals in {@see self::drain()} so nothing is
+     * written back to instance state — a second stream() in the same request
+     * cannot see a stale narrower filter.
      *
-     * @var list<GuardrailInterface&StreamRedactableInterface>
+     * @var list<GuardrailInterface>
      */
-    private array $streamRedactors;
+    private array $guardrails;
 
     /**
      * @param iterable<GuardrailInterface> $guardrails
@@ -124,17 +126,16 @@ final readonly class StreamingDispatcher
         private LoggerInterface $logger,
         private Context $context,
         private ExtensionConfiguration $extensionConfiguration,
+        // Autowired in production; the no-op default keeps the lean test wiring
+        // working (a null/empty selection runs all guardrails, unchanged from
+        // before ADR-106).
+        private GuardrailPolicyResolver $policyResolver = new GuardrailPolicyResolver(new GuardrailRegistry([], [])),
         #[AutowireIterator(GuardrailInterface::TAG_NAME)]
         iterable $guardrails = [],
     ) {
-        // Materialise once: the full set is walked for the end-of-stream audit;
-        // only the redaction-capable subset drives the live holdback path, so a
-        // policy-only (DENY) guardrail adds no streaming buffer or latency.
-        $this->guardrails      = array_values($guardrails instanceof Traversable ? iterator_to_array($guardrails) : $guardrails);
-        $this->streamRedactors = array_values(array_filter(
-            $this->guardrails,
-            static fn(GuardrailInterface $g): bool => $g instanceof StreamRedactableInterface,
-        ));
+        // Materialise the unfiltered baseline once; drain() derives the per-call
+        // live-redactor and audit lists from it via the policy resolver (ADR-106).
+        $this->guardrails = array_values($guardrails instanceof Traversable ? iterator_to_array($guardrails) : $guardrails);
     }
 
     /**
@@ -177,14 +178,23 @@ final readonly class StreamingDispatcher
         $firstTokenNs    = null;
         $completionBytes = 0;
         $completion      = '';
-        $redacts         = $this->streamRedactors !== [];
+        // Live redactors keyed on the REQUESTED config (the window must exist
+        // before openWithFallback picks $served). They are always mandatory
+        // (secret-redaction is the sole StreamRedactableInterface), so the
+        // per-config filter never drops one and the requested-vs-served
+        // distinction is moot for them (ADR-106).
+        $streamRedactors = array_values(array_filter(
+            $this->policyResolver->filter($this->guardrails, $configuration),
+            static fn(GuardrailInterface $g): bool => $g instanceof StreamRedactableInterface,
+        ));
+        $redacts         = $streamRedactors !== [];
         // Live redaction (ADR-088): a bounded, self-certifying sliding window that
         // masks secrets — including one split across chunk boundaries or positioned
         // arbitrarily far into a long stream — with bounded memory and no O(n^2)
         // rescan, and never passes a raw secret byte through. null when no
         // redaction-capable guardrail is registered (verbatim pass-through).
         $window          = $redacts
-            ? new StreamRedactionWindow(fn(string $s): string => $this->redactStream($s))
+            ? new StreamRedactionWindow(fn(string $s): string => $this->redactStream($streamRedactors, $s))
             : null;
         $served          = $configuration;
         $success         = false;
@@ -226,7 +236,11 @@ final readonly class StreamingDispatcher
             }
 
             $success = true;
-            $this->screenStreamedOutput($context, $served, $completion);
+            // End-of-stream audit keyed on the SERVED config (that produced the
+            // content), filtered per stream (ADR-106): a fallback swap can change
+            // which optional audit guardrails apply.
+            $auditGuardrails = $this->policyResolver->filter($this->guardrails, $served);
+            $this->screenStreamedOutput($context, $served, $completion, $auditGuardrails);
         } catch (Throwable $e) {
             $errorClass = $e::class;
 
@@ -438,10 +452,14 @@ final readonly class StreamingDispatcher
      * this never throws (a broken guardrail must not turn a delivered response
      * into an error).
      */
+    /**
+     * @param list<GuardrailInterface> $guardrails the config-filtered audit guardrails
+     */
     private function screenStreamedOutput(
         ProviderCallContext $context,
         LlmConfiguration $served,
         string $completion,
+        array $guardrails,
     ): void {
         if ($completion === '') {
             return;
@@ -454,7 +472,7 @@ final readonly class StreamingDispatcher
                 usage: UsageStatistics::fromTokens(0, 0),
             );
 
-            foreach ($this->guardrails as $guardrail) {
+            foreach ($guardrails as $guardrail) {
                 $verdict = $guardrail->checkOutput($response);
                 if ($verdict->verdict === GuardrailVerdict::ALLOW) {
                     continue;
@@ -496,9 +514,12 @@ final readonly class StreamingDispatcher
      * guardrail that throws leaves the fragment unchanged rather than breaking the
      * stream.
      */
-    private function redactStream(string $text): string
+    /**
+     * @param list<GuardrailInterface&StreamRedactableInterface> $redactors the config-filtered live redactors
+     */
+    private function redactStream(array $redactors, string $text): string
     {
-        foreach ($this->streamRedactors as $guardrail) {
+        foreach ($redactors as $guardrail) {
             try {
                 $verdict = $guardrail->checkOutput(new CompletionResponse($text, '', UsageStatistics::fromTokens(0, 0)));
             } catch (Throwable) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -319,6 +319,11 @@ services:
   Netresearch\NrLlm\Service\Tool\ToolRegistry:
     public: true
 
+  # Public so the TCA itemsProcFunc (GuardrailItems) can list the selectable
+  # guardrails via GeneralUtility::makeInstance (ADR-106).
+  Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry:
+    public: true
+
   Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface:
     alias: Netresearch\NrLlm\Service\Tool\ToolAvailabilityService
 

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Form\Tca\GuardrailItems;
 use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
 
 return [
@@ -47,6 +48,7 @@ return [
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.access,
                     allowed_groups,
                     allowed_tool_groups,
+                    allowed_guardrails,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     --palette--;;status
@@ -403,6 +405,16 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectCheckBox',
                 'itemsProcFunc' => ToolGroupItems::class . '->addItems',
+                'default' => '',
+            ],
+        ],
+        'allowed_guardrails' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.allowed_guardrails',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.allowed_guardrails.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'itemsProcFunc' => GuardrailItems::class . '->addItems',
                 'default' => '',
             ],
         ],

--- a/Documentation/Adr/Adr101AgentRuntime.rst
+++ b/Documentation/Adr/Adr101AgentRuntime.rst
@@ -121,8 +121,10 @@ Consequences
 ============
 
 - ``AgentRuntimeInterface`` is a **public DI alias** (Category B), raising the
-  audited public-service count from 34 to **35**. This ADR supersedes ADR-094
-  as the count authority. It is a *consumer* interface: call it, do not
+  audited public-service count from 34 to **35** (later raised to **36** by
+  :ref:`ADR-106 <adr-106>`, which makes ``GuardrailRegistry`` public for its TCA
+  itemsProcFunc). This ADR supersedes ADR-094 as the count authority. It is a
+  *consumer* interface: call it, do not
   implement or decorate it outside nr_llm — methods and ``AgentRunOutcome``
   cases may be added in minor releases (the queue epic will), so exhaustive
   matches need a default arm. ``ToolLoopServiceInterface`` stays public for

--- a/Documentation/Adr/Adr106PerConfigurationGuardrailPolicy.rst
+++ b/Documentation/Adr/Adr106PerConfigurationGuardrailPolicy.rst
@@ -1,0 +1,115 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-106:
+
+============================================================================
+ADR-106: Per-configuration guardrail policies
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-22
+:Authors: Netresearch DTT GmbH
+
+.. _adr-106-context:
+
+Context
+=======
+
+Guardrails (:ref:`ADR-085 <adr-085>` output, :ref:`ADR-087 <adr-087>` input,
+:ref:`ADR-088 <adr-088>` streaming) are applied GLOBALLY: every tagged guardrail
+runs on every provider response. Different use-cases need different policies — a
+public-facing configuration wants the provider content filter, an internal
+tooling configuration may not — but there was no way to vary the set per
+configuration. The P1 roadmap asks for exactly that, without ever letting a
+configuration weaken the security-critical guardrails.
+
+.. _adr-106-decision:
+
+Decision
+========
+
+A configuration selects which OPTIONAL guardrails apply; MANDATORY guardrails
+(secret redaction) always run and are never selectable.
+
+- **Identity + classification.** A shared ``GuardrailIdentity`` interface (parent
+  of both ``GuardrailInterface`` and ``InputGuardrailInterface``) adds
+  ``getIdentifier()`` (a stable slug, SHARED across the input and output sides —
+  the two secret-redaction classes report the same ``secret-redaction``) and
+  ``isMandatory()`` (the per-class authoring signal). An abstract method, not a
+  marker, so every implementer makes a PHPStan-checked conscious choice — a
+  forgotten marker would default insecure.
+- **Identifier-level authority, fail-closed.** ``GuardrailRegistry`` collects
+  both tagged iterators and computes mandatory-ness PER IDENTIFIER. Any side
+  mandatory ⇒ the identifier is mandatory; a cross-side disagreement (mandatory
+  on one side, optional on the other) THROWS at build — a copy-paste error that
+  flips one secret-redaction class to optional fails the container rather than
+  shipping a one-sided leak. The ``GuardrailPolicyResolver`` reads the
+  registry's verdict, never a raw per-instance flag.
+- **The filter.** ``GuardrailPolicyResolver::filter()`` drops a guardrail only
+  when the configuration has a NON-EMPTY selection AND the identifier is not
+  registry-mandatory AND not in the selection. A null configuration or an empty
+  selection runs everything (unchanged from before this ADR); a mandatory
+  guardrail is kept against ANY selection value (empty, partial, unknown, or
+  all-unknown). One filter, applied at all three points: ``GuardrailMiddleware``
+  (output), ``InputGuardrailScreener`` (input), ``StreamingDispatcher`` (live
+  redaction + end-of-stream audit) — each reading the configuration already in
+  scope (``ProviderCallContext`` / the streamed configuration), no re-plumbing.
+- **Storage.** A ``allowed_guardrails`` CSV column on ``tx_nrllm_configuration``
+  (mirroring ``allowed_tool_groups``) with a ``selectCheckBox`` TCA field whose
+  items are DISCOVERED from ``GuardrailRegistry::selectableIdentifiers()``
+  (optional-only; mandatory guardrails are never listed). The migration is
+  additive, defaulted ``NOT NULL DEFAULT ''`` — existing rows read ``''`` = run
+  all, byte-identical to today.
+
+.. _adr-106-fail-closed:
+
+Fail-closed rules
+=================
+
+- A degenerate/empty schema of selectable ids never means "run nothing": the
+  mandatory floor is kept unconditionally, and an all-unknown selection keeps
+  exactly the mandatory set.
+- A guardrail identifier is IMMUTABLE API — a rename silently drops the
+  guardrail for configurations that stored the old value (the mandatory floor is
+  unaffected; opted-in optional protections would silently stop). Introduce a
+  new guardrail instead; a genuine rename requires an Install Tool
+  ``UpgradeWizard`` that rewrites stored ``allowed_guardrails`` CSVs.
+
+.. _adr-106-consequences:
+
+Consequences
+============
+
+- **BREAKING API change.** ``GuardrailInterface`` / ``InputGuardrailInterface``
+  are documented public extension points (the ``nr_llm.guardrail`` /
+  ``nr_llm.input_guardrail`` tags). Adding ``getIdentifier()`` + ``isMandatory()``
+  fatals an out-of-tree implementer at container compile. See *Upgrading*.
+- ``GuardrailRegistry`` is public (Category E, for the TCA itemsProcFunc),
+  raising the audited public-service count 35 → **36** (Adr101 remains the count
+  authority and is updated in the same change).
+- **Content filter is optional.** ``provider-content-filter`` enforces the
+  provider's own policy block (``finishReason=content_filter`` → DENY), not
+  secret leakage, so a configuration may select it out; secret redaction stays
+  mandatory. Flip its ``isMandatory()`` to ``true`` if a deployment treats
+  suppressing a provider safety block as a security concern — the registry then
+  makes the identifier mandatory and drops it from the picker automatically.
+- **Input axis is inert today.** The only input guardrail is the mandatory
+  secret redaction, so per-config input filtering changes nothing yet. The
+  ``InputGuardrailScreener`` accepts the configuration and applies the same
+  filter; ``LlmServiceManager`` passes no configuration for now. When an
+  OPTIONAL input guardrail is added, thread the configuration at the
+  config-bound entrypoints (a localised follow-up).
+- **Eval unaffected.** ``allowed_guardrails`` is a new column defaulting ``''``,
+  so every existing configuration (including eval targets) runs all guardrails
+  exactly as before.
+
+.. _adr-106-upgrading:
+
+Upgrading
+=========
+
+A third-party guardrail implementing ``GuardrailInterface`` or
+``InputGuardrailInterface`` must add ``getIdentifier()`` (a stable kebab-case
+slug) and ``isMandatory()`` (``true`` only for a security-critical always-on
+guardrail). Input and output classes sharing a concept MUST return the same
+identifier and the same ``isMandatory()`` value, or the container fails closed.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -403,3 +403,4 @@ Tools
    Adr103CooperativeCancellation
    Adr104StaleRunReaperAndRetry
    Adr105TypedInputSuspension
+   Adr106PerConfigurationGuardrailPolicy

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -293,6 +293,14 @@
                 <source>Restrict agent runs with this configuration to tools of the selected groups. Empty = all groups allowed. Globally disabled tools or groups stay disabled regardless.</source>
                 <target>Beschränkt Agent-Läufe mit dieser Konfiguration auf Werkzeuge der gewählten Gruppen. Leer = alle Gruppen erlaubt. Global deaktivierte Werkzeuge oder Gruppen bleiben unabhängig davon deaktiviert.</target>
             </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_guardrails">
+                <source>Optional guardrails</source>
+                <target>Optionale Schutzmechanismen</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_guardrails.description">
+                <source>Which optional guardrails apply to runs with this configuration. Empty = all apply. Security-critical guardrails (secret redaction) always run and are not listed here.</source>
+                <target>Welche optionalen Schutzmechanismen für Läufe mit dieser Konfiguration gelten. Leer = alle aktiv. Sicherheitskritische Schutzmechanismen (Schwärzung von Geheimnissen) laufen immer und werden hier nicht aufgeführt.</target>
+            </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -228,6 +228,12 @@
             <trans-unit id="tx_nrllm_configuration.allowed_tool_groups.description">
                 <source>Restrict agent runs with this configuration to tools of the selected groups. Empty = all groups allowed. Globally disabled tools or groups stay disabled regardless.</source>
             </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_guardrails">
+                <source>Optional guardrails</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.allowed_guardrails.description">
+                <source>Which optional guardrails apply to runs with this configuration. Empty = all apply. Security-critical guardrails (secret redaction) always run and are not listed here.</source>
+            </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>

--- a/Tests/Fixture/DenyingInputGuardrail.php
+++ b/Tests/Fixture/DenyingInputGuardrail.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
  */
 final readonly class DenyingInputGuardrail implements InputGuardrailInterface
 {
+    use GuardrailIdentityDoubleTrait;
+
     public function __construct(private string $reason = 'denied by policy') {}
 
     public function checkInput(string $text): GuardrailResult

--- a/Tests/Fixture/GuardrailIdentityDoubleTrait.php
+++ b/Tests/Fixture/GuardrailIdentityDoubleTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixture;
+
+/**
+ * Default {@see \Netresearch\NrLlm\Service\Guardrail\GuardrailIdentity} members
+ * for guardrail test doubles (ADR-106).
+ *
+ * Most doubles exercise middleware/screener/dispatcher behaviour, not
+ * per-configuration filtering, so a generic optional identity suffices and
+ * keeps the doubles focused. A test that needs a specific identifier or a
+ * mandatory guardrail declares its own methods instead of using this trait.
+ */
+trait GuardrailIdentityDoubleTrait
+{
+    public function getIdentifier(): string
+    {
+        return 'test-guardrail';
+    }
+
+    public function isMandatory(): bool
+    {
+        return false;
+    }
+}

--- a/Tests/Fixture/RedactingInputGuardrail.php
+++ b/Tests/Fixture/RedactingInputGuardrail.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
  */
 final readonly class RedactingInputGuardrail implements InputGuardrailInterface
 {
+    use GuardrailIdentityDoubleTrait;
+
     public function __construct(
         private string $needle,
         private string $replacement,

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -40,6 +40,7 @@ use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
@@ -558,6 +559,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $this->setUpBackendUser(1);
 
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('blocked by test policy');
@@ -586,6 +588,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $this->setUpBackendUser(1);
 
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::requireApproval('needs a human');
@@ -612,6 +615,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $this->setUpBackendUser(1);
 
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('blocked by test policy');

--- a/Tests/Functional/Service/Guardrail/GuardrailContainerFloorTest.php
+++ b/Tests/Functional/Service/Guardrail/GuardrailContainerFloorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Guardrail;
+
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The real-DI mandatory floor (ADR-106): resolves the GuardrailRegistry from the
+ * container — built over the actual tagged guardrail iterators — and asserts the
+ * secret-redaction floor is present and mandatory.
+ *
+ * This is the load-bearing guard against a Services.yaml regression or an
+ * #[AutoconfigureTag] typo silently dropping a security guardrail from the
+ * collection while every isolated unit test (which uses doubles) stays green.
+ */
+#[CoversClass(GuardrailRegistry::class)]
+final class GuardrailContainerFloorTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function secretRedactionIsAMandatoryFloorInTheRealContainer(): void
+    {
+        $registry = $this->get(GuardrailRegistry::class);
+        self::assertInstanceOf(GuardrailRegistry::class, $registry);
+
+        // Building over the real tagged iterators must not throw (no cross-side
+        // mandatory disagreement) and must classify secret-redaction mandatory
+        // on both axes — so no configuration can ever disable it.
+        self::assertTrue($registry->isMandatoryIdentifier('secret-redaction'));
+
+        // A mandatory guardrail is never offered as a selectable (un-checkable) box.
+        self::assertNotContains('secret-redaction', $registry->selectableIdentifiers());
+
+        // The shipped optional guardrail is discoverable and selectable.
+        self::assertContains('provider-content-filter', $registry->selectableIdentifiers());
+    }
+}

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -79,7 +79,7 @@ final class PublicServicesPolicyTest extends TestCase
      * authority, superseding ADR-094's count) in the same PR — the diff is
      * the audit trail.
      */
-    private const EXPECTED_PUBLIC_TRUE_COUNT = 35;
+    private const EXPECTED_PUBLIC_TRUE_COUNT = 36;
 
     private const SERVICES_YAML_PATH = __DIR__ . '/../../../Configuration/Services.yaml';
 

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -45,6 +46,7 @@ final class GuardrailMiddlewareTest extends TestCase
             $this->guardrail(GuardrailResult::redact('[redacted]', 'secret')),
             // A second guardrail sees the redacted content and allows it.
             new class implements GuardrailInterface {
+                use GuardrailIdentityDoubleTrait;
                 public function checkOutput(CompletionResponse $response): GuardrailResult
                 {
                     return $response->content === '[redacted]'
@@ -117,6 +119,7 @@ final class GuardrailMiddlewareTest extends TestCase
         };
         // Retry while the content is 'first'; allow the fresh 'second'.
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return $response->content === 'first'
@@ -201,6 +204,24 @@ final class GuardrailMiddlewareTest extends TestCase
         $this->screen($middleware, static fn(): VisionResponse => new VisionResponse('desc', 'm', UsageStatistics::fromTokens(1, 1)));
     }
 
+    #[Test]
+    public function aConfigurationSelectionSkipsAnUnselectedOptionalGuardrail(): void
+    {
+        // ADR-106: the double is an OPTIONAL guardrail (id 'test-guardrail' via
+        // the trait). A configuration whose non-empty selection does not name it
+        // filters it out — so its DENY never runs and the response passes through.
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))]);
+
+        $config = new LlmConfiguration();
+        $config->setAllowedGuardrails('some-other-guardrail');
+        $context = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config);
+
+        $result = $middleware->handle($context, fn(): CompletionResponse => $this->response('hello'));
+
+        self::assertInstanceOf(CompletionResponse::class, $result);
+        self::assertSame('hello', $result->content);
+    }
+
     /**
      * @param callable(): mixed $terminal
      */
@@ -212,6 +233,7 @@ final class GuardrailMiddlewareTest extends TestCase
     private function guardrail(GuardrailResult $result): GuardrailInterface
     {
         return new class ($result) implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function __construct(private readonly GuardrailResult $result) {}
 
             public function checkOutput(CompletionResponse $response): GuardrailResult

--- a/Tests/Unit/Service/Guardrail/ConcreteGuardrailIdentityTest.php
+++ b/Tests/Unit/Service/Guardrail/ConcreteGuardrailIdentityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Service\Guardrail\ProviderContentFilterGuardrail;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
+use Netresearch\NrLlm\Service\Guardrail\SecretRedactionInputGuardrail;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the identity + policy classification of the shipped guardrails (ADR-106):
+ * both secret-redaction sides share one mandatory identifier (so a config can
+ * never disable it on either axis), and the provider content filter is optional.
+ */
+#[CoversNothing]
+final class ConcreteGuardrailIdentityTest extends TestCase
+{
+    #[Test]
+    public function secretRedactionIsMandatoryAndSharesOneIdentifierAcrossSides(): void
+    {
+        $output = new SecretRedactionGuardrail();
+        $input  = new SecretRedactionInputGuardrail();
+
+        self::assertSame('secret-redaction', $output->getIdentifier());
+        self::assertSame('secret-redaction', $input->getIdentifier());
+        self::assertTrue($output->isMandatory());
+        self::assertTrue($input->isMandatory());
+    }
+
+    #[Test]
+    public function providerContentFilterIsOptional(): void
+    {
+        $guardrail = new ProviderContentFilterGuardrail();
+
+        self::assertSame('provider-content-filter', $guardrail->getIdentifier());
+        self::assertFalse($guardrail->isMandatory());
+    }
+}

--- a/Tests/Unit/Service/Guardrail/GuardrailPolicyResolverTest.php
+++ b/Tests/Unit/Service/Guardrail/GuardrailPolicyResolverTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailPolicyResolver;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GuardrailPolicyResolver::class)]
+final class GuardrailPolicyResolverTest extends TestCase
+{
+    private GuardrailInterface $mandatory;
+
+    private GuardrailInterface $optional;
+
+    private GuardrailPolicyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mandatory = $this->guardrail('secret-redaction', true);
+        $this->optional  = $this->guardrail('content-filter', false);
+        $this->resolver  = new GuardrailPolicyResolver(new GuardrailRegistry([$this->mandatory, $this->optional], []));
+    }
+
+    #[Test]
+    public function aNullConfigurationRunsEveryGuardrail(): void
+    {
+        self::assertSame(
+            [$this->mandatory, $this->optional],
+            $this->resolver->filter([$this->mandatory, $this->optional], null),
+        );
+    }
+
+    #[Test]
+    public function anEmptySelectionRunsEveryGuardrail(): void
+    {
+        self::assertSame(
+            [$this->mandatory, $this->optional],
+            $this->resolver->filter([$this->mandatory, $this->optional], $this->config('')),
+        );
+    }
+
+    #[Test]
+    public function aSelectionKeepsMandatoryPlusTheSelectedOptional(): void
+    {
+        // Selecting only content-filter keeps it AND the mandatory guardrail.
+        self::assertSame(
+            [$this->mandatory, $this->optional],
+            $this->resolver->filter([$this->mandatory, $this->optional], $this->config('content-filter')),
+        );
+    }
+
+    #[Test]
+    public function aSelectionDropsUnselectedOptionalButNeverMandatory(): void
+    {
+        // Selecting an unrelated id drops the optional guardrail but the
+        // mandatory one is kept unconditionally.
+        self::assertSame(
+            [$this->mandatory],
+            $this->resolver->filter([$this->mandatory, $this->optional], $this->config('something-else')),
+        );
+    }
+
+    #[Test]
+    public function anAllUnknownSelectionKeepsOnlyMandatory(): void
+    {
+        // A stale '0' or garbage value yields a non-empty list -> filtering mode
+        // -> every optional dropped, the mandatory floor preserved (secure).
+        self::assertSame(
+            [$this->mandatory],
+            $this->resolver->filter([$this->mandatory, $this->optional], $this->config('0')),
+        );
+    }
+
+    private function config(string $allowedGuardrails): LlmConfiguration
+    {
+        $config = new LlmConfiguration();
+        $config->setAllowedGuardrails($allowedGuardrails);
+
+        return $config;
+    }
+
+    private function guardrail(string $id, bool $mandatory): GuardrailInterface
+    {
+        return new class ($id, $mandatory) implements GuardrailInterface {
+            public function __construct(private readonly string $id, private readonly bool $mandatory) {}
+
+            public function getIdentifier(): string
+            {
+                return $this->id;
+            }
+
+            public function isMandatory(): bool
+            {
+                return $this->mandatory;
+            }
+
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::allow();
+            }
+        };
+    }
+}

--- a/Tests/Unit/Service/Guardrail/GuardrailRegistryTest.php
+++ b/Tests/Unit/Service/Guardrail/GuardrailRegistryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Guardrail;
+
+use LogicException;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
+use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GuardrailRegistry::class)]
+final class GuardrailRegistryTest extends TestCase
+{
+    #[Test]
+    public function resolvesMandatoryPerIdentifierAndListsOnlyOptionalAsSelectable(): void
+    {
+        $registry = new GuardrailRegistry(
+            [$this->outputGuardrail('secret-redaction', true), $this->outputGuardrail('content-filter', false)],
+            [$this->inputGuardrail('secret-redaction', true)],
+        );
+
+        self::assertTrue($registry->isMandatoryIdentifier('secret-redaction'));
+        self::assertFalse($registry->isMandatoryIdentifier('content-filter'));
+        // Mandatory ids are never offered as selectable; the shared id is deduped.
+        self::assertSame(['content-filter'], $registry->selectableIdentifiers());
+    }
+
+    #[Test]
+    public function anyMandatorySideMakesTheIdentifierMandatory(): void
+    {
+        // Both sides agree mandatory — the identifier is mandatory and unlisted.
+        $registry = new GuardrailRegistry(
+            [$this->outputGuardrail('secret-redaction', true)],
+            [$this->inputGuardrail('secret-redaction', true)],
+        );
+
+        self::assertTrue($registry->isMandatoryIdentifier('secret-redaction'));
+        self::assertSame([], $registry->selectableIdentifiers());
+    }
+
+    #[Test]
+    public function crossSideMandatoryDisagreementFailsClosed(): void
+    {
+        // The output side says mandatory, the input twin says optional — a
+        // copy-paste error that would let a config disable one axis of a
+        // security guardrail. The build must throw rather than ship it.
+        $registry = new GuardrailRegistry(
+            [$this->outputGuardrail('secret-redaction', true)],
+            [$this->inputGuardrail('secret-redaction', false)],
+        );
+
+        $this->expectException(LogicException::class);
+        $registry->isMandatoryIdentifier('secret-redaction');
+    }
+
+    #[Test]
+    public function selectableIdentifiersAreSortedAndDeduped(): void
+    {
+        $registry = new GuardrailRegistry(
+            [$this->outputGuardrail('zeta', false), $this->outputGuardrail('alpha', false), $this->outputGuardrail('alpha', false)],
+            [],
+        );
+
+        self::assertSame(['alpha', 'zeta'], $registry->selectableIdentifiers());
+    }
+
+    private function outputGuardrail(string $id, bool $mandatory): GuardrailInterface
+    {
+        return new class ($id, $mandatory) implements GuardrailInterface {
+            public function __construct(private readonly string $id, private readonly bool $mandatory) {}
+
+            public function getIdentifier(): string
+            {
+                return $this->id;
+            }
+
+            public function isMandatory(): bool
+            {
+                return $this->mandatory;
+            }
+
+            public function checkOutput(CompletionResponse $response): GuardrailResult
+            {
+                return GuardrailResult::allow();
+            }
+        };
+    }
+
+    private function inputGuardrail(string $id, bool $mandatory): InputGuardrailInterface
+    {
+        return new class ($id, $mandatory) implements InputGuardrailInterface {
+            public function __construct(private readonly string $id, private readonly bool $mandatory) {}
+
+            public function getIdentifier(): string
+            {
+                return $this->id;
+            }
+
+            public function isMandatory(): bool
+            {
+                return $this->mandatory;
+            }
+
+            public function checkInput(string $text): GuardrailResult
+            {
+                return GuardrailResult::allow();
+            }
+        };
+    }
+}

--- a/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
+++ b/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
+use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -175,6 +176,7 @@ final class InputGuardrailScreenerTest extends TestCase
     private function allowing(): InputGuardrailInterface
     {
         return new class implements InputGuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkInput(string $text): GuardrailResult
             {
                 return GuardrailResult::allow();
@@ -185,6 +187,7 @@ final class InputGuardrailScreenerTest extends TestCase
     private function redacting(string $needle, string $replacement): InputGuardrailInterface
     {
         return new class ($needle, $replacement) implements InputGuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function __construct(private readonly string $needle, private readonly string $replacement) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -201,6 +204,7 @@ final class InputGuardrailScreenerTest extends TestCase
     private function denying(string $reason): InputGuardrailInterface
     {
         return new class ($reason) implements InputGuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function __construct(private readonly string $reason) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -213,6 +217,7 @@ final class InputGuardrailScreenerTest extends TestCase
     private function requireApproval(string $reason): InputGuardrailInterface
     {
         return new class ($reason) implements InputGuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function __construct(private readonly string $reason) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -225,6 +230,7 @@ final class InputGuardrailScreenerTest extends TestCase
     private function retrying(): InputGuardrailInterface
     {
         return new class implements InputGuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkInput(string $text): GuardrailResult
             {
                 return GuardrailResult::retry('later');

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -54,6 +54,7 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
@@ -1003,6 +1004,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     {
         return new InputGuardrailScreener([
             new class ($reason) implements InputGuardrailInterface {
+                use GuardrailIdentityDoubleTrait;
                 public function __construct(private readonly string $reason) {}
 
                 public function checkInput(string $text): GuardrailResult

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
 use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingLogger;
@@ -74,6 +75,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
     public function auditsTheAssembledStreamedResponseAgainstGuardrailsAfterDelivery(): void
     {
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return str_contains($response->content, 'sk-secret')
@@ -105,6 +107,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
     public function doesNotRecordAGuardrailAuditForACleanStream(): void
     {
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::allow();
@@ -335,6 +338,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         // A DENY guardrail is NOT StreamRedactable, so it must not pull the stream
         // onto the buffered path — chunks pass through 1:1, no re-chunking.
         $guardrail = new class implements GuardrailInterface {
+            use GuardrailIdentityDoubleTrait;
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('policy');
@@ -1006,7 +1010,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->logger,
             $this->contextWithAmbientUser(0),
             $extensionConfiguration ?? $this->extensionConfiguration(true),
-            $guardrails,
+            guardrails: $guardrails,
         );
     }
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -153,6 +153,7 @@ CREATE TABLE tx_nrllm_configuration (
 
     -- Comma list of permitted tool groups (empty = all groups allowed)
     allowed_tool_groups varchar(255) DEFAULT '' NOT NULL,
+    allowed_guardrails varchar(255) DEFAULT '' NOT NULL,
 
     -- Attached skills (MM relation to tx_nrllm_skill)
     skills int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## What

**ADR-106** (P1 #9): let each `LlmConfiguration` select which **optional** guardrails apply, while the **mandatory** ones (secret redaction) always run and can never be disabled. Until now every tagged guardrail ran globally on every provider response.

## How — security-first

- **Identity + classification** — a shared `GuardrailIdentity` parent adds `getIdentifier()` (a stable slug, **shared across the input and output sides** — the two secret-redaction classes report the same `secret-redaction`) and `isMandatory()` to both guardrail interfaces. An abstract method, not a marker, so a forgotten declaration is a compile error, not a default-insecure omission.
- **Fail-closed registry** — `GuardrailRegistry` resolves mandatory-ness **per identifier** and throws at build on a cross-side disagreement (one secret-redaction class mandatory, its twin optional) rather than shipping a one-sided leak.
- **One filter, three axes** — `GuardrailPolicyResolver::filter()` is applied at `GuardrailMiddleware` (output), `InputGuardrailScreener` (input), and `StreamingDispatcher` (live redaction + end-of-stream audit), each reading the configuration already in scope (`ProviderCallContext` / the streamed config) — no re-plumbing. It drops a guardrail only when the config has a non-empty selection **AND** the identifier is not registry-mandatory **AND** not selected. A null config or empty selection runs everything (unchanged); a mandatory guardrail is kept against **any** selection value; an all-unknown selection keeps exactly the mandatory floor.
- **Storage** mirrors `allowed_tool_groups`: an additive, defaulted `allowed_guardrails` CSV column + a `selectCheckBox` TCA field whose items are discovered from the registry (**optional-only**; mandatory guardrails never appear). Existing rows read `''` = run all, byte-identical to today.

## Product decisions (confirmed)

- `provider-content-filter` is **optional** (it enforces the provider's own policy block, not secret leakage). Secret redaction is mandatory.
- Scope is **on/off selection** only; per-guardrail mode tuning is a follow-up.
- The **input axis is inert today** (its sole guardrail is the mandatory secret redaction); the screener accepts the config and applies the same filter, and `LlmServiceManager` threads a config when an optional input guardrail lands (documented in the ADR).

## Breaking change

`GuardrailInterface` / `InputGuardrailInterface` (the public `nr_llm.guardrail` / `nr_llm.input_guardrail` extension points) gained `getIdentifier()` + `isMandatory()` via `GuardrailIdentity`. Out-of-tree guardrails must implement both, consistently across sides. See the ADR-106 *Upgrading* note. `GuardrailRegistry` is public for the TCA itemsProcFunc → audited public-service count 35 → 36 (Adr101 updated).

## Tests

Local gate green: PHP-CS-Fixer, PHPStan L10, unit (5515), functional/sqlite (1253), Rector, fuzzy (79). New: `GuardrailRegistryTest` (fail-closed cross-side disagreement, mandatory/selectable), `GuardrailPolicyResolverTest` (null/empty/selection/unknown/all-unknown → mandatory floor preserved), `ConcreteGuardrailIdentityTest`, a per-config `GuardrailMiddlewareTest` case, and a functional `GuardrailContainerFloorTest` asserting the real-DI mandatory floor.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
