### PR TITLE
test(architecture): enforce the ADR-090 horizontal module seams

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -163,3 +163,7 @@ services:
     class: Netresearch\NrLlm\Tests\Architecture\ServiceLayerTest
     tags:
       - phpat.test
+  -
+    class: Netresearch\NrLlm\Tests\Architecture\ModuleSeamTest
+    tags:
+      - phpat.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Architecture tests for the horizontal module seams ADR-090 names: the
-  specialized, tool/agent and guardrail modules may no longer depend on one
-  another, and nothing below the backend package may depend on controllers or
-  dashboard widgets. ADR-090 kept these boundaries as a review responsibility
-  and called extending phpat to cover them part of the split-readiness work;
+- Architecture tests for the horizontal module seams ADR-090 names. The
+  specialized and tool/agent modules may no longer depend on each other in
+  either direction, the guardrail module may depend on neither, and nothing
+  outside the backend package may depend on controllers or dashboard widgets.
+  Calls in the invoking direction stay allowed, since that is how the guardrail
+  pipeline runs. ADR-090 kept these boundaries as a review responsibility and
+  called extending phpat to cover them part of the split-readiness work;
   wrong-way coupling now fails CI. All four rules pass against the current tree
   without a baseline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Architecture tests for the horizontal module seams ADR-090 names: the
+  specialized, tool/agent and guardrail modules may no longer depend on one
+  another, and nothing below the backend package may depend on controllers or
+  dashboard widgets. ADR-090 kept these boundaries as a review responsibility
+  and called extending phpat to cover them part of the split-readiness work;
+  wrong-way coupling now fails CI. All four rules pass against the current tree
+  without a baseline.
+
 ### Fixed
 
 - `privacy.retention.governance` is now declared in `ext_conf_template.txt` and

--- a/Documentation/Adr/Adr090SingleExtensionUntil10.rst
+++ b/Documentation/Adr/Adr090SingleExtensionUntil10.rst
@@ -58,11 +58,12 @@ re-architecture. The phpat architecture tests (``Tests/Architecture/``) already
 enforce the **vertical** layering — Controller → Service → Provider / Domain
 (e.g. controllers use the tool registry rather than concrete adapters, services
 do not depend on controllers or concrete provider adapters, domain models stay
-free of repositories/HTTP). They do **not** yet police the **horizontal** seams
-*between* the feature modules (specialized ↔ tools ↔ guardrail ↔ backend); those
-are currently kept clean by review. Extending phpat to assert the horizontal
-module boundaries is itself part of the split-readiness work, and new
-cross-module coupling that would block an extraction is treated as a defect.
+free of repositories/HTTP). Since ``Tests/Architecture/ModuleSeamTest.php`` they
+also police the **horizontal** seams *between* the feature modules
+(specialized ↔ tools ↔ guardrail ↔ backend): the specialized, tool/agent and
+guardrail modules may not depend on one another, and nothing below the backend
+package may depend on ``Controller`` or ``Widgets``. Cross-module coupling that
+would block an extraction fails CI rather than only review.
 
 Anticipated split seams (candidate extensions):
 
@@ -114,11 +115,11 @@ Consequences
   and a broader default attack surface (mitigated by the tool availability
   gating and guardrail defaults).
 - **Split-ready discipline:** module boundaries must stay clean. The phpat
-  architecture tests guard the vertical layering automatically; the horizontal
-  seams (core reaching into the backend UI, or one feature module reaching into
-  another) are today a review responsibility. Adding phpat rules for the module
-  seams — so a wrong-way dependency fails CI rather than only review — is a
-  concrete, cheap step toward split-readiness.
+  architecture tests guard both the vertical layering and, since
+  ``ModuleSeamTest``, the horizontal seams — core reaching into the backend UI,
+  or one feature module reaching into another, fails CI. A deliberate new
+  dependency across a seam therefore has to change this ADR and the rule
+  together, which is the point.
 - **At 1.0:** re-evaluate against the criteria above. If the seams have held,
   the split is largely a ``composer.json`` / ``ext_emconf.php`` repackaging plus
   moving files along the documented boundaries; if a consumer need is real

--- a/Documentation/Adr/Adr090SingleExtensionUntil10.rst
+++ b/Documentation/Adr/Adr090SingleExtensionUntil10.rst
@@ -59,11 +59,14 @@ enforce the **vertical** layering — Controller → Service → Provider / Doma
 (e.g. controllers use the tool registry rather than concrete adapters, services
 do not depend on controllers or concrete provider adapters, domain models stay
 free of repositories/HTTP). Since ``Tests/Architecture/ModuleSeamTest.php`` they
-also police the **horizontal** seams *between* the feature modules
-(specialized ↔ tools ↔ guardrail ↔ backend): the specialized, tool/agent and
-guardrail modules may not depend on one another, and nothing below the backend
-package may depend on ``Controller`` or ``Widgets``. Cross-module coupling that
-would block an extraction fails CI rather than only review.
+also police the **horizontal** seams *between* the feature modules. The
+enforced rules are directional, not symmetric: specialized and tool/agent may
+not depend on each other in either direction, guardrail may depend on neither,
+and nothing outside the backend package may depend on ``Controller`` or
+``Widgets``. Calls in the invoking direction stay allowed — specialized and
+tool code reaching a guardrail is how the safety pipeline runs at all, and the
+backend depends on everything by design. Cross-module coupling that would block
+an extraction now fails CI rather than only review.
 
 Anticipated split seams (candidate extensions):
 

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -43,6 +43,20 @@ use PHPat\Test\PHPat;
  */
 final class ModuleSeamTest
 {
+    private const NS_SPECIALIZED = 'Netresearch\NrLlm\Specialized';
+
+    private const NS_TOOL = 'Netresearch\NrLlm\Service\Tool';
+
+    private const NS_AGENT = 'Netresearch\NrLlm\Service\Agent';
+
+    private const NS_RETRIEVAL = 'Netresearch\NrLlm\Service\Retrieval';
+
+    private const NS_GUARDRAIL = 'Netresearch\NrLlm\Service\Guardrail';
+
+    private const NS_CONTROLLER = 'Netresearch\NrLlm\Controller';
+
+    private const NS_WIDGETS = 'Netresearch\NrLlm\Widgets';
+
     /**
      * The specialized services must not reach into the tool/agent module.
      *
@@ -54,12 +68,12 @@ final class ModuleSeamTest
     public function testSpecializedServicesDoNotDependOnTheToolModule(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrLlm\Specialized'))
+            ->classes(Selector::inNamespace(self::NS_SPECIALIZED))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
+                Selector::inNamespace(self::NS_TOOL),
+                Selector::inNamespace(self::NS_AGENT),
+                Selector::inNamespace(self::NS_RETRIEVAL),
             )
             ->because('nr_llm_specialized depends on core only, never on nr_llm_tools (ADR-090).');
     }
@@ -76,12 +90,12 @@ final class ModuleSeamTest
     {
         return PHPat::rule()
             ->classes(
-                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
+                Selector::inNamespace(self::NS_TOOL),
+                Selector::inNamespace(self::NS_AGENT),
+                Selector::inNamespace(self::NS_RETRIEVAL),
             )
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrLlm\Specialized'))
+            ->classes(Selector::inNamespace(self::NS_SPECIALIZED))
             ->because('nr_llm_tools depends on core only, never on nr_llm_specialized (ADR-090).');
     }
 
@@ -97,13 +111,13 @@ final class ModuleSeamTest
     public function testGuardrailModuleDoesNotDependOnTheModulesItProtects(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrLlm\Service\Guardrail'))
+            ->classes(Selector::inNamespace(self::NS_GUARDRAIL))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
-                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
-                Selector::inNamespace('Netresearch\NrLlm\Specialized'),
+                Selector::inNamespace(self::NS_TOOL),
+                Selector::inNamespace(self::NS_AGENT),
+                Selector::inNamespace(self::NS_RETRIEVAL),
+                Selector::inNamespace(self::NS_SPECIALIZED),
             )
             ->because('Guardrails are invoked by the tool and specialized modules, never the reverse (ADR-090).');
     }
@@ -125,12 +139,12 @@ final class ModuleSeamTest
             ->classes(
                 Selector::inNamespace('Netresearch\NrLlm\Provider'),
                 Selector::inNamespace('Netresearch\NrLlm\Service'),
-                Selector::inNamespace('Netresearch\NrLlm\Specialized'),
+                Selector::inNamespace(self::NS_SPECIALIZED),
             )
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrLlm\Controller'),
-                Selector::inNamespace('Netresearch\NrLlm\Widgets'),
+                Selector::inNamespace(self::NS_CONTROLLER),
+                Selector::inNamespace(self::NS_WIDGETS),
             )
             ->because('nr_llm_backend depends on the feature packages; none of them may depend on it (ADR-090).');
     }

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * Architectural tests for the horizontal module seams named in ADR-090.
+ *
+ * ADR-090 keeps nr_llm a single extension until 1.0 but requires the
+ * architecture to stay *split-ready*, and names the candidate packages:
+ * core, `nr_llm_specialized`, `nr_llm_tools`, `nr_llm_guardrail` and
+ * `nr_llm_backend`. Every feature package depends on core and on nothing
+ * else; the backend package sits on top of all of them.
+ *
+ * The other tests in this directory enforce the *vertical* layering
+ * (Controller → Service → Provider / Domain). The seams *between* the
+ * feature modules were, until this test, kept clean by review only — which
+ * ADR-090 itself calls out as the gap, since new cross-module coupling is
+ * what would turn a future extraction from a packaging change back into a
+ * re-architecture.
+ *
+ * Namespace-to-package map used below, from the ADR's own scope column:
+ *
+ * - specialized: `Specialized`
+ * - tools:       `Service\Tool`, `Service\Agent` (agent-run persistence and
+ *                human-in-the-loop approval), `Service\Retrieval` (RAG
+ *                site-search)
+ * - guardrail:   `Service\Guardrail`
+ * - backend:     `Controller`, `Widgets`
+ *
+ * A dependency in the *other* direction — tools calling a guardrail, the
+ * backend calling anything — is legitimate and deliberately not restricted.
+ */
+final class ModuleSeamTest
+{
+    /**
+     * The specialized services must not reach into the tool/agent module.
+     *
+     * Translation, image and speech are a self-contained package on top of
+     * core. Reaching for the tool registry, the tool loop or agent-run
+     * persistence from here would make `nr_llm_specialized` depend on
+     * `nr_llm_tools`, which the ADR's dependency column forbids.
+     */
+    public function testSpecializedServicesDoNotDependOnTheToolModule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Specialized'))
+            ->shouldNotDependOn()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
+            )
+            ->because('nr_llm_specialized depends on core only, never on nr_llm_tools (ADR-090).');
+    }
+
+    /**
+     * The tool/agent module must not reach into the specialized services.
+     *
+     * A tool that needs translation, image generation or speech goes through
+     * the pipeline the same way any other consumer does; importing
+     * `Specialized\*` here would couple the two candidate packages in both
+     * directions and make either extraction impossible.
+     */
+    public function testToolModuleDoesNotDependOnSpecializedServices(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
+            )
+            ->shouldNotDependOn()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Specialized'))
+            ->because('nr_llm_tools depends on core only, never on nr_llm_specialized (ADR-090).');
+    }
+
+    /**
+     * The guardrail pipeline must not depend on the modules it protects.
+     *
+     * Guardrails are invoked *by* the tool loop and *by* the specialized
+     * services, never the reverse. A guardrail that imports a tool or a
+     * specialized service would both invert that relationship and prevent
+     * the safety pipeline from staying in core, which ADR-090 lists as the
+     * likely outcome for `nr_llm_guardrail`.
+     */
+    public function testGuardrailModuleDoesNotDependOnTheModulesItProtects(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrLlm\Service\Guardrail'))
+            ->shouldNotDependOn()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrLlm\Service\Tool'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Agent'),
+                Selector::inNamespace('Netresearch\NrLlm\Service\Retrieval'),
+                Selector::inNamespace('Netresearch\NrLlm\Specialized'),
+            )
+            ->because('Guardrails are invoked by the tool and specialized modules, never the reverse (ADR-090).');
+    }
+
+    /**
+     * Nothing below the backend package may depend on the backend UI.
+     *
+     * `nr_llm_backend` is the only package that depends on the others, so a
+     * provider, a specialized service or any core service importing a
+     * controller or a dashboard widget would make the backend
+     * non-extractable. `ServiceLayerTest` already asserts the Service →
+     * Controller half of this as a layering rule; it is repeated here because
+     * the seam statement is about packages, and because the widget namespace
+     * is not covered there.
+     */
+    public function testFeatureModulesDoNotDependOnTheBackendPackage(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrLlm\Provider'),
+                Selector::inNamespace('Netresearch\NrLlm\Service'),
+                Selector::inNamespace('Netresearch\NrLlm\Specialized'),
+            )
+            ->shouldNotDependOn()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrLlm\Controller'),
+                Selector::inNamespace('Netresearch\NrLlm\Widgets'),
+            )
+            ->because('nr_llm_backend depends on the feature packages; none of them may depend on it (ADR-090).');
+    }
+}

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -38,11 +38,23 @@ use PHPat\Test\PHPat;
  * - guardrail:   `Service\Guardrail`
  * - backend:     `Controller`, `Widgets`
  *
- * A dependency in the *other* direction — tools calling a guardrail, the
- * backend calling anything — is legitimate and deliberately not restricted.
+ * What is enforced is directional, not symmetric:
+ *
+ * - specialized ↮ tools, both ways
+ * - guardrail ↛ specialized, guardrail ↛ tools
+ * - everything outside the backend ↛ backend
+ *
+ * The two remaining pairs are deliberately free: specialized → guardrail and
+ * tools → guardrail are how the safety pipeline gets invoked at all, and
+ * `AbstractSpecializedService` uses it today. The backend calling anything is
+ * likewise legitimate. Do not "complete" this into a symmetric rule set.
  */
 final class ModuleSeamTest
 {
+    private const NS_ROOT = 'Netresearch\NrLlm';
+
+    private const NS_TESTS = 'Netresearch\NrLlm\Tests';
+
     private const NS_SPECIALIZED = 'Netresearch\NrLlm\Specialized';
 
     private const NS_TOOL = 'Netresearch\NrLlm\Service\Tool';
@@ -123,29 +135,36 @@ final class ModuleSeamTest
     }
 
     /**
-     * Nothing below the backend package may depend on the backend UI.
+     * Nothing outside the backend package may depend on the backend UI.
      *
      * `nr_llm_backend` is the only package that depends on the others, so a
      * provider, a specialized service or any core service importing a
      * controller or a dashboard widget would make the backend
-     * non-extractable. `ServiceLayerTest` already asserts the Service →
-     * Controller half of this as a layering rule; it is repeated here because
-     * the seam statement is about packages, and because the widget namespace
-     * is not covered there.
+     * non-extractable.
+     *
+     * The subject is expressed as "everything under the extension namespace
+     * except the backend itself and the test suite" rather than as a list of
+     * the namespaces that exist today, so a top-level namespace added later is
+     * covered without anyone remembering this rule. `ServiceLayerTest` already
+     * asserts the Service → Controller half as a layering rule; the seam
+     * statement is about packages and also covers the widget namespace.
      */
-    public function testFeatureModulesDoNotDependOnTheBackendPackage(): Rule
+    public function testNothingOutsideTheBackendDependsOnIt(): Rule
     {
         return PHPat::rule()
-            ->classes(
-                Selector::inNamespace('Netresearch\NrLlm\Provider'),
-                Selector::inNamespace('Netresearch\NrLlm\Service'),
-                Selector::inNamespace(self::NS_SPECIALIZED),
-            )
+            ->classes(Selector::AllOf(
+                Selector::inNamespace(self::NS_ROOT),
+                Selector::NoneOf(
+                    Selector::inNamespace(self::NS_CONTROLLER),
+                    Selector::inNamespace(self::NS_WIDGETS),
+                    Selector::inNamespace(self::NS_TESTS),
+                ),
+            ))
             ->shouldNotDependOn()
             ->classes(
                 Selector::inNamespace(self::NS_CONTROLLER),
                 Selector::inNamespace(self::NS_WIDGETS),
             )
-            ->because('nr_llm_backend depends on the feature packages; none of them may depend on it (ADR-090).');
+            ->because('nr_llm_backend depends on the other packages; nothing outside it may depend on the backend (ADR-090).');
     }
 }


### PR DESCRIPTION
Closes #537.

ADR-090 keeps `nr_llm` a single extension until 1.0 but requires the architecture to stay *split-ready*, and names the candidate packages: core, `nr_llm_specialized`, `nr_llm_tools`, `nr_llm_guardrail`, `nr_llm_backend`. Each feature package depends on core and nothing else; the backend package sits on top of all of them.

phpat enforced only the vertical layering (Controller → Service → Provider). The seams *between* the feature modules were kept clean by review — which ADR-090 itself names as the gap, since cross-module coupling is exactly what would turn a future extraction back from a packaging change into a re-architecture.

## Rules added

| Rule | Forbids |
|---|---|
| `testSpecializedServicesDoNotDependOnTheToolModule` | `Specialized` → `Service\Tool` / `Service\Agent` / `Service\Retrieval` |
| `testToolModuleDoesNotDependOnSpecializedServices` | the reverse |
| `testGuardrailModuleDoesNotDependOnTheModulesItProtects` | `Service\Guardrail` → tool/agent/retrieval/specialized |
| `testFeatureModulesDoNotDependOnTheBackendPackage` | `Provider` / `Service` / `Specialized` → `Controller` / `Widgets` |

Dependencies in the other direction — the tool loop calling a guardrail, the backend calling anything — stay allowed.

## Verification

All four pass against the current tree, so no baseline was needed. To confirm the rules actually select classes rather than passing vacuously, `FalImageService` was temporarily given a `ToolRegistry` parameter; phpat failed with `phpat.testSpecializedServicesDoNotDependOnTheToolModule` and the change was reverted.

Local gates: architecture, unit, cgl, rector, fuzzy.

ADR-090's own text described the horizontal seams as unenforced and is updated in the same commit, so a deliberate future dependency across a seam has to change the ADR and the rule together.
