### PR TITLE
fix(presets): tell the operator how to make an unimportable preset work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   never read again. Access control is unchanged: the gate that works is the
   per-configuration `allowed_groups` relation.
 
+### Fixed
+
+- A configuration preset that cannot be imported now says what to do about it,
+  and no longer renders a disabled button that looks exactly like the working
+  one. Both branches used `btn btn-primary btn-sm` with the same "Import" label
+  and the same download icon; the only difference was a `disabled` attribute
+  and a tooltip, so an inert control was indistinguishable from a broken one —
+  clicking it did nothing, by design, with no visible explanation.
+
+  "Not satisfiable — missing: capabilities: chat, vision" also stated the
+  diagnosis and left the operator to guess the cure. The preflight now
+  distinguishes four cases from the records already present and names the
+  action for each: a matching model exists but is switched off (activate it,
+  with the model named); no model declares the capabilities (add one to a
+  configured provider, or tick the capability on a model that has it, with the
+  providers named); no provider is configured at all; or the capabilities are
+  covered and a secondary requirement rules every model out. The first three
+  link to the module that fixes them.
+
 ## [0.25.1] - 2026-07-27
 
 A translation fix reported from the field, plus Extension Configuration

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -564,7 +564,7 @@ final class ConfigurationController extends ActionController
      * its preflight result so the list can show upfront whether an import
      * can succeed.
      *
-     * @return list<array{identifier: string, name: string, description: string, satisfiable: bool, matchedModelLabel: string|null, missingRequirement: string|null}>
+     * @return list<array{identifier: string, name: string, description: string, satisfiable: bool, matchedModelLabel: string|null, missingRequirement: string|null, remedy: string|null, remedySubject: string|null}>
      */
     private function buildPendingPresetRows(): array
     {
@@ -578,6 +578,8 @@ final class ConfigurationController extends ActionController
                 'satisfiable' => $preflight->satisfiable,
                 'matchedModelLabel' => $preflight->matchedModelLabel,
                 'missingRequirement' => $preflight->missingRequirement,
+                'remedy' => $preflight->remedy?->value,
+                'remedySubject' => $preflight->remedySubject,
             ];
         }
 

--- a/Classes/Service/Preset/ConfigurationPresetImportService.php
+++ b/Classes/Service/Preset/ConfigurationPresetImportService.php
@@ -310,7 +310,12 @@ final readonly class ConfigurationPresetImportService
      */
     private function determineRemedy(ModelSelectionCriteria $criteria, string $missingRequirement): array
     {
-        if ($this->providerRepository->countActive() === 0) {
+        // One source for both the gate and the names. ProviderRepository's
+        // countActive() counts every non-deleted provider regardless of
+        // is_active — a different definition of "there is a provider" from the
+        // one the AddModel message goes on to print.
+        $activeProviders = $this->activeProviderNames();
+        if ($activeProviders === []) {
             return [PresetRemedy::AddProvider, null];
         }
 
@@ -336,7 +341,7 @@ final readonly class ConfigurationPresetImportService
         // model declares them, and that is fixed on a model record — either by
         // adding one or by ticking a capability the model already has.
         if (str_starts_with($missingRequirement, 'capabilities:')) {
-            return [PresetRemedy::AddModel, $this->activeProviderNames()];
+            return [PresetRemedy::AddModel, implode(', ', $activeProviders)];
         }
 
         // Capabilities are covered; a secondary criterion rules the matches
@@ -355,7 +360,10 @@ final readonly class ConfigurationPresetImportService
             : $name;
     }
 
-    private function activeProviderNames(): string
+    /**
+     * @return list<string>
+     */
+    private function activeProviderNames(): array
     {
         $names = [];
         foreach ($this->providerRepository->findActive()->toArray() as $provider) {
@@ -364,6 +372,6 @@ final readonly class ConfigurationPresetImportService
             }
         }
 
-        return implode(', ', $names);
+        return $names;
     }
 }

--- a/Classes/Service/Preset/ConfigurationPresetImportService.php
+++ b/Classes/Service/Preset/ConfigurationPresetImportService.php
@@ -12,7 +12,11 @@ namespace Netresearch\NrLlm\Service\Preset;
 use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
 use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -56,6 +60,8 @@ final readonly class ConfigurationPresetImportService
         private LlmConfigurationRepository $configurationRepository,
         private PersistenceManagerInterface $persistenceManager,
         private ConfigurationPresetDiffService $diffService,
+        private ModelRepository $modelRepository,
+        private ProviderRepository $providerRepository,
     ) {}
 
     /**
@@ -70,7 +76,10 @@ final readonly class ConfigurationPresetImportService
             return PresetPreflightResult::satisfiable($label);
         }
 
-        return PresetPreflightResult::unsatisfiable($this->determineMissingRequirement($preset->criteria));
+        $missing = $this->determineMissingRequirement($preset->criteria);
+        [$remedy, $subject] = $this->determineRemedy($preset->criteria, $missing);
+
+        return PresetPreflightResult::unsatisfiable($missing, $remedy, $subject);
     }
 
     /**
@@ -288,5 +297,73 @@ final readonly class ConfigurationPresetImportService
         }
 
         return 'combined criteria';
+    }
+
+    /**
+     * Work out what the operator should DO, not just what is missing.
+     *
+     * The cases are distinguishable from the records already present, and they
+     * call for different actions — switching a model on, adding one, adding a
+     * provider, or reconsidering the requirement itself.
+     *
+     * @return array{0: PresetRemedy, 1: string|null}
+     */
+    private function determineRemedy(ModelSelectionCriteria $criteria, string $missingRequirement): array
+    {
+        if ($this->providerRepository->countActive() === 0) {
+            return [PresetRemedy::AddProvider, null];
+        }
+
+        // Would an inactive model satisfy every criterion? Then the fix is one
+        // toggle, and saying "add a model" would send the operator the long way
+        // round.
+        $inactiveMatches = [];
+        foreach ($this->modelRepository->findAll()->toArray() as $model) {
+            if (!$model instanceof Model || $model->isActive()) {
+                continue;
+            }
+
+            if ($this->modelSelectionService->modelMatchesCriteria($model, $criteria->toArray())) {
+                $inactiveMatches[] = $this->labelFor($model);
+            }
+        }
+
+        if ($inactiveMatches !== []) {
+            return [PresetRemedy::ActivateModel, implode(', ', $inactiveMatches)];
+        }
+
+        // Capabilities are the entry criterion: when they are what fails, no
+        // model declares them, and that is fixed on a model record — either by
+        // adding one or by ticking a capability the model already has.
+        if (str_starts_with($missingRequirement, 'capabilities:')) {
+            return [PresetRemedy::AddModel, $this->activeProviderNames()];
+        }
+
+        // Capabilities are covered; a secondary criterion rules the matches
+        // out. That is the one case where the honest answer may be that this
+        // setup cannot serve the preset.
+        return [PresetRemedy::AdjustSetup, null];
+    }
+
+    private function labelFor(Model $model): string
+    {
+        $name = $model->getName() !== '' ? $model->getName() : $model->getModelId();
+        $provider = $model->getProvider();
+
+        return $provider instanceof Provider
+            ? sprintf('%s (%s)', $name, $provider->getName())
+            : $name;
+    }
+
+    private function activeProviderNames(): string
+    {
+        $names = [];
+        foreach ($this->providerRepository->findActive()->toArray() as $provider) {
+            if ($provider instanceof Provider) {
+                $names[] = $provider->getName();
+            }
+        }
+
+        return implode(', ', $names);
     }
 }

--- a/Classes/Service/Preset/PresetPreflightResult.php
+++ b/Classes/Service/Preset/PresetPreflightResult.php
@@ -15,8 +15,13 @@ namespace Netresearch\NrLlm\Service\Preset;
  *
  * When satisfiable, `matchedModelLabel` names the model the criteria would
  * resolve to right now (informational — criteria-mode configurations re-resolve
- * on every run). When not, `missingRequirement` names the first criterion that
- * eliminates every candidate, so the admin knows what to configure.
+ * on every run).
+ *
+ * When not, `missingRequirement` names the first criterion that eliminates
+ * every candidate, and `remedy` names what to do about it — the two answer
+ * different questions, and the second is the one an operator acts on.
+ * `remedySubject` carries the concrete names the remedy talks about: the
+ * models to switch on, or the providers a model would be added to.
  */
 final readonly class PresetPreflightResult
 {
@@ -24,6 +29,8 @@ final readonly class PresetPreflightResult
         public bool $satisfiable,
         public ?string $missingRequirement,
         public ?string $matchedModelLabel,
+        public ?PresetRemedy $remedy = null,
+        public ?string $remedySubject = null,
     ) {}
 
     public static function satisfiable(string $matchedModelLabel): self
@@ -31,8 +38,11 @@ final readonly class PresetPreflightResult
         return new self(true, null, $matchedModelLabel);
     }
 
-    public static function unsatisfiable(string $missingRequirement): self
-    {
-        return new self(false, $missingRequirement, null);
+    public static function unsatisfiable(
+        string $missingRequirement,
+        ?PresetRemedy $remedy = null,
+        ?string $remedySubject = null,
+    ): self {
+        return new self(false, $missingRequirement, null, $remedy, $remedySubject);
     }
 }

--- a/Classes/Service/Preset/PresetRemedy.php
+++ b/Classes/Service/Preset/PresetRemedy.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Preset;
+
+/**
+ * What an administrator has to do to make an unsatisfiable preset importable.
+ *
+ * "Not satisfiable — missing: capabilities: chat, vision" states the diagnosis
+ * and leaves the operator to guess the cure: another provider? a model that is
+ * merely switched off? a capability nobody ticked? These cases need different
+ * actions, and they are distinguishable from the records already present, so
+ * the preflight names the action rather than only the symptom.
+ *
+ * The value is the suffix of the `configuration.presets.remedy.<value>` label.
+ */
+enum PresetRemedy: string
+{
+    /**
+     * A model matching every criterion exists but is switched off. The
+     * cheapest possible fix — one toggle in the Models module.
+     */
+    case ActivateModel = 'activateModel';
+
+    /**
+     * Providers are configured, but none of their models declares the
+     * required capabilities. Either the capability is genuinely absent, or a
+     * model that has it never got the checkbox — both are fixed in the Models
+     * module, not by adding a provider.
+     */
+    case AddModel = 'addModel';
+
+    /**
+     * No active provider at all. Nothing else can be diagnosed until one
+     * exists.
+     */
+    case AddProvider = 'addProvider';
+
+    /**
+     * Models cover the capabilities, but a secondary criterion — adapter
+     * type, context length, input cost — rules every one of them out. The
+     * preset's own requirement is the thing to reconsider here, so this is
+     * the one case where the answer may be "not with this setup".
+     */
+    case AdjustSetup = 'adjustSetup';
+}

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1012,19 +1012,19 @@
             </trans-unit>
             <trans-unit id="configuration.presets.remedy.activateModel">
                 <source>A model that meets every requirement exists but is switched off. Activate it:</source>
-                <target>Ein Modell, das alle Anforderungen erfüllt, ist vorhanden, aber deaktiviert. Aktiviere es:</target>
+                <target>Ein Modell, das alle Anforderungen erfüllt, ist vorhanden, aber deaktiviert. Aktivieren Sie es:</target>
             </trans-unit>
             <trans-unit id="configuration.presets.remedy.addModel">
                 <source>None of your models declares the required capabilities. Add a model that does to one of your providers — or, if a model already supports it, tick the capability on its record. Configured providers:</source>
-                <target>Keines deiner Modelle deklariert die geforderten Fähigkeiten. Lege bei einem deiner Provider ein Modell an, das sie mitbringt — oder setze die Fähigkeit am Datensatz, falls ein Modell sie bereits beherrscht. Eingerichtete Provider:</target>
+                <target>Keines Ihrer Modelle deklariert die geforderten Fähigkeiten. Legen Sie bei einem Ihrer Provider ein Modell an, das sie mitbringt — oder setzen Sie die Fähigkeit am Datensatz, falls ein Modell sie bereits beherrscht. Eingerichtete Provider:</target>
             </trans-unit>
             <trans-unit id="configuration.presets.remedy.addProvider">
                 <source>No provider is configured yet. Set one up first; models and their capabilities follow from it.</source>
-                <target>Es ist noch kein Provider eingerichtet. Richte zuerst einen ein; Modelle und ihre Fähigkeiten ergeben sich daraus.</target>
+                <target>Es ist noch kein Provider eingerichtet. Richten Sie zuerst einen ein; Modelle und ihre Fähigkeiten ergeben sich daraus.</target>
             </trans-unit>
             <trans-unit id="configuration.presets.remedy.adjustSetup">
                 <source>Your models cover the required capabilities, but another requirement rules them all out — see Requirement check. This preset may not be servable with the current setup.</source>
-                <target>Deine Modelle decken die geforderten Fähigkeiten ab, aber eine weitere Anforderung schließt alle aus — siehe Anforderungsprüfung. Möglicherweise lässt sich dieses Preset mit der aktuellen Einrichtung nicht bedienen.</target>
+                <target>Ihre Modelle decken die geforderten Fähigkeiten ab, aber eine weitere Anforderung schließt alle aus — siehe Anforderungsprüfung. Möglicherweise lässt sich dieses Preset mit der aktuellen Einrichtung nicht bedienen.</target>
             </trans-unit>
             <trans-unit id="configuration.presets.remedy.gotoModels">
                 <source>Open Models</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1002,9 +1002,37 @@
                 <source>Import</source>
                 <target>Importieren</target>
             </trans-unit>
-            <trans-unit id="configuration.presets.importDisabled.title">
-                <source>Cannot import: no active model satisfies the requirements</source>
-                <target>Import nicht möglich: Kein aktives Modell erfüllt die Anforderungen</target>
+            <trans-unit id="configuration.presets.importUnavailable">
+                <source>Import unavailable</source>
+                <target>Import nicht möglich</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.importUnavailable.reason">
+                <source>No active model satisfies the requirements — see Requirement check.</source>
+                <target>Kein aktives Modell erfüllt die Anforderungen — siehe Anforderungsprüfung.</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.activateModel">
+                <source>A model that meets every requirement exists but is switched off. Activate it:</source>
+                <target>Ein Modell, das alle Anforderungen erfüllt, ist vorhanden, aber deaktiviert. Aktiviere es:</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.addModel">
+                <source>None of your models declares the required capabilities. Add a model that does to one of your providers — or, if a model already supports it, tick the capability on its record. Configured providers:</source>
+                <target>Keines deiner Modelle deklariert die geforderten Fähigkeiten. Lege bei einem deiner Provider ein Modell an, das sie mitbringt — oder setze die Fähigkeit am Datensatz, falls ein Modell sie bereits beherrscht. Eingerichtete Provider:</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.addProvider">
+                <source>No provider is configured yet. Set one up first; models and their capabilities follow from it.</source>
+                <target>Es ist noch kein Provider eingerichtet. Richte zuerst einen ein; Modelle und ihre Fähigkeiten ergeben sich daraus.</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.adjustSetup">
+                <source>Your models cover the required capabilities, but another requirement rules them all out — see Requirement check. This preset may not be servable with the current setup.</source>
+                <target>Deine Modelle decken die geforderten Fähigkeiten ab, aber eine weitere Anforderung schließt alle aus — siehe Anforderungsprüfung. Möglicherweise lässt sich dieses Preset mit der aktuellen Einrichtung nicht bedienen.</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.gotoModels">
+                <source>Open Models</source>
+                <target>Modelle öffnen</target>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.gotoWizard">
+                <source>Open Setup Wizard</source>
+                <target>Einrichtungsassistenten öffnen</target>
             </trans-unit>
             <trans-unit id="configuration.presets.drift.badge">
                 <source>Preset changed</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -761,8 +761,29 @@
             <trans-unit id="configuration.presets.import">
                 <source>Import</source>
             </trans-unit>
-            <trans-unit id="configuration.presets.importDisabled.title">
-                <source>Cannot import: no active model satisfies the requirements</source>
+            <trans-unit id="configuration.presets.importUnavailable">
+                <source>Import unavailable</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.importUnavailable.reason">
+                <source>No active model satisfies the requirements — see Requirement check.</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.activateModel">
+                <source>A model that meets every requirement exists but is switched off. Activate it:</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.addModel">
+                <source>None of your models declares the required capabilities. Add a model that does to one of your providers — or, if a model already supports it, tick the capability on its record. Configured providers:</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.addProvider">
+                <source>No provider is configured yet. Set one up first; models and their capabilities follow from it.</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.adjustSetup">
+                <source>Your models cover the required capabilities, but another requirement rules them all out — see Requirement check. This preset may not be servable with the current setup.</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.gotoModels">
+                <source>Open Models</source>
+            </trans-unit>
+            <trans-unit id="configuration.presets.remedy.gotoWizard">
+                <source>Open Setup Wizard</source>
             </trans-unit>
             <trans-unit id="configuration.presets.drift.badge">
                 <source>Preset changed</source>

--- a/Resources/Private/Templates/Backend/Configuration/List.html
+++ b/Resources/Private/Templates/Backend/Configuration/List.html
@@ -85,12 +85,38 @@
                                                     </button>
                                                 </f:then>
                                                 <f:else>
-                                                    <button type="button" class="btn btn-primary btn-sm" disabled
-                                                            title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.importDisabled.title')}"
-                                                            aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.importDisabled.title')}">
-                                                        <core:icon identifier="actions-download" size="small" />
-                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.import" default="Import" />
-                                                    </button>
+                                                    <f:comment>
+                                                        No button here. A disabled btn-primary carrying the same label
+                                                        and icon as the working one is indistinguishable from a broken
+                                                        control, and its only cue was a tooltip. State the reason in
+                                                        the cell instead.
+                                                    </f:comment>
+                                                    <span class="text-body-secondary">
+                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.importUnavailable" default="Import unavailable" />
+                                                    </span>
+                                                    <br /><span class="small">
+                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.remedy.{preset.remedy}" default="No active model satisfies the requirements." />
+                                                        <f:if condition="{preset.remedySubject}">
+                                                            <br /><code>{preset.remedySubject}</code>
+                                                        </f:if>
+                                                    </span>
+                                                    <f:switch expression="{preset.remedy}">
+                                                        <f:case value="activateModel">
+                                                            <br /><a class="btn btn-default btn-sm mt-1" href="{be:moduleLink(route: 'nrllm_models')}">
+                                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.remedy.gotoModels" default="Open Models" />
+                                                            </a>
+                                                        </f:case>
+                                                        <f:case value="addModel">
+                                                            <br /><a class="btn btn-default btn-sm mt-1" href="{be:moduleLink(route: 'nrllm_models')}">
+                                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.remedy.gotoModels" default="Open Models" />
+                                                            </a>
+                                                        </f:case>
+                                                        <f:case value="addProvider">
+                                                            <br /><a class="btn btn-default btn-sm mt-1" href="{be:moduleLink(route: 'nrllm_wizard')}">
+                                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:configuration.presets.remedy.gotoWizard" default="Open Setup Wizard" />
+                                                            </a>
+                                                        </f:case>
+                                                    </f:switch>
                                                 </f:else>
                                             </f:if>
                                         </td>

--- a/Tests/Unit/Controller/Backend/PresetControllerTest.php
+++ b/Tests/Unit/Controller/Backend/PresetControllerTest.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
@@ -29,6 +31,7 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 /**
  * Unit tests for the PresetController AJAX actions (ADR-056).
@@ -94,11 +97,21 @@ final class PresetControllerTest extends TestCase
 
         $registry = new ConfigurationPresetRegistry([new FixturePresetProvider($presets)], $repository);
         $diffService = new ConfigurationPresetDiffService();
+        $emptyResult = $this->createMock(QueryResultInterface::class);
+        $emptyResult->method('toArray')->willReturn([]);
+        $models = $this->createMock(ModelRepository::class);
+        $models->method('findAll')->willReturn($emptyResult);
+        $providers = $this->createMock(ProviderRepository::class);
+        $providers->method('countActive')->willReturn(1);
+        $providers->method('findActive')->willReturn($emptyResult);
+
         $importService = new ConfigurationPresetImportService(
             $modelSelection,
             $repository,
             $this->createMock(PersistenceManagerInterface::class),
             $diffService,
+            $models,
+            $providers,
         );
 
         return new PresetController($registry, $importService, $diffService, $repository);

--- a/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
@@ -52,8 +52,11 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->providerRepository = $this->createMock(ProviderRepository::class);
         // A configured provider and no inactive models is the ordinary case;
         // the remedy tests override what they need.
-        $this->providerRepository->method('countActive')->willReturn(1);
-        $this->providerRepository->method('findActive')->willReturn($this->queryResult([]));
+        // The remedy gate reads findActive(); countActive() counts every
+        // non-deleted provider and is deliberately not used for it.
+        $defaultProvider = new Provider();
+        $defaultProvider->setName('OpenAI');
+        $this->providerRepository->method('findActive')->willReturn($this->queryResult([$defaultProvider]));
         $this->modelRepository->method('findAll')->willReturn($this->queryResult([]));
         $this->subject = new ConfigurationPresetImportService(
             $this->modelSelectionService,
@@ -449,7 +452,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     {
         // A fresh subject: the shared one is wired for "a provider exists".
         $providers = $this->createMock(ProviderRepository::class);
-        $providers->method('countActive')->willReturn(0);
+        $providers->method('findActive')->willReturn($this->queryResult([]));
 
         $subject = new ConfigurationPresetImportService(
             $this->modelSelectionService,
@@ -539,7 +542,6 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $ollama->setName('Ollama');
 
         $providers = $this->createMock(ProviderRepository::class);
-        $providers->method('countActive')->willReturn(2);
         $providers->method('findActive')->willReturn($this->queryResult([$openAi, $ollama]));
 
         $subject = new ConfigurationPresetImportService(
@@ -587,5 +589,31 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         self::assertTrue($result->satisfiable);
         self::assertNull($result->remedy);
         self::assertNull($result->remedySubject);
+    }
+
+    #[Test]
+    public function aProviderThatExistsButIsInactiveCountsAsNoProvider(): void
+    {
+        // ProviderRepository::countActive() would count it — it counts every
+        // non-deleted row. The remedy must not claim providers are configured
+        // and then print an empty list.
+        $providers = $this->createMock(ProviderRepository::class);
+        $providers->method('findActive')->willReturn($this->queryResult([]));
+
+        $subject = new ConfigurationPresetImportService(
+            $this->modelSelectionService,
+            $this->configurationRepository,
+            $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
+            $this->modelRepository,
+            $providers,
+        );
+
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+
+        $result = $subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::AddProvider, $result->remedy);
     }
 }

--- a/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
@@ -13,18 +13,23 @@ use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
 use Netresearch\NrLlm\Domain\Enum\ModelSelectionMode;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
+use Netresearch\NrLlm\Service\Preset\PresetRemedy;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 #[CoversClass(ConfigurationPresetImportService::class)]
@@ -33,6 +38,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     private ModelSelectionServiceInterface&MockObject $modelSelectionService;
     private LlmConfigurationRepository&MockObject $configurationRepository;
     private PersistenceManagerInterface&MockObject $persistenceManager;
+    private ModelRepository&MockObject $modelRepository;
+    private ProviderRepository&MockObject $providerRepository;
     private ConfigurationPresetImportService $subject;
 
     protected function setUp(): void
@@ -41,11 +48,20 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService = $this->createMock(ModelSelectionServiceInterface::class);
         $this->configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $this->persistenceManager = $this->createMock(PersistenceManagerInterface::class);
+        $this->modelRepository = $this->createMock(ModelRepository::class);
+        $this->providerRepository = $this->createMock(ProviderRepository::class);
+        // A configured provider and no inactive models is the ordinary case;
+        // the remedy tests override what they need.
+        $this->providerRepository->method('countActive')->willReturn(1);
+        $this->providerRepository->method('findActive')->willReturn($this->queryResult([]));
+        $this->modelRepository->method('findAll')->willReturn($this->queryResult([]));
         $this->subject = new ConfigurationPresetImportService(
             $this->modelSelectionService,
             $this->configurationRepository,
             $this->persistenceManager,
             new ConfigurationPresetDiffService(),
+            $this->modelRepository,
+            $this->providerRepository,
         );
     }
 
@@ -411,5 +427,165 @@ final class ConfigurationPresetImportServiceTest extends TestCase
 
         self::assertTrue($diff->hasChanges());
         self::assertContains('description', $diff->changedFields());
+    }
+
+    /**
+     * Extbase repositories return a QueryResultInterface, not an array.
+     *
+     * @param list<object> $items
+     *
+     * @return QueryResultInterface<int, object>&MockObject
+     */
+    private function queryResult(array $items): QueryResultInterface&MockObject
+    {
+        $result = $this->createMock(QueryResultInterface::class);
+        $result->method('toArray')->willReturn($items);
+
+        return $result;
+    }
+
+    #[Test]
+    public function remedyIsAddProviderWhenNoProviderIsConfigured(): void
+    {
+        // A fresh subject: the shared one is wired for "a provider exists".
+        $providers = $this->createMock(ProviderRepository::class);
+        $providers->method('countActive')->willReturn(0);
+
+        $subject = new ConfigurationPresetImportService(
+            $this->modelSelectionService,
+            $this->configurationRepository,
+            $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
+            $this->modelRepository,
+            $providers,
+        );
+
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+
+        $result = $subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::AddProvider, $result->remedy);
+        self::assertNull($result->remedySubject);
+    }
+
+    #[Test]
+    public function remedyIsActivateModelWhenAnInactiveModelWouldMatch(): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $inactive = new Model();
+        $inactive->setName('gpt-4o');
+        $inactive->setIsActive(false);
+        $inactive->setProvider($provider);
+
+        $this->modelRepository = $this->createMock(ModelRepository::class);
+        $this->modelRepository->method('findAll')->willReturn($this->queryResult([$inactive]));
+
+        $subject = new ConfigurationPresetImportService(
+            $this->modelSelectionService,
+            $this->configurationRepository,
+            $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
+            $this->modelRepository,
+            $this->providerRepository,
+        );
+
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+        $this->modelSelectionService->method('modelMatchesCriteria')->willReturn(true);
+
+        $result = $subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::ActivateModel, $result->remedy);
+        self::assertSame('gpt-4o (OpenAI)', $result->remedySubject);
+    }
+
+    #[Test]
+    public function anActiveModelIsNeverOfferedForActivation(): void
+    {
+        $active = new Model();
+        $active->setName('gpt-4o');
+        $active->setIsActive(true);
+
+        $models = $this->createMock(ModelRepository::class);
+        $models->method('findAll')->willReturn($this->queryResult([$active]));
+
+        $subject = new ConfigurationPresetImportService(
+            $this->modelSelectionService,
+            $this->configurationRepository,
+            $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
+            $models,
+            $this->providerRepository,
+        );
+
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+        $this->modelSelectionService->method('modelMatchesCriteria')->willReturn(true);
+
+        $result = $subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::AddModel, $result->remedy);
+    }
+
+    #[Test]
+    public function remedyIsAddModelAndNamesTheConfiguredProviders(): void
+    {
+        $openAi = new Provider();
+        $openAi->setName('OpenAI');
+        $ollama = new Provider();
+        $ollama->setName('Ollama');
+
+        $providers = $this->createMock(ProviderRepository::class);
+        $providers->method('countActive')->willReturn(2);
+        $providers->method('findActive')->willReturn($this->queryResult([$openAi, $ollama]));
+
+        $subject = new ConfigurationPresetImportService(
+            $this->modelSelectionService,
+            $this->configurationRepository,
+            $this->persistenceManager,
+            new ConfigurationPresetDiffService(),
+            $this->modelRepository,
+            $providers,
+        );
+
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        $this->modelSelectionService->method('findCandidates')->willReturn([]);
+
+        $result = $subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::AddModel, $result->remedy);
+        self::assertSame('OpenAI, Ollama', $result->remedySubject);
+    }
+
+    #[Test]
+    public function remedyIsAdjustSetupWhenCapabilitiesMatchButAnotherCriterionDoesNot(): void
+    {
+        $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
+        // Capabilities alone find a candidate; adding the context length does not.
+        $this->modelSelectionService->method('findCandidates')->willReturnCallback(
+            static fn(array $criteria): array => isset($criteria['minContextLength']) ? [] : [new Model()],
+        );
+
+        $result = $this->subject->preflight(self::preset());
+
+        self::assertSame(PresetRemedy::AdjustSetup, $result->remedy);
+        self::assertNull($result->remedySubject);
+    }
+
+    #[Test]
+    public function aSatisfiablePresetCarriesNoRemedy(): void
+    {
+        $model = new Model();
+        $model->setName('gpt-4o');
+        $this->modelSelectionService->method('findMatchingModel')->willReturn($model);
+
+        $result = $this->subject->preflight(self::preset());
+
+        self::assertTrue($result->satisfiable);
+        self::assertNull($result->remedy);
+        self::assertNull($result->remedySubject);
     }
 }


### PR DESCRIPTION
Reported from a deployed instance: the Import button on a pending configuration preset "seems to have a visible function — nothing happens when you click it."

It was not broken. `Resources/Private/Templates/Backend/Configuration/List.html` had **two** Import buttons. The working one carries `js-import-preset` and a `data-identifier`; the one in the `<f:else>` — rendered when the preflight finds no active model matching the preset's criteria — carried the same `btn btn-primary btn-sm`, the same label and the same `actions-download` icon, but `disabled` and no JS class. It did nothing by design. The only cues were greyed styling and a tooltip.

The whole chain was verified working end to end on a live TYPO3 14.3.4 instance (template class → delegated handler → `nrllm_preset_import` → `PresetController::importAction` → JSON), so this PR does not touch the wiring.

## The larger problem

`Not satisfiable — Missing: capabilities: chat, vision` is a diagnosis, not help. It leaves the operator guessing: do I need another provider? A model that is merely switched off? A capability nobody ticked? Those need different actions, and they are distinguishable from the records already present.

The preflight now derives a remedy alongside the missing requirement:

| Case | What the operator is told |
|---|---|
| A model meets every criterion but is inactive | Activate it — the model and its provider are named, with a link to Models |
| No model declares the capabilities | Add one to a configured provider, or tick the capability on a model that has it — the configured providers are named, with a link to Models |
| No provider is configured at all | Set one up first, with a link to the Setup Wizard |
| Capabilities covered, a secondary criterion rules every model out | Reconsider the requirement — this is the one case where the answer may be "not with this setup" |

The inactive-model case is derived by running `ModelSelectionService::modelMatchesCriteria()` — the same public matcher the runtime uses — against **all** models rather than only the active ones, so it cannot drift from runtime behaviour.

## Also

- The disabled look-alike button is gone; the cell renders the remedy instead.
- `configuration.presets.importDisabled.title` became orphaned and is removed.
- `PresetPreflightResult` gains `remedy` (a `PresetRemedy` enum) and `remedySubject` (the model or provider names the remedy talks about). `missingRequirement` is unchanged — the two answer different questions and both are shown.

## Verification

Six new unit tests cover all four remedies plus the counter-check that an **active** matching model is never offered for activation. Two existing test files were updated for the service's new constructor signature.

Local gates: unit (5638), PHPStan level 10, cgl, rector, functional on SQLite (1293 tests, 14244 assertions) — the last because the service's dependencies changed.

## Not addressed here

No test exercises the import flow end to end, because nr_llm declares no preset provider of its own, so the pending-preset panel never renders in this repo's own dev or CI environment. Closing that needs a preset-provider fixture in the functional or E2E suite — worth doing, separate change.
