### PR TITLE
feat(agent): queue delivery idempotency — tool effects + in-flight write fence (P0 #2)

### DIFF
--- a/Classes/Command/ReapStaleAgentRunsCommand.php
+++ b/Classes/Command/ReapStaleAgentRunsCommand.php
@@ -94,6 +94,20 @@ final class ReapStaleAgentRunsCommand extends Command
         $skipped    = 0;
 
         foreach ($staleRuns as $run) {
+            // Reaped mid non-idempotent write (ADR-111): its side effect may
+            // already have landed, so reclaiming it onto the queue could repeat
+            // the write. Dead-letter regardless of the retry budget — the whole
+            // point of the fence is that this one must not run twice.
+            if (!AgentRuntime::mayRetryAfterFence($run->pendingEffect)) {
+                if ($this->persister->settleDeadLetteredStale($run, $now, AgentRunTerminationReason::NOT_RETRYABLE)) {
+                    ++$deadLetter;
+                } else {
+                    ++$skipped;
+                }
+
+                continue;
+            }
+
             // Budget spent -> dead-letter; otherwise reclaim onto the queue. Both
             // writes re-check staleness in the repository, so a heartbeat renewal
             // between findStaleRunning() and here wins and the run is skipped.

--- a/Classes/Domain/Enum/ToolEffect.php
+++ b/Classes/Domain/Enum/ToolEffect.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * The side effect a tool's execution has on the world (ADR-111).
+ *
+ * The agent queue is at-least-once: a run whose provider/tool call outlives its
+ * lease is reaped and re-executed (ADR-104). That is safe only for operations
+ * that can run again without harm. A tool declares its effect so the runtime
+ * can (a) require a durable audit step for anything that writes and (b) refuse
+ * to auto-retry a write that is not safe to repeat.
+ *
+ * Fail-closed default: a tool that does not declare an effect is treated as
+ * {@see self::READ_ONLY} (via {@see \Netresearch\NrLlm\Service\Tool\ToolEffectInterface}).
+ * That is correct for every tool shipped today — all are read-only — and a tool
+ * that DOES write must opt in explicitly, so a new write can never be silently
+ * treated as a repeatable read.
+ */
+enum ToolEffect: string
+{
+    /**
+     * Observes only — no state changes. Re-running it is always safe, so a
+     * reaped-and-requeued run may repeat it freely.
+     */
+    case READ_ONLY = 'read_only';
+
+    /**
+     * Writes, but re-running it converges to the same state (a set, an upsert
+     * keyed by a stable identifier). Safe to auto-retry after a lease loss.
+     */
+    case IDEMPOTENT_WRITE = 'idempotent_write';
+
+    /**
+     * Writes with an effect that compounds on repeat (an append, a send, a
+     * counter increment, a resource creation without a caller-supplied key).
+     * Must NOT be auto-retried: a reaped run that may have completed the write
+     * fails terminally rather than risking a double effect.
+     */
+    case NON_IDEMPOTENT_WRITE = 'non_idempotent_write';
+
+    /**
+     * Whether the effect changes state (anything other than read-only).
+     */
+    public function isWrite(): bool
+    {
+        return $this !== self::READ_ONLY;
+    }
+
+    /**
+     * Whether an at-least-once runtime may safely re-execute this effect after a
+     * lease loss. False for a non-idempotent write — repeating it could double
+     * the effect.
+     */
+    public function isSafeToRetry(): bool
+    {
+        return $this !== self::NON_IDEMPOTENT_WRITE;
+    }
+}

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -54,6 +54,10 @@ final readonly class AgentRun
         // retryable-failure retry or a stale-lease reclaim; capped by
         // AgentRuntime::MAX_REQUEUES so a deterministic crash cannot loop.
         public int $requeueCount = 0,
+        // Side effect of the tool currently in flight (ADR-111), stamped before a
+        // tool runs and cleared when it completes; '' = none. A run reaped while
+        // this is a non-idempotent write is dead-lettered, not retried.
+        public string $pendingEffect = '',
     ) {}
 
     /**
@@ -89,6 +93,7 @@ final readonly class AgentRun
             claimedBy: $this->claimedBy,
             leaseExpires: $this->leaseExpires,
             requeueCount: $this->requeueCount,
+            pendingEffect: $this->pendingEffect,
         );
     }
 

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -304,7 +304,21 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             // Retryable in principle — but is the requeue budget spent? Re-read
             // the row; a null read (-1) forces the fail-closed dead-letter.
             $currentRun = $this->persister->findRun($runUuid);
-            $count      = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
+
+            // A non-idempotent write was in flight when this failed (ADR-111): its
+            // side effect may already have landed, so a retry could double it.
+            // Dead-letter regardless of the retry budget — a retryable error class
+            // does not make a repeated write safe.
+            if ($currentRun instanceof AgentRun && !self::mayRetryAfterFence($currentRun->pendingEffect)) {
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
+                $this->logger?->warning('Queued agent run failed mid non-idempotent write; dead-lettered instead of retried (ADR-111)', ['run' => $runUuid]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            $count = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
             if ($count < 0 || $count >= self::MAX_REQUEUES) {
                 if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity)) {
                     $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
@@ -889,16 +903,56 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 // renewal's ownership guard is the atomic check: 0 rows means
                 // the run was reclaimed/re-claimed/terminated — stop WITHOUT
                 // recording the step, so a zombie worker cannot append an event
-                // whose sequence collides with the new owner's stream.
-                if ($leaseOwner !== null
-                    && !$this->persister->renewLease($handle, $leaseOwner, time() + self::LEASE_SECONDS)
-                ) {
+                // whose sequence collides with the new owner's stream. A completed
+                // WRITE step also CLEARS the in-flight fence set before it ran
+                // (ADR-111) in the same guarded write.
+                if ($leaseOwner !== null && !$this->renewOrClearFence($handle, $leaseOwner, $step)) {
                     throw RunLeaseLostException::forRun($handle->uuid);
                 }
 
                 $this->recordStepFailClosedForWrites($handle, $step);
             },
+            onBeforeTool: $leaseOwner === null || $handle === null ? null : function (string $toolName) use ($handle, $leaseOwner): void {
+                // Fence a WRITE before it runs (ADR-111): stamp its effect and
+                // renew the lease so a reap mid non-idempotent-write dead-letters
+                // instead of retrying. Read-only tools need no fence — repeating
+                // them is always safe. A lost lease stops the worker before the
+                // side effect, exactly like the heartbeat guard.
+                $effect = $this->toolEffectResolver?->effectFor($toolName) ?? ToolEffect::READ_ONLY;
+                if ($effect->isWrite()
+                    && !$this->persister->markPendingEffect($handle, $leaseOwner, $effect->value, time() + self::LEASE_SECONDS)
+                ) {
+                    throw RunLeaseLostException::forRun($handle->uuid);
+                }
+            },
         );
+    }
+
+    /**
+     * Renew the lease at a step boundary and, for a completed WRITE step, clear
+     * the in-flight fence its {@see RunTrace::beforeToolExecution()} set — both in
+     * one ownership-guarded write (ADR-111). Returns false when the worker has
+     * lost the run, so the caller stops before recording the step.
+     */
+    private function renewOrClearFence(AgentRunHandle $handle, string $leaseOwner, RunStep $step): bool
+    {
+        $leaseExpires = time() + self::LEASE_SECONDS;
+        if ($this->stepEffect($step)->isWrite()) {
+            return $this->persister->markPendingEffect($handle, $leaseOwner, '', $leaseExpires);
+        }
+
+        return $this->persister->renewLease($handle, $leaseOwner, $leaseExpires);
+    }
+
+    /**
+     * Whether a run may be retried given the effect fence in flight when it
+     * failed (ADR-111). Empty (no tool fenced) or an unrecognised value is safe;
+     * only a fenced NON_IDEMPOTENT_WRITE — a side effect that must not repeat —
+     * blocks the retry. Shared by the in-process recover path and the reaper.
+     */
+    public static function mayRetryAfterFence(string $pendingEffect): bool
+    {
+        return ToolEffect::tryFrom($pendingEffect)?->isSafeToRetry() ?? true;
     }
 
     /**

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -28,6 +29,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
+use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
@@ -51,6 +53,7 @@ use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\InputSchema;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -129,6 +132,12 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // test wiring; production autowires the real resolver, and a null falls
         // back to a fresh default instance.
         private ?ActingBackendUserResolverInterface $actingBackendUserResolver = null,
+        // Classifies a tool's side effect so a WRITING tool's audit step is
+        // fail-closed (ADR-111). Optional only for the positional test wiring;
+        // production autowires it. A null resolver treats every tool as
+        // read-only — safe today (no builtin writes) and only reachable in bare
+        // test construction, never in the autowired runtime.
+        private ?ToolEffectResolver $toolEffectResolver = null,
     ) {}
 
     /**
@@ -867,8 +876,11 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                 // failure can never fabricate a cancellation.
                 if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
                     // Persist the step that already happened, then stop: the
-                    // audit stream stays complete up to the abort point.
-                    $this->persister->recordStep($handle, $step);
+                    // audit stream stays complete up to the abort point. A
+                    // writing tool whose audit cannot be stored fails the run
+                    // (ADR-111) even mid-cancel — an unrecorded mutation is the
+                    // more serious condition than the cancellation.
+                    $this->recordStepFailClosedForWrites($handle, $step);
 
                     throw RunCancellationRequestedException::forRun($handle->uuid);
                 }
@@ -884,9 +896,41 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
                     throw RunLeaseLostException::forRun($handle->uuid);
                 }
 
-                $this->persister->recordStep($handle, $step);
+                $this->recordStepFailClosedForWrites($handle, $step);
             },
         );
+    }
+
+    /**
+     * Persist a step, failing the run when a WRITING tool's audit event could
+     * not be stored (ADR-111). Read-only and non-tool steps stay fail-soft: a
+     * store hiccup is logged inside {@see AgentRunPersister::recordStep()} and
+     * the run continues. A write is different — an unrecorded mutation must not
+     * be waved through, so it throws {@see AuditPersistenceFailedException}
+     * (non-retryable: the write already ran once).
+     */
+    private function recordStepFailClosedForWrites(AgentRunHandle $handle, RunStep $step): void
+    {
+        $persisted = $this->persister->recordStep($handle, $step);
+        if (!$persisted && $this->stepEffect($step)->isWrite()) {
+            throw AuditPersistenceFailedException::forRun($handle->uuid, $step->toolName ?? '');
+        }
+    }
+
+    /**
+     * The side effect of the tool a step recorded (ADR-111). Only KIND_TOOL
+     * steps carry an effect; everything else is read-only. A tool name that no
+     * longer resolves is treated as the strictest effect (fail-closed), and a
+     * runtime built without the resolver (bare positional test wiring only)
+     * treats every tool as read-only.
+     */
+    private function stepEffect(RunStep $step): ToolEffect
+    {
+        if ($step->kind !== RunStep::KIND_TOOL || $this->toolEffectResolver === null) {
+            return ToolEffect::READ_ONLY;
+        }
+
+        return $this->toolEffectResolver->effectFor($step->toolName ?? '');
     }
 
     /**

--- a/Classes/Service/Agent/Exception/AuditPersistenceFailedException.php
+++ b/Classes/Service/Agent/Exception/AuditPersistenceFailedException.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use RuntimeException;
+
+/**
+ * A WRITING tool executed but its audit step could not be persisted (ADR-111).
+ *
+ * The agent queue is at-least-once and {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::recordStep()}
+ * is otherwise fail-soft — a store hiccup for a read-only step is logged and the
+ * run continues. That is unacceptable for a tool that changed state: an
+ * unrecorded write leaves no evidence the effect happened, and silently
+ * continuing would let the run report success over an unaudited mutation. So the
+ * runtime throws this instead, failing the run.
+ *
+ * It carries no {@see \Netresearch\NrLlm\Domain\Enum\FailureClass} of its own, so
+ * {@see \Netresearch\NrLlm\Provider\Middleware\FailureClassifier} maps it to
+ * {@see \Netresearch\NrLlm\Domain\Enum\FailureClass::UNKNOWN} — deliberately
+ * NOT retryable: re-running the run would re-execute the same write, and it
+ * already ran once. A queued run is therefore dead-lettered (NOT_RETRYABLE), an
+ * interactive one settles FAILED. Never auto-retried.
+ */
+final class AuditPersistenceFailedException extends RuntimeException
+{
+    public static function forRun(string $runUuid, string $toolName): self
+    {
+        return new self(
+            sprintf(
+                'Run %s: the audit step for writing tool "%s" could not be persisted; failing the run rather than continuing over an unrecorded write.',
+                $runUuid !== '' ? $runUuid : 'unknown',
+                $toolName !== '' ? $toolName : 'unknown',
+            ),
+            1785000001,
+        );
+    }
+}

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -34,7 +34,9 @@ use Throwable;
  * Every method is fail-soft: a persistence error is logged and swallowed so a
  * database hiccup can never break an otherwise-successful run. {@see self::begin()}
  * returns null on failure, which the caller treats as "do not record" — exactly
- * as a null {@see RunTrace} callback would.
+ * as a null {@see RunTrace} callback would. {@see self::recordStep()} still never
+ * throws, but returns whether it persisted so the runtime can fail-close a
+ * WRITING tool's audit step (ADR-111) while leaving read-only steps fail-soft.
  *
  * What a step actually stores is governed by the central privacy level via
  * {@see RunStepPrivacyFilter}: metadata-only by default, so persistence does not
@@ -158,8 +160,16 @@ final readonly class AgentRunPersister
 
     /**
      * Persist one recorded step as the next event in the run's stream.
+     *
+     * Returns whether the step was durably persisted. The store hiccup is still
+     * logged and swallowed here (this method never throws), but the boolean lets
+     * the caller enforce a stricter policy for an audit-critical step: the
+     * runtime fails a run whose WRITING tool executed but whose audit event
+     * could not be stored (ADR-111), rather than continuing as if the write were
+     * recorded. A read-only step's caller ignores the result, preserving the
+     * fail-soft behaviour of the rest of this class.
      */
-    public function recordStep(AgentRunHandle $handle, RunStep $step): void
+    public function recordStep(AgentRunHandle $handle, RunStep $step): bool
     {
         try {
             // The persisted copy follows the central privacy level; the live
@@ -177,8 +187,12 @@ final readonly class AgentRunPersister
                 $payload,
             );
             ++$handle->sequence;
+
+            return true;
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun step could not be persisted', ['exception' => $exception]);
+
+            return false;
         }
     }
 

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -142,6 +142,24 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * Stamp the in-flight tool's effect and renew the lease before it runs, or
+     * clear the stamp ('' effect) once it completed (ADR-111 lease-before-op).
+     * Fail-closed like {@see renewLease()}: a store error returns false so the
+     * worker treats the lease as lost and stops before executing the tool, rather
+     * than running a write it could not first fence.
+     */
+    public function markPendingEffect(AgentRunHandle $handle, string $claimedBy, string $effect, int $leaseExpires): bool
+    {
+        try {
+            return $this->repository->markPendingEffect($handle->runUid, $claimedBy, $effect, $leaseExpires);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun pending-effect fence could not be written; the worker will treat the lease as lost', ['exception' => $exception]);
+
+            return false;
+        }
+    }
+
+    /**
      * Put a running run this worker owns back on the queue for a retry (ADR-104).
      * Ownership-guarded in the repository; false when the worker no longer owned
      * the run (reclaimed/cancelled) or the store errored — the caller must then

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -321,6 +321,36 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
     }
 
     /**
+     * Stamp the effect of the tool about to run (or '' to clear it once done) and
+     * renew the lease in the same guarded write (ADR-111 lease-before-op). Guarded
+     * exactly like {@see renewLease()}: zero matched rows means this worker lost
+     * the run, and — because a repeated identical stamp is a MySQL no-op — the
+     * same ownership re-check distinguishes "nothing changed" from "lost lease".
+     */
+    public function markPendingEffect(int $runUid, string $claimedBy, string $effect, int $leaseExpires): bool
+    {
+        $affected = $this->connectionPool->getConnectionForTable(self::TABLE_RUN)->update(
+            self::TABLE_RUN,
+            [
+                'pending_effect' => $effect,
+                'lease_expires'  => $leaseExpires,
+                'tstamp'         => time(),
+            ],
+            [
+                'uid'        => $runUid,
+                'status'     => AgentRunStatus::RUNNING->value,
+                'claimed_by' => $claimedBy,
+            ],
+        );
+
+        if ($affected >= 1) {
+            return true;
+        }
+
+        return $this->ownsRunningRun($runUid, $claimedBy);
+    }
+
+    /**
      * Whether the run still exists RUNNING under this worker's claim — the
      * ownership predicate {@see renewLease()} uses to tell a no-op UPDATE
      * (nothing changed) apart from a lost lease (nothing matched). The reaper
@@ -694,6 +724,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             claimedBy: self::toStr($row['claimed_by'] ?? ''),
             leaseExpires: self::toInt($row['lease_expires'] ?? 0),
             requeueCount: self::toInt($row['requeue_count'] ?? 0),
+            pendingEffect: self::toStr($row['pending_effect'] ?? ''),
         );
     }
 

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -113,6 +113,15 @@ interface AgentRunRepositoryInterface
     public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool;
 
     /**
+     * Stamp the effect of the tool about to execute (or '' to clear it once the
+     * tool completed) and renew the lease in the same guarded write (ADR-111
+     * lease-before-op). Guarded like {@see renewLease()}; false means the worker
+     * lost the run. The reaper reads pending_effect to refuse retrying a run
+     * reaped mid non-idempotent-write.
+     */
+    public function markPendingEffect(int $runUid, string $claimedBy, string $effect, int $leaseExpires): bool;
+
+    /**
      * Put a running run this worker owns back on the queue for a retry (ADR-104
      * failure retry): ownership-guarded (status = running AND claimed_by = the
      * caller), increments requeue_count, clears claim and lease, keeps

--- a/Classes/Service/Tool/RunTrace.php
+++ b/Classes/Service/Tool/RunTrace.php
@@ -38,21 +38,39 @@ final class RunTrace
     private array $steps = [];
 
     /**
-     * @param bool                          $captureRaw When true the loop asks the provider to retain
-     *                                                  the decoded raw response so it can be inspected.
-     *                                                  Off by default so production runs never keep it.
-     * @param (Closure(RunStep): void)|null $onRecord   Fired the moment each step is recorded, so a
-     *                                                  caller can stream steps live as the loop runs.
-     *                                                  Null (every production/test caller) ⇒ collect only.
+     * @param bool                          $captureRaw   When true the loop asks the provider to retain
+     *                                                    the decoded raw response so it can be inspected.
+     *                                                    Off by default so production runs never keep it.
+     * @param (Closure(RunStep): void)|null $onRecord     Fired the moment each step is recorded, so a
+     *                                                    caller can stream steps live as the loop runs.
+     *                                                    Null (every production/test caller) ⇒ collect only.
+     * @param (Closure(string): void)|null  $onBeforeTool Fired with a tool's name immediately BEFORE it
+     *                                                    executes (ADR-111), so the runtime can fence the
+     *                                                    in-flight write and renew the lease before the op.
+     *                                                    Null ⇒ no fence (synchronous/interactive runs).
      */
     public function __construct(
         private readonly bool $captureRaw = false,
         private readonly ?Closure $onRecord = null,
+        private readonly ?Closure $onBeforeTool = null,
     ) {}
 
     public function capturesRaw(): bool
     {
         return $this->captureRaw;
+    }
+
+    /**
+     * Signal that the named tool is about to execute (ADR-111). Fired by the
+     * loop right before it invokes the tool, so a listener can durably fence the
+     * operation (record its effect, extend the lease) before any side effect
+     * happens. A no-op when no listener was wired.
+     */
+    public function beforeToolExecution(string $toolName): void
+    {
+        if ($this->onBeforeTool !== null) {
+            ($this->onBeforeTool)($toolName);
+        }
     }
 
     /**

--- a/Classes/Service/Tool/ToolEffectInterface.php
+++ b/Classes/Service/Tool/ToolEffectInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+
+/**
+ * Opt-in declaration of a tool's side effect (ADR-111).
+ *
+ * A tool implements this only when it writes: the runtime treats any tool that
+ * does NOT implement it as {@see ToolEffect::READ_ONLY} (fail-closed default),
+ * which is correct for every builtin shipped today. A write tool MUST declare
+ * itself so the at-least-once queue can guarantee a durable audit step for it
+ * and withhold auto-retry from a non-idempotent one.
+ *
+ * The value is a property of the CODE and is deliberately not configurable: an
+ * administrator must not be able to relabel a write as a read to dodge the
+ * audit and retry guarantees. Kept separate from {@see ToolInterface} — like
+ * {@see ToolDataClassInterface} — so the read-only builtins need no change and
+ * promoting it onto the tool contract stays a later, announced breaking change.
+ */
+interface ToolEffectInterface
+{
+    public function getEffect(): ToolEffect;
+}

--- a/Classes/Service/Tool/ToolEffectResolver.php
+++ b/Classes/Service/Tool/ToolEffectResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+
+/**
+ * Resolves the side effect of a tool (ADR-111).
+ *
+ * Two sources, in order:
+ *
+ * 1. an explicit {@see ToolEffectInterface} declaration on the tool;
+ * 2. {@see ToolEffect::READ_ONLY} for any tool that does not declare one —
+ *    correct for every builtin shipped today, and the reason a write MUST opt
+ *    in rather than be inferred.
+ *
+ * Resolution BY NAME is stricter: an unknown tool name resolves to
+ * {@see ToolEffect::NON_IDEMPOTENT_WRITE} — the class that is both
+ * audit-critical AND never auto-retried — so a stale or removed tool referenced
+ * in a persisted step is treated as the most dangerous possibility, never
+ * waved through as a repeatable read.
+ */
+final readonly class ToolEffectResolver
+{
+    public function __construct(
+        private ToolRegistry $registry,
+    ) {}
+
+    public function effectForTool(ToolInterface $tool): ToolEffect
+    {
+        if ($tool instanceof ToolEffectInterface) {
+            return $tool->getEffect();
+        }
+
+        return ToolEffect::READ_ONLY;
+    }
+
+    /**
+     * The effect of a tool by name; an unknown name resolves fail-closed to the
+     * strictest effect so a stale reference cannot dodge the audit/retry guards.
+     */
+    public function effectFor(string $toolName): ToolEffect
+    {
+        $tool = $this->registry->get($toolName);
+
+        return $tool === null ? ToolEffect::NON_IDEMPOTENT_WRITE : $this->effectForTool($tool);
+    }
+}

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -313,7 +313,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
                 foreach ($resp->toolCalls ?? [] as $call) {
                     $tt0 = hrtime(true);
-                    $tr  = $this->invoke($call, $allowedNames, $context);
+                    // Fence the operation before any side effect (ADR-111): the
+                    // runtime records the tool's effect and renews the lease so a
+                    // reap mid non-idempotent-write can refuse to retry it.
+                    $runTrace?->beforeToolExecution($call->name);
+                    $tr = $this->invoke($call, $allowedNames, $context);
                     // WIRE: content ONLY — artifacts are run-scoped and never egress to the provider.
                     $messages[] = ChatMessage::toolResult($call->id, $tr->content);
                     $trace[]    = new ToolInvocation($call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
@@ -500,7 +504,8 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $result = sprintf('Error: tool "%s" requires user input that was not provided.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
-                $tt0    = hrtime(true);
+                $tt0 = hrtime(true);
+                $runTrace?->beforeToolExecution($call->name);
                 $tr     = $this->invoke($call, $offered, $context);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
@@ -570,8 +575,9 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $result = sprintf('Error: tool "%s" is no longer permitted and was not executed.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } elseif ($call->name === $state->inputToolName) {
-                $tt0    = hrtime(true);
-                $tr     = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered, $context);
+                $tt0 = hrtime(true);
+                $runTrace?->beforeToolExecution($call->name);
+                $tr = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered, $context);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
@@ -580,7 +586,8 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $result = sprintf('Error: tool "%s" requires input that was not provided.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
-                $tt0    = hrtime(true);
+                $tt0 = hrtime(true);
+                $runTrace?->beforeToolExecution($call->name);
                 $tr     = $this->invoke($call, $offered, $context);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);

--- a/Documentation/Adr/Adr111ToolEffectAndWriteAudit.rst
+++ b/Documentation/Adr/Adr111ToolEffectAndWriteAudit.rst
@@ -1,0 +1,89 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-111:
+
+============================================================================
+ADR-111: Tool side effects and fail-closed audit for writes
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-111-context:
+
+Context
+=======
+
+The agent queue is at-least-once (:ref:`ADR-102 <adr-102>`). A worker renews its
+lease only at a step boundary, which fires *after* an operation completes, so a
+provider or tool call that outlives the ``LEASE_SECONDS`` lease is reaped and the
+run re-executed (:ref:`ADR-104 <adr-104>`). The ownership guard on ``finishRun``
+prevents a double *settle*, but not a double *execution*: a tool's side effect
+can land twice.
+
+That is harmless for the tools shipped today — all are read-only. It is not
+harmless for the WRITING tools the roadmap will add. Two gaps must close *before*
+the first write tool ships:
+
+1. :php:`AgentRunPersister::recordStep()` is fail-soft — a store hiccup is logged
+   and swallowed. A tool can therefore execute with its audit event never
+   persisted. For a write, that is an unrecorded mutation the run then reports
+   success over.
+2. Nothing tells the runtime whether re-running a reaped operation is safe.
+
+.. _adr-111-decision:
+
+Decision
+========
+
+Classify a tool's side effect and act on it.
+
+``ToolEffect``
+--------------
+
+A three-value enum: ``READ_ONLY``, ``IDEMPOTENT_WRITE``, ``NON_IDEMPOTENT_WRITE``.
+A tool declares it by implementing :php:`ToolEffectInterface::getEffect()`. A tool
+that does NOT implement it is ``READ_ONLY`` — the opt-in default that keeps all
+shipped builtins unchanged, and the reason a write must declare itself rather
+than be inferred. The value is a property of the CODE and is not configurable, so
+an administrator cannot relabel a write to dodge the guarantees. Resolution BY
+NAME (:php:`ToolEffectResolver::effectFor()`) is stricter: an unknown name — a
+stale or removed tool referenced in a persisted step — resolves to
+``NON_IDEMPOTENT_WRITE``, the class that is both audit-critical and never
+auto-retried.
+
+Fail-closed audit for writes
+----------------------------
+
+``recordStep()`` still never throws, but now RETURNS whether it persisted. The
+runtime fails a run whose WRITING tool executed but whose audit event could not
+be stored — :php:`AuditPersistenceFailedException` — rather than continuing over
+an unrecorded write. Read-only and non-tool steps keep the fail-soft behaviour:
+a transient database blip does not fail an observe-only run.
+
+No auto-retry for a failed write
+--------------------------------
+
+:php:`AuditPersistenceFailedException` carries no ``FailureClass`` of its own, so
+:php:`FailureClassifier` maps it to ``UNKNOWN`` — deliberately not retryable
+(:ref:`ADR-095 <adr-095>`). A queued run is dead-lettered (``NOT_RETRYABLE``); an
+interactive run settles ``FAILED``. Re-running would re-execute the write, which
+already ran once.
+
+.. _adr-111-consequences:
+
+Consequences
+============
+
+- The classification is the precondition, not the whole story. Two follow-ups
+  build on it: withholding auto-retry from a ``NON_IDEMPOTENT_WRITE`` whose *own*
+  execution (not just its audit) was interrupted, and a lease-extension-before-op
+  (``operation_deadline``) so a long write is not reaped mid-call. Both need this
+  enum first.
+- ``ToolEffect`` is a separate opt-in interface, like :php:`ToolDataClassInterface`
+  (:ref:`ADR-094 <adr-094>`); promoting it onto :php:`ToolInterface` is a later,
+  announced breaking change.
+- No builtin writes yet, so in production ``recordStep`` remains effectively
+  fail-soft today — the machinery is in place for the first write tool, which is
+  exactly when it must already exist.

--- a/Documentation/Adr/Adr112LeaseBeforeOpWriteFence.rst
+++ b/Documentation/Adr/Adr112LeaseBeforeOpWriteFence.rst
@@ -1,0 +1,81 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-112:
+
+============================================================================
+ADR-112: Lease-before-op fence — no retry for an interrupted write
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-112-context:
+
+Context
+=======
+
+:ref:`ADR-111 <adr-111>` classified a tool's side effect and made a write's
+audit fail-closed. It named two follow-ups; this is the one that closes the
+double-execution window itself.
+
+The queue is at-least-once (:ref:`ADR-102 <adr-102>`) and the lease renews at a
+step boundary — *after* an operation completes (:ref:`ADR-104 <adr-104>`). A
+tool call that outlives ``LEASE_SECONDS`` is reaped and the run re-executed. For
+a ``NON_IDEMPOTENT_WRITE`` that is a double effect: the reaper cannot tell that
+the run was mid-write, because nothing is recorded until *after* the tool
+returns.
+
+.. _adr-112-decision:
+
+Decision
+========
+
+Record the in-flight write BEFORE it runs, and refuse to retry a run reaped
+while that record stands.
+
+The fence
+---------
+
+``tx_nrllm_agentrun`` gains a ``pending_effect`` column. A new
+:php:`RunTrace::beforeToolExecution()` hook fires immediately before the loop
+invokes a tool; the runtime resolves the tool's :php:`ToolEffect` and, for a
+WRITE, stamps ``pending_effect`` and renews the lease in one ownership-guarded
+write (:php:`AgentRunRepository::markPendingEffect()`). When the tool's step is
+recorded, the same guarded write clears the fence. Read-only tools are never
+fenced — repeating them is always safe, so they cost no extra write. The stamp
+is guarded exactly like the heartbeat: a worker that has lost the run stamps
+nothing and stops before the side effect.
+
+Refuse the retry
+----------------
+
+Both retry deciders consult the fence and treat a fenced value through
+:php:`AgentRuntime::mayRetryAfterFence()` — ``NON_IDEMPOTENT_WRITE`` is not
+retryable, everything else (including an unset or unrecognised value) is:
+
+- the stale-run reaper (:php:`ReapStaleAgentRunsCommand`) dead-letters a run
+  reaped mid non-idempotent-write instead of reclaiming it onto the queue,
+  regardless of the remaining retry budget;
+- the in-process recovery (:php:`AgentRuntime::recoverQueuedFailure()`)
+  dead-letters such a run even when the failure class is otherwise retryable —
+  a transient provider blip does not make a repeated write safe.
+
+An ``IDEMPOTENT_WRITE`` converges on repeat, so it is reclaimed normally.
+
+.. _adr-112-consequences:
+
+Consequences
+============
+
+- The guarantee is "a non-idempotent write runs at most once": if it is reaped
+  or fails mid-flight, the run fails rather than repeating it. It is NOT
+  exactly-once — a write that completed but whose fence-clear did not persist is
+  still failed, never silently retried (fail-closed toward not-repeating).
+- ``pending_effect`` defaults to ``''`` so an un-migrated or fresh row reads as
+  "no write in flight" — the fail-safe default.
+- The lease-before-op renewal also gives each write a full lease window at its
+  start, but the durable fence — not the extra renewal — is what makes the
+  refusal correct.
+- Idempotency KEYS for safe dedup of an ``IDEMPOTENT_WRITE`` remain future work;
+  this ADR only guarantees a non-idempotent write is not repeated.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -409,3 +409,4 @@ Tools
    Adr109AgentRunsApprovalsInbox
    Adr110ServiceAccountScopes
    Adr111ToolEffectAndWriteAudit
+   Adr112LeaseBeforeOpWriteFence

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -408,3 +408,4 @@ Tools
    Adr108TypedToolResultWithArtifacts
    Adr109AgentRunsApprovalsInbox
    Adr110ServiceAccountScopes
+   Adr111ToolEffectAndWriteAudit

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -376,6 +376,36 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function markPendingEffectStampsAndClearsTheInFlightWriteFence(): void
+    {
+        // ADR-111 lease-before-op: the in-flight write's effect is stamped (and
+        // the lease renewed) in one ownership-guarded write, then cleared once
+        // the tool completes. A stranger cannot stamp it.
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame('', $run->pendingEffect, 'no fence on a fresh run');
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        // A stranger cannot fence the run.
+        self::assertFalse($this->persister->markPendingEffect($handle, 'worker-b:2', 'non_idempotent_write', time() + 999));
+
+        // The owner stamps the write fence + renews the lease.
+        self::assertTrue($this->persister->markPendingEffect($handle, 'worker-a:1', 'non_idempotent_write', time() + 999));
+        $fenced = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($fenced);
+        self::assertSame('non_idempotent_write', $fenced->pendingEffect);
+        self::assertGreaterThan(time() + 900, $fenced->leaseExpires);
+
+        // Completing the tool clears the fence.
+        self::assertTrue($this->persister->markPendingEffect($handle, 'worker-a:1', '', time() + 999));
+        $cleared = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($cleared);
+        self::assertSame('', $cleared->pendingEffect);
+    }
+
+    #[Test]
     public function renewLeaseSurvivesANoOpRenewalInTheSameSecond(): void
     {
         // ADR-104 heartbeat: two step boundaries in the same wall-clock second

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -100,6 +100,12 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    public function markPendingEffect(int $runUid, string $claimedBy, string $effect, int $leaseExpires): bool
+    {
+        // Not needed by the command tests.
+        return true;
+    }
+
     public function requeue(int $runUid, string $claimedBy): bool
     {
         // Not needed by the command tests.

--- a/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
+++ b/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Command;
 use Netresearch\NrLlm\Command\ReapStaleAgentRunsCommand;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
@@ -70,9 +71,42 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
         self::assertSame([], $this->repository->staleRequeues);
         self::assertCount(1, $this->repository->staleDeadLetters);
         self::assertSame(AgentRunTerminationReason::RETRIES_EXHAUSTED->value, $this->repository->staleDeadLetters[0]['reason']);
-        // A dead-letter is terminal — no wake-up is dispatched.
-        self::assertCount(0, $this->dispatched);
-        self::assertStringContainsString('1 dead-lettered', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function deadLettersARunReapedMidNonIdempotentWriteEvenUnderBudget(): void
+    {
+        // ADR-111: the write may already have landed, so reclaiming it onto the
+        // queue could double it — dead-letter regardless of the retry budget.
+        $this->repository->staleRunning = [
+            $this->staleRun('run-w', requeueCount: 0, pendingEffect: ToolEffect::NON_IDEMPOTENT_WRITE->value),
+        ];
+
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame([], $this->repository->staleRequeues, 'not reclaimed onto the queue');
+        self::assertSame(AgentRunTerminationReason::NOT_RETRYABLE->value, $this->repository->staleDeadLetters[0]['reason']);
+    }
+
+    #[Test]
+    public function reclaimsARunReapedMidIdempotentWrite(): void
+    {
+        // An idempotent write converges on repeat, so a stale reclaim is safe.
+        $this->repository->staleRunning = [
+            $this->staleRun('run-i', requeueCount: 0, pendingEffect: ToolEffect::IDEMPOTENT_WRITE->value),
+        ];
+
+        $tester = new CommandTester($this->command());
+        $exit   = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame([], $this->repository->staleDeadLetters, 'reclaimed, not dead-lettered');
+        self::assertCount(1, $this->repository->staleRequeues);
+        // Reclaimed onto the queue -> a wake-up is dispatched.
+        self::assertCount(1, $this->dispatched);
+        self::assertStringContainsString('1 requeued', $tester->getDisplay());
     }
 
     #[Test]
@@ -162,7 +196,7 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
         return $bus;
     }
 
-    private function staleRun(string $uuid, int $requeueCount): AgentRun
+    private function staleRun(string $uuid, int $requeueCount, string $pendingEffect = ''): AgentRun
     {
         return new AgentRun(
             uid: 1,
@@ -187,6 +221,7 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
             claimedBy: 'dead-worker:1',
             leaseExpires: 1,
             requeueCount: $requeueCount,
+            pendingEffect: $pendingEffect,
         );
     }
 }

--- a/Tests/Unit/Domain/Enum/ToolEffectTest.php
+++ b/Tests/Unit/Domain/Enum/ToolEffectTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ToolEffectTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{ToolEffect, bool, bool}>
+     */
+    public static function effects(): iterable
+    {
+        // effect => [isWrite, isSafeToRetry]
+        yield 'read-only'           => [ToolEffect::READ_ONLY, false, true];
+        yield 'idempotent write'    => [ToolEffect::IDEMPOTENT_WRITE, true, true];
+        yield 'non-idempotent write' => [ToolEffect::NON_IDEMPOTENT_WRITE, true, false];
+    }
+
+    #[Test]
+    #[DataProvider('effects')]
+    public function classifiesWriteAndRetrySafety(ToolEffect $effect, bool $isWrite, bool $isSafeToRetry): void
+    {
+        self::assertSame($isWrite, $effect->isWrite());
+        self::assertSame($isSafeToRetry, $effect->isSafeToRetry());
+    }
+
+    #[Test]
+    public function onlyTheNonIdempotentWriteIsUnsafeToRetry(): void
+    {
+        // The retry guard hinges on exactly one case: an at-least-once queue may
+        // repeat everything except a non-idempotent write.
+        $unsafe = array_filter(ToolEffect::cases(), static fn(ToolEffect $e): bool => !$e->isSafeToRetry());
+
+        self::assertSame([ToolEffect::NON_IDEMPOTENT_WRITE], array_values($unsafe));
+    }
+}

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -30,6 +31,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
@@ -47,10 +49,13 @@ use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -698,6 +703,63 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aWritingToolWhoseAuditCannotBePersistedFailsTheRunAndIsNotRetried(): void
+    {
+        // ADR-111: a WRITING tool executed but its audit event could not be
+        // stored. The run must fail rather than continue over an unrecorded
+        // mutation — and must NOT be requeued (the write already ran once).
+        $this->repository->findResult   = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+        $this->repository->throwOnRecord = true;
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([
+            new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]));
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordToolExecution(1, 0.0, 'send_mail', [], 'sent', false);
+
+                return $this->loopResult('unreachable');
+            },
+        );
+
+        $result = $this->runtime($loop, effectResolver: $resolver)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome, 'dead-lettered, not REQUEUED');
+        self::assertInstanceOf(AuditPersistenceFailedException::class, $result->error);
+        // Dead-lettered as non-retryable — the queue never re-dispatched it.
+        self::assertSame([], $this->repository->requeues);
+    }
+
+    #[Test]
+    public function aReadOnlyToolWhoseAuditCannotBePersistedLeavesTheRunUnaffected(): void
+    {
+        // The fail-soft path is preserved for reads: a store hiccup on a
+        // read-only tool's audit step is swallowed and the run completes, so a
+        // transient database blip does not fail an observe-only run.
+        $this->repository->findResult   = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+        $this->repository->throwOnRecord = true;
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([new FakeTool('list_pages')]));
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->recordToolExecution(1, 0.0, 'list_pages', [], 'p1, p2', false);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop, effectResolver: $resolver)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    #[Test]
     public function aQueuedRunFailingRetryablyIsRequeuedAndReDispatchedWithBackoff(): void
     {
         // ADR-104 failure retry: a retryable provider error requeues the run
@@ -1003,6 +1065,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         ToolLoopServiceInterface $loop,
         ?LlmConfiguration $configuration = new LlmConfiguration(),
         ?MessageBusInterface $bus = null,
+        ?ToolEffectResolver $effectResolver = null,
     ): AgentRuntime {
         $configurationRepository = self::createStub(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($configuration);
@@ -1018,6 +1081,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             // setBeUserByUid(). Tool authorization from a live user is covered by
             // the functional ActingBackendUserResolver and tool tests.
             actingBackendUserResolver: self::createStub(ActingBackendUserResolverInterface::class),
+            toolEffectResolver: $effectResolver,
         );
     }
 

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -734,6 +734,81 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function aWriteIsFencedBeforeItRunsAndTheFenceIsClearedWhenItCompletes(): void
+    {
+        // ADR-111 lease-before-op: the runtime stamps the in-flight write's
+        // effect BEFORE the tool runs (so a reap mid-write can refuse to retry)
+        // and clears the stamp once the tool's step is recorded.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([
+            new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]));
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->beforeToolExecution('send_mail');
+                $trace?->recordToolExecution(1, 0.0, 'send_mail', [], 'sent', false);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $result = $this->runtime($loop, effectResolver: $resolver)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        $effects = array_column($this->repository->pendingEffects, 'effect');
+        // Fenced with the write's effect before the op, cleared ('') after it.
+        self::assertSame(['non_idempotent_write', ''], $effects);
+    }
+
+    #[Test]
+    public function aReadOnlyToolIsNotFenced(): void
+    {
+        // A read is always safe to repeat, so no fence write is spent on it.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}');
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([new FakeTool('list_pages')]));
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(
+            function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed, mixed $options, ?int $max, ?RunTrace $trace): ToolLoopResult {
+                $trace?->beforeToolExecution('list_pages');
+                $trace?->recordToolExecution(1, 0.0, 'list_pages', [], 'p1', false);
+
+                return $this->loopResult('done');
+            },
+        );
+
+        $this->runtime($loop, effectResolver: $resolver)->runQueued('run-uuid-q');
+
+        self::assertSame([], $this->repository->pendingEffects, 'no fence for a read-only tool');
+    }
+
+    #[Test]
+    public function aRetryableFailureMidNonIdempotentWriteIsDeadLetteredNotRequeued(): void
+    {
+        // ADR-111: even a normally-retryable error must not requeue a run whose
+        // non-idempotent write was in flight — the side effect may have landed.
+        // The re-read inside recoverQueuedFailure sees the fence still set.
+        $this->repository->findResult = $this->queuedRun('run-uuid-q', '{"messages":[]}', pendingEffect: ToolEffect::NON_IDEMPOTENT_WRITE->value);
+
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('runLoop')->willReturnCallback(static function (): ToolLoopResult {
+            // A retryable class (would normally requeue within budget).
+            throw new RuntimeException('transient provider blip', 1785000099);
+        });
+
+        $result = $this->runtime($loop)->runQueued('run-uuid-q');
+
+        self::assertNotNull($result);
+        self::assertSame(AgentRunOutcome::FAILED, $result->outcome, 'dead-lettered, not REQUEUED');
+        self::assertSame([], $this->repository->requeues);
+    }
+
+    #[Test]
     public function aReadOnlyToolWhoseAuditCannotBePersistedLeavesTheRunUnaffected(): void
     {
         // The fail-soft path is preserved for reads: a store hiccup on a
@@ -1104,7 +1179,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         return $bus;
     }
 
-    private function queuedRun(string $uuid, string $requestJson, int $requeueCount = 0): AgentRun
+    private function queuedRun(string $uuid, string $requestJson, int $requeueCount = 0, string $pendingEffect = ''): AgentRun
     {
         return new AgentRun(
             uid: 1,
@@ -1127,6 +1202,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             suspendedState: null,
             queuedRequest: $requestJson,
             requeueCount: $requeueCount,
+            pendingEffect: $pendingEffect,
         );
     }
 

--- a/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeTool.php
@@ -9,10 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
 
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
-
 use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 
@@ -22,9 +23,12 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
  * Carries a configurable name (the registry index key), a canned result and an
  * optional list of run-only artifacts so a test can assert both the
  * lookup-by-name path and the execute() contract (including the artifact
- * channel) without touching the database or a real provider.
+ * channel) without touching the database or a real provider. It also declares a
+ * {@see ToolEffect} (READ_ONLY by default) so the same double covers a writing
+ * tool in the effect/audit tests; a tool that does NOT implement
+ * {@see ToolEffectInterface} is represented by a plain ToolInterface stub.
  */
-final readonly class FakeTool implements ToolInterface
+final readonly class FakeTool implements ToolInterface, ToolEffectInterface
 {
     /**
      * @param list<ToolArtifact> $artifacts
@@ -36,7 +40,13 @@ final readonly class FakeTool implements ToolInterface
         private bool $requiresAdmin = false,
         private string $group = 'test',
         private array $artifacts = [],
+        private ToolEffect $effect = ToolEffect::READ_ONLY,
     ) {}
+
+    public function getEffect(): ToolEffect
+    {
+        return $this->effect;
+    }
 
     public function getSpec(): ToolSpec
     {

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -295,6 +295,22 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return true;
     }
 
+    /** @var list<array{runUid: int, claimedBy: string, effect: string, leaseExpires: int}> */
+    public array $pendingEffects = [];
+
+    public function markPendingEffect(int $runUid, string $claimedBy, string $effect, int $leaseExpires): bool
+    {
+        if ($this->throwOnRenewLease) {
+            throw new RuntimeException('markPendingEffect failed', 1785000020);
+        }
+        if ($this->refuseRenewLease) {
+            return false;
+        }
+        $this->pendingEffects[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'effect' => $effect, 'leaseExpires' => $leaseExpires];
+
+        return true;
+    }
+
     public bool $throwOnRequeue = false;
 
     /** Simulates a run this worker no longer owns: requeue matches no row. */

--- a/Tests/Unit/Service/Tool/ToolEffectResolverTest.php
+++ b/Tests/Unit/Service/Tool/ToolEffectResolverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolEffectResolver::class)]
+final class ToolEffectResolverTest extends TestCase
+{
+    #[Test]
+    public function usesAnExplicitDeclaration(): void
+    {
+        $resolver = new ToolEffectResolver(new ToolRegistry([]));
+
+        self::assertSame(
+            ToolEffect::NON_IDEMPOTENT_WRITE,
+            $resolver->effectForTool(new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE)),
+        );
+    }
+
+    #[Test]
+    public function defaultsAnUndeclaredToolToReadOnly(): void
+    {
+        // A tool that does not implement ToolEffectInterface is read-only — the
+        // opt-in default that keeps all 45 shipped builtins unchanged.
+        $plain = self::createStub(ToolInterface::class);
+        $plain->method('getSpec')->willReturn(ToolSpec::function('list_pages', '', ['type' => 'object', 'properties' => []]));
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([]));
+
+        self::assertSame(ToolEffect::READ_ONLY, $resolver->effectForTool($plain));
+    }
+
+    #[Test]
+    public function resolvesByNameThroughTheRegistry(): void
+    {
+        $registry = new ToolRegistry([new FakeTool('upsert_record', effect: ToolEffect::IDEMPOTENT_WRITE)]);
+        $resolver = new ToolEffectResolver($registry);
+
+        self::assertSame(ToolEffect::IDEMPOTENT_WRITE, $resolver->effectFor('upsert_record'));
+    }
+
+    #[Test]
+    public function failsClosedForAnUnknownName(): void
+    {
+        // A stale or removed tool referenced in a persisted step must be treated
+        // as the most dangerous effect — audit-critical AND never auto-retried —
+        // not waved through as a repeatable read.
+        $resolver = new ToolEffectResolver(new ToolRegistry([]));
+
+        self::assertSame(ToolEffect::NON_IDEMPOTENT_WRITE, $resolver->effectFor('was_removed'));
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -705,6 +705,13 @@ CREATE TABLE tx_nrllm_agentrun (
     -- failing run cannot loop forever; 0 = never requeued.
     requeue_count int(11) unsigned DEFAULT '0' NOT NULL,
 
+    -- Side effect of the tool currently executing (ADR-111), stamped just BEFORE
+    -- a tool runs on the queued path and cleared once it completes. '' = no tool
+    -- in flight. The reaper reads it: a run reaped mid non-idempotent-write is
+    -- dead-lettered instead of requeued, so an at-least-once retry never repeats
+    -- a write that already ran once. Empty is the fail-safe default.
+    pending_effect varchar(32) DEFAULT '' NOT NULL,
+
     -- Time tracking
     started_at int(11) unsigned DEFAULT '0' NOT NULL,
     finished_at int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## What

**P0 #2 core — queue delivery idempotency.** The agent queue is at-least-once (ADR-102): a worker renews its lease only at a step boundary, *after* an op completes, so a provider/tool call that outlives `LEASE_SECONDS` is reaped and re-executed (ADR-104). The ownership guard (PR #506) stops a double *settle*, not a double *execution*. Harmless for the read-only tools shipped today — dangerous for the WRITING tools the roadmap adds. This PR is the precondition that must exist **before** the first write tool ships.

Two commits, one coherent feature:

### Slice 2a — classify effects + fail-close a write's audit (ADR-111)
- `ToolEffect {READ_ONLY, IDEMPOTENT_WRITE, NON_IDEMPOTENT_WRITE}`, opt-in via `ToolEffectInterface` (a tool that does not implement it is `READ_ONLY` — keeps all 45 builtins unchanged; a write MUST opt in). Not admin-configurable. `ToolEffectResolver` resolves by tool, and by name — an unknown name fails closed to `NON_IDEMPOTENT_WRITE`.
- `AgentRunPersister::recordStep()` now returns whether it persisted (was `void`). The runtime fails a run whose **writing** tool executed but whose audit event could not be stored (`AuditPersistenceFailedException`); read-only/non-tool steps stay fail-soft. The exception classifies `UNKNOWN` → non-retryable → dead-lettered.

### Slice 2c — fence the in-flight write (ADR-112)
- New `pending_effect` column (+ `AgentRun::$pendingEffect`; `''` = fail-safe default). `RunTrace::beforeToolExecution()` fires before every tool `invoke` (main loop + all 3 resume paths); the runtime stamps a WRITE's effect and renews the lease in one ownership-guarded write (`markPendingEffect`), and clears it when the tool's step records. Read-only tools are never fenced.
- `mayRetryAfterFence()`: the stale-run reaper dead-letters a run reaped mid non-idempotent-write regardless of retry budget; in-process recovery dead-letters it even on an otherwise-retryable error. Idempotent writes reclaim normally.

**Guarantee:** a non-idempotent write runs at most once — reaped or failed mid-flight, the run fails rather than repeating it. Not exactly-once (fail-closed toward not-repeating). Idempotency *keys* for safe dedup of idempotent writes remain future work.

## Tests
Enum + resolver units; AgentRuntime (audit-fail dead-letters; fence set/clear; read-only not fenced; retryable-failure-mid-write dead-lettered); reaper (dead-letters non-idempotent, reclaims idempotent); functional (`pending_effect` round-trip + ownership guard).

## Breaking
`AgentRunPersister::recordStep()` returns `bool` (was `void`); ignoring callers are unaffected. Pre-1.0, before 0.24.0.

## Gate
cgl, phpstan L10, unit, rector -n, fuzzy, functional -d sqlite — all green locally.
