### PR TITLE
feat(agent): context-window management for the tool loop (ADR-107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Agent-loop context-window management (ADR-107): an optional
+  `ContextWindowManager` keeps the tool loop's growing transcript within the
+  model's context window by dropping the oldest whole tool-call turns —
+  preserving the tool-call/tool-result pairing, the leading system/task
+  messages and the newest turn — before each provider send. The token estimate
+  errs high (a content-class-aware char heuristic that counts dense JSON/tool
+  payloads more heavily, calibrated up against real usage), so it never
+  under-prunes into an overflow. When even the pruned floor exceeds the window
+  no request is sent: the run ends on the new non-retryable
+  `AgentRunTerminationReason::CONTEXT_TRUNCATED` instead of a misclassified
+  provider 4xx. Absent the collaborator (lean wiring) the loop is unchanged.
+  Streaming is out of scope.
 - Per-configuration guardrail policies (ADR-106): an `LlmConfiguration` can now
   select which OPTIONAL guardrails apply via a new `allowed_guardrails` field;
   MANDATORY guardrails (secret redaction) always run and are never selectable.

--- a/Classes/Domain/Enum/AgentRunTerminationReason.php
+++ b/Classes/Domain/Enum/AgentRunTerminationReason.php
@@ -74,6 +74,15 @@ enum AgentRunTerminationReason: string
     case NOT_RETRYABLE = 'not_retryable';
 
     /**
+     * Even after pruning the transcript to its floor (the leading system/task
+     * messages plus the most recent turn) the request still exceeds the model's
+     * context window, so no provider call was made (ADR-107). Retrying re-sends
+     * the same oversized floor and overflows again; the run stops legibly rather
+     * than eating a raw provider 4xx.
+     */
+    case CONTEXT_TRUNCATED = 'context_truncated';
+
+    /**
      * @return list<string>
      */
     public static function values(): array

--- a/Classes/Domain/ValueObject/ContextFitResult.php
+++ b/Classes/Domain/ValueObject/ContextFitResult.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * The outcome of fitting an agent-loop transcript into the model's context
+ * window (ADR-107).
+ *
+ * {@see messages} is the (possibly pruned) message list to send — always a
+ * structurally valid, tool-call/tool-result-paired transcript with the leading
+ * system/task messages and the newest turn preserved. {@see overflowAtFloor} is
+ * true when even that floor still exceeds the budget: the caller must NOT send
+ * it (a provider 4xx), and stops the run on
+ * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason::CONTEXT_TRUNCATED}.
+ */
+final readonly class ContextFitResult
+{
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    public function __construct(
+        public array $messages,
+        public bool $pruned,
+        public int $droppedTurns,
+        public int $keptTurns,
+        public int $estimatedTokens,
+        public int $budget,
+        public bool $overflowAtFloor,
+        public float $calibration,
+    ) {}
+}

--- a/Classes/Exception/ContextTruncatedException.php
+++ b/Classes/Exception/ContextTruncatedException.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use RuntimeException;
+
+/**
+ * Thrown inside the agent loop when even the pruned floor of a transcript still
+ * exceeds the model's context window (ADR-107).
+ *
+ * Control flow, not a provider failure: {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}
+ * catches it, issues NO provider call, and settles the run on
+ * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason::CONTEXT_TRUNCATED}
+ * — a legible terminal state instead of a misclassified provider 4xx. Carries
+ * the {@see ContextFitResult} for observability.
+ */
+final class ContextTruncatedException extends RuntimeException implements NrLlmExceptionInterface
+{
+    public function __construct(
+        public readonly ContextFitResult $fit,
+    ) {
+        parent::__construct(
+            sprintf(
+                'The transcript exceeds the model context window even after pruning to its floor '
+                . '(estimated %d tokens > budget %d).',
+                $fit->estimatedTokens,
+                $fit->budget,
+            ),
+            1753100001,
+        );
+    }
+
+    /**
+     * Named constructor — thrown via this factory (not `throw new`) so the fixed
+     * code lives in the constructor once rather than at each throw site.
+     */
+    public static function fromFit(ContextFitResult $fit): self
+    {
+        return new self($fit);
+    }
+}

--- a/Classes/Service/Context/ContextWindowManager.php
+++ b/Classes/Service/Context/ContextWindowManager.php
@@ -1,0 +1,321 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Context;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Keeps an agent-loop transcript within the model's context window by dropping
+ * oldest whole tool-call turns (ADR-107).
+ *
+ * Stateful per run: it seeds a conservative calibration factor and only ever
+ * grows it toward the real prompt-token counts reported by each provider call,
+ * so the estimate always errs high and never under-prunes into an overflow.
+ * The pruning is turn-atomic — an assistant tool-call message and all its
+ * tool_result replies are kept or dropped together — so the tool-call/tool-
+ * result pairing the provider requires is never broken, and the leading
+ * system/task messages and the newest turn are always preserved.
+ */
+final class ContextWindowManager implements ContextWindowManagerInterface
+{
+    /** Applied when the model's context length is unknown — never leave a run unprotected. */
+    private const UNKNOWN_WINDOW_FALLBACK = 8192;
+
+    /** The first (pre-ground-truth) send is already over-estimated by this factor. */
+    private const CALIBRATION_SEED = 1.15;
+
+    /** Fraction of the window held back on top of the response reserve. */
+    private const SAFETY_FRACTION = 0.03;
+
+    private float $calibration = self::CALIBRATION_SEED;
+
+    /** Estimate of the exact payload approved for the previous send; null before the first. */
+    private ?int $lastSentEstimate = null;
+
+    public function __construct(
+        private readonly TranscriptEstimator $estimator = new TranscriptEstimator(),
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {}
+
+    public function fit(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?ChatOptions $options,
+        ?UsageStatistics $lastUsage,
+        array $toolSpecs = [],
+    ): ContextFitResult {
+        // A null $lastUsage marks the first send of a run's loop. Reset the
+        // per-run calibration state here so a single shared manager instance
+        // (ToolLoopService is a shared service) never carries one run's
+        // calibration into the next.
+        if ($lastUsage === null) {
+            $this->calibration      = self::CALIBRATION_SEED;
+            $this->lastSentEstimate = null;
+        }
+
+        $ctx = $configuration->getLlmModel()?->getContextLength() ?? 0;
+        if ($ctx <= 0) {
+            $ctx = self::UNKNOWN_WINDOW_FALLBACK;
+        }
+
+        $this->recalibrate($lastUsage);
+
+        $budget = $ctx - $this->reserve($options, $configuration, $ctx) - (int)ceil($ctx * self::SAFETY_FRACTION);
+        if ($budget <= 0) {
+            // Misconfiguration (reserve larger than window): defer to the provider.
+            $this->logger->warning('ContextWindow: non-positive budget, deferring to provider', ['contextLength' => $ctx]);
+
+            return $this->passthrough($messages);
+        }
+
+        // The system prompt is prepended by MessageShaper AFTER fit() on the
+        // public path (ADR-093), so when the transcript has no leading system
+        // message its size must still be counted against the wire.
+        $systemPromptTokens = $this->missingSystemPromptTokens($messages, $configuration);
+        $estimate           = fn(array $msgs): int => $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $systemPromptTokens;
+
+        [$head, $turns] = $this->partition($messages);
+
+        if ($estimate($messages) <= $budget) {
+            $result = $this->passthrough($messages, $estimate($messages), $budget);
+        } else {
+            $result = $this->drop($head, $turns, $budget, $estimate);
+        }
+
+        // Never emit a known-orphaned request: if pruning somehow produced a
+        // broken pairing, defer to the provider rather than send a 4xx.
+        if (!$this->isPairingValid($result->messages)) {
+            $this->logger->warning('ContextWindow: pruned array failed the pairing guard, deferring to provider');
+
+            return $this->passthrough($messages);
+        }
+
+        // Remember what we approved so the next recalibrate() divides real usage
+        // against THIS estimate, not the (grown) next transcript.
+        $this->lastSentEstimate = $result->estimatedTokens;
+
+        return $result;
+    }
+
+    private function recalibrate(?UsageStatistics $lastUsage): void
+    {
+        if ($lastUsage === null || $this->lastSentEstimate === null || $this->lastSentEstimate <= 0) {
+            return;
+        }
+        $ratio = $lastUsage->promptTokens / $this->lastSentEstimate;
+        // Monotone up: never trust an estimate below observed reality.
+        $this->calibration = max($this->calibration, $ratio);
+    }
+
+    private function reserve(?ChatOptions $options, LlmConfiguration $configuration, int $ctx): int
+    {
+        $optionMax = $options?->getMaxTokens() ?? 0;
+        if ($optionMax > 0) {
+            return $optionMax;
+        }
+        $modelMax = $configuration->getLlmModel()?->getMaxOutputTokens() ?? 0;
+        if ($modelMax > 0) {
+            return $modelMax;
+        }
+
+        return max(1000, (int)ceil($ctx * 0.02));
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function missingSystemPromptTokens(array $messages, LlmConfiguration $configuration): int
+    {
+        if (isset($messages[0]) && $this->roleOf($messages[0]) === 'system') {
+            return 0;
+        }
+        $systemPrompt = $configuration->getSystemPrompt();
+        if ($systemPrompt === '') {
+            return 0;
+        }
+
+        return $this->estimator->estimate([ChatMessage::system($systemPrompt)], [], $this->calibration);
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     *
+     * @return array{0: list<ChatMessage|array<string, mixed>>, 1: list<list<ChatMessage|array<string, mixed>>>}
+     */
+    private function partition(array $messages): array
+    {
+        $head     = [];
+        $count    = count($messages);
+        $index    = 0;
+        $seenUser = false;
+        // HEAD: the leading messages up to AND INCLUDING the first user turn (the
+        // system run plus any injected preamble). The task is never droppable.
+        for (; $index < $count; ++$index) {
+            $head[] = $messages[$index];
+            if ($this->roleOf($messages[$index]) === 'user') {
+                $seenUser = true;
+                ++$index;
+                break;
+            }
+        }
+        if (!$seenUser) {
+            return [$head, []];
+        }
+
+        // TURNS: everything after the first user, a new turn opening on each
+        // assistant message. A pre-assistant fragment attaches to the open turn.
+        $turns   = [];
+        $current = null;
+        for (; $index < $count; ++$index) {
+            $message = $messages[$index];
+            if ($this->roleOf($message) === 'assistant') {
+                if ($current !== null) {
+                    $turns[] = $current;
+                }
+                $current = [$message];
+            } elseif ($current === null) {
+                $current = [$message];
+            } else {
+                $current[] = $message;
+            }
+        }
+        if ($current !== null) {
+            $turns[] = $current;
+        }
+
+        return [$head, $turns];
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>>                $head
+     * @param list<list<ChatMessage|array<string, mixed>>>          $turns
+     * @param callable(list<ChatMessage|array<string, mixed>>): int $estimate
+     */
+    private function drop(array $head, array $turns, int $budget, callable $estimate): ContextFitResult
+    {
+        $kept    = $turns;
+        $dropped = 0;
+        // Drop oldest whole turns while it still overflows; NEVER drop the newest
+        // turn, so the output is never empty or system-only.
+        while (count($kept) > 1 && $estimate($this->assemble($head, $kept)) > $budget) {
+            array_shift($kept);
+            ++$dropped;
+        }
+
+        $messages = $this->assemble($head, $kept);
+        $estimated = $estimate($messages);
+        $overflow  = $estimated > $budget;
+
+        return new ContextFitResult(
+            messages: $messages,
+            pruned: $dropped > 0 || $overflow,
+            droppedTurns: $dropped,
+            keptTurns: count($kept),
+            estimatedTokens: $estimated,
+            budget: $budget,
+            overflowAtFloor: $overflow,
+            calibration: $this->calibration,
+        );
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>>       $head
+     * @param list<list<ChatMessage|array<string, mixed>>> $turns
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function assemble(array $head, array $turns): array
+    {
+        $out = $head;
+        foreach ($turns as $turn) {
+            foreach ($turn as $message) {
+                $out[] = $message;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function passthrough(array $messages, int $estimated = 0, int $budget = 0): ContextFitResult
+    {
+        [, $turns] = $this->partition($messages);
+
+        return new ContextFitResult(
+            messages: $messages,
+            pruned: false,
+            droppedTurns: 0,
+            keptTurns: count($turns),
+            estimatedTokens: $estimated,
+            budget: $budget,
+            overflowAtFloor: false,
+            calibration: $this->calibration,
+        );
+    }
+
+    /**
+     * A cheap post-fit backstop: every tool_result must follow an assistant turn
+     * that declared its tool_call_id. (An assistant tool-call turn WITHOUT its
+     * replies is the valid newest-pending turn, so the reverse is not checked.).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function isPairingValid(array $messages): bool
+    {
+        $openIds = [];
+        foreach ($messages as $message) {
+            $data = $this->normalise($message);
+            $role = is_string($data['role'] ?? null) ? $data['role'] : '';
+            if ($role === 'assistant') {
+                $toolCalls = is_array($data['tool_calls'] ?? null) ? $data['tool_calls'] : [];
+                foreach ($toolCalls as $call) {
+                    if (is_array($call) && is_string($call['id'] ?? null)) {
+                        $openIds[$call['id']] = true;
+                    }
+                }
+            } elseif ($role === 'tool') {
+                $id = is_string($data['tool_call_id'] ?? null) ? $data['tool_call_id'] : '';
+                if ($id === '' || !isset($openIds[$id])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     *
+     * @return array<string, mixed>
+     */
+    private function normalise(ChatMessage|array $message): array
+    {
+        return $message instanceof ChatMessage ? $message->toArray() : $message;
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    private function roleOf(ChatMessage|array $message): string
+    {
+        $data = $this->normalise($message);
+
+        return is_string($data['role'] ?? null) ? $data['role'] : '';
+    }
+}

--- a/Classes/Service/Context/ContextWindowManagerInterface.php
+++ b/Classes/Service/Context/ContextWindowManagerInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Context;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+
+/**
+ * Keeps an agent-loop transcript within the model's context window (ADR-107).
+ *
+ * Extracted as an interface so {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}
+ * can depend on and test-double it while the implementation stays final. It is a
+ * stateful, per-run collaborator (it accumulates a calibration factor across the
+ * run's provider calls), so one instance serves one run.
+ */
+interface ContextWindowManagerInterface
+{
+    /**
+     * Fit the transcript into the configuration's model context window, dropping
+     * oldest whole tool-call turns as needed while preserving the leading
+     * system/task messages, the tool-call/tool-result pairing and the newest
+     * turn. The returned {@see ContextFitResult::$messages} is what to send; when
+     * {@see ContextFitResult::$overflowAtFloor} is true the caller must not send
+     * it (even the floor overflows).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<array<string, mixed>>             $toolSpecs the tool schemas on the wire for THIS send; empty for a plain completion
+     * @param UsageStatistics|null                   $lastUsage the previous call's usage, to calibrate the estimator; null before the first call
+     */
+    public function fit(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?ChatOptions $options,
+        ?UsageStatistics $lastUsage,
+        array $toolSpecs = [],
+    ): ContextFitResult;
+}

--- a/Classes/Service/Context/TranscriptEstimator.php
+++ b/Classes/Service/Context/TranscriptEstimator.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Context;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+
+/**
+ * Estimates the token size of an agent transcript, erring HIGH by construction
+ * (ADR-107).
+ *
+ * No BPE tokenizer (no runtime dependency): a content-class-aware chars/N
+ * approximation. Ordinary prose divides by a generous 3.5 (over-counts typical
+ * Latin text vs the house 4.0), while DENSE segments — tool-call JSON arguments,
+ * tool_result payloads, ids and the tool-schema block — divide by 2.5, because
+ * minified JSON and code tokenize denser and were the previous overflow vector.
+ * A per-message and per-tool-call overhead covers the role/wrapper tokens the
+ * provider adds. The whole estimate is finally scaled by a calibration factor
+ * (>= 1.0) the manager grows toward the real prompt-token counts.
+ */
+final class TranscriptEstimator
+{
+    private const CHARS_PER_TOKEN_PROSE = 3.5;
+
+    private const CHARS_PER_TOKEN_DENSE = 2.5;
+
+    private const MESSAGE_OVERHEAD_TOKENS = 8;
+
+    private const TOOL_CALL_OVERHEAD_TOKENS = 12;
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<array<string, mixed>>             $toolSpecs empty for a plain-completion send
+     */
+    public function estimate(array $messages, array $toolSpecs, float $calibration): int
+    {
+        $proseChars = 0;
+        $denseChars = 0;
+        $tokens     = 0;
+
+        foreach ($messages as $message) {
+            $data = $message instanceof ChatMessage ? $message->toArray() : $message;
+            $tokens += self::MESSAGE_OVERHEAD_TOKENS;
+
+            $content = is_string($data['content'] ?? null) ? $data['content'] : '';
+            // tool_result content is dense (JSON/data); assistant/user text is prose.
+            if (($data['role'] ?? '') === 'tool') {
+                $denseChars += strlen($content);
+            } else {
+                $proseChars += strlen($content);
+            }
+            $denseChars += strlen(is_string($data['tool_call_id'] ?? null) ? $data['tool_call_id'] : '');
+
+            $toolCalls = is_array($data['tool_calls'] ?? null) ? $data['tool_calls'] : [];
+            foreach ($toolCalls as $call) {
+                $tokens += self::TOOL_CALL_OVERHEAD_TOKENS;
+                $function = is_array($call) && is_array($call['function'] ?? null) ? $call['function'] : [];
+                $proseChars += strlen(is_string($function['name'] ?? null) ? $function['name'] : '');
+                $denseChars += strlen(is_string($function['arguments'] ?? null) ? $function['arguments'] : '');
+                $denseChars += strlen(is_array($call) && is_string($call['id'] ?? null) ? $call['id'] : '');
+            }
+        }
+
+        // The tool JSON-schema block is on the wire for every tool-enabled call.
+        $denseChars += strlen((string)json_encode($toolSpecs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $raw = (int)ceil($proseChars / self::CHARS_PER_TOKEN_PROSE)
+            + (int)ceil($denseChars / self::CHARS_PER_TOKEN_DENSE)
+            + $tokens;
+
+        return (int)ceil($raw * max(1.0, $calibration));
+    }
+}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -20,7 +20,9 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
+use Netresearch\NrLlm\Exception\ContextTruncatedException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
@@ -91,6 +93,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // it. Absent it, resumeWithInput() skips its defence-in-depth
         // re-validation (the runtime already validated before the claim).
         private ?JsonSchemaValidator $schemaValidator = null,
+        // Bounds the growing transcript against the model's context window
+        // (ADR-107). Optional so the lean test wiring is unchanged; absent it the
+        // loop sends the full transcript exactly as before, and every
+        // enforcement site below is a no-op.
+        private ?ContextWindowManagerInterface $contextWindow = null,
     ) {}
 
     /**
@@ -153,6 +160,16 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // request with an empty `tools` array makes some providers (OpenAI) 400.
         // The design (§4.3) maps "no tools" to a single plain completion.
         if ($specs === []) {
+            // Bound the transcript against the context window (ADR-107). A resume
+            // continuation with no offered tools can still be over-long. No tools
+            // go on this wire, so pass toolSpecs = [].
+            try {
+                $messages = $this->enforceContextWindow($messages, $configuration, $options, null, 1, []);
+            } catch (ContextTruncatedException $e) {
+                $this->logger?->warning('Agent loop stopped: transcript exceeds the context window even at its floor.', ['exception' => $e]);
+
+                return $this->contextTruncatedResult([], $seedIterations + 1, $seedPromptTokens, $seedCompletionTokens);
+            }
             $runTrace?->recordRequest(1, $messages, []);
             $t0   = hrtime(true);
             $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options));
@@ -182,16 +199,23 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         $promptTokens     = $seedPromptTokens;
         $completionTokens = $seedCompletionTokens;
         $iterations       = $seedIterations;
+        // The previous call's usage, fed back to calibrate the token estimator
+        // (ADR-107); null before the first call.
+        $lastUsage = null;
 
         try {
             for ($i = 0; $i < $max; $i++) {
                 $iterations++;
+                // Bound the growing transcript against the context window BEFORE
+                // the send (ADR-107); tools are on this wire, so pass $specs.
+                $messages = $this->enforceContextWindow($messages, $configuration, $options, $lastUsage, $iterations, $specs);
                 // Streamed BEFORE the provider call so the inspector shows the
                 // outgoing request (and a waiting state) from second zero.
                 $runTrace?->recordRequest($iterations, $messages, $allowedNames);
                 $t0   = hrtime(true);
                 $resp = $this->mgr->chatWithToolsForConfiguration($messages, $specs, $configuration, $options);
                 $runTrace?->recordLlmCall($iterations, self::elapsedMs($t0), $resp);
+                $lastUsage         = $resp->usage;
                 $promptTokens     += $resp->usage->promptTokens;
                 $completionTokens += $resp->usage->completionTokens;
 
@@ -284,6 +308,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             // Record the synthesis as its own round (after the last tool round)
             // so the inspector's step list does not show two steps sharing a
             // round number.
+            // The synthesis is a plain completion (no tools on the wire), so
+            // bound it with toolSpecs = [] (ADR-107) — counting phantom schema
+            // bytes here, on the run's largest transcript, could otherwise
+            // discard a real final answer as a spurious overflow.
+            $messages = $this->enforceContextWindow($messages, $configuration, $options, $lastUsage, $iterations + 1, []);
             $runTrace?->recordRequest($iterations + 1, $messages, []);
             $t0    = hrtime(true);
             $final = $this->mgr->chatWithConfiguration(
@@ -303,6 +332,16 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 UsageStatistics::fromTokens($promptTokens, $completionTokens),
                 AgentRunTerminationReason::MAX_ITERATIONS,
             );
+        } catch (ContextTruncatedException $e) {
+            // ADR-107: even the pruned floor exceeds the context window, so no
+            // provider call was made. Stop legibly with the partial trace rather
+            // than sending an oversized request and eating a raw provider 4xx.
+            $this->logger?->warning(
+                'Tool loop stopped: transcript exceeds the context window even at its floor.',
+                ['exception' => $e],
+            );
+
+            return $this->contextTruncatedResult($trace, $iterations, $promptTokens, $completionTokens);
         } catch (BudgetExceededException $e) {
             // Budget fires pre-flight and tools are read-only, so the partial
             // trace is consistent. Surface what ran rather than aborting, and
@@ -322,6 +361,69 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 AgentRunTerminationReason::BUDGET_EXHAUSTED,
             );
         }
+    }
+
+    /**
+     * Enforce the model context window on the outgoing transcript (ADR-107). A
+     * no-op when the manager is absent (unchanged from before this feature).
+     * Returns the possibly-pruned messages; throws when even the floor overflows.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<array<string, mixed>>             $toolSpecs the tool schemas on THIS wire; [] for a plain completion
+     *
+     * @throws ContextTruncatedException when the pruned floor still exceeds the window
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function enforceContextWindow(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?ToolOptions $options,
+        ?UsageStatistics $lastUsage,
+        int $iteration,
+        array $toolSpecs,
+    ): array {
+        if ($this->contextWindow === null) {
+            return $messages;
+        }
+
+        $fit = $this->contextWindow->fit($messages, $configuration, $options, $lastUsage, $toolSpecs);
+
+        if ($fit->overflowAtFloor) {
+            throw ContextTruncatedException::fromFit($fit);
+        }
+
+        if ($fit->pruned) {
+            // Observability: distinguishes "trimmed history, run fine" from a
+            // failure. A dedicated inspector RunStep is a follow-up (ADR-107).
+            $this->logger?->info('Agent loop transcript pruned to fit the context window', [
+                'iteration'       => $iteration,
+                'droppedTurns'    => $fit->droppedTurns,
+                'keptTurns'       => $fit->keptTurns,
+                'estimatedTokens' => $fit->estimatedTokens,
+                'budget'          => $fit->budget,
+                'calibration'     => $fit->calibration,
+            ]);
+
+            return $fit->messages;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * @param list<ToolInvocation> $trace
+     */
+    private function contextTruncatedResult(array $trace, int $iterations, int $promptTokens, int $completionTokens): ToolLoopResult
+    {
+        return new ToolLoopResult(
+            '',
+            $trace,
+            $iterations,
+            true,
+            UsageStatistics::fromTokens($promptTokens, $completionTokens),
+            AgentRunTerminationReason::CONTEXT_TRUNCATED,
+        );
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -50,6 +50,12 @@ services:
   Netresearch\NrLlm\Service\TestPromptResolverInterface:
     alias: Netresearch\NrLlm\Service\TestPromptResolverService
 
+  # Agent-loop context-window management (ADR-107). Aliased so ToolLoopService's
+  # optional collaborator autowires; the manager is stateful per run and
+  # self-resets on each loop's first send.
+  Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface:
+    alias: Netresearch\NrLlm\Service\Context\ContextWindowManager
+
   Netresearch\NrLlm\Service\UsageTrackerServiceInterface:
     alias: Netresearch\NrLlm\Service\UsageTrackerService
     public: true

--- a/Documentation/Adr/Adr107ContextWindowManagement.rst
+++ b/Documentation/Adr/Adr107ContextWindowManagement.rst
@@ -1,0 +1,83 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-107:
+
+============================================================================
+ADR-107: Agent-loop context-window management
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-22
+:Authors: Netresearch DTT GmbH
+
+.. _adr-107-context:
+
+Context
+=======
+
+The tool loop (:ref:`ADR-081 <adr-081>` ff.) appends each assistant tool-call
+turn and its tool_result messages to one transcript that is re-sent on every
+iteration. Nothing bounded that transcript against the model's context window
+(``Model::getContextLength()``), so a long agentic run — many tool calls, large
+tool outputs — eventually overflowed the window and failed at the provider with
+a raw 4xx that :ref:`FailureClassifier <adr-095>` maps to a generic
+``CLIENT_ERROR``, indistinguishable from an auth or config error.
+
+.. _adr-107-decision:
+
+Decision
+========
+
+An optional ``ContextWindowManager`` collaborator on ``ToolLoopService`` bounds
+the transcript before each provider send. Absent it (the lean test wiring) the
+loop sends the full transcript exactly as before — every enforcement site is a
+no-op.
+
+- **Turn-atomic pruning (the correctness crux).** Pruning drops oldest WHOLE
+  turns — an assistant tool-call message together with ALL its tool_result
+  replies — so the tool-call/tool-result pairing the provider requires is never
+  broken. The head (the leading system run plus everything up to and including
+  the first user message) and the newest turn are never dropped, so the output
+  is a structurally valid, non-empty transcript that still carries the task and
+  the most recent context. A cheap post-fit pairing guard defers to the provider
+  rather than ever emit a known-orphaned request. Summarization was rejected: it
+  needs an extra provider call per prune (cost, latency, non-determinism through
+  ``SuspendedRunState``); dropping is deterministic, cheap and provably safe.
+- **Over-counting estimator.** No BPE tokenizer (no runtime dependency): a
+  content-class-aware ``chars/N`` — prose divides by 3.5, DENSE segments (tool
+  JSON arguments, tool_result payloads, the tool-schema block) by 2.5, plus
+  per-message and per-tool-call overhead. A calibration factor seeded above 1.0
+  scales the estimate and only ever grows toward the real prompt-token counts
+  each provider call reports, so the estimate errs high throughout and never
+  under-prunes into an overflow. The manager is stateful per run and self-resets
+  on each loop's first send (a null ``lastUsage``), so a single shared
+  ``ToolLoopService`` never carries one run's calibration into the next.
+- **Reserve + graceful failure.** ``budget = contextLength - reserve -
+  safety``, where the reserve is the response allocation (options ``max_tokens``,
+  else the model output cap, else a proportional floor) and an unknown context
+  length falls back to a conservative 8192. When even the pruned floor still
+  exceeds the budget, no provider call is made: a ``ContextTruncatedException``
+  stops the loop on the new ``AgentRunTerminationReason::CONTEXT_TRUNCATED``
+  (non-retryable) — a legible terminus instead of a misclassified provider 4xx.
+
+.. _adr-107-consequences:
+
+Consequences
+============
+
+- ``AgentRunTerminationReason`` gained ``CONTEXT_TRUNCATED``
+  (``isRetryable() === false``) — the documented minor-release growth path.
+- Global default only, no per-configuration knob (YAGNI); ``maxTokensPerDay`` /
+  ``modelSelectionMode`` are the storage precedent if an override is ever needed.
+- Enforcement covers the three real provider-send sites in ``runLoop`` (the
+  in-loop tool send, the no-tools plain completion, the cap-hit synthesis);
+  every send goes through one of them, so no separate pre-loop assembly pass is
+  needed. The plain-completion sites pass no tool schemas, so phantom schema
+  bytes never inflate the estimate of a payload that will not carry them.
+- **Streaming is out of scope.** ``StreamingDispatcher`` runs a separate
+  single-shot pipeline that never calls ``runLoop()``; bounding a streamed
+  request against the window (and reconciling its own ``chars/4`` heuristic) is
+  a follow-up.
+- Observability: a pruning event is logged at info level; a dedicated inspector
+  ``RunStep`` for the trace is a follow-up. The ``CONTEXT_TRUNCATED`` reason is
+  the load-bearing operator signal and is on the result.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -404,3 +404,4 @@ Tools
    Adr104StaleRunReaperAndRetry
    Adr105TypedInputSuspension
    Adr106PerConfigurationGuardrailPolicy
+   Adr107ContextWindowManagement

--- a/Tests/Unit/Domain/Enum/AgentRunTerminationReasonTest.php
+++ b/Tests/Unit/Domain/Enum/AgentRunTerminationReasonTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class AgentRunTerminationReasonTest extends TestCase
+{
+    #[Test]
+    public function onlyProviderFailureIsRetryable(): void
+    {
+        // A context-truncated run (ADR-107) re-sends the same oversized floor and
+        // overflows again — it must NOT be retryable.
+        self::assertFalse(AgentRunTerminationReason::CONTEXT_TRUNCATED->isRetryable());
+        self::assertTrue(AgentRunTerminationReason::PROVIDER_FAILED->isRetryable());
+        self::assertFalse(AgentRunTerminationReason::MAX_ITERATIONS->isRetryable());
+    }
+
+    #[Test]
+    public function contextTruncatedRoundTripsThroughItsBackingValue(): void
+    {
+        self::assertSame('context_truncated', AgentRunTerminationReason::CONTEXT_TRUNCATED->value);
+        self::assertSame(AgentRunTerminationReason::CONTEXT_TRUNCATED, AgentRunTerminationReason::tryFromString('context_truncated'));
+    }
+}

--- a/Tests/Unit/Service/Context/ContextWindowManagerTest.php
+++ b/Tests/Unit/Service/Context/ContextWindowManagerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Context;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\Context\ContextWindowManager;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContextWindowManager::class)]
+final class ContextWindowManagerTest extends TestCase
+{
+    #[Test]
+    public function fitsUnderBudgetReturnsPassthroughUnchanged(): void
+    {
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('hi'), ...$this->turn('call_1', 'small')];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(128000), null, null);
+
+        self::assertFalse($result->pruned);
+        self::assertSame($messages, $result->messages);
+        self::assertSame(0, $result->droppedTurns);
+    }
+
+    #[Test]
+    public function dropsOldestWholeTurnsWhenOverBudgetKeepingPairingAndTheNewest(): void
+    {
+        $big      = str_repeat('x', 6000);
+        $messages = [
+            ChatMessage::system('sys'),
+            ChatMessage::user('do the task'),
+            ...$this->turn('call_1', $big),   // oldest
+            ...$this->turn('call_2', $big),
+            ...$this->turn('call_3', 'the newest result'),
+        ];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(4000), null, null);
+
+        self::assertTrue($result->pruned);
+        self::assertGreaterThanOrEqual(1, $result->droppedTurns);
+        self::assertFalse($result->overflowAtFloor);
+        // Head survives.
+        self::assertSame('system', $this->roleOf($result->messages[0]));
+        self::assertSame('user', $this->roleOf($result->messages[1]));
+        // The newest turn survives.
+        $roles = array_map($this->roleOf(...), $result->messages);
+        self::assertContains('tool', $roles);
+        // Pairing intact: every tool result has a preceding assistant tool-call.
+        self::assertTrue($this->pairingValid($result->messages));
+    }
+
+    #[Test]
+    public function neverDropsTheLeadingSystemAndTaskUnderExtremePressure(): void
+    {
+        $big      = str_repeat('y', 8000);
+        $messages = [
+            ChatMessage::system('the system prompt'),
+            ChatMessage::user('the task'),
+            ...$this->turn('call_1', $big),
+            ...$this->turn('call_2', $big),
+        ];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(2000), null, null);
+
+        self::assertSame('system', $this->roleOf($result->messages[0]));
+        self::assertSame('user', $this->roleOf($result->messages[1]));
+        self::assertSame('the task', $this->contentOf($result->messages[1]));
+    }
+
+    #[Test]
+    public function overflowAtFloorWhenEvenTheNewestTurnIsTooBig(): void
+    {
+        $huge     = str_repeat('z', 40000);
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('go'), ...$this->turn('call_1', $huge)];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(4000), null, null);
+
+        self::assertTrue($result->overflowAtFloor);
+        self::assertTrue($result->pruned);
+    }
+
+    #[Test]
+    public function unknownContextLengthUsesTheFallbackCeilingNotANoOp(): void
+    {
+        $big      = str_repeat('q', 30000);
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('go'), ...$this->turn('call_1', $big), ...$this->turn('call_2', 'newest')];
+
+        // contextLength 0 (unknown) -> 8192 fallback ceiling still bounds it.
+        $result = (new ContextWindowManager())->fit($messages, $this->config(0), null, null);
+
+        self::assertTrue($result->pruned);
+        self::assertSame(8192 - 1000 - (int)ceil(8192 * 0.03), $result->budget);
+    }
+
+    #[Test]
+    public function optionMaxTokensTakesReservePrecedenceOverTheModelCap(): void
+    {
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('go')];
+        $options  = (new ChatOptions())->withMaxTokens(5000);
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(20000, 1000), $options, null);
+
+        // budget = ctx - option maxTokens(5000) - safety, NOT the model cap 1000.
+        self::assertSame(20000 - 5000 - (int)ceil(20000 * 0.03), $result->budget);
+    }
+
+    #[Test]
+    public function calibrationRisesWhenTheEstimateUnderShotTheRealPromptTokens(): void
+    {
+        $manager  = new ContextWindowManager();
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('go'), ...$this->turn('call_1', str_repeat('a', 2000)), ...$this->turn('call_2', 'newest')];
+        $config   = $this->config(128000);
+
+        // First send establishes lastSentEstimate.
+        $first = $manager->fit($messages, $config, null, null);
+
+        // Report real usage far above the estimate -> calibration must climb.
+        $second = $manager->fit($messages, $config, null, UsageStatistics::fromTokens($first->estimatedTokens * 3, 0));
+
+        self::assertGreaterThan(1.15, $second->calibration);
+        self::assertGreaterThan($first->estimatedTokens, $second->estimatedTokens);
+    }
+
+    /**
+     * @return list<ChatMessage>
+     */
+    private function turn(string $callId, string $result): array
+    {
+        return [
+            ChatMessage::assistantToolCalls([new ToolCall($callId, 'fetch', ['q' => 'x'])], null),
+            ChatMessage::toolResult($callId, $result),
+        ];
+    }
+
+    private function config(int $contextLength, int $maxOutputTokens = 0): LlmConfiguration
+    {
+        $model = new Model();
+        $model->setContextLength($contextLength);
+        $model->setMaxOutputTokens($maxOutputTokens);
+
+        $config = new LlmConfiguration();
+        $config->setLlmModel($model);
+
+        return $config;
+    }
+
+    private function roleOf(ChatMessage $message): string
+    {
+        return $message->toArray()['role'] ?? '';
+    }
+
+    private function contentOf(ChatMessage $message): string
+    {
+        $content = $message->toArray()['content'] ?? '';
+
+        return is_string($content) ? $content : '';
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    private function pairingValid(array $messages): bool
+    {
+        $open = [];
+        foreach ($messages as $message) {
+            $data = $message instanceof ChatMessage ? $message->toArray() : $message;
+            $role = $data['role'] ?? '';
+            if ($role === 'assistant') {
+                $toolCalls = is_array($data['tool_calls'] ?? null) ? $data['tool_calls'] : [];
+                foreach ($toolCalls as $call) {
+                    if (is_array($call) && is_string($call['id'] ?? null)) {
+                        $open[$call['id']] = true;
+                    }
+                }
+            } elseif ($role === 'tool') {
+                $id = is_string($data['tool_call_id'] ?? null) ? $data['tool_call_id'] : '';
+                if ($id === '' || !isset($open[$id])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/Tests/Unit/Service/Context/TranscriptEstimatorTest.php
+++ b/Tests/Unit/Service/Context/TranscriptEstimatorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Context;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\Context\TranscriptEstimator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TranscriptEstimator::class)]
+final class TranscriptEstimatorTest extends TestCase
+{
+    private TranscriptEstimator $estimator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->estimator = new TranscriptEstimator();
+    }
+
+    #[Test]
+    public function addingAMessageNeverLowersTheEstimate(): void
+    {
+        $one = [ChatMessage::user('a short prompt')];
+        $two = [ChatMessage::user('a short prompt'), ChatMessage::user('another one')];
+
+        self::assertGreaterThanOrEqual(
+            $this->estimator->estimate($one, [], 1.0),
+            $this->estimator->estimate($two, [], 1.0),
+        );
+    }
+
+    #[Test]
+    public function overCountsProseVersusTheHouseFourCharsPerToken(): void
+    {
+        $text     = str_repeat('word ', 200);
+        $estimate = $this->estimator->estimate([ChatMessage::user($text)], [], 1.0);
+
+        // Divisor 3.5 (+ per-message overhead) over-counts vs a flat chars/4.
+        self::assertGreaterThanOrEqual((int)ceil(strlen($text) / 4), $estimate);
+    }
+
+    #[Test]
+    public function denseToolResultContentUsesTheDenserDivisor(): void
+    {
+        $json = str_repeat('{"k":"v"}', 100);
+
+        $asToolResult = $this->estimator->estimate([ChatMessage::toolResult('call_1', $json)], [], 1.0);
+        $asUserProse  = $this->estimator->estimate([ChatMessage::user($json)], [], 1.0);
+
+        // Same bytes weigh MORE as a tool_result (2.5 divisor) than as prose (3.5).
+        self::assertGreaterThan($asUserProse, $asToolResult);
+    }
+
+    #[Test]
+    public function toolSchemaBytesAreCountedOnlyWhenPresent(): void
+    {
+        $messages  = [ChatMessage::user('go')];
+        $without   = $this->estimator->estimate($messages, [], 1.0);
+        $withSpecs = $this->estimator->estimate($messages, [['type' => 'function', 'function' => ['name' => 'fetch', 'parameters' => ['type' => 'object']]]], 1.0);
+
+        self::assertGreaterThan($without, $withSpecs);
+    }
+
+    #[Test]
+    public function toolCallArgumentsAreCountedAsDense(): void
+    {
+        $call     = new ToolCall('call_1', 'fetch', ['q' => str_repeat('x', 400)]);
+        $estimate = $this->estimator->estimate([ChatMessage::assistantToolCalls([$call], null)], [], 1.0);
+
+        self::assertGreaterThan(100, $estimate);
+    }
+
+    #[Test]
+    public function calibrationScalesUpNeverBelowTheRawEstimate(): void
+    {
+        $messages = [ChatMessage::user(str_repeat('token ', 100))];
+        $raw      = $this->estimator->estimate($messages, [], 1.0);
+
+        self::assertSame($raw, $this->estimator->estimate($messages, [], 0.5), 'calibration < 1 is floored to 1');
+        self::assertGreaterThan($raw, $this->estimator->estimate($messages, [], 2.0));
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -16,12 +16,14 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
@@ -1091,6 +1093,75 @@ final class ToolLoopServiceTest extends TestCase
         $this->expectException(LogicException::class);
         // Missing the required 'city'.
         $service->resumeWithInput($state, [], new LlmConfiguration());
+    }
+
+    #[Test]
+    public function theContextWindowManagerPrunedTranscriptIsWhatGetsSent(): void
+    {
+        // ADR-107: the loop sends the manager's pruned array, not the original.
+        $captured = [];
+        $mgr      = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (array $messages) use (&$captured): CompletionResponse {
+                $captured = $messages;
+
+                return $this->response('done');
+            },
+        );
+
+        $pruned  = [$this->userTurn('PRUNED')];
+        $service = $this->serviceWithContextWindow($mgr, $this->fakeContextWindow(
+            new ContextFitResult($pruned, true, 2, 1, 10, 100, false, 1.15),
+        ));
+
+        $service->runLoop([$this->userTurn('a'), $this->userTurn('b')], new LlmConfiguration(), null);
+
+        self::assertSame($pruned, $captured);
+    }
+
+    #[Test]
+    public function overflowAtFloorTerminatesContextTruncatedWithoutAProviderCall(): void
+    {
+        // ADR-107: even the floor overflows -> no provider call, legible stop.
+        $mgr = $this->createMock(LlmServiceManagerInterface::class);
+        $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
+        $mgr->expects(self::never())->method('chatWithConfiguration');
+
+        $service = $this->serviceWithContextWindow($mgr, $this->fakeContextWindow(
+            new ContextFitResult([], false, 0, 1, 999999, 100, true, 1.15),
+        ));
+
+        $result = $service->runLoop([$this->userTurn('x')], new LlmConfiguration(), null);
+
+        self::assertSame(AgentRunTerminationReason::CONTEXT_TRUNCATED, $result->terminationReason);
+        self::assertTrue($result->truncated);
+    }
+
+    private function fakeContextWindow(ContextFitResult $result): ContextWindowManagerInterface
+    {
+        $manager = self::createStub(ContextWindowManagerInterface::class);
+        $manager->method('fit')->willReturn($result);
+
+        return $manager;
+    }
+
+    private function serviceWithContextWindow(LlmServiceManagerInterface $mgr, ContextWindowManagerInterface $contextWindow): ToolLoopService
+    {
+        $registry = new ToolRegistry([new FakeTool('noop')]);
+
+        return new ToolLoopService(
+            $mgr,
+            $registry,
+            new FakeToolAvailability($registry->names()),
+            null,
+            5,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $contextWindow,
+        );
     }
 
     private function service(


### PR DESCRIPTION
## What

**ADR-107** (P1 #10): bound the agent loop's growing transcript against the model's context window. The loop appends every assistant tool-call turn and its tool_result messages to one transcript re-sent each iteration, with no bound against `Model::getContextLength()` — a long agentic run eventually overflowed the window and failed at the provider with a 4xx that `FailureClassifier` misclassifies as a generic client error.

## How

An optional `ContextWindowManager` collaborator on `ToolLoopService` prunes the transcript before each provider send. **Absent it (lean test wiring) the loop is byte-identical to before** — every enforcement site is a no-op.

- **Turn-atomic pruning (the correctness crux)** — drops oldest **whole turns** (an assistant tool-call message with **all** its tool_result replies) so the tool-call/tool-result pairing the provider requires is never broken. The head (leading system run + first user) and the newest turn are never dropped → the output is always a valid, non-empty transcript still carrying the task. A post-fit pairing guard defers to the provider rather than emit a known-orphaned request. Summarization was rejected (extra provider call, latency, non-determinism through `SuspendedRunState`); dropping is deterministic, cheap, provably safe.
- **Over-counting estimator** — content-class-aware `chars/N` (prose 3.5, dense JSON/tool payloads 2.5) + per-message overhead, scaled by a calibration factor seeded > 1.0 that only grows toward the real prompt-token counts each call reports — so it never under-prunes into an overflow. Stateful per run, self-resets on each loop's first send, so a shared `ToolLoopService` never leaks one run's calibration into the next.
- **Reserve + graceful failure** — `budget = contextLength − reserve − safety` (reserve = options `max_tokens`, else model output cap, else a proportional floor; unknown context length → 8192). When even the pruned floor overflows, **no request is sent**: a `ContextTruncatedException` stops the loop on the new non-retryable `AgentRunTerminationReason::CONTEXT_TRUNCATED` — a legible terminus, not a raw provider 4xx.

Enforcement covers the three real send sites in `runLoop` (in-loop tool send, no-tools completion, cap-hit synthesis); every send goes through one, so no separate pre-loop pass is needed. The plain-completion sites pass no tool schemas, so phantom schema bytes never inflate their estimate. **Streaming** (a separate single-shot pipeline that never calls `runLoop`) is out of scope.

## API / surface

- `AgentRunTerminationReason` += `CONTEXT_TRUNCATED` (`isRetryable() === false`)
- New `ContextWindowManager`/`Interface`, `TranscriptEstimator`, `ContextFitResult`, `ContextTruncatedException`; `ToolLoopService` gains an optional collaborator (DI-aliased). No schema change; global default only (YAGNI).

## Tests

Local gate green: PHP-CS-Fixer, PHPStan L10, unit (5520), functional/sqlite (1252), Rector, fuzzy (79). New: `TranscriptEstimatorTest` (monotonic, over-counts, dense divisor, tool-schema, calibration floor), `ContextWindowManagerTest` (passthrough, drop-oldest-whole-turns with pairing preserved, head pinned, floor overflow, unknown-window fallback, reserve precedence, calibration rise), `ToolLoopServiceTest` integration (pruned array is what's sent; overflow-at-floor → CONTEXT_TRUNCATED, no provider call), enum invariant.

https://claude.ai/code/session_01S2HQiw1c1XCXGLeMJ917Mr
