### PR TITLE
chore: release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-07-27
+
+A translation fix reported from the field, plus Extension Configuration
+settings that were unreadable or unsettable.
+
 ### Added
 
 - Architecture tests for the horizontal module seams ADR-090 names. The
@@ -20,6 +25,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Translation no longer requires a global default configuration.
+  `translateForConfiguration()` auto-detects the source language when none is
+  given, but the detection sub-call went through the default-resolving `chat()`
+  entry point instead of the configuration the caller had passed. An instance
+  with no configuration marked as default therefore failed with `No default LLM
+  configuration found` even though a configuration was supplied explicitly. The
+  configuration is now threaded through detection. Reported in #520, fixed in
+  #524.
 - `privacy.retention.governance` is now declared in `ext_conf_template.txt` and
   documented. The retention window added for governance events in 0.25.0 was
   read by the purge commands but had no Extension Configuration field, so the

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.25.0"
-        release="0.25.0"
+        version="0.25.1"
+        release="0.25.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.25.0",
+            "version": "0.25.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.25.0',
+    'version' => '0.25.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Version bump for 0.25.1 across the four surfaces (`ext_emconf.php`, `composer.json` `extra.typo3/cms.version`, `Documentation/guides.xml`, `CHANGELOG.md`), plus the changelog entry for #524, which merged without one.

## What is in the release

**Fixed**

- Translation no longer requires a global default configuration. `translateForConfiguration()` auto-detects the source language when none is given, but the detection sub-call went through the default-resolving `chat()` entry point instead of the configuration the caller had passed — so an instance with no default configuration failed with `No default LLM configuration found` even when a configuration was supplied explicitly. Reported in #520, fixed in #524.
- `privacy.retention.governance` had no Extension Configuration field, so the retention window the purge commands already honoured could neither be seen nor set (#543).
- Seven settings showed a description truncated mid-sentence, because TYPO3 splits an `ext_conf_template.txt` comment on `;` before splitting label from description (#543).

**Added**

- Architecture tests for the horizontal module seams ADR-090 names (#541).

`CONTRIBUTING.md` and the pull request template also gained the changelog/ADR expectations (#542) — not user-facing, so no changelog entry.

Merging this and tagging `v0.25.1` on the merge commit triggers `release.yml`, which builds the archives, SBOM, Cosign signatures and attestations and publishes to TER and Packagist.
