### PR TITLE
refactor(agent)!: require an actor for run approve/submitInput/cancel/status/events (P0 #1, slice 1c)

### DIFF
--- a/Classes/Command/CancelAgentRunCommand.php
+++ b/Classes/Command/CancelAgentRunCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -61,7 +62,7 @@ final class CancelAgentRunCommand extends Command
             return Command::INVALID;
         }
 
-        if (!$this->agentRuntime->cancel($uuid)) {
+        if (!$this->agentRuntime->cancel(AiActorContext::serviceAccount('cli:nrllm:agent:cancel'), $uuid)) {
             $io->warning(sprintf('Run "%s" was not cancelled: it is unknown or already finished.', $uuid));
 
             return Command::FAILURE;

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -124,6 +124,7 @@ final class AgentRunController extends ActionController
 
         try {
             $result = $this->agentRuntime->approve(
+                $this->currentActor(),
                 $runUuid,
                 new ApprovalDecision($approve, $this->currentBackendUserUid()),
             );
@@ -169,6 +170,7 @@ final class AgentRunController extends ActionController
 
         try {
             $result = $this->agentRuntime->submitInput(
+                $this->currentActor(),
                 $runUuid,
                 new InputSubmission($data, $this->currentBackendUserUid()),
             );

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -226,6 +226,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         try {
             $result = $this->agentRuntime->approve(
+                $this->currentActor(),
                 $runUuid,
                 new ApprovalDecision($approved, $this->currentBackendUserUid()),
             );
@@ -262,6 +263,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
         try {
             $result = $this->agentRuntime->submitInput(
+                $this->currentActor(),
                 $runUuid,
                 new InputSubmission($this->inputDataFromBody($body), $this->currentBackendUserUid()),
             );

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -112,6 +112,21 @@ final readonly class AiActorContext
     }
 
     /**
+     * Whether this actor may act on (approve, submit input to, cancel, read) the
+     * given agent run (ADR-083): the run's initiator, an administrator, or a
+     * service account acting on the system's behalf. A run UUID alone is never
+     * enough — a stranger who guesses a uuid must not drive somebody else's run.
+     */
+    public function mayActOnRun(AgentRun $run): bool
+    {
+        if ($this->isServiceAccount() || $this->isAdmin) {
+            return true;
+        }
+
+        return $this->backendUserUid > 0 && $this->backendUserUid === $run->beUser;
+    }
+
+    /**
      * A short, log-safe description of the actor for exception messages and
      * audit entries. Never contains a session uuid or any content.
      */

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
@@ -617,11 +618,14 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         return substr(($host !== false ? $host : 'unknown') . ':' . getmypid(), 0, 64);
     }
 
-    public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
+    public function approve(AiActorContext $actor, string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
     {
         $run = $this->persister->findRun($runUuid);
         if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
             throw RunNotAwaitingApprovalException::forRun($runUuid);
+        }
+        if (!$actor->mayActOnRun($run)) {
+            throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
 
         $configuration = $this->configurationRepository->findByUid($run->configurationUid);
@@ -694,11 +698,14 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         );
     }
 
-    public function submitInput(string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
+    public function submitInput(AiActorContext $actor, string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
     {
         $run = $this->persister->findRun($runUuid);
         if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
             throw RunNotAwaitingInputException::forRun($runUuid);
+        }
+        if (!$actor->mayActOnRun($run)) {
+            throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
 
         $configuration = $this->configurationRepository->findByUid($run->configurationUid);
@@ -774,15 +781,22 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         );
     }
 
-    public function cancel(string $runUuid): bool
+    public function cancel(AiActorContext $actor, string $runUuid): bool
     {
+        // Authorised like approve/submitInput: only the run's owner, an admin or
+        // a service account may cancel it (a guessed uuid is never enough).
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || !$actor->mayActOnRun($run)) {
+            return false;
+        }
+
         return $this->persister->cancel($runUuid);
     }
 
-    public function events(string $runUuid, int $afterSequence = -1): array
+    public function events(AiActorContext $actor, string $runUuid, int $afterSequence = -1): array
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null) {
+        if ($run === null || !$actor->mayActOnRun($run)) {
             return [];
         }
 
@@ -790,11 +804,16 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         return $this->persister->findEvents($run->uid, $afterSequence);
     }
 
-    public function status(string $runUuid): ?AgentRun
+    public function status(AiActorContext $actor, string $runUuid): ?AgentRun
     {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || !$actor->mayActOnRun($run)) {
+            return null;
+        }
+
         // The raw suspended transcript bypasses the privacy filter (it must —
         // resume needs it verbatim); the status surface must not expose it.
-        return $this->persister->findRun($runUuid)?->withoutSuspendedState();
+        return $run->withoutSuspendedState();
     }
 
     /**

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Agent;
 use Closure;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Service\Agent\Exception\AgentRuntimeException;
 
@@ -96,7 +97,7 @@ interface AgentRuntimeInterface
      *                               RunConfigurationGone, CorruptSuspendedState,
      *                               RunStateUnavailable, RunAlreadyResuming
      */
-    public function approve(string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
+    public function approve(AiActorContext $actor, string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult;
 
     /**
      * Submit typed input for a run suspended WAITING_FOR_INPUT (ADR-105) and
@@ -122,7 +123,7 @@ interface AgentRuntimeInterface
      *                               InvalidInputSubmission, RunStateUnavailable,
      *                               RunAlreadyResuming
      */
-    public function submitInput(string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult;
+    public function submitInput(AiActorContext $actor, string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult;
 
     /**
      * Cancel a run that is still queued, running or awaiting a decision. True
@@ -136,7 +137,7 @@ interface AgentRuntimeInterface
      * to whoever drove the run. A step already in flight (a provider call, a
      * tool) runs to its boundary — cancellation is not a signal.
      */
-    public function cancel(string $runUuid): bool;
+    public function cancel(AiActorContext $actor, string $runUuid): bool;
 
     /**
      * The persisted event stream of a run, ordered by sequence ascending —
@@ -146,7 +147,7 @@ interface AgentRuntimeInterface
      *
      * @return list<AgentRunEvent>
      */
-    public function events(string $runUuid, int $afterSequence = -1): array;
+    public function events(AiActorContext $actor, string $runUuid, int $afterSequence = -1): array;
 
     /**
      * The persisted run row, or null when unknown. The suspended-state
@@ -154,5 +155,5 @@ interface AgentRuntimeInterface
      * the privacy filter every event goes through (ADR-064), so it is not
      * part of the status surface.
      */
-    public function status(string $runUuid): ?AgentRun;
+    public function status(AiActorContext $actor, string $runUuid): ?AgentRun;
 }

--- a/Classes/Service/Agent/Exception/RunAccessDeniedException.php
+++ b/Classes/Service/Agent/Exception/RunAccessDeniedException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+
+/**
+ * The acting caller may not act on this run (ADR-083): approving, submitting
+ * input to, or cancelling a run belongs to its initiator, an administrator, or a
+ * service account. A run UUID alone is never sufficient authorization — this is
+ * thrown so a stranger who guesses a uuid cannot drive somebody else's run.
+ */
+final class RunAccessDeniedException extends AgentRuntimeException
+{
+    public static function forActor(AiActorContext $actor, string $runUuid): self
+    {
+        return new self(
+            $runUuid,
+            sprintf('%s may not act on run %s.', ucfirst($actor->describe()), $runUuid !== '' ? $runUuid : 'unknown'),
+        );
+    }
+}

--- a/Tests/Unit/Command/CancelAgentRunCommandTest.php
+++ b/Tests/Unit/Command/CancelAgentRunCommandTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Command;
 
 use Netresearch\NrLlm\Command\CancelAgentRunCommand;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,7 +25,7 @@ final class CancelAgentRunCommandTest extends TestCase
     public function cancelsARunThroughTheRuntimeAndReportsSuccess(): void
     {
         $runtime = $this->createMock(AgentRuntimeInterface::class);
-        $runtime->expects(self::once())->method('cancel')->with('run-uuid-1')->willReturn(true);
+        $runtime->expects(self::once())->method('cancel')->with(self::isInstanceOf(AiActorContext::class), 'run-uuid-1')->willReturn(true);
 
         $tester = new CommandTester(new CancelAgentRunCommand($runtime));
         $exit   = $tester->execute(['uuid' => 'run-uuid-1']);

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -31,6 +31,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
@@ -330,7 +331,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             },
         );
 
-        $result = $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(true, 42));
+        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 42));
 
         self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
         self::assertSame($loopResult, $result->loopResult);
@@ -358,7 +359,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->maxSequenceReturns = [4, 9];
 
         $this->runtime($this->loopReturning($this->loopResult('continued')))
-            ->approve('run-uuid-1', new ApprovalDecision(true, 1));
+            ->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
 
         self::assertNotSame([], $this->repository->events);
         self::assertSame(10, $this->repository->events[0]['sequence']);
@@ -370,7 +371,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = null;
 
         $this->expectException(RunNotAwaitingApprovalException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('unknown', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'unknown', new ApprovalDecision(true, 1));
     }
 
     #[Test]
@@ -379,7 +380,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun(status: 'completed');
 
         $this->expectException(RunNotAwaitingApprovalException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
     }
 
     #[Test]
@@ -388,7 +389,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun();
 
         $this->expectException(RunConfigurationGoneException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->approve('run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
     }
 
     #[Test]
@@ -397,7 +398,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun(stateJson: 'not-json{');
 
         $this->expectException(CorruptSuspendedStateException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
     }
 
     #[Test]
@@ -407,7 +408,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->throwOnMaxSequence = true;
 
         try {
-            $this->runtime($this->loopReturning($this->loopResult('x')))->approve('run-uuid-1', new ApprovalDecision(true, 1));
+            $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
             self::fail('Expected RunStateUnavailableException');
         } catch (RunStateUnavailableException) {
             // Fail-closed BEFORE the claim: the run is still suspended, so the
@@ -429,7 +430,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         });
 
         $this->expectException(RunAlreadyResumingException::class);
-        $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
     }
 
     #[Test]
@@ -447,7 +448,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             },
         );
 
-        $result = $this->runtime($loop)->approve('run-uuid-1', new ApprovalDecision(false, 7));
+        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(false, 7));
 
         // A denial does not terminate the run: the loop continues from the
         // refusal message (ADR-084) — and the denial is on the audit stream.
@@ -464,7 +465,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $again = $this->suspendedState();
 
         $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($again), onResume: true));
-        $result  = $runtime->approve('run-uuid-1', new ApprovalDecision(true, 1));
+        $result  = $runtime->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
 
         self::assertSame(AgentRunOutcome::AWAITING_APPROVAL, $result->outcome);
         self::assertSame($again, $result->suspendedState);
@@ -865,7 +866,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->inputRun();
 
         $result = $this->runtime($this->loopReturning($this->loopResult('answered')))
-            ->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+            ->submitInput($this->actor(), 'run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
 
         self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
         // The claim was consumed exactly once and an INPUT audit event recorded.
@@ -884,7 +885,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
 
         try {
-            $runtime->submitInput('run-uuid-i', new InputSubmission([], 7));
+            $runtime->submitInput($this->actor(), 'run-uuid-i', new InputSubmission([], 7));
             self::fail('Expected InvalidInputSubmissionException');
         } catch (InvalidInputSubmissionException) {
             // expected
@@ -902,7 +903,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
 
         // Unknown run.
         $this->expectException(RunNotAwaitingInputException::class);
-        $runtime->submitInput('unknown', new InputSubmission(['city' => 'Berlin'], 7));
+        $runtime->submitInput($this->actor(), 'unknown', new InputSubmission(['city' => 'Berlin'], 7));
     }
 
     #[Test]
@@ -918,7 +919,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
 
         $this->expectException(CorruptSuspendedStateException::class);
-        $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+        $runtime->submitInput($this->actor(), 'run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
     }
 
     #[Test]
@@ -928,12 +929,12 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $runtime = $this->runtime($this->loopReturning($this->loopResult('answered')));
 
         // First submission wins the atomic claim and resumes.
-        $first = $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
+        $first = $runtime->submitInput($this->actor(), 'run-uuid-i', new InputSubmission(['city' => 'Berlin'], 7));
         self::assertSame(AgentRunOutcome::COMPLETED, $first->outcome);
 
         // A second submission (the fixture grants only the first claim) is refused.
         $this->expectException(RunAlreadyResumingException::class);
-        $runtime->submitInput('run-uuid-i', new InputSubmission(['city' => 'Hamburg'], 7));
+        $runtime->submitInput($this->actor(), 'run-uuid-i', new InputSubmission(['city' => 'Hamburg'], 7));
     }
 
     #[Test]
@@ -941,7 +942,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     {
         $this->repository->findResult = $this->suspendedRun();
 
-        self::assertTrue($this->runtime($this->loopReturning($this->loopResult('x')))->cancel('run-uuid-1'));
+        self::assertTrue($this->runtime($this->loopReturning($this->loopResult('x')))->cancel($this->actor(), 'run-uuid-1'));
         self::assertNotNull($this->repository->finished);
         self::assertSame(AgentRunStatus::CANCELLED->value, $this->repository->finished['status']);
     }
@@ -951,7 +952,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     {
         $runtime = $this->runtime($this->loopReturning($this->loopResult('x')));
 
-        self::assertSame([], $runtime->events('unknown'));
+        self::assertSame([], $runtime->events($this->actor(), 'unknown'));
 
         $this->repository->findResult     = $this->suspendedRun();
         $this->repository->eventsToReturn = [
@@ -960,8 +961,8 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             new AgentRunEvent(3, 1, 2, 'tool', 1, 0.0, [], 0),
         ];
 
-        self::assertCount(3, $runtime->events('run-uuid-1'));
-        $paged = $runtime->events('run-uuid-1', 0);
+        self::assertCount(3, $runtime->events($this->actor(), 'run-uuid-1'));
+        $paged = $runtime->events($this->actor(), 'run-uuid-1', 0);
         self::assertCount(2, $paged);
         self::assertSame(1, $paged[0]->sequence);
     }
@@ -972,7 +973,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun();
         $runtime                      = $this->runtime($this->loopReturning($this->loopResult('x')));
 
-        $status = $runtime->status('run-uuid-1');
+        $status = $runtime->status($this->actor(), 'run-uuid-1');
 
         self::assertNotNull($status);
         self::assertSame('run-uuid-1', $status->uuid);
@@ -1112,6 +1113,48 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         );
 
         return $loop;
+    }
+
+    #[Test]
+    public function approveIsDeniedForANonOwnerNonAdmin(): void
+    {
+        // The run is owned by uid 9; a different, non-admin backend user must not
+        // approve it — a guessed uuid is never authorization (ADR-083).
+        $this->repository->findResult = $this->suspendedRun();
+
+        $this->expectException(RunAccessDeniedException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))
+            ->approve(AiActorContext::backendUser(5), 'run-uuid-1', new ApprovalDecision(true, 5));
+    }
+
+    #[Test]
+    public function cancelIsDeniedForANonOwnerNonAdmin(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+
+        // A stranger cannot cancel someone else's run: reported not-cancelled.
+        self::assertFalse(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->cancel(AiActorContext::backendUser(5), 'run-uuid-1'),
+        );
+    }
+
+    #[Test]
+    public function statusHidesARunFromANonOwnerNonAdmin(): void
+    {
+        $this->repository->findResult = $this->suspendedRun();
+
+        // Reading is scoped too: a stranger sees null, not another user's run.
+        self::assertNull(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->status(AiActorContext::backendUser(5), 'run-uuid-1'),
+        );
+    }
+
+    private function actor(): AiActorContext
+    {
+        // Owner (uid 9, matching request()) AND admin -> always authorised, so the
+        // lifecycle assertions are not gated by mayActOnRun. Authorization itself
+        // is covered by dedicated cases.
+        return AiActorContext::backendUser(9, isAdmin: true);
     }
 
     private function request(?int $maxIterations = null): AgentRunRequest


### PR DESCRIPTION
## What

Slice 1c of P0 #1 (thread `AiActorContext` through the agent runtime). The five **state-changing / observing** entry points of `AgentRuntimeInterface` now require an explicit actor and authorize it fail-closed, so a run uuid alone is never sufficient to drive or read somebody else's run (ADR-083).

Builds on slice 1a (#507, actor carried through a queued run) and slice 1b (#508, tools authorized from an explicit actor).

## Changes

- **`AiActorContext::mayActOnRun(AgentRun): bool`** — the run's initiator, an administrator, or a service account may act; everyone else is denied.
- **`AgentRuntimeInterface`** — `approve`, `submitInput`, `cancel`, `status`, `events` gain a required `AiActorContext $actor` first parameter.
- **`AgentRuntime`** — enforces `mayActOnRun` on every one of those five methods:
  - `approve` / `submitInput` → throw `RunAccessDeniedException` (a mutation the caller asked for and may not have).
  - `cancel` → `false`, `status` → `null`, `events` → `[]` (an unauthorized reader is indistinguishable from an unknown run — no existence oracle).
- **`RunAccessDeniedException`** (new) — `extends AgentRuntimeException`, log-safe `forActor()` message (no uuid-guessing oracle, no content).
- **Callers wired to a real actor:**
  - `AgentRunController` + `ToolPlaygroundController` pass `currentActor()` (BE_USER → actor at the HTTP boundary).
  - `CancelAgentRunCommand` passes a named service-account actor (`cli:nrllm:agent:cancel`).

## Tests

- New authorization tests in `AgentRuntimeTest`: a non-owner backend user (`AiActorContext::backendUser(5)`) is denied on `approve` / `cancel` / `status` against a run owned by user 9.
- `CancelAgentRunCommandTest` updated for the new actor-first `cancel` signature.

## Breaking change

`AgentRuntimeInterface` is a **consumer** interface (call it, don't implement it outside nr_llm). The five signatures change; in-tree callers are all updated in this PR. Pre-1.0, before 0.24.0.

## Gate

`cgl`, `phpstan` (level 10), `unit`, `rector -n`, `fuzzy`, `functional -d sqlite` — all green locally.
