### PR TITLE
test(e2e): seed waiting runs to axe the Agent Runs approve/input forms (ADR-109)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,11 @@ jobs:
     with:
       php-version: '8.5'
       db-image: 'mariadb:12.2'
+      # Seed WAITING_FOR_APPROVAL/INPUT runs before Playwright so the a11y
+      # suite can exercise the approve/deny + schema-input forms (ADR-109).
+      # Default-mode override: the workflow sets up TYPO3 and starts the
+      # server, then runs this instead of the default `npm run test:e2e`.
+      test-command: 'bash Tests/E2E/seed-and-test.sh'
       artifact-path: |
         Tests/E2E/Playwright/reports/
         Tests/E2E/Playwright/test-results/

--- a/Tests/E2E/Playwright/accessibility.spec.ts
+++ b/Tests/E2E/Playwright/accessibility.spec.ts
@@ -402,5 +402,43 @@ test.describe('Accessibility Tests @accessibility', () => {
         expect(await table.first().locator('th[scope="col"]').count()).toBeGreaterThan(0);
       }
     });
+
+    // These two exercise the actual approve/deny and schema-input FORMS. They
+    // rely on the two waiting runs seeded before the suite runs (CI:
+    // Tests/E2E/seed-and-test.sh). The axe scan above covers them too once
+    // present; here we assert the semantics and keyboard operability directly.
+    test('should expose accessible approve/deny controls for a waiting run @accessibility', async ({ authenticatedPage }) => {
+      const page = authenticatedPage;
+      const moduleFrame = await navigateToRuns(page);
+
+      const approve = moduleFrame.getByRole('button', { name: 'Approve' }).first();
+      const deny = moduleFrame.getByRole('button', { name: 'Deny' }).first();
+      await expect(approve).toBeVisible();
+      await expect(deny).toBeVisible();
+
+      // Native <button>s are keyboard-operable and carry an accessible name.
+      await approve.focus();
+      await expect(approve).toBeFocused();
+
+      // Approve/Deny sit in a labelled decision group (role=group + aria-label).
+      await expect(moduleFrame.getByRole('group', { name: /Decision for run/ }).first()).toBeVisible();
+    });
+
+    test('should render an accessible schema input form for a waiting run @accessibility', async ({ authenticatedPage }) => {
+      const page = authenticatedPage;
+      const moduleFrame = await navigateToRuns(page);
+
+      // The input run renders a <fieldset> with a <legend> and per-field <label>s.
+      await expect(moduleFrame.locator('fieldset').first()).toBeVisible();
+
+      // Every schema field is reachable by its native <label for> association.
+      const reason = moduleFrame.getByLabel('Reason', { exact: false }).first();
+      await expect(reason).toBeVisible();
+      await reason.focus();
+      await expect(reason).toBeFocused();
+
+      await expect(moduleFrame.getByLabel('Confirm', { exact: false }).first()).toBeVisible();
+      await expect(moduleFrame.getByRole('button', { name: 'Submit input' }).first()).toBeVisible();
+    });
   });
 });

--- a/Tests/E2E/Playwright/fixtures/agentrun-seed.sql
+++ b/Tests/E2E/Playwright/fixtures/agentrun-seed.sql
@@ -1,0 +1,12 @@
+-- E2E seed (ADR-109): two deterministic waiting agent runs so the Playwright
+-- accessibility suite can exercise the Agent Runs inbox's approve/deny and
+-- schema-input forms (an empty inbox only renders the module chrome).
+--
+-- CI-only, applied by Tests/E2E/seed-and-test.sh AFTER TYPO3 setup + the PHP
+-- server start. The suspended_state JSON was generated from the real
+-- SuspendedRunState/ToolCall value objects and verified to parse into the
+-- approval/input view modes (WaitingRunViewFactory). Re-runnable (DELETE first).
+DELETE FROM tx_nrllm_agentrun WHERE uuid IN ('e2e-approval-0001', 'e2e-input-0001');
+INSERT INTO tx_nrllm_agentrun (pid, uuid, status, configuration_identifier, be_user, crdate, tstamp, suspended_state) VALUES
+(0, 'e2e-approval-0001', 'waiting_for_approval', 'e2e-demo', 1, 1750000000, 1750000000, '{"messages":[],"pendingCalls":[{"id":"call_1","type":"function","function":{"name":"delete_thing","arguments":{"uid":42,"table":"pages"}}}],"iterations":1,"promptTokens":0,"completionTokens":0,"allowedToolNames":null,"options":[],"inputToolName":null,"inputSchema":[]}'),
+(0, 'e2e-input-0001', 'waiting_for_input', 'e2e-demo', 1, 1750000100, 1750000100, '{"messages":[],"pendingCalls":[{"id":"call_1","type":"function","function":{"name":"ask","arguments":[]}}],"iterations":1,"promptTokens":0,"completionTokens":0,"allowedToolNames":null,"options":[],"inputToolName":"ask","inputSchema":{"type":"object","properties":{"reason":{"type":"string","title":"Reason","description":"Why continue"},"max_items":{"type":"integer"},"confirm":{"type":"boolean","title":"Confirm"}},"required":["reason"]}}');

--- a/Tests/E2E/seed-and-test.sh
+++ b/Tests/E2E/seed-and-test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# CI-only E2E seed hook (ADR-109). The e2e reusable workflow
+# (netresearch/typo3-ci-workflows) runs this as its `test-command` AFTER TYPO3
+# setup and the PHP server start, so the schema exists and the backend is live.
+# It seeds two waiting agent runs (WAITING_FOR_APPROVAL + WAITING_FOR_INPUT) so
+# the accessibility suite can axe the approve/deny and schema-input forms of the
+# Agent Runs inbox, then hands off to the default Playwright run.
+#
+# DB coordinates are the fixed defaults the reusable workflow's default mode
+# provisions (see its "Setup TYPO3" step): host 127.0.0.1, root/root, db typo3.
+set -euo pipefail
+
+if command -v mysql >/dev/null 2>&1; then
+  DB_CLIENT="mysql"
+elif command -v mariadb >/dev/null 2>&1; then
+  DB_CLIENT="mariadb"
+else
+  echo "::error::No mysql/mariadb client on the runner; cannot seed the E2E database." >&2
+  exit 1
+fi
+
+echo "Seeding demo waiting agent runs for the E2E accessibility suite (${DB_CLIENT})..."
+"${DB_CLIENT}" -h 127.0.0.1 -u root -proot typo3 < Tests/E2E/Playwright/fixtures/agentrun-seed.sql
+
+echo "Running Playwright E2E suite..."
+npm run test:e2e


### PR DESCRIPTION
test(e2e): seed waiting runs to axe the Agent Runs approve/input forms (ADR-109)

The Agent Runs axe coverage (#500) tested the module chrome + empty state, but
the approve/deny and schema-input FORMS only render when a run is waiting — and a
fresh CI instance has none. Seed two deterministic waiting runs before the suite
so the accessibility tests exercise the actual forms.

- Tests/E2E/Playwright/fixtures/agentrun-seed.sql: a WAITING_FOR_APPROVAL and a
  WAITING_FOR_INPUT row. The suspended_state JSON was generated from the real
  SuspendedRunState/ToolCall value objects and verified to parse into the
  approval (1 pending call) and input (text/integer/checkbox fields, one
  required) view modes via WaitingRunViewFactory. Re-runnable (DELETE first).
- Tests/E2E/seed-and-test.sh: the e2e reusable workflow's default mode runs this
  as its test-command AFTER TYPO3 setup + the PHP server start (schema exists,
  backend live). It seeds via the mysql/mariadb client (the fixed CI DB
  127.0.0.1 root/root typo3) then runs `npm run test:e2e`.
- .github/workflows/e2e.yml: wire `test-command` to the seed hook (default mode,
  CI-only). No DDEV involved — DDEV is local-dev only.
- accessibility.spec.ts: two tests asserting the approve/deny controls (native
  buttons, accessible names, keyboard focus, labelled decision group) and the
  schema-input form (fieldset/legend, native <label for> per field, keyboard
  focus, submit). The existing axe scan of /runs now covers the forms too.

No production surface (Tests/ + .github only, no Classes, no shipped command).
Verified: spec parses (playwright --list finds both tests), seed JSON round-trips
through the real factory, adversarial review across CI-pipeline / seed / selector
/ hygiene lenses found no blocking issues.

Refs: ADR-109
