### PR TITLE
fix(agent): ownership-guard the terminal settle so a reclaimed run is never clobbered

### DIFF
--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -255,7 +255,14 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // dead-letter immediately, distinct from PROVIDER_FAILED so it never
             // reads as retryable.
             if (!$class->isRetryable()) {
-                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE);
+                // Ownership-guarded like the requeue branch below: if this worker
+                // no longer owns the run (reaper reclaimed it), do NOT settle —
+                // return LEASE_LOST and leave the row to its current owner.
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
+                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
                 $this->logger?->warning('Queued agent run failed with a non-retryable error; dead-lettered', ['run' => $runUuid, 'class' => $class->value]);
 
                 return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
@@ -266,7 +273,11 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             $currentRun = $this->persister->findRun($runUuid);
             $count      = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
             if ($count < 0 || $count >= self::MAX_REQUEUES) {
-                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED);
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity)) {
+                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
                 $this->logger?->warning('Queued agent run exhausted its retry budget; dead-lettered', ['run' => $runUuid, 'requeueCount' => $count]);
 
                 return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
@@ -293,7 +304,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         } catch (Throwable $internal) {
             $this->logger?->error('Queued agent run recovery failed; dead-lettering', ['run' => $runUuid, 'exception' => $internal]);
             try {
-                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED);
+                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity);
             } catch (Throwable) {
                 // The persister is itself fail-soft; nothing more can be done.
             }
@@ -359,6 +370,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 $request->augmentation,
             ),
             $recover,
+            $leaseOwner,
         );
     }
 
@@ -822,7 +834,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
      * @param Closure(): ToolLoopResult                                 $loopCall
      * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
      */
-    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null): AgentRunResult
+    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null, ?string $ownerGuard = null): AgentRunResult
     {
         $runUuid = $handle !== null ? $handle->uuid : '';
         $settled = false;
@@ -831,7 +843,15 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             $result = $loopCall();
 
             if ($handle !== null) {
-                $this->persister->settleCompleted($handle, $result);
+                $settledOk = $this->persister->settleCompleted($handle, $result, $ownerGuard);
+                // Ownership-guarded on the queued path: if the run was reclaimed
+                // to another worker mid-loop, this completion must not overwrite
+                // its state — stop as LEASE_LOST rather than reporting COMPLETED.
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps());
+                }
             }
             $settled = true;
 
@@ -880,7 +900,9 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // re-suspension AND announced awaiting-approval for unpersisted
             // runs).
             if ($handle !== null) {
-                $this->persister->settleFailed($handle, $approval);
+                // Ownership-guarded so a reclaimed queued run is not clobbered by
+                // this worker's fail-closed settle.
+                $this->persister->settleFailed($handle, $approval, $ownerGuard);
             }
             $this->logger?->error('Agent run could not be suspended for approval; no resume is possible', ['run' => $runUuid]);
 
@@ -914,7 +936,9 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // run was never persisted (null handle) — there is nothing to resume,
             // so promising an input flow would strand the client.
             if ($handle !== null) {
-                $this->persister->settleFailed($handle, $input);
+                // Ownership-guarded so a reclaimed queued run is not clobbered by
+                // this worker's fail-closed settle.
+                $this->persister->settleFailed($handle, $input, $ownerGuard);
             }
             $this->logger?->error('Agent run could not be suspended for input; no resume is possible', ['run' => $runUuid]);
 
@@ -929,13 +953,23 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // failure — and an approval that was required but never obtained
             // is not recorded as an outright denial (ADR-092).
             if ($handle !== null) {
-                $this->persister->settlePolicyStopped(
+                $settledOk = $this->persister->settlePolicyStopped(
                     $handle,
                     $guardrail,
                     $guardrail instanceof GuardrailApprovalRequiredException
                         ? AgentRunTerminationReason::APPROVAL_DENIED
                         : AgentRunTerminationReason::POLICY_DENIED,
+                    $ownerGuard,
                 );
+                // Ownership-guarded on the queued path: a run reclaimed to
+                // another worker must not be flipped to a policy-stopped terminal
+                // by this zombie worker — stop as LEASE_LOST.
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+                    $this->logger?->notice('Guardrail-stopped queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $guardrail);
+                }
             }
             $settled = true;
             $this->logger?->warning('Agent run blocked by guardrail', ['exception' => $guardrail, 'run' => $runUuid]);
@@ -978,7 +1012,13 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             }
 
             if ($handle !== null) {
-                $this->persister->settleFailed($handle, $e);
+                $settledOk = $this->persister->settleFailed($handle, $e, $ownerGuard);
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+                    $this->logger?->notice('Failed queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $e);
+                }
             }
             $settled = true;
             $this->logger?->error('Agent run failed', ['exception' => $e, 'run' => $runUuid]);
@@ -997,7 +1037,9 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // WAITING_FOR_APPROVAL or WAITING_FOR_INPUT — both non-terminal — and
             // settling it here would destroy its resumable state.
             if ($handle !== null && !$settled) {
-                $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'));
+                // Ownership-guarded so this safety-net settle cannot clobber a
+                // queued run the reaper reclaimed to another worker.
+                $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'), $ownerGuard);
             }
         }
     }

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -188,9 +188,9 @@ final readonly class AgentRunPersister
      * an iteration cap and an exhausted budget both truncate and are otherwise
      * indistinguishable in the stored row.
      */
-    public function settleCompleted(AgentRunHandle $handle, ToolLoopResult $result): void
+    public function settleCompleted(AgentRunHandle $handle, ToolLoopResult $result, ?string $ownedBy = null): bool
     {
-        $this->finish(
+        return $this->finish(
             $handle,
             AgentRunStatus::COMPLETED,
             $result->iterations,
@@ -201,6 +201,7 @@ final readonly class AgentRunPersister
             $result->usage->estimatedCost ?? 0.0,
             '',
             $result->terminationReason,
+            $ownedBy,
         );
     }
 
@@ -209,9 +210,9 @@ final readonly class AgentRunPersister
      * exhausted every fallback, or an unexpected error). The exception FQCN is
      * stored; the message is never persisted (it can carry payload fragments).
      */
-    public function settleFailed(AgentRunHandle $handle, Throwable $error): void
+    public function settleFailed(AgentRunHandle $handle, Throwable $error, ?string $ownedBy = null): bool
     {
-        $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, AgentRunTerminationReason::PROVIDER_FAILED);
+        return $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, AgentRunTerminationReason::PROVIDER_FAILED, $ownedBy);
     }
 
     /**
@@ -220,9 +221,9 @@ final readonly class AgentRunPersister
      * an outage — and an approval that was required but never obtained is not
      * read as a denial.
      */
-    public function settlePolicyStopped(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason): void
+    public function settlePolicyStopped(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason, ?string $ownedBy = null): bool
     {
-        $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason);
+        return $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason, $ownedBy);
     }
 
     /**
@@ -232,18 +233,18 @@ final readonly class AgentRunPersister
      * retrying). Distinct from {@see self::settleFailed()}, whose PROVIDER_FAILED
      * reason is retryable; a dead-letter terminus must not read as retryable.
      */
-    public function settleDeadLettered(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason): void
+    public function settleDeadLettered(AgentRunHandle $handle, Throwable $error, AgentRunTerminationReason $reason, ?string $ownedBy = null): bool
     {
-        $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason);
+        return $this->finish($handle, AgentRunStatus::FAILED, 0, false, 0, 0, 0, 0.0, $error::class, $reason, $ownedBy);
     }
 
     /**
      * Settle a run an operator cancelled. Distinct from a failure: nothing went
      * wrong, somebody stopped it.
      */
-    public function settleCancelled(AgentRunHandle $handle): void
+    public function settleCancelled(AgentRunHandle $handle, ?string $ownedBy = null): bool
     {
-        $this->finish($handle, AgentRunStatus::CANCELLED, 0, false, 0, 0, 0, 0.0, '', AgentRunTerminationReason::CANCELLED);
+        return $this->finish($handle, AgentRunStatus::CANCELLED, 0, false, 0, 0, 0, 0.0, '', AgentRunTerminationReason::CANCELLED, $ownedBy);
     }
 
     /**
@@ -587,7 +588,8 @@ final readonly class AgentRunPersister
         float $estimatedCost,
         string $errorClass,
         AgentRunTerminationReason $reason,
-    ): void {
+        ?string $ownedBy = null,
+    ): bool {
         try {
             $transitioned = $this->repository->finishRun(
                 $handle->runUid,
@@ -600,19 +602,27 @@ final readonly class AgentRunPersister
                 $estimatedCost,
                 $errorClass,
                 $reason->value,
+                $ownedBy,
             );
 
             if (!$transitioned) {
-                // The run was already terminal: a duplicate or late settle. The
-                // guard kept the first outcome, which is the correct one.
-                $this->logger?->notice('AgentRun was already settled; the later outcome was discarded', [
+                // Not settled by this call: the run was already terminal (a
+                // duplicate/late settle — the first, correct outcome was kept),
+                // or, on the ownership-guarded queued path, this worker no longer
+                // owns it (the reaper reclaimed it to another worker). Either way
+                // the caller must not report a terminal outcome it did not write.
+                $this->logger?->notice('AgentRun was not settled by this call (already terminal or ownership lost)', [
                     'run'    => $handle->uuid,
                     'status' => $status->value,
                     'reason' => $reason->value,
                 ]);
             }
+
+            return $transitioned;
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun could not be settled', ['exception' => $exception]);
+
+            return false;
         }
     }
 }

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -152,6 +152,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         float $estimatedCost,
         string $errorClass,
         string $terminationReason = '',
+        ?string $ownedBy = null,
     ): bool {
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_RUN);
         $builder    = $connection->createQueryBuilder();
@@ -160,6 +161,22 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         // Guarded transition: only a non-terminal run may be settled. Without the
         // predicate a late callback could reopen or overwrite a finished run —
         // COMPLETED -> RUNNING -> COMPLETED with different totals (ADR-092).
+        $predicates = [
+            $builder->expr()->eq('uid', $builder->createNamedParameter($runUid, Connection::PARAM_INT)),
+            $builder->expr()->in(
+                'status',
+                $builder->createNamedParameter(AgentRunStatus::nonTerminalValues(), Connection::PARAM_STR_ARRAY),
+            ),
+        ];
+        // Ownership guard for the queued-worker path (ADR-104): a slow worker
+        // whose lease expired and whose run the reaper reclaimed to another
+        // worker must NOT settle it — that would destroy the new owner's
+        // in-flight state. A null $ownedBy (the interactive run/approve path,
+        // which holds no lease) keeps the transition ownership-agnostic.
+        if ($ownedBy !== null) {
+            $predicates[] = $builder->expr()->eq('claimed_by', $builder->createNamedParameter($ownedBy));
+        }
+
         $affected = $builder
             ->update(self::TABLE_RUN)
             ->set('status', $status)
@@ -178,13 +195,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ->set('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT), false)
             ->set('finished_at', $builder->createNamedParameter($now, Connection::PARAM_INT), false)
             ->set('tstamp', $builder->createNamedParameter($now, Connection::PARAM_INT), false)
-            ->where(
-                $builder->expr()->eq('uid', $builder->createNamedParameter($runUid, Connection::PARAM_INT)),
-                $builder->expr()->in(
-                    'status',
-                    $builder->createNamedParameter(AgentRunStatus::nonTerminalValues(), Connection::PARAM_STR_ARRAY),
-                ),
-            )
+            ->where(...$predicates)
             ->executeStatement();
 
         return $affected > 0;

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -51,6 +51,7 @@ interface AgentRunRepositoryInterface
         float $estimatedCost,
         string $errorClass,
         string $terminationReason = '',
+        ?string $ownedBy = null,
     ): bool;
 
     /**

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -400,6 +400,61 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function anOwnershipGuardedSettleDoesNotClobberARunReclaimedByAnotherWorker(): void
+    {
+        // ADR-104: worker A claims a queued run whose lease then expires; the
+        // reaper reclaims it and worker B re-claims it. Worker A's late,
+        // ownership-guarded settle must be REFUSED so it cannot overwrite B's
+        // in-flight run (a >lease-length hung provider call is the trigger).
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+
+        // Worker A claims with an already-expired lease (100), so the reaper
+        // (now=200) finds it stale and reclaims it (RUNNING -> QUEUED, unclaimed).
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', 100));
+        self::assertTrue($this->persister->requeueStale($run, 200));
+
+        // Worker B re-claims the requeued run.
+        $requeued = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($requeued);
+        self::assertTrue($this->persister->claimQueued($requeued, 'worker-b:2', time() + 60));
+
+        // Worker A's late settle, guarded by A's identity, is refused.
+        self::assertFalse(
+            $this->persister->settleDeadLettered($handle, new RuntimeException('late A'), AgentRunTerminationReason::NOT_RETRYABLE, 'worker-a:1'),
+        );
+        $afterA = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($afterA);
+        self::assertSame('running', $afterA->status);      // not clobbered to failed
+        self::assertSame('worker-b:2', $afterA->claimedBy); // worker B still owns it
+
+        // Worker B's own guarded settle succeeds.
+        self::assertTrue(
+            $this->persister->settleDeadLettered($handle, new RuntimeException('done B'), AgentRunTerminationReason::NOT_RETRYABLE, 'worker-b:2'),
+        );
+        $final = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($final);
+        self::assertSame('failed', $final->status);
+    }
+
+    #[Test]
+    public function anInteractiveSettleWithoutAnOwnerGuardStillSettles(): void
+    {
+        // The interactive run/approve path holds no lease; its settle passes a
+        // null owner guard and must stay ownership-agnostic (unchanged).
+        $handle = $this->persister->begin(null, 0);
+        self::assertNotNull($handle);
+
+        self::assertTrue($this->persister->settleFailed($handle, new RuntimeException('boom')));
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('failed', $run->status);
+    }
+
+    #[Test]
     public function purgeClearsMoreThanOneChunkOfRunsAndLeavesFreshOnes(): void
     {
         // The purge selects AND deletes in bounded chunks so it never

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -39,7 +39,7 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         // Not needed by the command tests.
     }
 
-    /** @var list<array{runUid: int, status: string, errorClass: string, terminationReason: string}> */
+    /** @var list<array{runUid: int, status: string, errorClass: string, terminationReason: string, ownedBy: string|null}> */
     public array $finished = [];
 
     public function finishRun(
@@ -53,8 +53,9 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         float $estimatedCost,
         string $errorClass,
         string $terminationReason = '',
+        ?string $ownedBy = null,
     ): bool {
-        $this->finished[] = ['runUid' => $runUid, 'status' => $status, 'errorClass' => $errorClass, 'terminationReason' => $terminationReason];
+        $this->finished[] = ['runUid' => $runUid, 'status' => $status, 'errorClass' => $errorClass, 'terminationReason' => $terminationReason, 'ownedBy' => $ownedBy];
 
         return true;
     }

--- a/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
@@ -245,7 +245,7 @@ final class AgentRunPersisterTest extends TestCase
         $repository               = new RecordingAgentRunRepository();
         $repository->refuseFinish = true;
         $logger                   = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('notice')->with(self::stringContains('already settled'), self::anything());
+        $logger->expects(self::once())->method('notice')->with(self::stringContains('was not settled by this call'), self::anything());
 
         $persister = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), $logger);
         $persister->settleCompleted(new AgentRunHandle(1, 'uuid'), new ToolLoopResult('', [], 1, false, UsageStatistics::fromTokens(0, 0)));

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -35,7 +35,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
     /** @var list<array{runUid: int, sequence: int, kind: string, round: int, durationMs: float, payloadJson: string}> */
     public array $events = [];
 
-    /** @var array{runUid: int, status: string, iterations: int, truncated: bool, promptTokens: int, completionTokens: int, totalTokens: int, estimatedCost: float, errorClass: string, terminationReason: string}|null */
+    /** @var array{runUid: int, status: string, iterations: int, truncated: bool, promptTokens: int, completionTokens: int, totalTokens: int, estimatedCost: float, errorClass: string, terminationReason: string, ownedBy: string|null}|null */
     public ?array $finished = null;
 
     public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int
@@ -79,6 +79,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         float $estimatedCost,
         string $errorClass,
         string $terminationReason = '',
+        ?string $ownedBy = null,
     ): bool {
         if ($this->throwOnFinish) {
             throw new RuntimeException('finishRun failed', 7543565687);
@@ -97,6 +98,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
             'estimatedCost'    => $estimatedCost,
             'errorClass'         => $errorClass,
             'terminationReason'  => $terminationReason,
+            'ownedBy'            => $ownedBy,
         ];
 
         return true;


### PR DESCRIPTION
## Summary

Completes the agent-runtime concurrency hardening from the adversarial audit (findings [2]/[3], follow-up to #505). The **requeue** path already refuses to act when this worker no longer owns a run (ADR-104), but the terminal **settle** path did not: `finishRun()` guarded only on non-terminal *status*, not on `claimed_by`.

So a slow worker whose lease expired and whose run the reaper reclaimed to another worker could still settle it — **overwriting the new owner's in-flight run** (a COMPLETED / FAILED / POLICY_DENIED clobber; `recoverQueuedFailure`'s dead-letter branches had the same gap).

**Reachability:** after the reliable heartbeat from #505, the lease only expires mid-run if a single provider call outlives the 900 s lease — i.e. a provider `timeout` configured above the lease, or a hang that defeats the 120 s default. Low-probability, but the invariant ("no settle may clobber a run this worker no longer owns") is real, so it's fixed for defense-in-depth.

## The fix

Thread an optional owner guard through the terminal-settle contract:

- **`finishRun(..., ?string $ownedBy = null)`** adds `claimed_by = $ownedBy` to its `WHERE` only when set. A `null` guard — the interactive `run()`/`approve()` path, which holds no lease — keeps the transition ownership-agnostic (**unchanged behaviour**).
- **`AgentRunPersister::finish()`** and the five `settle*` methods take the guard and return whether they settled (`void → bool`; existing void callers are unaffected).
- **`AgentRuntime::execute()`** receives the queued worker identity as `$ownerGuard` (from `$leaseOwner`) and passes it to every terminal settle. When a guarded settle reports it did **not** own the run, execute stops as `LEASE_LOST` instead of reporting a terminal outcome — mirroring the existing requeue branch. `recoverQueuedFailure`'s dead-letter branches do the same with `$workerIdentity`.

Applied to **all** sibling settle paths (completed, failed, policy-stopped, dead-lettered, cancelled, and the `finally` safety net) — not just the two the audit flagged — so the ownership invariant holds uniformly.

## Test plan

New `AgentRunPersisterTest` (functional) cases:
- **a reclaimed run is not clobbered** — worker A claims a run whose lease expires, the reaper reclaims it, worker B re-claims it; A's guarded settle is refused (returns false, row stays `running` under B), and B's own guarded settle succeeds.
- **an interactive settle (null guard) still settles** — unchanged path.

The `claimed_by` predicate is portable (a plain `WHERE`, unlike #505's driver-specific no-op), so SQLite exercises it fully. Full local gate green (PHP 8.5): cgl, phpstan (L10), rector, unit (5582), fuzzy (79), functional `-d sqlite` (1262).

## Provenance

Found by the same adversarial bug-hunt as #505; every cited line hand-verified. This closes all four confirmed findings from that audit.
