### PR TITLE
docs(contributing): state the changelog and ADR expectations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,6 @@
 - [ ] I have run `composer ci` and all checks pass
 - [ ] I have added tests that prove my fix/feature works
 - [ ] I have updated the documentation accordingly
+- [ ] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
+- [ ] I have added an ADR under `Documentation/Adr/` if this changes the public surface
 - [ ] My changes generate no new warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,25 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting.
 - [ ] Tests added/updated
 - [ ] All CI checks pass
 - [ ] Documentation updated (if applicable)
+- [ ] `CHANGELOG.md` entry added under `## [Unreleased]`
+- [ ] ADR added under `Documentation/Adr/` if the public surface changed
 - [ ] No secrets committed
 - [ ] Follows existing code style
+
+### Changelog and ADRs
+
+Every change that a consumer or an integrator can notice gets a `CHANGELOG.md`
+entry under `## [Unreleased]`, in the Keep a Changelog section that fits
+(`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`).
+Version bumps belong to the release commit, never to a feature PR.
+
+A change to the public surface also gets an Architecture Decision Record under
+`Documentation/Adr/`, named `Adr<N><Description>.rst` — take the next free
+number and follow the format of an existing one. Public surface means anything
+a consumer builds against: an interface, a DI-tagged extension point, a database
+table, a TCA field, an Extension Configuration key, a console command, or the
+behaviour of any of them. Recording *why* matters more than recording what; the
+diff already shows what.
 
 ## Commit Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ ddev exec ".Build/bin/phpunit -c Build/phpunit.xml"
 Before submitting a PR, ensure all checks pass:
 
 ```bash
-# Run all CI checks
+# Code style, PHPStan, unit, integration and fuzzy tests.
+# Rector and the functional tests are not part of this script — CI runs those
+# too, so run them individually before pushing.
 ddev exec "composer ci"
 
 # Or run individually:
@@ -122,7 +124,10 @@ Version bumps belong to the release commit, never to a feature PR.
 
 A change to the public surface also gets an Architecture Decision Record under
 `Documentation/Adr/`, named `Adr<N><Description>.rst` — take the next free
-number and follow the format of an existing one. Public surface means anything
+number and follow the format of an existing one. Add the file name to the
+`toctree` at the bottom of `Documentation/Adr/Index.rst` as well; that toctree
+is explicit, so an unregistered ADR renders as an orphan page nothing links to.
+Public surface means anything
 a consumer builds against: an interface, a DI-tagged extension point, a database
 table, a TCA field, an Extension Configuration key, a console command, or the
 behaviour of any of them. Recording *why* matters more than recording what; the


### PR DESCRIPTION
Closes #540.

`AGENTS.md` requires a `CHANGELOG.md` entry for consumer-visible changes and an ADR for public-surface changes. Neither `CONTRIBUTING.md` nor `.github/PULL_REQUEST_TEMPLATE.md` mentioned either, so the rule reached agents and regular committers but not a first-time human contributor.

Adds both to the two checklists, and a short CONTRIBUTING section defining what "public surface" means — an interface, a DI-tagged extension point, a database table, a TCA field, an Extension Configuration key, a console command, or the behaviour of any of them.

Left advisory rather than CI-enforced. A changelog-diff gate is easy to add but produces false failures on release commits and pure-refactor PRs; whether to enforce is worth deciding separately.
