### PR TITLE
fix(tests): re-narrow $GLOBALS['TCA'] for PHPStan 2.2.6

### DIFF
--- a/Tests/Functional/Service/Tool/GetFlexFormSchemaToolTest.php
+++ b/Tests/Functional/Service/Tool/GetFlexFormSchemaToolTest.php
@@ -54,6 +54,9 @@ final class GetFlexFormSchemaToolTest extends AbstractFunctionalTestCase
         $singleDs = (new Typo3Version())->getMajorVersion() >= 14
             ? self::DS
             : ['default' => self::DS];
+        // Re-narrow here: the assertIsArray() above does not carry across the
+        // intervening statement, so $GLOBALS['TCA'] is mixed again by this line.
+        \assert(is_array($GLOBALS['TCA']));
         $GLOBALS['TCA']['tx_demo_flex'] = [
             'ctrl'    => ['title' => 'Demo Flex'],
             'columns' => [


### PR DESCRIPTION
## Problem
CI on `main` is red on all PHPStan matrix cells:

```
Tests/Functional/Service/Tool/GetFlexFormSchemaToolTest.php:57
  Cannot access offset 'tx_demo_flex' on mixed.
```

PHPStan 2.2.6 (released 2026-07-26, picked up because the extension does not commit `composer.lock`) no longer carries the `self::assertIsArray($GLOBALS['TCA'])` narrowing across the intervening `$singleDs` statement, so `$GLOBALS['TCA']` is `mixed` again by line 57 and the offset write fails.

## Fix
Re-narrow with a native `\assert(is_array($GLOBALS['TCA']))` directly before the write — the project convention for array narrowing (see `Tests/CLAUDE.md`).

## Verification
`./Build/Scripts/runTests.sh -s phpstan` locally (PHP 8.5): `[OK] No errors`.