### PR TITLE
fix(translation): detect source language via the passed configuration (#520)

### DIFF
--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Budget\BackendUserContextResolverInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -162,6 +163,7 @@ final readonly class TranslationService implements TranslationServiceInterface
             $sourceLanguage,
             $options,
             1719410501,
+            $configuration,
         );
 
         $messages = [
@@ -170,14 +172,7 @@ final readonly class TranslationService implements TranslationServiceInterface
 
         // Budget metadata for chatWithConfiguration's pipeline (ADR-052):
         // absent keys mean "skip the check", matching the middleware contract.
-        $metadata = [];
-        $beUserUid = $this->resolveBeUserUid($options);
-        if ($beUserUid !== null) {
-            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
-        }
-        if ($options->getPlannedCost() !== null) {
-            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $options->getPlannedCost();
-        }
+        $metadata = $this->budgetMetadata($options);
 
         // Only forward set generation knobs; unset ones let the configuration's
         // stored defaults apply. Provider is omitted — the configuration owns it.
@@ -246,6 +241,28 @@ final readonly class TranslationService implements TranslationServiceInterface
     }
 
     /**
+     * Budget-relevant pipeline metadata for a chatWithConfiguration() sub-call:
+     * the BE-user uid and planned cost when present. Absent keys mean "skip the
+     * check", matching the middleware contract (ADR-052).
+     *
+     * @return array<string, mixed>
+     */
+    private function budgetMetadata(TranslationOptions $options): array
+    {
+        $metadata  = [];
+        $beUserUid = $this->resolveBeUserUid($options);
+        if ($beUserUid !== null) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
+
+        if ($options->getPlannedCost() !== null) {
+            $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $options->getPlannedCost();
+        }
+
+        return $metadata;
+    }
+
+    /**
      * Shared language-detection implementation.
      *
      * @param bool $countsAsRequest false when detection runs as the internal
@@ -257,23 +274,42 @@ final readonly class TranslationService implements TranslationServiceInterface
      *
      * @return string Language code (ISO 639-1)
      */
-    private function runLanguageDetection(string $text, TranslationOptions $options, bool $countsAsRequest): string
+    private function runLanguageDetection(string $text, TranslationOptions $options, bool $countsAsRequest, ?LlmConfiguration $configuration = null): string
     {
         $messages = [
             ChatMessage::system('You are a language detection expert. Respond with ONLY the ISO 639-1 language code (e.g., "en", "de", "fr"). No explanation.'),
             ChatMessage::user("Detect the language of this text:\n\n" . $text),
         ];
 
-        $chatOptions = (new ChatOptions(
-            temperature: 0.1,
-            maxTokens: 10,
-            provider: $options->getProvider(),
-            model: $options->getModel(),
-            beUserUid: $this->resolveBeUserUid($options),
-            plannedCost: $options->getPlannedCost(),
-        ))->withSuppressRequestCount(!$countsAsRequest);
+        // A configuration-driven translation detects the source language through
+        // the SAME configuration it was passed, so it never needs a global default
+        // to be marked just to auto-detect (issue #520). Only the generic
+        // translate() path (no configuration) uses the default-resolving chat()
+        // entry point. Suppression is carried as pipeline metadata (issue #473).
+        if ($configuration !== null) {
+            $metadata = $this->budgetMetadata($options);
+            if (!$countsAsRequest) {
+                $metadata[UsageMiddleware::METADATA_SKIP_REQUEST_COUNT] = true;
+            }
 
-        $response = $this->llmManager->chat($messages, $chatOptions);
+            $response = $this->llmManager->chatWithConfiguration(
+                $messages,
+                $configuration,
+                $metadata,
+                ['temperature' => 0.1, 'max_tokens' => 10],
+            );
+        } else {
+            $chatOptions = (new ChatOptions(
+                temperature: 0.1,
+                maxTokens: 10,
+                provider: $options->getProvider(),
+                model: $options->getModel(),
+                beUserUid: $this->resolveBeUserUid($options),
+                plannedCost: $options->getPlannedCost(),
+            ))->withSuppressRequestCount(!$countsAsRequest);
+
+            $response = $this->llmManager->chat($messages, $chatOptions);
+        }
 
         $detectedLang = trim(strtolower($response->content));
 
@@ -521,6 +557,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?string $sourceLanguage,
         TranslationOptions $options,
         int $emptyTextErrorCode,
+        ?LlmConfiguration $configuration = null,
     ): array {
         if (empty($text)) {
             throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, $emptyTextErrorCode);
@@ -534,7 +571,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         // internal step of the translation, so it records its tokens/cost but
         // does not count as a separate request (issue #473 double-count).
         if ($sourceLanguage === null) {
-            $sourceLanguage = $this->runLanguageDetection($text, $options, false);
+            $sourceLanguage = $this->runLanguageDetection($text, $options, false, $configuration);
         } else {
             $this->validateLanguageCode($sourceLanguage);
         }

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -1924,21 +1924,25 @@ class TranslationServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function translateForConfigurationAutoDetectsSourceLanguageViaChat(): void
+    public function translateForConfigurationAutoDetectsSourceLanguageViaConfiguration(): void
     {
-        // Source omitted => detectLanguage() runs first (through chat()),
-        // then the translation runs through chatWithConfiguration().
+        // Source omitted => language auto-detection runs first. It must route
+        // through the SAME configuration (chatWithConfiguration), never the
+        // default-resolving chat() — so a configuration-driven translation needs
+        // no global default marked just to auto-detect the source (issue #520).
         $configuration = self::createStub(LlmConfiguration::class);
 
         $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
         $llmManagerMock
-            ->expects(self::once())
-            ->method('chat')
-            ->willReturn($this->createChatResponse('fr'));
-        $llmManagerMock
-            ->expects(self::once())
+            ->expects(self::exactly(2))
             ->method('chatWithConfiguration')
-            ->willReturn($this->createChatResponse('Hallo'));
+            ->willReturnOnConsecutiveCalls(
+                $this->createChatResponse('fr'),
+                $this->createChatResponse('Hallo'),
+            );
+        $llmManagerMock
+            ->expects(self::never())
+            ->method('chat');
 
         $subject = new TranslationService(
             $llmManagerMock,
@@ -1950,6 +1954,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
         $result = $subject->translateForConfiguration('Bonjour', 'de', $configuration);
 
         self::assertSame('fr', $result->sourceLanguage);
+        self::assertSame('Hallo', $result->translation);
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

`translateForConfiguration()` throws `No default LLM configuration found` when no LLM configuration is marked as default — even though the caller passes a configuration explicitly (reported by @lradloff in #520).

## Root cause

When `sourceLanguage` is omitted, `translateForConfiguration()` auto-detects it. But the detection sub-call was reached **without** the caller's configuration:

- `translateForConfiguration()` → `prepareTranslation()` (config not threaded) → `runLanguageDetection()`
- `runLanguageDetection()` called `llmManager->chat()` — the generic, **default-resolving** entry point — not `chatWithConfiguration()`.
- `chat()` resolves the default DB configuration and fails when none is marked default.

So the translation itself used the passed config, but the internal language-detection step ignored it and required a global default.

## Fix

Thread the `LlmConfiguration` through `prepareTranslation()` into `runLanguageDetection()`. When a configuration is present, detection runs through `chatWithConfiguration()` (the same config that does the translation) — no global default needed. The generic `translate()` path (no configuration) still uses `chat()`, unchanged.

- Request-count suppression for the internal detect step (issue #473 double-count) is preserved via `UsageMiddleware::METADATA_SKIP_REQUEST_COUNT` in the config path.
- Extracted a shared `budgetMetadata()` helper so the budget-metadata block isn't duplicated between `translateForConfiguration()` and detection.

## Tests

Updated `translateForConfigurationAutoDetectsSourceLanguageViaConfiguration`: with no `sourceLanguage` and a passed config, both detect + translate route through `chatWithConfiguration()` and `chat()` is asserted **never** called — i.e. no default configuration is required.

Full local gate green: unit (5650), functional-sqlite (1293), PHPStan L10 (no errors), rector, fuzzy.

Fixes #520
