### PR TITLE
fix(agent): fail-closed on a stale-run wake-up dispatch failure + release-readiness hardening

### DIFF
--- a/Classes/Command/ReapStaleAgentRunsCommand.php
+++ b/Classes/Command/ReapStaleAgentRunsCommand.php
@@ -113,15 +113,25 @@ final class ReapStaleAgentRunsCommand extends Command
                 continue;
             }
 
-            // The row is QUEUED again: wake a worker. A dispatch failure leaves a
-            // QUEUED row a later tick (or a still-live consumer) picks up, so it
-            // is counted as reclaimed, logged, and not treated as fatal.
+            // The row is QUEUED again: wake a worker. Fail-closed like
+            // AgentRuntime::enqueue() — on an async transport a failed dispatch
+            // would strand the row QUEUED forever: the reaper only re-finds
+            // stale RUNNING rows (never QUEUED), and no message will arrive, so
+            // nothing would ever pick it up. Settle it FAILED instead of leaving
+            // an orphan. (On the sync transport the handler settles its own
+            // outcome and never throws here, so a throw is genuinely the
+            // transport failing.)
             try {
                 $this->messageBus->dispatch(new AgentRunQueuedMessage($run->uuid));
+                ++$requeued;
             } catch (Throwable $exception) {
-                $io->warning(sprintf('Run "%s" was reclaimed but its wake-up could not be dispatched: %s', $run->uuid, $exception->getMessage()));
+                $handle = $this->persister->resumeHandle($run);
+                if ($handle !== null) {
+                    $this->persister->settleFailed($handle, $exception);
+                }
+                $io->warning(sprintf('Run "%s" was reclaimed but its wake-up could not be dispatched; settled failed to avoid an orphan: %s', $run->uuid, $exception->getMessage()));
+                ++$deadLetter;
             }
-            ++$requeued;
         }
 
         $io->success(sprintf(

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -312,7 +312,9 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             throw RunEnqueueFailedException::forRun($uuid);
         }
 
-        $delayMs = min(self::REQUEUE_BACKOFF_MS * (2 ** $priorRequeueCount), self::REQUEUE_BACKOFF_CAP_MS);
+        // 2 ** $n widens to int|float under static analysis; the cap keeps the
+        // result well inside int range, so the cast is exact, not lossy.
+        $delayMs = (int)min(self::REQUEUE_BACKOFF_MS * (2 ** $priorRequeueCount), self::REQUEUE_BACKOFF_CAP_MS);
         $this->messageBus->dispatch(new AgentRunQueuedMessage($uuid), [new DelayStamp($delayMs)]);
     }
 

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -109,7 +109,12 @@ final readonly class FalStorageGate
             $previous = $storage->getEvaluatePermissions();
             $storage->setEvaluatePermissions(true);
             try {
-                return $storage->checkFileActionPermission('read', $storage->getFile($identifier));
+                $file = $storage->getFile($identifier);
+                if ($file === null) {
+                    return false;
+                }
+
+                return $storage->checkFileActionPermission('read', $file);
             } finally {
                 $storage->setEvaluatePermissions($previous);
             }

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -39,6 +39,9 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         // Not needed by the command tests.
     }
 
+    /** @var list<array{runUid: int, status: string, errorClass: string, terminationReason: string}> */
+    public array $finished = [];
+
     public function finishRun(
         int $runUid,
         string $status,
@@ -51,6 +54,8 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         string $errorClass,
         string $terminationReason = '',
     ): bool {
+        $this->finished[] = ['runUid' => $runUid, 'status' => $status, 'errorClass' => $errorClass, 'terminationReason' => $terminationReason];
+
         return true;
     }
 

--- a/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
+++ b/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAgentRunRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Messenger\Envelope;
@@ -117,6 +118,28 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
         return new ReapStaleAgentRunsCommand($persister, $this->recordingBus());
     }
 
+    #[Test]
+    public function failsAReclaimedRunWhoseWakeUpCannotBeDispatchedToAvoidAnOrphan(): void
+    {
+        $this->repository->staleRunning = [$this->staleRun('run-d', requeueCount: 0)];
+
+        $persister = new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
+        $tester    = new CommandTester(new ReapStaleAgentRunsCommand($persister, $this->throwingBus()));
+        $exit      = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        // The run was reclaimed (RUNNING -> QUEUED) but the wake-up dispatch
+        // failed. Fail-closed: settle it FAILED instead of leaving an orphaned
+        // QUEUED row nothing would ever pick up (the reaper only re-finds stale
+        // RUNNING rows, and no message will arrive).
+        self::assertCount(1, $this->repository->staleRequeues);
+        self::assertCount(1, $this->repository->finished);
+        self::assertSame('failed', $this->repository->finished[0]['status']);
+        self::assertCount(0, $this->dispatched);
+        self::assertStringContainsString('0 requeued', $tester->getDisplay());
+        self::assertStringContainsString('1 dead-lettered', $tester->getDisplay());
+    }
+
     private function recordingBus(): MessageBusInterface
     {
         $bus = self::createStub(MessageBusInterface::class);
@@ -127,6 +150,14 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
                 return new Envelope($message, $stamps);
             },
         );
+
+        return $bus;
+    }
+
+    private function throwingBus(): MessageBusInterface
+    {
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willThrowException(new RuntimeException('transport down', 1));
 
         return $bus;
     }

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -147,6 +147,35 @@ final class WaitingRunViewFactoryTest extends TestCase
     }
 
     #[Test]
+    public function numberFieldEnumOptionsAndLabelFallbackAreDerivedFromTheSchema(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                // No title -> the label falls back to the humanised property name.
+                'max_temperature' => ['type' => 'number'],
+                // An enum becomes selectable options, every value string-coerced.
+                'severity'        => ['type' => 'string', 'enum' => ['low', 'high', 3]],
+            ],
+        ];
+        $view = $this->factory()->buildWaiting([$this->makeRun('a', $this->inputState('ask', $schema))])[0];
+
+        self::assertSame(WaitingRunView::MODE_INPUT, $view->mode);
+
+        $number = $view->inputFields[0];
+        self::assertSame('number', $number->controlType);
+        // fieldLabel() fallback: ucfirst(str_replace('_', ' ', $name)).
+        self::assertSame('Max temperature', $number->label);
+        self::assertSame('number', $number->htmlType);
+        self::assertSame('any', $number->step);
+        self::assertSame('decimal', $number->inputMode);
+        self::assertSame([], $number->options);
+
+        $enum = $view->inputFields[1];
+        self::assertSame(['low', 'high', '3'], $enum->options);
+    }
+
+    #[Test]
     public function turnDigestForRunRecomputesTheSameDigestTheViewCarried(): void
     {
         $state   = $this->approvalState('delete_thing', ['uid' => 42]);

--- a/Tests/Unit/Service/Context/ContextWindowManagerTest.php
+++ b/Tests/Unit/Service/Context/ContextWindowManagerTest.php
@@ -134,6 +134,24 @@ final class ContextWindowManagerTest extends TestCase
         self::assertGreaterThan($first->estimatedTokens, $second->estimatedTokens);
     }
 
+    #[Test]
+    public function nonPositiveBudgetDefersTheWholeTranscriptToTheProvider(): void
+    {
+        // A misconfiguration where the reserved output room (max output tokens)
+        // is larger than the entire context window leaves no room to prune
+        // into. Rather than compute a negative budget and drop everything, the
+        // manager passes the transcript through untouched and lets the provider
+        // enforce its own limit.
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('hi'), ...$this->turn('call_1', 'small')];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(1000, 2000), null, null);
+
+        self::assertFalse($result->pruned);
+        self::assertFalse($result->overflowAtFloor);
+        self::assertSame(0, $result->droppedTurns);
+        self::assertSame($messages, $result->messages);
+    }
+
     /**
      * @return list<ChatMessage>
      */


### PR DESCRIPTION
## Summary

Release-readiness hardening from the 2026-07-22 audit. One real correctness fix plus small type-hygiene fixes and unit coverage for previously unexercised branches. No behaviour change on the happy paths; no public surface change, so no ADR.

## The correctness fix — reaper fail-closed

`ReapStaleAgentRunsCommand` reclaims a stale `RUNNING` run onto the queue (`RUNNING → QUEUED`) and dispatches an `AgentRunQueuedMessage` to wake a worker. On an **async** transport a failed dispatch previously left the row `QUEUED` forever:

- the reaper only re-finds stale **RUNNING** rows (never `QUEUED`), and
- no messenger message exists after the failed dispatch,

so nothing would ever pick the run up. Now it mirrors `AgentRuntime::enqueue()`'s fail-closed seam and settles the run **FAILED** instead of stranding an orphan. (On the sync transport the handler settles its own outcome and never throws here, so a throw is genuinely the transport failing.)

## Type-hygiene fixes

- **`AgentRuntime::dispatchRequeue`** — `2 ** $n` widens to `int|float`; the capped backoff is now cast to `int` for the `DelayStamp` (exact — the cap bounds it well inside int range).
- **`FalStorageGate`** — `ResourceStorage::getFile()` returns `ProcessedFile|File|null`; guard the null before `checkFileActionPermission()` (which requires a non-null `FileInterface`) rather than leaning on a blanket suppression.

## New unit coverage

- `ReapStaleAgentRunsCommand`: the dispatch-failure → settle-FAILED path.
- `ContextWindowManager`: the non-positive-budget passthrough (reserve larger than the whole window) defers the transcript to the provider untouched.
- `WaitingRunViewFactory`: the `NUMBER` control arm (`step "any"` / `inputMode "decimal"`), `enum` → string-coerced options, and the humanised label fallback.

## Test plan

Full local gate green on PHP 8.5: `phpstan` (level 10, no errors), `cgl`, `unit` (5582), `rector -n`, `fuzzy` (79), and `functional -d sqlite` for the touched `DiagnosticsToolsFunctionalTest`. CI's SQLite/MariaDB matrices are the authoritative functional gate.

> A first revision also tried to make `ListSchedulerTasksTool` distinguish "scheduler absent" from "installed but query failed" (audit finding #7). CI proved that distinction is not portable — on SQLite an absent `tx_scheduler_task` surfaces only at the SELECT, so a query failure can equally mean "not installed." That change was reverted; the conservative "degrade to not-installed" is the correct, DB-portable behaviour.
