### PR TITLE
docs(adr): record why the modules stay under Administration, and what would change it

### DIFF
--- a/Documentation/Adr/Adr119BackendModulePlacement.rst
+++ b/Documentation/Adr/Adr119BackendModulePlacement.rst
@@ -1,0 +1,145 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-119:
+
+============================================================================
+ADR-119: Where the backend modules live — Administration, for now
+============================================================================
+
+:Status: Accepted (deferred — the placement is not finally settled, see Revisit)
+:Date: 2026-07-28
+:Authors: Netresearch DTT GmbH
+
+.. _adr-119-context:
+
+Context
+=======
+
+nr_llm registers a parent module ``nrllm`` with twelve submodules — providers,
+models, configurations, tasks, snippets, skills, tools, playground, agent runs,
+analytics, setup wizard and overview — under TYPO3's **Administration**
+section. The question raised: should this become its own top-level section,
+a sibling of Content, Media, Sites, Administration and System, and should it be
+called "LLM" or "AI"?
+
+Two arguments were made against a section and both turned out to be worthless,
+which is why they are recorded here rather than quietly dropped:
+
+**"They are all admin-only modules, and Administration is the section for
+admin-only modules."** Access level is not the grouping principle. In the core,
+``site`` holds ``site_configuration`` (``access => admin``) next to
+``link-management`` (``access => user``), and ``system`` is
+``systemMaintainer`` — stricter than admin, not the same. Sections mix access
+levels, so this explains nothing.
+
+**"A move is expensive."** It is — the ``nrllm`` route and its bookmarks, two
+``setShortcutContext`` calls, the docheader submodule dropdown, 33 references
+across 20 documentation files, roughly 17 backend screenshots, and
+``t3_cowriter``'s ``position => ['after' => 'nrllm']`` anchor. But cost answers
+"what does it take", not "what is right". The two must not be confused.
+
+.. _adr-119-context-principle:
+
+What the sections actually are
+------------------------------
+
+The core's own definitions (``cms-core/Configuration/Backend/Modules.php``)
+group by **subject**: content is where writing happens, media where files are
+worked with, site where sites are configured, system the installation itself.
+Administration is where the instance is administered.
+
+The core also, in v14, added ``integrations`` — ``parent => 'admin'``,
+``dependsOnSubmodules``, ``showSubmoduleOverview`` — which is structurally the
+same shape as ``nrllm``. That is the core's own answer for a cohesive group of
+admin-facing extension modules: a container under Administration, not a new
+top-level section.
+
+.. _adr-119-context-editor:
+
+The argument that actually decides it
+-------------------------------------
+
+Everything above points at Administration — as long as nr_llm's modules stay a
+place where a capability is *configured and inspected* rather than a place
+where work is done.
+
+They do not stay that, and the reason is not the editor action API. That API
+(see the roadmap) surfaces AI actions inside the consuming extension's UI, on
+the record the editor is already working on, so it argues *for* leaving nr_llm
+where it is: an editor would never open an nr_llm module.
+
+But a consumer's UI can only ever show data in that consumer's context. An
+editor also needs **cross-consumer** answers about themselves:
+
+- what is my budget, and how much of it have I used?
+- which tools am I allowed to use?
+- which skills apply to me?
+- what did I run, across every consuming extension?
+
+and a lead editor needs the same for their editors, or for a group. None of
+that is expressible in a consumer's UI, because it is by definition not about
+one consumer. It is editorial self-service, and it has no home today: the
+analytics module aggregates instance-wide and is admin-only, no per-user
+history exists, and per-user budgets have no user-facing view at all.
+
+Once those surfaces exist, nr_llm's module tree is no longer an administration
+toolset, and the subject argument flips: AI becomes a place where work happens,
+on a par with Content and Media.
+
+.. _adr-119-decision:
+
+Decision
+========
+
+**Keep the modules under Administration for now. Do not treat this as settled.**
+
+The cross-consumer editor surfaces do not exist yet, and building a top-level
+section for users who cannot yet be served by it would be premature. Nothing
+about the current placement blocks them.
+
+.. _adr-119-revisit:
+
+Revisit
+=======
+
+Reopen this the moment the first cross-consumer editor surface is planned —
+a personal usage-and-budget view, a personal run history, or a lead-editor
+view over a group. That is the trigger; not a count of modules, not a
+preference about menus.
+
+When it is reopened, these are settled in advance:
+
+- **The section is called "AI", not "LLM".** It would hold tasks, skills,
+  tools, agent runs and analytics — not just language models. Integrators look
+  for AI.
+- **The identifier is vendor-scoped** (``netresearch_ai``), never a bare
+  ``ai``. Module identifiers merge last-package-wins, so a generic top-level
+  identifier is a shared namespace with no owner: the label and icon would
+  depend on package load order, and removing the owning extension would strip
+  the routes of any foreign submodules parented to it.
+- **Twelve flat entries do not move as they are.** They read as a dumping
+  ground at any level. Group them by subject first — setup (provider, model,
+  configuration), authoring (tasks, skills, snippets), operation (tools,
+  playground, runs, analytics) — and let the section hold three or four
+  entries.
+- **Old routes keep working.** Keep the submodule identifiers and explicit
+  paths, repoint ``setShortcutContext`` from ``nrllm`` to ``nrllm_overview``,
+  and give that module ``'aliases' => ['nrllm']`` so existing bookmarks
+  resolve — valid only once ``nrllm`` is no longer a registered identifier,
+  since an alias is shadowed by a real module of the same name.
+
+.. _adr-119-consequences:
+
+Consequences
+============
+
+- No code changes. The placement, identifiers, routes and documentation stay
+  as they are.
+- The discoverability problem is real and remains: TYPO3's module menu renders
+  two levels, and nr_llm's twelve submodules sit at the third, so they are
+  invisible from the main menu. That is worth fixing on its own terms — by
+  strengthening the Overview as the hub, or by grouping the twelve — and does
+  not require the top level.
+- If the editor surfaces are built without reopening this ADR, they will land
+  in an admin-only section where their users cannot reach them. The revisit
+  trigger exists to prevent exactly that.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -415,3 +415,4 @@ Tools
    Adr115EnforceByDefaultForNewInstalls
    Adr116CentralToolingAuthority
    Adr117WithdrawCapabilityPermissions
+   Adr119BackendModulePlacement


### PR DESCRIPTION
Records the "should nr_llm get its own top-level backend section" discussion, the evidence behind it, and why it is deferred rather than answered.

## Why record a non-change

Two arguments were made against a section and both are worthless. Writing them down stops them coming back:

- **"They are all admin-only modules, and Administration is for admin-only modules."** Access level is not the grouping principle. The core's `site` section holds `site_configuration` (`access => admin`) next to `link-management` (`access => user`), and `system` is `systemMaintainer` — stricter than admin, not the same.
- **"A move is expensive."** It is, and the ADR lists what it costs. But that answers what it takes, not what is right.

## What actually decides it

The core groups sections by **subject**, and it added `integrations` in v14 — `parent => 'admin'`, `dependsOnSubmodules`, `showSubmoduleOverview` — which is structurally the same shape as `nrllm`. That is the core's own pattern for a cohesive group of admin-facing extension modules.

All of which points at Administration — as long as nr_llm's modules stay a place where a capability is configured and inspected rather than a place where work is done. The editor action API on the roadmap does not change that: it puts AI actions inside the *consuming extension's* UI, so an editor would never open an nr_llm module.

But a consumer's UI can only show data in that consumer's context, and an editor needs cross-consumer answers about themselves: their budget and how much of it is used, which tools they may use, which skills apply, what they ran across every consumer — and a lead editor the same for a group. That is editorial self-service, it cannot live in a consumer UI, and it has no home today (analytics is instance-wide and admin-only, no per-user history exists, per-user budgets have no user-facing view). Once it exists, the modules stop being an administration toolset.

## Decision

Keep the placement. Do not call it settled. Reopen when the first cross-consumer editor surface is planned — that is the trigger, not a module count or a menu preference.

Settled in advance so the revisit is about timing only: the section would be called **AI** (not LLM), the identifier **vendor-scoped** (`netresearch_ai` — module identifiers merge last-package-wins, so a bare `ai` is an unowned shared namespace), the twelve flat entries grouped by subject before any move, and old bookmarks preserved via an alias on `nrllm_overview`.

No code changes.

Note: the toctree entry sits after ADR-117; ADR-118 arrives with #546, so `Documentation/Adr/Index.rst` will conflict between the two branches and needs both lines in order.
