### PR TITLE
fix(agent): heartbeat lease loss on MySQL no-op UPDATE + unbounded purge SELECT

### DIFF
--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -295,7 +295,42 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ],
         );
 
-        return $affected === 1;
+        if ($affected >= 1) {
+            return true;
+        }
+
+        // MySQL/MariaDB report zero *changed* rows for a no-op UPDATE — two
+        // heartbeats in the same wall-clock second write an identical
+        // lease_expires and tstamp, so the second changes nothing even though
+        // the row still matches and the worker still owns it. Zero affected
+        // rows therefore does NOT prove lost ownership; confirm with an explicit
+        // ownership re-check so a healthy heartbeat is never misread as a lost
+        // lease (which would abandon the run RUNNING until the reaper requeues).
+        return $this->ownsRunningRun($runUid, $claimedBy);
+    }
+
+    /**
+     * Whether the run still exists RUNNING under this worker's claim — the
+     * ownership predicate {@see renewLease()} uses to tell a no-op UPDATE
+     * (nothing changed) apart from a lost lease (nothing matched). The reaper
+     * clears claimed_by on requeue, so a reclaimed run fails this check.
+     */
+    private function ownsRunningRun(int $runUid, string $claimedBy): bool
+    {
+        $builder = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->createQueryBuilder();
+
+        $count = $builder
+            ->count('uid')
+            ->from(self::TABLE_RUN)
+            ->where(
+                $builder->expr()->eq('uid', $builder->createNamedParameter($runUid, Connection::PARAM_INT)),
+                $builder->expr()->eq('status', $builder->createNamedParameter(AgentRunStatus::RUNNING->value)),
+                $builder->expr()->eq('claimed_by', $builder->createNamedParameter($claimedBy)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return self::toInt($count) === 1;
     }
 
     /**
@@ -554,27 +589,35 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             return 0;
         }
 
-        $runConnection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
-        $selectBuilder = $runConnection->createQueryBuilder();
-        $rows          = $selectBuilder
-            ->select('uid')
-            ->from(self::TABLE_RUN)
-            ->where(
-                $selectBuilder->expr()->lt('crdate', $selectBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)),
-                $selectBuilder->expr()->in('status', $selectBuilder->createNamedParameter($statuses, Connection::PARAM_STR_ARRAY)),
-            )
-            ->executeQuery()
-            ->fetchAllAssociative();
-
-        $uids = array_map(fn(array $row): int => self::toInt($row['uid'] ?? 0), $rows);
-        if ($uids === []) {
-            return 0;
-        }
-
+        $runConnection   = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
         $eventConnection = $this->connectionPool->getConnectionForTable(self::TABLE_EVENT);
         $deleted         = 0;
 
-        foreach (array_chunk($uids, self::PURGE_CHUNK_SIZE) as $chunk) {
+        // Select AND delete in bounded chunks. Materialising every matching uid
+        // up front would exhaust memory on exactly the long-neglected install
+        // the chunking exists to protect (millions of rows accrued because the
+        // purge never ran). Each pass reads at most one chunk of ids; the just
+        // deleted rows drop out of the next pass's WHERE, so no OFFSET is needed
+        // and the loop terminates when a short (or empty) chunk comes back.
+        do {
+            $selectBuilder = $runConnection->createQueryBuilder();
+            $rows          = $selectBuilder
+                ->select('uid')
+                ->from(self::TABLE_RUN)
+                ->where(
+                    $selectBuilder->expr()->lt('crdate', $selectBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)),
+                    $selectBuilder->expr()->in('status', $selectBuilder->createNamedParameter($statuses, Connection::PARAM_STR_ARRAY)),
+                )
+                ->orderBy('uid')
+                ->setMaxResults(self::PURGE_CHUNK_SIZE)
+                ->executeQuery()
+                ->fetchAllAssociative();
+
+            $chunk = array_map(fn(array $row): int => self::toInt($row['uid'] ?? 0), $rows);
+            if ($chunk === []) {
+                break;
+            }
+
             $eventBuilder = $eventConnection->createQueryBuilder();
             $eventBuilder
                 ->delete(self::TABLE_EVENT)
@@ -586,7 +629,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
                 ->delete(self::TABLE_RUN)
                 ->where($deleteBuilder->expr()->in('uid', $deleteBuilder->createNamedParameter($chunk, Connection::PARAM_INT_ARRAY)))
                 ->executeStatement();
-        }
+        } while (count($chunk) === self::PURGE_CHUNK_SIZE);
 
         return $deleted;
     }

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -376,6 +376,58 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function renewLeaseSurvivesANoOpRenewalInTheSameSecond(): void
+    {
+        // ADR-104 heartbeat: two step boundaries in the same wall-clock second
+        // renew with an identical lease_expires, so the second UPDATE changes
+        // nothing. MySQL/MariaDB report zero *changed* rows for that no-op,
+        // which must NOT be read as a lost lease — the worker still owns the run
+        // (regression: a healthy run was abandoned RUNNING until the reaper ran).
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        $lease = time() + 900;
+        self::assertTrue($this->persister->renewLease($handle, 'worker-a:1', $lease));
+        // Identical lease value, same second -> a no-op UPDATE. The ownership
+        // re-check must still confirm the live lease.
+        self::assertTrue($this->persister->renewLease($handle, 'worker-a:1', $lease));
+
+        // A genuine ownership loss (stranger) still returns false.
+        self::assertFalse($this->persister->renewLease($handle, 'worker-b:2', $lease));
+    }
+
+    #[Test]
+    public function purgeClearsMoreThanOneChunkOfRunsAndLeavesFreshOnes(): void
+    {
+        // The purge selects AND deletes in bounded chunks so it never
+        // materialises every matching uid at once (OOM on a neglected install).
+        // Seed just over one chunk of old finished runs and assert the loop
+        // clears them all — proving it iterates past the first chunk and
+        // terminates — while a run created after the cutoff is untouched.
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('tx_nrllm_agentrun');
+        $old        = 1000;
+        $count      = 501; // one full chunk (500) + 1 -> forces a second pass
+        for ($i = 0; $i < $count; ++$i) {
+            $connection->insert('tx_nrllm_agentrun', [
+                'uuid'   => sprintf('purge-%04d', $i),
+                'status' => 'completed',
+                'crdate' => $old,
+            ]);
+        }
+        $fresh = $this->persister->begin(null, 0);
+        self::assertNotNull($fresh);
+        $this->persister->settleCompleted($fresh, new ToolLoopResult('x', [], 1, false, UsageStatistics::fromTokens(0, 0)));
+
+        $deleted = $this->repository->purgeOlderThan($old + 1);
+
+        self::assertSame($count, $deleted);
+        self::assertNotNull($this->repository->findByUuid($fresh->uuid));
+    }
+
+    #[Test]
     public function requeueIsOwnershipGuardedIncrementsTheCountAndKeepsTheRequest(): void
     {
         // ADR-104 failure retry (review MAJOR): a zombie worker cannot requeue a


### PR DESCRIPTION
## Summary

Two defects in the agent-runtime persistence layer, surfaced by an adversarial audit and **both invisible under the SQLite CI leg** — they only manifest on MySQL/MariaDB or on a pathological data volume.

### 1. Heartbeat misreads a same-second no-op UPDATE as a lost lease (HIGH)

`renewLease()` returned `$affected === 1` to prove the worker still owns a running queued run. But it writes only `lease_expires` and `tstamp`, both derived from `time()`. Two heartbeats in the **same wall-clock second** (two fast tool calls in one round) write byte-identical values, so the second `UPDATE` changes nothing. On MySQL/MariaDB a no-op `UPDATE` reports **zero *changed* rows** (not matched rows), so `renewLease` wrongly returned `false` → `RunLeaseLostException` on a healthy run → the run was abandoned `RUNNING` for the full 900 s lease until the reaper requeued and **re-executed the round from scratch**.

**Fix:** on zero affected rows, distinguish "nothing changed" from "lost ownership" with an explicit ownership re-check (`ownsRunningRun`) rather than trusting the changed-row count. The reaper clears `claimed_by` on requeue, so a genuinely reclaimed run still fails the check.

### 2. Purge feeds chunked DELETEs from an unbounded SELECT (MEDIUM)

`purgeRuns()` chunked its `DELETE`s but first materialised **every** matching uid via one unbounded `SELECT uid … fetchAllAssociative()`. On exactly the long-neglected install the chunking exists to protect (millions of accrued runs), that SELECT exhausts `memory_limit` and the purge can never complete — so the table grows unbounded.

**Fix:** select *and* delete in bounded `PURGE_CHUNK_SIZE` passes; the just-deleted rows drop out of the next pass's `WHERE`, so no `OFFSET` is needed and the loop terminates on a short/empty chunk.

## Test plan

New `AgentRunPersisterTest` cases:
- **same-second no-op renewal stays owned** — verified on **MariaDB**: it *fails there without the fix* (`false is true`) and passes with it; SQLite masks the bug. A stranger's renewal still returns false.
- **purge across more than one chunk** — seeds 501 old finished runs (one full chunk + 1), asserts all are cleared (proving the loop iterates past the first chunk and terminates) while a fresh run survives.

Full local gate green (PHP 8.5): cgl, phpstan (L10), rector, unit (5582), fuzzy (79), functional `-d sqlite` (1260) and the two new cases on `-d mariadb`.

## Provenance

Found by an adversarial bug-hunt (5 dimension finders → 3 refuting skeptics per finding). Every cited line was re-read and confirmed by hand before fixing. Two further confirmed findings (an ownership guard missing on the terminal *settle* path, [2]/[3]) are a coupled-lifecycle change and will follow as a separate PR.
