### PR TITLE
ci(pages): make the landing-page workflow a pure reusable caller

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,40 +16,22 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# Zero step-level actions: build and deploy are both shared reusables, so
+# every pinned action version is maintained centrally in netresearch/.github.
+# The only repo-specific part left is the build command; the Pages base path
+# and origin arrive as PAGES_BASE_PATH / PAGES_ORIGIN from configure-pages
+# inside the build reusable, so a rename or custom domain needs no change here.
 jobs:
-  # Build stays here: it is repo-specific (uv + landingpage/build/build.py)
-  # and needs the Pages base_path/origin at build time. The deploy trio
-  # (configure-pages + upload-pages-artifact + deploy-pages) is delegated to
-  # the shared reusable below, which also hardens the deploy runner.
   build:
-    runs-on: ubuntu-latest
+    uses: netresearch/.github/.github/workflows/pages-build.yml@main
     permissions:
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Configure Pages
-        id: pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-
-      - name: Build site
-        env:
-          # Base path / origin come from the Pages config, so a rename or a
-          # custom domain needs no code change.
-          NRLLM_BASE: ${{ steps.pages.outputs.base_path }}
-          NRLLM_ORIGIN: ${{ steps.pages.outputs.origin }}
-        run: uv run landingpage/build/build.py
-
-      - name: Upload built site
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: github-pages-site
-          path: landingpage/public
-          if-no-files-found: error
+    with:
+      setup-uv: true
+      artifact-path: landingpage/public
+      build-command: >-
+        NRLLM_BASE="$PAGES_BASE_PATH" NRLLM_ORIGIN="$PAGES_ORIGIN"
+        uv run landingpage/build/build.py
 
   deploy:
     needs: build


### PR DESCRIPTION
## What

`pages.yml` becomes a **pure reusable caller** — its build job now calls the new shared [`pages-build.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/pages-build.yml) (netresearch/.github#260) instead of inlining `checkout` + `configure-pages` + `setup-uv` + `upload-artifact`.

## Why

This repo had exactly one workflow left with step-level action uses. After this change **the whole repo has zero stray actions** — every pinned action version lives centrally in `netresearch/.github`.

That also removes the source of the recurring per-repo bump PRs: **#475** (`actions/checkout`) and **#490** (`astral-sh/setup-uv`) become obsolete and should auto-close once this lands, since neither action is referenced here any more.

## Behavior preserved

- Same triggers, same `concurrency`, same output dir (`landingpage/public`).
- `NRLLM_BASE` / `NRLLM_ORIGIN` still drive the build — they are now derived from `PAGES_BASE_PATH` / `PAGES_ORIGIN`, which the reusable exports from `configure-pages`. A rename or custom domain still needs no code change.
- Artifact name (`github-pages-site`) matches `pages-deploy.yml`'s default, so build → deploy line up unchanged.
- Build job still needs only `contents: read`; the privileged Pages scopes stay on the deploy call.

## Validation
- `actionlint` clean
- Verified repo-wide: no remaining step-level `uses:` outside `netresearch/*` reusable calls.
