### PR TITLE
test(e2e): axe accessibility coverage for the Agent Runs module (ADR-109)

### DIFF
--- a/Tests/E2E/Playwright/accessibility.spec.ts
+++ b/Tests/E2E/Playwright/accessibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, navigateToLlmModule, navigateToProviders, navigateToModels, navigateToConfigurations, getModuleFrame } from './fixtures';
+import { test, expect, navigateToLlmModule, navigateToProviders, navigateToModels, navigateToConfigurations, navigateToRuns, getModuleFrame } from './fixtures';
 import AxeBuilder from '@axe-core/playwright';
 
 /**
@@ -353,6 +353,54 @@ test.describe('Accessibility Tests @accessibility', () => {
       );
 
       expect(criticalLandmarkIssues).toEqual([]);
+    });
+  });
+
+  test.describe('Agent Runs Module', () => {
+    test('should have no critical accessibility violations @accessibility', async ({ authenticatedPage }) => {
+      const page = authenticatedPage;
+
+      await page.goto('/typo3/module/nrllm/runs');
+      await page.waitForLoadState('networkidle');
+
+      const results = await runAxeAnalysis(page, 'Agent Runs');
+
+      const criticalViolations = results.violations.filter(
+        (v) => v.impact === 'critical' || v.impact === 'serious'
+      );
+
+      expect(criticalViolations).toEqual([]);
+    });
+
+    test('should have an h1 plus the two section landmarks @accessibility', async ({ authenticatedPage }) => {
+      const page = authenticatedPage;
+      const moduleFrame = await navigateToRuns(page);
+
+      // ADR-109 heading hierarchy: h1 "Agent Runs" -> h2 "Awaiting your
+      // decision" (waiting section) + h2 "Recent runs" (terminal section).
+      await expect(moduleFrame.getByRole('heading', { level: 1 })).toContainText('Agent Runs');
+      await expect(moduleFrame.getByRole('heading', { level: 2, name: 'Awaiting your decision' })).toBeVisible();
+      await expect(moduleFrame.getByRole('heading', { level: 2, name: 'Recent runs' })).toBeVisible();
+
+      // Both sections expose a labelled region (aria-labelledby on <section>).
+      const regions = moduleFrame.getByRole('region');
+      expect(await regions.count()).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should render the recent-runs table with header cells when present @accessibility', async ({ authenticatedPage }) => {
+      const page = authenticatedPage;
+      const moduleFrame = await navigateToRuns(page);
+
+      // The terminal-runs table is a real <table> with a <caption>, <thead> and
+      // scoped <th>s; on a fresh instance it may show the empty-state text
+      // instead — either is accessible.
+      const table = moduleFrame.locator('table');
+      const hasTable = await table.first().isVisible().catch(() => false);
+
+      if (hasTable) {
+        await expect(table.first().locator('thead')).toBeVisible();
+        expect(await table.first().locator('th[scope="col"]').count()).toBeGreaterThan(0);
+      }
     });
   });
 });

--- a/Tests/E2E/Playwright/fixtures.ts
+++ b/Tests/E2E/Playwright/fixtures.ts
@@ -126,6 +126,13 @@ async function navigateToTasks(page: Page): Promise<FrameLocator> {
 }
 
 /**
+ * Navigate to the Agent Runs approvals inbox sub-module (ADR-109).
+ */
+async function navigateToRuns(page: Page): Promise<FrameLocator> {
+  return navigateToSubModule(page, '/typo3/module/nrllm/runs', 'Agent Runs');
+}
+
+/**
  * Navigate to Setup Wizard sub-module.
  */
 async function navigateToSetupWizard(page: Page): Promise<FrameLocator> {
@@ -178,6 +185,7 @@ export {
   navigateToModels,
   navigateToConfigurations,
   navigateToTasks,
+  navigateToRuns,
   navigateToSetupWizard,
   navigateToConfigWizard,
   navigateToTaskWizard,


### PR DESCRIPTION
test(e2e): axe accessibility coverage for the Agent Runs module (ADR-109)

The Playwright accessibility suite (@axe-core/playwright) covered the main
dashboard and the providers/models/configurations modules, but not the new
Agent Runs approvals inbox (`nrllm_runs`) added in ADR-109 (#499). Add a
`navigateToRuns` fixture and an "Agent Runs Module" describe block that:

- runs axe (WCAG 2.1 AA) against /typo3/module/nrllm/runs and asserts no
  critical/serious violations;
- asserts the heading hierarchy (h1 "Agent Runs" -> the two labelled section
  landmarks "Awaiting your decision" and "Recent runs");
- checks the recent-runs <table> has a <thead> with scoped <th>s when present.

Runs in CI (the org e2e reusable workflow provisions TYPO3 and points Playwright
at it — no DDEV involved).

Scope note: on a fresh instance the inbox is empty, so this axe-checks the module
chrome and empty state. Axe-ing the approve/deny and schema-input FORMS needs a
seeded suspended run (WAITING_FOR_APPROVAL/INPUT), which the E2E harness does not
seed yet — a follow-up. The form structure/labels are already covered by the
functional AgentRunControllerTest, which renders them through the real
Fluid/ModuleTemplate stack.
