### PR TITLE
fix(tool)!: fail-closed tool data-class enforcement switch (P0 #3, slice 3a)

### DIFF
--- a/Classes/Service/Tool/ToolCallPolicy.php
+++ b/Classes/Service/Tool/ToolCallPolicy.php
@@ -26,15 +26,18 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * and above the trust-zone ceiling reports TOOL_DISABLED, so a denial message
  * never tells a caller who was already blocked that a trust-zone axis exists.
  *
- * The zone gate ships in **observe** mode: the decision is computed and
- * reported, but the tool is still offered. An operator flips
- * `tools.dataClassEnforcement` to `enforce` once the observations look right.
- * The four pre-existing gates always enforce — the switch governs only the new
- * axis, so turning it on cannot loosen anything.
+ * The zone gate ships in **observe** mode via the `tools.dataClassEnforcement`
+ * extension setting: the decision is computed and reported, but the tool is
+ * still offered. An operator sets it to any non-`observe` value (or the setting
+ * is missing/unreadable) to enforce. The switch is fail-closed (ADR-113): only
+ * a deliberate `observe` observes; everything else enforces, so a broken or
+ * mistyped setting cannot silently disable the gate. The four pre-existing
+ * gates always enforce — the switch governs only the new axis, so turning it on
+ * (or failing closed) cannot loosen anything.
  */
 final readonly class ToolCallPolicy implements ToolCallPolicyInterface
 {
-    private const ENFORCE = 'enforce';
+    private const OBSERVE = 'observe';
 
     public function __construct(
         private ToolRegistry $registry,
@@ -125,9 +128,15 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
     }
 
     /**
-     * Whether the trust-zone axis is enforced or merely observed. Anything other
-     * than an explicit `enforce` observes — a typo must not silently start
-     * removing tools from production runs.
+     * Whether the trust-zone axis is enforced or merely observed (ADR-113).
+     *
+     * Fail-closed: the axis observes ONLY on an explicit `observe`. Every other
+     * case enforces — an unreadable extension configuration, a malformed
+     * `tools` section, a missing value, or a typo (`observ`, `off`, ``). The
+     * gate is a security control, so an operator who cannot express a deliberate
+     * "only observe" gets the safe behaviour rather than a silently disabled
+     * gate. Turning the axis on never loosens anything (the four pre-existing
+     * gates always enforce), so failing closed here cannot over-permit.
      */
     private function enforcing(): bool
     {
@@ -135,16 +144,16 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
             /** @var array<string, mixed> $config */
             $config = $this->extensionConfiguration?->get('nr_llm') ?? [];
         } catch (Throwable) {
-            return false;
+            return true;
         }
 
         $tools = $config['tools'] ?? null;
         if (!is_array($tools)) {
-            return false;
+            return true;
         }
 
         $mode = $tools['dataClassEnforcement'] ?? null;
 
-        return is_string($mode) && strtolower(trim($mode)) === self::ENFORCE;
+        return !(is_string($mode) && strtolower(trim($mode)) === self::OBSERVE);
     }
 }

--- a/Documentation/Adr/Adr113FailClosedToolDataClassEnforcement.rst
+++ b/Documentation/Adr/Adr113FailClosedToolDataClassEnforcement.rst
@@ -1,0 +1,62 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-113:
+
+============================================================================
+ADR-113: Fail-closed tool data-class enforcement switch
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-113-context:
+
+Context
+=======
+
+The composite tool gate (:ref:`ADR-094 <adr-094>`) added a trust-zone axis that
+denies a tool whose data class exceeds the configuration's trust zone. It is
+governed by the ``tools.dataClassEnforcement`` extension setting so operators
+can watch it before turning it on: ``observe`` computes and reports the decision
+but still offers the tool, any other value enforces.
+
+The switch read **fail-open**: it enforced only on an exact ``enforce`` and
+observed on everything else — a typo (``enforced``, ``ENFORCE``), an empty
+value, a malformed ``tools`` section, or an extension configuration that threw
+on read all silently OBSERVED. A security gate that disables itself on a
+misconfiguration is exactly backwards: the operator believes the gate is on
+while a mistyped setting leaves it off.
+
+.. _adr-113-decision:
+
+Decision
+========
+
+The switch is fail-closed. The axis observes ONLY on a deliberate ``observe``
+(matched case- and whitespace-insensitively). Every other case enforces:
+
+- a missing value or ``tools`` section;
+- a malformed section (``tools`` is not an array, the value is not a string);
+- a typo or any unrecognised value;
+- an extension configuration that throws on read.
+
+This cannot over-permit: the four pre-existing gates always enforce, and turning
+the trust-zone axis on only ever removes an over-ceiling tool — so failing
+closed is strictly safer, never looser. An operator who genuinely wants
+observe-only must say so explicitly.
+
+.. _adr-113-consequences:
+
+Consequences
+============
+
+- The shipped default is unchanged in this step: ``ext_conf_template.txt`` still
+  sets ``tools.dataClassEnforcement = observe``, so a healthy install (fresh or
+  upgraded) reads an explicit ``observe`` and behaves exactly as before. Only a
+  broken, missing, or mistyped setting changes — from a silent observe to a
+  safe enforce.
+- Flipping the shipped default to ``enforce`` for new installs (while preserving
+  observe for existing ones via an upgrade wizard) and a readiness report are a
+  follow-up: they change behaviour for healthy installs and carry a
+  backwards-compatibility decision, kept separate from this pure fail-closed fix.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -410,3 +410,4 @@ Tools
    Adr110ServiceAccountScopes
    Adr111ToolEffectAndWriteAudit
    Adr112LeaseBeforeOpWriteFence
+   Adr113FailClosedToolDataClassEnforcement

--- a/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
+++ b/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
@@ -26,6 +26,7 @@ use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
@@ -115,20 +116,53 @@ final class ToolCallPolicyTest extends TestCase
     }
 
     #[Test]
-    public function anythingOtherThanAnExplicitEnforceObserves(): void
+    public function anythingOtherThanAnExplicitObserveEnforces(): void
     {
+        // ADR-113 fail-closed: only a deliberate `observe` observes; a typo, an
+        // empty string or any other value enforces, so a mistyped setting cannot
+        // silently disable the gate. `observe` is matched case/space-insensitively.
         $registry = new ToolRegistry([new FakeTool('system_tool', 'ok', true, false, 'system')]);
         $config   = $this->configuration(TrustZone::EXTERNAL_GLOBAL);
 
-        // A typo must not start removing tools from production runs.
-        foreach (['', 'enforced', 'ENFORCE ', 'yes'] as $value) {
-            $decision = $this->policy($registry, enforcement: $value)->decide('system_tool', $config, $this->admin());
-            self::assertSame(
-                $value === 'ENFORCE ',
-                !$decision->allowed,
-                sprintf('enforcement="%s"', $value),
+        $observeValues = ['observe', 'OBSERVE ', ' observe'];
+        $enforceValues = ['', 'observ', 'enforce', 'off', 'yes'];
+
+        foreach ($observeValues as $value) {
+            self::assertTrue(
+                $this->policy($registry, enforcement: $value)->decide('system_tool', $config, $this->admin())->allowed,
+                sprintf('enforcement="%s" should observe (tool still offered)', $value),
             );
         }
+        foreach ($enforceValues as $value) {
+            self::assertFalse(
+                $this->policy($registry, enforcement: $value)->decide('system_tool', $config, $this->admin())->allowed,
+                sprintf('enforcement="%s" should fail closed to enforce', $value),
+            );
+        }
+    }
+
+    #[Test]
+    public function anUnreadableOrMalformedConfigurationFailsClosedToEnforce(): void
+    {
+        // ADR-113: if the enforcement setting cannot be read (the extension
+        // configuration throws) or is malformed (no `tools` section), the gate
+        // enforces rather than silently observing.
+        $registry = new ToolRegistry([new FakeTool('system_tool', 'ok', true, false, 'system')]);
+        $config   = $this->configuration(TrustZone::EXTERNAL_GLOBAL);
+
+        $throwing = $this->createMock(ExtensionConfiguration::class);
+        $throwing->method('get')->willThrowException(new RuntimeException('config unreadable', 1785100001));
+        self::assertFalse(
+            $this->policyWith($registry, $throwing)->decide('system_tool', $config, $this->admin())->allowed,
+            'an unreadable configuration enforces',
+        );
+
+        $malformed = $this->createMock(ExtensionConfiguration::class);
+        $malformed->method('get')->willReturn(['tools' => 'not-an-array']);
+        self::assertFalse(
+            $this->policyWith($registry, $malformed)->decide('system_tool', $config, $this->admin())->allowed,
+            'a malformed configuration enforces',
+        );
     }
 
     #[Test]
@@ -182,10 +216,21 @@ final class ToolCallPolicyTest extends TestCase
         ?array $enabled = null,
         string $enforcement = 'observe',
     ): ToolCallPolicy {
-        $registry ??= new ToolRegistry([]);
-
         $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
         $extensionConfiguration->method('get')->willReturn(['tools' => ['dataClassEnforcement' => $enforcement]]);
+
+        return $this->policyWith($registry, $extensionConfiguration, $enabled);
+    }
+
+    /**
+     * @param list<string>|null $enabled null = every registered tool is enabled
+     */
+    private function policyWith(
+        ?ToolRegistry $registry,
+        ExtensionConfiguration $extensionConfiguration,
+        ?array $enabled = null,
+    ): ToolCallPolicy {
+        $registry ??= new ToolRegistry([]);
 
         return new ToolCallPolicy(
             $registry,


### PR DESCRIPTION
## What

**P0 #3 slice 3a — fail-closed the tool data-class enforcement switch.**

The trust-zone tool gate (ADR-094) is governed by `tools.dataClassEnforcement`: `observe` computes and reports the decision but still offers the tool; any other value enforces. The read was **fail-open** — it enforced only on an exact `enforce` and observed on everything else, so a typo (`enforced`, `ENFORCE`), an empty value, a malformed `tools` section, or an extension configuration that **threw on read** all silently OBSERVED. A security gate that disables itself on a misconfiguration is backwards.

Inverted (ADR-113): the axis observes **only** on a deliberate `observe` (case/whitespace-insensitive); every other case — missing, malformed, unreadable, or a typo — fails closed to **enforce**. This cannot over-permit: the four pre-existing gates always enforce and turning the trust-zone axis on only ever removes an over-ceiling tool, so failing closed is strictly safer.

## Not in this PR (deliberate)

The shipped default is unchanged: `ext_conf_template.txt` still sets `observe`, so a healthy install (fresh or upgraded) reads an explicit `observe` and behaves exactly as before. Flipping the default to `enforce` for **new** installs (with an upgrade wizard pinning **existing** installs to observe) and a readiness report change behavior for healthy installs and carry a BC decision — a separate follow-up (3b).

## Tests
`anythingOtherThanAnExplicitObserveEnforces` (inverts the old fail-open codification) + `anUnreadableOrMalformedConfigurationFailsClosedToEnforce` (throwing / malformed config → enforce).

## Breaking
An install whose `dataClassEnforcement` is a typo or malformed value now enforces instead of silently observing. Pre-1.0, before 0.24.0.

## Gate
cgl, phpstan L10, unit, rector -n, fuzzy, functional -d sqlite — all green locally.
