### PR TITLE
feat(agent): encrypt queued and suspended agent-run state at rest (P0 #4)

### DIFF
--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -39,6 +39,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
 
     public function __construct(
         private ConnectionPool $connectionPool,
+        private AgentStateCodec $stateCodec = new AgentStateCodec(),
     ) {}
 
     public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int
@@ -90,7 +91,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             'estimated_cost'           => 0.0,
             'error_class'              => '',
             'termination_reason'       => '',
-            'queued_request'           => $requestJson,
+            'queued_request'           => $this->stateCodec->encode($requestJson),
             'started_at'               => 0,
             'finished_at'              => 0,
             'tstamp'                   => $now,
@@ -244,7 +245,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             self::TABLE_RUN,
             [
                 'status'          => $target->value,
-                'suspended_state' => $stateJson,
+                'suspended_state' => $this->stateCodec->encode($stateJson),
                 'claimed_by'      => '',
                 'lease_expires'   => 0,
                 'tstamp'          => time(),
@@ -734,7 +735,16 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
      */
     private function suspendedStateOf(mixed $value): ?string
     {
-        return is_string($value) && $value !== '' ? $value : null;
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+
+        // Decrypt at the read boundary (ADR-114). A tampered or unreadable
+        // payload throws {@see AgentStateDecryptionException}; the fail-soft
+        // read path treats it as an unresumable run rather than a forged state.
+        $decoded = $this->stateCodec->decode($value);
+
+        return $decoded !== '' ? $decoded : null;
     }
 
     /**

--- a/Classes/Service/Tool/AgentStateCodec.php
+++ b/Classes/Service/Tool/AgentStateCodec.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\Exception\AgentStateDecryptionException;
+use SensitiveParameter;
+
+/**
+ * Authenticated encryption for an agent run's state at rest (ADR-114).
+ *
+ * A queued run stores its serialised request, and a suspended run its
+ * transcript and pending tool calls, in `tx_nrllm_agentrun` while it waits for a
+ * worker or a human. Both hold prompts, tool arguments and internal TYPO3
+ * content in cleartext — readable by anyone with database access. This codec
+ * encrypts them so the row carries ciphertext, not the conversation.
+ *
+ * Format (version-tagged so a later scheme is distinguishable):
+ * ``v1:`` + base64( nonce ‖ ciphertext‖tag ), using libsodium's XChaCha20-Poly1305
+ * AEAD — authenticated, so a tampered or truncated row fails to decrypt rather
+ * than yielding garbage. A fresh random nonce per encryption means the same
+ * plaintext never encrypts to the same bytes. The key is derived from the
+ * instance's ``encryptionKey`` via HKDF with a fixed context, so it is
+ * instance-specific and never the raw site secret.
+ *
+ * Backwards compatible: {@see decode()} returns any value WITHOUT the ``v1:``
+ * marker verbatim, so rows written before this landed (plaintext JSON) still
+ * rehydrate. New writes are always encrypted.
+ */
+final readonly class AgentStateCodec
+{
+    private const VERSION_PREFIX = 'v1:';
+
+    /**
+     * HKDF context binding the derived key to this purpose, so the same
+     * ``encryptionKey`` used elsewhere never yields the same key.
+     */
+    private const KDF_CONTEXT = 'nr_llm:agent-state:v1';
+
+    /**
+     * @param string|null $encryptionKey the instance master secret; null reads
+     *                                   the TYPO3 site ``encryptionKey`` (the
+     *                                   production path). Injected explicitly
+     *                                   only by tests.
+     */
+    public function __construct(
+        #[SensitiveParameter]
+        private ?string $encryptionKey = null,
+    ) {}
+
+    /**
+     * Encrypt a plaintext state payload for storage. An empty string stores as
+     * empty (the "no state" sentinel the columns already use), never as a
+     * ciphertext of the empty string.
+     */
+    public function encode(string $plaintext): string
+    {
+        if ($plaintext === '') {
+            return '';
+        }
+
+        $nonce      = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+        $ciphertext = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($plaintext, '', $nonce, $this->key());
+
+        return self::VERSION_PREFIX . base64_encode($nonce . $ciphertext);
+    }
+
+    /**
+     * Decrypt a stored state payload. A value without the version marker is
+     * treated as legacy cleartext and returned verbatim (upgrade path); an empty
+     * value returns empty. A version-tagged value that fails authentication —
+     * tampered, truncated, or written under a different key — throws rather than
+     * returning a forged plaintext.
+     *
+     * @throws AgentStateDecryptionException
+     */
+    public function decode(string $stored): string
+    {
+        if ($stored === '' || !str_starts_with($stored, self::VERSION_PREFIX)) {
+            return $stored;
+        }
+
+        $raw = base64_decode(substr($stored, strlen(self::VERSION_PREFIX)), true);
+        if ($raw === false || strlen($raw) <= SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES) {
+            throw AgentStateDecryptionException::corrupted();
+        }
+
+        $nonce      = substr($raw, 0, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+        $ciphertext = substr($raw, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+
+        $plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, '', $nonce, $this->key());
+        if ($plaintext === false) {
+            throw AgentStateDecryptionException::authenticationFailed();
+        }
+
+        return $plaintext;
+    }
+
+    /**
+     * The 32-byte AEAD key, derived from the instance secret. Fail-closed: with
+     * no ``encryptionKey`` there is no safe key, so encryption refuses rather
+     * than falling back to storing cleartext.
+     */
+    private function key(): string
+    {
+        $master = $this->encryptionKey ?? self::instanceEncryptionKey();
+        if ($master === '') {
+            throw AgentStateDecryptionException::noEncryptionKey();
+        }
+
+        return hash_hkdf('sha256', $master, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES, self::KDF_CONTEXT);
+    }
+
+    /**
+     * The TYPO3 site ``encryptionKey``, or '' when absent (narrowed step by step
+     * because the ``$GLOBALS`` shape is untyped).
+     */
+    private static function instanceEncryptionKey(): string
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sys      = is_array($confVars) ? ($confVars['SYS'] ?? null) : null;
+        $key      = is_array($sys) ? ($sys['encryptionKey'] ?? '') : '';
+
+        return is_string($key) ? $key : '';
+    }
+}

--- a/Classes/Service/Tool/Exception/AgentStateDecryptionException.php
+++ b/Classes/Service/Tool/Exception/AgentStateDecryptionException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Exception;
+
+use RuntimeException;
+
+/**
+ * An agent-run state payload could not be decrypted (ADR-114).
+ *
+ * Thrown by {@see \Netresearch\NrLlm\Service\Tool\AgentStateCodec::decode()}
+ * when a version-tagged value fails authentication (tampered, truncated, or
+ * written under a different key) or by {@see \Netresearch\NrLlm\Service\Tool\AgentStateCodec}
+ * when no instance ``encryptionKey`` is configured. The message never contains
+ * the ciphertext or key. The persister treats it like any other read failure —
+ * a run whose state cannot be decrypted is left where it is (fail-soft on read),
+ * never resumed from a forged plaintext.
+ */
+final class AgentStateDecryptionException extends RuntimeException
+{
+    public static function authenticationFailed(): self
+    {
+        return new self('The stored agent run state failed authentication and was not decrypted.', 1785200001);
+    }
+
+    public static function corrupted(): self
+    {
+        return new self('The stored agent run state is malformed and could not be decoded.', 1785200002);
+    }
+
+    public static function noEncryptionKey(): self
+    {
+        return new self('No instance encryption key is configured; agent run state cannot be encrypted.', 1785200003);
+    }
+}

--- a/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
+++ b/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
@@ -1,0 +1,80 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-114:
+
+============================================================================
+ADR-114: Encrypt queued and suspended agent-run state at rest
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-114-context:
+
+Context
+=======
+
+An agent run parks two payloads in ``tx_nrllm_agentrun`` while it waits: the
+serialised request of a QUEUED run (:ref:`ADR-102 <adr-102>`) and the transcript
+plus pending tool calls of a run suspended for approval or input
+(:ref:`ADR-084 <adr-084>`, :ref:`ADR-105 <adr-105>`). Both were stored as
+cleartext JSON. Unlike the event stream — which passes through the privacy
+filter (:ref:`ADR-064 <adr-064>`) — these are stored VERBATIM, because a resume
+must replay them exactly. They hold user prompts, tool arguments and internal
+TYPO3 content, readable by anyone with database access (a backup, a replica, a
+support dump).
+
+.. _adr-114-decision:
+
+Decision
+========
+
+Encrypt both columns at rest with an :php:`AgentStateCodec`.
+
+Primitive
+---------
+
+libsodium XChaCha20-Poly1305 AEAD — authenticated encryption, bundled with PHP,
+no userland crypto. The library owns the dangerous parts: a fresh random 24-byte
+nonce per encryption (so identical state never yields identical ciphertext, and
+there is no equality oracle across rows) and an authentication tag verified on
+decrypt (so a tampered, truncated, or foreign-key row fails to decrypt rather
+than yielding a forged plaintext). The key is derived from the instance
+``encryptionKey`` via HKDF-SHA256 with a fixed context, so it is
+instance-specific and never the raw site secret.
+
+Format and versioning
+---------------------
+
+Stored as ``v1:`` + base64( nonce ‖ ciphertext‖tag ). The version prefix makes a
+later scheme (a rotated key, a different cipher) distinguishable at read time
+rather than guessed.
+
+Seam
+----
+
+The codec lives at the repository boundary: the two columns are encrypted on
+write and decrypted in ``hydrateRun`` on read, so the persister and the runtime
+keep handling plaintext JSON and nothing above the repository changes.
+
+.. _adr-114-consequences:
+
+Consequences
+============
+
+- **Backwards compatible.** ``decode()`` returns any value WITHOUT the ``v1:``
+  marker verbatim, so a row written before this landed (plaintext JSON) still
+  rehydrates. New writes are always encrypted; an upgrade needs no data
+  migration.
+- **Fail-closed.** With no ``encryptionKey`` the codec refuses to encrypt rather
+  than silently storing cleartext, and a payload that fails authentication
+  throws — the fail-soft read path then treats the run as unreadable rather than
+  resuming a forged or corrupt state.
+- The columns stay ``mediumtext``; base64 ciphertext is larger than the JSON but
+  well within the 16 MB bound.
+- Key ROTATION beyond the single ``v1`` key (a key id in the prefix, a
+  re-encrypt pass) is future work; the version tag reserves room for it. The
+  privacy-retention policy (:ref:`ADR-064 <adr-064>`) still governs how long
+  state is kept — encryption protects it while it exists, it does not extend its
+  life.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -411,3 +411,4 @@ Tools
    Adr111ToolEffectAndWriteAudit
    Adr112LeaseBeforeOpWriteFence
    Adr113FailClosedToolDataClassEnforcement
+   Adr114EncryptAgentStateAtRest

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -153,6 +153,55 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function theQueuedRequestIsEncryptedAtRestAndTransparentlyDecrypted(): void
+    {
+        // ADR-114: the serialised request holds prompts and tool arguments; the
+        // stored column must be ciphertext, but reads return the plaintext.
+        $plaintext = '{"messages":[{"role":"user","content":"a private prompt"}]}';
+        $handle    = $this->persister->enqueue(null, 7, $plaintext);
+        self::assertNotNull($handle);
+
+        $stored = $this->rawColumn($handle->uuid, 'queued_request');
+        self::assertStringStartsWith('v1:', $stored, 'stored at rest as ciphertext');
+        self::assertStringNotContainsString('private prompt', $stored);
+
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertSame($plaintext, $run->queuedRequest, 'transparently decrypted on read');
+    }
+
+    #[Test]
+    public function aLegacyCleartextRowStillRehydrates(): void
+    {
+        // A run enqueued before encryption landed stored plaintext JSON. The
+        // read path returns it verbatim so the upgrade does not strand it.
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('tx_nrllm_agentrun');
+        $connection->insert('tx_nrllm_agentrun', [
+            'uuid'           => 'legacy-uuid',
+            'status'         => 'queued',
+            'queued_request' => '{"messages":[]}',
+        ]);
+
+        $run = $this->repository->findByUuid('legacy-uuid');
+        self::assertNotNull($run);
+        self::assertSame('{"messages":[]}', $run->queuedRequest);
+    }
+
+    private function rawColumn(string $uuid, string $column): string
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)->getQueryBuilderForTable('tx_nrllm_agentrun');
+        $queryBuilder->getRestrictions()->removeAll();
+        $value = $queryBuilder
+            ->select($column)
+            ->from('tx_nrllm_agentrun')
+            ->where($queryBuilder->expr()->eq('uuid', $queryBuilder->createNamedParameter($uuid)))
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_string($value) ? $value : '';
+    }
+
+    #[Test]
     public function aSuspensionClearsTheWorkerLease(): void
     {
         // ADR-102: the lease means "presumed executing until" — a run suspended

--- a/Tests/Unit/Service/Tool/AgentStateCodecTest.php
+++ b/Tests/Unit/Service/Tool/AgentStateCodecTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Service\Tool\Exception\AgentStateDecryptionException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AgentStateCodec::class)]
+final class AgentStateCodecTest extends TestCase
+{
+    private const KEY = 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1';
+
+    private function codec(): AgentStateCodec
+    {
+        return new AgentStateCodec(self::KEY);
+    }
+
+    #[Test]
+    public function encryptsAndDecryptsRoundTrip(): void
+    {
+        $plaintext = '{"messages":[{"role":"user","content":"secret prompt"}]}';
+
+        $encoded = $this->codec()->encode($plaintext);
+
+        self::assertStringStartsWith('v1:', $encoded);
+        self::assertStringNotContainsString('secret prompt', $encoded);
+        self::assertSame($plaintext, $this->codec()->decode($encoded));
+    }
+
+    #[Test]
+    public function theSamePlaintextEncryptsToDifferentBytesEachTime(): void
+    {
+        // A fresh random nonce per encryption: identical state never produces
+        // identical ciphertext (no equality oracle across rows).
+        $codec = $this->codec();
+
+        self::assertNotSame($codec->encode('same'), $codec->encode('same'));
+    }
+
+    #[Test]
+    public function emptyStateStaysEmpty(): void
+    {
+        self::assertSame('', $this->codec()->encode(''));
+        self::assertSame('', $this->codec()->decode(''));
+    }
+
+    #[Test]
+    public function legacyCleartextIsReturnedVerbatim(): void
+    {
+        // A row written before encryption landed is plaintext JSON with no
+        // version marker; it must still rehydrate after the upgrade.
+        $legacy = '{"messages":[]}';
+
+        self::assertSame($legacy, $this->codec()->decode($legacy));
+    }
+
+    #[Test]
+    public function aTamperedCiphertextFailsAuthentication(): void
+    {
+        $encoded = $this->codec()->encode('{"x":1}');
+        // Flip the last base64 character (part of the auth tag / ciphertext).
+        $tampered = substr($encoded, 0, -1) . ($encoded[-1] === 'A' ? 'B' : 'A');
+
+        $this->expectException(AgentStateDecryptionException::class);
+        $this->codec()->decode($tampered);
+    }
+
+    #[Test]
+    public function aValueWrittenUnderADifferentKeyDoesNotDecrypt(): void
+    {
+        $encoded = $this->codec()->encode('{"x":1}');
+
+        $this->expectException(AgentStateDecryptionException::class);
+        (new AgentStateCodec('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'))->decode($encoded);
+    }
+
+    #[Test]
+    public function aMalformedVersionedPayloadIsRejected(): void
+    {
+        $this->expectException(AgentStateDecryptionException::class);
+        $this->codec()->decode('v1:@@@not-base64@@@');
+    }
+
+    #[Test]
+    public function encodingWithoutAKeyFailsClosed(): void
+    {
+        // No instance secret -> refuse to encrypt rather than store cleartext.
+        $this->expectException(AgentStateDecryptionException::class);
+        (new AgentStateCodec(''))->encode('{"x":1}');
+    }
+}


### PR DESCRIPTION
## What

**P0 #4 — encrypt queued/suspended agent-run state at rest.**

A queued run parks its serialised request, and a suspended run its transcript + pending tool calls, in `tx_nrllm_agentrun` while it waits (ADR-102/084/105). Unlike the event stream (privacy-filtered, ADR-064), these are stored **verbatim** — a resume must replay them exactly — so they held user prompts, tool arguments and internal TYPO3 content as **cleartext**, readable by anyone with DB access (a backup, replica, or support dump).

`AgentStateCodec` (ADR-114) encrypts both columns:
- **libsodium XChaCha20-Poly1305 AEAD** — no userland crypto. Fresh random nonce per encryption (identical state never yields identical ciphertext; no cross-row equality oracle); auth tag verified on decrypt (tampered/truncated/foreign-key → decrypt fails, never a forged plaintext).
- Key **derived from the instance `encryptionKey`** via HKDF-SHA256 with a fixed context — instance-specific, never the raw site secret.
- Stored as `v1:` + base64(nonce ‖ ciphertext‖tag) — version-tagged so a later scheme (key rotation, different cipher) is distinguishable.
- Applied at the **repository boundary** (encrypt on write, decrypt in `hydrateRun`), so the persister and runtime keep handling plaintext and nothing above the repo changes.

## Backwards compatible

`decode()` returns any value **without** the `v1:` marker verbatim, so a row written before this landed (plaintext JSON) still rehydrates — **no data migration**. New writes are always encrypted.

## Fail-closed

No `encryptionKey` → refuse to encrypt (never silent cleartext). A payload that fails authentication → throws; the fail-soft read path treats the run as unreadable rather than resuming a forged/corrupt state.

## Tests
Unit: round-trip, nonce-uniqueness, tamper rejection, wrong-key rejection, malformed rejection, legacy passthrough, no-key fail-closed. Functional: the stored `queued_request` column is ciphertext (`v1:`, no plaintext) yet reads back decrypted; a legacy cleartext row still rehydrates.

## Gate
cgl, phpstan L10, unit, rector -n, fuzzy, functional -d sqlite — all green locally.
