### PR TITLE
feat(agent): typed ToolResult with run-only artifacts (ADR-108)

### DIFF
--- a/Classes/Domain/Enum/ArtifactType.php
+++ b/Classes/Domain/Enum/ArtifactType.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * The rendering shape of a {@see \Netresearch\NrLlm\Domain\ValueObject\ToolArtifact}.
+ *
+ * Deliberately the SMALLEST closed set whose every case has a v1 emitter plus a
+ * fallback — NOT a semantic taxonomy (no `page-tree`/`records` cases) and NOT a
+ * free-form string:
+ * - TABLE: {columns: list<string>, rows: list<list<string>>}. Emitted by
+ *   {@see \Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool}.
+ * - TEXT: a plain string payload {text: string}. The fallback for an unknown
+ *   shape and the carrier for the fail-closed "artifacts omitted" marker.
+ *
+ * Additive by design: TREE, LIST, KEY_VALUE, LINK, CODE land later as a new
+ * enum case plus one JS branch — no consumer migration, no persisted-data
+ * migration. TREE specifically is a documented follow-up (a page-tree emitter),
+ * intentionally NOT shipped in v1 so no enum case exists without a committed
+ * producer.
+ */
+enum ArtifactType: string
+{
+    case TABLE = 'table';
+    case TEXT  = 'text';
+}

--- a/Classes/Domain/ValueObject/RunStep.php
+++ b/Classes/Domain/ValueObject/RunStep.php
@@ -24,7 +24,8 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  *   provider reported it) and — only when raw capture was requested — the
  *   decoded provider response body.
  * - {@see self::KIND_TOOL}: one executed tool call — its name, arguments, the
- *   returned string, an error flag and the execution timing.
+ *   returned string, an error flag, the execution timing and any run-only
+ *   structured artifacts.
  * - {@see self::KIND_ASSEMBLED}: a dry run — the fully assembled message list
  *   (system + snippets + skills + user) that WOULD have been sent, with no
  *   provider call made.
@@ -48,6 +49,7 @@ final readonly class RunStep
      * @param list<array{id: string, name: string, arguments: array<string, mixed>}>|null $requestedToolCalls Tool calls the model asked for (LLM).
      * @param array<string, mixed>|null                                                   $raw                Decoded raw provider response — only when capture was requested (LLM).
      * @param array<string, mixed>|null                                                   $toolArguments      Arguments the model supplied for a tool call (TOOL).
+     * @param list<ToolArtifact>|null                                                     $toolArtifacts      Run-only structured artifacts a tool attached (TOOL); NEVER provider-facing.
      */
     public function __construct(
         public string $kind,
@@ -68,6 +70,7 @@ final readonly class RunStep
         public ?array $toolArguments = null,
         public ?string $toolResult = null,
         public ?bool $toolIsError = null,
+        public ?array $toolArtifacts = null,
     ) {}
 
     /**
@@ -100,6 +103,9 @@ final readonly class RunStep
             'toolArguments'      => $this->toolArguments,
             'toolResult'         => $this->toolResult,
             'toolIsError'        => $this->toolIsError,
+            'toolArtifacts'      => $this->toolArtifacts === null
+                ? null
+                : array_map(static fn(ToolArtifact $a): array => $a->toArray(), $this->toolArtifacts),
         ];
 
         foreach ($optional as $key => $value) {

--- a/Classes/Domain/ValueObject/ToolArtifact.php
+++ b/Classes/Domain/ValueObject/ToolArtifact.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+
+/**
+ * One structured, run-scoped result fragment a tool may attach ALONGSIDE its
+ * text {@see ToolResult::$content} for richer backend rendering.
+ *
+ * An artifact NEVER reaches the external provider — the runtime places only
+ * `content` on the wire (see {@see ToolResult}). It egresses to the backend DOM
+ * (Tool Playground inspector) and the persisted audit stream ONLY.
+ *
+ * Both `label` and every string leaf of `$data` are UNTRUSTED tool bytes: the
+ * runtime ({@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}) UTF-8-coerces
+ * and byte-bounds them before egress. An emitting tool MUST apply the SAME
+ * redaction to `$data` that it applies to its text output — an artifact must
+ * never re-expose a field the text path deliberately withheld.
+ */
+final readonly class ToolArtifact
+{
+    /**
+     * @param array<array-key, mixed> $data JSON-serialisable payload matching
+     *                                      the shape declared by $type.
+     */
+    public function __construct(
+        public ArtifactType $type,
+        public string $label,
+        public array $data,
+    ) {}
+
+    /**
+     * @return array{type: string, label: string, data: array<array-key, mixed>}
+     */
+    public function toArray(): array
+    {
+        return ['type' => $this->type->value, 'label' => $this->label, 'data' => $this->data];
+    }
+}

--- a/Classes/Domain/ValueObject/ToolInvocation.php
+++ b/Classes/Domain/ValueObject/ToolInvocation.php
@@ -13,19 +13,22 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  * One executed tool call recorded during a {@see ToolLoopService} run.
  *
  * Captures the model-requested tool name, the arguments it supplied, the
- * string the PHP tool returned, and whether that turn was an error (unknown
- * tool or a caught, sanitised exception). The collected list of invocations
- * forms the {@see ToolLoopResult::$trace} audit trail.
+ * string the PHP tool returned, whether that turn was an error (unknown tool or
+ * a caught, sanitised exception), and any run-only structured artifacts the
+ * tool attached. The collected list of invocations forms the
+ * {@see ToolLoopResult::$trace} audit trail.
  */
 final readonly class ToolInvocation
 {
     /**
      * @param array<string, mixed> $arguments The arguments the model supplied for the call.
+     * @param list<ToolArtifact>   $artifacts Run-only structured artifacts (NEVER provider-facing).
      */
     public function __construct(
         public string $name,
         public array $arguments,
         public string $result,
         public bool $isError,
+        public array $artifacts = [],
     ) {}
 }

--- a/Classes/Domain/ValueObject/ToolResult.php
+++ b/Classes/Domain/ValueObject/ToolResult.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * The typed return value of {@see \Netresearch\NrLlm\Service\Tool\ToolInterface::execute()}.
+ *
+ * SECURITY INVARIANT — egress separation by construction:
+ *   `$content` is the ONLY member that may cross the provider wire (it also
+ *   egresses to the backend DOM). `$artifacts` are RUN-SCOPED: trace, inspector
+ *   and persisted audit only. This class has NO __toString() and NO accessor
+ *   that merges an artifact into a wire string, so `->content` is the single
+ *   path to a wire string. Both channels are untrusted tool bytes; both are
+ *   UTF-8-coerced and byte-bounded in {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}::invoke()
+ *   before egress.
+ *
+ * Fail-closed: {@see self::error()} carries NO artifacts.
+ */
+final readonly class ToolResult
+{
+    /**
+     * @param list<ToolArtifact> $artifacts
+     */
+    private function __construct(
+        public string $content,
+        public bool $isError,
+        public array $artifacts,
+    ) {}
+
+    /**
+     * A non-error result with optional run-only structured artifacts.
+     */
+    public static function text(string $content, ToolArtifact ...$artifacts): self
+    {
+        return new self($content, false, array_values($artifacts));
+    }
+
+    /**
+     * An error result. Fail-closed by construction: NO artifacts ever ride an
+     * error result, so a failing tool cannot leak a half-built structure.
+     */
+    public static function error(string $content): self
+    {
+        return new self($content, true, []);
+    }
+}

--- a/Classes/Service/Privacy/RunStepPrivacyFilter.php
+++ b/Classes/Service/Privacy/RunStepPrivacyFilter.php
@@ -48,6 +48,7 @@ final readonly class RunStepPrivacyFilter
         'raw',
         'toolArguments',
         'toolResult',
+        'toolArtifacts',
     ];
 
     public function __construct(
@@ -101,6 +102,18 @@ final readonly class RunStepPrivacyFilter
 
         if (is_string($payload['toolResult'] ?? null)) {
             $out['toolResultLength'] = mb_strlen($payload['toolResult']);
+        }
+
+        $artifacts = $payload['toolArtifacts'] ?? null;
+        if (is_array($artifacts)) {
+            $out['toolArtifactsCount'] = count($artifacts);
+            $types = [];
+            foreach ($artifacts as $artifact) {
+                if (is_array($artifact) && is_string($artifact['type'] ?? null)) {
+                    $types[] = $artifact['type'];
+                }
+            }
+            $out['toolArtifactTypes'] = $types;
         }
 
         $requested = $payload['requestedToolCalls'] ?? null;

--- a/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
+++ b/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -63,17 +64,17 @@ final readonly class BrowseFalFolderTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user      = $this->actingBackendUser();
         $effective = $this->storageGate->effectiveStorages($user);
         if ($effective === []) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $storageUid = self::toInt($arguments['storage'] ?? ($effective[0] ?? 0));
         if (!in_array($storageUid, $effective, true)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $folderId = trim(self::toStr($arguments['folder'] ?? '/'));
@@ -84,7 +85,7 @@ final readonly class BrowseFalFolderTool implements ToolInterface
         try {
             $storage = $this->storageRepository->findByUid($storageUid);
             if ($storage === null || !$storage->isOnline()) {
-                return self::NOT_PERMITTED;
+                return ToolResult::text(self::NOT_PERMITTED);
             }
             // Folder-level enforcement on top of the storage gate: with
             // evaluatePermissions the read calls below check the acting
@@ -128,11 +129,11 @@ final readonly class BrowseFalFolderTool implements ToolInterface
         } catch (Throwable) {
             // Neutral by design: a missing folder, a folder outside the
             // storage and a driver error are indistinguishable to the model.
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         if ($lines === []) {
-            return sprintf('Folder %s of storage %d is empty.', $folder->getIdentifier(), $storageUid);
+            return ToolResult::text(sprintf('Folder %s of storage %d is empty.', $folder->getIdentifier(), $storageUid));
         }
 
         $header = sprintf(
@@ -143,7 +144,7 @@ final readonly class BrowseFalFolderTool implements ToolInterface
             $skipped > 0 ? sprintf(', %d more not shown', $skipped) : '',
         );
 
-        return $header . "\n" . implode("\n", $lines);
+        return ToolResult::text($header . "\n" . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -84,11 +85,11 @@ final readonly class CheckTypoScriptTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $pageUid = self::toInt($arguments['pageUid'] ?? 0);
         if ($pageUid < 1) {
-            return self::NEUTRAL_ERROR;
+            return ToolResult::text(self::NEUTRAL_ERROR);
         }
 
         try {
@@ -101,7 +102,7 @@ final readonly class CheckTypoScriptTool implements ToolInterface
             // itself (site sets / site-defined TS, v13+) — the tree builder
             // includes those; only bail out when NEITHER source exists.
             if ($sysTemplateRows === [] && !$site->isTypoScriptRoot()) {
-                return self::NEUTRAL_ERROR;
+                return ToolResult::text(self::NEUTRAL_ERROR);
             }
 
             $errors = [];
@@ -121,7 +122,7 @@ final readonly class CheckTypoScriptTool implements ToolInterface
         } catch (Throwable) {
             // Deliberately neutral: rootline/site/template resolution failures
             // must not leak exception internals into the provider egress.
-            return self::NEUTRAL_ERROR;
+            return ToolResult::text(self::NEUTRAL_ERROR);
         }
 
         $errors = array_values(array_unique($errors));
@@ -138,11 +139,11 @@ final readonly class CheckTypoScriptTool implements ToolInterface
                 $sources[] = 'site-set TypoScript';
             }
 
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'No TypoScript syntax errors on page %d (constants and setup of %s checked).',
                 $pageUid,
                 implode(' + ', $sources),
-            );
+            ));
         }
 
         $total = count($errors);
@@ -151,8 +152,8 @@ final readonly class CheckTypoScriptTool implements ToolInterface
             $errors[] = sprintf('… %d more errors not shown', $total - self::MAX_ERRORS);
         }
 
-        return sprintf("TypoScript syntax errors on page %d (%d):\n", $pageUid, $total)
-            . '- ' . implode("\n- ", $errors);
+        return ToolResult::text(sprintf("TypoScript syntax errors on page %d (%d):\n", $pageUid, $total)
+            . '- ' . implode("\n- ", $errors));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -69,7 +70,7 @@ final readonly class FetchLogsTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         if ($limit < 1) {
@@ -98,7 +99,7 @@ final readonly class FetchLogsTool implements ToolInterface
         $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
 
         if ($rows === []) {
-            return 'No log entries.';
+            return ToolResult::text('No log entries.');
         }
 
         $lines = [sprintf('Recent sys_log entries (showing %d):', count($rows))];
@@ -113,7 +114,7 @@ final readonly class FetchLogsTool implements ToolInterface
             );
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
+++ b/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -68,19 +69,19 @@ final readonly class FindMissingFilesTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user      = $this->actingBackendUser();
         $effective = $this->storageGate->effectiveStorages($user);
         if ($effective === []) {
-            return 'No accessible file storages.';
+            return ToolResult::text('No accessible file storages.');
         }
 
         $storageFilter = self::toInt($arguments['storage'] ?? 0);
         if ($storageFilter > 0) {
             $effective = in_array($storageFilter, $effective, true) ? [$storageFilter] : [];
             if ($effective === []) {
-                return 'No accessible file storages.';
+                return ToolResult::text('No accessible file storages.');
             }
         }
 
@@ -105,7 +106,7 @@ final readonly class FindMissingFilesTool implements ToolInterface
             ->fetchOne());
 
         if ($total === 0) {
-            return 'No missing files in the accessible storages.';
+            return ToolResult::text('No missing files in the accessible storages.');
         }
 
         $listQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
@@ -142,7 +143,7 @@ final readonly class FindMissingFilesTool implements ToolInterface
         }
 
         if ($rows === []) {
-            return 'No missing files in the accessible storages.';
+            return ToolResult::text('No missing files in the accessible storages.');
         }
 
         // The storage-wide $total is only meaningful (and non-leaking) for an
@@ -160,7 +161,7 @@ final readonly class FindMissingFilesTool implements ToolInterface
             );
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/FluidResolveTool.php
+++ b/Classes/Service/Tool/Builtin/FluidResolveTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -67,16 +68,16 @@ final readonly class FluidResolveTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $name = trim(self::toStr($arguments['name'] ?? ''));
         if ($name === '') {
-            return 'Provide a template/partial/layout name.';
+            return ToolResult::text('Provide a template/partial/layout name.');
         }
         // Reject path traversal outright — names address files under the
         // extension's private folder, never elsewhere.
         if (str_contains($name, '..')) {
-            return 'Invalid name.';
+            return ToolResult::text('Invalid name.');
         }
         $name = preg_replace('/\.html$/i', '', $name) ?? $name;
 
@@ -87,10 +88,10 @@ final readonly class FluidResolveTool implements ToolInterface
 
         $extension = trim(self::toStr($arguments['extension'] ?? ''));
         if ($extension === '') {
-            return 'Provide the "extension" key so the Fluid root paths can be resolved.';
+            return ToolResult::text('Provide the "extension" key so the Fluid root paths can be resolved.');
         }
         if (preg_match('/^[a-z0-9_]+$/', $extension) !== 1) {
-            return 'Invalid extension key.';
+            return ToolResult::text('Invalid extension key.');
         }
 
         $subfolder = self::SUBFOLDER[$type];
@@ -98,7 +99,7 @@ final readonly class FluidResolveTool implements ToolInterface
         $absolute  = GeneralUtility::getFileAbsFileName($candidate);
 
         if ($absolute === '') {
-            return sprintf('Extension "%s" is not resolvable (not installed?).', $extension);
+            return ToolResult::text(sprintf('Extension "%s" is not resolvable (not installed?).', $extension));
         }
 
         $exists   = is_file($absolute);
@@ -118,7 +119,7 @@ final readonly class FluidResolveTool implements ToolInterface
         $lines[] = '';
         $lines[] = 'Note: TypoScript-configured override root paths are not included (they need a live rendering context).';
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetEnvRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvRawTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -45,11 +46,11 @@ final readonly class GetEnvRawTool implements ToolInterface, ToolDataClassInterf
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $env = $this->collectEnvironment();
         if ($env === []) {
-            return 'No environment variables.';
+            return ToolResult::text('No environment variables.');
         }
 
         ksort($env);
@@ -58,7 +59,7 @@ final readonly class GetEnvRawTool implements ToolInterface, ToolDataClassInterf
             $lines[] = $name . '=' . $value;
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -54,11 +55,11 @@ final readonly class GetEnvTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $env = $this->collectEnvironment();
         if ($env === []) {
-            return 'No environment variables.';
+            return ToolResult::text('No environment variables.');
         }
 
         ksort($env);
@@ -76,7 +77,7 @@ final readonly class GetEnvTool implements ToolInterface
             $lines[] = $name . '=' . $masked;
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
@@ -68,11 +69,11 @@ final readonly class GetFalReferencesTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $uid = self::toInt($arguments['uid'] ?? 0);
         if ($uid < 1) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $user = $this->actingBackendUser();
@@ -94,7 +95,7 @@ final readonly class GetFalReferencesTool implements ToolInterface
             self::toInt($file['storage'] ?? 0),
             self::toStr($file['identifier'] ?? ''),
         )) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $refQuery = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
@@ -144,10 +145,10 @@ final readonly class GetFalReferencesTool implements ToolInterface
         }
 
         if ($lines === []) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'No references to %s — the file appears unused (soft references and inline RTE links are not tracked here).',
                 self::toStr($file['name'] ?? ''),
-            );
+            ));
         }
 
         $header = sprintf(
@@ -157,7 +158,7 @@ final readonly class GetFalReferencesTool implements ToolInterface
             $skipped > 0 ? sprintf(', %d more not shown', $skipped) : '',
         );
 
-        return $header . "\n" . implode("\n", $lines);
+        return ToolResult::text($header . "\n" . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -70,17 +71,17 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $table = trim(self::toStr($arguments['table'] ?? ''));
         $field = trim(self::toStr($arguments['field'] ?? ''));
         if ($table === '' || $field === '') {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $user = $this->actingBackendUser();
         if (!$this->tableAccess->canReadTable($user, $table)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $tableTca  = $this->tableTca($table);
@@ -88,10 +89,10 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
         $columnTca = is_array($columns[$field] ?? null) ? $columns[$field] : [];
         $conf      = is_array($columnTca['config'] ?? null) ? $columnTca['config'] : null;
         if (!is_array($conf)) {
-            return sprintf('Field %s.%s not found.', $table, $field);
+            return ToolResult::text(sprintf('Field %s.%s not found.', $table, $field));
         }
         if (self::toStr($conf['type'] ?? '') !== 'flex') {
-            return sprintf('Field %s.%s is not a FlexForm field (type=%s).', $table, $field, self::toStr($conf['type'] ?? '?'));
+            return ToolResult::text(sprintf('Field %s.%s is not a FlexForm field (type=%s).', $table, $field, self::toStr($conf['type'] ?? '?')));
         }
 
         $pointer = trim(self::toStr($arguments['ds_pointer'] ?? ''));
@@ -104,12 +105,12 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
             static fn(string $k): bool => $k !== 'default',
         ));
         if ($pointer === '' && $variantKeys !== []) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 "FlexForm field %s.%s has multiple data structures. Re-call with ds_pointer set to one of:\n%s",
                 $table,
                 $field,
                 implode("\n", array_map(static fn(string $k): string => '- ' . $k, $variantKeys)),
-            );
+            ));
         }
 
         try {
@@ -128,10 +129,10 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
             }
         } catch (Throwable) {
             // Neutral by design — resolution internals must not egress.
-            return sprintf('Could not resolve the FlexForm data structure for %s.%s%s.', $table, $field, $pointer !== '' ? sprintf(' (ds_pointer "%s")', $pointer) : '');
+            return ToolResult::text(sprintf('Could not resolve the FlexForm data structure for %s.%s%s.', $table, $field, $pointer !== '' ? sprintf(' (ds_pointer "%s")', $pointer) : ''));
         }
 
-        return $this->renderStructure($table, $field, $pointer, $structure);
+        return ToolResult::text($this->renderStructure($table, $field, $pointer, $structure));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetFullTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetFullTcaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -63,16 +64,16 @@ final readonly class GetFullTcaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $allTca = $GLOBALS['TCA'] ?? null;
         if (!is_array($allTca) || $allTca === []) {
-            return 'No TCA available.';
+            return ToolResult::text('No TCA available.');
         }
 
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return 'Accessible tables (0).';
+            return ToolResult::text('Accessible tables (0).');
         }
 
         $filter    = mb_strtolower(trim(self::toStr($arguments['filter'] ?? '')));
@@ -118,7 +119,7 @@ final readonly class GetFullTcaTool implements ToolInterface
         }
 
         if ($lines === []) {
-            return 'Accessible tables (0). Nothing matched the filter, or you may not read any matching table.';
+            return ToolResult::text('Accessible tables (0). Nothing matched the filter, or you may not read any matching table.');
         }
 
         $header = sprintf(
@@ -127,7 +128,7 @@ final readonly class GetFullTcaTool implements ToolInterface
             $skipped > 0 ? sprintf(', %d more not shown', $skipped) : '',
         );
 
-        return $header . "\n" . implode("\n", $lines);
+        return ToolResult::text($header . "\n" . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
+++ b/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\ValueObject\LogExceptionEntry;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
 use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
@@ -72,7 +73,7 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $index  = max(0, self::toInt($arguments['index'] ?? 0));
         $search = trim(self::toStr($arguments['search'] ?? ''));
@@ -81,10 +82,10 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
         $entry   = $entries[$index] ?? null;
 
         if (!$entry instanceof LogExceptionEntry) {
-            return $entries === []
+            return ToolResult::text($entries === []
                 ? 'No error-level entries found in the TYPO3 file logs. '
                   . 'For database-logged events try the fetch_logs tool (sys_log).'
-                : sprintf('Only %d matching error(s) available — index %d is out of range.', count($entries), $index);
+                : sprintf('Only %d matching error(s) available — index %d is out of range.', count($entries), $index));
         }
 
         $lines   = [];
@@ -108,7 +109,7 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
         if ($entry->frames === []) {
             $lines[] = 'No stack trace recorded for this entry.';
 
-            return implode("\n", $lines);
+            return ToolResult::text(implode("\n", $lines));
         }
 
         $lines[]  = 'Stack trace:';
@@ -144,7 +145,7 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
             }
         }
 
-        return implode("\n", array_slice($lines, 0, self::MAX_OUTPUT_LINES));
+        return ToolResult::text(implode("\n", array_slice($lines, 0, self::MAX_OUTPUT_LINES)));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -84,16 +85,16 @@ final readonly class GetPageContentTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $uid = self::toInt($arguments['uid'] ?? 0);
         if ($uid < 1) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $language = self::toInt($arguments['language'] ?? 0);
@@ -106,7 +107,7 @@ final readonly class GetPageContentTool implements ToolInterface
         // Non-admins may only read content in languages they are permitted;
         // otherwise a language restriction is a no-op against this tool.
         if (!$isAdmin && !$user->checkLanguageAccess($language)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         // Non-admins must hold PAGE_SHOW on the page itself; a missing page and
@@ -114,13 +115,13 @@ final readonly class GetPageContentTool implements ToolInterface
         if (!$isAdmin) {
             $permsClause = self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW));
             if (!is_array(BackendUtility::readPageAccess($uid, $permsClause))) {
-                return self::NOT_PERMITTED;
+                return ToolResult::text(self::NOT_PERMITTED);
             }
         }
 
         $page = $this->fetchPage($uid, $isAdmin);
         if ($page === null) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $lines   = [];
@@ -137,7 +138,7 @@ final readonly class GetPageContentTool implements ToolInterface
         if ($rows === []) {
             $lines[] = sprintf('No content elements (language %d).', $language);
 
-            return implode("\n", $lines);
+            return ToolResult::text(implode("\n", $lines));
         }
 
         $lines[] = sprintf('Content elements (%d, language %d):', count($rows), $language);
@@ -158,7 +159,7 @@ final readonly class GetPageContentTool implements ToolInterface
             }
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -74,7 +75,7 @@ final readonly class GetPageTreeTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $rootUid = self::toInt($arguments['rootUid'] ?? 0);
         if ($rootUid < 0) {
@@ -92,12 +93,12 @@ final readonly class GetPageTreeTool implements ToolInterface
         $this->appendChildren($rootUid, 0, $depth, $lines, $count);
 
         if ($lines === []) {
-            return 'No pages.';
+            return ToolResult::text('No pages.');
         }
 
         array_unshift($lines, sprintf('Page tree from uid %d (depth %d):', $rootUid, $depth));
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoRawTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -41,14 +42,14 @@ final readonly class GetPhpInfoRawTool implements ToolInterface, ToolDataClassIn
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         ob_start();
         phpinfo(INFO_ALL);
         $info = ob_get_clean();
 
         if (!is_string($info) || $info === '') {
-            return 'phpinfo unavailable.';
+            return ToolResult::text('phpinfo unavailable.');
         }
 
         // In a web SAPI (the TYPO3 backend) phpinfo() emits HTML, not the CLI's
@@ -63,7 +64,7 @@ final readonly class GetPhpInfoRawTool implements ToolInterface, ToolDataClassIn
             $info = trim($info);
         }
 
-        return $info !== '' ? $info : 'phpinfo unavailable.';
+        return ToolResult::text($info !== '' ? $info : 'phpinfo unavailable.');
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
+++ b/Classes/Service/Tool/Builtin/GetPhpInfoTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -52,7 +53,7 @@ final readonly class GetPhpInfoTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $extensions = get_loaded_extensions();
         sort($extensions);
@@ -64,7 +65,7 @@ final readonly class GetPhpInfoTool implements ToolInterface
             $lines[] = $key . ' = ' . self::toStr(ini_get($key));
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
+++ b/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -86,25 +87,25 @@ final readonly class GetRecordHistoryTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $table = trim(self::toStr($arguments['table'] ?? ''));
         $uid   = self::toInt($arguments['uid'] ?? 0);
         if ($table === '' || $uid < 1) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $user = $this->actingBackendUser();
         if (!$this->tableAccess->canReadTable($user, $table)) {
             // Same neutral string whether unknown, denylisted or unpermitted.
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         // Non-admins must hold PAGE_SHOW on the record's page (same gate as
         // read_records) — history values must not leak from unreadable pages.
         // Fail-closed: an unresolvable record (e.g. hard-deleted) denies too.
         if ($user !== null && !$user->isAdmin() && !$this->recordPageIsReadable($user, $table, $uid)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $fieldFilter = trim(self::toStr($arguments['field'] ?? ''));
@@ -113,7 +114,7 @@ final readonly class GetRecordHistoryTool implements ToolInterface
 
         $rows = $this->fetchHistory($table, $uid, $limit);
         if ($rows === []) {
-            return sprintf('No change history for %s:%d.', $table, $uid);
+            return ToolResult::text(sprintf('No change history for %s:%d.', $table, $uid));
         }
 
         $usernames = $this->resolveUsernames($rows);
@@ -138,13 +139,13 @@ final readonly class GetRecordHistoryTool implements ToolInterface
         }
 
         if ($entries === []) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'No changes touching "%s" in the last %d history entries of %s:%d.',
                 $fieldFilter,
                 count($rows),
                 $table,
                 $uid,
-            );
+            ));
         }
 
         $header = sprintf(
@@ -159,7 +160,7 @@ final readonly class GetRecordHistoryTool implements ToolInterface
             $entries[] = sprintf('(%d entries not touching "%s" skipped.)', $skipped, $fieldFilter);
         }
 
-        return $header . "\n" . implode("\n", $entries);
+        return ToolResult::text($header . "\n" . implode("\n", $entries));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
@@ -65,7 +66,7 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $identifier = trim(self::toStr($arguments['identifier'] ?? ''));
 
@@ -80,20 +81,20 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
                 );
             }
             if ($lines === []) {
-                return 'No sites configured.';
+                return ToolResult::text('No sites configured.');
             }
             sort($lines);
 
-            return sprintf(
+            return ToolResult::text(sprintf(
                 "Configured sites (%d) — pass \"identifier\" for a site's configuration:\n",
                 count($lines),
-            ) . implode("\n", $lines);
+            ) . implode("\n", $lines));
         }
 
         $sites = $this->siteFinder->getAllSites();
         $site  = $sites[$identifier] ?? null;
         if ($site === null) {
-            return sprintf('No site "%s". Call without arguments to list the identifiers.', $identifier);
+            return ToolResult::text(sprintf('No site "%s". Call without arguments to list the identifiers.', $identifier));
         }
 
         $lines = [];
@@ -105,8 +106,8 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
             $lines[] = sprintf('… %d more lines not shown', $total - self::MAX_LINES);
         }
 
-        return sprintf("Site \"%s\" configuration (%d entries):\n", $identifier, $total)
-            . implode("\n", $lines);
+        return ToolResult::text(sprintf("Site \"%s\" configuration (%d entries):\n", $identifier, $total)
+            . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetSystemStatusTool.php
+++ b/Classes/Service/Tool/Builtin/GetSystemStatusTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Throwable;
@@ -45,7 +46,7 @@ final readonly class GetSystemStatusTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $typo3 = new Typo3Version();
 
@@ -58,7 +59,7 @@ final readonly class GetSystemStatusTool implements ToolInterface
         $lines[] = sprintf('OS family: %s', PHP_OS_FAMILY);
         $lines[] = sprintf('Timezone: %s', date_default_timezone_get());
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -62,24 +63,24 @@ final readonly class GetTableSchemaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $table = trim(self::toStr($arguments['table'] ?? ''));
         if ($table === '') {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $user = $this->actingBackendUser();
         if (!$this->tableAccess->canReadTable($user, $table)) {
             // Same neutral string whether unknown, denylisted or unpermitted —
             // the tool never confirms a table's existence to the unauthorised.
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $allTca = $GLOBALS['TCA'] ?? null;
         $tca    = is_array($allTca) ? ($allTca[$table] ?? null) : null;
         if (!is_array($tca) || !is_array($tca['columns'] ?? null)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $ctrl  = is_array($tca['ctrl'] ?? null) ? $tca['ctrl'] : [];
@@ -103,7 +104,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
             ++$count;
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTcaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -56,19 +57,19 @@ final readonly class GetTcaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $tca = $GLOBALS['TCA'] ?? [];
         if (!is_array($tca) || $tca === []) {
-            return 'No TCA available.';
+            return ToolResult::text('No TCA available.');
         }
 
         $table = self::toStr($arguments['table'] ?? '');
         if ($table === '') {
-            return $this->listTables($tca);
+            return ToolResult::text($this->listTables($tca));
         }
 
-        return $this->describeTable($tca, $table);
+        return ToolResult::text($this->describeTable($tca, $table));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetTsConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetTsConfigTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -66,11 +67,11 @@ final readonly class GetTsConfigTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $pageUid = self::toInt($arguments['pageUid'] ?? 0);
         if ($pageUid < 1 || !$this->pageExists($pageUid)) {
-            return self::NOT_FOUND;
+            return ToolResult::text(self::NOT_FOUND);
         }
 
         $path = trim(self::toStr($arguments['path'] ?? ''));
@@ -79,11 +80,11 @@ final readonly class GetTsConfigTool implements ToolInterface
             $tsConfig = BackendUtility::getPagesTSconfig($pageUid);
         } catch (Throwable) {
             // Neutral by design — resolution internals must not egress.
-            return self::NOT_FOUND;
+            return ToolResult::text(self::NOT_FOUND);
         }
 
         if ($tsConfig === []) {
-            return sprintf('No Page TSconfig for page %d.', $pageUid);
+            return ToolResult::text(sprintf('No Page TSconfig for page %d.', $pageUid));
         }
 
         if ($path === '') {
@@ -94,12 +95,12 @@ final readonly class GetTsConfigTool implements ToolInterface
                 count($tsConfig),
             ));
 
-            return implode("\n", $lines);
+            return ToolResult::text(implode("\n", $lines));
         }
 
         [$value, $subtree] = $this->drillPath($tsConfig, $path);
         if ($value === null && $subtree === null) {
-            return sprintf('No Page TSconfig at path "%s".', $path);
+            return ToolResult::text(sprintf('No Page TSconfig at path "%s".', $path));
         }
 
         $lines = [sprintf('Page TSconfig for page %d at "%s":', $pageUid, $path)];
@@ -111,7 +112,7 @@ final readonly class GetTsConfigTool implements ToolInterface
             $this->renderTree($subtree, $lines, 0);
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -83,11 +84,11 @@ final readonly class GetTypoScriptTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $pageUid = self::toInt($arguments['pageUid'] ?? 0);
         if ($pageUid < 1) {
-            return 'Page not found or no TypoScript template.';
+            return ToolResult::text('Page not found or no TypoScript template.');
         }
 
         $type = self::toStr($arguments['type'] ?? self::TYPE_SETUP);
@@ -99,14 +100,14 @@ final readonly class GetTypoScriptTool implements ToolInterface
 
         try {
             if ($type === self::TYPE_CONSTANTS) {
-                return $this->renderConstants($this->resolveFlatConstants($pageUid), $pageUid, $path);
+                return ToolResult::text($this->renderConstants($this->resolveFlatConstants($pageUid), $pageUid, $path));
             }
 
-            return $this->renderSetup($this->resolveSetup($pageUid), $pageUid, $path);
+            return ToolResult::text($this->renderSetup($this->resolveSetup($pageUid), $pageUid, $path));
         } catch (Throwable) {
             // Deliberately neutral: rootline/site/template resolution failures
             // must not leak exception internals into the provider egress.
-            return 'Page not found or no TypoScript template.';
+            return ToolResult::text('Page not found or no TypoScript template.');
         }
     }
 

--- a/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -53,7 +54,7 @@ final readonly class ListBeGroupsTool implements ToolInterface, ToolDataClassInt
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->getRestrictions()->removeAll();
@@ -69,7 +70,7 @@ final readonly class ListBeGroupsTool implements ToolInterface, ToolDataClassInt
             ->fetchAllAssociative();
 
         if ($rows === []) {
-            return 'No backend groups.';
+            return ToolResult::text('No backend groups.');
         }
 
         $lines = [sprintf('Backend groups (%d):', count($rows))];
@@ -77,7 +78,7 @@ final readonly class ListBeGroupsTool implements ToolInterface, ToolDataClassInt
             $lines[] = sprintf('[%d] %s', self::toInt($row['uid'] ?? 0), self::toStr($row['title'] ?? ''));
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -68,7 +69,7 @@ final readonly class ListBeUsersRawTool implements ToolInterface, ToolDataClassI
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->getRestrictions()->removeAll();
@@ -84,7 +85,7 @@ final readonly class ListBeUsersRawTool implements ToolInterface, ToolDataClassI
             ->fetchAllAssociative();
 
         if ($rows === []) {
-            return 'No backend users.';
+            return ToolResult::text('No backend users.');
         }
 
         $blocks = [];
@@ -100,7 +101,7 @@ final readonly class ListBeUsersRawTool implements ToolInterface, ToolDataClassI
             $blocks[] = sprintf('[%d]', self::toInt($row['uid'] ?? 0)) . "\n" . implode("\n", $pairs);
         }
 
-        return sprintf("Backend users (%d):\n", count($rows)) . implode("\n", $blocks);
+        return ToolResult::text(sprintf("Backend users (%d):\n", count($rows)) . implode("\n", $blocks));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListBeUsersTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -52,7 +53,7 @@ final readonly class ListBeUsersTool implements ToolInterface, ToolDataClassInte
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->getRestrictions()->removeAll();
@@ -69,7 +70,7 @@ final readonly class ListBeUsersTool implements ToolInterface, ToolDataClassInte
             ->fetchAllAssociative();
 
         if ($rows === []) {
-            return 'No backend users.';
+            return ToolResult::text('No backend users.');
         }
 
         $lines = [sprintf('Backend users (%d):', count($rows))];
@@ -87,7 +88,7 @@ final readonly class ListBeUsersTool implements ToolInterface, ToolDataClassInte
             );
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
+++ b/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -63,19 +64,19 @@ final readonly class ListDeprecationsTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         $limit = max(1, min(self::MAX_LIMIT, $limit));
 
         $file = $this->newestLogFile();
         if ($file === null) {
-            return self::NO_LOG;
+            return ToolResult::text(self::NO_LOG);
         }
 
         $tail = $this->tail($file);
         if ($tail === '') {
-            return self::NO_LOG;
+            return ToolResult::text(self::NO_LOG);
         }
 
         // Newest last in the file → iterate reversed so "newest first" wins.
@@ -88,7 +89,7 @@ final readonly class ListDeprecationsTool implements ToolInterface
             $counts[$message] = ($counts[$message] ?? 0) + 1;
         }
         if ($counts === []) {
-            return self::NO_LOG;
+            return ToolResult::text(self::NO_LOG);
         }
 
         $total  = count($counts);
@@ -99,11 +100,11 @@ final readonly class ListDeprecationsTool implements ToolInterface
             $lines[] = sprintf('- %s%s', $message, $count > 1 ? sprintf(' (×%d)', $count) : '');
         }
 
-        return sprintf(
+        return ToolResult::text(sprintf(
             "Deprecations (%d distinct%s, newest first):\n",
             $total,
             $total > $limit ? sprintf(', showing %d', $limit) : '',
-        ) . implode("\n", $lines);
+        ) . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListExtensionsTool.php
+++ b/Classes/Service/Tool/Builtin/ListExtensionsTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -45,7 +46,7 @@ final readonly class ListExtensionsTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $lines = [];
         foreach ($this->packageManager->getActivePackages() as $package) {
@@ -63,12 +64,12 @@ final readonly class ListExtensionsTool implements ToolInterface
         }
 
         if ($lines === []) {
-            return 'No active packages.';
+            return ToolResult::text('No active packages.');
         }
 
         ksort($lines);
 
-        return sprintf("Active extensions (%d):\n", count($lines)) . implode("\n", $lines);
+        return ToolResult::text(sprintf("Active extensions (%d):\n", count($lines)) . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
+++ b/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -47,7 +48,7 @@ final readonly class ListFalStoragesTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user  = $this->actingBackendUser();
         $lines = [];
@@ -80,10 +81,10 @@ final readonly class ListFalStoragesTool implements ToolInterface
         }
 
         if ($lines === []) {
-            return 'No accessible file storages.';
+            return ToolResult::text('No accessible file storages.');
         }
 
-        return sprintf("Accessible file storages (%d):\n", count($lines)) . implode("\n", $lines);
+        return ToolResult::text(sprintf("Accessible file storages (%d):\n", count($lines)) . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
+++ b/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -57,11 +58,11 @@ final readonly class ListMiddlewaresTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $stack = trim(self::toStr($arguments['stack'] ?? 'frontend'));
         if (!in_array($stack, self::STACKS, true)) {
-            return sprintf('Unknown stack — use one of: %s.', implode(', ', self::STACKS));
+            return ToolResult::text(sprintf('Unknown stack — use one of: %s.', implode(', ', self::STACKS)));
         }
 
         $lines = [];
@@ -79,15 +80,15 @@ final readonly class ListMiddlewaresTool implements ToolInterface
                 $lines[] = sprintf('%2d. %s (%s)', $shown, (string)$identifier, self::toStr($className));
             }
         } catch (Throwable) {
-            return 'Could not resolve the middleware stack.';
+            return ToolResult::text('Could not resolve the middleware stack.');
         }
 
         if ($shown === 0) {
-            return sprintf('The %s middleware stack is empty.', $stack);
+            return ToolResult::text(sprintf('The %s middleware stack is empty.', $stack));
         }
 
-        return sprintf("PSR-15 %s middleware stack (%d, execution order):\n", $stack, $shown)
-            . implode("\n", $lines);
+        return ToolResult::text(sprintf("PSR-15 %s middleware stack (%d, execution order):\n", $stack, $shown)
+            . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
+++ b/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -59,16 +60,16 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         try {
             $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
             $available  = array_keys($connection->createSchemaManager()->listTableColumns(self::TABLE));
         } catch (Throwable) {
-            return self::NOT_INSTALLED;
+            return ToolResult::text(self::NOT_INSTALLED);
         }
         if ($available === []) {
-            return self::NOT_INSTALLED;
+            return ToolResult::text(self::NOT_INSTALLED);
         }
 
         $select = array_values(array_intersect(
@@ -87,11 +88,11 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
                 ->executeQuery()
                 ->fetchAllAssociative();
         } catch (Throwable) {
-            return self::NOT_INSTALLED;
+            return ToolResult::text(self::NOT_INSTALLED);
         }
 
         if ($rows === []) {
-            return 'No scheduler tasks configured.';
+            return ToolResult::text('No scheduler tasks configured.');
         }
 
         $lines = [];
@@ -123,8 +124,8 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
             $lines[] = sprintf('- [%d] %s (%s)', self::toInt($row['uid'] ?? 0), $label, implode(', ', $flags));
         }
 
-        return sprintf("Scheduler tasks (%d, capped at %d):\n", count($lines), self::MAX_TASKS)
-            . implode("\n", $lines);
+        return ToolResult::text(sprintf("Scheduler tasks (%d, capped at %d):\n", count($lines), self::MAX_TASKS)
+            . implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\EgressPolicyService;
 use Netresearch\NrLlm\Service\Tool\LogExceptionReader;
@@ -82,21 +83,21 @@ final readonly class ProbeUrlTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $input = trim(self::toStr($arguments['url'] ?? ''));
         if ($input === '') {
-            return 'Error: "url" is required.';
+            return ToolResult::text('Error: "url" is required.');
         }
 
         $url = $this->egressPolicy->resolveAllowedUrl($this->getGroup(), $input);
         if ($url === null) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'Denied: "%s" is not a URL of this instance. Allowed hosts: %s. '
                 . 'Relative paths like "/imprint" are resolved against the first site.',
                 $this->displayUrl($input),
                 implode(', ', $this->egressPolicy->allowedHosts()) ?: '(no site configured)',
-            );
+            ));
         }
 
         $started   = microtime(true);
@@ -109,12 +110,12 @@ final readonly class ProbeUrlTool implements ToolInterface
                 'http_errors'     => false,
             ]);
         } catch (Throwable $e) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'Probe of %s FAILED transport-level after %.0f ms: %s',
                 $url,
                 (microtime(true) - $started) * 1000,
                 $this->sanitizeErrorMessage($e->getMessage()),
-            );
+            ));
         }
 
         $elapsedMs = (microtime(true) - $started) * 1000;
@@ -145,7 +146,7 @@ final readonly class ProbeUrlTool implements ToolInterface
             $lines[] = $this->correlateLogs($probeTime);
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -67,11 +68,11 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $uid = self::toInt($arguments['uid'] ?? 0);
         if ($uid < 1) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         // sys_file / sys_file_metadata are FAL system tables without enable
@@ -92,7 +93,7 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
             ->fetchAssociative();
 
         if (!is_array($file) || !in_array(self::toInt($file['storage'] ?? 0), $this->allowedStorages, true)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $lines = [
@@ -129,7 +130,7 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
             }
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -106,28 +109,28 @@ final readonly class ReadRecordsTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $table = trim(self::toStr($arguments['table'] ?? ''));
         if (!$this->tableAccess->canReadTable($user, $table)) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $columns = $this->tcaColumns($table);
 
         $fields = $this->resolveFields($table, $columns, $arguments['fields'] ?? null);
         if ($fields === []) {
-            return 'No readable fields.';
+            return ToolResult::text('No readable fields.');
         }
 
         $filters = $this->resolveFilters($columns, $arguments);
         if ($filters === null) {
-            return 'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.';
+            return ToolResult::text('Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.');
         }
 
         // A non-admin explicitly filtering by a language they may not access
@@ -136,7 +139,7 @@ final readonly class ReadRecordsTool implements ToolInterface
             && isset($filters['sys_language_uid'])
             && !$user->checkLanguageAccess((int)$filters['sys_language_uid'])
         ) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
@@ -172,22 +175,35 @@ final readonly class ReadRecordsTool implements ToolInterface
         }
 
         if ($rows === []) {
-            return sprintf('No records in %s for the given filters.', $table);
+            return ToolResult::text(sprintf('No records in %s for the given filters.', $table));
         }
 
-        $lines = [sprintf('Records in %s (%d, offset %d):', $table, count($rows), $offset)];
+        // Build the human-readable text and the structured TABLE artifact in ONE
+        // pass from the SAME redacted/formatted cells, so the artifact can never
+        // drift from — or re-expose more than — the text egress (ADR-108). The
+        // artifact is run-only; only the text `content` reaches the provider.
+        $lines        = [sprintf('Records in %s (%d, offset %d):', $table, count($rows), $offset)];
+        $artifactRows = [];
         foreach ($rows as $row) {
-            $lines[] = sprintf('- %s:%d', $table, self::toInt($row['uid'] ?? 0));
+            $lines[]     = sprintf('- %s:%d', $table, self::toInt($row['uid'] ?? 0));
+            $artifactRow = [];
             foreach ($fields as $field) {
-                if ($field === 'uid') {
-                    continue;
+                $value         = $this->formatValue($row[$field] ?? null);
+                $artifactRow[] = $value;
+                if ($field !== 'uid') {
+                    $lines[] = sprintf('  %s: %s', $field, $value);
                 }
-                $value   = $this->formatValue($row[$field] ?? null);
-                $lines[] = sprintf('  %s: %s', $field, $value);
             }
+            $artifactRows[] = $artifactRow;
         }
 
-        return implode("\n", $lines);
+        return ToolResult::text(
+            implode("\n", $lines),
+            new ToolArtifact(ArtifactType::TABLE, sprintf('%s records', $table), [
+                'columns' => $fields,
+                'rows'    => $artifactRows,
+            ]),
+        );
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ReadSourceTool.php
+++ b/Classes/Service/Tool/Builtin/ReadSourceTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -64,11 +65,11 @@ final readonly class ReadSourceTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $path = trim(self::toStr($arguments['path'] ?? ''));
         if ($path === '') {
-            return 'Error: "path" is required.';
+            return ToolResult::text('Error: "path" is required.');
         }
 
         $fromLine = max(1, self::toInt($arguments['from_line'] ?? 1));
@@ -80,12 +81,12 @@ final readonly class ReadSourceTool implements ToolInterface
 
         $read = $this->guard->readLines($path, $fromLine, $lines);
         if ($read === null) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'Denied or not found: "%s". Paths must resolve inside the project root; dotfiles, '
                 . 'var/* (except var/log), config/system, settings/additional.php, key material and '
                 . 'credential paths are not readable.',
                 $path,
-            );
+            ));
         }
 
         $out   = [];
@@ -98,7 +99,7 @@ final readonly class ReadSourceTool implements ToolInterface
             $out[] = '(range is beyond the end of the file)';
         }
 
-        return implode("\n", $out);
+        return ToolResult::text(implode("\n", $out));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ResolveUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ResolveUrlTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -75,56 +76,56 @@ final readonly class ResolveUrlTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $input = trim(self::toStr($arguments['url'] ?? ''));
         if ($input === '') {
-            return 'Error: "url" is required.';
+            return ToolResult::text('Error: "url" is required.');
         }
 
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return self::NOT_PERMITTED;
+            return ToolResult::text(self::NOT_PERMITTED);
         }
 
         $url = $this->absoluteUrl($input);
         if ($url === null) {
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
 
         try {
             $request     = new ServerRequest($url, 'GET');
             $routeResult = $this->siteMatcher->matchRequest($request);
         } catch (Throwable) {
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
 
         if (!$routeResult instanceof SiteRouteResult) {
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
         $site = $routeResult->getSite();
         if (!$site instanceof Site) {
             // NullSite: the host/path prefix belongs to no configured site.
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
 
         try {
             $pageArguments = $site->getRouter()->matchRequest($request, $routeResult);
         } catch (RouteNotFoundException) {
-            return sprintf(
+            return ToolResult::text(sprintf(
                 'No page route matches "%s" on site "%s" — the slug may not exist, or the page is hidden/not translated.',
                 $this->pathOf($url),
                 $site->getIdentifier(),
-            );
+            ));
         } catch (Throwable) {
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
 
         if (!$pageArguments instanceof PageArguments) {
-            return self::NO_SITE;
+            return ToolResult::text(self::NO_SITE);
         }
 
-        return $this->renderResult($site, $routeResult, $pageArguments, $user->isAdmin());
+        return ToolResult::text($this->renderResult($site, $routeResult, $pageArguments, $user->isAdmin()));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/SearchCodeTool.php
+++ b/Classes/Service/Tool/Builtin/SearchCodeTool.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
 use FilesystemIterator;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\SourcePathGuard;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -78,11 +79,11 @@ final readonly class SearchCodeTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $pattern = self::toStr($arguments['pattern'] ?? '');
         if ($pattern === '') {
-            return 'Error: "pattern" is required.';
+            return ToolResult::text('Error: "pattern" is required.');
         }
 
         $isRegex = (bool)($arguments['regex'] ?? false);
@@ -98,7 +99,7 @@ final readonly class SearchCodeTool implements ToolInterface
                 restore_error_handler();
             }
             if (!$patternIsValid) {
-                return sprintf('Error: invalid regular expression "%s".', $pattern);
+                return ToolResult::text(sprintf('Error: invalid regular expression "%s".', $pattern));
             }
         }
 
@@ -110,7 +111,7 @@ final readonly class SearchCodeTool implements ToolInterface
 
         $root = $this->guard->rootPath();
         if ($root === null) {
-            return 'Error: project root not resolvable.';
+            return ToolResult::text('Error: project root not resolvable.');
         }
 
         $base    = $root;
@@ -118,10 +119,10 @@ final readonly class SearchCodeTool implements ToolInterface
         if ($subPath !== '') {
             $candidate = realpath($root . '/' . $subPath);
             if ($candidate === false || !is_dir($candidate) || !str_starts_with($candidate . '/', $root . '/')) {
-                return sprintf('Denied or not found: search path "%s".', $subPath);
+                return ToolResult::text(sprintf('Denied or not found: search path "%s".', $subPath));
             }
             if ($this->guard->isDeniedRelativePath(substr($candidate, strlen($root) + 1) . '/x')) {
-                return sprintf('Denied: search path "%s".', $subPath);
+                return ToolResult::text(sprintf('Denied: search path "%s".', $subPath));
             }
             $base = $candidate;
         }
@@ -179,9 +180,9 @@ final readonly class SearchCodeTool implements ToolInterface
         }
 
         if ($hits === []) {
-            return $truncated !== ''
+            return ToolResult::text($truncated !== ''
                 ? "No matches found before the budget ran out.\n" . $truncated
-                : sprintf('No matches for "%s".', $pattern);
+                : sprintf('No matches for "%s".', $pattern));
         }
 
         $header = sprintf('%d match(es) for "%s"%s:', count($hits), $pattern, count($hits) >= $maxResults ? ' (capped)' : '');
@@ -190,7 +191,7 @@ final readonly class SearchCodeTool implements ToolInterface
             $out[] = $truncated;
         }
 
-        return implode("\n", $out);
+        return ToolResult::text(implode("\n", $out));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -74,24 +75,24 @@ final readonly class SearchFalFilesTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $query = trim(self::toStr($arguments['query'] ?? ''));
         if ($query === '') {
-            return 'Error: "query" is required.';
+            return ToolResult::text('Error: "query" is required.');
         }
 
         $user      = $this->actingBackendUser();
         $effective = $this->storageGate->effectiveStorages($user);
         if ($effective === []) {
-            return 'No accessible file storages.';
+            return ToolResult::text('No accessible file storages.');
         }
 
         $storageFilter = self::toInt($arguments['storage'] ?? 0);
         if ($storageFilter > 0) {
             $effective = in_array($storageFilter, $effective, true) ? [$storageFilter] : [];
             if ($effective === []) {
-                return 'No accessible file storages.';
+                return ToolResult::text('No accessible file storages.');
             }
         }
 
@@ -149,7 +150,7 @@ final readonly class SearchFalFilesTool implements ToolInterface
         }
 
         if ($rows === []) {
-            return sprintf('No files match "%s" in the accessible storages.', $query);
+            return ToolResult::text(sprintf('No files match "%s" in the accessible storages.', $query));
         }
 
         $lines = [sprintf('Files matching "%s" (%d, capped at %d):', $query, count($rows), $limit)];
@@ -165,7 +166,7 @@ final readonly class SearchFalFilesTool implements ToolInterface
         }
         $lines[] = 'Use read_fal_asset_meta(uid) for title/alternative detail.';
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -93,16 +94,16 @@ final readonly class SearchRecordsTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return 'Not permitted.';
+            return ToolResult::text('Not permitted.');
         }
 
         $query = trim(self::toStr($arguments['query'] ?? ''));
         if (mb_strlen($query) < self::MIN_QUERY_LENGTH) {
-            return 'Query too short (minimum 2 characters).';
+            return ToolResult::text('Query too short (minimum 2 characters).');
         }
         $query = mb_substr($query, 0, self::MAX_QUERY_LENGTH);
 
@@ -115,9 +116,9 @@ final readonly class SearchRecordsTool implements ToolInterface
         $restrictTable = trim(self::toStr($arguments['table'] ?? ''));
         $tables        = $this->searchableTables($restrictTable);
         if ($tables === []) {
-            return $restrictTable !== ''
+            return ToolResult::text($restrictTable !== ''
                 ? 'Table not found or not permitted.'
-                : 'No searchable tables available.';
+                : 'No searchable tables available.');
         }
 
         $isAdmin     = $user->isAdmin();
@@ -146,12 +147,12 @@ final readonly class SearchRecordsTool implements ToolInterface
         }
 
         if ($lines === []) {
-            return 'No matches.';
+            return ToolResult::text('No matches.');
         }
 
         array_unshift($lines, sprintf('Matches for "%s" (%d):', $query, count($lines)));
 
-        return implode("\n", $lines);
+        return ToolResult::text(implode("\n", $lines));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/SiteFetchSourceTool.php
+++ b/Classes/Service/Tool/Builtin/SiteFetchSourceTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Retrieval\AccessContext;
 use Netresearch\NrLlm\Service\Retrieval\RetrievalService;
@@ -57,28 +58,28 @@ final readonly class SiteFetchSourceTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return 'Not permitted.';
+            return ToolResult::text('Not permitted.');
         }
 
         $reference = SourceReference::parse(trim(self::toStr($arguments['source_id'] ?? '')));
         if ($reference === null) {
-            return 'Invalid source_id.';
+            return ToolResult::text('Invalid source_id.');
         }
 
         $text = $this->retrievalService->fetchSource($reference, AccessContext::forBackendUser($user));
         if ($text === null || trim($text) === '') {
-            return 'Source not found or not permitted.';
+            return ToolResult::text('Source not found or not permitted.');
         }
 
         if (mb_strlen($text) > self::MAX_OUTPUT_CHARS) {
             $text = mb_substr($text, 0, self::MAX_OUTPUT_CHARS) . '…';
         }
 
-        return $text;
+        return ToolResult::text($text);
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/SiteRagQueryTool.php
+++ b/Classes/Service/Tool/Builtin/SiteRagQueryTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Retrieval\AccessContext;
 use Netresearch\NrLlm\Service\Retrieval\EvidenceList;
@@ -76,11 +77,11 @@ final readonly class SiteRagQueryTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $user = $this->actingBackendUser();
         if ($user === null) {
-            return 'Not permitted.';
+            return ToolResult::text('Not permitted.');
         }
 
         $question = trim(self::toStr($arguments['question'] ?? ''));
@@ -88,7 +89,7 @@ final readonly class SiteRagQueryTool implements ToolInterface
         // whitespace and shrink the trimmed length below the minimum.
         $question = trim(mb_substr($question, 0, RetrievalQuery::MAX_QUERY_LENGTH));
         if (mb_strlen($question) < RetrievalQuery::MIN_QUERY_LENGTH) {
-            return 'Question too short (minimum 2 characters).';
+            return ToolResult::text('Question too short (minimum 2 characters).');
         }
 
         $maxSources = self::toInt($arguments['max_sources'] ?? self::DEFAULT_SOURCES);
@@ -105,7 +106,7 @@ final readonly class SiteRagQueryTool implements ToolInterface
             AccessContext::forBackendUser($user),
         );
 
-        return $this->format($question, $result);
+        return ToolResult::text($this->format($question, $result));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool\Builtin;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -67,11 +68,11 @@ final readonly class ValidateTcaTool implements ToolInterface
         );
     }
 
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $allTca = $GLOBALS['TCA'] ?? null;
         if (!is_array($allTca) || $allTca === []) {
-            return 'No TCA available.';
+            return ToolResult::text('No TCA available.');
         }
 
         $user  = $this->actingBackendUser();
@@ -79,15 +80,15 @@ final readonly class ValidateTcaTool implements ToolInterface
 
         if ($table !== '') {
             if (!$this->tableAccess->canReadTable($user, $table) || !is_array($allTca[$table] ?? null)) {
-                return self::NOT_PERMITTED;
+                return ToolResult::text(self::NOT_PERMITTED);
             }
 
             $findings = $this->validateTable($table, $allTca[$table], $allTca);
             if ($findings === []) {
-                return sprintf('No TCA issues found in table "%s".', $table);
+                return ToolResult::text(sprintf('No TCA issues found in table "%s".', $table));
             }
 
-            return $this->render($findings, 1);
+            return ToolResult::text($this->render($findings, 1));
         }
 
         $findings = [];
@@ -104,10 +105,10 @@ final readonly class ValidateTcaTool implements ToolInterface
         }
 
         if ($findings === []) {
-            return sprintf('No TCA issues found in %d checked tables.', $checked);
+            return ToolResult::text(sprintf('No TCA issues found in %d checked tables.', $checked));
         }
 
-        return $this->render($findings, $checked);
+        return ToolResult::text($this->render($findings, $checked));
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Service/Tool/RunTrace.php
+++ b/Classes/Service/Tool/RunTrace.php
@@ -13,6 +13,7 @@ use Closure;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 
 /**
@@ -127,6 +128,7 @@ final class RunTrace
      * Record one executed tool call.
      *
      * @param array<string, mixed> $arguments
+     * @param list<ToolArtifact>   $artifacts run-only structured artifacts (NEVER provider-facing)
      */
     public function recordToolExecution(
         int $round,
@@ -135,6 +137,7 @@ final class RunTrace
         array $arguments,
         string $result,
         bool $isError,
+        array $artifacts = [],
     ): void {
         $this->add(new RunStep(
             kind: RunStep::KIND_TOOL,
@@ -144,6 +147,7 @@ final class RunTrace
             toolArguments: $arguments,
             toolResult: $result,
             toolIsError: $isError,
+            toolArtifacts: $artifacts === [] ? null : $artifacts,
         ));
     }
 

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -9,23 +9,28 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * A PHP "tool" the model may call mid-generation during the agent loop.
  *
- * Implementations are admin-curated, read-only, and return a plain string.
- * They are discovered via the `nr_llm.tool` DI tag (auto-applied by
- * AutoconfigureTag, mirroring ProviderMiddlewareInterface) and collected by
- * ToolRegistry through a tagged iterator.
+ * Implementations are admin-curated, read-only, and return a typed
+ * {@see ToolResult}. They are discovered via the `nr_llm.tool` DI tag
+ * (auto-applied by AutoconfigureTag, mirroring ProviderMiddlewareInterface) and
+ * collected by ToolRegistry through a tagged iterator.
  *
  * Security contract: a tool's array `$arguments` are model-chosen and
  * therefore attacker-influenceable (the model is steerable by injected,
- * externally-authored skill prose), and its return value egresses both to
- * the external provider AND the rendered backend DOM. Implementations MUST
- * treat `$arguments` as untrusted: validate and scope them, and never expose
- * secrets.
+ * externally-authored skill prose). The result's `content` egresses to BOTH
+ * the external provider AND the rendered backend DOM. Any `artifacts` egress
+ * to the backend DOM and the persisted audit stream ONLY — the runtime never
+ * places them on the provider wire. Implementations MUST treat `$arguments`
+ * as untrusted (validate and scope them, never expose secrets) and MUST apply
+ * the SAME redaction to an artifact's structured `data` that they apply to
+ * `content` — an artifact must never re-expose a field the text path
+ * deliberately withheld.
  *
  * Authorization is enforced at TWO levels (see {@see requiresAdmin()}):
  * a coarse admin-only tier checked by the runtime ({@see ToolLoopService}
@@ -47,12 +52,16 @@ interface ToolInterface
     public function getSpec(): ToolSpec;
 
     /**
-     * Execute the tool with the model-provided arguments and return a string
-     * result that is fed back into the conversation as a tool turn.
+     * Execute the tool with the model-provided arguments and return a typed
+     * {@see ToolResult}: a provider-facing `content` string, an error flag, and
+     * an optional list of run-only {@see \Netresearch\NrLlm\Domain\ValueObject\ToolArtifact}s
+     * for richer backend rendering. The content is fed back into the
+     * conversation as a tool turn; the artifacts never reach the provider (see
+     * the security contract above).
      *
      * @param array<string, mixed> $arguments
      */
-    public function execute(array $arguments): string;
+    public function execute(array $arguments): ToolResult;
 
     /**
      * Whether this tool is offered by default when an admin has not set an

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -9,15 +9,19 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use JsonException;
 use LogicException;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\ContextTruncatedException;
@@ -67,6 +71,16 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      * provider payload limit, bypass the token budget and pressure memory.
      */
     private const MAX_TOOL_RESULT_BYTES = 50000;
+
+    /**
+     * Hard cap on the total serialised bytes of a single tool call's artifacts.
+     * Independent of {@see self::MAX_TOOL_RESULT_BYTES}: content and artifacts
+     * are separate egress channels, so each is bounded on its own so a large one
+     * cannot mask an over-budget other. The rationale is crash-safety and
+     * DOM/persistence size, NOT provider-context starvation — artifacts have no
+     * provider path, so they can never starve model-visible content.
+     */
+    private const MAX_TOOL_ARTIFACT_BYTES = 50000;
 
     public function __construct(
         private LlmServiceManagerInterface $mgr,
@@ -293,11 +307,12 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 }
 
                 foreach ($resp->toolCalls ?? [] as $call) {
-                    $tt0                = hrtime(true);
-                    [$result, $isError] = $this->invoke($call, $allowedNames);
-                    $messages[]         = ChatMessage::toolResult($call->id, $result);
-                    $trace[] = new ToolInvocation($call->name, $call->arguments, $result, $isError);
-                    $runTrace?->recordToolExecution($iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+                    $tt0 = hrtime(true);
+                    $tr  = $this->invoke($call, $allowedNames);
+                    // WIRE: content ONLY — artifacts are run-scoped and never egress to the provider.
+                    $messages[] = ChatMessage::toolResult($call->id, $tr->content);
+                    $trace[]    = new ToolInvocation($call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
+                    $runTrace?->recordToolExecution($iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
                 }
             }
 
@@ -479,9 +494,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $result = sprintf('Error: tool "%s" requires user input that was not provided.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
-                $tt0                = hrtime(true);
-                [$result, $isError] = $this->invoke($call, $offered);
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+                $tt0    = hrtime(true);
+                $tr     = $this->invoke($call, $offered);
+                $result = $tr->content;
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
@@ -546,18 +562,20 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $result = sprintf('Error: tool "%s" is no longer permitted and was not executed.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } elseif ($call->name === $state->inputToolName) {
-                $tt0                = hrtime(true);
-                [$result, $isError] = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered);
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+                $tt0    = hrtime(true);
+                $tr     = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered);
+                $result = $tr->content;
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
                 // A second input-requiring call in the same turn got no data —
                 // one submission satisfies one tool. Fail-closed refusal.
                 $result = sprintf('Error: tool "%s" requires input that was not provided.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
-                $tt0                = hrtime(true);
-                [$result, $isError] = $this->invoke($call, $offered);
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $result, $isError);
+                $tt0    = hrtime(true);
+                $tr     = $this->invoke($call, $offered);
+                $result = $tr->content;
+                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
@@ -670,8 +688,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      * X@host') that URL-sanitising would not strip, so it must never reach the
      * provider.
      *
-     *
-     * @return array{0: string, 1: bool} [result, isError]
+     * @return ToolResult
      */
     /**
      * Resolve the tool names offered for a run: the caller's per-run allow-list
@@ -742,22 +759,29 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
     }
 
     /**
-     * @param list<string> $allowedNames
+     * Resolve and execute a single tool call, returning a typed {@see ToolResult}.
+     * A missing tool, a tool not in the offered allow-list, or a thrown exception
+     * becomes a fail-closed error result (`isError = true`, NO artifacts) so the
+     * loop can continue instead of aborting or leaking internals.
      *
-     * @return array{string, bool} the tool result and whether it is an error
+     * Both channels are bounded here — the single seam every executed call passes
+     * through — before any ToolResult leaves the process: `content` via
+     * {@see self::capResult()}, `artifacts` via {@see self::boundArtifacts()}.
+     *
+     * @param list<string> $allowedNames
      */
-    private function invoke(ToolCall $call, array $allowedNames): array
+    private function invoke(ToolCall $call, array $allowedNames): ToolResult
     {
         $tool = $this->registry->get($call->name);
         if ($tool === null) {
-            return [sprintf('Error: unknown tool "%s"', $call->name), true];
+            return ToolResult::error(sprintf('Error: unknown tool "%s"', $call->name));
         }
         if (!in_array($call->name, $allowedNames, true)) {
-            return [sprintf('Error: tool "%s" not permitted', $call->name), true];
+            return ToolResult::error(sprintf('Error: tool "%s" not permitted', $call->name));
         }
 
         try {
-            return [$this->capResult($tool->execute($call->arguments)), false];
+            $result = $tool->execute($call->arguments);
         } catch (Throwable $e) {
             // Keep the logged summary generic — the exception body may embed
             // DBAL/PDO credentials that URL-sanitising would not strip. The full
@@ -768,8 +792,102 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 ['exception' => $e],
             );
 
-            return [sprintf('Error: tool "%s" failed.', $call->name), true];
+            return ToolResult::error(sprintf('Error: tool "%s" failed.', $call->name));
         }
+
+        return $result->isError
+            ? ToolResult::error($this->capResult($result->content))
+            : ToolResult::text(
+                $this->capResult($result->content),
+                ...$this->boundArtifacts($result->artifacts),
+            );
+    }
+
+    /**
+     * Bound and sanitise a tool's artifacts before they enter the trace /
+     * inspector / persisted stream. UTF-8-coerces every string leaf (reusing the
+     * same seam that makes untrusted tool bytes JSON-safe for `content`), then
+     * validates the whole list with the EXACT json_encode flags AND a depth cap
+     * the downstream sinks use ({@see \Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController}
+     * and {@see AgentRunPersister::recordStep()} all encode with
+     * JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE). Anything that survives
+     * here therefore CANNOT throw at those sinks — crash-safety by construction,
+     * not by a lenient superset.
+     *
+     * Fail-closed: on a JsonException (non-finite float, unencodable type,
+     * over-depth from a corrupt/cyclic structure) or an over-budget encode, the
+     * WHOLE list is replaced by one TEXT marker — never a mid-structure
+     * truncation.
+     *
+     * @param list<ToolArtifact> $artifacts
+     *
+     * @return list<ToolArtifact>
+     */
+    private function boundArtifacts(array $artifacts): array
+    {
+        if ($artifacts === []) {
+            return [];
+        }
+
+        $coerced = array_map(
+            fn(ToolArtifact $a): ToolArtifact => new ToolArtifact(
+                $a->type,
+                $this->toValidUtf8($a->label),
+                $this->coerceLeaves($a->data),
+            ),
+            $artifacts,
+        );
+
+        try {
+            // Depth 64 leaves ample headroom below json_encode's default 512 so
+            // an artifact that encodes here also encodes when the sink nests it a
+            // few levels deeper inside the RunStep payload. A legitimate TABLE
+            // nests ~4 deep; a malicious deep structure trips the fail-closed
+            // marker.
+            $json = json_encode(
+                array_map(static fn(ToolArtifact $a): array => $a->toArray(), $coerced),
+                JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE,
+                64,
+            );
+        } catch (JsonException) {
+            return [$this->artifactsOmitted('could not be encoded')];
+        }
+
+        if (strlen($json) > self::MAX_TOOL_ARTIFACT_BYTES) {
+            return [$this->artifactsOmitted('exceeded ' . self::MAX_TOOL_ARTIFACT_BYTES . ' bytes')];
+        }
+
+        return array_values($coerced);
+    }
+
+    /**
+     * Recursively coerce every string leaf of an artifact payload to valid UTF-8,
+     * reusing {@see self::toValidUtf8()}. `array<array-key, mixed>` (not
+     * `array<string, mixed>`): a TABLE's `rows` are int-keyed sub-arrays.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function coerceLeaves(array $data): array
+    {
+        $out = [];
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $out[$key] = $this->toValidUtf8($value);
+            } elseif (is_array($value)) {
+                $out[$key] = $this->coerceLeaves($value);
+            } else {
+                $out[$key] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    private function artifactsOmitted(string $reason): ToolArtifact
+    {
+        return new ToolArtifact(ArtifactType::TEXT, 'Artifacts omitted', ['text' => $reason]);
     }
 
     /**

--- a/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
+++ b/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
@@ -53,7 +53,9 @@ Tool calls returned in :php:`CompletionResponse::$toolCalls`:
 - A typed ``list<ToolCall>`` (nullable) of :php:`ToolCall` value objects —
   each with the tool ``id``, ``name`` and its arguments as an already
   **JSON-decoded** associative array (not an encoded string). A full
-  tool-execution runtime was added later in :ref:`ADR-038 <adr-038>`.
+  tool-execution runtime was added later in :ref:`ADR-038 <adr-038>`, and the
+  PHP tool return type evolved from a plain string to a typed ``ToolResult``
+  (provider-facing content plus run-only artifacts) in :ref:`ADR-108 <adr-108>`.
 
 .. _adr-010-consequences:
 

--- a/Documentation/Adr/Adr108TypedToolResultWithArtifacts.rst
+++ b/Documentation/Adr/Adr108TypedToolResultWithArtifacts.rst
@@ -1,0 +1,142 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-108:
+
+============================================================================
+ADR-108: Typed ToolResult with run-only artifacts
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-22
+:Authors: Netresearch DTT GmbH
+
+.. _adr-108-context:
+
+Context
+=======
+
+``ToolInterface::execute()`` returned a plain ``string`` that
+:ref:`ToolLoopService <adr-010>` fed straight back to the provider AND rendered
+into the backend Tool Playground inspector. A tool that computes something
+inherently structured — a set of records, a schema, a file listing — could only
+flatten it to text, so the inspector had nothing richer to show than the same
+line-based blob the model receives.
+
+Adding structured output naively is a security problem: a tool result already
+egresses to an external LLM provider, so any structured payload bolted onto the
+return value would ride the wire too, widening the egress surface for
+attacker-influenceable tool bytes (the model is steerable by injected skill
+prose, see :ref:`ADR-064 <adr-064>`).
+
+:ref:`ADR-094 <adr-094>` introduced ``ToolDataClassInterface`` as an *opt-in
+marker* deliberately kept OFF ``ToolInterface`` to avoid editing all 41
+builtins at once. That precedent does not apply here: egress separation must BE
+the return value (a structured channel that is unreachable from the wire), not
+an annotation a tool may forget to add.
+
+.. _adr-108-decision:
+
+Decision
+========
+
+Replace ``execute(array $arguments): string`` with
+``execute(array $arguments): ToolResult`` — a ``final readonly`` value object
+carrying exactly one provider-facing ``string $content``, a ``bool $isError``,
+and a ``list<ToolArtifact> $artifacts`` that is **run-scoped**: it flows only to
+the trace, the inspector event stream and the persisted audit copy, and has NO
+code path to the provider wire.
+
+Egress separation is enforced *by construction*:
+
+- ``ToolResult`` has no ``__toString()`` and no accessor that merges an artifact
+  into a wire string; ``->content`` is the single path to a wire string.
+- The sole wire sink, ``ChatMessage::toolResult()``, is only ever handed
+  ``$result->content``.
+- ``ToolLoopService::invoke()`` — the single seam every executed call passes
+  through — UTF-8-coerces and byte-bounds BOTH channels before any
+  ``ToolResult`` leaves the process. ``content`` keeps its existing 50 000-byte
+  cap (``capResult()``); ``artifacts`` get an independent 50 000-byte serialised
+  budget (``boundArtifacts()``).
+
+The private constructor forces the ``ToolResult::text()`` / ``ToolResult::error()``
+factories; ``error()`` carries no artifacts, so a failing tool can never leak a
+half-built structure.
+
+Artifact type model
+--------------------
+
+``ArtifactType`` is the smallest closed set whose every case has a v1 emitter
+plus a fallback::
+
+   enum ArtifactType: string {
+       case TABLE = 'table';   // {columns: list<string>, rows: list<list<string>>}
+       case TEXT  = 'text';    // {text: string} — fallback + "artifacts omitted" marker
+   }
+
+This is a *rendering* shape, NOT a semantic taxonomy. ``TREE``, ``LIST``,
+``KEY_VALUE``, ``LINK`` and ``CODE`` are additive follow-ups — each lands later
+as one new enum case plus one JS branch, with no consumer or persisted-data
+migration. No case ships without a committed producer: ``TREE`` (a page-tree
+emitter) is intentionally deferred rather than shipped empty.
+
+The sole v1 emitter is ``ReadRecordsTool``, which builds its ``TABLE`` rows from
+the SAME already-redacted ``formatValue()`` cells its text lines use, in one
+pass — the artifact can never drift from, or re-expose more than, the text
+egress. The other 40 builtins ship text-parity via a mechanical
+``ToolResult::text($string)`` wrap.
+
+Fail-closed bounding
+--------------------
+
+``boundArtifacts()`` UTF-8-coerces every string leaf, then validates the whole
+list with the EXACT flags the downstream sinks use
+(``JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE``) plus a depth-64 cap.
+Anything that survives therefore cannot throw at
+``ToolPlaygroundController`` (``streamLine()`` / ``respondJson()``) or
+``AgentRunPersister::recordStep()`` — crash-safety by construction, not by a
+lenient superset. On a ``JsonException`` (non-finite float, unencodable type,
+over-depth) or an over-budget encode, the WHOLE list is replaced by a single
+``TEXT`` "Artifacts omitted" marker — never a mid-structure truncation.
+
+Privacy
+-------
+
+``toolArtifacts`` is added to ``RunStepPrivacyFilter``'s ``CONTENT_KEYS``.
+Consequences flow from the existing machinery:
+
+- At the default METADATA/NONE level the artifact data is ``unset()``; a
+  summary (``toolArtifactsCount`` + ``toolArtifactTypes``) records shape and
+  count but never bytes — mirroring ``toolResultLength``.
+- At REDACTED the normalised ``list<{type,label,data}>`` is masked by the
+  existing recursive redactor with no new code (the ``type`` discriminator and
+  ``label`` are masked too; the JS renderer then falls to its unknown-shape
+  fallback — fail-safe).
+- At FULL it is verbatim (deliberate).
+
+As with ``toolResult`` (:ref:`ADR-081 <adr-081>`), the LIVE NDJSON stream
+renders unfiltered from memory (``RunStep::toArray()``), so an admin's browser
+sees full artifacts even at METADATA while the *persisted* copy is summarised.
+This is intentional for the admin-only module, not a bypass.
+
+.. _adr-108-consequences:
+
+Consequences
+============
+
+- ``ToolInterface`` is a breaking change across all 41 builtins. Pre-1.0
+  (:ref:`ADR-090 <adr-090>`) this is acceptable and announced; third-party tools
+  discovered via the ``nr_llm.tool`` tag must return a ``ToolResult`` (the
+  ``ToolResult::text()`` factory keeps the trivial case a one-line change).
+- The provider wire is unchanged: ``ChatMessage::toolResult()`` still receives a
+  string, so no provider adapter changes.
+- ``ToolInvocation`` and ``RunStep`` gain a typed artifact field (appended with a
+  default, positions stable). ``ChatMessage``, ``ToolLoopResult`` and
+  ``SuspendedRunState`` are untouched — artifacts are audit/display state, never
+  resumable functional state, so they must not ride the suspend payload.
+- The inspector gains a conditional "Artifacts" tab rendering ``TABLE`` / ``TEXT``
+  and an unknown-type JSON fallback, all via ``textContent`` (never
+  ``innerHTML``) because artifacts are attacker-influenceable.
+
+See also :ref:`ADR-010 <adr-010>` (tool function-calling design),
+:ref:`ADR-094 <adr-094>` (tool data-class trust zones) and
+:ref:`ADR-064 <adr-064>` (event privacy).

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -405,3 +405,4 @@ Tools
    Adr105TypedInputSuspension
    Adr106PerConfigurationGuardrailPolicy
    Adr107ContextWindowManagement
+   Adr108TypedToolResultWithArtifacts

--- a/Resources/Public/JavaScript/Backend/ToolPlayground.js
+++ b/Resources/Public/JavaScript/Backend/ToolPlayground.js
@@ -482,11 +482,16 @@ class ToolPlayground {
 
         if (step.kind === 'tool') {
             detail.appendChild(this.detailHeader(`Tool · ${step.toolName || ''}`, this.ms(step.durationMs), step.toolIsError ? 'error' : 'ok'));
-            const tabs = this.tabBox([
+            const tabs = [
                 ['Arguments', () => this.pre(this.json(step.toolArguments))],
                 ['Result', () => this.pre(typeof step.toolResult === 'string' ? step.toolResult : '')],
-            ]);
-            detail.appendChild(tabs);
+            ];
+            // ADR-108: run-only artifacts, shown only when present. Never
+            // provider-facing; hardcoded label matches the sibling tab literals.
+            if (Array.isArray(step.toolArtifacts) && step.toolArtifacts.length > 0) {
+                tabs.push(['Artifacts', () => this.artifacts(step.toolArtifacts)]);
+            }
+            detail.appendChild(this.tabBox(tabs));
             return;
         }
 
@@ -526,6 +531,60 @@ class ToolPlayground {
             ['Thinking', () => step.thinking?.trim() ? this.pre(step.thinking) : this.note('No reasoning returned for this round.')],
         ];
         detail.appendChild(this.tabBox(tabs));
+    }
+
+    /**
+     * Render a step's run-only artifacts (ADR-108). NEVER provider-facing; every
+     * value is written via textContent (never innerHTML) since artifacts carry
+     * attacker-influenceable tool bytes. An unknown type (a newer backend, or a
+     * REDACTED-masked discriminator) degrades to a JSON dump.
+     */
+    artifacts(list) {
+        const wrap = document.createElement('div');
+        (Array.isArray(list) ? list : []).forEach((a) => {
+            const box = document.createElement('div');
+            box.className = 'nrllm-pg-artifact';
+            const label = document.createElement('div');
+            label.className = 'nrllm-pg-artifact-label';
+            label.textContent = (a && typeof a.label === 'string') ? a.label : 'Artifact';
+            box.appendChild(label);
+            const data = (a && a.data && typeof a.data === 'object') ? a.data : {};
+            if (a && a.type === 'table' && Array.isArray(data.columns) && Array.isArray(data.rows)) {
+                box.appendChild(this.artifactTable(data.columns, data.rows));
+            } else if (a && a.type === 'text') {
+                box.appendChild(this.pre(typeof data.text === 'string' ? data.text : ''));
+            } else {
+                box.appendChild(this.pre(this.json(a)));
+            }
+            wrap.appendChild(box);
+        });
+        return wrap;
+    }
+
+    artifactTable(columns, rows) {
+        const table = document.createElement('table');
+        table.className = 'nrllm-pg-artifact-table';
+        const thead = document.createElement('thead');
+        const htr = document.createElement('tr');
+        columns.forEach((col) => {
+            const th = document.createElement('th');
+            th.textContent = typeof col === 'string' ? col : String(col);
+            htr.appendChild(th);
+        });
+        thead.appendChild(htr);
+        table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        (Array.isArray(rows) ? rows : []).forEach((row) => {
+            const tr = document.createElement('tr');
+            (Array.isArray(row) ? row : []).forEach((cell) => {
+                const td = document.createElement('td');
+                td.textContent = typeof cell === 'string' ? cell : String(cell);
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        return table;
     }
 
     /**

--- a/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
+++ b/Tests/Functional/Service/Tool/BrowseFalFolderToolFileMountTest.php
@@ -106,11 +106,11 @@ final class BrowseFalFolderToolFileMountTest extends AbstractFunctionalTestCase
 
         // The storage root lies outside the /docs/ mount — denied, and the
         // root file's name never egresses.
-        $rootOutput = $this->tool->execute(['folder' => '/']);
+        $rootOutput = $this->tool->execute(['folder' => '/'])->content;
         self::assertSame('Folder not found or not permitted.', $rootOutput);
 
         // The mounted folder lists.
-        $output = $this->tool->execute(['folder' => '/docs/']);
+        $output = $this->tool->execute(['folder' => '/docs/'])->content;
         self::assertStringContainsString('- manual.txt (text/plain, 10 B)', $output);
         self::assertStringNotContainsString('top-secret', $output);
     }

--- a/Tests/Functional/Service/Tool/BrowseFalFolderToolTest.php
+++ b/Tests/Functional/Service/Tool/BrowseFalFolderToolTest.php
@@ -53,7 +53,7 @@ final class BrowseFalFolderToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Folder / of storage 1', $output);
         self::assertStringContainsString('- docs/ (1 files)', $output);
@@ -65,7 +65,7 @@ final class BrowseFalFolderToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['folder' => '/docs/']);
+        $output = $this->tool->execute(['folder' => '/docs/'])->content;
 
         self::assertStringContainsString('- manual.txt (text/plain, 10 B)', $output);
         self::assertStringNotContainsString('hello.txt', $output);
@@ -78,7 +78,7 @@ final class BrowseFalFolderToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Folder not found or not permitted.',
-            $this->tool->execute(['folder' => '/does-not-exist/']),
+            $this->tool->execute(['folder' => '/does-not-exist/'])->content,
         );
     }
 
@@ -89,13 +89,13 @@ final class BrowseFalFolderToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Folder not found or not permitted.',
-            $this->tool->execute(['storage' => 99]),
+            $this->tool->execute(['storage' => 99])->content,
         );
     }
 
     #[Test]
     public function failsClosedWithoutBackendUser(): void
     {
-        self::assertSame('Folder not found or not permitted.', $this->tool->execute([]));
+        self::assertSame('Folder not found or not permitted.', $this->tool->execute([])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/CheckTypoScriptToolSiteSetTest.php
+++ b/Tests/Functional/Service/Tool/CheckTypoScriptToolSiteSetTest.php
@@ -69,7 +69,7 @@ final class CheckTypoScriptToolSiteSetTest extends AbstractFunctionalTestCase
     #[Test]
     public function scansSiteProvidedTypoScriptWithoutSysTemplateRow(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1]);
+        $output = $this->tool->execute(['pageUid' => 1])->content;
 
         self::assertStringContainsString('TypoScript syntax errors on page 1', $output);
         self::assertStringContainsString('missing closing "}"', $output);

--- a/Tests/Functional/Service/Tool/CheckTypoScriptToolTest.php
+++ b/Tests/Functional/Service/Tool/CheckTypoScriptToolTest.php
@@ -78,7 +78,7 @@ final class CheckTypoScriptToolTest extends AbstractFunctionalTestCase
             'config' => "page = PAGE\npage {\n  10 = TEXT\n  10.value = secret-value-99\n",
         ]);
 
-        $output = $this->tool->execute(['pageUid' => 1]);
+        $output = $this->tool->execute(['pageUid' => 1])->content;
 
         self::assertStringContainsString('TypoScript syntax errors on page 1', $output);
         self::assertStringContainsString('missing closing "}"', $output);
@@ -96,7 +96,7 @@ final class CheckTypoScriptToolTest extends AbstractFunctionalTestCase
             'config' => "page = PAGE\npage.10 = TEXT\npage.10.value = Hello\n",
         ]);
 
-        $output = $this->tool->execute(['pageUid' => 1]);
+        $output = $this->tool->execute(['pageUid' => 1])->content;
 
         self::assertStringContainsString('No TypoScript syntax errors on page 1', $output);
     }
@@ -106,11 +106,11 @@ final class CheckTypoScriptToolTest extends AbstractFunctionalTestCase
     {
         self::assertSame(
             'Page not found or no TypoScript template.',
-            $this->tool->execute(['pageUid' => 1]),
+            $this->tool->execute(['pageUid' => 1])->content,
         );
         self::assertSame(
             'Page not found or no TypoScript template.',
-            $this->tool->execute(['pageUid' => 12345]),
+            $this->tool->execute(['pageUid' => 12345])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/DiagnosticsToolsFunctionalTest.php
+++ b/Tests/Functional/Service/Tool/DiagnosticsToolsFunctionalTest.php
@@ -52,7 +52,7 @@ final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
     #[Test]
     public function systemStatusReportsVersionsWithoutPaths(): void
     {
-        $output = $this->tool('get_system_status')->execute([]);
+        $output = $this->tool('get_system_status')->execute([])->content;
 
         self::assertStringContainsString('TYPO3: ' . (new Typo3Version())->getVersion(), $output);
         self::assertStringContainsString('PHP: ' . PHP_VERSION, $output);
@@ -67,7 +67,7 @@ final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
     public function schedulerAbsenceDegradesGracefully(): void
     {
         // EXT:scheduler is not part of the test instance.
-        self::assertSame('Scheduler is not installed.', $this->tool('list_scheduler_tasks')->execute([]));
+        self::assertSame('Scheduler is not installed.', $this->tool('list_scheduler_tasks')->execute([])->content);
     }
 
     #[Test]
@@ -82,7 +82,7 @@ final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
             'Tue, 08 Jul 2026 12:00:02 +0000 [NOTICE] request="a3" component="TYPO3.CMS.deprecations": Class deprecated in ' . $projectFile,
         ]) . "\n");
 
-        $output = (new ListDeprecationsTool($logDir))->execute([]);
+        $output = (new ListDeprecationsTool($logDir))->execute([])->content;
 
         self::assertStringContainsString('Method foo() is deprecated (×2)', $output);
         self::assertStringContainsString('vendor/acme/thing/Classes/Old.php', $output);
@@ -97,14 +97,14 @@ final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'No deprecation log found (the deprecation channel may be disabled).',
-            (new ListDeprecationsTool($emptyDir))->execute([]),
+            (new ListDeprecationsTool($emptyDir))->execute([])->content,
         );
     }
 
     #[Test]
     public function middlewareStackListsBackendMiddlewares(): void
     {
-        $output = $this->tool('list_middlewares')->execute(['stack' => 'backend']);
+        $output = $this->tool('list_middlewares')->execute(['stack' => 'backend'])->content;
 
         self::assertStringContainsString('PSR-15 backend middleware stack (', $output);
         self::assertStringContainsString('typo3/cms-core/normalized-params-attribute', $output);
@@ -116,7 +116,7 @@ final class DiagnosticsToolsFunctionalTest extends AbstractFunctionalTestCase
     {
         self::assertStringContainsString(
             'Unknown stack',
-            $this->tool('list_middlewares')->execute(['stack' => 'cli']),
+            $this->tool('list_middlewares')->execute(['stack' => 'cli'])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
+++ b/Tests/Functional/Service/Tool/FalToolsFileMountTest.php
@@ -139,7 +139,7 @@ final class FalToolsFileMountTest extends AbstractFunctionalTestCase
     {
         $this->loginEditorInBackendRequest();
 
-        $output = $this->tool('search_fal_files')->execute(['query' => 'txt']);
+        $output = $this->tool('search_fal_files')->execute(['query' => 'txt'])->content;
 
         self::assertStringContainsString('docs/manual.txt', $output);
         self::assertStringNotContainsString('top-secret.txt', $output);
@@ -150,7 +150,7 @@ final class FalToolsFileMountTest extends AbstractFunctionalTestCase
     {
         $this->loginEditorInBackendRequest();
 
-        $output = $this->tool('find_missing_files')->execute([]);
+        $output = $this->tool('find_missing_files')->execute([])->content;
 
         self::assertStringContainsString('docs/gone-inside.txt', $output);
         self::assertStringNotContainsString('gone-outside.txt', $output);
@@ -162,7 +162,7 @@ final class FalToolsFileMountTest extends AbstractFunctionalTestCase
         $this->loginEditorInBackendRequest();
 
         // File 11 (root, out of the /docs/ mount) must not reveal its usages.
-        $output = $this->tool('get_fal_references')->execute(['uid' => 11]);
+        $output = $this->tool('get_fal_references')->execute(['uid' => 11])->content;
 
         self::assertSame('Asset not found or not permitted.', $output);
     }
@@ -174,7 +174,7 @@ final class FalToolsFileMountTest extends AbstractFunctionalTestCase
 
         // File 10 (/docs/, in mount) is reachable — no references seeded, so the
         // neutral "no references" answer (not the permission denial) is returned.
-        $output = $this->tool('get_fal_references')->execute(['uid' => 10]);
+        $output = $this->tool('get_fal_references')->execute(['uid' => 10])->content;
 
         self::assertStringContainsString('No references to manual.txt', $output);
     }

--- a/Tests/Functional/Service/Tool/FetchLogsToolTest.php
+++ b/Tests/Functional/Service/Tool/FetchLogsToolTest.php
@@ -61,7 +61,7 @@ final class FetchLogsToolTest extends AbstractFunctionalTestCase
     {
         $this->importFixture('sys_log_tools.csv');
 
-        $output = $this->tool->execute(['limit' => 2]);
+        $output = $this->tool->execute(['limit' => 2])->content;
 
         self::assertStringContainsString('Cache cleared', $output);
         self::assertStringContainsString('Login failed', $output);
@@ -75,7 +75,7 @@ final class FetchLogsToolTest extends AbstractFunctionalTestCase
     {
         $this->importFixture('sys_log_tools.csv');
 
-        $output = $this->tool->execute(['limit' => 10]);
+        $output = $this->tool->execute(['limit' => 10])->content;
 
         self::assertStringNotContainsString(self::RAW_IP, $output);
         self::assertStringNotContainsString(self::USER_ID, $output);
@@ -87,7 +87,7 @@ final class FetchLogsToolTest extends AbstractFunctionalTestCase
     {
         $this->importFixture('sys_log_tools.csv');
 
-        $output = $this->tool->execute(['level' => 'error']);
+        $output = $this->tool->execute(['level' => 'error'])->content;
 
         self::assertStringContainsString('Login failed', $output);
         self::assertStringNotContainsString('Cache cleared', $output);
@@ -113,7 +113,7 @@ final class FetchLogsToolTest extends AbstractFunctionalTestCase
             ]);
         }
 
-        $output = $this->tool->execute(['limit' => 9999]);
+        $output = $this->tool->execute(['limit' => 9999])->content;
 
         self::assertCount(50, $this->entryLines($output));
     }
@@ -121,7 +121,7 @@ final class FetchLogsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function returnsPlaceholderWhenNoEntriesMatch(): void
     {
-        $output = $this->tool->execute(['level' => 'no-such-level']);
+        $output = $this->tool->execute(['level' => 'no-such-level'])->content;
 
         self::assertSame('No log entries.', $output);
     }

--- a/Tests/Functional/Service/Tool/FindMissingFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/FindMissingFilesToolTest.php
@@ -63,7 +63,7 @@ final class FindMissingFilesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('1 missing file (showing 1):', $output);
         self::assertStringContainsString('- [30] 1:/lost.pdf (last known size 1234 bytes)', $output);
@@ -76,12 +76,12 @@ final class FindMissingFilesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        self::assertSame('No accessible file storages.', $this->tool->execute(['storage' => 2]));
+        self::assertSame('No accessible file storages.', $this->tool->execute(['storage' => 2])->content);
     }
 
     #[Test]
     public function failsClosedWithoutBackendUser(): void
     {
-        self::assertSame('No accessible file storages.', $this->tool->execute([]));
+        self::assertSame('No accessible file storages.', $this->tool->execute([])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/FluidResolveToolTest.php
+++ b/Tests/Functional/Service/Tool/FluidResolveToolTest.php
@@ -35,7 +35,7 @@ final class FluidResolveToolTest extends AbstractFunctionalTestCase
         $output = $this->tool->execute([
             'name'      => 'Backend/Playground/List',
             'extension' => 'nr_llm',
-        ]);
+        ])->content;
 
         self::assertStringContainsString('[x]', $output);
         self::assertStringContainsString('Backend/Playground/List.html', $output);
@@ -49,7 +49,7 @@ final class FluidResolveToolTest extends AbstractFunctionalTestCase
         $output = $this->tool->execute([
             'name'      => 'Backend/DoesNotExistAnywhere',
             'extension' => 'nr_llm',
-        ]);
+        ])->content;
 
         self::assertStringContainsString('[ ]', $output);
         self::assertStringContainsString('Resolved: (none', $output);

--- a/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFalReferencesToolTest.php
@@ -72,7 +72,7 @@ final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['uid' => 20]);
+        $output = $this->tool->execute(['uid' => 20])->content;
 
         self::assertStringContainsString('References to logo.svg (2):', $output);
         self::assertStringContainsString('- tt_content:5 (field image)', $output);
@@ -94,7 +94,7 @@ final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
 
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['uid' => 20]);
+        $output = $this->tool->execute(['uid' => 20])->content;
 
         self::assertStringNotContainsString('tt_content:77', $output);
         self::assertStringContainsString('References to logo.svg (2):', $output);
@@ -114,7 +114,7 @@ final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
             'name' => 'unused.png', 'mime_type' => 'image/png', 'size' => 10, 'missing' => 0,
         ]);
 
-        $output = $this->tool->execute(['uid' => 22]);
+        $output = $this->tool->execute(['uid' => 22])->content;
 
         self::assertStringContainsString('No references to unused.png', $output);
         self::assertStringContainsString('soft references', $output);
@@ -125,12 +125,12 @@ final class GetFalReferencesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 21]));
+        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 21])->content);
     }
 
     #[Test]
     public function failsClosedWithoutBackendUser(): void
     {
-        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 20]));
+        self::assertSame('Asset not found or not permitted.', $this->tool->execute(['uid' => 20])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/GetFlexFormSchemaToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFlexFormSchemaToolTest.php
@@ -73,7 +73,7 @@ final class GetFlexFormSchemaToolTest extends AbstractFunctionalTestCase
 
         self::assertStringContainsString(
             'is not a FlexForm field',
-            $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'title']),
+            $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'title'])->content,
         );
     }
 
@@ -82,7 +82,7 @@ final class GetFlexFormSchemaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'multi_ff']);
+        $output = $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'multi_ff'])->content;
 
         self::assertStringContainsString('multiple data structures', $output);
         self::assertStringContainsString('- alpha', $output);
@@ -94,7 +94,7 @@ final class GetFlexFormSchemaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'single_ff']);
+        $output = $this->tool->execute(['table' => 'tx_demo_flex', 'field' => 'single_ff'])->content;
 
         self::assertStringContainsString('FlexForm schema for tx_demo_flex.single_ff', $output);
         self::assertStringContainsString('Sheet:', $output);
@@ -108,7 +108,7 @@ final class GetFlexFormSchemaToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Table not found or not permitted.',
-            $this->tool->execute(['table' => 'be_users', 'field' => 'anything']),
+            $this->tool->execute(['table' => 'be_users', 'field' => 'anything'])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/GetFullTcaToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFullTcaToolTest.php
@@ -36,7 +36,7 @@ final class GetFullTcaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('pages', $output);
         self::assertStringContainsString('tt_content', $output);
@@ -51,7 +51,7 @@ final class GetFullTcaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['filter' => 'tt_content']);
+        $output = $this->tool->execute(['filter' => 'tt_content'])->content;
 
         self::assertStringContainsString('tt_content', $output);
         self::assertStringNotContainsString("\npages —", $output);
@@ -60,7 +60,7 @@ final class GetFullTcaToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function noBackendUserYieldsEmptyIndex(): void
     {
-        self::assertStringContainsString('(0)', $this->tool->execute([]));
+        self::assertStringContainsString('(0)', $this->tool->execute([])->content);
     }
 
     #[Test]
@@ -68,7 +68,7 @@ final class GetFullTcaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         // Drop the header line; every remaining line starts with a table name.
         $lines = explode("\n", $output);

--- a/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
+++ b/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
@@ -69,7 +69,7 @@ final class GetLastExceptionToolFunctionalTest extends AbstractFunctionalTestCas
     #[Test]
     public function parsesSeededLogAndExpandsSourceContext(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('DomainException', $output);
         self::assertStringContainsString('functional failure', $output);
@@ -79,13 +79,13 @@ final class GetLastExceptionToolFunctionalTest extends AbstractFunctionalTestCas
     #[Test]
     public function searchFilterNarrowsToTheSeededEntry(): void
     {
-        $output = $this->tool->execute(['search' => 'functional kaboom or nothing']);
+        $output = $this->tool->execute(['search' => 'functional kaboom or nothing'])->content;
 
         // A non-matching search yields the no-entries message…
         self::assertStringContainsString('No error-level entries', $output);
 
         // …while a matching one finds the seeded record.
-        self::assertStringContainsString('DomainException', $this->tool->execute(['search' => 'DomainException']));
+        self::assertStringContainsString('DomainException', $this->tool->execute(['search' => 'DomainException'])->content);
     }
 
     protected function tearDown(): void

--- a/Tests/Functional/Service/Tool/GetPageContentToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageContentToolTest.php
@@ -71,7 +71,7 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['uid' => 1]);
+        $output = $this->tool->execute(['uid' => 1])->content;
 
         self::assertStringContainsString('Page [1] Home (doktype 1, slug /)', $output);
         // colPos 0 before colPos 1; hidden element present and marked.
@@ -103,7 +103,7 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
 
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['uid' => 1]);
+        $output = $this->tool->execute(['uid' => 1])->content;
 
         self::assertStringNotContainsString('DraftOnlyMarker', $output);
         self::assertStringContainsString('Intro', $output);
@@ -114,7 +114,7 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(2); // editor, no rights on page 1
 
-        $output = $this->tool->execute(['uid' => 1]);
+        $output = $this->tool->execute(['uid' => 1])->content;
 
         self::assertSame('Page not found or not permitted.', $output);
     }
@@ -124,7 +124,7 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['uid' => 999]);
+        $output = $this->tool->execute(['uid' => 999])->content;
 
         self::assertSame('Page not found or not permitted.', $output);
     }
@@ -152,12 +152,12 @@ final class GetPageContentToolTest extends AbstractFunctionalTestCase
         // Language 0 is permitted -> the page resolves past the language gate.
         self::assertStringContainsString(
             'Page [5] Public',
-            $this->tool->execute(['uid' => 5, 'language' => 0]),
+            $this->tool->execute(['uid' => 5, 'language' => 0])->content,
         );
         // Language 1 is not permitted -> neutral denial at the language gate.
         self::assertSame(
             'Page not found or not permitted.',
-            $this->tool->execute(['uid' => 5, 'language' => 1]),
+            $this->tool->execute(['uid' => 5, 'language' => 1])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
+++ b/Tests/Functional/Service/Tool/GetPageTreeToolTest.php
@@ -66,7 +66,7 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function returnsDepthIndentedLiveTree(): void
     {
-        $output = $this->tool->execute(['rootUid' => 0, 'depth' => 3]);
+        $output = $this->tool->execute(['rootUid' => 0, 'depth' => 3])->content;
 
         self::assertStringContainsString('[1] Home (doktype 1)', $output);
         // About is one level below Home, Team two levels below.
@@ -77,7 +77,7 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function excludesHiddenAndDeletedPages(): void
     {
-        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3]);
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3])->content;
 
         self::assertStringNotContainsString('Hidden Branch', $output);
         self::assertStringNotContainsString('Deleted Branch', $output);
@@ -95,7 +95,7 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
             't3ver_wsid' => 1, 't3ver_oid' => 2, 't3ver_state' => 0,
         ]);
 
-        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3]);
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 3])->content;
 
         self::assertStringNotContainsString('Draft Branch', $output);
         self::assertStringContainsString('[2] About', $output);
@@ -104,7 +104,7 @@ final class GetPageTreeToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function depthOneStopsAtImmediateChildren(): void
     {
-        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 1]);
+        $output = $this->tool->execute(['rootUid' => 1, 'depth' => 1])->content;
 
         self::assertStringContainsString('[2] About', $output);
         // Team is a grandchild — beyond depth 1.

--- a/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
+++ b/Tests/Functional/Service/Tool/GetRecordHistoryToolTest.php
@@ -84,7 +84,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5])->content;
 
         self::assertStringContainsString('Change history for tt_content:5 (3 entries, newest first):', $output);
         self::assertStringContainsString("header: 'Old headline' → 'New headline'", $output);
@@ -103,7 +103,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5])->content;
 
         self::assertStringContainsString('secret_token: [changed — detail withheld]', $output);
         self::assertStringNotContainsString('oldtoken123', $output);
@@ -115,7 +115,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5, 'field' => 'header']);
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 5, 'field' => 'header'])->content;
 
         self::assertStringContainsString('filtered to "header"', $output);
         self::assertStringContainsString("header: 'Old headline' → 'New headline'", $output);
@@ -130,7 +130,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'No change history for tt_content:999.',
-            $this->tool->execute(['table' => 'tt_content', 'uid' => 999]),
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 999])->content,
         );
     }
 
@@ -141,7 +141,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Table not found or not permitted.',
-            $this->tool->execute(['table' => 'be_users', 'uid' => 1]),
+            $this->tool->execute(['table' => 'be_users', 'uid' => 1])->content,
         );
     }
 
@@ -150,7 +150,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
     {
         self::assertSame(
             'Table not found or not permitted.',
-            $this->tool->execute(['table' => 'tt_content', 'uid' => 5]),
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 5])->content,
         );
     }
 
@@ -166,7 +166,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Table not found or not permitted.',
-            $this->tool->execute(['table' => 'tt_content', 'uid' => 40]),
+            $this->tool->execute(['table' => 'tt_content', 'uid' => 40])->content,
         );
     }
 
@@ -178,7 +178,7 @@ final class GetRecordHistoryToolTest extends AbstractFunctionalTestCase
         $this->insertPageWithContentAndHistory(9, Permission::PAGE_SHOW, 40);
         $this->setUpBackendUser(2);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 40]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 40])->content;
 
         self::assertStringContainsString('Change history for tt_content:40', $output);
         self::assertStringContainsString("header: 'A' → 'B'", $output);

--- a/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
+++ b/Tests/Functional/Service/Tool/GetSiteConfigToolTest.php
@@ -62,7 +62,7 @@ final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function listsAllSitesWithoutIdentifier(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Configured sites (', $output);
         self::assertStringContainsString('- diag (base http://localhost:59999/, root page 1)', $output);
@@ -71,7 +71,7 @@ final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function flattensConfigurationAndRedactsCredentialKeys(): void
     {
-        $output = $this->tool->execute(['identifier' => 'diag']);
+        $output = $this->tool->execute(['identifier' => 'diag'])->content;
 
         self::assertStringContainsString('rootPageId: 1', $output);
         self::assertStringContainsString('languages.0.locale: en_US.UTF-8', $output);
@@ -92,7 +92,7 @@ final class GetSiteConfigToolTest extends AbstractFunctionalTestCase
     {
         self::assertStringContainsString(
             'No site "nope"',
-            $this->tool->execute(['identifier' => 'nope']),
+            $this->tool->execute(['identifier' => 'nope'])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/GetTableSchemaToolTest.php
+++ b/Tests/Functional/Service/Tool/GetTableSchemaToolTest.php
@@ -51,7 +51,7 @@ final class GetTableSchemaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tx_demo_thing']);
+        $output = $this->tool->execute(['table' => 'tx_demo_thing'])->content;
 
         self::assertStringContainsString('Table: tx_demo_thing', $output);
         self::assertStringContainsString('name: input', $output);
@@ -66,7 +66,7 @@ final class GetTableSchemaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content']);
+        $output = $this->tool->execute(['table' => 'tt_content'])->content;
 
         self::assertStringContainsString('Table: tt_content', $output);
         self::assertStringContainsString('Fields:', $output);
@@ -78,13 +78,13 @@ final class GetTableSchemaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        self::assertSame('Table not found or not permitted.', $this->tool->execute(['table' => 'be_users']));
+        self::assertSame('Table not found or not permitted.', $this->tool->execute(['table' => 'be_users'])->content);
     }
 
     #[Test]
     public function deniesWithoutBackendUser(): void
     {
-        self::assertSame('Table not found or not permitted.', $this->tool->execute(['table' => 'tt_content']));
+        self::assertSame('Table not found or not permitted.', $this->tool->execute(['table' => 'tt_content'])->content);
     }
 
     #[Test]
@@ -103,7 +103,7 @@ final class GetTableSchemaToolTest extends AbstractFunctionalTestCase
             'columns' => ['name' => ['config' => ['type' => 'input']]],
         ];
 
-        $output = $this->tool->execute(['table' => 'tx_demo_ver']);
+        $output = $this->tool->execute(['table' => 'tx_demo_ver'])->content;
 
         self::assertStringContainsString('Title: Description', $output);
         self::assertStringNotContainsString('LLL:', $output);

--- a/Tests/Functional/Service/Tool/GetTsConfigToolTest.php
+++ b/Tests/Functional/Service/Tool/GetTsConfigToolTest.php
@@ -51,7 +51,7 @@ final class GetTsConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function topLevelKeysListWithoutPath(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1]);
+        $output = $this->tool->execute(['pageUid' => 1])->content;
 
         self::assertStringContainsString('Page TSconfig for page 1', $output);
         self::assertStringContainsString('demo (+', $output);
@@ -60,7 +60,7 @@ final class GetTsConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function dottedPathDrillsIntoTheSubtree(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo']);
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo'])->content;
 
         self::assertStringContainsString('flag = 1', $output);
         self::assertStringContainsString('nested {', $output);
@@ -70,7 +70,7 @@ final class GetTsConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function credentialValuesAreRedacted(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'vault']);
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'vault'])->content;
 
         self::assertStringContainsString('apiKey = [redacted]', $output);
         self::assertStringNotContainsString('top-secret-value', $output);
@@ -79,6 +79,6 @@ final class GetTsConfigToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function missingPageReturnsNeutralString(): void
     {
-        self::assertSame('Page not found.', $this->tool->execute(['pageUid' => 999]));
+        self::assertSame('Page not found.', $this->tool->execute(['pageUid' => 999])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/GetTypoScriptToolTest.php
+++ b/Tests/Functional/Service/Tool/GetTypoScriptToolTest.php
@@ -79,7 +79,7 @@ final class GetTypoScriptToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function setupTopLevelKeysListWithoutPath(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1]);
+        $output = $this->tool->execute(['pageUid' => 1])->content;
 
         self::assertStringContainsString('TypoScript setup for page 1', $output);
         self::assertStringContainsString('page = PAGE', $output);
@@ -89,7 +89,7 @@ final class GetTypoScriptToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function pathDrillsIntoSetupSubtreeAndRedactsSecrets(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo']);
+        $output = $this->tool->execute(['pageUid' => 1, 'path' => 'demo'])->content;
 
         self::assertStringContainsString('endpoint = https://api.example.org', $output);
         self::assertStringContainsString('apiKey = [redacted]', $output);
@@ -99,7 +99,7 @@ final class GetTypoScriptToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function constantsResolveFlatAndRedactSecrets(): void
     {
-        $output = $this->tool->execute(['pageUid' => 1, 'type' => 'constants']);
+        $output = $this->tool->execute(['pageUid' => 1, 'type' => 'constants'])->content;
 
         self::assertStringContainsString('myConst.plain = visible-value', $output);
         self::assertStringContainsString('myConst.apiKey = [redacted]', $output);
@@ -109,7 +109,7 @@ final class GetTypoScriptToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function pageWithoutSiteReturnsNeutralString(): void
     {
-        $output = $this->tool->execute(['pageUid' => 999]);
+        $output = $this->tool->execute(['pageUid' => 999])->content;
 
         self::assertSame('Page not found or no TypoScript template.', $output);
     }

--- a/Tests/Functional/Service/Tool/ListBeGroupsToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeGroupsToolTest.php
@@ -52,7 +52,7 @@ final class ListBeGroupsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeListsLiveGroupsTitleOrdered(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Backend groups (2):', $output);
         // Title ASC: Administrators before Editors.
@@ -66,7 +66,7 @@ final class ListBeGroupsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeExcludesSoftDeletedGroupsAndPermissionMasks(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringNotContainsString('Deleted Group', $output);
         // Only uid + title are emitted — never authorization columns.

--- a/Tests/Functional/Service/Tool/ListBeUsersRawToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersRawToolTest.php
@@ -65,7 +65,7 @@ final class ListBeUsersRawToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeEmitsWideColumnSet(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Backend users (1):', $output);
         self::assertStringContainsString('[20]', $output);
@@ -78,7 +78,7 @@ final class ListBeUsersRawToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeStripsCredentialColumnsEvenWithSelectStar(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringNotContainsString(self::SECRET_HASH, $output);
         self::assertStringNotContainsString(self::SECRET_MFA, $output);

--- a/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
+++ b/Tests/Functional/Service/Tool/ListBeUsersToolTest.php
@@ -78,7 +78,7 @@ final class ListBeUsersToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeListsLiveUsersWithProfileColumns(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Backend users (2):', $output);
         self::assertStringContainsString('[10] alice | Alice Admin <alice@example.com> | admin=1 disabled=0', $output);
@@ -90,7 +90,7 @@ final class ListBeUsersToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeExcludesSoftDeletedUsers(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringNotContainsString('carol', $output);
     }
@@ -98,7 +98,7 @@ final class ListBeUsersToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function executeNeverLeaksPasswordHashOrMfaSecret(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringNotContainsString(self::SECRET_HASH, $output);
         self::assertStringNotContainsString(self::SECRET_MFA, $output);

--- a/Tests/Functional/Service/Tool/ListExtensionsToolTest.php
+++ b/Tests/Functional/Service/Tool/ListExtensionsToolTest.php
@@ -41,7 +41,7 @@ final class ListExtensionsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function listsActivePackagesWithVersions(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Active extensions (', $output);
         self::assertStringContainsString('- nr_llm ', $output);

--- a/Tests/Functional/Service/Tool/ListFalStoragesToolTest.php
+++ b/Tests/Functional/Service/Tool/ListFalStoragesToolTest.php
@@ -48,7 +48,7 @@ final class ListFalStoragesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('Accessible file storages (1):', $output);
         self::assertStringContainsString('[1] Main storage (driver Local', $output);
@@ -60,6 +60,6 @@ final class ListFalStoragesToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function failsClosedWithoutBackendUser(): void
     {
-        self::assertSame('No accessible file storages.', $this->tool->execute([]));
+        self::assertSame('No accessible file storages.', $this->tool->execute([])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ProbeUrlToolTest.php
@@ -75,7 +75,7 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function deniesForeignHostWithoutRequesting(): void
     {
-        $output = $this->tool->execute(['url' => 'https://evil.example.com/steal']);
+        $output = $this->tool->execute(['url' => 'https://evil.example.com/steal'])->content;
 
         self::assertStringContainsString('Denied', $output);
         self::assertStringContainsString('localhost:59999', $output);
@@ -84,8 +84,8 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function deniesNonHttpScheme(): void
     {
-        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'file:///etc/passwd']));
-        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'gopher://localhost:59999/x']));
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'file:///etc/passwd'])->content);
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'gopher://localhost:59999/x'])->content);
     }
 
     #[Test]
@@ -94,7 +94,7 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
         // The site declares a staging baseVariant on an internal host; its
         // condition is inactive in the test context, so it is NOT the served
         // base — probe_url must not reach it (only the active base is trusted).
-        $output = $this->tool->execute(['url' => 'http://staging.internal:8080/']);
+        $output = $this->tool->execute(['url' => 'http://staging.internal:8080/'])->content;
 
         self::assertStringContainsString('Denied', $output);
     }
@@ -104,15 +104,15 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     {
         // Same host, different port than the site (59999) — must NOT pass the
         // gate, or an attacker could probe localhost:6379 (Redis), :3306, …
-        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost:6379/']));
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost:6379/'])->content);
         // Bare host defaults to port 80, also != 59999.
-        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost/']));
+        self::assertStringContainsString('Denied', $this->tool->execute(['url' => 'http://localhost/'])->content);
     }
 
     #[Test]
     public function deniesUserinfoAndDoesNotEchoCredentials(): void
     {
-        $output = $this->tool->execute(['url' => 'http://user:s3cr3t@localhost:59999/']);
+        $output = $this->tool->execute(['url' => 'http://user:s3cr3t@localhost:59999/'])->content;
 
         self::assertStringContainsString('Denied', $output);
         self::assertStringNotContainsString('s3cr3t', $output);
@@ -121,7 +121,7 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function ownHostPassesTheGate(): void
     {
-        $output = $this->tool->execute(['url' => 'http://localhost:59999/some/page']);
+        $output = $this->tool->execute(['url' => 'http://localhost:59999/some/page'])->content;
 
         // The request is ATTEMPTED (gate passed) and fails at transport
         // level because nothing listens on the closed port.
@@ -131,7 +131,7 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function relativePathResolvesAgainstTheFirstSite(): void
     {
-        $output = $this->tool->execute(['url' => '/imprint']);
+        $output = $this->tool->execute(['url' => '/imprint'])->content;
 
         self::assertStringContainsString('FAILED transport-level', $output);
         self::assertStringContainsString('http://localhost:59999/imprint', $output);
@@ -140,6 +140,6 @@ final class ProbeUrlToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function emptyUrlIsRejected(): void
     {
-        self::assertStringContainsString('"url" is required', $this->tool->execute([]));
+        self::assertStringContainsString('"url" is required', $this->tool->execute([])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
@@ -59,7 +59,7 @@ final class ReadFalAssetMetaToolTest extends AbstractFunctionalTestCase
         $this->importFixture('sys_file_tools.csv');
         $this->importFixture('sys_file_metadata_tools.csv');
 
-        $output = $this->tool->execute(['uid' => 1]);
+        $output = $this->tool->execute(['uid' => 1])->content;
 
         self::assertStringContainsString('logo.png', $output);
         self::assertStringContainsString('image/png', $output);
@@ -73,7 +73,7 @@ final class ReadFalAssetMetaToolTest extends AbstractFunctionalTestCase
     {
         $this->importFixture('sys_file_tools.csv');
 
-        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 2]));
+        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 2])->content);
     }
 
     #[Test]
@@ -81,6 +81,6 @@ final class ReadFalAssetMetaToolTest extends AbstractFunctionalTestCase
     {
         $this->importFixture('sys_file_tools.csv');
 
-        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 999999]));
+        self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 999999])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Service\Tool\Builtin\ReadRecordsTool;
 use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
@@ -68,7 +69,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
             'table'        => 'tt_content',
             'where_equals' => ['CType' => 'textmedia'],
             'fields'       => ['header', 'CType'],
-        ]);
+        ])->content;
 
         self::assertStringContainsString('tt_content:31', $output);
         self::assertStringContainsString('header: Beta', $output);
@@ -80,7 +81,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 30]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'uid' => 30])->content;
 
         self::assertStringContainsString('tt_content:30', $output);
         self::assertStringContainsString('header: Alpha', $output);
@@ -91,10 +92,48 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content', 'limit' => 1]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'limit' => 1])->content;
 
         self::assertStringContainsString('tt_content:30', $output);
         self::assertStringNotContainsString('tt_content:31', $output);
+    }
+
+    #[Test]
+    public function emitsATableArtifactFromTheSameFieldsAndCellsAsTheText(): void
+    {
+        // ADR-108: the run-only TABLE artifact is projected from the SAME
+        // TCA-validated field set the text egress uses (uid + pid + requested),
+        // so it can never re-expose a column the text path withheld.
+        $this->setUpBackendUser(1);
+
+        $result = $this->tool->execute([
+            'table'  => 'tt_content',
+            'fields' => ['header'],
+        ]);
+
+        self::assertCount(1, $result->artifacts);
+        $artifact = $result->artifacts[0];
+        self::assertSame(ArtifactType::TABLE, $artifact->type);
+
+        // Columns are exactly uid, pid and the requested field — nothing else.
+        self::assertSame(['uid', 'pid', 'header'], $artifact->data['columns']);
+
+        // Rows carry the same formatted cells the text lines show.
+        $rows = $artifact->data['rows'];
+        self::assertIsArray($rows);
+
+        $headers = [];
+        foreach ($rows as $row) {
+            self::assertIsArray($row);
+            foreach ($row as $cell) {
+                self::assertIsString($cell);
+                // Parity: no cell re-exposes a value absent from the text egress.
+                self::assertStringContainsString($cell, $result->content);
+            }
+            $headers[] = $row[2] ?? null;
+        }
+        self::assertContains('Alpha', $headers);
+        self::assertContains('Beta', $headers);
     }
 
     #[Test]
@@ -111,7 +150,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
 
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tt_content']);
+        $output = $this->tool->execute(['table' => 'tt_content'])->content;
 
         self::assertStringNotContainsString('DraftSecret', $output);
         self::assertStringNotContainsString('tt_content:99', $output);
@@ -123,7 +162,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(2); // editor without any group rights
 
-        $output = $this->tool->execute(['table' => 'tt_content']);
+        $output = $this->tool->execute(['table' => 'tt_content'])->content;
 
         self::assertSame('Table not found or not permitted.', $output);
     }
@@ -143,7 +182,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
         $output = $this->tool->execute([
             'table'        => 'tt_content',
             'where_equals' => ['sys_language_uid' => 1],
-        ]);
+        ])->content;
 
         self::assertSame('Table not found or not permitted.', $output);
     }
@@ -180,7 +219,7 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
         // No language filter given: the language-0 row is returned, the
         // language-1 row (on the same, accessible page) is dropped and its
         // content never egresses.
-        $output = $this->tool->execute(['table' => 'tt_content', 'where_equals' => ['pid' => 7]]);
+        $output = $this->tool->execute(['table' => 'tt_content', 'where_equals' => ['pid' => 7]])->content;
 
         self::assertStringContainsString('tt_content:40', $output);
         self::assertStringNotContainsString('tt_content:41', $output);

--- a/Tests/Functional/Service/Tool/ResolveUrlToolRelativeBaseTest.php
+++ b/Tests/Functional/Service/Tool/ResolveUrlToolRelativeBaseTest.php
@@ -72,7 +72,7 @@ final class ResolveUrlToolRelativeBaseTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['url' => '/imprint']);
+        $output = $this->tool->execute(['url' => '/imprint'])->content;
 
         self::assertStringContainsString('Page: [2] Imprint', $output);
         self::assertStringContainsString('slug /imprint', $output);

--- a/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
+++ b/Tests/Functional/Service/Tool/ResolveUrlToolTest.php
@@ -71,7 +71,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['url' => '/imprint']);
+        $output = $this->tool->execute(['url' => '/imprint'])->content;
 
         self::assertStringContainsString('Site: resolver (base http://localhost:59999/)', $output);
         self::assertStringContainsString('Page: [2] Imprint', $output);
@@ -84,7 +84,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['url' => 'http://localhost:59999/']);
+        $output = $this->tool->execute(['url' => 'http://localhost:59999/'])->content;
 
         self::assertStringContainsString('Page: [1] Home', $output);
         self::assertStringContainsString('Language: 0', $output);
@@ -95,7 +95,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['url' => 'imprint']);
+        $output = $this->tool->execute(['url' => 'imprint'])->content;
 
         self::assertStringContainsString('Page: [2] Imprint', $output);
     }
@@ -107,7 +107,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Not a URL of this instance (no site matches).',
-            $this->tool->execute(['url' => '//evil.example.com/x']),
+            $this->tool->execute(['url' => '//evil.example.com/x'])->content,
         );
     }
 
@@ -118,7 +118,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Not a URL of this instance (no site matches).',
-            $this->tool->execute(['url' => 'https://evil.example.com/x']),
+            $this->tool->execute(['url' => 'https://evil.example.com/x'])->content,
         );
     }
 
@@ -127,7 +127,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['url' => '/nope']);
+        $output = $this->tool->execute(['url' => '/nope'])->content;
 
         self::assertStringContainsString('No page route matches "/nope" on site "resolver"', $output);
     }
@@ -137,7 +137,7 @@ final class ResolveUrlToolTest extends AbstractFunctionalTestCase
     {
         self::assertSame(
             'Page not found or not permitted.',
-            $this->tool->execute(['url' => '/imprint']),
+            $this->tool->execute(['url' => '/imprint'])->content,
         );
     }
 }

--- a/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
@@ -73,7 +73,7 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['query' => 'brochure']);
+        $output = $this->tool->execute(['query' => 'brochure'])->content;
 
         // Name match (uid 10) and metadata-title match (uid 11).
         self::assertStringContainsString('[10] 1:/brochure-2026.pdf', $output);
@@ -90,7 +90,7 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
 
         self::assertStringContainsString(
             'No files match "%"',
-            $this->tool->execute(['query' => '%']),
+            $this->tool->execute(['query' => '%'])->content,
         );
     }
 
@@ -101,7 +101,7 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'No accessible file storages.',
-            $this->tool->execute(['query' => 'brochure', 'storage' => 2]),
+            $this->tool->execute(['query' => 'brochure', 'storage' => 2])->content,
         );
     }
 
@@ -110,7 +110,7 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
     {
         self::assertSame(
             'No accessible file storages.',
-            $this->tool->execute(['query' => 'brochure']),
+            $this->tool->execute(['query' => 'brochure'])->content,
         );
     }
     #[Test]
@@ -120,11 +120,11 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
 
         // Fixture name is lowercase 'brochure-2026.pdf'; DB collations with
         // case-sensitive LIKE (e.g. PostgreSQL) must still match.
-        $output = $this->tool->execute(['query' => 'BROCHURE']);
+        $output = $this->tool->execute(['query' => 'BROCHURE'])->content;
 
         self::assertStringContainsString('brochure-2026.pdf', $output);
         // Uppercase name matched by lowercase query, too.
-        $output = $this->tool->execute(['query' => 'dsc01']);
+        $output = $this->tool->execute(['query' => 'dsc01'])->content;
         self::assertStringContainsString('DSC01.jpg', $output);
     }
 }

--- a/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchRecordsToolTest.php
@@ -63,7 +63,7 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function findsSeededContentThroughSearchFieldsWithExcerpt(): void
     {
-        $output = $this->tool->execute(['query' => 'Netresearch']);
+        $output = $this->tool->execute(['query' => 'Netresearch'])->content;
 
         self::assertStringContainsString('tt_content:10', $output);
         self::assertStringContainsString('About Netresearch', $output);
@@ -73,7 +73,7 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function hiddenRowsNeverReachTheOutput(): void
     {
-        $output = $this->tool->execute(['query' => 'hidden gem']);
+        $output = $this->tool->execute(['query' => 'hidden gem'])->content;
 
         self::assertSame('No matches.', $output);
     }
@@ -81,7 +81,7 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function tableRestrictionLimitsTheSearch(): void
     {
-        $output = $this->tool->execute(['query' => 'Netresearch', 'table' => 'pages']);
+        $output = $this->tool->execute(['query' => 'Netresearch', 'table' => 'pages'])->content;
 
         self::assertStringNotContainsString('tt_content:', $output);
     }
@@ -89,7 +89,7 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
     #[Test]
     public function sensitiveTableIsDeniedEvenForAdmin(): void
     {
-        $output = $this->tool->execute(['query' => 'admin', 'table' => 'be_users']);
+        $output = $this->tool->execute(['query' => 'admin', 'table' => 'be_users'])->content;
 
         self::assertSame('Table not found or not permitted.', $output);
     }
@@ -106,7 +106,7 @@ final class SearchRecordsToolTest extends AbstractFunctionalTestCase
             't3ver_wsid' => 1, 't3ver_oid' => 10, 't3ver_state' => 0,
         ]);
 
-        $output = $this->tool->execute(['query' => 'workspacedraftmarker']);
+        $output = $this->tool->execute(['query' => 'workspacedraftmarker'])->content;
 
         self::assertSame('No matches.', $output);
     }

--- a/Tests/Functional/Service/Tool/SiteRagToolsTest.php
+++ b/Tests/Functional/Service/Tool/SiteRagToolsTest.php
@@ -97,7 +97,7 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->queryTool->execute(['question' => 'aikido']);
+        $output = $this->queryTool->execute(['question' => 'aikido'])->content;
 
         self::assertStringContainsString('backend: database', $output);
         self::assertStringContainsString('database:2:0', $output);
@@ -111,7 +111,7 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->fetchTool->execute(['source_id' => 'database:2:0']);
+        $output = $this->fetchTool->execute(['source_id' => 'database:2:0'])->content;
 
         self::assertStringContainsString('# Aikido Migration Services', $output);
         self::assertStringContainsString('Aikido migrations done right.', $output);
@@ -122,12 +122,12 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        self::assertSame('Question too short (minimum 2 characters).', $this->queryTool->execute(['question' => 'x']));
-        self::assertSame('Invalid source_id.', $this->fetchTool->execute(['source_id' => "db:1' OR '1"]));
-        self::assertSame('Source not found or not permitted.', $this->fetchTool->execute(['source_id' => 'database:999:0']));
+        self::assertSame('Question too short (minimum 2 characters).', $this->queryTool->execute(['question' => 'x'])->content);
+        self::assertSame('Invalid source_id.', $this->fetchTool->execute(['source_id' => "db:1' OR '1"])->content);
+        self::assertSame('Source not found or not permitted.', $this->fetchTool->execute(['source_id' => 'database:999:0'])->content);
         self::assertSame(
             'No evidence found for "zzz-not-present" (backend: database).',
-            $this->queryTool->execute(['question' => 'zzz-not-present']),
+            $this->queryTool->execute(['question' => 'zzz-not-present'])->content,
         );
     }
 
@@ -139,18 +139,18 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
         // Each of these once mapped to a RetrievalQuery::create() guard —
         // the tool must clamp them, not surface an exception (temperature=5
         // bug class).
-        $overCap = $this->queryTool->execute(['question' => 'aikido', 'max_sources' => 999]);
+        $overCap = $this->queryTool->execute(['question' => 'aikido', 'max_sources' => 999])->content;
         self::assertStringContainsString('database:2:0', $overCap);
 
-        $zero = $this->queryTool->execute(['question' => 'aikido', 'max_sources' => 0]);
+        $zero = $this->queryTool->execute(['question' => 'aikido', 'max_sources' => 0])->content;
         self::assertStringContainsString('database:2:0', $zero);
 
-        $negativeLanguage = $this->queryTool->execute(['question' => 'aikido', 'language' => -3]);
+        $negativeLanguage = $this->queryTool->execute(['question' => 'aikido', 'language' => -3])->content;
         self::assertStringContainsString('database:2:0', $negativeLanguage);
 
         // 350 chars in, truncated to 200 and answered cleanly — the echoed
         // question ends mid-word instead of raising a VO exception.
-        $longQuestion = $this->queryTool->execute(['question' => str_repeat('aikido ', 50)]);
+        $longQuestion = $this->queryTool->execute(['question' => str_repeat('aikido ', 50)])->content;
         self::assertStringStartsWith('Evidence for "aikido ', $longQuestion);
         self::assertStringContainsString('aiki" (backend:', $longQuestion);
         self::assertStringContainsString('database:2:0', $longQuestion);
@@ -170,7 +170,7 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
             'header' => 'Long chapter', 'bodytext' => str_repeat('aikido wisdom ', 1000),
         ]);
 
-        $output = $this->fetchTool->execute(['source_id' => 'database:2:0']);
+        $output = $this->fetchTool->execute(['source_id' => 'database:2:0'])->content;
 
         self::assertSame(8001, mb_strlen($output));
         self::assertStringEndsWith('…', $output);
@@ -179,7 +179,7 @@ final class SiteRagToolsTest extends AbstractFunctionalTestCase
     #[Test]
     public function bothToolsFailClosedWithoutBackendUser(): void
     {
-        self::assertSame('Not permitted.', $this->queryTool->execute(['question' => 'aikido']));
-        self::assertSame('Not permitted.', $this->fetchTool->execute(['source_id' => 'database:2:0']));
+        self::assertSame('Not permitted.', $this->queryTool->execute(['question' => 'aikido'])->content);
+        self::assertSame('Not permitted.', $this->fetchTool->execute(['source_id' => 'database:2:0'])->content);
     }
 }

--- a/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
+++ b/Tests/Functional/Service/Tool/ValidateTcaToolTest.php
@@ -97,7 +97,7 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute(['table' => 'tx_demo_broken']);
+        $output = $this->tool->execute(['table' => 'tx_demo_broken'])->content;
 
         self::assertStringContainsString('ctrl.label "missing_label_column" is not a defined column', $output);
         self::assertStringContainsString('foreign_table "tx_does_not_exist" is not a TCA table', $output);
@@ -113,7 +113,7 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'No TCA issues found in table "tx_demo_clean".',
-            $this->tool->execute(['table' => 'tx_demo_clean']),
+            $this->tool->execute(['table' => 'tx_demo_clean'])->content,
         );
     }
 
@@ -124,7 +124,7 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'No TCA issues found in table "tx_demo_ctrlfields".',
-            $this->tool->execute(['table' => 'tx_demo_ctrlfields']),
+            $this->tool->execute(['table' => 'tx_demo_ctrlfields'])->content,
         );
     }
 
@@ -133,7 +133,7 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('tx_demo_broken: ctrl.label "missing_label_column"', $output);
         self::assertStringContainsString('Checked', $output);
@@ -146,7 +146,7 @@ final class ValidateTcaToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(
             'Table not found or not permitted.',
-            $this->tool->execute(['table' => 'be_users']),
+            $this->tool->execute(['table' => 'be_users'])->content,
         );
     }
 }

--- a/Tests/Unit/Domain/ValueObject/RunStepTest.php
+++ b/Tests/Unit/Domain/ValueObject/RunStepTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
 
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +43,31 @@ final class RunStepTest extends TestCase
         self::assertArrayNotHasKey('content', $array);
         self::assertArrayNotHasKey('promptTokens', $array);
         self::assertArrayNotHasKey('messagesSent', $array);
+        // No artifacts on this step: the key is dropped entirely (ADR-108).
+        self::assertArrayNotHasKey('toolArtifacts', $array);
+    }
+
+    #[Test]
+    public function toArraySerialisesToolArtifactsAsPlainArrayList(): void
+    {
+        $step = new RunStep(
+            kind: RunStep::KIND_TOOL,
+            round: 1,
+            durationMs: 5.0,
+            toolName: 'read_records',
+            toolResult: 'ok',
+            toolIsError: false,
+            toolArtifacts: [
+                new ToolArtifact(ArtifactType::TABLE, 'pages', ['columns' => ['uid'], 'rows' => [['1']]]),
+            ],
+        );
+
+        $array = $step->toArray();
+
+        self::assertSame(
+            [['type' => 'table', 'label' => 'pages', 'data' => ['columns' => ['uid'], 'rows' => [['1']]]]],
+            $array['toolArtifacts'],
+        );
     }
 
     #[Test]

--- a/Tests/Unit/Domain/ValueObject/ToolArtifactTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolArtifactTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolArtifact::class)]
+final class ToolArtifactTest extends TestCase
+{
+    #[Test]
+    public function toArrayEmitsTypeValueLabelAndData(): void
+    {
+        $artifact = new ToolArtifact(ArtifactType::TABLE, 'pages records', [
+            'columns' => ['uid', 'title'],
+            'rows'    => [['1', 'Home'], ['2', 'About']],
+        ]);
+
+        self::assertSame(
+            [
+                'type'  => 'table',
+                'label' => 'pages records',
+                'data'  => [
+                    'columns' => ['uid', 'title'],
+                    'rows'    => [['1', 'Home'], ['2', 'About']],
+                ],
+            ],
+            $artifact->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayMapsTheTextTypeToItsEnumValue(): void
+    {
+        $artifact = new ToolArtifact(ArtifactType::TEXT, 'Artifacts omitted', ['text' => 'too big']);
+
+        $array = $artifact->toArray();
+
+        self::assertSame('text', $array['type']);
+        self::assertSame('Artifacts omitted', $array['label']);
+        self::assertSame(['text' => 'too big'], $array['data']);
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/ToolResultTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolResultTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionNamedType;
+
+#[CoversClass(ToolResult::class)]
+final class ToolResultTest extends TestCase
+{
+    #[Test]
+    public function textIsANonErrorResultWithNoArtifactsByDefault(): void
+    {
+        $result = ToolResult::text('hello');
+
+        self::assertSame('hello', $result->content);
+        self::assertFalse($result->isError);
+        self::assertSame([], $result->artifacts);
+    }
+
+    #[Test]
+    public function textPreservesArtifactOrder(): void
+    {
+        $a = new ToolArtifact(ArtifactType::TABLE, 'first', ['columns' => [], 'rows' => []]);
+        $b = new ToolArtifact(ArtifactType::TEXT, 'second', ['text' => 'x']);
+
+        $result = ToolResult::text('content', $a, $b);
+
+        self::assertSame([$a, $b], $result->artifacts);
+        self::assertFalse($result->isError);
+    }
+
+    #[Test]
+    public function errorIsFailClosed_flagsErrorAndCarriesNoArtifacts(): void
+    {
+        $result = ToolResult::error('Error: tool "x" failed.');
+
+        self::assertSame('Error: tool "x" failed.', $result->content);
+        self::assertTrue($result->isError);
+        self::assertSame([], $result->artifacts);
+    }
+
+    #[Test]
+    public function contentIsTheOnlyStringPath_noToStringOrWireAccessorExists(): void
+    {
+        $reflection = new ReflectionClass(ToolResult::class);
+
+        // Egress separation by construction: no __toString() that could merge an
+        // artifact into a wire string, and the constructor is private so the
+        // fail-closed invariant cannot be bypassed.
+        self::assertFalse($reflection->hasMethod('__toString'));
+        self::assertTrue($reflection->getConstructor()?->isPrivate());
+
+        // The only string-typed public member is `content`.
+        $stringProps = [];
+        foreach ($reflection->getProperties() as $property) {
+            $type = $property->getType();
+            if ($type instanceof ReflectionNamedType && $type->getName() === 'string') {
+                $stringProps[] = $property->getName();
+            }
+        }
+        self::assertSame(['content'], $stringProps);
+    }
+}

--- a/Tests/Unit/Service/Privacy/RunStepPrivacyFilterTest.php
+++ b/Tests/Unit/Service/Privacy/RunStepPrivacyFilterTest.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Privacy;
 
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Service\Privacy\RunStepPrivacyFilter;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -108,6 +110,51 @@ final class RunStepPrivacyFilterTest extends TestCase
 
         self::assertArrayNotHasKey('content', $filtered);
         self::assertTrue($filtered['contentRedacted']);
+    }
+
+    #[Test]
+    public function metadataLevelDropsArtifactDataButSummarisesCountAndTypes(): void
+    {
+        // ADR-108: artifact `data` is content and must never persist at the
+        // default level, but a shape/count summary keeps the audit useful.
+        $step = new RunStep(
+            kind: RunStep::KIND_TOOL,
+            round: 1,
+            durationMs: 4.0,
+            toolName: 'read_records',
+            toolResult: 'pages: Impressum',
+            toolIsError: false,
+            toolArtifacts: [
+                new ToolArtifact(ArtifactType::TABLE, 'pages', ['columns' => ['secret'], 'rows' => [['sk-abcdefghijklmnop']]]),
+            ],
+        );
+
+        $filtered = FixedPrivacyPolicy::filterAt(PrivacyLevel::METADATA)->filter($step->toArray());
+
+        self::assertArrayNotHasKey('toolArtifacts', $filtered);
+        self::assertStringNotContainsString('sk-abcdefghijklmnop', json_encode($filtered, JSON_THROW_ON_ERROR));
+        self::assertSame(1, $filtered['toolArtifactsCount']);
+        self::assertSame(['table'], $filtered['toolArtifactTypes']);
+    }
+
+    #[Test]
+    public function redactedLevelMasksSecretsInsideArtifactDataLeaves(): void
+    {
+        $step = new RunStep(
+            kind: RunStep::KIND_TOOL,
+            round: 1,
+            durationMs: 4.0,
+            toolName: 'read_records',
+            toolResult: 'ok',
+            toolArtifacts: [
+                new ToolArtifact(ArtifactType::TABLE, 'creds', ['columns' => ['token'], 'rows' => [['sk-abcdefghijklmnopqrstuvwxyz']]]),
+            ],
+        );
+
+        $filtered = FixedPrivacyPolicy::filterAt(PrivacyLevel::REDACTED)->filter($step->toArray());
+
+        self::assertArrayHasKey('toolArtifacts', $filtered);
+        self::assertStringNotContainsString('sk-abcdefghijklmnopqrstuvwxyz', json_encode($filtered['toolArtifacts'], JSON_THROW_ON_ERROR));
     }
 
     private function llmStep(): RunStep

--- a/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
@@ -89,7 +89,7 @@ final class ContentToolsSpecTest extends TestCase
     #[Test]
     public function searchFailsClosedWithoutBackendUser(): void
     {
-        self::assertSame('Not permitted.', $this->searchTool()->execute(['query' => 'foo']));
+        self::assertSame('Not permitted.', $this->searchTool()->execute(['query' => 'foo'])->content);
     }
 
     #[Test]
@@ -99,7 +99,7 @@ final class ContentToolsSpecTest extends TestCase
 
         self::assertSame(
             'Query too short (minimum 2 characters).',
-            $this->searchTool()->execute(['query' => 'x']),
+            $this->searchTool()->execute(['query' => 'x'])->content,
         );
     }
 
@@ -108,7 +108,7 @@ final class ContentToolsSpecTest extends TestCase
     {
         self::assertSame(
             'Page not found or not permitted.',
-            $this->pageContentTool()->execute(['uid' => 1]),
+            $this->pageContentTool()->execute(['uid' => 1])->content,
         );
     }
 
@@ -119,7 +119,7 @@ final class ContentToolsSpecTest extends TestCase
 
         self::assertSame(
             'Page not found or not permitted.',
-            $this->pageContentTool()->execute(['uid' => 0]),
+            $this->pageContentTool()->execute(['uid' => 0])->content,
         );
     }
 
@@ -128,7 +128,7 @@ final class ContentToolsSpecTest extends TestCase
     {
         self::assertSame(
             'Table not found or not permitted.',
-            $this->readRecordsTool()->execute(['table' => 'tt_content']),
+            $this->readRecordsTool()->execute(['table' => 'tt_content'])->content,
         );
     }
 
@@ -140,7 +140,7 @@ final class ContentToolsSpecTest extends TestCase
 
         self::assertSame(
             'Table not found or not permitted.',
-            $this->readRecordsTool()->execute(['table' => 'be_users']),
+            $this->readRecordsTool()->execute(['table' => 'be_users'])->content,
         );
     }
 
@@ -154,7 +154,7 @@ final class ContentToolsSpecTest extends TestCase
             $this->readRecordsTool()->execute([
                 'table'        => 'tt_content',
                 'where_equals' => ['no_such_column' => 'x'],
-            ]),
+            ])->content,
         );
     }
 
@@ -169,7 +169,7 @@ final class ContentToolsSpecTest extends TestCase
             $this->readRecordsTool()->execute([
                 'table'        => 'tt_content',
                 'where_equals' => ['api_key' => 'x'],
-            ]),
+            ])->content,
         );
     }
 
@@ -178,14 +178,14 @@ final class ContentToolsSpecTest extends TestCase
     {
         self::assertSame(
             'Page not found or no TypoScript template.',
-            $this->typoScriptTool()->execute(['pageUid' => 0]),
+            $this->typoScriptTool()->execute(['pageUid' => 0])->content,
         );
     }
 
     #[Test]
     public function tsConfigRejectsInvalidPageUid(): void
     {
-        self::assertSame('Page not found.', $this->tsConfigTool()->execute(['pageUid' => 0]));
+        self::assertSame('Page not found.', $this->tsConfigTool()->execute(['pageUid' => 0])->content);
     }
 
     private function adminUser(): BackendUserAuthentication

--- a/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
@@ -100,11 +100,11 @@ final class FalToolsSpecTest extends TestCase
         // no storages and every tool answers with its neutral denial.
         self::assertSame(
             'Asset not found or not permitted.',
-            self::bare(GetFalReferencesTool::class)->execute(['uid' => 0]),
+            self::bare(GetFalReferencesTool::class)->execute(['uid' => 0])->content,
         );
         self::assertSame(
             'Error: "query" is required.',
-            self::bare(SearchFalFilesTool::class)->execute([]),
+            self::bare(SearchFalFilesTool::class)->execute([])->content,
         );
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
@@ -50,7 +50,7 @@ final class GetEnvRawToolTest extends TestCase
     #[Test]
     public function returnsSecretValueUnredacted(): void
     {
-        $output = (new GetEnvRawTool())->execute([]);
+        $output = (new GetEnvRawTool())->execute([])->content;
 
         self::assertStringContainsString(self::SECRET_KEY . '=' . self::SECRET_VALUE, $output);
     }

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -82,7 +82,7 @@ final class GetEnvToolTest extends TestCase
     #[Test]
     public function nonSecretValueIsShownButSecretValueIsRedacted(): void
     {
-        $output = (new GetEnvTool())->execute([]);
+        $output = (new GetEnvTool())->execute([])->content;
 
         self::assertStringContainsString(self::PLAIN_KEY . '=' . self::PLAIN_VALUE, $output);
         // The secret variable appears, but its value is masked.
@@ -93,7 +93,7 @@ final class GetEnvToolTest extends TestCase
     #[Test]
     public function pwdStyleSecretNameIsRedacted(): void
     {
-        $output = (new GetEnvTool())->execute([]);
+        $output = (new GetEnvTool())->execute([])->content;
 
         // MYSQL_PWD uses PWD, not PASS — it must still be caught.
         self::assertStringContainsString(self::PWD_KEY . '=***redacted***', $output);
@@ -103,7 +103,7 @@ final class GetEnvToolTest extends TestCase
     #[Test]
     public function inlineUrlCredentialsAreRedactedWhileHostRemains(): void
     {
-        $output = (new GetEnvTool())->execute([]);
+        $output = (new GetEnvTool())->execute([])->content;
 
         // The variable NAME is not secret-looking, but its VALUE embeds
         // credentials: the userinfo is stripped, the host/port kept for context.
@@ -115,7 +115,7 @@ final class GetEnvToolTest extends TestCase
     #[Test]
     public function inlineUrlCredentialsWithEmptyUsernameAreRedacted(): void
     {
-        $output = (new GetEnvTool())->execute([]);
+        $output = (new GetEnvTool())->execute([])->content;
 
         // redis://:password@host has no username — the password must still be
         // stripped rather than leaking to the provider.

--- a/Tests/Unit/Service/Tool/Builtin/GetLastExceptionToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetLastExceptionToolTest.php
@@ -73,7 +73,7 @@ final class GetLastExceptionToolTest extends TestCase
     #[Test]
     public function rendersExceptionWithSourceContextAroundProjectFrames(): void
     {
-        $output = $this->tool->execute([]);
+        $output = $this->tool->execute([])->content;
 
         self::assertStringContainsString('RuntimeException', $output);
         self::assertStringContainsString('it broke', $output);
@@ -87,7 +87,7 @@ final class GetLastExceptionToolTest extends TestCase
     #[Test]
     public function indexOutOfRangeIsExplained(): void
     {
-        self::assertStringContainsString('out of range', $this->tool->execute(['index' => 5]));
+        self::assertStringContainsString('out of range', $this->tool->execute(['index' => 5])->content);
     }
 
     #[Test]
@@ -97,7 +97,7 @@ final class GetLastExceptionToolTest extends TestCase
         mkdir($empty, 0o777, true);
         $tool = new GetLastExceptionTool(new LogExceptionReader($empty), new SourcePathGuard($this->base . '/project'));
 
-        $output = $tool->execute([]);
+        $output = $tool->execute([])->content;
 
         self::assertStringContainsString('No error-level entries', $output);
         self::assertStringContainsString('fetch_logs', $output);

--- a/Tests/Unit/Service/Tool/Builtin/GetPhpInfoRawToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetPhpInfoRawToolTest.php
@@ -33,7 +33,7 @@ final class GetPhpInfoRawToolTest extends TestCase
     #[Test]
     public function capturesFullPhpInfoOutput(): void
     {
-        $output = (new GetPhpInfoRawTool())->execute([]);
+        $output = (new GetPhpInfoRawTool())->execute([])->content;
 
         // phpinfo() always emits the PHP version line in its capture; in CLI it
         // is plain text ("PHP Version => x.y.z").

--- a/Tests/Unit/Service/Tool/Builtin/GetPhpInfoToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetPhpInfoToolTest.php
@@ -34,7 +34,7 @@ final class GetPhpInfoToolTest extends TestCase
     #[Test]
     public function returnsCuratedRuntimeSubset(): void
     {
-        $output = (new GetPhpInfoTool())->execute([]);
+        $output = (new GetPhpInfoTool())->execute([])->content;
 
         self::assertStringContainsString('PHP version: ' . PHP_VERSION, $output);
         self::assertStringContainsString('Loaded extensions (', $output);

--- a/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
@@ -86,7 +86,7 @@ final class GetTcaToolTest extends TestCase
     #[Test]
     public function withoutTableArgumentListsSortedTableNames(): void
     {
-        $output = (new GetTcaTool(new TableReadAccessService()))->execute([]);
+        $output = (new GetTcaTool(new TableReadAccessService()))->execute([])->content;
 
         self::assertStringContainsString('TCA tables (2):', $output);
         // Sorted: pages before tt_content.
@@ -96,7 +96,7 @@ final class GetTcaToolTest extends TestCase
     #[Test]
     public function withTableArgumentReturnsColumnNamesAndTypes(): void
     {
-        $output = (new GetTcaTool(new TableReadAccessService()))->execute(['table' => 'pages']);
+        $output = (new GetTcaTool(new TableReadAccessService()))->execute(['table' => 'pages'])->content;
 
         self::assertStringContainsString('TCA columns for pages:', $output);
         self::assertStringContainsString('title: input', $output);
@@ -108,7 +108,7 @@ final class GetTcaToolTest extends TestCase
     #[Test]
     public function unknownTableReturnsNeutralString(): void
     {
-        self::assertSame('Unknown TCA table.', (new GetTcaTool(new TableReadAccessService()))->execute(['table' => 'no_such_table']));
+        self::assertSame('Unknown TCA table.', (new GetTcaTool(new TableReadAccessService()))->execute(['table' => 'no_such_table'])->content);
     }
 
     #[Test]
@@ -123,9 +123,9 @@ final class GetTcaToolTest extends TestCase
 
         $tool = new GetTcaTool(new TableReadAccessService());
 
-        self::assertSame('Unknown TCA table.', $tool->execute(['table' => 'tx_nrllm_provider']));
-        self::assertStringNotContainsString('tx_nrllm_provider', $tool->execute([]));
+        self::assertSame('Unknown TCA table.', $tool->execute(['table' => 'tx_nrllm_provider'])->content);
+        self::assertStringNotContainsString('tx_nrllm_provider', $tool->execute([])->content);
         // A normal table is still described in full — the gate must not over-block.
-        self::assertStringContainsString('title', $tool->execute(['table' => 'pages']));
+        self::assertStringContainsString('title', $tool->execute(['table' => 'pages'])->content);
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
@@ -83,19 +83,19 @@ final class HistoryValidationToolsSpecTest extends TestCase
         // No $GLOBALS['BE_USER'] in unit context → fail-closed paths.
         self::assertSame(
             'Table not found or not permitted.',
-            self::bare(GetRecordHistoryTool::class)->execute(['table' => '', 'uid' => 0]),
+            self::bare(GetRecordHistoryTool::class)->execute(['table' => '', 'uid' => 0])->content,
         );
         self::assertSame(
             'Page not found or no TypoScript template.',
-            self::bare(CheckTypoScriptTool::class)->execute(['pageUid' => 0]),
+            self::bare(CheckTypoScriptTool::class)->execute(['pageUid' => 0])->content,
         );
         self::assertSame(
             'Error: "url" is required.',
-            self::bare(ResolveUrlTool::class)->execute([]),
+            self::bare(ResolveUrlTool::class)->execute([])->content,
         );
         self::assertSame(
             'Page not found or not permitted.',
-            self::bare(ResolveUrlTool::class)->execute(['url' => '/x']),
+            self::bare(ResolveUrlTool::class)->execute(['url' => '/x'])->content,
         );
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
@@ -178,7 +178,7 @@ final class ReadRecordsToolTest extends TestCase
         $output = $tool->execute([
             'table'  => '  tt_content  ',
             'fields' => ['uid', 'header'],
-        ]);
+        ])->content;
 
         self::assertSame(['tt_content'], $this->requestedTables);
         self::assertSame([['uid', 'pid', 'header']], $this->selectCalls);
@@ -205,7 +205,7 @@ final class ReadRecordsToolTest extends TestCase
             ['uid' => 7, 'pid' => 1, 'header' => 'A', 'bodytext' => 'B'],
         ]);
 
-        $output = $tool->execute(['table' => 'tt_content']);
+        $output = $tool->execute(['table' => 'tt_content'])->content;
 
         // label "header" plus label_alt "bodytext" (trimmed); "no_such_col"
         // (not a TCA column) and "password_field" (credential-ish) are dropped.
@@ -233,7 +233,7 @@ final class ReadRecordsToolTest extends TestCase
         ];
         $tool = $this->tool([['uid' => 9, 'pid' => 4, 'header' => 'H']]);
 
-        $output = $tool->execute(['table' => 'tt_content']);
+        $output = $tool->execute(['table' => 'tt_content'])->content;
 
         // "ghost_col" is a ctrl label without a column definition: it must
         // not be selected; only the label_alt column survives.
@@ -260,7 +260,7 @@ final class ReadRecordsToolTest extends TestCase
                 'sorting'  => 3,
                 'layout'   => 1,
             ],
-        ]);
+        ])->content;
 
         // uid first, then pid (0 is valid: the root page), then the five
         // where_equals columns in argument order with the key trimmed.
@@ -316,7 +316,7 @@ final class ReadRecordsToolTest extends TestCase
                 'sorting'  => 2,
                 'layout'   => 3,
             ],
-        ]);
+        ])->content;
 
         self::assertSame(
             'Invalid filter: only existing, non-credential TCA columns with scalar values are allowed.',
@@ -336,7 +336,7 @@ final class ReadRecordsToolTest extends TestCase
             'fields' => ['header'],
             'uid'    => 0,
             'pid'    => -3,
-        ]);
+        ])->content;
 
         // A present-but-negative pid and a zero uid are no filters at all.
         self::assertSame(0, $this->andWhereCalls);

--- a/Tests/Unit/Service/Tool/Builtin/ReadSourceToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadSourceToolTest.php
@@ -54,7 +54,7 @@ final class ReadSourceToolTest extends TestCase
     #[Test]
     public function readsARangeWithLineNumbers(): void
     {
-        $output = $this->tool->execute(['path' => 'Classes/Demo.php', 'from_line' => 3, 'lines' => 2]);
+        $output = $this->tool->execute(['path' => 'Classes/Demo.php', 'from_line' => 3, 'lines' => 2])->content;
 
         self::assertStringContainsString('Classes/Demo.php (lines 3-4 of 10):', $output);
         self::assertStringContainsString('    3 | // line 3', $output);
@@ -65,7 +65,7 @@ final class ReadSourceToolTest extends TestCase
     #[Test]
     public function deniesSettingsPhp(): void
     {
-        $output = $this->tool->execute(['path' => 'config/system/settings.php']);
+        $output = $this->tool->execute(['path' => 'config/system/settings.php'])->content;
 
         self::assertStringContainsString('Denied or not found', $output);
         self::assertStringNotContainsString('secret', $output);
@@ -74,7 +74,7 @@ final class ReadSourceToolTest extends TestCase
     #[Test]
     public function requiresAPath(): void
     {
-        self::assertStringContainsString('"path" is required', $this->tool->execute([]));
+        self::assertStringContainsString('"path" is required', $this->tool->execute([])->content);
     }
 
     protected function tearDown(): void

--- a/Tests/Unit/Service/Tool/Builtin/SchemaToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SchemaToolsSpecTest.php
@@ -51,9 +51,9 @@ final class SchemaToolsSpecTest extends TestCase
     {
         $tool = new FluidResolveTool();
 
-        self::assertSame('Provide a template/partial/layout name.', $tool->execute(['name' => '']));
-        self::assertSame('Invalid name.', $tool->execute(['name' => '../../etc/passwd']));
-        self::assertStringContainsString('Provide the "extension"', $tool->execute(['name' => 'Foo']));
-        self::assertSame('Invalid extension key.', $tool->execute(['name' => 'Foo', 'extension' => 'Bad Key!']));
+        self::assertSame('Provide a template/partial/layout name.', $tool->execute(['name' => ''])->content);
+        self::assertSame('Invalid name.', $tool->execute(['name' => '../../etc/passwd'])->content);
+        self::assertStringContainsString('Provide the "extension"', $tool->execute(['name' => 'Foo'])->content);
+        self::assertSame('Invalid extension key.', $tool->execute(['name' => 'Foo', 'extension' => 'Bad Key!'])->content);
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
@@ -86,7 +86,7 @@ final class SearchCodeToolTest extends TestCase
     #[Test]
     public function findsLiteralHitsOnlyInAllowedSourceFiles(): void
     {
-        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+        $output = $this->tool->execute(['pattern' => 'findMeHere'])->content;
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
         // Relative path is root-stripped with no leading slash and not the full/offset pathname:
@@ -110,18 +110,18 @@ final class SearchCodeToolTest extends TestCase
     {
         self::assertStringContainsString(
             'invalid regular expression',
-            $this->tool->execute(['pattern' => '([unclosed', 'regex' => true]),
+            $this->tool->execute(['pattern' => '([unclosed', 'regex' => true])->content,
         );
         self::assertStringContainsString(
             'Classes/Alpha.php:2:',
-            $this->tool->execute(['pattern' => 'findMe\w+\(\)', 'regex' => true]),
+            $this->tool->execute(['pattern' => 'findMe\w+\(\)', 'regex' => true])->content,
         );
     }
 
     #[Test]
     public function capsResults(): void
     {
-        $output = $this->tool->execute(['pattern' => 'findMeHere', 'max_results' => 1]);
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'max_results' => 1])->content;
 
         self::assertStringContainsString('1 match(es)', $output);
         self::assertStringContainsString('(capped)', $output);
@@ -134,14 +134,14 @@ final class SearchCodeToolTest extends TestCase
         // so pin the exact denial message.
         self::assertSame(
             'Denied or not found: search path "..".',
-            $this->tool->execute(['pattern' => 'x', 'path' => '../']),
+            $this->tool->execute(['pattern' => 'x', 'path' => '../'])->content,
         );
     }
 
     #[Test]
     public function reportsNoMatches(): void
     {
-        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'zzz-not-there']));
+        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'zzz-not-there'])->content);
     }
 
     #[Test]
@@ -149,7 +149,7 @@ final class SearchCodeToolTest extends TestCase
     {
         // "findMe." is absent as a literal but, as a regex, matches "findMeH".
         // Without regex=true the tool must treat it literally -> no match.
-        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'findMe.']));
+        self::assertStringContainsString('No matches', $this->tool->execute(['pattern' => 'findMe.'])->content);
     }
 
     #[Test]
@@ -159,7 +159,7 @@ final class SearchCodeToolTest extends TestCase
 
         // "~" is the delimiter; it must be escaped in the pattern body, otherwise
         // "~a~b~" reads "b" as a modifier and the pattern is rejected as invalid.
-        $output = $this->tool->execute(['pattern' => 'a~b', 'regex' => true]);
+        $output = $this->tool->execute(['pattern' => 'a~b', 'regex' => true])->content;
 
         self::assertStringContainsString('Classes/Tilde.php:2:', $output);
         self::assertStringNotContainsString('invalid regular expression', $output);
@@ -173,7 +173,7 @@ final class SearchCodeToolTest extends TestCase
         // `find.{2}Here` appear nowhere in the fixture, so if the pre-filter
         // were (wrongly) applied in regex mode it would skip the file and this
         // assertion would fail.
-        $output = $this->tool->execute(['pattern' => 'find.{2}Here', 'regex' => true]);
+        $output = $this->tool->execute(['pattern' => 'find.{2}Here', 'regex' => true])->content;
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
     }
@@ -182,7 +182,7 @@ final class SearchCodeToolTest extends TestCase
     public function searchesWithinValidSubPath(): void
     {
         // A valid subdirectory resolves under the root and scopes the walk to it.
-        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes']);
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes'])->content;
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
         self::assertStringNotContainsString('Denied', $output);
@@ -193,7 +193,7 @@ final class SearchCodeToolTest extends TestCase
     public function searchesWholeRootWithDotPath(): void
     {
         // path="." resolves to the root itself; containment must accept root == candidate.
-        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => '.']);
+        $output = $this->tool->execute(['pattern' => 'findMeHere', 'path' => '.'])->content;
 
         self::assertStringContainsString('Classes/Alpha.php:2:', $output);
         self::assertStringContainsString('Resources/notes.md:1:', $output);
@@ -205,7 +205,7 @@ final class SearchCodeToolTest extends TestCase
         // A file (not a directory) must be rejected by the is_dir() guard.
         self::assertStringContainsString(
             'Denied or not found',
-            $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes/Alpha.php']),
+            $this->tool->execute(['pattern' => 'findMeHere', 'path' => 'Classes/Alpha.php'])->content,
         );
     }
 
@@ -222,7 +222,7 @@ final class SearchCodeToolTest extends TestCase
             $output = $this->tool->execute([
                 'pattern' => 'findMeHere',
                 'path'    => '../' . basename($this->root) . 'x',
-            ]);
+            ])->content;
 
             self::assertStringContainsString('Denied or not found', $output);
             self::assertStringNotContainsString('Sib.php', $output);
@@ -236,7 +236,7 @@ final class SearchCodeToolTest extends TestCase
     {
         file_put_contents($this->root . '/Classes/Indent.php', "<?php\n    findMeHere indented\n");
 
-        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+        $output = $this->tool->execute(['pattern' => 'findMeHere'])->content;
 
         // The leading indentation is trimmed: exactly ": findMeHere indented" follows the line number.
         self::assertStringContainsString('Classes/Indent.php:2: findMeHere indented', $output);
@@ -252,7 +252,7 @@ final class SearchCodeToolTest extends TestCase
         file_put_contents($this->root . '/Classes/Exact.php', $exact . "\n");
         file_put_contents($this->root . '/Classes/Multibyte.php', $multibyte . "\n");
 
-        $output = $this->tool->execute(['pattern' => 'findMeHere']);
+        $output = $this->tool->execute(['pattern' => 'findMeHere'])->content;
 
         self::assertStringContainsString('Classes/Exact.php:1: ' . $exact, $output);
         self::assertStringNotContainsString($exact . '…', $output);

--- a/Tests/Unit/Service/Tool/Fixtures/FakeInputTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeInputTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
@@ -41,11 +42,11 @@ final class FakeInputTool implements ToolInterface, RequiresInputInterface
     /**
      * @param array<string, mixed> $arguments
      */
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
         $this->capturedArguments = $arguments;
 
-        return 'input-tool ran';
+        return ToolResult::text('input-tool ran');
     }
 
     public function isEnabledByDefault(): bool

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -9,24 +9,31 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
 
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 
 /**
  * Minimal in-memory ToolInterface double used by the ToolRegistry unit tests.
  *
- * Carries a configurable name (the registry index key) and a canned result so
- * a test can assert both the lookup-by-name path and the execute() contract
- * without touching the database or a real provider.
+ * Carries a configurable name (the registry index key), a canned result and an
+ * optional list of run-only artifacts so a test can assert both the
+ * lookup-by-name path and the execute() contract (including the artifact
+ * channel) without touching the database or a real provider.
  */
 final readonly class FakeTool implements ToolInterface
 {
+    /**
+     * @param list<ToolArtifact> $artifacts
+     */
     public function __construct(
         private string $name,
         private string $result = 'ok',
         private bool $enabledByDefault = true,
         private bool $requiresAdmin = false,
         private string $group = 'test',
+        private array $artifacts = [],
     ) {}
 
     public function getSpec(): ToolSpec
@@ -41,9 +48,9 @@ final readonly class FakeTool implements ToolInterface
     /**
      * @param array<string, mixed> $arguments
      */
-    public function execute(array $arguments): string
+    public function execute(array $arguments): ToolResult
     {
-        return $this->result;
+        return ToolResult::text($this->result, ...$this->artifacts);
     }
 
     public function isEnabledByDefault(): bool

--- a/Tests/Unit/Service/Tool/RunTraceTest.php
+++ b/Tests/Unit/Service/Tool/RunTraceTest.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -112,6 +114,20 @@ final class RunTraceTest extends TestCase
         self::assertNotNull($assembled->messagesSent);
         self::assertCount(2, $assembled->messagesSent);
         self::assertSame('system', $assembled->messagesSent[0]['role']);
+
+        // No artifacts passed → the step carries null, so toArray() drops the key.
+        self::assertNull($tool->toolArtifacts);
+    }
+
+    #[Test]
+    public function recordsToolExecutionArtifactsOnTheStep(): void
+    {
+        $artifact = new ToolArtifact(ArtifactType::TABLE, 'pages', ['columns' => ['uid'], 'rows' => [['1']]]);
+        $trace    = new RunTrace();
+        $trace->recordToolExecution(1, 3.5, 'read_records', [], 'ok', false, [$artifact]);
+
+        $step = $trace->getSteps()[0];
+        self::assertSame([$artifact], $step->toolArtifacts);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 use LogicException;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
@@ -19,7 +20,9 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
@@ -96,6 +99,132 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function artifactsRideTheTraceButNeverTheProviderWire(): void
+    {
+        // ADR-108 security centrepiece: an artifact's structured data reaches the
+        // trace/inspector but MUST NOT egress to the provider wire, which carries
+        // only the content string.
+        $tool = new FakeTool('fetch_records', 'PUBLIC content', true, false, 'test', [
+            new ToolArtifact(ArtifactType::TABLE, 'rows', [
+                'columns' => ['secret_col'],
+                'rows'    => [['TOPSECRET-value']],
+            ]),
+        ]);
+
+        $captured = [];
+        $mgr      = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_1', 'fetch_records', [])]),
+            $this->response('done'),
+        ], $captured));
+
+        $service = $this->service($mgr, new ToolRegistry([$tool]));
+        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+
+        // The second provider call carries the tool-result turn: content only.
+        self::assertArrayHasKey(1, $captured);
+        $wire = json_encode(
+            array_map(static fn(mixed $m): mixed => $m instanceof ChatMessage ? $m->toArray() : $m, $captured[1]),
+            JSON_THROW_ON_ERROR,
+        );
+        self::assertStringContainsString('PUBLIC content', $wire);
+        self::assertStringNotContainsString('TOPSECRET-value', $wire);
+
+        // The trace DOES carry the artifact for the inspector/audit.
+        self::assertCount(1, $result->trace[0]->artifacts);
+        self::assertSame(ArtifactType::TABLE, $result->trace[0]->artifacts[0]->type);
+        self::assertStringContainsString('TOPSECRET-value', json_encode($result->trace[0]->artifacts[0]->data, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function artifactStringLeavesAreCoercedToValidUtf8BeforeEgress(): void
+    {
+        $tool = new FakeTool('t', 'ok', true, false, 'test', [
+            new ToolArtifact(ArtifactType::TEXT, "bad\xFFlabel", ['text' => "bad\xFFleaf"]),
+        ]);
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('c', 't', [])]),
+            $this->response('done'),
+        ]));
+
+        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+        $artifact = $result->trace[0]->artifacts[0];
+
+        // The label and every nested string leaf are valid UTF-8, and the raw
+        // invalid byte is gone (the exact substitute char is an mbstring detail).
+        self::assertTrue(mb_check_encoding($artifact->label, 'UTF-8'));
+        self::assertStringNotContainsString("\xFF", $artifact->label);
+        $leaf = self::str($artifact->data['text'] ?? null);
+        self::assertTrue(mb_check_encoding($leaf, 'UTF-8'));
+        self::assertStringNotContainsString("\xFF", $leaf);
+    }
+
+    #[Test]
+    public function oversizeArtifactsCollapseToASingleFailClosedMarker(): void
+    {
+        $tool = new FakeTool('t', 'ok', true, false, 'test', [
+            new ToolArtifact(ArtifactType::TEXT, 'big', ['text' => str_repeat('a', 60000)]),
+        ]);
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('c', 't', [])]),
+            $this->response('done'),
+        ]));
+
+        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+        $artifacts = $result->trace[0]->artifacts;
+
+        self::assertCount(1, $artifacts);
+        self::assertSame(ArtifactType::TEXT, $artifacts[0]->type);
+        self::assertSame('Artifacts omitted', $artifacts[0]->label);
+        self::assertStringContainsString('exceeded', self::str($artifacts[0]->data['text'] ?? ''));
+    }
+
+    #[Test]
+    public function unencodableArtifactCollapsesToTheFailClosedMarker(): void
+    {
+        // A non-finite float cannot be JSON-encoded; boundArtifacts must fail
+        // closed to the marker rather than let the JsonException reach a sink.
+        $tool = new FakeTool('t', 'ok', true, false, 'test', [
+            new ToolArtifact(ArtifactType::TABLE, 'bad', ['columns' => ['x'], 'rows' => [[INF]]]),
+        ]);
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('c', 't', [])]),
+            $this->response('done'),
+        ]));
+
+        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+        $artifacts = $result->trace[0]->artifacts;
+
+        self::assertCount(1, $artifacts);
+        self::assertSame('Artifacts omitted', $artifacts[0]->label);
+        self::assertStringContainsString('could not be encoded', self::str($artifacts[0]->data['text'] ?? ''));
+    }
+
+    #[Test]
+    public function aValidTableArtifactPassesThroughUnchanged(): void
+    {
+        $data = ['columns' => ['uid', 'title'], 'rows' => [['1', 'Home']]];
+        $tool = new FakeTool('t', 'ok', true, false, 'test', [
+            new ToolArtifact(ArtifactType::TABLE, 'pages', $data),
+        ]);
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('c', 't', [])]),
+            $this->response('done'),
+        ]));
+
+        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), null);
+        $artifact = $result->trace[0]->artifacts[0];
+
+        self::assertSame(ArtifactType::TABLE, $artifact->type);
+        self::assertSame('pages', $artifact->label);
+        self::assertSame($data, $artifact->data);
+    }
+
+    #[Test]
     public function unknownToolYieldsErrorResultNotCrash(): void
     {
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -131,7 +260,7 @@ final class ToolLoopServiceTest extends TestCase
             /**
              * @param array<string, mixed> $arguments
              */
-            public function execute(array $arguments): string
+            public function execute(array $arguments): ToolResult
             {
                 throw new RuntimeException('boom https://x?key=secret', 1782700101);
             }
@@ -185,7 +314,7 @@ final class ToolLoopServiceTest extends TestCase
             /**
              * @param array<string, mixed> $arguments
              */
-            public function execute(array $arguments): string
+            public function execute(array $arguments): ToolResult
             {
                 throw new RuntimeException('boom https://x?key=secret', 1782700101);
             }
@@ -516,11 +645,11 @@ final class ToolLoopServiceTest extends TestCase
             /**
              * @param array<string, mixed> $arguments
              */
-            public function execute(array $arguments): string
+            public function execute(array $arguments): ToolResult
             {
                 $this->executed = true;
 
-                return 'META';
+                return ToolResult::text('META');
             }
 
             public function isEnabledByDefault(): bool
@@ -864,9 +993,9 @@ final class ToolLoopServiceTest extends TestCase
             /**
              * @param array<string, mixed> $arguments
              */
-            public function execute(array $arguments): string
+            public function execute(array $arguments): ToolResult
             {
-                return 'DELETED';
+                return ToolResult::text('DELETED');
             }
 
             public function isEnabledByDefault(): bool
@@ -1243,6 +1372,17 @@ final class ToolLoopServiceTest extends TestCase
     private static function arr(mixed $value): array
     {
         self::assertIsArray($value);
+
+        return $value;
+    }
+
+    /**
+     * Assert a mixed value is a string and return it narrowed (PHPStan-clean
+     * access into artifact `data` leaves).
+     */
+    private static function str(mixed $value): string
+    {
+        self::assertIsString($value);
 
         return $value;
     }

--- a/Tests/Unit/Service/Tool/ToolRegistryTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
 use LogicException;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
@@ -67,9 +68,9 @@ final class ToolRegistryTest extends TestCase
             /**
              * @param array<string, mixed> $arguments
              */
-            public function execute(array $arguments): string
+            public function execute(array $arguments): ToolResult
             {
-                return 'ok';
+                return ToolResult::text('ok');
             }
 
             public function isEnabledByDefault(): bool


### PR DESCRIPTION
## What

Replaces `ToolInterface::execute()`'s `string` return with a typed **`ToolResult`** value object (ADR-108) carrying a provider-facing `content` string, a `bool $isError`, and a **run-only** `list<ToolArtifact> $artifacts` that reaches the trace, Tool Playground inspector and persisted audit stream — but has **no code path to the provider wire**.

## Why

A tool result already egresses to an external LLM provider, so structured output had to be added as a channel that is *unreachable from the wire* rather than an annotation. `ToolDataClassInterface` (ADR-094) stayed an opt-in marker precisely to avoid editing 41 builtins; here egress separation **is** the return value, so the contract changes (acceptable pre-1.0, ADR-090).

## Egress separation, by construction

- `ToolResult` has no `__toString()` / no accessor merging an artifact into a wire string → `->content` is the only path to a wire string.
- `ChatMessage::toolResult()` is only ever handed `$result->content`.
- `ToolLoopService::invoke()` (the single seam every executed call passes through) UTF-8-coerces and byte-bounds **both** channels before any result leaves the process. `content` keeps its 50 000-byte cap; `artifacts` get an independent 50 000-byte serialised budget validated **fail-closed** with the exact `JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE` flags + a depth-64 cap the downstream sinks use — a surviving artifact cannot throw at them. Over-budget / unencodable → one `TEXT` "Artifacts omitted" marker.

## Artifact model (smallest real set)

`ArtifactType` = `{TABLE, TEXT}` — each with a v1 emitter/fallback, not a semantic taxonomy. `ReadRecordsTool` emits a `TABLE` from the **same redacted `formatValue()` cells** its text lines use (one pass, no drift). The other 40 builtins ship text-parity via `ToolResult::text()`. `TREE`/`LIST`/… are additive follow-ups (one enum case + one JS branch), intentionally not shipped without a producer.

`RunStepPrivacyFilter` treats artifacts as content (ADR-064): count+types summary at METADATA, masked at REDACTED, verbatim at FULL. The inspector gains a conditional **Artifacts** tab (table / text / unknown-fallback, `textContent` only). `ChatMessage`, `ToolLoopResult`, `SuspendedRunState` are untouched — artifacts are audit/display state, never resumable functional state.

## Tests / gate

Local gate green: **PHP-CS-Fixer, PHPStan L10, unit (5547), functional/sqlite (1254), Rector, fuzzy (79)**.

New coverage: `ToolResultTest` (fail-closed `error()`, no `__toString`/wire accessor, private ctor), `ToolArtifactTest`; `ToolLoopServiceTest` **wire-isolation** (an artifact's SECRET never reaches the provider wire but does reach the trace), UTF-8 leaf coercion, over-budget + unencodable → fail-closed marker, valid-TABLE passthrough; `RunStepTest` / `RunTraceTest` / `RunStepPrivacyFilterTest` (artifact serialisation, METADATA summary, REDACTED masking); `ReadRecordsToolTest` functional (TABLE columns/rows parity with the text egress).

41 builtins + ~209 tool-test call sites migrated to the typed result.

## Manual verification note

No E2E covers the inspector render. The new **Artifacts** tab is additive and rendered via `textContent`; it has been syntax-checked and reviewed, but the live table/omission-marker render on a running backend (≥1440px) has **not** been exercised in this PR — recommended before relying on it visually.

Refs: ADR-108 · builds on ADR-010 / ADR-094 / ADR-064 / ADR-081.
