### PR TITLE
fix(privacy): declare the governance retention override in ext_conf_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- `privacy.retention.governance` is now declared in `ext_conf_template.txt` and
+  documented. The retention window added for governance events in 0.25.0 was
+  read by the purge commands but had no Extension Configuration field, so the
+  category silently fell back to the global `privacy.retentionDays` and the
+  operator could neither see nor set it. A drift guard now asserts that every
+  `PrivacyDataCategory` has both a template field and a documentation entry.
+
 ## [0.25.0] - 2026-07-24
 
 Backend dashboard widgets for the Agent Runtime, plus a queryable governance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   category silently fell back to the global `privacy.retentionDays` and the
   operator could neither see nor set it. A drift guard now asserts that every
   `PrivacyDataCategory` has both a template field and a documentation entry.
+- Seven Extension Configuration settings showed a description truncated
+  mid-sentence. TYPO3 splits an `ext_conf_template.txt` comment on `;` before
+  splitting the label from its description, so a semicolon inside a label cuts
+  everything after it — the DeepL identifier, minimum skill trust level,
+  health-aware fallback, tool data-class enforcement, content privacy level and
+  default retention window all lost part of their explanation in the Install
+  Tool. A test now fails on a semicolon in any label.
 
 ## [0.25.0] - 2026-07-24
 

--- a/Documentation/Administration/DataRetention.rst
+++ b/Documentation/Administration/DataRetention.rst
@@ -64,6 +64,8 @@ default:
      - Graded evaluation output
    * - ``privacy.retention.skillAudit``
      - Skill scan findings
+   * - ``privacy.retention.governance``
+     - Tool-gate denials and guardrail blocks (no prompts, no responses)
 
 A zero, negative or non-numeric value never means "delete immediately" — it
 means "no override".

--- a/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
+++ b/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
@@ -70,13 +70,46 @@ final class PrivacyRetentionConfigurationTest extends AbstractUnitTestCase
         self::assertIsString($docs, 'DataRetention.rst must be readable');
 
         foreach (PrivacyDataCategory::cases() as $category) {
+            // Anchored on the RST literal's closing backticks: an unanchored
+            // substring would let a future key that is a prefix of an existing
+            // one (e.g. 'agent' vs the documented 'agentRun') pass without ever
+            // being documented — the exact drift this guard exists to catch.
             self::assertStringContainsString(
-                'privacy.retention.' . $category->configKey(),
+                sprintf('``privacy.retention.%s``', $category->configKey()),
                 $docs,
                 sprintf(
-                    'DataRetention.rst must document "privacy.retention.%s" for PrivacyDataCategory::%s',
+                    'DataRetention.rst must document ``privacy.retention.%s`` for PrivacyDataCategory::%s',
                     $category->configKey(),
                     $category->name,
+                ),
+            );
+        }
+    }
+
+    /**
+     * TYPO3 splits an ext_conf_template comment on ';' before splitting the
+     * label from its description, so a semicolon anywhere inside a label
+     * truncates the operator-visible description at that point and silently
+     * drops the rest — see AstConstantCommentVisitor::parseNodeComment().
+     */
+    #[Test]
+    public function noSettingLabelContainsASemicolon(): void
+    {
+        $contents = file_get_contents(dirname(__DIR__, 3) . '/ext_conf_template.txt');
+        self::assertIsString($contents, 'ext_conf_template.txt must be readable');
+
+        foreach (explode("\n", $contents) as $number => $line) {
+            $position = strpos($line, 'label=');
+            if (!str_starts_with($line, '# cat=') || $position === false) {
+                continue;
+            }
+
+            self::assertStringNotContainsString(
+                ';',
+                substr($line, $position),
+                sprintf(
+                    'ext_conf_template.txt line %d: a semicolon in a label truncates the description TYPO3 shows the operator',
+                    $number + 1,
                 ),
             );
         }

--- a/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
+++ b/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Configuration;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the per-category retention overrides against drift.
+ *
+ * PrivacyPolicy::retentionDaysFor() resolves `privacy.retention.<configKey>`
+ * from the extension configuration. A category whose key is missing from
+ * ext_conf_template.txt still works — it silently falls back to the global
+ * privacy.retentionDays — but the operator gets no field for it in the
+ * Extension Configuration form and cannot see that the category exists. Adding
+ * a case to the enum without adding the template line is therefore an invisible
+ * regression, which is what this test exists to catch.
+ */
+#[CoversNothing]
+final class PrivacyRetentionConfigurationTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function everyPrivacyDataCategoryHasARetentionOverrideField(): void
+    {
+        $declared = $this->declaredRetentionKeys();
+
+        foreach (PrivacyDataCategory::cases() as $category) {
+            self::assertContains(
+                $category->configKey(),
+                $declared,
+                sprintf(
+                    'ext_conf_template.txt must declare "privacy.retention.%s" for PrivacyDataCategory::%s',
+                    $category->configKey(),
+                    $category->name,
+                ),
+            );
+        }
+    }
+
+    #[Test]
+    public function everyRetentionOverrideFieldMapsToAPrivacyDataCategory(): void
+    {
+        $known = array_map(
+            static fn(PrivacyDataCategory $category): string => $category->configKey(),
+            PrivacyDataCategory::cases(),
+        );
+
+        foreach ($this->declaredRetentionKeys() as $key) {
+            self::assertContains(
+                $key,
+                $known,
+                sprintf('ext_conf_template.txt declares "privacy.retention.%s", which no PrivacyDataCategory maps to', $key),
+            );
+        }
+    }
+
+    #[Test]
+    public function everyPrivacyDataCategoryIsListedInTheRetentionDocumentation(): void
+    {
+        $docs = file_get_contents(dirname(__DIR__, 3) . '/Documentation/Administration/DataRetention.rst');
+        self::assertIsString($docs, 'DataRetention.rst must be readable');
+
+        foreach (PrivacyDataCategory::cases() as $category) {
+            self::assertStringContainsString(
+                'privacy.retention.' . $category->configKey(),
+                $docs,
+                sprintf(
+                    'DataRetention.rst must document "privacy.retention.%s" for PrivacyDataCategory::%s',
+                    $category->configKey(),
+                    $category->name,
+                ),
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function declaredRetentionKeys(): array
+    {
+        $contents = file_get_contents(dirname(__DIR__, 3) . '/ext_conf_template.txt');
+        self::assertIsString($contents, 'ext_conf_template.txt must be readable');
+
+        preg_match_all('/^privacy\.retention\.(\w+)\s*=/m', $contents, $matches);
+
+        return $matches[1];
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -148,3 +148,6 @@ privacy.retention.evaluation = 0
 
 # cat=privacy; type=int+; label=Retention override — Skill audit (days): Skill scan findings. 0 uses the default retention window.
 privacy.retention.skillAudit = 0
+
+# cat=privacy; type=int+; label=Retention override — Governance events (days): Tool-gate denials and guardrail blocks (be_user, decision, tool name; no prompts or responses). 0 uses the default retention window.
+privacy.retention.governance = 0

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,7 +13,7 @@
 # cat=openai; type=string; label=OpenAI Vault Identifier: nr-vault secret identifier for the OpenAI API key used by the DALL-E, Whisper, and TTS specialized services
 providers.openai.apiKeyIdentifier =
 
-# cat=deepl; type=string; label=DeepL Vault Identifier: nr-vault secret identifier for the DeepL API key (Free or Pro; Free keys end with ':fx', auto-detected on first request)
+# cat=deepl; type=string; label=DeepL Vault Identifier: nr-vault secret identifier for the DeepL API key (Free or Pro — Free keys end with ':fx', auto-detected on first request)
 translators.deepl.apiKeyIdentifier =
 
 # cat=deepl; type=string; label=DeepL Base URL: Custom base URL (leave empty for auto-detection based on key type)
@@ -71,7 +71,7 @@ image.fal.defaultModel = flux-schnell
 # Skills (ingest isolation — ADR-061)
 # =============================================================================
 
-# cat=skills; type=options[untrusted,community,verified,first_party]; label=Minimum Skill Trust Level: Only skills from a source classified at or above this publisher-trust level are injected into prompts and may grant tools. "untrusted" (default) accepts every enabled skill; raising it drops lower-trust skills fail-closed.
+# cat=skills; type=options[untrusted,community,verified,first_party]; label=Minimum Skill Trust Level: Only skills from a source classified at or above this publisher-trust level are injected into prompts and may grant tools. "untrusted" (default) accepts every enabled skill. Raising it drops lower-trust skills fail-closed.
 skills.minTrustLevel = untrusted
 
 # =============================================================================
@@ -87,7 +87,7 @@ circuitBreaker.failureThreshold = 5
 # cat=resilience; type=int+; label=Circuit Breaker Cooldown (seconds): How long an open circuit fails fast before allowing one half-open probe call.
 circuitBreaker.cooldownSeconds = 30
 
-# cat=resilience; type=boolean; label=Health-Aware Fallback Reorder: When on, the fallback chain is reordered by recent provider health (from telemetry) so a healthier provider is preferred; configured order is the tie-break. Off (default) keeps the configured order untouched.
+# cat=resilience; type=boolean; label=Health-Aware Fallback Reorder: When on, the fallback chain is reordered by recent provider health (from telemetry) so a healthier provider is preferred. The configured order is the tie-break. Off (default) keeps the configured order untouched.
 health.reorderFallback = 0
 
 # =============================================================================
@@ -118,17 +118,17 @@ telemetry.enabled = 1
 # Tool egress policy (ADR-094)
 # =============================================================================
 
-# cat=tools; type=options[Enforce=enforce,Observe (log only)=observe]; label=Tool data-class enforcement: Whether a tool whose data class exceeds the trust zone of the provider a run can reach is removed from that run ("Enforce") or merely reported ("Observe"). Enforce is the default so a new install is safe by default (ADR-113); the read is fail-closed, so a missing or mistyped value also enforces. An install upgraded from an older version is pinned to Observe by an upgrade wizard so the change does not silently strip tools from a working setup — review the run log there, then switch back to Enforce. The other tool gates (global enablement, admin-only tools, the configuration's allowed tool groups) always apply regardless of this setting.
+# cat=tools; type=options[Enforce=enforce,Observe (log only)=observe]; label=Tool data-class enforcement: Whether a tool whose data class exceeds the trust zone of the provider a run can reach is removed from that run ("Enforce") or merely reported ("Observe"). Enforce is the default so a new install is safe by default (ADR-113). The read is fail-closed, so a missing or mistyped value also enforces. An install upgraded from an older version is pinned to Observe by an upgrade wizard so the change does not silently strip tools from a working setup — review the run log there, then switch back to Enforce. The other tool gates (global enablement, admin-only tools, the configuration's allowed tool groups) always apply regardless of this setting.
 tools.dataClassEnforcement = enforce
 
 # =============================================================================
 # Privacy & data retention (ADR-064)
 # =============================================================================
 
-# cat=privacy; type=options[None=none,Metadata=metadata,Redacted=redacted,Full=full]; label=Content Privacy Level: How much per-request content the extension stores in its log tables. "None" and "Metadata" drop the content payload and keep only metadata (identifiers, counts, timestamps); "Redacted" stores a length-capped copy with obvious credentials and email addresses masked; "Full" stores it verbatim. Metadata-only is the default and matches the extension's historical behaviour. Governs tx_nrllm_eval_result.details and tx_nrllm_skill_audit.scan_result/detail.
+# cat=privacy; type=options[None=none,Metadata=metadata,Redacted=redacted,Full=full]; label=Content Privacy Level: How much per-request content the extension stores in its log tables. "None" and "Metadata" drop the content payload and keep only metadata (identifiers, counts, timestamps). "Redacted" stores a length-capped copy with obvious credentials and email addresses masked. "Full" stores it verbatim. Metadata-only is the default and matches the extension's historical behaviour. Governs tx_nrllm_eval_result.details and tx_nrllm_skill_audit.scan_result/detail.
 privacy.level = metadata
 
-# cat=privacy; type=int+; label=Retention (days): Default retention window for every content-bearing table before the nrllm:privacy:purge command deletes the rows (evaluation results, skill audit, telemetry, conversation sessions, agent runs). Minimum 1 day; an empty or zero value falls back to 30 days. Override individual categories below.
+# cat=privacy; type=int+; label=Retention (days): Default retention window for every content-bearing table before the nrllm:privacy:purge command deletes the rows (evaluation results, skill audit, telemetry, conversation sessions, agent runs). Minimum 1 day. An empty or zero value falls back to 30 days. Override individual categories below.
 privacy.retentionDays = 30
 
 # cat=privacy; type=int+; label=Retention override — Conversation sessions (days): Sessions inactive for longer than this, and their message transcripts, are deleted. Conversation content is the most sensitive data the extension stores. 0 uses the default retention window.
@@ -149,5 +149,5 @@ privacy.retention.evaluation = 0
 # cat=privacy; type=int+; label=Retention override — Skill audit (days): Skill scan findings. 0 uses the default retention window.
 privacy.retention.skillAudit = 0
 
-# cat=privacy; type=int+; label=Retention override — Governance events (days): Tool-gate denials and guardrail blocks (be_user, decision, tool name; no prompts or responses). 0 uses the default retention window.
+# cat=privacy; type=int+; label=Retention override — Governance events (days): Tool-gate denials and guardrail blocks — attributable metadata only, no prompts or responses. 0 uses the default retention window.
 privacy.retention.governance = 0


### PR DESCRIPTION
`PrivacyDataCategory::GOVERNANCE` shipped in 0.25.0 together with `nrllm:governance:purge` and the `PurgePrivacyDataCommand` wiring, and `PrivacyPolicy::retentionDaysFor()` resolves it from `privacy.retention.governance`.

That key was never added to `ext_conf_template.txt`. It is the only one of the seven categories without a field, so the purge commands honoured a retention window the operator could neither see nor set — the category silently fell back to the global `privacy.retentionDays`. `Documentation/Administration/DataRetention.rst` lists the same six and omits it too.

## Changes

- `privacy.retention.governance` in `ext_conf_template.txt`, labelled like its six siblings.
- The missing row in the retention documentation table.
- `Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php`: three drift guards — every `PrivacyDataCategory` case must have a template field and a documentation entry, and every declared `privacy.retention.*` key must map back to a case.

The guard covers all three surfaces rather than only the one that drifted, because the enum, the template and the docs are three independent places a new category has to be added and nothing connected them. It follows `VersionConsistencyTest`, which does the same job for the version surfaces.

No behaviour change beyond the value now being settable: the purge already read the key.

## Verification

The test was written first and failed on `governance` alone (`Failed asserting that an array contains 'governance'`) before the template line was added.

Local gates: unit (5653 tests), PHPStan level 10, cgl, rector, fuzzy. The local functional run was still in flight at the time of pushing; CI covers it across the matrix.
