### PR TITLE
build(phpstan): gate argument.type & varTag.nativeType on production code

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,2 +1,157 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$array of function array_intersect expects an array of values castable to string, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+
+		-
+			message: '#^Parameter \#2 \$arrays of function array_intersect expects an array of values castable to string, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Fuzzy/Domain/ModelFuzzyTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Fuzzy/Domain/ProviderFuzzyTest.php
+
+		-
+			message: '#^Parameter \#2 \$stamps of class Symfony\\Component\\Messenger\\Envelope constructor expects array\<Symfony\\Component\\Messenger\\Stamp\\StampInterface\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
+
+		-
+			message: '#^Parameter \$toolCalls of class Netresearch\\NrLlm\\Domain\\Model\\CompletionResponse constructor expects list\<Netresearch\\NrLlm\\Domain\\ValueObject\\ToolCall\>\|null, array\{array\{id\: ''call_1'', type\: ''function'', function\: array\{name\: ''get_weather'', arguments\: ''\{\}''\}\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Domain/Model/CompletionResponseTest.php
+
+		-
+			message: '#^Parameter \#2 \$vectorB of static method Netresearch\\NrLlm\\Domain\\Model\\EmbeddingResponse\:\:cosineSimilarity\(\) expects array\<int, float\>, array\<string, float\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Domain/Model/EmbeddingResponseTest.php
+
+		-
+			message: '#^Parameter \#1 \$beGroups of method Netresearch\\NrLlm\\Domain\\Model\\LlmConfiguration\:\:setBeGroups\(\) expects TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage\<Netresearch\\NrLlm\\Domain\\Model\\BackendUserGroup\>\|null, TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage\<object\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Domain/Model/LlmConfigurationTest.php
+
+		-
+			message: '#^Parameter \#1 \$data of static method Netresearch\\NrLlm\\Domain\\ValueObject\\ToolSpec\:\:fromArray\(\) expects array\{type\?\: string, function\: array\{name\: string, description\?\: string, parameters\?\: array\<string, mixed\>\}\}, array\{\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Exception/NrLlmExceptionInterfaceTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Provider/OpenRouterProviderTest.php
+
+		-
+			message: '#^Parameter \#2 \$stamps of class Symfony\\Component\\Messenger\\Envelope constructor expects array\<Symfony\\Component\\Messenger\\Stamp\\StampInterface\>, array given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../Tests/Unit/Service/Agent/AgentRuntimeTest.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(array\<string, mixed\>\|Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage\)\: mixed\)\|null, Closure\(Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage\)\: string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Context/ContextWindowManagerTest.php
+
+		-
+			message: '#^Parameter \#1 \$message of method Netresearch\\NrLlm\\Tests\\Unit\\Service\\Context\\ContextWindowManagerTest\:\:contentOf\(\) expects Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage, array\<string, mixed\>\|Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Context/ContextWindowManagerTest.php
+
+		-
+			message: '#^Parameter \#1 \$message of method Netresearch\\NrLlm\\Tests\\Unit\\Service\\Context\\ContextWindowManagerTest\:\:roleOf\(\) expects Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage, array\<string, mixed\>\|Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage given\.$#'
+			identifier: argument.type
+			count: 4
+			path: ../Tests/Unit/Service/Context/ContextWindowManagerTest.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage\)\: string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../Tests/Unit/Service/LlmServiceManagerTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertContains\(\) expects iterable, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/LlmServiceManagerTest.php
+
+		-
+			message: '#^Parameter \#2 \$string of static method PHPUnit\\Framework\\Assert\:\:assertMatchesRegularExpression\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/LlmServiceManagerTest.php
+
+		-
+			message: '#^Parameter \#1 \$messages of method Netresearch\\NrLlm\\Service\\MessageShaper\:\:normalise\(\) expects list\<array\<string, mixed\>\|Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage\>, array\{5\: array\{role\: ''user'', content\: ''Hi''\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/MessageShaperTest.php
+
+		-
+			message: '#^Parameter \#1 \$identifier of class Netresearch\\NrLlm\\Service\\Preset\\ConfigurationPreset constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Preset/ConfigurationPresetTest.php
+
+		-
+			message: '#^Parameter \#1 \$captured of method Netresearch\\NrLlm\\Tests\\Unit\\Service\\SetupWizard\\ModelDiscoveryTest\:\:configureCapturingRequestFactory\(\) expects array\{method\: string\|null, uri\: string\|null, headers\: array\<string, string\>\}, array\{\} given\.$#'
+			identifier: argument.type
+			count: 8
+			path: ../Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+
+		-
+			message: '#^Parameter \#1 \$storage of static method Netresearch\\NrLlm\\Service\\Skill\\SkillInjectionService\:\:toList\(\) expects TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage\<Netresearch\\NrLlm\\Domain\\Model\\Skill\>, TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage\<object\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Skill/SkillInjectionServiceTest.php
+
+		-
+			message: '#^Parameter \#1 \$message of method Netresearch\\NrLlm\\Tests\\Unit\\Service\\SkillConfigInjectionTest\:\:content\(\) expects array\<string, mixed\>\|Netresearch\\NrLlm\\Domain\\ValueObject\\ChatMessage, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: ../Tests/Unit/Service/SkillConfigInjectionTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertContains\(\) expects iterable, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Tool/Builtin/SchemaToolsSpecTest.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(Netresearch\\NrLlm\\Domain\\ValueObject\\ToolSpec\)\: string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+
+		-
+			message: '#^Parameter \#2 \$uri of class Netresearch\\NrLlm\\Tests\\Unit\\Specialized\\TestableRequest constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../Tests/Unit/Specialized/AbstractSpecializedServiceTest.php

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -124,13 +124,6 @@ parameters:
     -
       message: '#should be contravariant with parameter#'
       reportUnmatched: false
-    # --- Type strictness (level 10) ---
-    -
-      identifier: varTag.nativeType
-      reportUnmatched: false
-    -
-      identifier: argument.type
-      reportUnmatched: false
     -
       identifier: phpunit.dynamicCallOnStaticMethod
       reportUnmatched: false

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -218,11 +218,12 @@ final class SetupWizardController extends ActionController
             endpoint: $endpoint,
         );
 
-        // `fromDiscoveredModels()` reindexes via `array_values(array_map(...))`
-        // internally, so passing the raw discover() result here is fine.
+        // `discover()` is typed `array<DiscoveredModel>`; `array_values()`
+        // narrows it to the `list<DiscoveredModel>` the response DTO expects
+        // (the factory reindexes internally anyway, so this is behaviour-neutral).
         return new JsonResponse(
             DiscoveredModelsResponse::fromDiscoveredModels(
-                $this->modelDiscovery->discover($detected, $apiKey),
+                array_values($this->modelDiscovery->discover($detected, $apiKey)),
             )->jsonSerialize(),
         );
     }
@@ -261,13 +262,13 @@ final class SetupWizardController extends ActionController
         // Convert model data to DTOs
         $models = $this->buildDiscoveredModels($modelsData);
 
-        // `fromSuggestedConfigurations()` reindexes via
-        // `array_values(array_map(...))` internally — the redundant
-        // `array_values()` wrapper here was a leftover from the
-        // pre-DTO inline-array shape.
+        // `generate()` is typed `array<SuggestedConfiguration>`; `array_values()`
+        // narrows it to the `list<SuggestedConfiguration>` the response DTO
+        // expects (the factory reindexes internally anyway, so this is
+        // behaviour-neutral).
         return new JsonResponse(
             GeneratedConfigurationsResponse::fromSuggestedConfigurations(
-                $this->configurationGenerator->generate($detected, $apiKey, $models),
+                array_values($this->configurationGenerator->generate($detected, $apiKey, $models)),
             )->jsonSerialize(),
         );
     }
@@ -593,7 +594,9 @@ final class SetupWizardController extends ActionController
             }
         }
 
-        /** @var array<string, mixed>|null $body */
+        // At this point $body is `array{}|object|null` (a non-empty array
+        // returned early above); the guard yields the empty-array/null the
+        // declared `array<string, mixed>|null` return type accepts.
         return is_array($body) ? $body : null;
     }
 

--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -74,6 +74,7 @@ final readonly class EmbeddingResponse
         if (!\is_array($usageData)) {
             $usageData = [];
         }
+        /** @var array<string, mixed> $usageData The serialized usage shape is a JSON object (string keys). */
 
         return new self(
             embeddings: $embeddings,

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -240,6 +240,7 @@ final readonly class ChatMessage implements JsonSerializable
                         1752400007,
                     );
                 }
+                /** @var array{id?: string, type?: string, function?: array{name?: string, arguments?: string|array<string, mixed>}} $call */
                 $toolCalls[] = ToolCall::fromArray($call);
             }
         }

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -112,6 +112,7 @@ final readonly class SuspendedRunState
     {
         $calls = [];
         foreach ($this->pendingCalls as $call) {
+            /** @var array{id?: string, type?: string, function?: array{name?: string, arguments?: array<string, mixed>|string}} $call */
             $calls[] = ToolCall::fromArray($call);
         }
 

--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -83,14 +83,13 @@ final readonly class ToolCall implements JsonSerializable
      * variation is what makes calling code today so noisy — this
      * factory normalises it once.
      *
-     * @param array{
-     *     id?: string,
-     *     type?: string,
-     *     function?: array{
-     *         name?: string,
-     *         arguments?: string|array<string, mixed>,
-     *     },
-     * } $data
+     * Expected wire shape: `id` (string), `type` (string), and `function`
+     * with `name` (string) and `arguments` (JSON string OR decoded map). Every
+     * field is validated defensively below, so the declared input is the widest
+     * untrusted map — a nonconforming entry degrades to empty strings rather
+     * than a type error.
+     *
+     * @param array<string, mixed> $data
      */
     public static function fromArray(array $data): self
     {

--- a/Classes/Form/Element/ModelIdElement.php
+++ b/Classes/Form/Element/ModelIdElement.php
@@ -48,6 +48,7 @@ final class ModelIdElement extends AbstractFormElement
 
         // The provider_uid field name follows TYPO3's naming convention
         $tableName = is_string($data['tableName'] ?? null) ? $data['tableName'] : 'tx_nrllm_model';
+        /** @var array<string, mixed> $databaseRow */
         $databaseRow = is_array($data['databaseRow'] ?? null) ? $data['databaseRow'] : [];
         $currentProviderUid = $this->resolveCurrentProviderUid($databaseRow);
 

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -674,7 +674,7 @@ final class ClaudeProvider extends AbstractProvider implements
 
         // Multimodal content array: convert to Claude format
         if (is_array($content)) {
-            return ['role' => $role, 'content' => $this->convertMultimodalContent($content)];
+            return ['role' => $role, 'content' => $this->convertMultimodalContent(array_values($content))];
         }
 
         // Plain text message: pass through

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -684,7 +684,7 @@ final class GeminiProvider extends AbstractProvider implements
         if (is_array($content)) {
             return [
                 'role' => $geminiRole,
-                'parts' => $this->convertMultimodalToParts($content),
+                'parts' => $this->convertMultimodalToParts(array_values($content)),
             ];
         }
 

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -228,8 +228,10 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
         // The heartbeat renews the lease under this worker's identity, and the
         // recover closure decides retry-vs-dead-letter for a failure (ADR-104).
-        $recover = fn(Throwable $e, array $steps): AgentRunResult
-            => $this->recoverQueuedFailure($handle, $runUuid, $workerIdentity, $e, $steps);
+        $recover = function (Throwable $e, array $steps) use ($handle, $runUuid, $workerIdentity): AgentRunResult {
+            /** @var list<RunStep> $steps the ladder always passes the accumulated step list */
+            return $this->recoverQueuedFailure($handle, $runUuid, $workerIdentity, $e, $steps);
+        };
 
         return $this->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
     }
@@ -576,6 +578,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         if (!is_array($decoded)) {
             throw CorruptSuspendedStateException::forRun($runUuid);
         }
+        /** @var array<string, mixed> $decoded */
         $state = SuspendedRunState::fromArray($decoded);
 
         // Probe the event-stream position BEFORE the claim: a failure here
@@ -645,6 +648,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         if (!is_array($decoded)) {
             throw CorruptSuspendedStateException::forRun($runUuid);
         }
+        /** @var array<string, mixed> $decoded */
         $state = SuspendedRunState::fromArray($decoded);
 
         // Well-formedness gate (ADR-105 M2): an input suspension with no target

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -208,6 +208,7 @@ final readonly class WaitingRunViewFactory
             if (!is_array($propSchema)) {
                 continue;
             }
+            /** @var array<string, mixed> $propSchema */
             $name        = (string)$name;
             $controlType = $this->classifier->classify($propSchema);
             $fields[]    = new InputFieldView(

--- a/Classes/Service/Context/ContextWindowManager.php
+++ b/Classes/Service/Context/ContextWindowManager.php
@@ -85,7 +85,10 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         // public path (ADR-093), so when the transcript has no leading system
         // message its size must still be counted against the wire.
         $systemPromptTokens = $this->missingSystemPromptTokens($messages, $configuration);
-        $estimate           = fn(array $msgs): int => $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $systemPromptTokens;
+        $estimate = function (array $msgs) use ($toolSpecs, $systemPromptTokens): int {
+            /** @var list<ChatMessage|array<string, mixed>> $msgs the caller always passes the partitioned transcript */
+            return $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $systemPromptTokens;
+        };
 
         [$head, $turns] = $this->partition($messages);
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -342,8 +342,13 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
 
         $normalisedContent = array_values(array_map(
-            static fn(VisionContent|array $item): VisionContent
-                => $item instanceof VisionContent ? $item : VisionContent::fromArray($item),
+            static function (VisionContent|array $item): VisionContent {
+                if ($item instanceof VisionContent) {
+                    return $item;
+                }
+                /** @var array{type?: string, text?: string, image_url?: array{url?: string}|string} $item */
+                return VisionContent::fromArray($item);
+            },
             $content,
         ));
 
@@ -466,7 +471,13 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
-            static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
+            static function (ToolSpec|array $tool): ToolSpec {
+                if ($tool instanceof ToolSpec) {
+                    return $tool;
+                }
+                /** @var array{type?: string, function: array{name: string, description?: string, parameters?: array<string, mixed>}} $tool */
+                return ToolSpec::fromArray($tool);
+            },
             $tools,
         ));
 
@@ -518,7 +529,13 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
         $normalisedTools    = array_values(array_map(
-            static fn(ToolSpec|array $tool): ToolSpec => $tool instanceof ToolSpec ? $tool : ToolSpec::fromArray($tool),
+            static function (ToolSpec|array $tool): ToolSpec {
+                if ($tool instanceof ToolSpec) {
+                    return $tool;
+                }
+                /** @var array{type?: string, function: array{name: string, description?: string, parameters?: array<string, mixed>}} $tool */
+                return ToolSpec::fromArray($tool);
+            },
             $tools,
         ));
 
@@ -885,8 +902,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      *
      * @template T
      *
-     * @param callable(LlmConfiguration): T $terminal
-     * @param array<string, mixed>          $metadata
+     * @param callable(ProviderCallContext): T $terminal
+     * @param array<string, mixed>             $metadata
      *
      * @return T
      */

--- a/Classes/Service/Rerank/HttpReranker.php
+++ b/Classes/Service/Rerank/HttpReranker.php
@@ -52,7 +52,7 @@ final readonly class HttpReranker implements RerankerInterface
     }
 
     /**
-     * @param list<array{id: string, text: string}> $candidates
+     * @param list<array{id: int|string, text: string}> $candidates
      *
      * @return list<array{id: string, score: float}>
      */

--- a/Classes/Service/Retrieval/SolrSearchBackend.php
+++ b/Classes/Service/Retrieval/SolrSearchBackend.php
@@ -323,6 +323,7 @@ final class SolrSearchBackend implements SearchBackendInterface
      */
     private function selectUrl(Site $site, int $languageId): ?string
     {
+        /** @var array<string, mixed> $siteConfig */
         $siteConfig = $site->getConfiguration();
         $languageConfig = [];
         foreach ($this->configuredLanguages($siteConfig) as $language) {

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -140,14 +140,11 @@ final class SkillSyncService
                     static fn(string $path): string => $sourcePrefix . $path,
                     $collected['discovered'],
                 );
-                $prefixIds = static fn(?array $prefixes): ?array => $prefixes === null
-                    ? null
-                    : array_map(static fn(string $prefix): string => $sourcePrefix . $prefix, $prefixes);
                 $orphaned = $this->orphanRemoved(
                     $source,
                     $discoveredIds,
-                    $prefixIds($collected['reachedPrefixes']),
-                    $prefixIds($collected['listedPrefixes']),
+                    $this->prefixIdentifiers($collected['reachedPrefixes'], $sourcePrefix),
+                    $this->prefixIdentifiers($collected['listedPrefixes'], $sourcePrefix),
                 );
 
                 $status = $errors === [] ? SyncStatus::OK : SyncStatus::PARTIAL;
@@ -476,11 +473,11 @@ final class SkillSyncService
         $checksum = hash('sha256', $parsed->body);
         $scan     = $this->scanner?->scan($parsed->body);
         $highConf = $scan?->hasHighConfidence() ?? false;
-        $existing = $this->skillRepository->findBySourceAndIdentifier($source->getUid(), $identifier);
+        $existing = $this->skillRepository->findBySourceAndIdentifier($source->getUid() ?? 0, $identifier);
 
         if ($existing === null) {
             $skill = new Skill();
-            $skill->setSource($source->getUid());
+            $skill->setSource($source->getUid() ?? 0);
             $skill->setIdentifier($identifier);
             $this->apply($skill, $parsed, $sha, $checksum);
             $this->applyIsolationMetadata($skill, $source, $scan);
@@ -587,6 +584,22 @@ final class SkillSyncService
     }
 
     /**
+     * Prefix every entry with the per-source identifier prefix, preserving the
+     * null passthrough (null means "not a marketplace source").
+     *
+     * @param list<string>|null $prefixes
+     *
+     * @return list<string>|null
+     */
+    private function prefixIdentifiers(?array $prefixes, string $sourcePrefix): ?array
+    {
+        if ($prefixes === null) {
+            return null;
+        }
+        return array_map(static fn(string $prefix): string => $sourcePrefix . $prefix, $prefixes);
+    }
+
+    /**
      * Orphan DB skills that are absent from the discovered (upstream-present) set.
      *
      * @param list<string>  $discovered      Full identifiers present upstream this run.
@@ -602,7 +615,7 @@ final class SkillSyncService
         // so array_flip is a faithful hash set.
         $discoveredSet = array_flip($discovered);
         $count = 0;
-        foreach ($this->skillRepository->findBySource($source->getUid()) as $skill) {
+        foreach ($this->skillRepository->findBySource($source->getUid() ?? 0) as $skill) {
             $identifier = $skill->getIdentifier();
             if (isset($discoveredSet[$identifier])) {
                 continue;

--- a/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
@@ -87,7 +87,8 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
         $tableTca  = $this->tableTca($table);
         $columns   = is_array($tableTca['columns'] ?? null) ? $tableTca['columns'] : [];
         $columnTca = is_array($columns[$field] ?? null) ? $columns[$field] : [];
-        $conf      = is_array($columnTca['config'] ?? null) ? $columnTca['config'] : null;
+        /** @var array<string, mixed>|null $conf */
+        $conf = is_array($columnTca['config'] ?? null) ? $columnTca['config'] : null;
         if (!is_array($conf)) {
             return ToolResult::text(sprintf('Field %s.%s not found.', $table, $field));
         }
@@ -120,12 +121,14 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
                 // v14+: the resolver requires the table TCA as the $schema
                 // argument — with null it throws instead of reading a global.
                 $identifier = $flexFormTools->getDataStructureIdentifier($columnTca, $table, $field, $row, $tableTca);
-                $structure  = $flexFormTools->parseDataStructureByIdentifier($identifier, $tableTca);
+                /** @var array<string, mixed> $structure */
+                $structure = $flexFormTools->parseDataStructureByIdentifier($identifier, $tableTca);
             } else {
                 // 13.4: 4-/1-parameter signatures; the resolver reads
                 // $GLOBALS['TCA'] itself.
                 $identifier = $flexFormTools->getDataStructureIdentifier($columnTca, $table, $field, $row);
-                $structure  = $flexFormTools->parseDataStructureByIdentifier($identifier);
+                /** @var array<string, mixed> $structure */
+                $structure = $flexFormTools->parseDataStructureByIdentifier($identifier);
             }
         } catch (Throwable) {
             // Neutral by design — resolution internals must not egress.

--- a/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
@@ -83,6 +83,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
             return ToolResult::text(self::NOT_PERMITTED);
         }
 
+        /** @var array<string, mixed> $ctrl */
         $ctrl  = is_array($tca['ctrl'] ?? null) ? $tca['ctrl'] : [];
         $lines = [sprintf('Table: %s', $table)];
 

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -135,6 +135,7 @@ final readonly class ValidateTcaTool implements ToolInterface
      */
     private function validateTable(string $table, array $tca, array $allTca): array
     {
+        /** @var array<string, mixed> $ctrl */
         $ctrl     = is_array($tca['ctrl'] ?? null) ? $tca['ctrl'] : [];
         $columns  = is_array($tca['columns'] ?? null) ? $tca['columns'] : [];
         $palettes = is_array($tca['palettes'] ?? null) ? $tca['palettes'] : [];

--- a/Classes/Service/Tool/SchemaInputCoercer.php
+++ b/Classes/Service/Tool/SchemaInputCoercer.php
@@ -55,7 +55,11 @@ final readonly class SchemaInputCoercer
 
         foreach ($properties as $name => $propSchema) {
             $name = (string)$name;
-            $type = is_array($propSchema) ? $this->classifier->classify($propSchema) : SchemaPropertyClassifier::TEXT;
+            $type = SchemaPropertyClassifier::TEXT;
+            if (is_array($propSchema)) {
+                /** @var array<string, mixed> $propSchema a JSON-Schema property object is keyed by string */
+                $type = $this->classifier->classify($propSchema);
+            }
             $isRequired = in_array($name, $required, true);
             $posted     = $rawInput[$name] ?? null;
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -222,7 +222,14 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $iterations++;
                 // Bound the growing transcript against the context window BEFORE
                 // the send (ADR-107); tools are on this wire, so pass $specs.
-                $messages = $this->enforceContextWindow($messages, $configuration, $options, $lastUsage, $iterations, $specs);
+                $messages = $this->enforceContextWindow(
+                    $messages,
+                    $configuration,
+                    $options,
+                    $lastUsage,
+                    $iterations,
+                    array_map(static fn(ToolSpec $s): array => $s->toArray(), $specs),
+                );
                 // Streamed BEFORE the provider call so the inspector shows the
                 // outgoing request (and a waiting state) from second zero.
                 $runTrace?->recordRequest($iterations, $messages, $allowedNames);

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -262,7 +262,7 @@ final readonly class LlmTranslator implements TranslatorInterface
      *
      * @param array<string, mixed> $options
      *
-     * @return array{messages: array<int, array{role: string, content: string}>}
+     * @return array{messages: list<array{role: string, content: string}>}
      */
     private function buildPrompt(
         string $text,


### PR DESCRIPTION
## Summary

Hardens the PHPStan level-10 gate (audit follow-up #1). The config carried two blanket `reportUnmatched: false` ignores — `argument.type` and `varTag.nativeType` — that suppressed those identifiers **everywhere, including in new code**. Any loosely-typed array or mistyped `@var` passed silently. This removes both ignores, fixes the 45 production violations they hid, and baselines the 40 test-side ones so **new production code is now gated** while legacy test debt stays visible and unblocking.

No runtime behaviour changes — every fix is a precise, behaviour-preserving type annotation/narrowing.

## What changed

- **`Build/phpstan/phpstan.neon`** — removed the two blanket ignores.
- **45 production type fixes across 21 files** — no `@phpstan-ignore`, no widening a signature to `mixed`/bare `array`:
  - narrow decoded JSON / DB rows / site config at the source (`/** @var array<string, mixed> $x */` or a sealed `array{…}` shape);
  - `array_values()` / null-guards for `list<…>` and `?int → int` expectations — notably `SkillSyncService`'s `getUid()` would in fact have *fatal'd* on a null uid, so `?? 0` is the defensive, correct value;
  - an inline `@var` inside two closures whose `@param` docblock PHPStan does not honour on an assigned closure (`AgentRuntime`, `ContextWindowManager`);
  - `ToolCall::fromArray()`'s `@param` widened to `array<string, mixed>` — the honest type for a factory that defensively validates every field of an untrusted decoded object.
- **`Build/phpstan-baseline.neon`** — populated with the 40 remaining `Tests/`-only violations (mock/fixture arrays). The config already `includes:` this file. **Zero production entries** are frozen.

## Why baseline the tests instead of fixing them

Production type-safety is the value; test fixtures are mostly deliberately-loose mock arrays where narrowing distorts intent. Freezing them keeps the debt visible and lets the gate bite on new production code immediately, rather than blocking this PR on 40 low-value test edits.

## Enforcement parity

CI's `ci:` job runs `composer ci:test:php:phpstan` → `phpstan analyse -c Build/phpstan/phpstan.neon`, i.e. this exact config (the 8 PHPStan matrix cells). Verified the change is CI-enforced, not local-only.

## Test plan

Full local gate green on PHP 8.5: `phpstan` (No errors, both blanket ignores removed), `cgl`, `unit` (5582), `rector -n`, `fuzzy` (79), `functional -d sqlite` (1258). No new failures vs base.
