### PR TITLE
feat(dashboard): agentic, telemetry & governance widgets (+ governance_event audit table)

### DIFF
--- a/Classes/Command/PurgeGovernanceCommand.php
+++ b/Classes/Command/PurgeGovernanceCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Prunes old rows from the governance-event log (tx_nrllm_governance_event).
+ *
+ * The governance log appends one row per denied or gated decision, so the table
+ * grows with agent activity. This command bounds that growth by deleting rows
+ * older than the retention window taken from the central privacy policy
+ * ({@see PrivacyDataCategory::GOVERNANCE}). Run it from the scheduler or cron —
+ * or schedule `nrllm:privacy:purge`, which covers every table at once.
+ */
+#[AsCommand(
+    name: 'nrllm:governance:purge',
+    description: 'Delete governance-event rows older than the configured retention window.',
+)]
+final class PurgeGovernanceCommand extends Command
+{
+    public function __construct(
+        private readonly GovernanceEventRepositoryInterface $repository,
+        private readonly PrivacyPolicyInterface $privacyPolicy,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'days',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Delete governance-event rows older than this many days. Defaults to the configured governance retention window.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $daysOption = $input->getOption('days');
+        $days       = $daysOption === null
+            ? $this->privacyPolicy->retentionDaysFor(PrivacyDataCategory::GOVERNANCE)
+            : (is_numeric($daysOption) ? (int)$daysOption : 0);
+
+        if ($days < 1) {
+            $io->error('The --days option must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $cutoff  = time() - ($days * 86400);
+        $deleted = $this->repository->purgeOlderThan($cutoff);
+
+        $io->success(sprintf('Deleted %d governance-event row(s) older than %d day(s).', $deleted, $days));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Command/PurgePrivacyDataCommand.php
+++ b/Classes/Command/PurgePrivacyDataCommand.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Command;
 
 use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
 use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
 use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
 use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
 use Netresearch\NrLlm\Service\Skill\SkillAuditRepositoryInterface;
@@ -41,7 +42,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 #[AsCommand(
     name: 'nrllm:privacy:purge',
-    description: 'Delete content-bearing rows (eval results, skill audit, telemetry, conversations, agent runs) past their retention window.',
+    description: 'Delete content-bearing rows (eval results, skill audit, telemetry, conversations, agent runs, governance events) past their retention window.',
 )]
 final class PurgePrivacyDataCommand extends Command
 {
@@ -52,6 +53,7 @@ final class PurgePrivacyDataCommand extends Command
         private readonly TelemetryRepositoryInterface $telemetry,
         private readonly AiSessionRepositoryInterface $sessions,
         private readonly AgentRunRepositoryInterface $agentRuns,
+        private readonly GovernanceEventRepositoryInterface $governanceEvents,
     ) {
         parent::__construct();
     }
@@ -100,6 +102,9 @@ final class PurgePrivacyDataCommand extends Command
 
         [$days, $cutoff] = $window(PrivacyDataCategory::APPROVAL);
         $purged[]        = sprintf('Unfinished agent runs (%d d): %d', $days, $this->agentRuns->purgeUnfinishedOlderThan($cutoff));
+
+        [$days, $cutoff] = $window(PrivacyDataCategory::GOVERNANCE);
+        $purged[]        = sprintf('Governance events (%d d): %d', $days, $this->governanceEvents->purgeOlderThan($cutoff));
 
         $io->success('Retention enforced across all content-bearing tables.');
         $io->listing($purged);

--- a/Classes/Domain/Enum/GovernanceDecision.php
+++ b/Classes/Domain/Enum/GovernanceDecision.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * What kind of governance decision an append-only governance event records
+ * (tx_nrllm_governance_event).
+ *
+ * One vocabulary spanning the two write points that were previously only logged
+ * or reflected on a run: a tool-gate denial ({@see self::TOOL_DENIED}, from the
+ * tool loop) and a guardrail outcome on a provider response
+ * ({@see self::RESPONSE_BLOCKED}, {@see self::APPROVAL_REQUIRED},
+ * {@see self::CONTENT_FILTER}, from the guardrail middleware). Keeps the
+ * `decision` column type-safe, mirroring the sibling enums'
+ * {@see self::values()} contract.
+ */
+enum GovernanceDecision: string
+{
+    /**
+     * The tool gate denied (or observe-mode flagged) a tool for a run.
+     */
+    case TOOL_DENIED = 'tool_denied';
+
+    /**
+     * A guardrail denied a provider response outright (GuardrailVerdict::DENY).
+     */
+    case RESPONSE_BLOCKED = 'response_blocked';
+
+    /**
+     * A guardrail routed a provider response to human approval
+     * (GuardrailVerdict::REQUIRE_APPROVAL).
+     */
+    case APPROVAL_REQUIRED = 'approval_required';
+
+    /**
+     * A guardrail denied a response the provider itself flagged as filtered
+     * (finishReason = content_filter) — distinguished from a generic block so a
+     * provider-side safety stop is separately measurable.
+     */
+    case CONTENT_FILTER = 'content_filter';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+}

--- a/Classes/Domain/Enum/PrivacyDataCategory.php
+++ b/Classes/Domain/Enum/PrivacyDataCategory.php
@@ -57,6 +57,13 @@ enum PrivacyDataCategory: string
     case APPROVAL = 'approval';
 
     /**
+     * Governance decisions — tool-gate denials and guardrail blocks
+     * (tx_nrllm_governance_event). Attributable metadata (be_user, decision,
+     * tool name), no prompts or responses; purged like telemetry.
+     */
+    case GOVERNANCE = 'governance';
+
+    /**
      * The `privacy.retention.<key>` extension-configuration key this category
      * reads its override from.
      */

--- a/Classes/Domain/ValueObject/GovernanceEvent.php
+++ b/Classes/Domain/ValueObject/GovernanceEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One immutable governance-decision row, produced at a denial/gate choke point
+ * and written by GovernanceEventRepository (tx_nrllm_governance_event).
+ *
+ * Privacy by construction (ADR-064): no prompt, no response, no tool arguments
+ * or output. `detail` carries only policy facts (trust zone, ceiling,
+ * observe-mode flag) or a guardrail's policy reason — never response content —
+ * and `guardrail` is the deciding guardrail's FQCN only, matching telemetry's
+ * class-name-not-message stance.
+ */
+final readonly class GovernanceEvent
+{
+    /**
+     * @param string $correlationId           trace id linking a guardrail-origin row to its telemetry / run; '' when unknown at the write point
+     * @param string $decision                a {@see \Netresearch\NrLlm\Domain\Enum\GovernanceDecision} value
+     * @param string $reason                  raw enum value: ToolDenialReason, GuardrailVerdict, or the 'content_filter' literal
+     * @param string $provider                provider identifier ('' when unknown)
+     * @param string $model                   model identifier ('' when unknown)
+     * @param string $configurationIdentifier configuration identifier ('' when unknown)
+     * @param int    $beUser                  acting backend user uid (0 for CLI / scheduler / unauthenticated)
+     * @param string $toolName                the tool this decision was about; '' for guardrail / content_filter rows
+     * @param int    $agentrunUid             the agent run this decision belongs to; 0 when not available at the write point
+     * @param string $guardrail               the deciding guardrail FQCN for guardrail rows; '' for tool_denied rows
+     * @param string $detail                  optional short policy detail — never content
+     */
+    public function __construct(
+        public string $correlationId,
+        public string $decision,
+        public string $reason,
+        public string $provider,
+        public string $model,
+        public string $configurationIdentifier,
+        public int $beUser,
+        public string $toolName,
+        public int $agentrunUid,
+        public string $guardrail,
+        public string $detail,
+    ) {}
+}

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -9,17 +9,21 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailPolicyResolver;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Applies the guardrail collection to every non-streaming provider response
@@ -64,6 +68,11 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         // working (a null/empty selection runs all guardrails, unchanged from
         // before ADR-106).
         private GuardrailPolicyResolver $policyResolver = new GuardrailPolicyResolver(new GuardrailRegistry([], [])),
+        // Records a DENY / REQUIRE_APPROVAL / content-filter outcome so it becomes
+        // queryable (governance-blocks widget). Nullable to preserve the lean test
+        // wiring, like the $policyResolver default above; absent it the verdict is
+        // still enforced, it just is not persisted.
+        private ?GovernanceEventRepositoryInterface $governanceEvents = null,
     ) {}
 
     public function handle(
@@ -79,7 +88,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             return $this->screen($result, $context, $next, false, $guardrails);
         }
         if ($result instanceof VisionResponse) {
-            return $this->screenVision($result, $guardrails);
+            return $this->screenVision($result, $context, $guardrails);
         }
 
         return $result;
@@ -95,12 +104,13 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
     /**
      * @param list<GuardrailInterface> $guardrails the config-filtered output guardrails
      */
-    private function screenVision(VisionResponse $vision, array $guardrails): VisionResponse
+    private function screenVision(VisionResponse $vision, ProviderCallContext $context, array $guardrails): VisionResponse
     {
         $screened = $vision->description;
         foreach ($guardrails as $guardrail) {
-            $result  = $guardrail->checkOutput(new CompletionResponse($screened, $vision->model, $vision->usage, provider: $vision->provider));
-            $verdict = $result->verdict;
+            $candidate = new CompletionResponse($screened, $vision->model, $vision->usage, provider: $vision->provider);
+            $result    = $guardrail->checkOutput($candidate);
+            $verdict   = $result->verdict;
             if ($verdict === GuardrailVerdict::RETRY) {
                 throw new GuardrailViolationException(
                     $guardrail::class,
@@ -110,14 +120,8 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             $screened = match ($verdict) {
                 GuardrailVerdict::ALLOW => $screened,
                 GuardrailVerdict::REDACT => $result->redactedContent ?? $screened,
-                GuardrailVerdict::DENY => throw new GuardrailViolationException(
-                    $guardrail::class,
-                    $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
-                ),
-                GuardrailVerdict::REQUIRE_APPROVAL => throw new GuardrailApprovalRequiredException(
-                    $guardrail::class,
-                    $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
-                ),
+                GuardrailVerdict::DENY,
+                GuardrailVerdict::REQUIRE_APPROVAL => $this->recordAndThrow($verdict, $guardrail, $result, $candidate, $context),
             };
         }
 
@@ -167,14 +171,8 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
                     $result->redactedContent ?? $response->content,
                     $result->redactedThinking,
                 ),
-                GuardrailVerdict::DENY => throw new GuardrailViolationException(
-                    $guardrail::class,
-                    $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
-                ),
-                GuardrailVerdict::REQUIRE_APPROVAL => throw new GuardrailApprovalRequiredException(
-                    $guardrail::class,
-                    $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
-                ),
+                GuardrailVerdict::DENY,
+                GuardrailVerdict::REQUIRE_APPROVAL => $this->recordAndThrow($verdict, $guardrail, $result, $response, $context),
             };
         }
 
@@ -227,5 +225,87 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
             metadata: $response->metadata,
             thinking: $thinking ?? $response->thinking,
         );
+    }
+
+    /**
+     * Persist the governance event for a blocking verdict, then throw the
+     * matching exception — one helper shared by the DENY / REQUIRE_APPROVAL arms
+     * of {@see screen()} and {@see screenVision()} so the record()+throw is not
+     * duplicated four times. Recorded before throwing so a blocked response is
+     * captured even though the pipeline unwinds. Only class names and policy
+     * facts are stored — never the response content (ADR-064).
+     *
+     * A DENY on a provider-flagged response (finishReason = content_filter) is
+     * tagged CONTENT_FILTER so a provider-side safety stop is separately
+     * measurable; REQUIRE_APPROVAL is always APPROVAL_REQUIRED.
+     */
+    private function recordAndThrow(
+        GuardrailVerdict $verdict,
+        GuardrailInterface $guardrail,
+        GuardrailResult $result,
+        CompletionResponse $response,
+        ProviderCallContext $context,
+    ): never {
+        $decision = match (true) {
+            $verdict === GuardrailVerdict::REQUIRE_APPROVAL => GovernanceDecision::APPROVAL_REQUIRED,
+            $response->wasFiltered()                        => GovernanceDecision::CONTENT_FILTER,
+            default                                         => GovernanceDecision::RESPONSE_BLOCKED,
+        };
+        $reason = match ($decision) {
+            GovernanceDecision::APPROVAL_REQUIRED => GuardrailVerdict::REQUIRE_APPROVAL->value,
+            GovernanceDecision::CONTENT_FILTER    => GovernanceDecision::CONTENT_FILTER->value,
+            default                               => GuardrailVerdict::DENY->value,
+        };
+
+        $this->governanceEvents?->record(new GovernanceEvent(
+            correlationId: $context->correlationId,
+            decision: $decision->value,
+            reason: $reason,
+            provider: $response->provider !== '' ? $response->provider : $context->telemetryProvider(),
+            model: $response->model !== '' ? $response->model : $context->telemetryModel(),
+            configurationIdentifier: $context->telemetryConfigurationIdentifier(),
+            beUser: $this->resolveBeUser($context),
+            toolName: '',
+            // The middleware runs below the run identity, so the run uid is not
+            // known here; correlation_id is the join key to the run instead.
+            agentrunUid: 0,
+            guardrail: $guardrail::class,
+            // The guardrail's policy reason — a policy fact, never response content.
+            detail: $result->reason,
+        ));
+
+        if ($verdict === GuardrailVerdict::REQUIRE_APPROVAL) {
+            throw new GuardrailApprovalRequiredException(
+                $guardrail::class,
+                $result->reason !== '' ? $result->reason : 'A guardrail flagged the response for human approval.',
+            );
+        }
+
+        throw new GuardrailViolationException(
+            $guardrail::class,
+            $result->reason !== '' ? $result->reason : 'A guardrail denied the response.',
+        );
+    }
+
+    /**
+     * The acting backend user uid, mirroring TelemetryMiddleware's resolution:
+     * the explicit metadata uid the runtime threads through (ADR-083), else the
+     * ambient backend user, else 0 (CLI / scheduler / unauthenticated).
+     */
+    private function resolveBeUser(ProviderCallContext $context): int
+    {
+        $fromMetadata = $context->metadata[BudgetMiddleware::METADATA_BE_USER_UID] ?? null;
+        if (\is_int($fromMetadata)) {
+            return $fromMetadata;
+        }
+
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if ($backendUser instanceof BackendUserAuthentication && \is_array($backendUser->user)) {
+            $uid = $backendUser->user['uid'] ?? null;
+
+            return \is_numeric($uid) ? (int)$uid : 0;
+        }
+
+        return 0;
     }
 }

--- a/Classes/Service/Governance/GovernanceEventRepository.php
+++ b/Classes/Service/Governance/GovernanceEventRepository.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Governance;
+
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Append-only store for the governance-decision audit trail
+ * (tx_nrllm_governance_event).
+ *
+ * By construction the application can only INSERT: {@see record()} plus read
+ * aggregates for the dashboard, and — the one retention exception — a purge
+ * driven by the nrllm:governance:purge command. Uses the Doctrine ConnectionPool
+ * directly, mirroring {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepository}:
+ * the table is a UI-less log with no Extbase / TCA. No update or delete path
+ * beyond the age-based purge.
+ */
+final readonly class GovernanceEventRepository implements GovernanceEventRepositoryInterface, SingletonInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_governance_event';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function record(GovernanceEvent $event): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'correlation_id'           => $event->correlationId,
+            'decision'                 => $event->decision,
+            'reason'                   => $event->reason,
+            'provider'                 => $event->provider,
+            'model'                    => $event->model,
+            'configuration_identifier' => $event->configurationIdentifier,
+            'be_user'                  => $event->beUser,
+            'tool_name'                => $event->toolName,
+            'agentrun_uid'             => $event->agentrunUid,
+            'guardrail'                => $event->guardrail,
+            'detail'                   => $event->detail,
+            'crdate'                   => time(),
+        ]);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+
+        return (int)$queryBuilder
+            ->delete(self::TABLE)
+            ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
+            ->executeStatement();
+    }
+
+    public function countByDecision(int $since = 0): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('decision')
+            ->addSelectLiteral('COUNT(uid) AS event_count')
+            ->from(self::TABLE);
+        if ($since > 0) {
+            $queryBuilder->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            );
+        }
+        $rows = $queryBuilder
+            ->groupBy('decision')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $this->tallyBy($rows, 'decision', 'event_count');
+    }
+
+    public function countToolDenialsByReason(int $since = 0): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('reason')
+            ->addSelectLiteral('COUNT(uid) AS event_count')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('decision', $queryBuilder->createNamedParameter('tool_denied')),
+            );
+        if ($since > 0) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            );
+        }
+        $rows = $queryBuilder
+            ->groupBy('reason')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $this->tallyBy($rows, 'reason', 'event_count');
+    }
+
+    public function countToolDecisionsByName(int $since = 0): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('tool_name')
+            ->addSelectLiteral('COUNT(uid) AS event_count')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->neq('tool_name', $queryBuilder->createNamedParameter('')),
+            );
+        if ($since > 0) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            );
+        }
+        $rows = $queryBuilder
+            ->groupBy('tool_name')
+            ->orderBy('event_count', 'DESC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $this->tallyBy($rows, 'tool_name', 'event_count');
+    }
+
+    /**
+     * Fold GROUP BY rows into a value => count map, dropping empty keys.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return array<string, int>
+     */
+    private function tallyBy(array $rows, string $keyColumn, string $countColumn): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            $key = self::toStr($row[$keyColumn] ?? '');
+            if ($key === '') {
+                continue;
+            }
+            $out[$key] = self::toInt($row[$countColumn] ?? 0);
+        }
+
+        return $out;
+    }
+}

--- a/Classes/Service/Governance/GovernanceEventRepositoryInterface.php
+++ b/Classes/Service/Governance/GovernanceEventRepositoryInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Governance;
+
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
+
+/**
+ * Persistence boundary for the append-only governance-decision audit trail
+ * (tx_nrllm_governance_event).
+ *
+ * Append one immutable row, purge old rows, or read a small set of dashboard
+ * aggregates. Mirrors {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface}:
+ * there is no update path — governance events are immutable — and the read
+ * methods only ever aggregate, never expose a single row's detail.
+ */
+interface GovernanceEventRepositoryInterface
+{
+    /**
+     * Append one governance-decision row. Never throws for a caller-visible
+     * reason: recording a denial must not break the run it observes.
+     */
+    public function record(GovernanceEvent $event): void;
+
+    /**
+     * Delete rows created strictly before the given UNIX timestamp.
+     *
+     * @return int number of rows deleted
+     */
+    public function purgeOlderThan(int $timestamp): int;
+
+    /**
+     * Count events per decision kind on/after $since (0 = all time). Keys are
+     * raw {@see \Netresearch\NrLlm\Domain\Enum\GovernanceDecision} values.
+     *
+     * @return array<string, int>
+     */
+    public function countByDecision(int $since = 0): array;
+
+    /**
+     * Count tool-gate denials per denial reason on/after $since (0 = all time):
+     * rows with decision = tool_denied, grouped by reason.
+     *
+     * @return array<string, int>
+     */
+    public function countToolDenialsByReason(int $since = 0): array;
+
+    /**
+     * Count tool-gate decisions per tool name on/after $since (0 = all time):
+     * rows carrying a non-empty tool_name, grouped by tool_name. This measures
+     * gate DECISIONS by tool (which tools get blocked/observed), not successful
+     * invocation volume.
+     *
+     * @return array<string, int>
+     */
+    public function countToolDecisionsByName(int $since = 0): array;
+}

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Telemetry;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
 
@@ -56,5 +57,43 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             ->delete(self::TABLE)
             ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
             ->executeStatement();
+    }
+
+    public function successRatePercent(int $since): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $row = $queryBuilder
+            ->addSelectLiteral('COUNT(uid) AS total', 'SUM(success) AS ok')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!is_array($row)) {
+            return 0;
+        }
+        $total = is_numeric($row['total'] ?? null) ? (int)$row['total'] : 0;
+        $ok    = is_numeric($row['ok'] ?? null) ? (int)$row['ok'] : 0;
+
+        return $total === 0 ? 0 : (int)round($ok * 100 / $total);
+    }
+
+    public function averageLatencyMs(int $since): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $avg = $queryBuilder
+            ->addSelectLiteral('AVG(latency_ms) AS avg_latency')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($avg) ? (int)round((float)$avg) : 0;
     }
 }

--- a/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
+++ b/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
@@ -12,9 +12,9 @@ namespace Netresearch\NrLlm\Service\Telemetry;
 /**
  * Persistence boundary for provider pipeline telemetry rows (ADR-058).
  *
- * Deliberately narrow: append one row, or purge old rows. There is no update
- * or read path — telemetry is append-only and analytics query the table
- * directly.
+ * Append one row, purge old rows, or read a small set of dashboard aggregates.
+ * Telemetry stays append-only — there is no update path; the read methods only
+ * ever aggregate, never expose a single row's payload.
  */
 interface TelemetryRepositoryInterface
 {
@@ -30,4 +30,16 @@ interface TelemetryRepositoryInterface
      * @return int number of rows deleted
      */
     public function purgeOlderThan(int $timestamp): int;
+
+    /**
+     * Success rate as an integer percent (0-100) over rows created on/after
+     * $since. Zero matching rows ⇒ 0.
+     */
+    public function successRatePercent(int $since): int;
+
+    /**
+     * Average latency_ms (rounded to an int) over rows created on/after $since.
+     * Zero matching rows ⇒ 0.
+     */
+    public function averageLatencyMs(int $since): int;
 }

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -604,6 +604,89 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return is_numeric($max) ? (int)$max : -1;
     }
 
+    public function countByStatus(int $since = 0): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('status')
+            ->addSelectLiteral('COUNT(uid) AS run_count')
+            ->from(self::TABLE_RUN);
+        if ($since > 0) {
+            $queryBuilder->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            );
+        }
+        $rows = $queryBuilder
+            ->groupBy('status')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $this->tallyBy($rows, 'status', 'run_count');
+    }
+
+    public function countByTerminationReason(int $since = 0): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('termination_reason')
+            ->addSelectLiteral('COUNT(uid) AS run_count')
+            ->from(self::TABLE_RUN)
+            ->where(
+                $queryBuilder->expr()->neq('termination_reason', $queryBuilder->createNamedParameter('')),
+            );
+        if ($since > 0) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+            );
+        }
+        $rows = $queryBuilder
+            ->groupBy('termination_reason')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $this->tallyBy($rows, 'termination_reason', 'run_count');
+    }
+
+    public function countInStatus(AgentRunStatus $status): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_RUN)
+            ->where(
+                $queryBuilder->expr()->eq('status', $queryBuilder->createNamedParameter($status->value)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return self::toInt($count);
+    }
+
+    /**
+     * Fold GROUP BY rows into a value => count map, dropping empty keys. Shared
+     * by {@see countByStatus()} and {@see countByTerminationReason()}.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return array<string, int>
+     */
+    private function tallyBy(array $rows, string $keyColumn, string $countColumn): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            $key = self::toStr($row[$keyColumn] ?? '');
+            if ($key === '') {
+                continue;
+            }
+            $out[$key] = self::toInt($row[$countColumn] ?? 0);
+        }
+
+        return $out;
+    }
+
     public function purgeOlderThan(int $timestamp): int
     {
         return $this->purgeRuns($timestamp, AgentRunStatus::terminalValues());

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 
@@ -172,6 +173,31 @@ interface AgentRunRepositoryInterface
      * @return list<AgentRun>
      */
     public function findRecentTerminal(int $limit = 20): array;
+
+    /**
+     * Count runs per lifecycle status created on/after $since (0 = all time).
+     * Keys are raw {@see AgentRunStatus} values present in the data; absent
+     * statuses are omitted.
+     *
+     * @return array<string, int>
+     */
+    public function countByStatus(int $since = 0): array;
+
+    /**
+     * Count TERMINATED runs per termination_reason on/after $since (0 = all
+     * time). Only rows with a non-empty termination_reason are counted (a run
+     * still in flight has none).
+     *
+     * @return array<string, int>
+     */
+    public function countByTerminationReason(int $since = 0): array;
+
+    /**
+     * Count runs currently in one status (e.g. WAITING_FOR_APPROVAL). A live
+     * gauge — no $since window, because an approval waiting from last week still
+     * needs a human decision now.
+     */
+    public function countInStatus(AgentRunStatus $status): int;
 
     /**
      * @param int $afterSequence only events with sequence > this value; -1

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -13,9 +13,11 @@ use JsonException;
 use LogicException;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
@@ -27,6 +29,7 @@ use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\ContextTruncatedException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
@@ -109,6 +112,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // loop sends the full transcript exactly as before, and every
         // enforcement site below is a no-op.
         private ?ContextWindowManagerInterface $contextWindow = null,
+        // Records tool-gate denials so "tool denials by reason / by tool" become
+        // queryable. Nullable, matching the optional $toolPolicy above: absent it
+        // (the lean test wiring) the gate still logs, it just does not persist.
+        private ?GovernanceEventRepositoryInterface $governanceEvents = null,
     ) {}
 
     /**
@@ -731,6 +738,32 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                         'reason' => $decision->reason->value,
                         'zone'   => $decision->zone->value,
                     ]);
+                    // Persist the denial (or observe-mode flag) so it is queryable
+                    // by tool name and reason (the log line is not). This gate is
+                    // the one place tool_name is structurally available. The run's
+                    // correlation id / uid are not in scope at this seam, so a
+                    // tool-denied row carries neither — its value is the by-tool /
+                    // by-reason breakdown, not a per-run join. observed-mode rows
+                    // are recorded too (flagged in detail) so the trust-zone
+                    // rollout is measurable before it is enforced.
+                    $this->governanceEvents?->record(new GovernanceEvent(
+                        correlationId: '',
+                        decision: GovernanceDecision::TOOL_DENIED->value,
+                        reason: $decision->reason->value,
+                        provider: $configuration->getProviderType(),
+                        model: $configuration->getModelId(),
+                        configurationIdentifier: $configuration->getIdentifier(),
+                        beUser: $context->actor->backendUserUid,
+                        toolName: $decision->toolName,
+                        agentrunUid: 0,
+                        guardrail: '',
+                        detail: sprintf(
+                            'zone=%s;ceiling=%s;observedOnly=%d',
+                            $decision->zone->value,
+                            $decision->ceiling->value,
+                            $decision->observedOnly ? 1 : 0,
+                        ),
+                    ));
                 }
             }
 

--- a/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
+++ b/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesLanguageLabelTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js doughnut data provider for "agent runs by status (last N days)".
+ *
+ * Aggregates tx_nrllm_agentrun by lifecycle status. Slices are emitted in
+ * {@see AgentRunStatus} case order so the doughnut is stable regardless of which
+ * statuses happen to be present, each labelled via XLIFF and coloured by a fixed
+ * semantic map (terminal green/red/grey, waiting amber, running/queued blue).
+ */
+final readonly class AgentRunsByStatusDataProvider implements ChartDataProviderInterface
+{
+    use ResolvesLanguageLabelTrait;
+
+    private const DEFAULT_DAYS = 30;
+
+    private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
+
+    /** Semantic colour per status value; a missing key falls back to grey. */
+    private const STATUS_COLORS = [
+        'queued'               => '#6DAEDB',
+        'running'              => '#2F99A4',
+        'waiting_for_approval' => '#E8A33D',
+        'waiting_for_input'    => '#E8C33D',
+        'completed'            => '#4CAF50',
+        'failed'               => '#D9534F',
+        'cancelled'            => '#9E9E9E',
+    ];
+
+    public function __construct(
+        private AgentRunRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return self::shapeChartData($this->repository->countByStatus($since), $this->statusLabels());
+    }
+
+    /**
+     * Shape the value => count map into chart.js doughnut format.
+     *
+     * Extracted as a pure static for unit-testability — the ConnectionPool query
+     * path and the LanguageService lookup are covered by functional/backend
+     * context, this is fed pre-resolved labels.
+     *
+     * @param array<string, int>    $counts value => count, absent statuses omitted
+     * @param array<string, string> $labels value => translated display label
+     *
+     * @return array{labels: list<string>, datasets: list<array{backgroundColor: list<string>, data: list<int>}>}
+     */
+    public static function shapeChartData(array $counts, array $labels): array
+    {
+        $chartLabels = [];
+        $data        = [];
+        $colors      = [];
+        foreach (AgentRunStatus::cases() as $case) {
+            $count = $counts[$case->value] ?? 0;
+            if ($count <= 0) {
+                continue;
+            }
+            $chartLabels[] = $labels[$case->value] ?? $case->value;
+            $data[]        = $count;
+            $colors[]      = self::STATUS_COLORS[$case->value] ?? '#9E9E9E';
+        }
+
+        return [
+            'labels'   => $chartLabels,
+            'datasets' => [
+                [
+                    'backgroundColor' => $colors,
+                    'data'            => $data,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * The translated display label per status value, in enum order.
+     *
+     * @return array<string, string>
+     */
+    private function statusLabels(): array
+    {
+        $labels = [];
+        foreach (AgentRunStatus::cases() as $case) {
+            $labels[$case->value] = $this->resolveLabel(self::LLL . 'widget.agent_runs_by_status.status.' . $case->value);
+        }
+
+        return $labels;
+    }
+}

--- a/Classes/Widgets/DataProvider/AverageLatencyDataProvider.php
+++ b/Classes/Widgets/DataProvider/AverageLatencyDataProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
+
+/**
+ * Data provider for the "average latency" NumberWithIcon widget.
+ *
+ * Returns the mean end-to-end provider pipeline latency in milliseconds over
+ * the last N days, from tx_nrllm_telemetry. Paired with the success-rate tile:
+ * a percent and a millisecond figure are heterogeneous, so they are two tiles,
+ * never one misleading shared axis.
+ */
+final readonly class AverageLatencyDataProvider implements NumberWithIconDataProviderInterface
+{
+    private const DEFAULT_DAYS = 7;
+
+    public function __construct(
+        private TelemetryRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    public function getNumber(): int
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return $this->repository->averageLatencyMs($since);
+    }
+}

--- a/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
+++ b/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesLanguageLabelTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js bar-chart data provider for "governance blocks (last N days)".
+ *
+ * Aggregates tx_nrllm_governance_event by decision kind: tool-gate denials,
+ * guardrail response blocks, approval-required routings and provider
+ * content-filter blocks — the outcomes that were previously only logged or
+ * reflected on a run. Bars are emitted in {@see GovernanceDecision} case order
+ * so the chart is stable.
+ */
+final readonly class GovernanceBlocksOverTimeDataProvider implements ChartDataProviderInterface
+{
+    use ResolvesLanguageLabelTrait;
+
+    private const DEFAULT_DAYS = 30;
+
+    private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
+
+    /** Semantic colour per decision; a missing key falls back to grey. */
+    private const DECISION_COLORS = [
+        'tool_denied'       => '#607D8B',
+        'response_blocked'  => '#D9534F',
+        'approval_required' => '#E8A33D',
+        'content_filter'    => '#8E2A27',
+    ];
+
+    public function __construct(
+        private GovernanceEventRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return self::shapeChartData(
+            $this->repository->countByDecision($since),
+            $this->decisionLabels(),
+            $this->resolveLabel(self::LLL . 'widget.governance_blocks.dataset'),
+        );
+    }
+
+    /**
+     * Pure static for unit-testability, fed pre-resolved labels.
+     *
+     * @param array<string, int>    $counts       value => count, absent decisions omitted
+     * @param array<string, string> $labels       value => translated display label
+     * @param string                $datasetLabel translated legend for the single dataset
+     *
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public static function shapeChartData(array $counts, array $labels, string $datasetLabel): array
+    {
+        $chartLabels = [];
+        $data        = [];
+        $colors      = [];
+        foreach (GovernanceDecision::cases() as $case) {
+            $count = $counts[$case->value] ?? 0;
+            if ($count <= 0) {
+                continue;
+            }
+            $chartLabels[] = $labels[$case->value] ?? $case->value;
+            $data[]        = $count;
+            $colors[]      = self::DECISION_COLORS[$case->value] ?? '#9E9E9E';
+        }
+
+        return [
+            'labels'   => $chartLabels,
+            'datasets' => [
+                [
+                    'label'           => $datasetLabel,
+                    'backgroundColor' => $colors,
+                    'data'            => $data,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * The translated display label per decision, in enum order.
+     *
+     * @return array<string, string>
+     */
+    private function decisionLabels(): array
+    {
+        $labels = [];
+        foreach (GovernanceDecision::cases() as $case) {
+            $labels[$case->value] = $this->resolveLabel(self::LLL . 'widget.governance_blocks.decision.' . $case->value);
+        }
+
+        return $labels;
+    }
+}

--- a/Classes/Widgets/DataProvider/RequestSuccessRateDataProvider.php
+++ b/Classes/Widgets/DataProvider/RequestSuccessRateDataProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
+
+/**
+ * Data provider for the "request success rate" NumberWithIcon widget.
+ *
+ * Returns the share (integer percent, 0-100) of provider pipeline runs that
+ * succeeded over the last N days, from tx_nrllm_telemetry. The tile is an
+ * at-a-glance health indicator, not an SLA report.
+ */
+final readonly class RequestSuccessRateDataProvider implements NumberWithIconDataProviderInterface
+{
+    private const DEFAULT_DAYS = 7;
+
+    public function __construct(
+        private TelemetryRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    public function getNumber(): int
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return $this->repository->successRatePercent($since);
+    }
+}

--- a/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
+++ b/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesLanguageLabelTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js bar-chart data provider for "agent run outcomes (last N days)".
+ *
+ * Aggregates terminated tx_nrllm_agentrun rows by termination_reason. Grouping
+ * by the reason (ADR-092) — not the raw status — is what distinguishes a cost
+ * stop (budget_exhausted) from a policy stop (policy_denied / approval_denied)
+ * from a provider failure (provider_failed): all three otherwise surface as a
+ * completed-but-truncated or failed run. Bars are emitted in
+ * {@see AgentRunTerminationReason} case order so the chart is stable.
+ */
+final readonly class RunTerminationReasonsDataProvider implements ChartDataProviderInterface
+{
+    use ResolvesLanguageLabelTrait;
+
+    private const DEFAULT_DAYS = 30;
+
+    private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
+
+    /** Semantic colour per termination reason; a missing key falls back to grey. */
+    private const REASON_COLORS = [
+        'completed'         => '#4CAF50',
+        'max_iterations'    => '#E8A33D',
+        'budget_exhausted'  => '#E8731A',
+        'policy_denied'     => '#D9534F',
+        'approval_denied'   => '#B0413E',
+        'provider_failed'   => '#8E2A27',
+        'cancelled'         => '#9E9E9E',
+        'retries_exhausted' => '#7A5C3E',
+        'not_retryable'     => '#5A4632',
+        'context_truncated' => '#607D8B',
+    ];
+
+    public function __construct(
+        private AgentRunRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return self::shapeChartData(
+            $this->repository->countByTerminationReason($since),
+            $this->reasonLabels(),
+            $this->resolveLabel(self::LLL . 'widget.run_termination_reasons.dataset'),
+        );
+    }
+
+    /**
+     * Shape the value => count map into chart.js bar format.
+     *
+     * Pure static for unit-testability, fed pre-resolved labels.
+     *
+     * @param array<string, int>    $counts       value => count, absent reasons omitted
+     * @param array<string, string> $labels       value => translated display label
+     * @param string                $datasetLabel translated legend for the single dataset
+     *
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public static function shapeChartData(array $counts, array $labels, string $datasetLabel): array
+    {
+        $chartLabels = [];
+        $data        = [];
+        $colors      = [];
+        foreach (AgentRunTerminationReason::cases() as $case) {
+            $count = $counts[$case->value] ?? 0;
+            if ($count <= 0) {
+                continue;
+            }
+            $chartLabels[] = $labels[$case->value] ?? $case->value;
+            $data[]        = $count;
+            $colors[]      = self::REASON_COLORS[$case->value] ?? '#9E9E9E';
+        }
+
+        return [
+            'labels'   => $chartLabels,
+            'datasets' => [
+                [
+                    'label'           => $datasetLabel,
+                    'backgroundColor' => $colors,
+                    'data'            => $data,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * The translated display label per termination reason, in enum order.
+     *
+     * @return array<string, string>
+     */
+    private function reasonLabels(): array
+    {
+        $labels = [];
+        foreach (AgentRunTerminationReason::cases() as $case) {
+            $labels[$case->value] = $this->resolveLabel(self::LLL . 'widget.run_termination_reasons.reason.' . $case->value);
+        }
+
+        return $labels;
+    }
+}

--- a/Classes/Widgets/DataProvider/RunsAwaitingApprovalDataProvider.php
+++ b/Classes/Widgets/DataProvider/RunsAwaitingApprovalDataProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
+
+/**
+ * Data provider for the "runs awaiting approval" NumberWithIcon widget.
+ *
+ * A live gauge — no time window: an agent run suspended WAITING_FOR_APPROVAL
+ * (ADR-084) from last week still needs a human decision now. Served by the
+ * status_lookup index on tx_nrllm_agentrun.
+ */
+final readonly class RunsAwaitingApprovalDataProvider implements NumberWithIconDataProviderInterface
+{
+    public function __construct(
+        private AgentRunRepositoryInterface $repository,
+    ) {}
+
+    public function getNumber(): int
+    {
+        return $this->repository->countInStatus(AgentRunStatus::WAITING_FOR_APPROVAL);
+    }
+}

--- a/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesLanguageLabelTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js bar-chart data provider for "tool denials by reason (last N days)".
+ *
+ * Aggregates tx_nrllm_governance_event rows with decision = tool_denied by
+ * their {@see ToolDenialReason}. Bars are emitted in enum order so the chart is
+ * stable; the NONE case never carries a count (a denial always has a reason)
+ * and is skipped with every other zero-count reason.
+ */
+final readonly class ToolDenialsByReasonDataProvider implements ChartDataProviderInterface
+{
+    use ResolvesLanguageLabelTrait;
+
+    private const DEFAULT_DAYS = 30;
+
+    private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
+
+    /** Semantic colour per denial reason; a missing key falls back to grey. */
+    private const REASON_COLORS = [
+        'notRegistered'      => '#607D8B',
+        'toolDisabled'       => '#9E9E9E',
+        'requiresAdmin'      => '#D9534F',
+        'configurationGroup' => '#E8A33D',
+        'trustZone'          => '#8E2A27',
+    ];
+
+    public function __construct(
+        private GovernanceEventRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return self::shapeChartData(
+            $this->repository->countToolDenialsByReason($since),
+            $this->reasonLabels(),
+            $this->resolveLabel(self::LLL . 'widget.tool_denials.dataset'),
+        );
+    }
+
+    /**
+     * Pure static for unit-testability, fed pre-resolved labels.
+     *
+     * @param array<string, int>    $counts       value => count, absent reasons omitted
+     * @param array<string, string> $labels       value => translated display label
+     * @param string                $datasetLabel translated legend for the single dataset
+     *
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public static function shapeChartData(array $counts, array $labels, string $datasetLabel): array
+    {
+        $chartLabels = [];
+        $data        = [];
+        $colors      = [];
+        foreach (ToolDenialReason::cases() as $case) {
+            // NONE is the "not denied" case; it never carries a denial count, and
+            // a "denials by reason" chart must never show it even if a stray row
+            // did.
+            if ($case === ToolDenialReason::NONE) {
+                continue;
+            }
+            $count = $counts[$case->value] ?? 0;
+            if ($count <= 0) {
+                continue;
+            }
+            $chartLabels[] = $labels[$case->value] ?? $case->value;
+            $data[]        = $count;
+            $colors[]      = self::REASON_COLORS[$case->value] ?? '#9E9E9E';
+        }
+
+        return [
+            'labels'   => $chartLabels,
+            'datasets' => [
+                [
+                    'label'           => $datasetLabel,
+                    'backgroundColor' => $colors,
+                    'data'            => $data,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * The translated display label per denial reason, in enum order.
+     *
+     * @return array<string, string>
+     */
+    private function reasonLabels(): array
+    {
+        $labels = [];
+        foreach (ToolDenialReason::cases() as $case) {
+            $labels[$case->value] = $this->resolveLabel(self::LLL . 'widget.tool_denials.reason.' . $case->value);
+        }
+
+        return $labels;
+    }
+}

--- a/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Widgets\DataProvider;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+use Netresearch\NrLlm\Service\Tool\Builtin\ResolvesLanguageLabelTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js bar-chart data provider for "tool gate decisions by tool
+ * (last N days)".
+ *
+ * Aggregates tx_nrllm_governance_event rows carrying a tool_name, grouped by
+ * tool, most-decided first.
+ *
+ * Scope honesty: this table records tool DENIALS / gate decisions by name — a
+ * truthful "which tools get blocked, and how often" view. It is NOT
+ * successful-invocation volume; genuine successful tool usage still lives in
+ * tx_nrllm_agentrun_event (kind = tool, name inside the payload). The widget is
+ * labelled accordingly so the two are never conflated.
+ */
+final readonly class ToolUsageByNameDataProvider implements ChartDataProviderInterface
+{
+    use ResolvesLanguageLabelTrait;
+
+    private const DEFAULT_DAYS = 30;
+
+    private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
+
+    public function __construct(
+        private GovernanceEventRepositoryInterface $repository,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $since = (new DateTimeImmutable())
+            ->modify(sprintf('-%d days', max(1, $this->days)))
+            ->getTimestamp();
+
+        return self::shapeChartData(
+            $this->repository->countToolDecisionsByName($since),
+            $this->resolveLabel(self::LLL . 'widget.tool_usage.dataset'),
+        );
+    }
+
+    /**
+     * Shape the tool_name => count map (already ordered most-decided first by the
+     * repository) into chart.js bar format. Tool names are their own labels —
+     * they are dynamic identifiers, not a fixed enum, so there is nothing to
+     * translate. Pure static for unit-testability.
+     *
+     * @param array<string, int> $counts       tool_name => count
+     * @param string             $datasetLabel translated legend for the single dataset
+     *
+     * @return array{labels: list<string>, datasets: list<array{label: string, backgroundColor: list<string>, data: list<int>}>}
+     */
+    public static function shapeChartData(array $counts, string $datasetLabel): array
+    {
+        $labels = [];
+        $data   = [];
+        foreach ($counts as $toolName => $count) {
+            if ($toolName === '' || $count <= 0) {
+                continue;
+            }
+            $labels[] = $toolName;
+            $data[]   = $count;
+        }
+
+        return [
+            'labels'   => $labels,
+            'datasets' => [
+                [
+                    'label'           => $datasetLabel,
+                    'backgroundColor' => array_fill(0, count($data), '#2F99A4'),
+                    'data'            => $data,
+                ],
+            ],
+        ];
+    }
+}

--- a/Configuration/Services.Dashboard.php
+++ b/Configuration/Services.Dashboard.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 use Netresearch\NrLlm\Widgets\DataProvider\AgentRunsByStatusDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\AverageLatencyDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\GovernanceBlocksOverTimeDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\MonthlyCostDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\RequestsByProviderDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\RequestSuccessRateDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\RunsAwaitingApprovalDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\RunTerminationReasonsDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\ToolDenialsByReasonDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\ToolUsageByNameDataProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
 use TYPO3\CMS\Dashboard\Widgets\DoughnutChartWidget;
@@ -159,5 +162,51 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'iconIdentifier' => 'actions-clock',
             'height'         => 'small',
             'width'          => 'small',
+        ]);
+
+    // --- Governance / tool-usage widgets (group: nrllm), backed by
+    // tx_nrllm_governance_event ---
+
+    $services->set(GovernanceBlocksOverTimeDataProvider::class);
+    $services->set(ToolDenialsByReasonDataProvider::class);
+    $services->set(ToolUsageByNameDataProvider::class);
+
+    // Governance blocks by kind over the last 30 days (bar).
+    $services->set('dashboard.widget.nrllm.governance_blocks', BarChartWidget::class)
+        ->arg('$dataProvider', service(GovernanceBlocksOverTimeDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-governance-blocks',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.governance_blocks.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.governance_blocks.description',
+            'iconIdentifier' => 'content-widget-chart-bar',
+            'height'         => 'medium',
+            'width'          => 'medium',
+        ]);
+
+    // Tool-gate denials by reason over the last 30 days (bar).
+    $services->set('dashboard.widget.nrllm.tool_denials_by_reason', BarChartWidget::class)
+        ->arg('$dataProvider', service(ToolDenialsByReasonDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-tool-denials-by-reason',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.tool_denials.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.tool_denials.description',
+            'iconIdentifier' => 'content-widget-chart-bar',
+            'height'         => 'medium',
+            'width'          => 'medium',
+        ]);
+
+    // Tool-gate decisions by tool name over the last 30 days (bar).
+    $services->set('dashboard.widget.nrllm.tool_usage_by_name', BarChartWidget::class)
+        ->arg('$dataProvider', service(ToolUsageByNameDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-tool-usage-by-name',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.tool_usage.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.tool_usage.description',
+            'iconIdentifier' => 'content-widget-chart-bar',
+            'height'         => 'medium',
+            'width'          => 'medium',
         ]);
 };

--- a/Configuration/Services.Dashboard.php
+++ b/Configuration/Services.Dashboard.php
@@ -7,10 +7,16 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Widgets\DataProvider\AgentRunsByStatusDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\AverageLatencyDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\MonthlyCostDataProvider;
 use Netresearch\NrLlm\Widgets\DataProvider\RequestsByProviderDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\RequestSuccessRateDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\RunsAwaitingApprovalDataProvider;
+use Netresearch\NrLlm\Widgets\DataProvider\RunTerminationReasonsDataProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
+use TYPO3\CMS\Dashboard\Widgets\DoughnutChartWidget;
 use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -62,5 +68,96 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'iconIdentifier' => 'content-elements-mailform',
             'height'         => 'medium',
             'width'          => 'medium',
+        ]);
+
+    // --- Agentic / governance / telemetry widgets (group: nrllm) ---
+
+    $services->set(AgentRunsByStatusDataProvider::class);
+    $services->set(RunsAwaitingApprovalDataProvider::class);
+    $services->set(RunTerminationReasonsDataProvider::class);
+    $services->set(RequestSuccessRateDataProvider::class);
+    $services->set(AverageLatencyDataProvider::class);
+
+    // Agent runs by lifecycle status over the last 30 days (doughnut).
+    $services->set('dashboard.widget.nrllm.agent_runs_by_status', DoughnutChartWidget::class)
+        ->arg('$dataProvider', service(AgentRunsByStatusDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-agent-runs-by-status',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.agent_runs_by_status.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.agent_runs_by_status.description',
+            'iconIdentifier' => 'content-widget-chart-pie',
+            'height'         => 'medium',
+            'width'          => 'medium',
+        ]);
+
+    // Runs currently suspended waiting for a human approval (live gauge).
+    // NumberWithIconWidget carries no footer button in TYPO3 v14, so the tile
+    // is the count alone; the Agent Runs approvals module (nrllm_runs) is where
+    // an admin acts on them.
+    $services->set('dashboard.widget.nrllm.runs_awaiting_approval', NumberWithIconWidget::class)
+        ->arg('$dataProvider', service(RunsAwaitingApprovalDataProvider::class))
+        ->arg('$options', [
+            'icon'     => 'actions-check',
+            'title'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.runs_awaiting_approval.title',
+            'subtitle' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.runs_awaiting_approval.subtitle',
+        ])
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-runs-awaiting-approval',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.runs_awaiting_approval.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.runs_awaiting_approval.description',
+            'iconIdentifier' => 'actions-check',
+            'height'         => 'small',
+            'width'          => 'small',
+        ]);
+
+    // Why terminated agent runs ended, over the last 30 days (bar).
+    $services->set('dashboard.widget.nrllm.run_termination_reasons', BarChartWidget::class)
+        ->arg('$dataProvider', service(RunTerminationReasonsDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-run-termination-reasons',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.run_termination_reasons.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.run_termination_reasons.description',
+            'iconIdentifier' => 'content-widget-chart-bar',
+            'height'         => 'medium',
+            'width'          => 'medium',
+        ]);
+
+    // Provider pipeline success rate (%, last 7 days) from telemetry.
+    $services->set('dashboard.widget.nrllm.request_success_rate', NumberWithIconWidget::class)
+        ->arg('$dataProvider', service(RequestSuccessRateDataProvider::class))
+        ->arg('$options', [
+            'icon'     => 'actions-check-circle',
+            'title'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.request_success_rate.title',
+            'subtitle' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.request_success_rate.subtitle',
+        ])
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-request-success-rate',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.request_success_rate.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.request_success_rate.description',
+            'iconIdentifier' => 'actions-check-circle',
+            'height'         => 'small',
+            'width'          => 'small',
+        ]);
+
+    // Mean end-to-end provider pipeline latency (ms, last 7 days) from telemetry.
+    $services->set('dashboard.widget.nrllm.average_latency', NumberWithIconWidget::class)
+        ->arg('$dataProvider', service(AverageLatencyDataProvider::class))
+        ->arg('$options', [
+            'icon'     => 'actions-clock',
+            'title'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.average_latency.title',
+            'subtitle' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.average_latency.subtitle',
+        ])
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrllm-average-latency',
+            'groupNames'     => 'nrllm',
+            'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.average_latency.title',
+            'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.average_latency.description',
+            'iconIdentifier' => 'actions-clock',
+            'height'         => 'small',
+            'width'          => 'small',
         ]);
 };

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -251,6 +251,15 @@ services:
     alias: Netresearch\NrLlm\Service\Tool\AgentRunRepository
     public: false
 
+  # Governance-event audit store — private; consumed nullably by
+  # GuardrailMiddleware (guardrail blocks / approval-required / content-filter)
+  # and ToolLoopService (tool-gate denials), and by the nrllm:governance:purge
+  # command. The concrete repository stays private too; functional tests
+  # instantiate it directly with the real ConnectionPool.
+  Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface:
+    alias: Netresearch\NrLlm\Service\Governance\GovernanceEventRepository
+    public: false
+
   # Conversation session store (ADR-083) — private; consumed by ConversationService
   # and the nrllm:session:purge command. The concrete repository stays private too;
   # functional tests instantiate it directly with the real ConnectionPool.

--- a/Resources/Private/Language/de.locallang_dashboard.xlf
+++ b/Resources/Private/Language/de.locallang_dashboard.xlf
@@ -22,6 +22,134 @@
                 <source>Bar chart of nr-llm requests grouped by provider over the last seven days. Combines chat, vision, translation, speech, and image generation.</source>
                 <target>Balkendiagramm der nr-llm-Anfragen nach Anbieter in den letzten sieben Tagen. Umfasst Chat, Vision, Übersetzung, Sprache und Bilderzeugung.</target>
             </trans-unit>
+            <trans-unit id="widgetGroup.nrllm.title">
+                <source>AI agents</source>
+                <target>KI-Agenten</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.title">
+                <source>Agent runs by status</source>
+                <target>Agentenläufe nach Status</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.description">
+                <source>Doughnut of persisted agent runs grouped by lifecycle status over the last 30 days.</source>
+                <target>Ringdiagramm der gespeicherten Agentenläufe nach Lebenszyklus-Status der letzten 30 Tage.</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.queued">
+                <source>Queued</source>
+                <target>In Warteschlange</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.running">
+                <source>Running</source>
+                <target>Läuft</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.waiting_for_approval">
+                <source>Awaiting approval</source>
+                <target>Wartet auf Freigabe</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.waiting_for_input">
+                <source>Awaiting input</source>
+                <target>Wartet auf Eingabe</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.completed">
+                <source>Completed</source>
+                <target>Abgeschlossen</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.failed">
+                <source>Failed</source>
+                <target>Fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.cancelled">
+                <source>Cancelled</source>
+                <target>Abgebrochen</target>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.title">
+                <source>Runs awaiting approval</source>
+                <target>Läufe mit ausstehender Freigabe</target>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.subtitle">
+                <source>waiting for a human decision</source>
+                <target>wartet auf menschliche Entscheidung</target>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.description">
+                <source>Number of agent runs currently suspended waiting for approval. Review them in the Agent Runs module.</source>
+                <target>Anzahl der Agentenläufe, die derzeit auf eine Freigabe warten. Prüfung im Modul „Agentenläufe“.</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.title">
+                <source>Agent run outcomes</source>
+                <target>Ergebnisse der Agentenläufe</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.description">
+                <source>Bar chart of why agent runs ended (completed, budget exhausted, policy denied, provider failed, ...) over the last 30 days.</source>
+                <target>Balkendiagramm der Gründe, warum Agentenläufe endeten (abgeschlossen, Budget erschöpft, durch Richtlinie abgelehnt, Anbieter fehlgeschlagen, …), der letzten 30 Tage.</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.dataset">
+                <source>Runs</source>
+                <target>Läufe</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.completed">
+                <source>Completed</source>
+                <target>Abgeschlossen</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.max_iterations">
+                <source>Max iterations reached</source>
+                <target>Iterationsgrenze erreicht</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.budget_exhausted">
+                <source>Budget exhausted</source>
+                <target>Budget erschöpft</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.policy_denied">
+                <source>Policy denied</source>
+                <target>Durch Richtlinie abgelehnt</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.approval_denied">
+                <source>Approval denied</source>
+                <target>Freigabe verweigert</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.provider_failed">
+                <source>Provider failed</source>
+                <target>Anbieter fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.cancelled">
+                <source>Cancelled</source>
+                <target>Abgebrochen</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.retries_exhausted">
+                <source>Retries exhausted</source>
+                <target>Wiederholungen erschöpft</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.not_retryable">
+                <source>Not retryable</source>
+                <target>Nicht wiederholbar</target>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.context_truncated">
+                <source>Context truncated</source>
+                <target>Kontext gekürzt</target>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.title">
+                <source>Request success rate</source>
+                <target>Erfolgsquote der Anfragen</target>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.subtitle">
+                <source>%, last 7 days</source>
+                <target>%, letzte 7 Tage</target>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.description">
+                <source>Share of provider pipeline runs that succeeded, from telemetry.</source>
+                <target>Anteil der erfolgreichen Anbieter-Pipeline-Läufe, aus der Telemetrie.</target>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.title">
+                <source>Average latency</source>
+                <target>Durchschnittliche Latenz</target>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.subtitle">
+                <source>ms, last 7 days</source>
+                <target>ms, letzte 7 Tage</target>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.description">
+                <source>Mean end-to-end provider pipeline latency, from telemetry.</source>
+                <target>Mittlere Ende-zu-Ende-Latenz der Anbieter-Pipeline, aus der Telemetrie.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_dashboard.xlf
+++ b/Resources/Private/Language/de.locallang_dashboard.xlf
@@ -150,6 +150,78 @@
                 <source>Mean end-to-end provider pipeline latency, from telemetry.</source>
                 <target>Mittlere Ende-zu-Ende-Latenz der Anbieter-Pipeline, aus der Telemetrie.</target>
             </trans-unit>
+            <trans-unit id="widget.governance_blocks.title">
+                <source>Governance blocks</source>
+                <target>Governance-Blockierungen</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.description">
+                <source>Bar chart of governance decisions (tool denials, guardrail blocks, approvals required, content-filter blocks) over the last 30 days.</source>
+                <target>Balkendiagramm der Governance-Entscheidungen (Tool-Ablehnungen, Guardrail-Blockierungen, erforderliche Freigaben, Content-Filter-Blockierungen) der letzten 30 Tage.</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.dataset">
+                <source>Events</source>
+                <target>Ereignisse</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.tool_denied">
+                <source>Tool denied</source>
+                <target>Tool abgelehnt</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.response_blocked">
+                <source>Response blocked</source>
+                <target>Antwort blockiert</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.approval_required">
+                <source>Approval required</source>
+                <target>Freigabe erforderlich</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.content_filter">
+                <source>Content filter</source>
+                <target>Content-Filter</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.title">
+                <source>Tool denials by reason</source>
+                <target>Tool-Ablehnungen nach Grund</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.description">
+                <source>Bar chart of tool-gate denials grouped by reason over the last 30 days.</source>
+                <target>Balkendiagramm der Tool-Gate-Ablehnungen nach Grund der letzten 30 Tage.</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.dataset">
+                <source>Denials</source>
+                <target>Ablehnungen</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.notRegistered">
+                <source>Not registered</source>
+                <target>Nicht registriert</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.toolDisabled">
+                <source>Tool disabled</source>
+                <target>Tool deaktiviert</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.requiresAdmin">
+                <source>Requires admin</source>
+                <target>Nur für Administratoren</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.configurationGroup">
+                <source>Outside configuration groups</source>
+                <target>Außerhalb der Konfigurationsgruppen</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.trustZone">
+                <source>Trust zone ceiling</source>
+                <target>Trust-Zone-Obergrenze</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.title">
+                <source>Tool gate decisions by tool</source>
+                <target>Tool-Gate-Entscheidungen nach Tool</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.description">
+                <source>Bar chart of tool-gate decisions grouped by tool name over the last 30 days. These are gate decisions (denials / observe-mode), not successful invocation volume.</source>
+                <target>Balkendiagramm der Tool-Gate-Entscheidungen nach Tool-Name der letzten 30 Tage. Dies sind Gate-Entscheidungen (Ablehnungen / Beobachtungsmodus), nicht die Zahl erfolgreicher Aufrufe.</target>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.dataset">
+                <source>Decisions</source>
+                <target>Entscheidungen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -113,6 +113,60 @@
             <trans-unit id="widget.average_latency.description">
                 <source>Mean end-to-end provider pipeline latency, from telemetry.</source>
             </trans-unit>
+            <trans-unit id="widget.governance_blocks.title">
+                <source>Governance blocks</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.description">
+                <source>Bar chart of governance decisions (tool denials, guardrail blocks, approvals required, content-filter blocks) over the last 30 days.</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.dataset">
+                <source>Events</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.tool_denied">
+                <source>Tool denied</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.response_blocked">
+                <source>Response blocked</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.approval_required">
+                <source>Approval required</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.content_filter">
+                <source>Content filter</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.title">
+                <source>Tool denials by reason</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.description">
+                <source>Bar chart of tool-gate denials grouped by reason over the last 30 days.</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.dataset">
+                <source>Denials</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.notRegistered">
+                <source>Not registered</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.toolDisabled">
+                <source>Tool disabled</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.requiresAdmin">
+                <source>Requires admin</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.configurationGroup">
+                <source>Outside configuration groups</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_denials.reason.trustZone">
+                <source>Trust zone ceiling</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.title">
+                <source>Tool gate decisions by tool</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.description">
+                <source>Bar chart of tool-gate decisions grouped by tool name over the last 30 days. These are gate decisions (denials / observe-mode), not successful invocation volume.</source>
+            </trans-unit>
+            <trans-unit id="widget.tool_usage.dataset">
+                <source>Decisions</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -17,6 +17,102 @@
             <trans-unit id="widget.requests_by_provider.description">
                 <source>Bar chart of nr-llm requests grouped by provider over the last seven days. Combines chat, vision, translation, speech, and image generation.</source>
             </trans-unit>
+            <trans-unit id="widgetGroup.nrllm.title">
+                <source>AI agents</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.title">
+                <source>Agent runs by status</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.description">
+                <source>Doughnut of persisted agent runs grouped by lifecycle status over the last 30 days.</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.queued">
+                <source>Queued</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.running">
+                <source>Running</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.waiting_for_approval">
+                <source>Awaiting approval</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.waiting_for_input">
+                <source>Awaiting input</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.completed">
+                <source>Completed</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.failed">
+                <source>Failed</source>
+            </trans-unit>
+            <trans-unit id="widget.agent_runs_by_status.status.cancelled">
+                <source>Cancelled</source>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.title">
+                <source>Runs awaiting approval</source>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.subtitle">
+                <source>waiting for a human decision</source>
+            </trans-unit>
+            <trans-unit id="widget.runs_awaiting_approval.description">
+                <source>Number of agent runs currently suspended waiting for approval. Review them in the Agent Runs module.</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.title">
+                <source>Agent run outcomes</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.description">
+                <source>Bar chart of why agent runs ended (completed, budget exhausted, policy denied, provider failed, ...) over the last 30 days.</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.dataset">
+                <source>Runs</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.completed">
+                <source>Completed</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.max_iterations">
+                <source>Max iterations reached</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.budget_exhausted">
+                <source>Budget exhausted</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.policy_denied">
+                <source>Policy denied</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.approval_denied">
+                <source>Approval denied</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.provider_failed">
+                <source>Provider failed</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.cancelled">
+                <source>Cancelled</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.retries_exhausted">
+                <source>Retries exhausted</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.not_retryable">
+                <source>Not retryable</source>
+            </trans-unit>
+            <trans-unit id="widget.run_termination_reasons.reason.context_truncated">
+                <source>Context truncated</source>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.title">
+                <source>Request success rate</source>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.subtitle">
+                <source>%, last 7 days</source>
+            </trans-unit>
+            <trans-unit id="widget.request_success_rate.description">
+                <source>Share of provider pipeline runs that succeeded, from telemetry.</source>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.title">
+                <source>Average latency</source>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.subtitle">
+                <source>ms, last 7 days</source>
+            </trans-unit>
+            <trans-unit id="widget.average_latency.description">
+                <source>Mean end-to-end provider pipeline latency, from telemetry.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
+++ b/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
@@ -81,5 +81,12 @@ final class DashboardWidgetRegistrationTest extends FunctionalTestCase
 
         self::assertArrayHasKey('nrllm-monthly-cost', $widgets);
         self::assertArrayHasKey('nrllm-requests-by-provider', $widgets);
+
+        // Agentic / governance / telemetry widgets (group: nrllm).
+        self::assertArrayHasKey('nrllm-agent-runs-by-status', $widgets);
+        self::assertArrayHasKey('nrllm-runs-awaiting-approval', $widgets);
+        self::assertArrayHasKey('nrllm-run-termination-reasons', $widgets);
+        self::assertArrayHasKey('nrllm-request-success-rate', $widgets);
+        self::assertArrayHasKey('nrllm-average-latency', $widgets);
     }
 }

--- a/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
+++ b/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
@@ -88,5 +88,10 @@ final class DashboardWidgetRegistrationTest extends FunctionalTestCase
         self::assertArrayHasKey('nrllm-run-termination-reasons', $widgets);
         self::assertArrayHasKey('nrllm-request-success-rate', $widgets);
         self::assertArrayHasKey('nrllm-average-latency', $widgets);
+
+        // Governance / tool-usage widgets (backed by tx_nrllm_governance_event).
+        self::assertArrayHasKey('nrllm-governance-blocks', $widgets);
+        self::assertArrayHasKey('nrllm-tool-denials-by-reason', $widgets);
+        self::assertArrayHasKey('nrllm-tool-usage-by-name', $widgets);
     }
 }

--- a/Tests/Functional/Service/Governance/GovernanceEventRepositoryTest.php
+++ b/Tests/Functional/Service/Governance/GovernanceEventRepositoryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Governance;
+
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+#[CoversClass(GovernanceEventRepository::class)]
+#[CoversClass(GovernanceEvent::class)]
+final class GovernanceEventRepositoryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_governance_event';
+
+    private GovernanceEventRepository $repository;
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        $this->repository = new GovernanceEventRepository($this->connectionPool);
+    }
+
+    #[Test]
+    public function recordInsertsOneRowWithAllFields(): void
+    {
+        $this->repository->record(new GovernanceEvent(
+            correlationId: 'corr-1',
+            decision: 'response_blocked',
+            reason: 'deny',
+            provider: 'openai',
+            model: 'gpt-4o',
+            configurationIdentifier: 'primary',
+            beUser: 7,
+            toolName: '',
+            agentrunUid: 0,
+            guardrail: 'Acme\\SecretGuardrail',
+            detail: 'contained a secret pattern',
+        ));
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row        = $connection->select(['*'], self::TABLE, ['correlation_id' => 'corr-1'])->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertSame('response_blocked', $row['decision']);
+        self::assertSame('deny', $row['reason']);
+        self::assertSame('openai', $row['provider']);
+        self::assertSame('gpt-4o', $row['model']);
+        self::assertSame('primary', $row['configuration_identifier']);
+        self::assertSame(7, (int)$row['be_user']);
+        self::assertSame('Acme\\SecretGuardrail', $row['guardrail']);
+        self::assertSame('contained a secret pattern', $row['detail']);
+        self::assertGreaterThan(0, (int)$row['crdate']);
+    }
+
+    #[Test]
+    public function countByDecisionGroupsWithinTheWindow(): void
+    {
+        $now = time();
+        $this->insert('tool_denied', 'trustZone', '', $now);
+        $this->insert('tool_denied', 'requiresAdmin', '', $now);
+        $this->insert('response_blocked', 'deny', '', $now);
+        // Out of window: excluded.
+        $this->insert('content_filter', 'content_filter', '', $now - (10 * 86400));
+
+        $counts = $this->repository->countByDecision($now - (5 * 86400));
+        ksort($counts);
+
+        self::assertSame(['response_blocked' => 1, 'tool_denied' => 2], $counts);
+    }
+
+    #[Test]
+    public function countToolDenialsByReasonCountsOnlyToolDeniedRows(): void
+    {
+        $now = time();
+        $this->insert('tool_denied', 'trustZone', 'fetch_logs', $now);
+        $this->insert('tool_denied', 'trustZone', 'get_env', $now);
+        $this->insert('tool_denied', 'requiresAdmin', 'list_be_users', $now);
+        // A guardrail block also carries a reason, but must not count as a tool denial.
+        $this->insert('response_blocked', 'deny', '', $now);
+
+        $counts = $this->repository->countToolDenialsByReason(0);
+        ksort($counts);
+
+        self::assertSame(['requiresAdmin' => 1, 'trustZone' => 2], $counts);
+    }
+
+    #[Test]
+    public function countToolDecisionsByNameGroupsByToolAndSkipsEmptyNames(): void
+    {
+        $now = time();
+        $this->insert('tool_denied', 'trustZone', 'fetch_logs', $now);
+        $this->insert('tool_denied', 'trustZone', 'fetch_logs', $now);
+        $this->insert('tool_denied', 'requiresAdmin', 'get_env', $now);
+        // Guardrail row has no tool name: excluded.
+        $this->insert('response_blocked', 'deny', '', $now);
+
+        $counts = $this->repository->countToolDecisionsByName(0);
+
+        self::assertSame(2, $counts['fetch_logs']);
+        self::assertSame(1, $counts['get_env']);
+        self::assertArrayNotHasKey('', $counts);
+    }
+
+    #[Test]
+    public function purgeOlderThanDeletesOnlyOlderRows(): void
+    {
+        $now = time();
+        $this->insert('tool_denied', 'trustZone', 'fetch_logs', $now - (10 * 86400));
+        $this->insert('tool_denied', 'trustZone', 'fetch_logs', $now);
+
+        $deleted = $this->repository->purgeOlderThan($now - (5 * 86400));
+
+        self::assertSame(1, $deleted);
+        self::assertSame(1, $this->connectionPool->getConnectionForTable(self::TABLE)->count('*', self::TABLE, []));
+    }
+
+    private function insert(string $decision, string $reason, string $toolName, int $crdate): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'crdate'                   => $crdate,
+            'correlation_id'           => '',
+            'decision'                 => $decision,
+            'reason'                   => $reason,
+            'provider'                 => 'openai',
+            'model'                    => 'gpt',
+            'configuration_identifier' => 'primary',
+            'be_user'                  => 0,
+            'tool_name'                => $toolName,
+            'agentrun_uid'             => 0,
+            'guardrail'                => '',
+            'detail'                   => '',
+        ]);
+    }
+}

--- a/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
+++ b/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
@@ -49,6 +49,7 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
         'tx_nrllm_ai_session_message',
         'tx_nrllm_agentrun',
         'tx_nrllm_agentrun_event',
+        'tx_nrllm_governance_event',
     ];
 
     /**
@@ -243,6 +244,22 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
 
         $connectionPool->getConnectionForTable('tx_nrllm_agentrun_event')
             ->insert('tx_nrllm_agentrun_event', $this->eventRow($runUid, $timestamp));
+
+        $connectionPool->getConnectionForTable('tx_nrllm_governance_event')->insert('tx_nrllm_governance_event', [
+            'pid'                      => 0,
+            'crdate'                   => $timestamp,
+            'correlation_id'           => 'c-1',
+            'decision'                 => 'tool_denied',
+            'reason'                   => 'trustZone',
+            'provider'                 => 'openai',
+            'model'                    => 'gpt',
+            'configuration_identifier' => 'default',
+            'be_user'                  => 1,
+            'tool_name'                => 'fetch_logs',
+            'agentrun_uid'             => 0,
+            'guardrail'                => '',
+            'detail'                   => 'zone=externalGlobal;ceiling=editorContent;observedOnly=0',
+        ]);
     }
 
     /**

--- a/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
+++ b/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
@@ -166,4 +166,64 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
 
         self::assertSame(0, $deleted);
     }
+
+    #[Test]
+    public function successRatePercentRoundsTheShareOfSucceededRunsInWindow(): void
+    {
+        $now = time();
+        // 3 of 4 in-window rows succeeded ⇒ 75%.
+        $this->insertRow('a', true, 100, $now);
+        $this->insertRow('b', true, 100, $now);
+        $this->insertRow('c', true, 100, $now);
+        $this->insertRow('d', false, 100, $now);
+        // An out-of-window failure must not drag the rate down.
+        $this->insertRow('old', false, 100, $now - (10 * 86400));
+
+        self::assertSame(75, $this->repository->successRatePercent($now - (5 * 86400)));
+    }
+
+    #[Test]
+    public function successRatePercentIsZeroWhenNoRowsInWindow(): void
+    {
+        self::assertSame(0, $this->repository->successRatePercent(time() - 60));
+    }
+
+    #[Test]
+    public function averageLatencyMsRoundsTheMeanLatencyInWindow(): void
+    {
+        $now = time();
+        // Mean of 100, 200, 300 = 200.
+        $this->insertRow('a', true, 100, $now);
+        $this->insertRow('b', true, 200, $now);
+        $this->insertRow('c', true, 300, $now);
+        // An out-of-window row must not skew the mean.
+        $this->insertRow('old', true, 9000, $now - (10 * 86400));
+
+        self::assertSame(200, $this->repository->averageLatencyMs($now - (5 * 86400)));
+    }
+
+    #[Test]
+    public function averageLatencyMsIsZeroWhenNoRowsInWindow(): void
+    {
+        self::assertSame(0, $this->repository->averageLatencyMs(time() - 60));
+    }
+
+    private function insertRow(string $correlationId, bool $success, int $latencyMs, int $crdate): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'correlation_id'           => $correlationId,
+            'operation'                => 'chat',
+            'provider'                 => '',
+            'model'                    => '',
+            'configuration_identifier' => 'primary',
+            'be_user'                  => 0,
+            'success'                  => $success ? 1 : 0,
+            'error_class'              => '',
+            'latency_ms'               => $latencyMs,
+            'cache_hit'                => 0,
+            'fallback_attempts'        => 0,
+            'crdate'                   => $crdate,
+        ]);
+    }
 }

--- a/Tests/Functional/Service/Tool/AgentRunRepositoryAggregatesTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunRepositoryAggregatesTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
+use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional coverage for the dashboard aggregate read methods on
+ * {@see AgentRunRepository}: countByStatus / countByTerminationReason /
+ * countInStatus. Rows are inserted directly with controlled status,
+ * termination_reason and crdate so the GROUP BY and windowing are exercised
+ * against the real schema.
+ */
+#[CoversClass(AgentRunRepository::class)]
+final class AgentRunRepositoryAggregatesTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_agentrun';
+
+    private AgentRunRepository $repository;
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        $this->repository = new AgentRunRepository($connectionPool, $this->get(AgentStateCodec::class));
+    }
+
+    #[Test]
+    public function countByStatusGroupsAllTimeWhenSinceIsZero(): void
+    {
+        $now = time();
+        $this->insertRun(AgentRunStatus::COMPLETED->value, 'completed', $now);
+        $this->insertRun(AgentRunStatus::COMPLETED->value, 'completed', $now);
+        $this->insertRun(AgentRunStatus::FAILED->value, 'provider_failed', $now);
+        $this->insertRun(AgentRunStatus::RUNNING->value, '', $now);
+
+        self::assertSame(
+            ['completed' => 2, 'failed' => 1, 'running' => 1],
+            $this->sorted($this->repository->countByStatus(0)),
+        );
+    }
+
+    #[Test]
+    public function countByStatusWindowsByCrdate(): void
+    {
+        $now        = time();
+        $tenDaysAgo = $now - (10 * 86400);
+        $this->insertRun(AgentRunStatus::COMPLETED->value, 'completed', $now);
+        $this->insertRun(AgentRunStatus::COMPLETED->value, 'completed', $tenDaysAgo);
+
+        $since = $now - (5 * 86400);
+
+        self::assertSame(['completed' => 1], $this->repository->countByStatus($since));
+    }
+
+    #[Test]
+    public function countByTerminationReasonSkipsRunsWithoutAReason(): void
+    {
+        $now = time();
+        $this->insertRun(AgentRunStatus::COMPLETED->value, 'completed', $now);
+        $this->insertRun(AgentRunStatus::FAILED->value, 'budget_exhausted', $now);
+        $this->insertRun(AgentRunStatus::FAILED->value, 'budget_exhausted', $now);
+        // A run still in flight carries no termination_reason: excluded.
+        $this->insertRun(AgentRunStatus::RUNNING->value, '', $now);
+
+        self::assertSame(
+            ['budget_exhausted' => 2, 'completed' => 1],
+            $this->sorted($this->repository->countByTerminationReason(0)),
+        );
+    }
+
+    #[Test]
+    public function countInStatusIsALiveGaugeIgnoringAge(): void
+    {
+        $now        = time();
+        $longAgo    = $now - (30 * 86400);
+        $this->insertRun(AgentRunStatus::WAITING_FOR_APPROVAL->value, '', $longAgo);
+        $this->insertRun(AgentRunStatus::WAITING_FOR_APPROVAL->value, '', $now);
+        $this->insertRun(AgentRunStatus::RUNNING->value, '', $now);
+
+        self::assertSame(2, $this->repository->countInStatus(AgentRunStatus::WAITING_FOR_APPROVAL));
+        self::assertSame(0, $this->repository->countInStatus(AgentRunStatus::CANCELLED));
+    }
+
+    private function insertRun(string $status, string $terminationReason, int $crdate): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                      => 0,
+            'uuid'                     => bin2hex(random_bytes(8)),
+            'status'                   => $status,
+            'configuration_uid'        => 0,
+            'configuration_identifier' => 'primary',
+            'be_user'                  => 0,
+            'termination_reason'       => $terminationReason,
+            'started_at'               => $crdate,
+            'finished_at'              => 0,
+            'tstamp'                   => $crdate,
+            'crdate'                   => $crdate,
+        ]);
+    }
+
+    /**
+     * ksort a value => count map so assertions do not depend on GROUP BY order.
+     *
+     * @param array<string, int> $counts
+     *
+     * @return array<string, int>
+     */
+    private function sorted(array $counts): array
+    {
+        ksort($counts);
+
+        return $counts;
+    }
+}

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Command\Fixture;
 
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
 
@@ -175,6 +176,30 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
     public function maxEventSequence(int $runUid): int
     {
         return -1;
+    }
+
+    /** @var array<string, int> value => count returned by countByStatus() */
+    public array $countByStatusReturns = [];
+
+    /** @var array<string, int> value => count returned by countByTerminationReason() */
+    public array $countByTerminationReasonReturns = [];
+
+    /** @var array<string, int> status value => count returned by countInStatus() */
+    public array $countInStatusReturns = [];
+
+    public function countByStatus(int $since = 0): array
+    {
+        return $this->countByStatusReturns;
+    }
+
+    public function countByTerminationReason(int $since = 0): array
+    {
+        return $this->countByTerminationReasonReturns;
+    }
+
+    public function countInStatus(AgentRunStatus $status): int
+    {
+        return $this->countInStatusReturns[$status->value] ?? 0;
     }
 
     public function purgeOlderThan(int $timestamp): int

--- a/Tests/Unit/Command/Fixture/InMemoryGovernanceEventRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryGovernanceEventRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command\Fixture;
+
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
+use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+
+/**
+ * In-memory governance-event repository for command and widget unit tests:
+ * captures recorded events and the purge cutoff, and returns pre-set aggregate
+ * maps, so the flows can be exercised without a database.
+ */
+final class InMemoryGovernanceEventRepository implements GovernanceEventRepositoryInterface
+{
+    /** @var list<GovernanceEvent> */
+    public array $recorded = [];
+
+    /** The cutoff timestamp the last purgeOlderThan() was asked to delete below. */
+    public ?int $purgeCutoff = null;
+
+    /** The row count purgeOlderThan() reports as deleted. */
+    public int $purgeReturns = 0;
+
+    /** @var array<string, int> value => count returned by countByDecision() */
+    public array $countByDecisionReturns = [];
+
+    /** @var array<string, int> value => count returned by countToolDenialsByReason() */
+    public array $countToolDenialsByReasonReturns = [];
+
+    /** @var array<string, int> tool_name => count returned by countToolDecisionsByName() */
+    public array $countToolDecisionsByNameReturns = [];
+
+    public function record(GovernanceEvent $event): void
+    {
+        $this->recorded[] = $event;
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $this->purgeCutoff = $timestamp;
+
+        return $this->purgeReturns;
+    }
+
+    public function countByDecision(int $since = 0): array
+    {
+        return $this->countByDecisionReturns;
+    }
+
+    public function countToolDenialsByReason(int $since = 0): array
+    {
+        return $this->countToolDenialsByReasonReturns;
+    }
+
+    public function countToolDecisionsByName(int $since = 0): array
+    {
+        return $this->countToolDecisionsByNameReturns;
+    }
+}

--- a/Tests/Unit/Command/PurgeGovernanceCommandTest.php
+++ b/Tests/Unit/Command/PurgeGovernanceCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\PurgeGovernanceCommand;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(PurgeGovernanceCommand::class)]
+final class PurgeGovernanceCommandTest extends TestCase
+{
+    #[Test]
+    public function purgesWithTheConfiguredGovernanceWindow(): void
+    {
+        $repository = $this->spyRepository(deleted: 4);
+        $tester     = new CommandTester(new PurgeGovernanceCommand($repository, $this->policyWithGovernanceRetention(30)));
+
+        $before = time();
+        $exit   = $tester->execute([]);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotNull($repository->purgeCutoff);
+        self::assertGreaterThanOrEqual($before - (30 * 86400), $repository->purgeCutoff);
+        self::assertLessThanOrEqual($after - (30 * 86400), $repository->purgeCutoff);
+        self::assertStringContainsString('4 governance-event row(s)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function honoursCustomDaysOption(): void
+    {
+        $repository = $this->spyRepository(deleted: 0);
+        $tester     = new CommandTester(new PurgeGovernanceCommand($repository, $this->policyWithGovernanceRetention(30)));
+
+        $before = time();
+        $exit   = $tester->execute(['--days' => '7']);
+        $after  = time();
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotNull($repository->purgeCutoff);
+        self::assertGreaterThanOrEqual($before - (7 * 86400), $repository->purgeCutoff);
+        self::assertLessThanOrEqual($after - (7 * 86400), $repository->purgeCutoff);
+    }
+
+    #[Test]
+    public function rejectsNonPositiveDays(): void
+    {
+        $repository = $this->spyRepository(deleted: 0);
+        $tester     = new CommandTester(new PurgeGovernanceCommand($repository, $this->policyWithGovernanceRetention(30)));
+
+        $exit = $tester->execute(['--days' => '0']);
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertNull($repository->purgeCutoff, 'No purge must run for an invalid window.');
+        self::assertStringContainsString('positive integer', $tester->getDisplay());
+    }
+
+    private function policyWithGovernanceRetention(int $days): PrivacyPolicy
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([
+            'privacy' => ['retention' => ['governance' => (string)$days]],
+        ]);
+
+        return new PrivacyPolicy($extensionConfiguration, new ContentRedactor());
+    }
+
+    private function spyRepository(int $deleted): InMemoryGovernanceEventRepository
+    {
+        $repository               = new InMemoryGovernanceEventRepository();
+        $repository->purgeReturns = $deleted;
+
+        return $repository;
+    }
+}

--- a/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
+++ b/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAgentRunRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAiSessionRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryEvaluationResultRepository;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemorySkillAuditRepository;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,13 +38,16 @@ final class PurgePrivacyDataCommandTest extends TestCase
 
     private InMemoryAgentRunRepository $agentRuns;
 
+    private InMemoryGovernanceEventRepository $governance;
+
     protected function setUp(): void
     {
-        $this->eval      = new InMemoryEvaluationResultRepository();
-        $this->audit     = new InMemorySkillAuditRepository();
-        $this->telemetry = new InMemoryTelemetryRepository();
-        $this->sessions  = new InMemoryAiSessionRepository();
-        $this->agentRuns = new InMemoryAgentRunRepository();
+        $this->eval       = new InMemoryEvaluationResultRepository();
+        $this->audit      = new InMemorySkillAuditRepository();
+        $this->telemetry  = new InMemoryTelemetryRepository();
+        $this->sessions   = new InMemoryAiSessionRepository();
+        $this->agentRuns  = new InMemoryAgentRunRepository();
+        $this->governance = new InMemoryGovernanceEventRepository();
     }
 
     #[Test]
@@ -55,6 +59,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
         $this->sessions->purgeReturns            = 7;
         $this->agentRuns->purgeReturns           = 11;
         $this->agentRuns->purgeUnfinishedReturns = 1;
+        $this->governance->purgeReturns          = 4;
 
         $tester = new CommandTester($this->command(['retentionDays' => '45']));
 
@@ -73,6 +78,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
             $this->sessions->purgeCutoff,
             $this->agentRuns->purgeCutoff,
             $this->agentRuns->purgeUnfinishedCutoff,
+            $this->governance->purgeCutoff,
         ];
 
         foreach ($cutoffs as $cutoff) {
@@ -88,6 +94,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
         self::assertStringContainsString('Conversation sessions (45 d): 7', $display);
         self::assertStringContainsString('Finished agent runs (45 d): 11', $display);
         self::assertStringContainsString('Unfinished agent runs (45 d): 1', $display);
+        self::assertStringContainsString('Governance events (45 d): 4', $display);
     }
 
     #[Test]
@@ -159,6 +166,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
         self::assertNull($this->sessions->purgeCutoff);
         self::assertNull($this->agentRuns->purgeCutoff);
         self::assertNull($this->agentRuns->purgeUnfinishedCutoff);
+        self::assertNull($this->governance->purgeCutoff);
         self::assertStringContainsString('positive integer', $tester->getDisplay());
     }
 
@@ -177,6 +185,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
             $this->telemetry,
             $this->sessions,
             $this->agentRuns,
+            $this->governance,
         );
     }
 }

--- a/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
+++ b/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
@@ -48,4 +48,20 @@ final class InMemoryTelemetryRepository implements TelemetryRepositoryInterface
 
         return $this->purgeReturns;
     }
+
+    /** Value returned by successRatePercent(), regardless of $since. */
+    public int $successRatePercentReturns = 0;
+
+    /** Value returned by averageLatencyMs(), regardless of $since. */
+    public int $averageLatencyMsReturns = 0;
+
+    public function successRatePercent(int $since): int
+    {
+        return $this->successRatePercentReturns;
+    }
+
+    public function averageLatencyMs(int $since): int
+    {
+        return $this->averageLatencyMsReturns;
+    }
 }

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
@@ -21,6 +22,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -220,6 +222,84 @@ final class GuardrailMiddlewareTest extends TestCase
 
         self::assertInstanceOf(CompletionResponse::class, $result);
         self::assertSame('hello', $result->content);
+    }
+
+    #[Test]
+    public function denyRecordsAResponseBlockedGovernanceEvent(): void
+    {
+        $recorder   = new InMemoryGovernanceEventRepository();
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))], governanceEvents: $recorder);
+
+        try {
+            $this->screen($middleware, fn(): CompletionResponse => $this->response('bad'));
+            self::fail('Expected a GuardrailViolationException.');
+        } catch (GuardrailViolationException) {
+            // expected — the record happens before the throw.
+        }
+
+        self::assertCount(1, $recorder->recorded);
+        $event = $recorder->recorded[0];
+        self::assertSame(GovernanceDecision::RESPONSE_BLOCKED->value, $event->decision);
+        self::assertSame('deny', $event->reason);
+        self::assertSame('blocked', $event->detail);
+        self::assertSame('', $event->toolName);
+        self::assertSame(0, $event->agentrunUid);
+        self::assertNotSame('', $event->guardrail, 'The deciding guardrail FQCN is recorded.');
+    }
+
+    #[Test]
+    public function aProviderFilteredDenyIsTaggedContentFilter(): void
+    {
+        $recorder   = new InMemoryGovernanceEventRepository();
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('filtered by provider'))], governanceEvents: $recorder);
+
+        $filtered = fn(): CompletionResponse => new CompletionResponse('bad', 'test-model', UsageStatistics::fromTokens(1, 1), 'content_filter');
+
+        try {
+            $this->screen($middleware, $filtered);
+            self::fail('Expected a GuardrailViolationException.');
+        } catch (GuardrailViolationException) {
+            // expected
+        }
+
+        self::assertCount(1, $recorder->recorded);
+        self::assertSame(GovernanceDecision::CONTENT_FILTER->value, $recorder->recorded[0]->decision);
+        self::assertSame(GovernanceDecision::CONTENT_FILTER->value, $recorder->recorded[0]->reason);
+    }
+
+    #[Test]
+    public function requireApprovalRecordsAnApprovalRequiredEvent(): void
+    {
+        $recorder   = new InMemoryGovernanceEventRepository();
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::requireApproval('needs review'))], governanceEvents: $recorder);
+
+        try {
+            $this->screen($middleware, fn(): CompletionResponse => $this->response('maybe'));
+            self::fail('Expected a GuardrailApprovalRequiredException.');
+        } catch (GuardrailApprovalRequiredException) {
+            // expected
+        }
+
+        self::assertCount(1, $recorder->recorded);
+        self::assertSame(GovernanceDecision::APPROVAL_REQUIRED->value, $recorder->recorded[0]->decision);
+        self::assertSame('require_approval', $recorder->recorded[0]->reason);
+    }
+
+    #[Test]
+    public function aVisionDenyRecordsAGovernanceEvent(): void
+    {
+        $recorder   = new InMemoryGovernanceEventRepository();
+        $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))], governanceEvents: $recorder);
+
+        try {
+            $this->screen($middleware, static fn(): VisionResponse => new VisionResponse('bad', 'm', UsageStatistics::fromTokens(1, 1)));
+            self::fail('Expected a GuardrailViolationException.');
+        } catch (GuardrailViolationException) {
+            // expected
+        }
+
+        self::assertCount(1, $recorder->recorded);
+        self::assertSame(GovernanceDecision::RESPONSE_BLOCKED->value, $recorder->recorded[0]->decision);
     }
 
     /**

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
 
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
@@ -385,6 +386,30 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         $this->staleDeadLetters[] = ['runUid' => $runUid, 'now' => $now, 'reason' => $terminationReason];
 
         return true;
+    }
+
+    /** @var array<string, int> value => count returned by countByStatus() */
+    public array $countByStatusReturns = [];
+
+    /** @var array<string, int> value => count returned by countByTerminationReason() */
+    public array $countByTerminationReasonReturns = [];
+
+    /** @var array<string, int> status value => count returned by countInStatus() */
+    public array $countInStatusReturns = [];
+
+    public function countByStatus(int $since = 0): array
+    {
+        return $this->countByStatusReturns;
+    }
+
+    public function countByTerminationReason(int $since = 0): array
+    {
+        return $this->countByTerminationReasonReturns;
+    }
+
+    public function countInStatus(AgentRunStatus $status): int
+    {
+        return $this->countInStatusReturns[$status->value] ?? 0;
     }
 
     public function purgeOlderThan(int $timestamp): int

--- a/Tests/Unit/Service/Tool/ToolLoopServiceGovernanceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceGovernanceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\ToolPolicyDecision;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicyInterface;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * The tool gate is the one place a tool NAME is structurally available, so it is
+ * where a tool denial becomes a queryable governance event.
+ */
+#[CoversClass(ToolLoopService::class)]
+final class ToolLoopServiceGovernanceTest extends TestCase
+{
+    #[Test]
+    public function aDeniedToolIsRecordedAsAGovernanceEvent(): void
+    {
+        $recorder = new InMemoryGovernanceEventRepository();
+        $policy   = $this->policyDenying('fetch_logs', ToolDenialReason::TRUST_ZONE);
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn(
+            new CompletionResponse('done', 'test-model', UsageStatistics::fromTokens(1, 1)),
+        );
+        $mgr->method('chatWithConfiguration')->willReturn(
+            new CompletionResponse('done', 'test-model', UsageStatistics::fromTokens(1, 1)),
+        );
+
+        $registry = new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]);
+        $service  = new ToolLoopService(
+            $mgr,
+            $registry,
+            new FakeToolAvailability(['fetch_logs']),
+            toolPolicy: $policy,
+            governanceEvents: $recorder,
+        );
+
+        $context = ToolExecutionContext::forBackendUser(AiActorContext::backendUser(42, true), null);
+        $service->runLoop([['role' => 'user', 'content' => 'show logs']], new LlmConfiguration(), $context, null);
+
+        self::assertCount(1, $recorder->recorded);
+        $event = $recorder->recorded[0];
+        self::assertSame(GovernanceDecision::TOOL_DENIED->value, $event->decision);
+        self::assertSame(ToolDenialReason::TRUST_ZONE->value, $event->reason);
+        self::assertSame('fetch_logs', $event->toolName);
+        self::assertSame(42, $event->beUser);
+        self::assertSame('', $event->guardrail);
+        self::assertStringContainsString('zone=', $event->detail);
+        self::assertStringContainsString('observedOnly=0', $event->detail);
+    }
+
+    #[Test]
+    public function anAllowedToolRecordsNothing(): void
+    {
+        $recorder = new InMemoryGovernanceEventRepository();
+        $policy   = $this->policyAllowing('fetch_logs');
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn(
+            new CompletionResponse('done', 'test-model', UsageStatistics::fromTokens(1, 1)),
+        );
+
+        $registry = new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]);
+        $service  = new ToolLoopService(
+            $mgr,
+            $registry,
+            new FakeToolAvailability(['fetch_logs']),
+            toolPolicy: $policy,
+            governanceEvents: $recorder,
+        );
+
+        $service->runLoop([['role' => 'user', 'content' => 'hi']], new LlmConfiguration(), ToolExecutionContext::none(), null);
+
+        self::assertSame([], $recorder->recorded);
+    }
+
+    private function policyDenying(string $toolName, ToolDenialReason $reason): ToolCallPolicyInterface
+    {
+        return new class ($toolName, $reason) implements ToolCallPolicyInterface {
+            public function __construct(private readonly string $toolName, private readonly ToolDenialReason $reason) {}
+
+            public function decide(string $toolName, LlmConfiguration $configuration, ?BackendUserAuthentication $user): ToolPolicyDecision
+            {
+                return $this->decision(false);
+            }
+
+            public function filterOfferable(?array $requested, LlmConfiguration $configuration, ?BackendUserAuthentication $user): array
+            {
+                return [];
+            }
+
+            public function explain(?array $requested, LlmConfiguration $configuration, ?BackendUserAuthentication $user): array
+            {
+                return [$this->decision(false)];
+            }
+
+            private function decision(bool $allowed): ToolPolicyDecision
+            {
+                return new ToolPolicyDecision(
+                    toolName: $this->toolName,
+                    allowed: $allowed,
+                    dataClass: ToolDataClass::SYSTEM_DIAGNOSTICS,
+                    zone: TrustZone::EXTERNAL_GLOBAL,
+                    ceiling: ToolDataClass::EDITOR_CONTENT,
+                    reason: $this->reason,
+                );
+            }
+        };
+    }
+
+    private function policyAllowing(string $toolName): ToolCallPolicyInterface
+    {
+        return new class ($toolName) implements ToolCallPolicyInterface {
+            public function __construct(private readonly string $toolName) {}
+
+            public function decide(string $toolName, LlmConfiguration $configuration, ?BackendUserAuthentication $user): ToolPolicyDecision
+            {
+                return $this->decision();
+            }
+
+            public function filterOfferable(?array $requested, LlmConfiguration $configuration, ?BackendUserAuthentication $user): array
+            {
+                return [$this->toolName];
+            }
+
+            public function explain(?array $requested, LlmConfiguration $configuration, ?BackendUserAuthentication $user): array
+            {
+                return [$this->decision()];
+            }
+
+            private function decision(): ToolPolicyDecision
+            {
+                return new ToolPolicyDecision(
+                    toolName: $this->toolName,
+                    allowed: true,
+                    dataClass: ToolDataClass::PUBLIC_CONTENT,
+                    zone: TrustZone::LOCAL,
+                    ceiling: ToolDataClass::SECRET_ADJACENT,
+                    reason: ToolDenialReason::NONE,
+                );
+            }
+        };
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/AgentRunsByStatusDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/AgentRunsByStatusDataProviderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Widgets\DataProvider\AgentRunsByStatusDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(AgentRunsByStatusDataProvider::class)]
+final class AgentRunsByStatusDataProviderTest extends AbstractUnitTestCase
+{
+    /** @var array<string, string> */
+    private const LABELS = [
+        'queued'               => 'Queued',
+        'running'              => 'Running',
+        'waiting_for_approval' => 'Awaiting approval',
+        'waiting_for_input'    => 'Awaiting input',
+        'completed'            => 'Completed',
+        'failed'               => 'Failed',
+        'cancelled'            => 'Cancelled',
+    ];
+
+    #[Test]
+    public function emitsSlicesInEnumOrderRegardlessOfCountOrder(): void
+    {
+        $shaped = AgentRunsByStatusDataProvider::shapeChartData([
+            'failed'    => 3,
+            'completed' => 10,
+            'running'   => 2,
+        ], self::LABELS);
+
+        // Enum order is queued, running, waiting_*, completed, failed, cancelled.
+        self::assertSame(['Running', 'Completed', 'Failed'], $shaped['labels']);
+        self::assertSame([2, 10, 3], $shaped['datasets'][0]['data']);
+        self::assertCount(3, $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function skipsZeroAndNegativeCounts(): void
+    {
+        $shaped = AgentRunsByStatusDataProvider::shapeChartData([
+            'completed' => 0,
+            'running'   => 5,
+            'failed'    => -1,
+        ], self::LABELS);
+
+        self::assertSame(['Running'], $shaped['labels']);
+        self::assertSame([5], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function fallsBackToRawStatusValueWhenLabelMissing(): void
+    {
+        $shaped = AgentRunsByStatusDataProvider::shapeChartData([
+            'running' => 4,
+        ], []);
+
+        self::assertSame(['running'], $shaped['labels']);
+    }
+
+    #[Test]
+    public function assignsTheFixedSemanticColourPerStatus(): void
+    {
+        $shaped = AgentRunsByStatusDataProvider::shapeChartData([
+            'completed' => 1,
+            'failed'    => 1,
+        ], self::LABELS);
+
+        self::assertSame(['#4CAF50', '#D9534F'], $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function returnsEmptyStructureForNoCounts(): void
+    {
+        $shaped = AgentRunsByStatusDataProvider::shapeChartData([], self::LABELS);
+
+        self::assertSame([], $shaped['labels']);
+        self::assertSame([], $shaped['datasets'][0]['data']);
+        self::assertSame([], $shaped['datasets'][0]['backgroundColor']);
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/AverageLatencyDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/AverageLatencyDataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Widgets\DataProvider\AverageLatencyDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(AverageLatencyDataProvider::class)]
+final class AverageLatencyDataProviderTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function returnsTheAverageLatencyFromTheRepository(): void
+    {
+        $repository = new InMemoryTelemetryRepository();
+        $repository->averageLatencyMsReturns = 842;
+
+        $provider = new AverageLatencyDataProvider($repository, 7);
+
+        self::assertSame(842, $provider->getNumber());
+    }
+
+    #[Test]
+    public function returnsZeroWhenNoTelemetry(): void
+    {
+        $provider = new AverageLatencyDataProvider(new InMemoryTelemetryRepository());
+
+        self::assertSame(0, $provider->getNumber());
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/GovernanceBlocksOverTimeDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/GovernanceBlocksOverTimeDataProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Widgets\DataProvider\GovernanceBlocksOverTimeDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(GovernanceBlocksOverTimeDataProvider::class)]
+final class GovernanceBlocksOverTimeDataProviderTest extends AbstractUnitTestCase
+{
+    /** @var array<string, string> */
+    private const LABELS = [
+        'tool_denied'       => 'Tool denied',
+        'response_blocked'  => 'Response blocked',
+        'approval_required' => 'Approval required',
+        'content_filter'    => 'Content filter',
+    ];
+
+    #[Test]
+    public function emitsBarsInEnumOrderWithColoursAndDatasetLabel(): void
+    {
+        $shaped = GovernanceBlocksOverTimeDataProvider::shapeChartData([
+            'content_filter'   => 2,
+            'tool_denied'      => 9,
+            'response_blocked' => 3,
+        ], self::LABELS, 'Events');
+
+        self::assertSame(['Tool denied', 'Response blocked', 'Content filter'], $shaped['labels']);
+        self::assertSame('Events', $shaped['datasets'][0]['label']);
+        self::assertSame([9, 3, 2], $shaped['datasets'][0]['data']);
+        self::assertSame(['#607D8B', '#D9534F', '#8E2A27'], $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function skipsZeroCounts(): void
+    {
+        $shaped = GovernanceBlocksOverTimeDataProvider::shapeChartData([
+            'tool_denied'       => 0,
+            'approval_required' => 4,
+        ], self::LABELS, 'Events');
+
+        self::assertSame(['Approval required'], $shaped['labels']);
+        self::assertSame([4], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function fallsBackToRawDecisionValueWhenLabelMissing(): void
+    {
+        $shaped = GovernanceBlocksOverTimeDataProvider::shapeChartData([
+            'tool_denied' => 1,
+        ], [], 'Events');
+
+        self::assertSame(['tool_denied'], $shaped['labels']);
+    }
+
+    #[Test]
+    public function returnsEmptyStructureForNoCounts(): void
+    {
+        $shaped = GovernanceBlocksOverTimeDataProvider::shapeChartData([], self::LABELS, 'Events');
+
+        self::assertSame([], $shaped['labels']);
+        self::assertSame([], $shaped['datasets'][0]['data']);
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/RequestSuccessRateDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/RequestSuccessRateDataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Widgets\DataProvider\RequestSuccessRateDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(RequestSuccessRateDataProvider::class)]
+final class RequestSuccessRateDataProviderTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function returnsThePercentFromTheRepository(): void
+    {
+        $repository = new InMemoryTelemetryRepository();
+        $repository->successRatePercentReturns = 97;
+
+        $provider = new RequestSuccessRateDataProvider($repository, 7);
+
+        self::assertSame(97, $provider->getNumber());
+    }
+
+    #[Test]
+    public function returnsZeroWhenNoTelemetry(): void
+    {
+        $provider = new RequestSuccessRateDataProvider(new InMemoryTelemetryRepository());
+
+        self::assertSame(0, $provider->getNumber());
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/RunTerminationReasonsDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/RunTerminationReasonsDataProviderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Widgets\DataProvider\RunTerminationReasonsDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(RunTerminationReasonsDataProvider::class)]
+final class RunTerminationReasonsDataProviderTest extends AbstractUnitTestCase
+{
+    /** @var array<string, string> */
+    private const LABELS = [
+        'completed'         => 'Completed',
+        'budget_exhausted'  => 'Budget exhausted',
+        'policy_denied'     => 'Policy denied',
+        'provider_failed'   => 'Provider failed',
+    ];
+
+    #[Test]
+    public function emitsBarsInEnumOrderWithTheDatasetLabel(): void
+    {
+        $shaped = RunTerminationReasonsDataProvider::shapeChartData([
+            'provider_failed'  => 4,
+            'completed'        => 20,
+            'budget_exhausted' => 7,
+        ], self::LABELS, 'Runs');
+
+        // Enum order places completed first, budget_exhausted before provider_failed.
+        self::assertSame(['Completed', 'Budget exhausted', 'Provider failed'], $shaped['labels']);
+        self::assertCount(1, $shaped['datasets']);
+        self::assertSame('Runs', $shaped['datasets'][0]['label']);
+        self::assertSame([20, 7, 4], $shaped['datasets'][0]['data']);
+        self::assertSame(['#4CAF50', '#E8731A', '#8E2A27'], $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function skipsZeroCounts(): void
+    {
+        $shaped = RunTerminationReasonsDataProvider::shapeChartData([
+            'completed'       => 0,
+            'policy_denied'   => 2,
+        ], self::LABELS, 'Runs');
+
+        self::assertSame(['Policy denied'], $shaped['labels']);
+        self::assertSame([2], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function fallsBackToRawReasonValueWhenLabelMissing(): void
+    {
+        $shaped = RunTerminationReasonsDataProvider::shapeChartData([
+            'policy_denied' => 1,
+        ], [], 'Runs');
+
+        self::assertSame(['policy_denied'], $shaped['labels']);
+    }
+
+    #[Test]
+    public function returnsEmptyStructureForNoCounts(): void
+    {
+        $shaped = RunTerminationReasonsDataProvider::shapeChartData([], self::LABELS, 'Runs');
+
+        self::assertSame([], $shaped['labels']);
+        self::assertSame([], $shaped['datasets'][0]['data']);
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/RunsAwaitingApprovalDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/RunsAwaitingApprovalDataProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAgentRunRepository;
+use Netresearch\NrLlm\Widgets\DataProvider\RunsAwaitingApprovalDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(RunsAwaitingApprovalDataProvider::class)]
+final class RunsAwaitingApprovalDataProviderTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function returnsTheWaitingForApprovalCount(): void
+    {
+        $repository = new InMemoryAgentRunRepository();
+        $repository->countInStatusReturns = [AgentRunStatus::WAITING_FOR_APPROVAL->value => 3];
+
+        $provider = new RunsAwaitingApprovalDataProvider($repository);
+
+        self::assertSame(3, $provider->getNumber());
+    }
+
+    #[Test]
+    public function returnsZeroWhenNoneAreWaiting(): void
+    {
+        $provider = new RunsAwaitingApprovalDataProvider(new InMemoryAgentRunRepository());
+
+        self::assertSame(0, $provider->getNumber());
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/ToolDenialsByReasonDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/ToolDenialsByReasonDataProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Widgets\DataProvider\ToolDenialsByReasonDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ToolDenialsByReasonDataProvider::class)]
+final class ToolDenialsByReasonDataProviderTest extends AbstractUnitTestCase
+{
+    /** @var array<string, string> */
+    private const LABELS = [
+        'notRegistered'      => 'Not registered',
+        'toolDisabled'       => 'Tool disabled',
+        'requiresAdmin'      => 'Requires admin',
+        'configurationGroup' => 'Outside configuration groups',
+        'trustZone'          => 'Trust zone ceiling',
+    ];
+
+    #[Test]
+    public function emitsBarsInEnumOrderWithColoursAndDatasetLabel(): void
+    {
+        $shaped = ToolDenialsByReasonDataProvider::shapeChartData([
+            'trustZone'     => 5,
+            'requiresAdmin' => 2,
+            'toolDisabled'  => 8,
+        ], self::LABELS, 'Denials');
+
+        // Enum order: notRegistered, toolDisabled, requiresAdmin, configurationGroup, trustZone.
+        self::assertSame(['Tool disabled', 'Requires admin', 'Trust zone ceiling'], $shaped['labels']);
+        self::assertSame('Denials', $shaped['datasets'][0]['label']);
+        self::assertSame([8, 2, 5], $shaped['datasets'][0]['data']);
+        self::assertSame(['#9E9E9E', '#D9534F', '#8E2A27'], $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function skipsZeroAndTheNoneCase(): void
+    {
+        $shaped = ToolDenialsByReasonDataProvider::shapeChartData([
+            'none'          => 3,
+            'toolDisabled'  => 0,
+            'requiresAdmin' => 1,
+        ], self::LABELS, 'Denials');
+
+        // The NONE case is skipped outright (a "denials by reason" chart never
+        // shows "not denied"), and zero-count reasons drop out — leaving
+        // requiresAdmin as the sole bar.
+        self::assertSame(['Requires admin'], $shaped['labels']);
+        self::assertSame([1], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function returnsEmptyStructureForNoCounts(): void
+    {
+        $shaped = ToolDenialsByReasonDataProvider::shapeChartData([], self::LABELS, 'Denials');
+
+        self::assertSame([], $shaped['labels']);
+        self::assertSame([], $shaped['datasets'][0]['data']);
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/ToolUsageByNameDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/ToolUsageByNameDataProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Widgets\DataProvider\ToolUsageByNameDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ToolUsageByNameDataProvider::class)]
+final class ToolUsageByNameDataProviderTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function preservesTheRepositoryOrderAndUsesToolNamesAsLabels(): void
+    {
+        // The repository already returns most-decided first; the shaper keeps that order.
+        $shaped = ToolUsageByNameDataProvider::shapeChartData([
+            'fetch_logs'  => 12,
+            'get_env'     => 5,
+            'read_source' => 1,
+        ], 'Decisions');
+
+        self::assertSame(['fetch_logs', 'get_env', 'read_source'], $shaped['labels']);
+        self::assertSame('Decisions', $shaped['datasets'][0]['label']);
+        self::assertSame([12, 5, 1], $shaped['datasets'][0]['data']);
+        self::assertCount(3, $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function skipsEmptyNamesAndNonPositiveCounts(): void
+    {
+        $shaped = ToolUsageByNameDataProvider::shapeChartData([
+            'fetch_logs' => 4,
+            ''           => 99,
+            'get_env'    => 0,
+        ], 'Decisions');
+
+        self::assertSame(['fetch_logs'], $shaped['labels']);
+        self::assertSame([4], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function returnsEmptyStructureForNoRows(): void
+    {
+        $shaped = ToolUsageByNameDataProvider::shapeChartData([], 'Decisions');
+
+        self::assertSame([], $shaped['labels']);
+        self::assertSame([], $shaped['datasets'][0]['data']);
+        self::assertSame([], $shaped['datasets'][0]['backgroundColor']);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -124,4 +124,12 @@ defined('TYPO3') or die();
     // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
         = ProviderEndpointNormalizationHook::class;
+
+    // Dedicated dashboard widget group for the agentic / governance / telemetry
+    // widgets, so they do not scatter into the built-in 'general' group. Inert
+    // without typo3/cms-dashboard installed (the array is simply never read).
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dashboard']['widgetGroups']['nrllm'] ??= [
+        'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widgetGroup.nrllm.title',
+    ];
 })();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -808,3 +808,73 @@ CREATE TABLE tx_nrllm_ai_session_message (
     -- concurrent turns owns a sequence (ADR-083).
     UNIQUE KEY session_sequence (session, sequence)
 );
+
+#
+# Table structure for table 'tx_nrllm_governance_event'
+# Append-only governance/tool-decision audit trail. One row per denied or
+# gated decision: a guardrail DENY/REQUIRE_APPROVAL, a provider content-filter
+# block, or a tool-gate denial. Closes the gap that these outcomes were only
+# reflected on a run (termination_reason) or logged, never queryable. Written
+# only by GovernanceEventRepository::record() (INSERT); no update/delete path.
+# No TCA, no soft-delete, no tstamp -- crdate is the immutable event time.
+# Growth is bounded by a nrllm:governance:purge command (mirrors telemetry).
+#
+CREATE TABLE tx_nrllm_governance_event (
+    uid int(11) unsigned NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Immutable event time (append-only; no tstamp).
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Trace correlation (UUID v4, 36 chars) -- links a middleware-origin row to
+    -- the telemetry row and, via the run's correlation, to its agent run.
+    correlation_id varchar(36) DEFAULT '' NOT NULL,
+
+    -- What kind of decision: tool_denied | response_blocked | approval_required | content_filter
+    decision varchar(32) DEFAULT '' NOT NULL,
+
+    -- Why, as a raw enum value: ToolDenialReason (notRegistered/toolDisabled/
+    -- requiresAdmin/configurationGroup/trustZone), GuardrailVerdict (deny/
+    -- require_approval), or the 'content_filter' literal -- see the
+    -- decision->reason mapping in the write points.
+    reason varchar(64) DEFAULT '' NOT NULL,
+
+    -- Provider context (strings, like telemetry -- resolved from the response /
+    -- context, '' when unknown at the write point).
+    provider varchar(64) DEFAULT '' NOT NULL,
+    model varchar(128) DEFAULT '' NOT NULL,
+    configuration_identifier varchar(150) DEFAULT '' NOT NULL,
+
+    -- Attribution (backend user; 0 for CLI/scheduler/unauthenticated).
+    be_user int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- The tool this decision was about; '' for guardrail/content_filter rows.
+    tool_name varchar(190) DEFAULT '' NOT NULL,
+
+    -- The agent run this decision belongs to; 0 when not available at the write
+    -- point (the guardrail middleware and the tool gate both run below the run
+    -- identity -- correlation_id links a guardrail row instead).
+    agentrun_uid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- The deciding guardrail FQCN for guardrail/content_filter rows ('' for
+    -- tool_denied). Class name only -- never the reason string's payload
+    -- fragments, matching telemetry's error_class privacy stance.
+    guardrail varchar(255) DEFAULT '' NOT NULL,
+
+    -- Optional short policy detail (trust zone, ceiling, ...). NEVER tool
+    -- arguments/output or response content (ADR-064 privacy).
+    detail text,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- Purge + time-range analytics scan by crdate only.
+    KEY crdate (crdate),
+    -- "governance blocks over time", broken down by kind.
+    KEY decision_lookup (decision, crdate),
+    -- "tool denials by reason" / "guardrail denials by reason".
+    KEY reason_lookup (decision, reason, crdate),
+    -- "tool usage/denials by tool_name".
+    KEY tool_lookup (tool_name, crdate),
+    -- Join a middleware-origin row to its trace.
+    KEY correlation (correlation_id)
+);


### PR DESCRIPTION
Adds agentic, telemetry and governance dashboard widgets to nr_llm, in two phases.

## Phase 1 — widgets on existing data (commit 2f21c731, no schema change)
A new `nrllm` dashboard group with 5 widgets reading existing tables:
- **Agent runs by status** (doughnut) — `tx_nrllm_agentrun.status`
- **Runs awaiting approval** (count tile) — `waiting_for_approval`
- **Agent run outcomes / termination reasons** (bar) — `termination_reason`
- **Request success rate** and **Average latency** (tiles) — `tx_nrllm_telemetry`

New read aggregates on `AgentRunRepository` (countByStatus / countByTerminationReason / countInStatus) and `TelemetryRepository` (successRatePercent / averageLatencyMs).

## Phase 2 — governance & tool-usage, with the backing data (commit 01614dcb)
Guardrail verdicts, tool-gate denials and content-filter blocks were only reflected on a run (termination_reason / outcome) or logged — never queryable. This adds:
- **`tx_nrllm_governance_event`** — append-only audit table (crdate, be_user, provider, model, decision, reason, tool_name, agentrun_uid, correlation_id), matching the `tx_nrllm_telemetry` / `tx_nrllm_skill_audit` conventions. Written only by `GovernanceEventRepository::record()`.
- **Write points**: `GuardrailMiddleware` (DENY / REQUIRE_APPROVAL / content_filter) and `ToolLoopService` (tool-gate denials).
- **Widgets**: governance blocks over time, tool denials by reason, tool usage by tool name.
- **Retention**: `PrivacyDataCategory::GOVERNANCE` + `PurgePrivacyDataCommand` + `nrllm:governance:purge`, so the table is purge-covered (required by `RetentionCoverageTest`).

## Deviations from the design (verified against TYPO3 v14.3.5)
1. `NumberWithIconWidget` has no button-provider ctor arg in this version → the awaiting-approval tile is **count-only** (the `nrllm_runs` module is the action surface). No dead button-provider class.
2. Tool-denial rows carry `agentrun_uid=0` and empty `correlation_id` — run identity is not in scope at the `resolveOfferedNames` tool-gate seam; the widget value is by tool_name/reason. Guardrail rows use `correlation_id` as the run-join key.
3. Retention wiring (category + purge command) was added though the design said "no wizard" — `RetentionCoverageTest` enumerates every `tx_nrllm_*` table, so the new table **must** be purge-covered. No upgrade wizard (nothing to backfill).

## CI
Local (PHP 8.4): cgl ✅, unit ✅ (5650), PHPStan L10 ✅, fuzzy ✅, rector -n ✅, functional -d sqlite ✅ (1293 tests, 14244 assertions).
