### PR TITLE
feat(backend): let an admin verify translation and image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Translation and image generation can be tried from the backend. The test page
+  gained two cards: translate a snippet with a chosen translator, or generate a
+  single image with the OpenAI or the FAL service. Until now nothing in the
+  backend reached these services — the Playground drives the agent runtime, and
+  every "Test" button issues a plain chat completion — so an operator who
+  configured a DeepL or FAL identifier had no way to find out whether it works
+  short of writing consumer code. A missing credential is reported as such and
+  names the Extension Configuration, rather than surfacing as a generic
+  failure. Nothing is stored: the translation is text, the image is rendered
+  from what the provider returned and is gone on reload. Taking an image into
+  the file storage remains the consuming extension's job. See ADR-118.
+- `ImageGeneratorInterface`, the one call `DallEImageService` and
+  `FalImageService` have in common. Their `generate()` signatures differ beyond
+  the prompt and stay that way; the interface serves callers that want the
+  service's own defaults, and makes the two mockable.
+
 ### Removed
 
 - **Breaking:** the backend capability permissions are gone —

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -185,6 +185,7 @@ final class LlmModuleController extends ActionController
         // than as a classic <script> (which would throw "Cannot use import
         // statement outside a module").
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/Test.js');
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/SpecializedTest.js');
 
         $providers = $this->llmServiceManager->getAvailableProviders();
 

--- a/Classes/Controller/Backend/SpecializedTestController.php
+++ b/Classes/Controller/Backend/SpecializedTestController.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Image\ImageGeneratorInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Lets an administrator exercise the specialized services from the backend.
+ *
+ * Translation and image generation are configured through the Extension
+ * Configuration — a vault identifier per credential — and until now nothing in
+ * the backend could reach them: the Playground drives the agent runtime, and
+ * every "Test" button on a provider, model or configuration record issues a
+ * plain chat completion. An operator who pasted a DeepL or OpenAI identifier
+ * had no way to find out whether it works short of writing consumer code.
+ *
+ * These endpoints verify a credential; they are not a feature. Nothing is
+ * persisted. A translation comes back as text, a generated image as whatever
+ * the provider returned — a URL from FAL, a data URI from the OpenAI family.
+ * Storing the image, moving it into FAL or attaching it to a record is the
+ * consuming extension's job and deliberately out of scope.
+ *
+ * Registered in AjaxRoutes.php, so the module's `access => admin` does not
+ * apply — every action calls denyNonAdmin() first (ADR-037).
+ */
+final readonly class SpecializedTestController
+{
+    use RequiresBackendAdminTrait;
+
+    private const MAX_INPUT_LENGTH = 5000;
+
+    public function __construct(
+        private TranslationServiceInterface $translationService,
+        private ImageGeneratorInterface $openAiImage,
+        private ImageGeneratorInterface $falImage,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Translate a snippet and report which translator answered.
+     *
+     * With no translator identifier the LLM path runs, which needs a usable
+     * provider but no specialized credential. Naming one (`deepl`) routes to
+     * that translator, which is the case worth testing after configuring its
+     * vault identifier.
+     */
+    public function translateAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body = $request->getParsedBody();
+        $text = $this->stringFromBody($body, 'text');
+        $targetLanguage = $this->stringFromBody($body, 'targetLanguage');
+        $sourceLanguage = $this->stringFromBody($body, 'sourceLanguage');
+        $translator = $this->stringFromBody($body, 'translator');
+
+        if ($text === '' || $targetLanguage === '') {
+            return $this->badRequest('Text and target language are required.');
+        }
+
+        if (mb_strlen($text) > self::MAX_INPUT_LENGTH) {
+            return $this->badRequest(sprintf('Text must not exceed %d characters for a test.', self::MAX_INPUT_LENGTH));
+        }
+
+        $source = $sourceLanguage !== '' ? $sourceLanguage : null;
+
+        try {
+            if ($translator !== '') {
+                $result = $this->translationService
+                    ->getTranslator($translator)
+                    ->translate($text, $targetLanguage, $source);
+
+                return new JsonResponse([
+                    'success'         => true,
+                    'translation'     => $result->translatedText,
+                    'sourceLanguage'  => $result->sourceLanguage,
+                    'targetLanguage'  => $result->targetLanguage,
+                    'translator'      => $result->translator,
+                    'confidence'      => $result->confidence,
+                    'charactersUsed'  => $result->charactersUsed,
+                ]);
+            }
+
+            $result = $this->translationService->translate($text, $targetLanguage, $source);
+
+            return new JsonResponse([
+                'success'        => true,
+                'translation'    => $result->translation,
+                'sourceLanguage' => $result->sourceLanguage,
+                'targetLanguage' => $result->targetLanguage,
+                'translator'     => 'llm',
+                'confidence'     => $result->confidence,
+                'usage'          => [
+                    'promptTokens'     => $result->usage->promptTokens,
+                    'completionTokens' => $result->usage->completionTokens,
+                    'totalTokens'      => $result->usage->totalTokens,
+                ],
+            ]);
+        } catch (ServiceUnavailableException $e) {
+            return $this->unconfigured('translator', $e);
+        } catch (Throwable $e) {
+            return $this->failed('translation', $e);
+        }
+    }
+
+    /**
+     * List the registered translators and whether each one is configured.
+     */
+    public function translatorsAction(): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        try {
+            return new JsonResponse([
+                'success'     => true,
+                'translators' => array_values($this->translationService->getAvailableTranslators()),
+            ]);
+        } catch (Throwable $e) {
+            return $this->failed('listing translators', $e);
+        }
+    }
+
+    /**
+     * Generate one image and hand it back without storing it.
+     */
+    public function generateImageAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $body = $request->getParsedBody();
+        $prompt = $this->stringFromBody($body, 'prompt');
+        $service = $this->stringFromBody($body, 'service');
+
+        if ($prompt === '') {
+            return $this->badRequest('A prompt is required.');
+        }
+
+        if (mb_strlen($prompt) > self::MAX_INPUT_LENGTH) {
+            return $this->badRequest(sprintf('Prompt must not exceed %d characters for a test.', self::MAX_INPUT_LENGTH));
+        }
+
+        $generator = $service === 'fal' ? $this->falImage : $this->openAiImage;
+
+        try {
+            $result = $generator->generate($prompt);
+
+            // FAL answers with a URL, the OpenAI family may answer with base64.
+            // Return whichever exists; the caller renders it and forgets it.
+            return new JsonResponse([
+                'success'       => true,
+                'url'           => $result->url !== '' ? $result->url : null,
+                'dataUrl'       => $result->hasBase64() ? $result->toDataUrl() : null,
+                'model'         => $result->model,
+                'size'          => $result->size,
+                'provider'      => $result->provider,
+                'revisedPrompt' => $result->revisedPrompt,
+            ]);
+        } catch (ServiceUnavailableException $e) {
+            return $this->unconfigured('image service', $e);
+        } catch (Throwable $e) {
+            return $this->failed('image generation', $e);
+        }
+    }
+
+    private function badRequest(string $message): ResponseInterface
+    {
+        return new JsonResponse(['success' => false, 'error' => $message], 400);
+    }
+
+    /**
+     * The failure this endpoint exists to reveal: no credential, or a vault
+     * secret that no longer resolves. Reported as 503 with a message that
+     * names where to fix it, rather than folded into the generic 500.
+     */
+    private function unconfigured(string $subject, Throwable $e): ResponseInterface
+    {
+        $this->logger->info(sprintf('Specialized test: %s unavailable', $subject), ['exception' => $e]);
+
+        return new JsonResponse([
+            'success' => false,
+            'error'   => sprintf(
+                'This %s is not available. Check its vault identifier in the Extension Configuration.',
+                $subject,
+            ),
+        ], 503);
+    }
+
+    private function failed(string $subject, Throwable $e): ResponseInterface
+    {
+        $this->logger->error(sprintf('Specialized test: %s failed', $subject), ['exception' => $e]);
+
+        return new JsonResponse([
+            'success' => false,
+            'error'   => sprintf('The %s test failed. See system log for details.', $subject),
+        ], 500);
+    }
+
+    private function stringFromBody(mixed $body, string $key): string
+    {
+        if (!is_array($body) || !isset($body[$key]) || !is_string($body[$key])) {
+            return '';
+        }
+
+        return trim($body[$key]);
+    }
+}

--- a/Classes/Controller/Backend/SpecializedTestController.php
+++ b/Classes/Controller/Backend/SpecializedTestController.php
@@ -9,13 +9,16 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use JsonException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\ImageGeneratorInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
@@ -37,6 +40,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  * Registered in AjaxRoutes.php, so the module's `access => admin` does not
  * apply — every action calls denyNonAdmin() first (ADR-037).
  */
+#[AsController]
 final readonly class SpecializedTestController
 {
     use RequiresBackendAdminTrait;
@@ -64,7 +68,7 @@ final readonly class SpecializedTestController
             return $deny;
         }
 
-        $body = $request->getParsedBody();
+        $body = $this->bodyOf($request);
         $text = $this->stringFromBody($body, 'text');
         $targetLanguage = $this->stringFromBody($body, 'targetLanguage');
         $sourceLanguage = $this->stringFromBody($body, 'sourceLanguage');
@@ -112,6 +116,8 @@ final readonly class SpecializedTestController
                     'totalTokens'      => $result->usage->totalTokens,
                 ],
             ]);
+        } catch (ServiceConfigurationException $e) {
+            return $this->rejected('translator', $e);
         } catch (ServiceUnavailableException $e) {
             return $this->unconfigured('translator', $e);
         } catch (Throwable $e) {
@@ -147,7 +153,7 @@ final readonly class SpecializedTestController
             return $deny;
         }
 
-        $body = $request->getParsedBody();
+        $body = $this->bodyOf($request);
         $prompt = $this->stringFromBody($body, 'prompt');
         $service = $this->stringFromBody($body, 'service');
 
@@ -175,6 +181,8 @@ final readonly class SpecializedTestController
                 'provider'      => $result->provider,
                 'revisedPrompt' => $result->revisedPrompt,
             ]);
+        } catch (ServiceConfigurationException $e) {
+            return $this->rejected('image service', $e);
         } catch (ServiceUnavailableException $e) {
             return $this->unconfigured('image service', $e);
         } catch (Throwable $e) {
@@ -199,10 +207,28 @@ final readonly class SpecializedTestController
         return new JsonResponse([
             'success' => false,
             'error'   => sprintf(
-                'This %s is not available. Check its vault identifier in the Extension Configuration.',
+                'This %s is not available — either no credential is configured for it, or the provider could not be reached. Check its vault identifier in the Extension Configuration.',
                 $subject,
             ),
         ], 503);
+    }
+
+    /**
+     * A credential exists and the provider refused it — the likeliest real
+     * failure, and a different action from "nothing is configured": the
+     * identifier resolves, the secret behind it is wrong or revoked.
+     */
+    private function rejected(string $subject, Throwable $e): ResponseInterface
+    {
+        $this->logger->info(sprintf('Specialized test: %s rejected the credential', $subject), ['exception' => $e]);
+
+        return new JsonResponse([
+            'success' => false,
+            'error'   => sprintf(
+                'The provider rejected the credential for this %s. The vault identifier resolves — check the secret behind it.',
+                $subject,
+            ),
+        ], 502);
     }
 
     private function failed(string $subject, Throwable $e): ResponseInterface
@@ -215,9 +241,46 @@ final readonly class SpecializedTestController
         ], 500);
     }
 
-    private function stringFromBody(mixed $body, string $key): string
+    /**
+     * TYPO3 fills `getParsedBody()` from `$_POST`, and no core middleware
+     * decodes a JSON body into it — an `application/json` request would arrive
+     * with every field empty. Mirrors SetupWizardController::parseRequestBody().
+     *
+     * @return array<string, mixed>
+     */
+    private function bodyOf(ServerRequestInterface $request): array
     {
-        if (!is_array($body) || !isset($body[$key]) || !is_string($body[$key])) {
+        $body = $request->getParsedBody();
+        if (is_array($body) && $body !== []) {
+            /** @var array<string, mixed> $body */
+            return $body;
+        }
+
+        if (!str_contains($request->getHeaderLine('Content-Type'), 'application/json')) {
+            return [];
+        }
+
+        $contents = $request->getBody()->getContents();
+        if ($contents === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function stringFromBody(array $body, string $key): string
+    {
+        if (!isset($body[$key]) || !is_string($body[$key])) {
             return '';
         }
 

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -36,7 +36,7 @@ use Throwable;
  *
  * @see https://platform.openai.com/docs/guides/images
  */
-final class DallEImageService extends AbstractSpecializedService
+final class DallEImageService extends AbstractSpecializedService implements ImageGeneratorInterface
 {
     use MultipartBodyBuilderTrait;
 

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -34,7 +34,7 @@ use Throwable;
  *
  * @see https://fal.ai/docs
  */
-final class FalImageService extends AbstractSpecializedService
+final class FalImageService extends AbstractSpecializedService implements ImageGeneratorInterface
 {
     private const API_URL = 'https://fal.run';
     private const QUEUE_API_URL = 'https://queue.fal.run';

--- a/Classes/Specialized/Image/ImageGeneratorInterface.php
+++ b/Classes/Specialized/Image/ImageGeneratorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Specialized\Image;
+
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+
+/**
+ * The one call every image service has in common: a prompt in, an image out.
+ *
+ * The concrete services take different second parameters — `DallEImageService`
+ * an `ImageGenerationOptions` object, `FalImageService` a model identifier —
+ * because their providers model the request differently. That divergence is
+ * deliberate and stays; a caller that wants provider-specific control depends
+ * on the concrete class.
+ *
+ * This interface exists for the callers that do not: hand over a prompt, take
+ * whatever the service's own defaults produce, and treat the two
+ * interchangeably. Both implementations already default every parameter after
+ * the prompt, so neither changes behaviour by implementing it.
+ */
+interface ImageGeneratorInterface
+{
+    /**
+     * Generate a single image from a prompt using the service's defaults.
+     *
+     * @throws ServiceUnavailableException when the service has no usable credential
+     */
+    public function generate(string $prompt): ImageGenerationResult;
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Controller\Backend\PresetController;
 use Netresearch\NrLlm\Controller\Backend\ProviderController;
 use Netresearch\NrLlm\Controller\Backend\SetupWizardController;
 use Netresearch\NrLlm\Controller\Backend\SkillSourceController;
+use Netresearch\NrLlm\Controller\Backend\SpecializedTestController;
 use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
 use Netresearch\NrLlm\Controller\Backend\TaskRecordsController;
 use Netresearch\NrLlm\Controller\Backend\ToolController;
@@ -33,6 +34,21 @@ return [
     'nrllm_test' => [
         'path' => '/nrllm/test',
         'target' => LlmModuleController::class . '::executeTestAction',
+    ],
+
+    // Specialized-service verification (translation, image generation).
+    // Each action guards itself with RequiresBackendAdminTrait (ADR-037).
+    'nrllm_test_translate' => [
+        'path' => '/nrllm/test/translate',
+        'target' => SpecializedTestController::class . '::translateAction',
+    ],
+    'nrllm_test_translators' => [
+        'path' => '/nrllm/test/translators',
+        'target' => SpecializedTestController::class . '::translatorsAction',
+    ],
+    'nrllm_test_image' => [
+        'path' => '/nrllm/test/image',
+        'target' => SpecializedTestController::class . '::generateImageAction',
     ],
 
     // Overview: token-free provider reachability probe (loaded async so

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -413,6 +413,13 @@ services:
   Netresearch\NrLlm\Specialized\Image\FalImageService:
     public: true
 
+  # Both image services satisfy ImageGeneratorInterface, so the argument
+  # types alone cannot tell them apart — bind each one explicitly.
+  Netresearch\NrLlm\Controller\Backend\SpecializedTestController:
+    arguments:
+      $openAiImage: '@Netresearch\NrLlm\Specialized\Image\DallEImageService'
+      $falImage: '@Netresearch\NrLlm\Specialized\Image\FalImageService'
+
   # ========================================
   # Document Analysis Services
   # ========================================

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -71,6 +71,7 @@ left-hand navigation:
    Tools
    Wizards
    UserBudgets
+   SpecializedServices
    Analytics
    AgentRuns
    DataRetention

--- a/Documentation/Administration/SpecializedServices.rst
+++ b/Documentation/Administration/SpecializedServices.rst
@@ -1,0 +1,91 @@
+..  include:: /Includes.rst.txt
+
+..  _administration-specialized-services:
+
+============================================
+Verifying the specialized services
+============================================
+
+Translation, image generation and speech are not configured as records. Each
+one reads a nr-vault identifier from the Extension Configuration, and until a
+consuming extension calls it, nothing tells you whether that identifier
+resolves to a working credential.
+
+The test page — :guilabel:`LLM > Overview > Test` — answers that directly for
+translation and image generation.
+
+..  _administration-specialized-services-keys:
+
+Which setting belongs to which service
+======================================
+
+..  list-table::
+    :header-rows: 1
+
+    * - Setting
+      - Used by
+    * - ``translators.deepl.apiKeyIdentifier``
+      - DeepL translation
+    * - ``image.fal.apiKeyIdentifier``
+      - FAL image generation
+    * - ``providers.openai.apiKeyIdentifier``
+      - DALL·E images, Whisper transcription and text-to-speech — all three
+        share this one identifier and cannot be configured separately
+
+..  _administration-specialized-services-translation:
+
+Translation
+===========
+
+Enter a text and a target language. Leaving the source language empty makes the
+service detect it.
+
+The translator picker lists every registered translator and marks the ones
+without a usable credential. Leaving it on :guilabel:`LLM (default)` runs the
+LLM path, which needs a working provider but no specialized key — useful to
+confirm the page itself works before pointing at DeepL.
+
+Selecting a translator routes to that one, which is the case worth running
+after entering its vault identifier. The result names the translator that
+answered, the detected source language, and either the characters billed
+(specialized translators) or the tokens used (the LLM path).
+
+..  _administration-specialized-services-image:
+
+Image generation
+================
+
+Enter a prompt and pick :guilabel:`OpenAI (DALL·E)` or :guilabel:`FAL`. Each
+service applies its own default model and size; the result reports which were
+used, and DALL·E additionally reports the prompt it rewrote yours into.
+
+..  note::
+
+    The generated image is **not stored**. It is rendered from what the
+    provider returned — a URL for FAL, an inline data URI for OpenAI — and is
+    gone when you reload. Putting an image into the file storage, attaching it
+    to a record or reusing it is the job of the extension that consumes
+    nr_llm; this page only proves the credential works.
+
+..  _administration-specialized-services-errors:
+
+Reading the result
+==================
+
+A missing or unresolvable credential is reported as such, naming the Extension
+Configuration — that is the failure this page exists to surface. Any other
+failure of an otherwise-configured service is reported generically, with the
+detail in the system log, so that provider responses never reach the browser.
+
+Both endpoints are admin-only and spend real provider quota on every run.
+
+..  _administration-specialized-services-speech:
+
+Speech
+======
+
+Transcription and text-to-speech have no test surface. Transcription needs an
+audio upload and synthesis returns binary audio, which raises the same storage
+question the image test declines to answer, with less to gain from answering
+it. Their credential is the shared OpenAI identifier above, so a successful
+DALL·E test also confirms the key those two use.

--- a/Documentation/Adr/Adr118SpecializedServiceVerification.rst
+++ b/Documentation/Adr/Adr118SpecializedServiceVerification.rst
@@ -1,0 +1,119 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-118:
+
+============================================================================
+ADR-118: Verify the specialized services from the backend
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-28
+:Authors: Netresearch DTT GmbH
+
+.. _adr-118-context:
+
+Context
+=======
+
+Translation, image generation and speech are configured through the Extension
+Configuration: one nr-vault identifier per credential
+(``translators.deepl.apiKeyIdentifier``, ``image.fal.apiKeyIdentifier``,
+``providers.openai.apiKeyIdentifier`` for the DALL·E / Whisper / TTS family).
+
+Nothing in the backend could reach any of them. Every entry point terminates in
+a plain chat completion:
+
+- the Playground drives :php:`AgentRuntimeInterface` with a single text prompt;
+- the "Test" buttons on provider, model and configuration records call
+  :php:`$adapter->complete()`;
+- :php:`TaskExecutionService::execute()` never branches on ``TaskCategory``,
+  ``TaskInputType`` or ``TaskOutputFormat`` — it always calls
+  ``completeWithConfiguration()``, so a translation or image Task cannot be
+  defined.
+
+A repository-wide search confirms it: outside their own directories,
+:php:`TranslationService` appears only in doc comments, and the image services
+not at all. They are implemented, DI-wired and unit-tested, and reachable only
+by a consuming extension that injects them.
+
+The practical consequence is that an operator pastes a DeepL identifier into
+the Extension Configuration and has no way to learn whether it works. The
+failure surfaces later, in a consumer, as a runtime error.
+
+.. _adr-118-decision:
+
+Decision
+========
+
+**Add backend endpoints that exercise translation and image generation, as
+verification surfaces rather than features.**
+
+Three AJAX routes on :php:`SpecializedTestController`, rendered as two cards on
+the existing test page:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Route
+     - Purpose
+   * - ``nrllm_test_translate``
+     - Translate a snippet. With no translator named, the LLM path runs (no
+       specialized credential needed); naming one routes to it, which is the
+       case worth testing after configuring its vault identifier.
+   * - ``nrllm_test_translators``
+     - List the registered translators and whether each is configured, so the
+       picker shows the answer before anything runs.
+   * - ``nrllm_test_image``
+     - Generate one image with either the OpenAI or the FAL service.
+
+**Nothing is persisted.** A translation is returned as text. An image is
+returned as whatever the provider produced — a URL from FAL, a data URI from
+the OpenAI family — rendered in the browser and gone on reload. Storing it,
+moving it into FAL or attaching it to a record is the consuming extension's
+job and deliberately out of scope: nr_llm has no storage wiring for generated
+images and this ADR does not add one.
+
+**A missing credential is reported as 503, not 500.** That distinction is the
+whole point of the endpoints, so :php:`ServiceUnavailableException` is caught
+separately and answered with a message naming the Extension Configuration.
+A runtime failure of a configured service stays a 500 with the detail in the
+log, per the existing error-sanitising convention.
+
+.. _adr-118-decision-interface:
+
+``ImageGeneratorInterface``
+---------------------------
+
+:php:`DallEImageService::generate()` takes an
+:php:`ImageGenerationOptions` object as its second parameter,
+:php:`FalImageService::generate()` a model identifier. The divergence is
+deliberate — the providers model a request differently — and stays.
+
+The new :php:`ImageGeneratorInterface` declares only the part they share,
+``generate(string $prompt): ImageGenerationResult``. Both classes already
+default every parameter after the prompt, so neither changes behaviour by
+implementing it. It lets a caller that wants no provider-specific control treat
+the two interchangeably, and it makes them mockable — both are ``final``, which
+would otherwise leave the controller untestable.
+
+Because both services satisfy the interface, the controller's two image
+arguments are bound explicitly in ``Services.yaml``; the type alone cannot
+disambiguate them.
+
+.. _adr-118-consequences:
+
+Consequences
+============
+
+- An operator can answer "does this credential work?" without writing consumer
+  code, which is what the Extension Configuration fields have been missing
+  since they were introduced.
+- The endpoints spend real provider quota on each run. They are admin-only
+  (:ref:`ADR-037 <adr-037>` guards every action), single-shot, and input is
+  capped at 5000 characters.
+- Speech (Whisper, text-to-speech) stays unreachable. Transcription needs an
+  audio upload and synthesis produces a binary response; both raise the same
+  storage question this ADR declines to answer for images, with less to gain.
+- :php:`ImageGeneratorInterface` is public surface. A future image provider is
+  expected to implement it.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -415,4 +415,5 @@ Tools
    Adr115EnforceByDefaultForNewInstalls
    Adr116CentralToolingAuthority
    Adr117WithdrawCapabilityPermissions
+   Adr118SpecializedServiceVerification
    Adr119BackendModulePlacement

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1358,6 +1358,54 @@
                 <source>Back to Overview</source>
                 <target>Zurück zur Übersicht</target>
             </trans-unit>
+            <trans-unit id="test.card.translation">
+                <source>Translation</source>
+                <target>Übersetzung</target>
+            </trans-unit>
+            <trans-unit id="test.card.image">
+                <source>Image generation</source>
+                <target>Bildgenerierung</target>
+            </trans-unit>
+            <trans-unit id="test.translation.info">
+                <source>Verifies a translator's credential. Leave the translator empty to use the LLM path, which needs no specialized key.</source>
+                <target>Prüft die Zugangsdaten eines Übersetzers. Ohne Auswahl läuft der LLM-Pfad, der keinen eigenen Schlüssel braucht.</target>
+            </trans-unit>
+            <trans-unit id="test.image.info">
+                <source>Generates one image to verify the credential. The result is shown here and not stored — putting it into the file storage is the consuming extension's job.</source>
+                <target>Erzeugt ein Bild, um die Zugangsdaten zu prüfen. Das Ergebnis wird hier angezeigt und nicht gespeichert — die Übernahme in die Dateiablage ist Sache der konsumierenden Extension.</target>
+            </trans-unit>
+            <trans-unit id="test.field.text">
+                <source>Text</source>
+                <target>Text</target>
+            </trans-unit>
+            <trans-unit id="test.field.sourceLanguage">
+                <source>Source language (optional)</source>
+                <target>Quellsprache (optional)</target>
+            </trans-unit>
+            <trans-unit id="test.field.targetLanguage">
+                <source>Target language</source>
+                <target>Zielsprache</target>
+            </trans-unit>
+            <trans-unit id="test.field.translator">
+                <source>Translator</source>
+                <target>Übersetzer</target>
+            </trans-unit>
+            <trans-unit id="test.field.service">
+                <source>Service</source>
+                <target>Dienst</target>
+            </trans-unit>
+            <trans-unit id="test.translator.default">
+                <source>LLM (default)</source>
+                <target>LLM (Standard)</target>
+            </trans-unit>
+            <trans-unit id="test.btn.translate">
+                <source>Translate</source>
+                <target>Übersetzen</target>
+            </trans-unit>
+            <trans-unit id="test.btn.generateImage">
+                <source>Generate image</source>
+                <target>Bild erzeugen</target>
+            </trans-unit>
             <trans-unit id="test.card.response">
                 <source>Response</source>
                 <target>Antwort</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1406,6 +1406,10 @@
                 <source>Generate image</source>
                 <target>Bild erzeugen</target>
             </trans-unit>
+            <trans-unit id="test.image.open">
+                <source>Open the generated image</source>
+                <target>Erzeugtes Bild öffnen</target>
+            </trans-unit>
             <trans-unit id="test.card.response">
                 <source>Response</source>
                 <target>Antwort</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1067,6 +1067,9 @@
             <trans-unit id="test.btn.generateImage">
                 <source>Generate image</source>
             </trans-unit>
+            <trans-unit id="test.image.open">
+                <source>Open the generated image</source>
+            </trans-unit>
             <trans-unit id="test.card.response">
                 <source>Response</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1031,6 +1031,42 @@
             <trans-unit id="test.btn.back">
                 <source>Back to Overview</source>
             </trans-unit>
+            <trans-unit id="test.card.translation">
+                <source>Translation</source>
+            </trans-unit>
+            <trans-unit id="test.card.image">
+                <source>Image generation</source>
+            </trans-unit>
+            <trans-unit id="test.translation.info">
+                <source>Verifies a translator's credential. Leave the translator empty to use the LLM path, which needs no specialized key.</source>
+            </trans-unit>
+            <trans-unit id="test.image.info">
+                <source>Generates one image to verify the credential. The result is shown here and not stored — putting it into the file storage is the consuming extension's job.</source>
+            </trans-unit>
+            <trans-unit id="test.field.text">
+                <source>Text</source>
+            </trans-unit>
+            <trans-unit id="test.field.sourceLanguage">
+                <source>Source language (optional)</source>
+            </trans-unit>
+            <trans-unit id="test.field.targetLanguage">
+                <source>Target language</source>
+            </trans-unit>
+            <trans-unit id="test.field.translator">
+                <source>Translator</source>
+            </trans-unit>
+            <trans-unit id="test.field.service">
+                <source>Service</source>
+            </trans-unit>
+            <trans-unit id="test.translator.default">
+                <source>LLM (default)</source>
+            </trans-unit>
+            <trans-unit id="test.btn.translate">
+                <source>Translate</source>
+            </trans-unit>
+            <trans-unit id="test.btn.generateImage">
+                <source>Generate image</source>
+            </trans-unit>
             <trans-unit id="test.card.response">
                 <source>Response</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -102,6 +102,97 @@
         </div>
     </div>
 
+    <div class="container-fluid mt-4">
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.card.translation" default="Translation" /></h2>
+                    </div>
+                    <div class="card-body">
+                        <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.translation.info" default="Verifies a translator's credential. Leave the translator empty to use the LLM path, which needs no specialized key." /></p>
+                        <form id="translationForm">
+                            <div class="mb-3">
+                                <label for="translationText" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.text" default="Text" /></label>
+                                <textarea id="translationText" class="form-control" rows="3">Guten Tag, dies ist ein Test.</textarea>
+                            </div>
+                            <div class="row">
+                                <div class="col mb-3">
+                                    <label for="translationSource" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.sourceLanguage" default="Source language (optional)" /></label>
+                                    <input type="text" id="translationSource" class="form-control" placeholder="de" />
+                                </div>
+                                <div class="col mb-3">
+                                    <label for="translationTarget" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.targetLanguage" default="Target language" /></label>
+                                    <input type="text" id="translationTarget" class="form-control" value="en" />
+                                </div>
+                            </div>
+                            <div class="mb-3">
+                                <label for="translationTranslator" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.translator" default="Translator" /></label>
+                                <select id="translationTranslator" class="form-select">
+                                    <option value=""><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.translator.default" default="LLM (default)" /></option>
+                                </select>
+                            </div>
+                            <button type="submit" class="btn btn-primary">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.btn.translate" default="Translate" />
+                            </button>
+                        </form>
+
+                        <div id="translationLoading" class="mt-3" style="display: none;">
+                            <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                            <span class="ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.loading" default="Sending request..." /></span>
+                        </div>
+                        <div id="translationError" class="alert alert-danger mt-3" style="display: none;">
+                            <span id="translationErrorMessage"></span>
+                        </div>
+                        <div id="translationResult" class="mt-3" style="display: none;">
+                            <pre id="translationOutput" class="bg-light p-3"></pre>
+                            <p class="text-body-secondary small mb-0" id="translationMeta"></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.card.image" default="Image generation" /></h2>
+                    </div>
+                    <div class="card-body">
+                        <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.image.info" default="Generates one image to verify the credential. The result is shown here and not stored — putting it into the file storage is the consuming extension's job." /></p>
+                        <form id="imageForm">
+                            <div class="mb-3">
+                                <label for="imagePrompt" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.prompt" default="Prompt" /></label>
+                                <textarea id="imagePrompt" class="form-control" rows="3">A red bicycle in front of a white wall.</textarea>
+                            </div>
+                            <div class="mb-3">
+                                <label for="imageService" class="form-label"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.field.service" default="Service" /></label>
+                                <select id="imageService" class="form-select">
+                                    <option value="openai">OpenAI (DALL-E)</option>
+                                    <option value="fal">FAL</option>
+                                </select>
+                            </div>
+                            <button type="submit" class="btn btn-primary">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.btn.generateImage" default="Generate image" />
+                            </button>
+                        </form>
+
+                        <div id="imageLoading" class="mt-3" style="display: none;">
+                            <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                            <span class="ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.loading" default="Sending request..." /></span>
+                        </div>
+                        <div id="imageError" class="alert alert-danger mt-3" style="display: none;">
+                            <span id="imageErrorMessage"></span>
+                        </div>
+                        <div id="imageResult" class="mt-3" style="display: none;">
+                            <img id="imagePreview" class="img-fluid rounded" alt="" />
+                            <p class="text-body-secondary small mt-2 mb-0" id="imageMeta"></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <footer class="text-body-secondary small mt-4">
         Provided by <a href="https://www.netresearch.de" target="_blank" rel="noopener">Netresearch DTT GmbH</a>
     </footer>

--- a/Resources/Private/Templates/Backend/Test.html
+++ b/Resources/Private/Templates/Backend/Test.html
@@ -184,7 +184,10 @@
                             <span id="imageErrorMessage"></span>
                         </div>
                         <div id="imageResult" class="mt-3" style="display: none;">
-                            <img id="imagePreview" class="img-fluid rounded" alt="" />
+                            <img id="imagePreview" class="img-fluid rounded" alt="" style="display: none;" />
+                            <a id="imageLink" class="btn btn-default btn-sm" target="_blank" rel="noopener" style="display: none;">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:test.image.open" default="Open the generated image" />
+                            </a>
                             <p class="text-body-secondary small mt-2 mb-0" id="imageMeta"></p>
                         </div>
                     </div>

--- a/Resources/Public/JavaScript/Backend/SpecializedTest.js
+++ b/Resources/Public/JavaScript/Backend/SpecializedTest.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Wires the translation and image-generation forms on the test page to their
+ * AJAX endpoints and renders the result.
+ *
+ * Neither result is stored anywhere: a translation is printed, an image is
+ * rendered from the URL or data URI the provider returned and is gone on
+ * reload. Taking an image further — into FAL, onto a record — is the consuming
+ * extension's job.
+ *
+ * Loaded as an ES module through the import map, so wrap in DOMContentLoaded
+ * and bail out when the elements or the AJAX URLs are absent.
+ */
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
+
+document.addEventListener('DOMContentLoaded', function () {
+    wireTranslation();
+    wireImage();
+    loadTranslators();
+});
+
+function show(id, visible) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.style.display = visible ? 'block' : 'none';
+    }
+}
+
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.textContent = value ?? '';
+    }
+}
+
+/**
+ * Populate the translator picker so an operator sees which ones are
+ * configured before running anything.
+ */
+async function loadTranslators() {
+    const select = document.getElementById('translationTranslator');
+    const url = TYPO3?.settings?.ajaxUrls?.['nrllm_test_translators'];
+    if (!select || !url) {
+        return;
+    }
+
+    try {
+        const data = await (await new AjaxRequest(url).post('')).resolve();
+        if (!data.success) {
+            return;
+        }
+
+        for (const translator of data.translators) {
+            const option = document.createElement('option');
+            option.value = translator.identifier;
+            option.textContent = translator.available
+                ? translator.name
+                : `${translator.name} (not configured)`;
+            select.appendChild(option);
+        }
+    } catch (error) {
+        // The picker is a convenience; a failure here must not block the
+        // form, which works with the default (LLM) translator.
+    }
+}
+
+function wireTranslation() {
+    const form = document.getElementById('translationForm');
+    const url = TYPO3?.settings?.ajaxUrls?.['nrllm_test_translate'];
+    if (!form || !url) {
+        return;
+    }
+
+    form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+
+        show('translationLoading', true);
+        show('translationResult', false);
+        show('translationError', false);
+
+        try {
+            const data = await (await new AjaxRequest(url).post(
+                JSON.stringify({
+                    text: document.getElementById('translationText').value,
+                    targetLanguage: document.getElementById('translationTarget').value,
+                    sourceLanguage: document.getElementById('translationSource').value,
+                    translator: document.getElementById('translationTranslator').value,
+                }),
+                { headers: { 'Content-Type': 'application/json' } },
+            )).resolve();
+
+            show('translationLoading', false);
+
+            if (!data.success) {
+                show('translationError', true);
+                setText('translationErrorMessage', data.error);
+                return;
+            }
+
+            show('translationResult', true);
+            setText('translationOutput', data.translation);
+            setText('translationMeta', [
+                `${data.sourceLanguage} → ${data.targetLanguage}`,
+                `translator: ${data.translator}`,
+                data.charactersUsed != null ? `characters: ${data.charactersUsed}` : null,
+                data.usage != null ? `tokens: ${data.usage.totalTokens}` : null,
+            ].filter(Boolean).join(' · '));
+        } catch (error) {
+            show('translationLoading', false);
+            show('translationError', true);
+            setText('translationErrorMessage', await readAjaxError(error));
+        }
+    });
+}
+
+function wireImage() {
+    const form = document.getElementById('imageForm');
+    const url = TYPO3?.settings?.ajaxUrls?.['nrllm_test_image'];
+    if (!form || !url) {
+        return;
+    }
+
+    form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+
+        show('imageLoading', true);
+        show('imageResult', false);
+        show('imageError', false);
+
+        try {
+            const data = await (await new AjaxRequest(url).post(
+                JSON.stringify({
+                    prompt: document.getElementById('imagePrompt').value,
+                    service: document.getElementById('imageService').value,
+                }),
+                { headers: { 'Content-Type': 'application/json' } },
+            )).resolve();
+
+            show('imageLoading', false);
+
+            if (!data.success) {
+                show('imageError', true);
+                setText('imageErrorMessage', data.error);
+                return;
+            }
+
+            const preview = document.getElementById('imagePreview');
+            if (preview) {
+                // dataUrl for the OpenAI family, url for FAL — whichever came back.
+                preview.src = data.dataUrl ?? data.url ?? '';
+                preview.alt = data.revisedPrompt ?? document.getElementById('imagePrompt').value;
+            }
+
+            show('imageResult', true);
+            setText('imageMeta', [
+                `${data.provider} · ${data.model}`,
+                data.size,
+                data.revisedPrompt ? `revised: ${data.revisedPrompt}` : null,
+            ].filter(Boolean).join(' · '));
+        } catch (error) {
+            show('imageLoading', false);
+            show('imageError', true);
+            setText('imageErrorMessage', await readAjaxError(error));
+        }
+    });
+}

--- a/Resources/Public/JavaScript/Backend/SpecializedTest.js
+++ b/Resources/Public/JavaScript/Backend/SpecializedTest.js
@@ -64,8 +64,10 @@ async function loadTranslators() {
             select.appendChild(option);
         }
     } catch (error) {
-        // The picker is a convenience; a failure here must not block the
-        // form, which works with the default (LLM) translator.
+        // The picker is a convenience; a failure here must not block the form,
+        // which still works with the default (LLM) translator. Surfaced in the
+        // console rather than swallowed, so it is diagnosable.
+        console.warn('[nr-llm] Could not load the translator list:', error);
     }
 }
 

--- a/Resources/Public/JavaScript/Backend/SpecializedTest.js
+++ b/Resources/Public/JavaScript/Backend/SpecializedTest.js
@@ -152,10 +152,32 @@ function wireImage() {
             }
 
             const preview = document.getElementById('imagePreview');
+            const link = document.getElementById('imageLink');
+            const alt = data.revisedPrompt ?? document.getElementById('imagePrompt').value;
+
+            // The backend's Content-Security-Policy allows images from 'self'
+            // and data: only, so a provider's external URL cannot be rendered
+            // inline — FAL returns one. Show the data URI when there is one,
+            // and otherwise link out rather than render a broken image.
             if (preview) {
-                // dataUrl for the OpenAI family, url for FAL — whichever came back.
-                preview.src = data.dataUrl ?? data.url ?? '';
-                preview.alt = data.revisedPrompt ?? document.getElementById('imagePrompt').value;
+                if (data.dataUrl) {
+                    preview.src = data.dataUrl;
+                    preview.alt = alt;
+                    preview.style.display = '';
+                } else {
+                    preview.removeAttribute('src');
+                    preview.style.display = 'none';
+                }
+            }
+
+            if (link) {
+                if (!data.dataUrl && data.url) {
+                    link.href = data.url;
+                    link.style.display = '';
+                } else {
+                    link.removeAttribute('href');
+                    link.style.display = 'none';
+                }
             }
 
             show('imageResult', true);

--- a/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
+++ b/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\SpecializedTestController;
+use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
+use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
+use Netresearch\NrLlm\Specialized\Image\ImageGeneratorInterface;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+/**
+ * Unit tests for the specialized-service verification endpoints.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class SpecializedTestControllerTest extends TestCase
+{
+    private TranslationServiceInterface&MockObject $translationService;
+
+    private ImageGeneratorInterface&MockObject $openAiImage;
+
+    private ImageGeneratorInterface&MockObject $falImage;
+
+    private mixed $previousBeUser = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The actions are guarded by RequiresBackendAdminTrait (ADR-037);
+        // provide an admin so the tests reach the action body.
+        $this->previousBeUser = $GLOBALS['BE_USER'] ?? null;
+        $backendUser = new BackendUserAuthentication();
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $this->translationService = $this->createMock(TranslationServiceInterface::class);
+        $this->openAiImage = $this->createMock(ImageGeneratorInterface::class);
+        $this->falImage = $this->createMock(ImageGeneratorInterface::class);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousBeUser === null) {
+            unset($GLOBALS['BE_USER']);
+        } else {
+            $GLOBALS['BE_USER'] = $this->previousBeUser;
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function translationWithoutATranslatorUsesTheLlmPath(): void
+    {
+        $this->translationService
+            ->expects(self::once())
+            ->method('translate')
+            ->with('Guten Tag', 'en', null)
+            ->willReturn(new TranslationResult(
+                translation: 'Good day',
+                sourceLanguage: 'de',
+                targetLanguage: 'en',
+                confidence: 0.9,
+                usage: new UsageStatistics(11, 4, 15),
+            ));
+
+        $body = $this->decode($this->subject()->translateAction(
+            $this->request(['text' => 'Guten Tag', 'targetLanguage' => 'en']),
+        ));
+
+        self::assertTrue($body['success']);
+        self::assertSame('Good day', $body['translation']);
+        self::assertSame('llm', $body['translator']);
+        self::assertSame(15, $body['usage']['totalTokens']);
+    }
+
+    #[Test]
+    public function namingATranslatorRoutesToThatTranslator(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects(self::once())
+            ->method('translate')
+            ->with('Guten Tag', 'en', 'de')
+            ->willReturn(new TranslatorResult(
+                translatedText: 'Good day',
+                sourceLanguage: 'de',
+                targetLanguage: 'en',
+                translator: 'deepl',
+                confidence: 1.0,
+                charactersUsed: 9,
+            ));
+
+        $this->translationService
+            ->expects(self::once())
+            ->method('getTranslator')
+            ->with('deepl')
+            ->willReturn($translator);
+
+        $this->translationService->expects(self::never())->method('translate');
+
+        $body = $this->decode($this->subject()->translateAction($this->request([
+            'text'           => 'Guten Tag',
+            'targetLanguage' => 'en',
+            'sourceLanguage' => 'de',
+            'translator'     => 'deepl',
+        ])));
+
+        self::assertTrue($body['success']);
+        self::assertSame('deepl', $body['translator']);
+        self::assertSame(9, $body['charactersUsed']);
+    }
+
+    #[Test]
+    public function anUnconfiguredTranslatorIsReportedAsUnavailableNotAsAFailure(): void
+    {
+        $this->translationService
+            ->method('getTranslator')
+            ->willThrowException(ServiceUnavailableException::notConfigured('translation', 'deepl'));
+
+        $response = $this->subject()->translateAction($this->request([
+            'text'           => 'Guten Tag',
+            'targetLanguage' => 'en',
+            'translator'     => 'deepl',
+        ]));
+
+        self::assertSame(503, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
+        self::assertStringContainsString('Extension Configuration', $body['error']);
+    }
+
+    #[Test]
+    public function aRuntimeTranslationFailureIsNotDisguisedAsAConfigurationProblem(): void
+    {
+        $this->translationService
+            ->method('translate')
+            ->willThrowException(new RuntimeException('upstream exploded'));
+
+        $response = $this->subject()->translateAction(
+            $this->request(['text' => 'Guten Tag', 'targetLanguage' => 'en']),
+        );
+
+        self::assertSame(500, $response->getStatusCode());
+        self::assertStringNotContainsString('upstream exploded', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function translationRequiresTextAndTargetLanguage(): void
+    {
+        self::assertSame(400, $this->subject()->translateAction($this->request(['targetLanguage' => 'en']))->getStatusCode());
+        self::assertSame(400, $this->subject()->translateAction($this->request(['text' => 'x']))->getStatusCode());
+    }
+
+    #[Test]
+    public function translationRejectsOverlongInput(): void
+    {
+        $response = $this->subject()->translateAction($this->request([
+            'text'           => str_repeat('a', 5001),
+            'targetLanguage' => 'en',
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function imageGenerationDefaultsToTheOpenAiService(): void
+    {
+        $this->openAiImage
+            ->expects(self::once())
+            ->method('generate')
+            ->with('a cat')
+            ->willReturn($this->imageResult(url: '', base64: base64_encode('binary')));
+
+        $this->falImage->expects(self::never())->method('generate');
+
+        $body = $this->decode($this->subject()->generateImageAction($this->request(['prompt' => 'a cat'])));
+
+        self::assertTrue($body['success']);
+        self::assertNull($body['url']);
+        self::assertIsString($body['dataUrl']);
+        self::assertStringStartsWith('data:image/png;base64,', $body['dataUrl']);
+    }
+
+    #[Test]
+    public function requestingFalRoutesToTheFalService(): void
+    {
+        $this->falImage
+            ->expects(self::once())
+            ->method('generate')
+            ->willReturn($this->imageResult(url: 'https://fal.example/img.png', base64: null));
+
+        $this->openAiImage->expects(self::never())->method('generate');
+
+        $body = $this->decode($this->subject()->generateImageAction(
+            $this->request(['prompt' => 'a cat', 'service' => 'fal']),
+        ));
+
+        self::assertSame('https://fal.example/img.png', $body['url']);
+        self::assertNull($body['dataUrl']);
+    }
+
+    #[Test]
+    public function anUnconfiguredImageServiceIsReportedAsUnavailable(): void
+    {
+        $this->openAiImage
+            ->method('generate')
+            ->willThrowException(ServiceUnavailableException::notConfigured('image', 'dall-e'));
+
+        $response = $this->subject()->generateImageAction($this->request(['prompt' => 'a cat']));
+
+        self::assertSame(503, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function imageGenerationRequiresAPrompt(): void
+    {
+        self::assertSame(400, $this->subject()->generateImageAction($this->request([]))->getStatusCode());
+    }
+
+    #[Test]
+    public function everyActionRefusesANonAdmin(): void
+    {
+        $editor = new BackendUserAuthentication();
+        $editor->user = ['uid' => 42, 'admin' => 0];
+        $GLOBALS['BE_USER'] = $editor;
+
+        $subject = $this->subject();
+
+        self::assertSame(403, $subject->translateAction($this->request(['text' => 'x', 'targetLanguage' => 'en']))->getStatusCode());
+        self::assertSame(403, $subject->translatorsAction()->getStatusCode());
+        self::assertSame(403, $subject->generateImageAction($this->request(['prompt' => 'x']))->getStatusCode());
+    }
+
+    #[Test]
+    public function listingTranslatorsReportsWhichAreConfigured(): void
+    {
+        $this->translationService
+            ->method('getAvailableTranslators')
+            ->willReturn([
+                'deepl' => ['identifier' => 'deepl', 'name' => 'DeepL', 'available' => false],
+                'llm'   => ['identifier' => 'llm', 'name' => 'LLM', 'available' => true],
+            ]);
+
+        $body = $this->decode($this->subject()->translatorsAction());
+
+        self::assertTrue($body['success']);
+        self::assertIsArray($body['translators']);
+        self::assertCount(2, $body['translators']);
+        self::assertIsArray($body['translators'][0]);
+        self::assertFalse($body['translators'][0]['available']);
+    }
+
+    private function subject(): SpecializedTestController
+    {
+        return new SpecializedTestController(
+            $this->translationService,
+            $this->openAiImage,
+            $this->falImage,
+            new NullLogger(),
+        );
+    }
+
+    private function imageResult(string $url, ?string $base64): ImageGenerationResult
+    {
+        return new ImageGenerationResult(
+            url: $url,
+            base64: $base64,
+            prompt: 'a cat',
+            revisedPrompt: null,
+            model: 'test-model',
+            size: '1024x1024',
+            provider: 'test',
+        );
+    }
+
+    /**
+     * @param array<string, string> $body
+     */
+    private function request(array $body): ServerRequest
+    {
+        return (new ServerRequest('/ajax/test', 'POST'))->withParsedBody($body);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
+++ b/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Controller\Backend\SpecializedTestController;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Specialized\Exception\ServiceConfigurationException;
 use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
 use Netresearch\NrLlm\Specialized\Image\ImageGenerationResult;
 use Netresearch\NrLlm\Specialized\Image\ImageGeneratorInterface;
@@ -27,6 +28,7 @@ use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
 
 /**
  * Unit tests for the specialized-service verification endpoints.
@@ -312,5 +314,54 @@ final class SpecializedTestControllerTest extends TestCase
 
         /** @var array<string, mixed> $decoded */
         return $decoded;
+    }
+
+    #[Test]
+    public function aRejectedCredentialIsDistinguishedFromAMissingOne(): void
+    {
+        // The likeliest real failure: the vault identifier resolves, the secret
+        // behind it is wrong. Reporting that as "not configured" sends the
+        // operator to the wrong place.
+        $this->translationService
+            ->method('translate')
+            ->willThrowException(ServiceConfigurationException::invalidApiKey('translation', 'deepl', 401));
+
+        $response = $this->subject()->translateAction(
+            $this->request(['text' => 'Guten Tag', 'targetLanguage' => 'en']),
+        );
+
+        self::assertSame(502, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertIsString($body['error']);
+        self::assertStringContainsString('rejected the credential', $body['error']);
+    }
+
+    #[Test]
+    public function aJsonRequestBodyIsRead(): void
+    {
+        // TYPO3 fills getParsedBody() from $_POST only; the backend JS posts
+        // application/json, so without decoding it every field arrives empty.
+        $this->translationService
+            ->expects(self::once())
+            ->method('translate')
+            ->with('Guten Tag', 'en', null)
+            ->willReturn(new TranslationResult(
+                translation: 'Good day',
+                sourceLanguage: 'de',
+                targetLanguage: 'en',
+                confidence: 0.9,
+                usage: new UsageStatistics(11, 4, 15),
+            ));
+
+        $request = (new ServerRequest('/ajax/test', 'POST'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(new Stream('php://temp', 'rw'));
+        $request->getBody()->write(json_encode(['text' => 'Guten Tag', 'targetLanguage' => 'en'], JSON_THROW_ON_ERROR));
+        $request->getBody()->rewind();
+
+        $body = $this->decode($this->subject()->translateAction($request));
+
+        self::assertTrue($body['success']);
+        self::assertSame('Good day', $body['translation']);
     }
 }


### PR DESCRIPTION
Translation, image generation and speech are configured through the Extension Configuration — one nr-vault identifier per credential — and nothing in the backend could reach any of them.

Verified rather than assumed: outside their own directories, `TranslationService` appears only in doc comments and the image services not at all. Every backend entry point ends in a plain chat completion — the Playground drives `AgentRuntimeInterface`, the "Test" buttons on provider/model/configuration records call `$adapter->complete()`, and `TaskExecutionService::execute()` never branches on `TaskCategory`, `TaskInputType` or `TaskOutputFormat`. So an operator who pasted a DeepL or FAL identifier had no way to learn whether it works short of writing consumer code; the failure surfaced later, in a consumer, as a runtime error.

## What this adds

Two cards on the existing test page (`LLM > Overview > Test`), backed by three admin-guarded AJAX routes:

| Route | Purpose |
|---|---|
| `nrllm_test_translate` | Translate a snippet. No translator named → the LLM path (no specialized credential). Naming one routes to it. |
| `nrllm_test_translators` | List registered translators and whether each is configured, so the picker answers before anything runs. |
| `nrllm_test_image` | Generate one image with the OpenAI or the FAL service. |

**A missing credential answers 503 and names the Extension Configuration.** That distinction is the point of the endpoints, so `ServiceUnavailableException` is caught separately; a runtime failure of a configured service stays a sanitised 500 with the detail in the log.

**Nothing is persisted.** The translation is text; the image is rendered from the URL (FAL) or data URI (OpenAI family) the provider returned and is gone on reload. Taking an image into the file storage, onto a record, anywhere — the consuming extension's job, deliberately out of scope. nr_llm has no storage wiring for generated images and this does not add one.

## `ImageGeneratorInterface`

`DallEImageService::generate()` takes an `ImageGenerationOptions` object as its second parameter, `FalImageService::generate()` a model identifier. That divergence is deliberate and stays. The new interface declares only what they share — `generate(string $prompt): ImageGenerationResult`. Both already default every parameter after the prompt, so neither changes behaviour by implementing it.

It also makes them testable: both are `final`, which would otherwise leave the controller unmockable. Because both satisfy the interface, the controller's two image arguments are bound explicitly in `Services.yaml`.

## Verification

12 unit tests covering both paths, both failure classes, the input caps and the admin guard on all three actions.

Rendered and checked in a browser on TYPO3 14.3.4: both cards render with all fields, the three AJAX URLs are registered, no console errors.

Local gates: unit (5644), PHPStan level 10, cgl, rector, functional on SQLite (1293 tests, 14244 assertions) — the last one matters here because this touches `Services.yaml`.

## Not covered

Speech stays unreachable. Transcription needs an audio upload and synthesis returns binary audio; both raise the same storage question this declines to answer for images, with less to gain. Their credential is the shared OpenAI identifier, so a successful DALL-E test also confirms the key those two use.

See ADR-118 for the reasoning and `Documentation/Administration/SpecializedServices.rst` for the operator-facing description.
