### PR TITLE
chore: release v0.25.0

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.24.0"
-        release="0.24.0"
+        version="0.25.0"
+        release="0.25.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.24.0",
+            "version": "0.25.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.24.0',
+    'version' => '0.25.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release 0.25.0 — bumps ext_emconf, composer extra.typo3/cms.version, and guides.xml.

Highlights (since 0.24.0): agentic/telemetry/governance dashboard widgets and the new append-only `tx_nrllm_governance_event` audit table (#521).