### PR TITLE
feat(tool)!: enforce tool data-class gate by default for new installs (P0 #3, slice 3b)

### DIFF
--- a/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
+++ b/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Updates;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+/**
+ * Pin the tool data-class gate to ``observe`` on an existing install (ADR-115).
+ *
+ * The shipped default of ``tools.dataClassEnforcement`` flips from ``observe`` to
+ * ``enforce`` so a NEW install is safe by default (ADR-094/113). For an EXISTING
+ * install that never set the value, that flip would silently start removing
+ * over-ceiling tools from working runs. This wizard preserves the old behaviour:
+ * it writes an explicit ``observe`` so the upgrade changes nothing, and its
+ * description tells the operator to review the run log and switch to ``enforce``
+ * when ready.
+ *
+ * A fresh install is distinguished by having no configured providers — you
+ * cannot run a tool without one — so it keeps the new ``enforce`` default and the
+ * wizard does not fire. An operator who ALREADY chose a mode explicitly (the
+ * stored config carries a value) is left untouched: an explicit ``enforce`` is
+ * respected, an explicit ``observe`` already matches.
+ */
+#[UpgradeWizard('nrLlm_dataClassEnforcementObserveForExisting')]
+final readonly class DataClassEnforcementDefaultUpdateWizard implements UpgradeWizardInterface
+{
+    private const EXT_KEY = 'nr_llm';
+
+    private const TABLE_PROVIDER = 'tx_nrllm_provider';
+
+    private const OBSERVE = 'observe';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    public function getTitle(): string
+    {
+        return 'Preserve "observe" tool data-class enforcement on this existing nr_llm install';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The tool data-class gate now defaults to ENFORCE for new installations, so an '
+            . 'over-ceiling tool is removed from a run rather than merely logged. This install '
+            . 'relied on the previous OBSERVE default, so this wizard pins it to observe to keep '
+            . 'the upgrade from silently stripping tools from working setups. Review the agent run '
+            . 'log (observe records what enforcement would do), then set '
+            . 'tools.dataClassEnforcement to "enforce" in the extension configuration when ready.';
+    }
+
+    public function updateNecessary(): bool
+    {
+        // Existing install (a provider is configured) that never explicitly chose
+        // an enforcement mode -> it relied on the old observe default and the new
+        // enforce default would change its behaviour. A fresh install has no
+        // providers and keeps enforce.
+        return $this->hasProviders() && $this->storedEnforcement() === null;
+    }
+
+    public function executeUpdate(): bool
+    {
+        $config = $this->extensionConfiguration->get(self::EXT_KEY);
+        $config = is_array($config) ? $config : [];
+        $tools  = is_array($config['tools'] ?? null) ? $config['tools'] : [];
+
+        $tools['dataClassEnforcement'] = self::OBSERVE;
+        $config['tools']               = $tools;
+
+        $this->extensionConfiguration->set(self::EXT_KEY, $config);
+
+        return true;
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    private function hasProviders(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_PROVIDER);
+        // Hidden/deleted providers still count as prior use of the extension.
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_PROVIDER)
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) && (int)$count > 0;
+    }
+
+    /**
+     * The enforcement mode as EXPLICITLY stored (pre-template-merge), or null when
+     * the install never set it and relied on the shipped default. Read from the
+     * raw stored configuration rather than {@see ExtensionConfiguration::get()},
+     * whose merged result cannot tell "relying on the default" apart from an
+     * explicit choice.
+     */
+    private function storedEnforcement(): ?string
+    {
+        // Narrowed step by step because the $GLOBALS shape is untyped.
+        $confVars   = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $extensions = is_array($confVars) ? ($confVars['EXTENSIONS'] ?? null) : null;
+        $extension  = is_array($extensions) ? ($extensions[self::EXT_KEY] ?? null) : null;
+        $tools      = is_array($extension) ? ($extension['tools'] ?? null) : null;
+        $value      = is_array($tools) ? ($tools['dataClassEnforcement'] ?? null) : null;
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/Documentation/Adr/Adr115EnforceByDefaultForNewInstalls.rst
+++ b/Documentation/Adr/Adr115EnforceByDefaultForNewInstalls.rst
@@ -1,0 +1,72 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-115:
+
+============================================================================
+ADR-115: Tool data-class enforcement is the default for new installs
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-23
+:Authors: Netresearch DTT GmbH
+
+.. _adr-115-context:
+
+Context
+=======
+
+The trust-zone tool gate (:ref:`ADR-094 <adr-094>`) shipped in ``observe`` mode:
+it computed and logged the decision but still offered an over-ceiling tool, so an
+operator could watch it before turning it on. :ref:`ADR-113 <adr-113>` made the
+switch fail-closed — only an explicit ``observe`` observes — but the shipped
+DEFAULT was still ``observe``, so a brand-new install offered over-ceiling tools
+until someone opted in to enforcement. A security control that is off by default
+on a fresh install is the wrong default.
+
+The reason it shipped observe-by-default was to avoid an upgrade silently
+stripping tools from a working setup. That constraint is real, but it applies to
+EXISTING installs, not new ones.
+
+.. _adr-115-decision:
+
+Decision
+========
+
+Ship ``enforce`` as the default and preserve ``observe`` for existing installs
+with an upgrade wizard, so the two cases are treated differently:
+
+- **New install** — ``ext_conf_template.txt`` now sets
+  ``tools.dataClassEnforcement = enforce``. Combined with the fail-closed read
+  (:ref:`ADR-113 <adr-113>`), a fresh install enforces without any operator
+  action, and a missing or mistyped value also enforces.
+- **Existing install** — :php:`DataClassEnforcementDefaultUpdateWizard` pins an
+  explicit ``observe`` so the flip changes nothing for a setup that relied on the
+  old default, and its description points the operator at the run log and the
+  switch to enforce when ready.
+
+Distinguishing the two
+----------------------
+
+The wizard fires only when a **provider is configured** (you cannot run a tool
+without one, so a fresh install has none) AND the enforcement mode was **never
+explicitly stored** — read from the raw
+``$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_llm']`` rather than the
+template-merged :php:`ExtensionConfiguration::get()`, which cannot tell "relying
+on the default" apart from a deliberate choice. An operator who already chose a
+mode is left untouched: an explicit ``enforce`` is respected, an explicit
+``observe`` already matches.
+
+.. _adr-115-consequences:
+
+Consequences
+============
+
+- A new install is safe by default; the tool gate no longer waits for an opt-in.
+- An existing install's behaviour is unchanged across the upgrade — the wizard
+  makes its implicit ``observe`` explicit before the default flips under it.
+- The change is announced in the extension configuration label and the wizard
+  description; combined with the fail-closed read, an operator cannot end up in
+  ``observe`` by accident, only by deliberate choice.
+- A dedicated readiness report (how many tools each configuration would lose
+  under enforce) remains future work; the run log already records what
+  enforcement would do while an install is in observe.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -412,3 +412,4 @@ Tools
    Adr112LeaseBeforeOpWriteFence
    Adr113FailClosedToolDataClassEnforcement
    Adr114EncryptAgentStateAtRest
+   Adr115EnforceByDefaultForNewInstalls

--- a/Tests/Functional/Updates/DataClassEnforcementDefaultUpdateWizardTest.php
+++ b/Tests/Functional/Updates/DataClassEnforcementDefaultUpdateWizardTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Updates;
+
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Updates\DataClassEnforcementDefaultUpdateWizard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(DataClassEnforcementDefaultUpdateWizard::class)]
+final class DataClassEnforcementDefaultUpdateWizardTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_provider';
+
+    private mixed $originalConfVars = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalConfVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS'] = $this->originalConfVars;
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function pinsObserveForAnExistingInstallThatNeverChoseAMode(): void
+    {
+        $this->addProvider('openai-1');
+        // Raw stored config carries no enforcement value: relied on the old default.
+        $this->storeNrLlmConfig(['tools' => []]);
+
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['tools' => []]);
+        $extensionConfiguration->expects(self::once())->method('set')->with(
+            'nr_llm',
+            self::callback(static fn(mixed $c): bool => is_array($c)
+                && is_array($c['tools'] ?? null)
+                && ($c['tools']['dataClassEnforcement'] ?? null) === 'observe'),
+        );
+
+        $wizard = new DataClassEnforcementDefaultUpdateWizard($this->getConnectionPool(), $extensionConfiguration);
+
+        self::assertTrue($wizard->updateNecessary());
+        self::assertTrue($wizard->executeUpdate());
+    }
+
+    #[Test]
+    public function doesNotFireForAFreshInstallWithoutProviders(): void
+    {
+        // No provider rows -> a fresh install keeps the new enforce default.
+        $this->storeNrLlmConfig(['tools' => []]);
+
+        $wizard = new DataClassEnforcementDefaultUpdateWizard(
+            $this->getConnectionPool(),
+            $this->createMock(ExtensionConfiguration::class),
+        );
+
+        self::assertFalse($wizard->updateNecessary());
+    }
+
+    #[Test]
+    public function respectsAnExplicitEnforceChoice(): void
+    {
+        $this->addProvider('openai-2');
+        $this->storeNrLlmConfig(['tools' => ['dataClassEnforcement' => 'enforce']]);
+
+        $wizard = new DataClassEnforcementDefaultUpdateWizard(
+            $this->getConnectionPool(),
+            $this->createMock(ExtensionConfiguration::class),
+        );
+
+        self::assertFalse($wizard->updateNecessary(), 'an explicit enforce is left untouched');
+    }
+
+    #[Test]
+    public function respectsAnExplicitObserveChoice(): void
+    {
+        $this->addProvider('openai-3');
+        $this->storeNrLlmConfig(['tools' => ['dataClassEnforcement' => 'observe']]);
+
+        $wizard = new DataClassEnforcementDefaultUpdateWizard(
+            $this->getConnectionPool(),
+            $this->createMock(ExtensionConfiguration::class),
+        );
+
+        self::assertFalse($wizard->updateNecessary(), 'already observe -> nothing to do');
+    }
+
+    private function addProvider(string $identifier): void
+    {
+        $this->getConnectionPool()->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'          => 0,
+            'identifier'   => $identifier,
+            'name'         => 'Provider ' . $identifier,
+            'adapter_type' => 'openai',
+        ]);
+    }
+
+    /**
+     * Write the raw stored nr_llm extension configuration, narrowing the untyped
+     * $GLOBALS shape step by step so the writes stay PHPStan-clean.
+     *
+     * @param array<string, mixed> $nrLlm
+     */
+    private function storeNrLlmConfig(array $nrLlm): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        if (!is_array($confVars)) {
+            $confVars = [];
+        }
+        $extensions = $confVars['EXTENSIONS'] ?? [];
+        if (!is_array($extensions)) {
+            $extensions = [];
+        }
+        $extensions['nr_llm']   = $nrLlm;
+        $confVars['EXTENSIONS'] = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -118,8 +118,8 @@ telemetry.enabled = 1
 # Tool egress policy (ADR-094)
 # =============================================================================
 
-# cat=tools; type=options[Observe (log only)=observe,Enforce=enforce]; label=Tool data-class enforcement: Whether a tool whose data class exceeds the trust zone of the provider a run can reach is removed from that run ("Enforce") or merely reported ("Observe"). Observe is the default so an upgrade cannot silently strip tools from working setups; check the run log, then switch to Enforce. The other tool gates (global enablement, admin-only tools, the configuration's allowed tool groups) always apply regardless of this setting.
-tools.dataClassEnforcement = observe
+# cat=tools; type=options[Enforce=enforce,Observe (log only)=observe]; label=Tool data-class enforcement: Whether a tool whose data class exceeds the trust zone of the provider a run can reach is removed from that run ("Enforce") or merely reported ("Observe"). Enforce is the default so a new install is safe by default (ADR-113); the read is fail-closed, so a missing or mistyped value also enforces. An install upgraded from an older version is pinned to Observe by an upgrade wizard so the change does not silently strip tools from a working setup — review the run log there, then switch back to Enforce. The other tool gates (global enablement, admin-only tools, the configuration's allowed tool groups) always apply regardless of this setting.
+tools.dataClassEnforcement = enforce
 
 # =============================================================================
 # Privacy & data retention (ADR-064)


### PR DESCRIPTION
## What

**P0 #3 slice 3b — make enforcement the default for new installs.**

Slice 3a (#514) made the `tools.dataClassEnforcement` switch fail-closed but left the shipped **default** at `observe`, so a brand-new install still offered over-ceiling tools until someone opted in. A security control that is off by default on a fresh install is the wrong default (ADR-115).

Ship `enforce` as the default and preserve `observe` for existing installs:

- **New install** — `ext_conf_template.txt` now sets `tools.dataClassEnforcement = enforce`. Combined with the fail-closed read (ADR-113), a fresh install enforces with no operator action; a missing/mistyped value also enforces.
- **Existing install** — `DataClassEnforcementDefaultUpdateWizard` pins an explicit `observe` so the flip changes nothing for a setup that relied on the old default. Its description points the operator at the run log and the switch to enforce.

### Distinguishing the two
The wizard fires only when a **provider is configured** (a fresh install has none → keeps `enforce`) **AND** the mode was **never explicitly stored** — read from the raw `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_llm']`, since the template-merged `ExtensionConfiguration::get()` can't tell "relying on the default" from a deliberate choice. An explicit `enforce` is respected; an explicit `observe` already matches.

## Not in this PR
A dedicated readiness report (how many tools each configuration would lose under enforce) remains future work; the run log already records what enforcement would do while an install is in observe.

## Tests
Functional: pins observe for an existing install that never chose a mode (asserts the `set()` call); does not fire for a fresh install (no providers); respects an explicit `enforce`; respects an explicit `observe`.

## Breaking
A **new** install now enforces the trust-zone tool gate by default (over-ceiling tools are removed, not just logged). Existing installs are pinned to observe by the wizard and unchanged. Pre-1.0, before 0.24.0.

## Gate
cgl, phpstan L10, unit, rector -n, fuzzy, functional -d sqlite — all green locally.
