### PR TITLE
refactor(agent)!: carry the full AiActorContext through a queued run (P0 #1, slice 1a)

### DIFF
--- a/Classes/Controller/Backend/BackendUserUidTrait.php
+++ b/Classes/Controller/Backend/BackendUserUidTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
@@ -34,5 +35,29 @@ trait BackendUserUidTrait
         $uid = is_array($backendUser->user) ? ($backendUser->user['uid'] ?? 0) : 0;
 
         return is_numeric($uid) ? (int)$uid : 0;
+    }
+
+    /**
+     * The full actor for the current backend request (ADR-083): the backend
+     * user's uid, admin flag and group uids captured HERE, at the HTTP boundary,
+     * where the authenticated BE user genuinely is the caller. This is the one
+     * sanctioned reading of the ambient BE user — everything downstream (a run
+     * request, a queue worker) carries the resulting {@see AiActorContext}
+     * explicitly instead of re-reading `$GLOBALS['BE_USER']`.
+     */
+    private function currentActor(): AiActorContext
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        $uid         = $this->currentBackendUserUid();
+        if (!$backendUser instanceof BackendUserAuthentication || $uid === 0) {
+            return AiActorContext::anonymous();
+        }
+
+        $groupIds = array_values(array_filter(
+            array_map(static fn(mixed $g): int => is_numeric($g) ? (int)$g : 0, $backendUser->userGroupsUID),
+            static fn(int $g): bool => $g > 0,
+        ));
+
+        return AiActorContext::backendUser($uid, $backendUser->isAdmin(), $groupIds);
     }
 }

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -192,7 +192,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 dryRun: $dryRun,
             ),
             captureRaw: $captureRaw,
-            beUserUid: $this->currentBackendUserUid(),
+            actor: $this->currentActor(),
         );
 
         // Live path: stream each recorded step to the browser as it happens.

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -65,6 +65,29 @@ final readonly class AiActorContext
         return new self(0, false, [], null);
     }
 
+    /**
+     * Rebuild an actor from its {@see toArray()} form when a queued run is
+     * rehydrated in a worker (ADR-102/083), so the worker acts with the same
+     * identity that enqueued the work rather than the ambient (absent) BE user.
+     * Every field degrades to its least-privileged default, so a malformed or
+     * truncated row can never yield a MORE privileged actor than was stored.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $uid            = $data['backendUserUid'] ?? 0;
+        $groupIds       = $data['backendGroupIds'] ?? [];
+        $serviceAccount = $data['serviceAccount'] ?? null;
+
+        return new self(
+            is_int($uid) ? $uid : 0,
+            ($data['isAdmin'] ?? false) === true,
+            is_array($groupIds) ? array_values(array_filter($groupIds, is_int(...))) : [],
+            is_string($serviceAccount) && $serviceAccount !== '' ? $serviceAccount : null,
+        );
+    }
+
     public function isServiceAccount(): bool
     {
         return $this->serviceAccount !== null;
@@ -103,5 +126,21 @@ final readonly class AiActorContext
         }
 
         return 'an unauthenticated caller';
+    }
+
+    /**
+     * The serialised form persisted with a queued run so a worker can restore
+     * the full actor (not just a backend-user id) via {@see fromArray()}.
+     *
+     * @return array{backendUserUid: int, isAdmin: bool, backendGroupIds: list<int>, serviceAccount: string|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'backendUserUid'  => $this->backendUserUid,
+            'isAdmin'         => $this->isAdmin,
+            'backendGroupIds' => $this->backendGroupIds,
+            'serviceAccount'  => $this->serviceAccount,
+        ];
     }
 }

--- a/Classes/Service/Agent/AgentRunRequest.php
+++ b/Classes/Service/Agent/AgentRunRequest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Agent;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
@@ -35,18 +36,24 @@ final readonly class AgentRunRequest
      *                                                                 loop default. The runtime clamps a
      *                                                                 non-null value to its ceiling
      *                                                                 ({@see AgentRuntime::MAX_ITERATIONS}).
-     * @param int                                    $beUserUid        the initiating backend user, recorded
-     *                                                                 on the run row and used for the budget
-     *                                                                 pre-flight (0 = anonymous)
+     * @param AiActorContext                         $actor            who initiated the run — the full identity
+     *                                                                 (backend user + admin flag + groups, or a
+     *                                                                 service account). Persisted with a queued
+     *                                                                 run and restored in the worker so a run
+     *                                                                 authorises identically whether it executes
+     *                                                                 synchronously or on a worker (ADR-083),
+     *                                                                 rather than inheriting the worker's absent
+     *                                                                 ambient BE user. Also drives the budget
+     *                                                                 pre-flight and the run-row attribution.
      */
     public function __construct(
         public LlmConfiguration $configuration,
         public array $messages,
+        public AiActorContext $actor,
         public ?array $allowedToolNames = null,
         public ?ToolOptions $options = null,
         public ?int $maxIterations = null,
         public ?RunAugmentation $augmentation = null,
         public bool $captureRaw = false,
-        public int $beUserUid = 0,
     ) {}
 }

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
@@ -122,7 +123,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
     public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult
     {
-        $handle = $this->persister->begin($request->configuration, $request->beUserUid);
+        $handle = $this->persister->begin($request->configuration, $request->actor->backendUserUid);
 
         return $this->executeRequest($request, $handle, $onStep);
     }
@@ -149,7 +150,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
         // Fail-closed, unlike run(): a live run can proceed unpersisted, but a
         // queued run without a stored row simply does not exist.
-        $handle = $this->persister->enqueue($request->configuration, $request->beUserUid, $requestJson);
+        $handle = $this->persister->enqueue($request->configuration, $request->actor->backendUserUid, $requestJson);
         if ($handle === null) {
             throw RunEnqueueFailedException::forRun('');
         }
@@ -391,6 +392,11 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m,
                 $request->messages,
             ),
+            // The FULL initiating actor (ADR-083), not just its backend-user id:
+            // a worker rehydrating this run must authorise with the identity that
+            // enqueued the work — admin flag, groups, service account — rather
+            // than the worker's absent ambient BE user.
+            'actor'            => $request->actor->toArray(),
             'allowedToolNames' => $request->allowedToolNames,
             'options'          => $request->options?->toArray(),
             // ToolOptions::toArray() deliberately excludes the budget fields and
@@ -487,15 +493,27 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             );
         }
 
+        // Restore the full initiating actor from the serialised request. A row
+        // queued before actors were persisted has no 'actor' key: fall back to
+        // the stored be_user id (the same single-int identity the pre-actor
+        // worker had), so an in-flight upgrade never loses or invents privilege.
+        $actorData = $data['actor'] ?? null;
+        if (is_array($actorData)) {
+            /** @var array<string, mixed> $actorData a serialised actor is a JSON object (string keys) */
+            $actor = AiActorContext::fromArray($actorData);
+        } else {
+            $actor = AiActorContext::backendUser($run->beUser);
+        }
+
         return new AgentRunRequest(
             configuration: $configuration,
             messages: $messages,
+            actor: $actor,
             allowedToolNames: $allowed,
             options: $options,
             maxIterations: is_int($data['maxIterations'] ?? null) ? $data['maxIterations'] : null,
             augmentation: $augmentation,
             captureRaw: ($data['captureRaw'] ?? false) === true,
-            beUserUid: $run->beUser,
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
@@ -521,6 +522,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             new AgentRunRequest(
                 configuration: $config,
                 messages: [ChatMessage::user('analyse the logs')],
+                actor: AiActorContext::anonymous(),
                 allowedToolNames: ['fetch_logs'],
                 options: new ToolOptions(),
             ),
@@ -635,6 +637,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             new AgentRunRequest(
                 configuration: $config,
                 messages: [ChatMessage::user('do it')],
+                actor: AiActorContext::anonymous(),
                 allowedToolNames: ['fetch_logs'],
                 options: new ToolOptions(),
             ),

--- a/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
+++ b/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AiActorContext::class)]
+final class AiActorContextTest extends TestCase
+{
+    #[Test]
+    public function aBackendUserActorSurvivesTheQueueRoundTrip(): void
+    {
+        // ADR-083: the full identity — uid, admin flag AND group uids — must
+        // survive serialisation, so a worker restores it instead of collapsing
+        // to a bare backend-user id.
+        $actor = AiActorContext::backendUser(9, isAdmin: true, backendGroupIds: [3, 4]);
+
+        $restored = AiActorContext::fromArray($actor->toArray());
+
+        self::assertSame(9, $restored->backendUserUid);
+        self::assertTrue($restored->isAdmin);
+        self::assertSame([3, 4], $restored->backendGroupIds);
+        self::assertNull($restored->serviceAccount);
+    }
+
+    #[Test]
+    public function aServiceAccountAndAnAnonymousActorSurviveTheRoundTrip(): void
+    {
+        $service = AiActorContext::fromArray(AiActorContext::serviceAccount('nightly-import')->toArray());
+        self::assertTrue($service->isServiceAccount());
+        self::assertSame('nightly-import', $service->serviceAccount);
+
+        $anon = AiActorContext::fromArray(AiActorContext::anonymous()->toArray());
+        self::assertFalse($anon->isAuthenticated());
+        self::assertSame(0, $anon->backendUserUid);
+    }
+
+    #[Test]
+    public function fromArrayFailsClosedAndNeverInventsPrivilege(): void
+    {
+        // A malformed / truncated row must never rebuild a MORE privileged actor
+        // than was stored: unknown or wrong-typed fields degrade to the
+        // least-privileged default.
+        $actor = AiActorContext::fromArray([
+            'backendUserUid'  => 'not-an-int',   // -> 0
+            'isAdmin'         => '1',            // not true -> false
+            'backendGroupIds' => [5, 'x', 6],    // non-ints filtered out
+            'serviceAccount'  => '',            // empty -> null
+        ]);
+
+        self::assertSame(0, $actor->backendUserUid);
+        self::assertFalse($actor->isAdmin);
+        self::assertSame([5, 6], $actor->backendGroupIds);
+        self::assertNull($actor->serviceAccount);
+        self::assertFalse($actor->isAuthenticated());
+    }
+
+    #[Test]
+    public function fromArrayOnAnEmptyRowIsAnonymous(): void
+    {
+        $actor = AiActorContext::fromArray([]);
+
+        self::assertFalse($actor->isAdmin);
+        self::assertFalse($actor->isServiceAccount());
+        self::assertSame(0, $actor->backendUserUid);
+        self::assertSame([], $actor->backendGroupIds);
+    }
+}

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
@@ -545,7 +546,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             options: (new ToolOptions(temperature: 0.5, plannedCost: 1.25))->withIdempotencyKey('idem-1'),
             maxIterations: 50,
             captureRaw: true,
-            beUserUid: 9,
+            actor: AiActorContext::backendUser(9),
         ));
 
         $this->repository->findResult = $this->queuedRun($uuid, $this->repository->enqueuedRuns[0]['requestJson']);
@@ -1112,7 +1113,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             configuration: new LlmConfiguration(),
             messages: [ChatMessage::user('go')],
             maxIterations: $maxIterations,
-            beUserUid: 9,
+            actor: AiActorContext::backendUser(9),
         );
     }
 


### PR DESCRIPTION
## Summary

**First slice of P0 #1 (Actor Context) — the 0.24 hardening roadmap.** Today a queued run persists only a backend-user id, and the worker rehydrates it as `beUserUid: $run->beUser` — the admin flag, backend groups and any service-account identity are **lost**, so the same run can authorise differently on a worker than it did synchronously. This slice makes the run request carry the whole identity and round-trip it through the queue.

## What changed

- **`AgentRunRequest`**: `int $beUserUid` → required **`AiActorContext $actor`** (backend user + admin flag + groups, or a service account).
- **`AiActorContext`** gains `toArray()`/`fromArray()`. `fromArray` **fails closed** — every unknown/wrong-typed field degrades to its least-privileged default, so a malformed or truncated row can never rebuild a *more* privileged actor.
- **`AgentRuntime::dehydrateRequest()`** serialises the actor into `queued_request`; **`rehydrateRequest()`** restores it, falling back to the stored `be_user` id for a row queued *before* this change (no lost or invented privilege across an in-flight upgrade).
- The actor is **born at the HTTP boundary**: `BackendUserUidTrait::currentActor()` captures uid + `isAdmin` + group uids from `$GLOBALS['BE_USER']` once, and the playground controller passes it. Everything downstream carries the actor explicitly.

## Scope

Deliberately **plumbing only** — no tool yet consumes the restored actor for authorization. That is slice **1b** (`ToolExecutionContext`, removing ambient `$GLOBALS['BE_USER']` from the 18 tool sites). Slices **1c** (actor on `approve`/`submitInput`/`cancel`/`status`/`events`) and **1d** (service-account scopes) follow.

## ⚠️ Breaking change

`AgentRunRequest`'s constructor replaces `int $beUserUid = 0` with a required `AiActorContext $actor` (3rd positional parameter). Callers build it via `AiActorContext::backendUser()` / `serviceAccount()` / `anonymous()`. This is expected for the 0.24 breaking-change budget.

## Test plan

`AiActorContextTest` covers the round-trip (backend user incl. admin + groups, service account, anonymous) and the fail-closed reconstruction; the existing `enqueue → runQueued` round-trip now carries an actor. Full local gate green (PHP 8.5): cgl, phpstan (L10), unit (5586), rector, fuzzy (79), functional `-d sqlite` (1262).
