### PR TITLE
feat(agent)!: gate service accounts by declared scopes, fail-closed (P0 #1, slice 1d)

### DIFF
--- a/Classes/Command/CancelAgentRunCommand.php
+++ b/Classes/Command/CancelAgentRunCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -62,7 +63,8 @@ final class CancelAgentRunCommand extends Command
             return Command::INVALID;
         }
 
-        if (!$this->agentRuntime->cancel(AiActorContext::serviceAccount('cli:nrllm:agent:cancel'), $uuid)) {
+        $actor = AiActorContext::serviceAccount('cli:nrllm:agent:cancel', [ServiceAccountScope::AGENT_CANCEL]);
+        if (!$this->agentRuntime->cancel($actor, $uuid)) {
             $io->warning(sprintf('Run "%s" was not cancelled: it is unknown or already finished.', $uuid));
 
             return Command::FAILURE;

--- a/Classes/Domain/Enum/ServiceAccountScope.php
+++ b/Classes/Domain/Enum/ServiceAccountScope.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * A capability a non-interactive service account is permitted (ADR-110).
+ *
+ * A backend user is authorised by ownership and admin rights; a service account
+ * (CLI, scheduler task, queue worker — {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::serviceAccount()})
+ * owns nothing and has no backend privileges, so it would otherwise have to be
+ * trusted for everything. Instead it carries an explicit, minimal set of scopes,
+ * and every entry point a service account can reach checks the ONE scope that
+ * entry point requires. Fail-closed: a service account declaring no scopes may
+ * do nothing, so a narrow automation (a nightly cancel sweep) can never be
+ * escalated into full access by guessing a uuid or session id.
+ *
+ * Each case maps to exactly one enforcement point — there is no wildcard scope,
+ * so a new automation must name precisely what it needs.
+ */
+enum ServiceAccountScope: string
+{
+    /**
+     * Approve or submit input to a run suspended for a human decision
+     * ({@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::approve()},
+     * {@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::submitInput()}).
+     */
+    case AGENT_APPROVE = 'agent:approve';
+
+    /**
+     * Cancel a queued, running or suspended run
+     * ({@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::cancel()}).
+     */
+    case AGENT_CANCEL = 'agent:cancel';
+
+    /**
+     * Read a run's status and event stream
+     * ({@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::status()},
+     * {@see \Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface::events()}).
+     */
+    case AGENT_READ = 'agent:read';
+
+    /**
+     * Read and continue a conversation session on the system's behalf
+     * ({@see \Netresearch\NrLlm\Service\Feature\ConversationService::send()}).
+     */
+    case CONVERSATION_ACCESS = 'conversation:access';
+
+    /**
+     * Use an LLM configuration that is restricted to specific backend groups
+     * ({@see \Netresearch\NrLlm\Service\ConfigurationResolver}).
+     */
+    case CONFIGURATION_USE = 'configuration:use';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $c): string => $c->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+}

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+
 /**
  * Who is driving an AI call (ADR-083).
  *
@@ -26,13 +28,15 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 final readonly class AiActorContext
 {
     /**
-     * @param list<int> $backendGroupIds The actor's backend group uids, used to evaluate configuration access restrictions (ADR-070).
+     * @param list<int>                 $backendGroupIds The actor's backend group uids, used to evaluate configuration access restrictions (ADR-070).
+     * @param list<ServiceAccountScope> $scopes          The capabilities a service account is permitted (ADR-110); empty (and irrelevant) for a backend user, who is authorised by ownership and admin rights instead.
      */
     private function __construct(
         public int $backendUserUid,
         public bool $isAdmin,
         public array $backendGroupIds,
         public ?string $serviceAccount,
+        public array $scopes = [],
     ) {}
 
     /**
@@ -47,12 +51,15 @@ final readonly class AiActorContext
 
     /**
      * A non-interactive caller — CLI, scheduler task or queue worker. It owns
-     * nothing, so it may act on any session; the name is recorded so an
-     * operator can tell which automation ran.
+     * nothing and has no backend privileges, so it is authorised solely by the
+     * scopes it declares (ADR-110): with none it may do nothing. The name is
+     * recorded so an operator can tell which automation ran.
+     *
+     * @param list<ServiceAccountScope> $scopes
      */
-    public static function serviceAccount(string $name): self
+    public static function serviceAccount(string $name, array $scopes = []): self
     {
-        return new self(0, false, [], $name);
+        return new self(0, false, [], $name, array_values($scopes));
     }
 
     /**
@@ -79,18 +86,53 @@ final readonly class AiActorContext
         $uid            = $data['backendUserUid'] ?? 0;
         $groupIds       = $data['backendGroupIds'] ?? [];
         $serviceAccount = $data['serviceAccount'] ?? null;
+        $scopes         = $data['scopes'] ?? [];
 
         return new self(
             is_int($uid) ? $uid : 0,
             ($data['isAdmin'] ?? false) === true,
             is_array($groupIds) ? array_values(array_filter($groupIds, is_int(...))) : [],
             is_string($serviceAccount) && $serviceAccount !== '' ? $serviceAccount : null,
+            is_array($scopes) ? self::decodeScopes($scopes) : [],
         );
+    }
+
+    /**
+     * Restore the scope set from its serialised string form, dropping anything
+     * that is not a known scope value — so a truncated or tampered row can never
+     * yield a scope the process does not define (fail-closed).
+     *
+     * @param array<array-key, mixed> $values
+     *
+     * @return list<ServiceAccountScope>
+     */
+    private static function decodeScopes(array $values): array
+    {
+        $scopes = [];
+        foreach ($values as $value) {
+            $scope = is_string($value) ? ServiceAccountScope::tryFrom($value) : null;
+            if ($scope !== null) {
+                $scopes[] = $scope;
+            }
+        }
+
+        return $scopes;
     }
 
     public function isServiceAccount(): bool
     {
         return $this->serviceAccount !== null;
+    }
+
+    /**
+     * Whether a service account declares the given scope (ADR-110). Always false
+     * for a backend user or an anonymous caller: scopes govern service accounts
+     * only, so an entry point must combine this with its own ownership/admin
+     * check rather than relying on scopes for interactive callers.
+     */
+    public function hasScope(ServiceAccountScope $scope): bool
+    {
+        return in_array($scope, $this->scopes, true);
     }
 
     public function isAuthenticated(): bool
@@ -100,27 +142,39 @@ final readonly class AiActorContext
 
     /**
      * Whether this actor may read and continue the given session: its owner, an
-     * administrator, or a service account acting on the system's behalf.
+     * administrator, or a service account that declares the
+     * {@see ServiceAccountScope::CONVERSATION_ACCESS} scope (ADR-110). A scopeless
+     * service account is denied — knowing a session uuid is never enough.
      */
     public function mayAccessSession(AiSession $session): bool
     {
-        if ($this->isServiceAccount() || $this->isAdmin) {
+        if ($this->isAdmin) {
             return true;
+        }
+
+        if ($this->isServiceAccount()) {
+            return $this->hasScope(ServiceAccountScope::CONVERSATION_ACCESS);
         }
 
         return $this->backendUserUid > 0 && $this->backendUserUid === $session->beUser;
     }
 
     /**
-     * Whether this actor may act on (approve, submit input to, cancel, read) the
-     * given agent run (ADR-083): the run's initiator, an administrator, or a
-     * service account acting on the system's behalf. A run UUID alone is never
-     * enough — a stranger who guesses a uuid must not drive somebody else's run.
+     * Whether this actor may perform the operation identified by $scope on the
+     * given agent run (ADR-083/110): the run's initiator, an administrator, or a
+     * service account that declares exactly that scope. A run UUID alone is never
+     * enough — a stranger who guesses a uuid must not drive somebody else's run,
+     * and a service account is limited to the operations it was granted (a cancel
+     * sweep cannot also approve or read).
      */
-    public function mayActOnRun(AgentRun $run): bool
+    public function mayActOnRun(AgentRun $run, ServiceAccountScope $scope): bool
     {
-        if ($this->isServiceAccount() || $this->isAdmin) {
+        if ($this->isAdmin) {
             return true;
+        }
+
+        if ($this->isServiceAccount()) {
+            return $this->hasScope($scope);
         }
 
         return $this->backendUserUid > 0 && $this->backendUserUid === $run->beUser;
@@ -147,7 +201,7 @@ final readonly class AiActorContext
      * The serialised form persisted with a queued run so a worker can restore
      * the full actor (not just a backend-user id) via {@see fromArray()}.
      *
-     * @return array{backendUserUid: int, isAdmin: bool, backendGroupIds: list<int>, serviceAccount: string|null}
+     * @return array{backendUserUid: int, isAdmin: bool, backendGroupIds: list<int>, serviceAccount: string|null, scopes: list<string>}
      */
     public function toArray(): array
     {
@@ -156,6 +210,7 @@ final readonly class AiActorContext
             'isAdmin'         => $this->isAdmin,
             'backendGroupIds' => $this->backendGroupIds,
             'serviceAccount'  => $this->serviceAccount,
+            'scopes'          => array_map(static fn(ServiceAccountScope $s): string => $s->value, $this->scopes),
         ];
     }
 }

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -13,6 +13,7 @@ use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -624,7 +625,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
             throw RunNotAwaitingApprovalException::forRun($runUuid);
         }
-        if (!$actor->mayActOnRun($run)) {
+        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
             throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
 
@@ -704,7 +705,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
             throw RunNotAwaitingInputException::forRun($runUuid);
         }
-        if (!$actor->mayActOnRun($run)) {
+        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
             throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
 
@@ -786,7 +787,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // Authorised like approve/submitInput: only the run's owner, an admin or
         // a service account may cancel it (a guessed uuid is never enough).
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run)) {
+        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_CANCEL)) {
             return false;
         }
 
@@ -796,7 +797,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     public function events(AiActorContext $actor, string $runUuid, int $afterSequence = -1): array
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run)) {
+        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
             return [];
         }
 
@@ -807,7 +808,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     public function status(AiActorContext $actor, string $runUuid): ?AgentRun
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run)) {
+        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
             return null;
         }
 

--- a/Classes/Service/ConfigurationResolver.php
+++ b/Classes/Service/ConfigurationResolver.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
@@ -141,9 +142,10 @@ final readonly class ConfigurationResolver
      *
      * The counterpart of {@see self::getActiveByIdentifier()} for callers that
      * do have a caller identity: a group-restricted configuration resolves when
-     * the actor is an administrator, a service account, or a member of one of
-     * the configuration's backend groups. Unlike
-     * {@see \Netresearch\NrLlm\Service\LlmConfigurationService::hasAccess()},
+     * the actor is an administrator, a service account that declares the
+     * {@see \Netresearch\NrLlm\Domain\Enum\ServiceAccountScope::CONFIGURATION_USE}
+     * scope (ADR-110), or a member of one of the configuration's backend groups.
+     * Unlike {@see \Netresearch\NrLlm\Service\LlmConfigurationService::hasAccess()},
      * the check runs against the passed actor rather than the ambient
      * `$GLOBALS['BE_USER']`, so a worker can act for the user who queued the
      * work (ADR-070, ADR-083).
@@ -190,8 +192,12 @@ final readonly class ConfigurationResolver
             return true;
         }
 
-        if ($actor->isAdmin || $actor->isServiceAccount()) {
+        if ($actor->isAdmin) {
             return true;
+        }
+
+        if ($actor->isServiceAccount()) {
+            return $actor->hasScope(ServiceAccountScope::CONFIGURATION_USE);
         }
 
         $allowed = [];

--- a/Documentation/Adr/Adr110ServiceAccountScopes.rst
+++ b/Documentation/Adr/Adr110ServiceAccountScopes.rst
@@ -1,0 +1,97 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-110:
+
+============================================================================
+ADR-110: Service account scopes
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-110-context:
+
+Context
+=======
+
+Every stateful entry point now carries an explicit
+:php:`AiActorContext` (:ref:`ADR-091 <adr-091>`) instead of reading
+``$GLOBALS['BE_USER']``. An interactive caller is a backend user, authorised by
+ownership and admin rights. A non-interactive caller — a CLI command, a
+scheduler task, a queue worker — has no backend user, so it identifies itself as
+a named **service account**.
+
+Until now a service account was trusted for *everything*: ``mayAccessSession()``,
+``mayActOnRun()`` and the restricted-configuration gate
+(:php:`ConfigurationResolver`) all returned ``true`` for any service account.
+That is too coarse. A narrow automation — say a nightly job that only cancels
+stale runs — would, the moment it holds a service-account context, also be able
+to approve pending runs, read any conversation, and use configurations
+restricted to other groups. A single over-broad principal is exactly the
+escalation surface the actor context was introduced to close.
+
+.. _adr-110-decision:
+
+Decision
+========
+
+A service account carries an explicit, minimal set of **scopes**
+(:php:`Netresearch\NrLlm\Domain\Enum\ServiceAccountScope`). Each entry point a
+service account can reach checks the one scope it requires; a service account
+that does not declare that scope is denied. Backend users are unaffected —
+scopes govern service accounts only, and :php:`hasScope()` is always ``false``
+for an interactive caller, so an entry point must still combine it with its own
+ownership/admin check.
+
+Fail-closed
+-----------
+
+``serviceAccount($name)`` with no scopes may do **nothing**. A capability is
+granted only by naming it: ``serviceAccount('cli:nrllm:agent:cancel',
+[ServiceAccountScope::AGENT_CANCEL])``. There is no wildcard scope, so a new or
+mis-declared automation can never acquire a capability it did not ask for, and a
+truncated or tampered serialised row drops any value that is not a known scope
+(:php:`AiActorContext::fromArray()`).
+
+One scope per enforcement point
+-------------------------------
+
+The taxonomy is deliberately small — every case maps to exactly one existing
+gate, so there are no unenforced scopes:
+
+- ``agent:approve`` — :php:`AgentRuntime::approve()` / ``submitInput()``
+- ``agent:cancel`` — :php:`AgentRuntime::cancel()`
+- ``agent:read`` — :php:`AgentRuntime::status()` / ``events()``
+- ``conversation:access`` — :php:`ConversationService::send()`
+- ``configuration:use`` — restricted-configuration gate
+
+Run operations do not share one scope: an account granted ``agent:cancel`` can
+cancel but neither read nor approve. This is why :php:`mayActOnRun()` takes the
+required :php:`ServiceAccountScope` rather than deciding one blanket verdict for
+all five run methods.
+
+Scopes round-trip with the actor
+--------------------------------
+
+The queue persists the full actor with a queued run (:ref:`ADR-102 <adr-102>`)
+and rehydrates it in the worker. Scopes are part of that serialisation, so a
+service account that enqueues work resumes with exactly the capabilities it
+started with — never more.
+
+.. _adr-110-consequences:
+
+Consequences
+============
+
+- The single shipped service account (the ``nrllm:agent:cancel`` CLI command)
+  declares ``agent:cancel`` and nothing else.
+- ``enqueue()`` / ``run()`` are **not** gated by a scope: who may start a run is
+  decided by whoever builds the request (a controller behind backend auth, a
+  CLI behind shell access), not by a runtime scope check. A dedicated
+  ``agent:run`` scope is deferred until a service-account caller actually reaches
+  those methods, so no unenforced scope is shipped.
+- ``conversation:access`` is a single read-and-continue capability; a finer
+  read-only vs write split is deferred until a consumer needs it.
+- New service-account callers must declare their scopes explicitly — a scopeless
+  account failing closed is the intended behaviour, not a regression.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -407,3 +407,4 @@ Tools
    Adr107ContextWindowManagement
    Adr108TypedToolResultWithArtifacts
    Adr109AgentRunsApprovalsInbox
+   Adr110ServiceAccountScopes

--- a/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
+++ b/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\AiSession;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -74,5 +76,76 @@ final class AiActorContextTest extends TestCase
         self::assertFalse($actor->isServiceAccount());
         self::assertSame(0, $actor->backendUserUid);
         self::assertSame([], $actor->backendGroupIds);
+    }
+
+    #[Test]
+    public function aServiceAccountIsAuthorisedSolelyByItsDeclaredScopes(): void
+    {
+        // ADR-110: a service account owns nothing, so it may do only what its
+        // scopes name — and a scopeless one may do nothing (fail-closed).
+        $scoped = AiActorContext::serviceAccount('cancel-sweep', [ServiceAccountScope::AGENT_CANCEL]);
+        self::assertTrue($scoped->hasScope(ServiceAccountScope::AGENT_CANCEL));
+        self::assertFalse($scoped->hasScope(ServiceAccountScope::AGENT_APPROVE));
+
+        $scopeless = AiActorContext::serviceAccount('no-grants');
+        self::assertFalse($scopeless->hasScope(ServiceAccountScope::AGENT_CANCEL));
+    }
+
+    #[Test]
+    public function scopesGovernServiceAccountsOnlyNeverBackendUsers(): void
+    {
+        // A backend user is authorised by ownership/admin, never by scopes:
+        // hasScope() is always false for them so an entry point cannot be
+        // tricked into treating an interactive caller as a scoped automation.
+        $admin = AiActorContext::backendUser(9, isAdmin: true);
+        self::assertFalse($admin->hasScope(ServiceAccountScope::CONFIGURATION_USE));
+    }
+
+    #[Test]
+    public function serviceAccountScopesSurviveTheQueueRoundTrip(): void
+    {
+        $actor = AiActorContext::serviceAccount('nightly-import', [
+            ServiceAccountScope::CONVERSATION_ACCESS,
+            ServiceAccountScope::CONFIGURATION_USE,
+        ]);
+
+        $restored = AiActorContext::fromArray($actor->toArray());
+
+        self::assertTrue($restored->hasScope(ServiceAccountScope::CONVERSATION_ACCESS));
+        self::assertTrue($restored->hasScope(ServiceAccountScope::CONFIGURATION_USE));
+        self::assertFalse($restored->hasScope(ServiceAccountScope::AGENT_CANCEL));
+    }
+
+    #[Test]
+    public function fromArrayDropsUnknownScopeStrings(): void
+    {
+        // A tampered/older row must never yield a scope the process does not
+        // define: unknown values are dropped, known ones survive (fail-closed).
+        $actor = AiActorContext::fromArray([
+            'serviceAccount' => 'partial',
+            'scopes'         => ['agent:cancel', 'agent:root', 42, 'conversation:access'],
+        ]);
+
+        self::assertTrue($actor->hasScope(ServiceAccountScope::AGENT_CANCEL));
+        self::assertTrue($actor->hasScope(ServiceAccountScope::CONVERSATION_ACCESS));
+        self::assertFalse($actor->hasScope(ServiceAccountScope::AGENT_APPROVE));
+    }
+
+    #[Test]
+    public function mayAccessSessionIsScopedForServiceAccountsAndOwnedForUsers(): void
+    {
+        $session = new AiSession(1, 'sess-uuid', 42, 'default', '', 0, 0, 0);
+
+        self::assertTrue(AiActorContext::backendUser(42)->mayAccessSession($session), 'owner');
+        self::assertFalse(AiActorContext::backendUser(7)->mayAccessSession($session), 'non-owner');
+        self::assertTrue(AiActorContext::backendUser(7, isAdmin: true)->mayAccessSession($session), 'admin');
+        self::assertTrue(
+            AiActorContext::serviceAccount('w', [ServiceAccountScope::CONVERSATION_ACCESS])->mayAccessSession($session),
+            'scoped service account',
+        );
+        self::assertFalse(
+            AiActorContext::serviceAccount('w')->mayAccessSession($session),
+            'scopeless service account is denied',
+        );
     }
 }

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -1146,6 +1147,50 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         // Reading is scoped too: a stranger sees null, not another user's run.
         self::assertNull(
             $this->runtime($this->loopReturning($this->loopResult('x')))->status(AiActorContext::backendUser(5), 'run-uuid-1'),
+        );
+    }
+
+    #[Test]
+    public function aServiceAccountActsOnlyWithinItsDeclaredScopes(): void
+    {
+        // ADR-110: a service account owns nothing and is authorised solely by the
+        // scope each operation requires. One granted for cancellation may cancel
+        // but neither read nor approve — scopes do not leak across operations.
+        $cancelOnly = AiActorContext::serviceAccount('sweep', [ServiceAccountScope::AGENT_CANCEL]);
+
+        $this->repository->findResult = $this->suspendedRun();
+        self::assertTrue(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->cancel($cancelOnly, 'run-uuid-1'),
+            'cancel scope grants cancel',
+        );
+
+        $this->repository->findResult = $this->suspendedRun();
+        self::assertNull(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->status($cancelOnly, 'run-uuid-1'),
+            'cancel scope does NOT grant read',
+        );
+
+        $this->repository->findResult = $this->suspendedRun();
+        $this->expectException(RunAccessDeniedException::class);
+        $this->runtime($this->loopReturning($this->loopResult('x')))
+            ->approve($cancelOnly, 'run-uuid-1', new ApprovalDecision(true, 5));
+    }
+
+    #[Test]
+    public function aScopelessServiceAccountMayDoNothing(): void
+    {
+        // Fail-closed: a service account that declares no scopes is as powerless
+        // as a stranger — it cannot cancel or read another principal's run.
+        $powerless = AiActorContext::serviceAccount('no-grants');
+
+        $this->repository->findResult = $this->suspendedRun();
+        self::assertFalse(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->cancel($powerless, 'run-uuid-1'),
+        );
+
+        $this->repository->findResult = $this->suspendedRun();
+        self::assertNull(
+            $this->runtime($this->loopReturning($this->loopResult('x')))->status($powerless, 'run-uuid-1'),
         );
     }
 

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
@@ -90,17 +91,34 @@ final class ConversationServiceTest extends TestCase
     }
 
     #[Test]
-    public function aServiceAccountMayContinueASessionOnTheSystemsBehalf(): void
+    public function aServiceAccountWithTheConversationScopeMayContinueASessionOnTheSystemsBehalf(): void
     {
         $repository = new RecordingAiSessionRepository();
         $llmManager = $this->createMock(LlmServiceManagerInterface::class);
         $llmManager->method('chat')->willReturn($this->response('ok'));
         $service = $this->service($llmManager, $repository);
 
+        $worker   = AiActorContext::serviceAccount('nrllm-worker', [ServiceAccountScope::CONVERSATION_ACCESS]);
         $session  = $service->startSession($this->owner());
-        $response = $service->send(AiActorContext::serviceAccount('nrllm-worker'), $session->uuid, 'resume');
+        $response = $service->send($worker, $session->uuid, 'resume');
 
         self::assertSame('ok', $response->content);
+    }
+
+    #[Test]
+    public function aServiceAccountWithoutTheConversationScopeMayNotContinueASession(): void
+    {
+        $repository = new RecordingAiSessionRepository();
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->expects(self::never())->method('chat');
+        $service = $this->service($llmManager, $repository);
+
+        $session = $service->startSession($this->owner());
+
+        $this->expectException(AccessDeniedException::class);
+        // A scopeless service account is fail-closed (ADR-110): knowing the
+        // session uuid is not enough to continue somebody else's conversation.
+        $service->send(AiActorContext::serviceAccount('nrllm-worker'), $session->uuid, 'resume');
     }
 
     #[Test]


### PR DESCRIPTION
## What

Slice 1d of P0 #1 (thread `AiActorContext` through the agent runtime) — the final sub-slice. A **service account** (CLI, scheduler task, queue worker) owns nothing and has no backend privileges, yet every entry point it could reach — `mayAccessSession`, `mayActOnRun`, and the restricted-configuration gate — used to trust it for **everything**. A narrow automation (a nightly cancel sweep) thus held god-mode: it could also approve runs, read any conversation, and use group-restricted configurations.

This makes service accounts declare **scopes** and fail closed. See ADR-110.

Builds on 1a (#507), 1b (#508), 1c (#510).

## Changes

- **`ServiceAccountScope`** (new enum) — one case per enforcement point, no wildcard:
  - `agent:approve` → `AgentRuntime::approve()` / `submitInput()`
  - `agent:cancel` → `AgentRuntime::cancel()`
  - `agent:read` → `AgentRuntime::status()` / `events()`
  - `conversation:access` → `ConversationService::send()`
  - `configuration:use` → restricted-configuration gate
- **`AiActorContext`**:
  - `serviceAccount(string $name, array $scopes = [])` — a scopeless account may do **nothing** (fail-closed).
  - `hasScope()` — always false for a backend user (they are authorized by ownership/admin, never scopes).
  - `mayActOnRun(AgentRun, ServiceAccountScope)` — run operations no longer share one verdict, so an `agent:cancel` account can cancel but neither read nor approve.
  - `mayAccessSession()` requires `conversation:access` for a service account.
  - Scopes round-trip through `toArray()`/`fromArray()`; a tampered/older row **drops any value that is not a known scope** (fail-closed).
- **`ConfigurationResolver::actorMayUse()`** — a service account needs `configuration:use` (was blanket-allow).
- **`CancelAgentRunCommand`** — the one shipped service account declares `agent:cancel` and nothing else.

## Deferred (documented in ADR-110)

- `enqueue()` / `run()` stay ungated (who may start a run is decided by whoever builds the request); a dedicated `agent:run` scope is deferred until a service-account caller reaches those methods — so **no unenforced scope ships**.
- `conversation:access` is a single read-and-continue capability; a finer read/write split waits for a consumer.

## Tests

- `AiActorContextTest`: scope authorization, per-op isolation, backend-users-unaffected, queue round-trip, and fail-closed drop of unknown scope strings.
- `AgentRuntimeTest`: a scoped service account acts only within its scope (cancel-only may cancel but not read/approve); a scopeless one may do nothing.
- `ConversationServiceTest`: scoped service account may continue a session; scopeless is denied.

## Breaking change

`AiActorContext::mayActOnRun()` and `serviceAccount()` signatures change; all in-tree callers are updated. Pre-1.0, before 0.24.0.

## Gate

`cgl`, `phpstan` (level 10), `unit`, `rector -n`, `fuzzy`, `functional -d sqlite` — all green locally.
