### PR TITLE
docs(agents): document tag-driven TER publish + Renovate auto-merge gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,10 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
 - Issues: https://github.com/netresearch/t3x-nr-llm/issues
 - Discussions: https://github.com/netresearch/t3x-nr-llm/discussions
 <!-- AGENTS-GENERATED:END help -->
+
+<!-- Hand-maintained; intentionally outside the AGENTS-GENERATED blocks above. -->
+## Release & dependency automation (agent notes)
+
+- **Releasing is a tag push, and the tag publishes TER automatically.** Pushing an annotated signed tag `vX.Y.Z` on `main` triggers `release.yml`, which calls the reusable `netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in: it produces the SBOM / Cosign / SLSA artifacts, creates the GitHub release, **and publishes to TER + Packagist**. `ter-publish.yml` ("Manual TER publish" in the workflow table) is only a `workflow_dispatch` re-publish fallback — it is *not* the primary path and does not need to be run for a normal release. Verify a release by checking Packagist (`repo.packagist.org/p2/netresearch/nr-llm.json`, tags are `v`-prefixed), TER (`extensions.typo3.org/api/v1/extension/nr_llm/versions`) and the docs 0.X URL — do not assume TER is a separate manual step.
+- **The `chore(release): X.Y.Z` commit bumps four files:** `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml`, and `CHANGELOG.md` (not `Changelog.rst`). Version bumps belong to this release flow, never to a feature PR.
+- **Renovate/Dependabot PRs auto-merge via `auto-merge-deps.yml` — do not hand-merge them by default.** Known gap (2026-07-24): `auto-merge-deps.yml` did **not** auto-merge #511/#509 and they were admin-merged manually to unblock the 0.24.0 release; root cause (merge-queue interaction vs an unmet workflow condition) is **not yet verified**. Investigate the workflow's condition/queue behaviour before relying on it for the next release rather than reflexively hand-merging.


### PR DESCRIPTION
## What

Two operational notes captured during the 0.24.0 release, in a **hand-maintained** section placed intentionally *outside* the `AGENTS-GENERATED` blocks (the rest of `AGENTS.md` is generated).

### Release & TER (P5)

Clarifies an ambiguity that misled me twice: the CI table lists `ter-publish.yml` as "Manual TER publish", which reads as if TER is a manual step. It is not the primary path. Evidence:

- `release.yml` calls the reusable `netresearch/typo3-ci-workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in.
- `ter-publish.yml` (`workflow_dispatch`) last ran **2026-03-24**, not for 0.24.0.
- Yet TER 0.24.0 is live → `release.yml` published it on tag push.

So: tag `vX.Y.Z` → `release.yml` → SBOM/Cosign/SLSA + GitHub release **+ TER + Packagist**. `ter-publish.yml` is a manual re-publish fallback only. Also records the four files a `chore(release)` bumps.

### Renovate auto-merge gap (P4)

`auto-merge-deps.yml` exists but did **not** auto-merge #511/#509 during the 0.24.0 release; they were admin-merged manually to unblock. Root cause (merge-queue interaction vs an unmet workflow condition) is **not yet verified** — the note says to investigate before relying on it next release, not to hand-merge by default.

Came from /retro: yes
