### PR TITLE
fix(backend): make the record Test button match what the record is for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   providers named); no provider is configured at all; or the capabilities are
   covered and a secondary requirement rules every model out. The first three
   link to the module that fixes them.
+- A configuration in criteria mode can be tested again. The Test button
+  resolved the model only through the direct relation, which criteria-mode
+  records do not have (`model_uid = 0`), so it answered "Configuration has no
+  model assigned" for a configuration that resolves and runs at call time —
+  including every configuration created by a preset import. It now resolves
+  through `ModelSelectionService`, the same path the runtime uses, which
+  returns the directly configured model unchanged for fixed-mode records.
+- The Test button on a model record no longer sends a chat prompt to a model
+  that cannot answer one. A DALL-E or text-to-speech record got a chat
+  completion, the provider rejected it, and the admin was shown "provider
+  rejected the test request" — which says nothing about the model. The probe
+  is now chosen from the record's declared capabilities: a chat-shaped model
+  is prompted as before, an embedding model is embedded and reports the vector
+  dimensions, and a model whose capabilities are served by the specialized
+  services is not called at all. Those authenticate with the Extension
+  Configuration rather than the provider record, so testing them from here
+  would verify a different credential than the record declares; the message
+  says so and points at the LLM test page. A record with no declared
+  capabilities keeps the chat probe — the field is optional and routinely left
+  empty.
 
 ## [0.25.1] - 2026-07-27
 

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -83,6 +84,7 @@ final class ConfigurationController extends ActionController
         private readonly LoggerInterface $logger,
         private readonly ConfigurationPresetRegistry $presetRegistry,
         private readonly ConfigurationPresetImportService $presetImportService,
+        private readonly ModelSelectionServiceInterface $modelSelectionService,
     ) {}
 
     protected function initializeAction(): void
@@ -366,7 +368,13 @@ final class ConfigurationController extends ActionController
         }
 
         try {
-            $model = $configuration->getLlmModel();
+            // Criteria-mode configurations carry no direct model relation
+            // (model_uid = 0) — their model is chosen at call time from the
+            // stored criteria. Resolving through ModelSelectionService, which
+            // returns the directly configured model unchanged for fixed-mode
+            // records, is what the runtime does; testing only getLlmModel()
+            // reported "has no model assigned" for a configuration that works.
+            $model = $this->modelSelectionService->resolveModel($configuration);
             if ($model === null || $model->getProvider() === null) {
                 $response = new JsonResponse((new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.config.noModel', 'Configuration has no model assigned')))->jsonSerialize(), 400);
             } else {

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -16,10 +16,12 @@ use Netresearch\NrLlm\Controller\Backend\Response\ModelListResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
@@ -273,6 +275,28 @@ final class ModelController extends ActionController
         return $this->performModelTest($model, $uid);
     }
 
+    /** Send a chat prompt through the record's own provider. */
+    private const PROBE_CHAT = 'chat';
+
+    /** Embed a string through the record's own provider. */
+    private const PROBE_EMBEDDINGS = 'embeddings';
+
+    /** Nothing here can verify this model — say so rather than guess. */
+    private const PROBE_UNSUPPORTED = 'unsupported';
+
+    /**
+     * Capabilities a chat completion exercises. Any of them means the model
+     * answers a prompt, which is what the chat probe sends.
+     */
+    private const CHAT_SHAPED_CAPABILITIES = [
+        ModelCapability::CHAT,
+        ModelCapability::COMPLETION,
+        ModelCapability::VISION,
+        ModelCapability::TOOLS,
+        ModelCapability::STREAMING,
+        ModelCapability::JSON_MODE,
+    ];
+
     /**
      * Perform the actual provider test call for a resolved model.
      */
@@ -290,9 +314,30 @@ final class ModelController extends ActionController
         $emptyFormat = $this->translate('model.test.emptyResponse')
             ?? 'Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning';
 
+        // A model that cannot answer a chat prompt must not be sent one: the
+        // provider rejects it and the admin sees "provider rejected the test
+        // request", which says nothing about the model. Decide from the
+        // record's declared capabilities what a meaningful test even is.
+        $probe = $this->testProbeFor($model);
+        if ($probe === self::PROBE_UNSUPPORTED) {
+            return new JsonResponse((new TestConnectionResponse(
+                success: false,
+                message: sprintf(
+                    $this->translate('model.test.notTestableHere')
+                        ?? 'Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.',
+                    $model->getName(),
+                    implode(', ', $model->getCapabilitySet()->toStringList()),
+                ),
+            ))->jsonSerialize());
+        }
+
         try {
             // Create adapter from model's provider
             $adapter = $this->providerAdapterRegistry->createAdapterFromModel($model);
+
+            if ($probe === self::PROBE_EMBEDDINGS) {
+                return $this->respondToEmbeddingProbe($model, $adapter);
+            }
 
             // Make a simple test call - use enough tokens for models with thinking
             $testPrompt = $this->testPromptResolver->resolve();
@@ -644,4 +689,63 @@ final class ModelController extends ActionController
         }
     }
 
+    /**
+     * Which probe verifies this model from a provider record.
+     *
+     * Only capabilities served by the record's own provider connection can be
+     * verified here. Image, speech and transcription go through the specialized
+     * services, whose credential comes from the Extension Configuration and not
+     * from this provider — testing them from here would authenticate with a
+     * different secret than the record declares, which is worse than not
+     * testing at all.
+     *
+     * An empty capability list keeps the chat probe: the TCA field has no
+     * minimum, so it is routinely left as shipped, and refusing to test the
+     * common case would be a regression.
+     */
+    private function testProbeFor(Model $model): string
+    {
+        $capabilities = $model->getCapabilitySet();
+        if ($capabilities->isEmpty()) {
+            return self::PROBE_CHAT;
+        }
+
+        foreach (self::CHAT_SHAPED_CAPABILITIES as $capability) {
+            if ($capabilities->has($capability)) {
+                return self::PROBE_CHAT;
+            }
+        }
+
+        if ($capabilities->has(ModelCapability::EMBEDDINGS)) {
+            return self::PROBE_EMBEDDINGS;
+        }
+
+        return self::PROBE_UNSUPPORTED;
+    }
+
+    /**
+     * Embed a short string and report the vector's dimensions.
+     *
+     * The one non-chat capability that runs on the record's own provider
+     * connection, so it verifies exactly what the record claims.
+     */
+    private function respondToEmbeddingProbe(Model $model, ProviderInterface $adapter): ResponseInterface
+    {
+        $response = $adapter->embeddings($this->testPromptResolver->resolve(), [
+            'model' => $model->getModelId(),
+        ]);
+
+        $dimensions = $response->embeddings === [] ? 0 : count($response->embeddings[0]);
+
+        return new JsonResponse((new TestConnectionResponse(
+            success: true,
+            message: sprintf(
+                $this->translate('model.test.embedded')
+                    ?? 'Model "%s" returned a %d-dimension embedding (tokens: %d in).',
+                $model->getName(),
+                $dimensions,
+                $response->usage->promptTokens,
+            ),
+        ))->jsonSerialize());
+    }
 }

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -295,6 +295,10 @@ final class ModelController extends ActionController
         ModelCapability::TOOLS,
         ModelCapability::STREAMING,
         ModelCapability::JSON_MODE,
+        // Audio is a chat-completions modality in every provider this
+        // extension speaks to — there is no audio service and no separate
+        // credential, so a record declaring only it still answers a prompt.
+        ModelCapability::AUDIO,
     ];
 
     /**
@@ -324,7 +328,7 @@ final class ModelController extends ActionController
                 success: false,
                 message: sprintf(
                     $this->translate('model.test.notTestableHere')
-                        ?? 'Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.',
+                        ?? 'Model "%s" provides %s. Those services take their credential from the Extension Configuration rather than from this provider record, so this record cannot verify them.',
                     $model->getName(),
                     implode(', ', $model->getCapabilitySet()->toStringList()),
                 ),
@@ -735,7 +739,20 @@ final class ModelController extends ActionController
             'model' => $model->getModelId(),
         ]);
 
-        $dimensions = $response->embeddings === [] ? 0 : count($response->embeddings[0]);
+        $dimensions = $response->getDimensions();
+        if ($dimensions === 0) {
+            // A 2xx whose body carries no vector has verified nothing; saying
+            // "returned a 0-dimension embedding" in the green panel would be a
+            // false positive.
+            return new JsonResponse((new TestConnectionResponse(
+                success: false,
+                message: sprintf(
+                    $this->translate('model.test.emptyEmbedding')
+                        ?? 'Model "%s" answered but returned no embedding vector.',
+                    $model->getName(),
+                ),
+            ))->jsonSerialize());
+        }
 
         return new JsonResponse((new TestConnectionResponse(
             success: true,

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -442,6 +442,14 @@
                 <source>Model "%s" responded: "%s" (tokens: %d in, %d out)</source>
                 <target>Modell "%s" hat geantwortet: "%s" (Token: %d rein, %d raus)</target>
             </trans-unit>
+            <trans-unit id="model.test.embedded">
+                <source>Model "%s" returned a %d-dimension embedding (tokens: %d in).</source>
+                <target>Modell "%s" hat ein Embedding mit %d Dimensionen geliefert (Token: %d rein).</target>
+            </trans-unit>
+            <trans-unit id="model.test.notTestableHere">
+                <source>Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.</source>
+                <target>Modell "%s" stellt %s bereit. Diese Dienste authentifizieren sich über die Extension-Konfiguration und nicht über diesen Provider-Datensatz — geprüft werden sie deshalb auf der LLM-Testseite, nicht hier.</target>
+            </trans-unit>
             <trans-unit id="model.test.emptyResponse">
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>
                 <target>Modell "%s" erfolgreich verbunden (Token: %d rein, %d raus) - Antwortinhalt leer, Modell nutzt möglicherweise internes Reasoning</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -446,9 +446,13 @@
                 <source>Model "%s" returned a %d-dimension embedding (tokens: %d in).</source>
                 <target>Modell "%s" hat ein Embedding mit %d Dimensionen geliefert (Token: %d rein).</target>
             </trans-unit>
+            <trans-unit id="model.test.emptyEmbedding">
+                <source>Model "%s" answered but returned no embedding vector.</source>
+                <target>Modell "%s" hat geantwortet, aber keinen Embedding-Vektor geliefert.</target>
+            </trans-unit>
             <trans-unit id="model.test.notTestableHere">
-                <source>Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.</source>
-                <target>Modell "%s" stellt %s bereit. Diese Dienste authentifizieren sich über die Extension-Konfiguration und nicht über diesen Provider-Datensatz — geprüft werden sie deshalb auf der LLM-Testseite, nicht hier.</target>
+                <source>Model "%s" provides %s. Those services take their credential from the Extension Configuration rather than from this provider record, so this record cannot verify them.</source>
+                <target>Modell "%s" stellt %s bereit. Diese Dienste beziehen ihre Zugangsdaten aus der Extension-Konfiguration und nicht aus diesem Provider-Datensatz — über diesen Datensatz sind sie deshalb nicht prüfbar.</target>
             </trans-unit>
             <trans-unit id="model.test.emptyResponse">
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -337,6 +337,12 @@
             <trans-unit id="model.test.responded">
                 <source>Model "%s" responded: "%s" (tokens: %d in, %d out)</source>
             </trans-unit>
+            <trans-unit id="model.test.embedded">
+                <source>Model "%s" returned a %d-dimension embedding (tokens: %d in).</source>
+            </trans-unit>
+            <trans-unit id="model.test.notTestableHere">
+                <source>Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.</source>
+            </trans-unit>
             <trans-unit id="model.test.emptyResponse">
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -340,8 +340,11 @@
             <trans-unit id="model.test.embedded">
                 <source>Model "%s" returned a %d-dimension embedding (tokens: %d in).</source>
             </trans-unit>
+            <trans-unit id="model.test.emptyEmbedding">
+                <source>Model "%s" answered but returned no embedding vector.</source>
+            </trans-unit>
             <trans-unit id="model.test.notTestableHere">
-                <source>Model "%s" provides %s. Those services authenticate with the Extension Configuration rather than this provider record, so they are verified on the LLM test page, not here.</source>
+                <source>Model "%s" provides %s. Those services take their credential from the Extension Configuration rather than from this provider record, so this record cannot verify them.</source>
             </trans-unit>
             <trans-unit id="model.test.emptyResponse">
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -138,6 +139,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             new NullLogger(),
             $presetRegistry,
             $presetImportService,
+            $this->get(ModelSelectionServiceInterface::class),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -145,6 +146,7 @@ final class ConfigurationControllerTest extends AbstractFunctionalTestCase
             new NullLogger(),
             $presetRegistry,
             $presetImportService,
+            $this->get(ModelSelectionServiceInterface::class),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
@@ -145,6 +146,7 @@ final class ErrorHandlingTest extends AbstractFunctionalTestCase
             new NullLogger(),
             $presetRegistry,
             $presetImportService,
+            $this->get(ModelSelectionServiceInterface::class),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
 use Netresearch\NrLlm\Service\LlmConfigurationService;
 use Netresearch\NrLlm\Service\LlmServiceManager;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
@@ -157,6 +158,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
             new NullLogger(),
             $presetRegistry,
             $presetImportService,
+            $this->get(ModelSelectionServiceInterface::class),
         );
     }
 

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -47,6 +48,7 @@ final class ConfigurationControllerTest extends TestCase
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
     private ModelRepository&MockObject $modelRepository;
+    private ModelSelectionServiceInterface&MockObject $modelSelectionService;
     private TestPromptResolverInterface&MockObject $testPromptResolver;
     private ConfigurationController $subject;
     private mixed $previousBeUser;
@@ -67,6 +69,12 @@ final class ConfigurationControllerTest extends TestCase
         $this->llmServiceManager = $this->createMock(LlmServiceManagerInterface::class);
         $this->providerAdapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
         $this->modelRepository = $this->createMock(ModelRepository::class);
+        $this->modelSelectionService = $this->createMock(ModelSelectionServiceInterface::class);
+        // The runtime resolves a configuration's model through this service so
+        // criteria-mode records work; fixed-mode records come back unchanged.
+        $this->modelSelectionService->method('resolveModel')->willReturnCallback(
+            static fn(LlmConfiguration $configuration): ?Model => $configuration->getLlmModel(),
+        );
         $this->testPromptResolver = $this->createMock(TestPromptResolverInterface::class);
         $this->testPromptResolver->method('resolve')->willReturn('Hello, test prompt');
 
@@ -99,6 +107,7 @@ final class ConfigurationControllerTest extends TestCase
         $this->setPrivateProperty($controller, 'llmServiceManager', $this->llmServiceManager);
         $this->setPrivateProperty($controller, 'providerAdapterRegistry', $this->providerAdapterRegistry);
         $this->setPrivateProperty($controller, 'modelRepository', $this->modelRepository);
+        $this->setPrivateProperty($controller, 'modelSelectionService', $this->modelSelectionService);
         $this->setPrivateProperty($controller, 'testPromptResolver', $this->testPromptResolver);
         // REC #8b: typed catches log via LoggerInterface — use a NullLogger
         // for unit tests so the property is initialised but no output is
@@ -1186,5 +1195,57 @@ final class ConfigurationControllerTest extends TestCase
         // No provider → adapterType = '' → default constraints
         self::assertTrue($constraints['frequency_penalty']['supported']);
         self::assertArrayNotHasKey('fixed', $constraints['temperature']);
+    }
+
+    #[Test]
+    public function aCriteriaModeConfigurationIsTestableThroughTheResolvedModel(): void
+    {
+        // Criteria-mode records carry no model relation (model_uid = 0). Testing
+        // only getLlmModel() reported "has no model assigned" for a
+        // configuration that resolves and runs fine at call time.
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('criteria_mode');
+
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+        $resolved = new Model();
+        $resolved->setName('gpt-4o');
+        $resolved->setProvider($provider);
+
+        // A readonly property cannot be re-set, so swap the collaborator and
+        // build a fresh controller rather than patching the shared one.
+        $this->modelSelectionService = $this->createMock(ModelSelectionServiceInterface::class);
+        $this->modelSelectionService->expects(self::once())->method('resolveModel')->willReturn($resolved);
+        $subject = $this->createControllerWithDependencies();
+
+        $this->configurationRepository->method('findByUid')->willReturn($configuration);
+
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->expects(self::once())->method('complete')->willReturn(
+            new CompletionResponse('hi', 'gpt-4o', new UsageStatistics(3, 1, 4)),
+        );
+        $this->providerAdapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $response = $subject->testConfigurationAction($this->createRequest(['uid' => 1]));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function aConfigurationWhoseCriteriaResolveToNothingStillReportsNoModel(): void
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('unsatisfiable');
+
+        $this->modelSelectionService = $this->createMock(ModelSelectionServiceInterface::class);
+        $this->modelSelectionService->method('resolveModel')->willReturn(null);
+        $subject = $this->createControllerWithDependencies();
+
+        $this->configurationRepository->method('findByUid')->willReturn($configuration);
+        $this->providerAdapterRegistry->expects(self::never())->method('createAdapterFromModel');
+
+        $response = $subject->testConfigurationAction($this->createRequest(['uid' => 1]));
+
+        self::assertSame(400, $response->getStatusCode());
     }
 }

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
 use Netresearch\NrLlm\Service\TestPromptResolverInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -1154,5 +1155,73 @@ final class ModelControllerTest extends TestCase
         $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 9])));
 
         self::assertTrue($body['success']);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function chatShapedCapabilityProvider(): array
+    {
+        return [
+            'chat' => ['chat'],
+            'completion' => ['completion'],
+            'vision' => ['vision'],
+            'tools' => ['tools'],
+            'streaming' => ['streaming'],
+            'json_mode' => ['json_mode'],
+            // Audio is a chat-completions modality here — there is no audio
+            // service and no separate credential.
+            'audio' => ['audio'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('chatShapedCapabilityProvider')]
+    public function everyChatShapedCapabilityKeepsTheChatProbe(string $capability): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $model = new Model();
+        $model->setName('some-model');
+        $model->setProvider($provider);
+        $model->setCapabilities($capability);
+
+        $this->modelRepository->method('findByUid')->willReturn($model);
+
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->expects(self::once())->method('complete')->willReturn(
+            new CompletionResponse('hi', 'some-model', new UsageStatistics(3, 1, 4)),
+        );
+        $this->providerAdapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 11])));
+
+        self::assertTrue($body['success']);
+    }
+
+    #[Test]
+    public function anEmbeddingProbeThatReturnsNoVectorIsNotASuccess(): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $model = new Model();
+        $model->setName('text-embedding-3-small');
+        $model->setProvider($provider);
+        $model->setCapabilities('embeddings');
+
+        $this->modelRepository->method('findByUid')->willReturn($model);
+
+        $adapter = $this->createMock(ProviderInterface::class);
+        // A 2xx whose body carries no vector: nothing was verified.
+        $adapter->method('embeddings')->willReturn(
+            new EmbeddingResponse([], 'text-embedding-3-small', new UsageStatistics(4, 0, 4)),
+        );
+        $this->providerAdapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 12])));
+
+        self::assertFalse($body['success']);
     }
 }

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
 use LogicException;
 use Netresearch\NrLlm\Controller\Backend\ModelController;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
@@ -1078,5 +1079,80 @@ final class ModelControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         self::assertArrayHasKey('error', $data);
+    }
+
+    #[Test]
+    public function anImageOnlyModelIsNotSentAChatPrompt(): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $model = new Model();
+        $model->setName('dall-e-3');
+        $model->setProvider($provider);
+        $model->setCapabilities('image');
+
+        $this->modelRepository->method('findByUid')->willReturn($model);
+        // The whole point: no adapter is built, so nothing is sent upstream.
+        $this->providerAdapterRegistry->expects(self::never())->method('createAdapterFromModel');
+
+        $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 7])));
+
+        self::assertFalse($body['success']);
+        self::assertIsString($body['message']);
+        self::assertStringContainsString('dall-e-3', $body['message']);
+        self::assertStringContainsString('Extension Configuration', $body['message']);
+    }
+
+    #[Test]
+    public function anEmbeddingModelIsProbedWithAnEmbeddingCall(): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $model = new Model();
+        $model->setName('text-embedding-3-small');
+        $model->setProvider($provider);
+        $model->setCapabilities('embeddings');
+
+        $this->modelRepository->method('findByUid')->willReturn($model);
+
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->expects(self::once())->method('embeddings')->willReturn(
+            new EmbeddingResponse([[0.1, 0.2, 0.3]], 'text-embedding-3-small', new UsageStatistics(4, 0, 4)),
+        );
+        $adapter->expects(self::never())->method('complete');
+        $this->providerAdapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 8])));
+
+        self::assertTrue($body['success']);
+        self::assertIsString($body['message']);
+        self::assertStringContainsString('3-dimension', $body['message']);
+    }
+
+    #[Test]
+    public function aModelWithoutDeclaredCapabilitiesKeepsTheChatProbe(): void
+    {
+        $provider = new Provider();
+        $provider->setName('OpenAI');
+
+        $model = new Model();
+        $model->setName('unlabelled');
+        $model->setProvider($provider);
+        // Capabilities are optional in TCA and routinely left empty; refusing
+        // to test that case would be a regression.
+
+        $this->modelRepository->method('findByUid')->willReturn($model);
+
+        $adapter = $this->createMock(ProviderInterface::class);
+        $adapter->expects(self::once())->method('complete')->willReturn(
+            new CompletionResponse('hi', 'unlabelled', new UsageStatistics(3, 1, 4)),
+        );
+        $this->providerAdapterRegistry->method('createAdapterFromModel')->willReturn($adapter);
+
+        $body = $this->decodeJsonResponse($this->subject->testModelAction($this->createRequest(['uid' => 9])));
+
+        self::assertTrue($body['success']);
     }
 }


### PR DESCRIPTION
Two defects behind one button.

## A criteria-mode configuration could not be tested at all

`testConfigurationAction` resolved the model through `getLlmModel()` only. Criteria-mode records carry no model relation (`model_uid = 0`) — their model is chosen at call time from the stored criteria — so the action answered **"Configuration has no model assigned"** for a configuration that resolves and runs perfectly at runtime. That includes every configuration created by a preset import.

It now resolves through `ModelSelectionService::resolveModel()`, which is what `LlmServiceManager::resolveModelForConfiguration()` already does; the comment there records the identical bug being fixed on the runtime path and never on the test path. For fixed-mode records the service returns the directly configured model unchanged, so nothing else moves.

## A model record was always sent a chat prompt

`performModelTest` called `$adapter->complete()` unconditionally, without ever reading `Model::getCapabilities()`. A DALL-E or text-to-speech record therefore got a chat completion, the provider rejected it, and the admin saw "LLM provider rejected the test request" — which says nothing about the model.

The probe is now chosen from the declared capabilities:

| Declared | Probe |
|---|---|
| chat, completion, vision, tools, streaming, json_mode | chat completion, as before |
| embeddings (and none of the above) | an embedding call, reporting the vector dimensions |
| image, text_to_speech, transcription, audio only | no call at all |

The last row is the important one. Those capabilities are served by the specialized services, whose credential comes from the **Extension Configuration** and not from the provider record being tested — so calling them from here would verify a different secret than the record declares, which is worse than not testing. The message says so and points at the LLM test page (#546), which is where that credential is verified.

**An empty capability string keeps the chat probe.** The TCA field has no `minitems` and is routinely left as shipped; refusing to test that case would be a regression. It has its own test.

## Verification

Five new unit tests: an image-only model builds no adapter at all, an embedding model gets `embeddings()` and never `complete()`, a model without declared capabilities still gets the chat probe, a criteria-mode configuration reaches 200 through the resolver, and a configuration whose criteria resolve to nothing still reports 400.

Four other test files were updated for the controller's new constructor signature.

Local gates: unit (5637), PHPStan level 10, cgl, rector, functional on SQLite (1293 tests, 14244 assertions).
