### PR TITLE
refactor(agent): decompose AgentRuntime along the eight roadmap seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   consumer calling one of the three action methods directly on
   `ModelController` has to call it on the new controller instead. Same split by
   request pathway as ADR-027.
+- The agent runtime no longer carries the queued-request serialisation. Turning
+  an `AgentRunRequest` into the JSON stored on a queued run row, and reading it
+  back, moved into `AgentRunRequestCodec`. The two directions have to agree
+  field for field — including the budget and idempotency values that
+  `ToolOptions::toArray()` drops and the codec therefore carries out of band —
+  and that agreement is now stated in one class and tested directly rather than
+  inferred from a run. `AgentRuntime` loses its `SkillRepository` and
+  `PromptSnippetRepository` constructor arguments, which only the serialisation
+  used; the codec takes them instead. Consumers use `AgentRuntimeInterface` and
+  are unaffected. First step of the runtime decomposition on the roadmap.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inside the run loop. The retry budget and the backoff stay `AgentRuntime`
   constants; only the decision reading them moved. Second step of the runtime
   decomposition.
+- Driving a run from its first round to a settled outcome moved into
+  `AgentRunExecutor`. This is the lifecycle ladder: the catch order ADR-084
+  makes a hard guarantee, ADR-103's cancellation probe, ADR-104's lease
+  heartbeat, ADR-111's write fence and fail-closed audit. It no longer knows
+  where a run came from — a request, a claimed queue row and a resumed
+  suspension all reach it as a handle, a trace and a closure producing the next
+  tool-loop result, so the ordering guarantees hold identically on all three
+  paths and can be exercised without a queue row, a resume claim or a provider.
+  The two resume paths, which previously repeated trace-then-context-then-ladder
+  each in their own method, now share one entry point that fixes that order in
+  one place. Third step of the runtime decomposition.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The two resume paths, which previously repeated trace-then-context-then-ladder
   each in their own method, now share one entry point that fixes that order in
   one place. Third step of the runtime decomposition.
+- Putting a run on the queue and picking it back up in a worker moved into
+  `QueuedRunCoordinator`. The two halves are one protocol and only make sense
+  together: what `enqueue()` stores is what `runQueued()` has to be able to
+  claim, position and rehydrate, and both are fail-closed in the same direction
+  — a queued run that cannot be stored, dispatched, positioned or rehydrated is
+  settled rather than left as an orphan a worker would later find in an
+  impossible state. Fourth step of the runtime decomposition.
+- Picking a suspended run back up moved into `ResumeCoordinator`. An approval
+  and a submitted input follow the same claim protocol, and the order in it is
+  the safety property: probe, win the atomic claim, then re-resolve the
+  event-stream position from a fresh row because the claim moved it. The one
+  deliberate divergence — a submitted input is validated against the tool's
+  declared schema before anything is claimed, so a rejection leaves the run
+  resumable — is now visible as a divergence inside one class instead of as a
+  difference between two long methods. Fifth step of the runtime decomposition.
+
+  `AgentRuntime` is now 266 lines, down from 1218. What remains is the
+  interface contract, the published constants, the retry predicate and
+  delegation; every algorithm lives in a class named after it.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `PromptSnippetRepository` constructor arguments, which only the serialisation
   used; the codec takes them instead. Consumers use `AgentRuntimeInterface` and
   are unaffected. First step of the runtime decomposition on the roadmap.
+- What becomes of a failed queued run moved out of the agent runtime into
+  `QueuedRunFailureRecovery`. Four independent conditions can each force a
+  dead-letter instead of a retry — a non-retryable error class, a
+  non-idempotent write fenced in flight, an exhausted requeue budget, and a
+  lost claim on the row — and the order between them is the whole of the
+  behaviour, which is easier to review in a class named after the decision than
+  inside the run loop. The retry budget and the backoff stay `AgentRuntime`
+  constants; only the decision reading them moved. Second step of the runtime
+  decomposition.
 
 ### Removed
 

--- a/Classes/Service/Agent/AgentRunExecutor.php
+++ b/Classes/Service/Agent/AgentRunExecutor.php
@@ -1,0 +1,521 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Closure;
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
+use Netresearch\NrLlm\Exception\GuardrailViolationException;
+use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunLeaseLostException;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Drives one agent run from its first round to a settled outcome.
+ *
+ * This is the lifecycle ladder: the catch order that ADR-084 makes a hard
+ * guarantee — {@see ToolApprovalRequiredException} and
+ * {@see ToolInputRequiredException} are control flow, not failure, and are
+ * caught before the guardrail pair and before the generic Throwable — together
+ * with ADR-103's cancellation probe, ADR-104's lease heartbeat and lease-lost
+ * stop, and ADR-111's write fence and fail-closed audit.
+ *
+ * It knows nothing about where the run came from. A request, a claimed queue
+ * row and a resumed suspension all reach it as a handle, a trace and a closure
+ * that produces the next {@see ToolLoopResult}, so the ordering guarantees hold
+ * identically on all three paths — and can be exercised without a queue row, a
+ * resume claim or a provider.
+ */
+final readonly class AgentRunExecutor
+{
+    public function __construct(
+        private ToolLoopServiceInterface $toolLoop,
+        private AgentRunPersister $persister,
+        private ?LoggerInterface $logger = null,
+        // Resolves a run's actor to a live acting backend user for tool
+        // authorization (ADR-083). A null falls back to a fresh default
+        // instance, the same as in the runtime that builds this executor.
+        private ?ActingBackendUserResolverInterface $actingBackendUserResolver = null,
+        // Classifies a tool's side effect so a WRITING tool's audit step is
+        // fail-closed (ADR-111). A null resolver treats every tool as read-only.
+        private ?ToolEffectResolver $toolEffectResolver = null,
+    ) {}
+
+    /**
+     * The shared execution path behind {@see AgentRuntime::run()} and {@see AgentRuntime::runQueued()}:
+     * clamp the round cap, build the trace, drive the ladder.
+     *
+     * A queued run passes its worker identity as $leaseOwner (so each step
+     * boundary renews the lease and detects a reaper reclaim, ADR-104) and a
+     * $recover closure that decides retry-vs-dead-letter for a failure. An
+     * interactive run() passes neither: it holds no lease and surfaces failures
+     * to its caller unchanged.
+     *
+     * @param (Closure(RunStep): void)|null                             $onStep
+     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
+     */
+    public function executeRequest(
+        AgentRunRequest $request,
+        ?AgentRunHandle $handle,
+        ?Closure $onStep,
+        ?string $leaseOwner = null,
+        ?Closure $recover = null,
+    ): AgentRunResult {
+        $maxIterations = $request->maxIterations !== null
+            ? min($request->maxIterations, AgentRuntime::MAX_ITERATIONS)
+            : null;
+
+        $trace = $this->trace($handle, $onStep, $request->captureRaw, $leaseOwner);
+        // Resolve the run's explicit actor to a live acting backend user ONCE,
+        // identically whether this runs synchronously or in a worker (ADR-083).
+        $context = $this->toolContext($request->actor);
+
+        return $this->execute(
+            $handle,
+            $trace,
+            fn(): ToolLoopResult => $this->toolLoop->runLoop(
+                $request->messages,
+                $request->configuration,
+                $context,
+                $request->allowedToolNames,
+                $request->options,
+                $maxIterations,
+                $trace,
+                $request->augmentation,
+            ),
+            $recover,
+            $leaseOwner,
+        );
+    }
+
+    /**
+     * The resume entry point behind {@see AgentRuntime::approve()} and
+     * {@see AgentRuntime::submitInput()}.
+     *
+     * Both resume paths need the same three things in the same order — a trace
+     * over the claimed handle, a tool context built from the RUN OWNER's
+     * identity rather than the approver's or the submitter's (ADR-083), and the
+     * ladder around the loop call — and they differ only in which
+     * {@see ToolLoopServiceInterface} call they make. Taking that call as a
+     * factory over the context and the trace keeps the ordering here, where it
+     * is stated once, instead of in each caller.
+     *
+     * A resume holds no worker lease and carries no recovery: it is the
+     * interactive continuation of a suspended run, so a failure surfaces to its
+     * caller exactly as an interactive run's does.
+     *
+     * @param (Closure(RunStep): void)|null                           $onStep
+     * @param Closure(ToolExecutionContext, RunTrace): ToolLoopResult $loopCall
+     */
+    public function executeResume(AgentRunHandle $handle, ?Closure $onStep, AiActorContext $owner, Closure $loopCall): AgentRunResult
+    {
+        $trace   = $this->trace($handle, $onStep, false);
+        $context = $this->toolContext($owner);
+
+        return $this->execute($handle, $trace, fn(): ToolLoopResult => $loopCall($context, $trace));
+    }
+
+    /**
+     * The trace every segment runs under: each recorded step reaches the live
+     * observer FIRST (preserving the streaming path's emit-before-persist
+     * order — a step is shown even when its persist fails), then the persisted
+     * event stream — and then the cancellation probe runs (ADR-103).
+     *
+     * The probe is what makes {@see cancel()} cooperative: the loop itself
+     * stays persistence-unaware (ADR-081), but every step boundary — after a
+     * provider response, after each tool execution, before the next round —
+     * records a step, and the probe checks the run row there. A run cancelled
+     * mid-flight therefore stops before the NEXT provider call or tool
+     * execution instead of running to completion with its outcome discarded.
+     * The step that just happened is still emitted and persisted: the audit
+     * stream stays complete up to the abort point. One indexed row read per
+     * step; steps are provider-call-slow, so the cost is negligible.
+     *
+     * For a queued run $leaseOwner is this worker's identity (ADR-104): after
+     * the cancellation check, the lease is renewed under an ownership guard
+     * BEFORE the step is persisted. If the renewal affects no row the worker no
+     * longer owns the run — the reaper reclaimed it and another worker may hold
+     * it now — so it stops WITHOUT writing the step, which would otherwise
+     * collide with the new owner's stream. Interactive runs pass null and never
+     * renew (they hold no lease).
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw, ?string $leaseOwner = null): RunTrace
+    {
+        if ($handle === null && $onStep === null) {
+            return new RunTrace(captureRaw: $captureRaw);
+        }
+
+        return new RunTrace(
+            captureRaw: $captureRaw,
+            onRecord: function (RunStep $step) use ($handle, $onStep, $leaseOwner): void {
+                // The live observer sees the step FIRST (emit-before-persist),
+                // so a step is shown even when its persistence or the checks
+                // below abort the loop.
+                if ($onStep !== null) {
+                    $onStep($step);
+                }
+                if ($handle === null) {
+                    return;
+                }
+
+                // A single indexed read drives the cancellation probe (ADR-103).
+                // findRun is fail-soft (null on a store hiccup), so a read
+                // failure can never fabricate a cancellation.
+                if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
+                    // Persist the step that already happened, then stop: the
+                    // audit stream stays complete up to the abort point. A
+                    // writing tool whose audit cannot be stored fails the run
+                    // (ADR-111) even mid-cancel — an unrecorded mutation is the
+                    // more serious condition than the cancellation.
+                    $this->recordStepFailClosedForWrites($handle, $step);
+
+                    throw RunCancellationRequestedException::forRun($handle->uuid);
+                }
+
+                // Heartbeat + lease-lost guard for a worker run (ADR-104). The
+                // renewal's ownership guard is the atomic check: 0 rows means
+                // the run was reclaimed/re-claimed/terminated — stop WITHOUT
+                // recording the step, so a zombie worker cannot append an event
+                // whose sequence collides with the new owner's stream. A completed
+                // WRITE step also CLEARS the in-flight fence set before it ran
+                // (ADR-111) in the same guarded write.
+                if ($leaseOwner !== null && !$this->renewOrClearFence($handle, $leaseOwner, $step)) {
+                    throw RunLeaseLostException::forRun($handle->uuid);
+                }
+
+                $this->recordStepFailClosedForWrites($handle, $step);
+            },
+            onBeforeTool: $leaseOwner === null || $handle === null ? null : function (string $toolName) use ($handle, $leaseOwner): void {
+                // Fence a WRITE before it runs (ADR-111): stamp its effect and
+                // renew the lease so a reap mid non-idempotent-write dead-letters
+                // instead of retrying. Read-only tools need no fence — repeating
+                // them is always safe. A lost lease stops the worker before the
+                // side effect, exactly like the heartbeat guard.
+                $effect = $this->toolEffectResolver?->effectFor($toolName) ?? ToolEffect::READ_ONLY;
+                if ($effect->isWrite()
+                    && !$this->persister->markPendingEffect($handle, $leaseOwner, $effect->value, time() + AgentRuntime::LEASE_SECONDS)
+                ) {
+                    throw RunLeaseLostException::forRun($handle->uuid);
+                }
+            },
+        );
+    }
+
+    /**
+     * Build the tool-execution context for a run from its explicit actor: the
+     * one place the actor becomes a live acting backend user, identically on the
+     * synchronous and worker paths (ADR-083), so no tool reads the ambient
+     * `$GLOBALS['BE_USER']`.
+     */
+    private function toolContext(AiActorContext $actor): ToolExecutionContext
+    {
+        $resolver = $this->actingBackendUserResolver ?? new ActingBackendUserResolver();
+
+        return new ToolExecutionContext($actor, $resolver->resolve($actor));
+    }
+
+    /**
+     * Renew the lease at a step boundary and, for a completed WRITE step, clear
+     * the in-flight fence its {@see RunTrace::beforeToolExecution()} set — both in
+     * one ownership-guarded write (ADR-111). Returns false when the worker has
+     * lost the run, so the caller stops before recording the step.
+     */
+    private function renewOrClearFence(AgentRunHandle $handle, string $leaseOwner, RunStep $step): bool
+    {
+        $leaseExpires = time() + AgentRuntime::LEASE_SECONDS;
+        if ($this->stepEffect($step)->isWrite()) {
+            return $this->persister->markPendingEffect($handle, $leaseOwner, '', $leaseExpires);
+        }
+
+        return $this->persister->renewLease($handle, $leaseOwner, $leaseExpires);
+    }
+
+    /**
+     * Persist a step, failing the run when a WRITING tool's audit event could
+     * not be stored (ADR-111). Read-only and non-tool steps stay fail-soft: a
+     * store hiccup is logged inside {@see AgentRunPersister::recordStep()} and
+     * the run continues. A write is different — an unrecorded mutation must not
+     * be waved through, so it throws {@see AuditPersistenceFailedException}
+     * (non-retryable: the write already ran once).
+     */
+    private function recordStepFailClosedForWrites(AgentRunHandle $handle, RunStep $step): void
+    {
+        $persisted = $this->persister->recordStep($handle, $step);
+        if (!$persisted && $this->stepEffect($step)->isWrite()) {
+            throw AuditPersistenceFailedException::forRun($handle->uuid, $step->toolName ?? '');
+        }
+    }
+
+    /**
+     * The side effect of the tool a step recorded (ADR-111). Only KIND_TOOL
+     * steps carry an effect; everything else is read-only. A tool name that no
+     * longer resolves is treated as the strictest effect (fail-closed), and a
+     * runtime built without the resolver (bare positional test wiring only)
+     * treats every tool as read-only.
+     */
+    private function stepEffect(RunStep $step): ToolEffect
+    {
+        if ($step->kind !== RunStep::KIND_TOOL || $this->toolEffectResolver === null) {
+            return ToolEffect::READ_ONLY;
+        }
+
+        return $this->toolEffectResolver->effectFor($step->toolName ?? '');
+    }
+
+    /**
+     * The single lifecycle ladder (ADR-101; previously copied three times in
+     * the playground controller).
+     *
+     * Every branch both settles the persisted row and marks the run settled so
+     * the finally-guard cannot touch it — including a SUCCESSFUL suspension:
+     * WAITING_FOR_APPROVAL is non-terminal, so an unguarded finally-settle
+     * would flip a resumable run to FAILED and destroy its suspended state.
+     * The finally-guard exists for the abandoned-run case (a live-stream
+     * observer dying mid-run, mirroring StreamingDispatcher) and costs the
+     * settled paths nothing.
+     *
+     * A queued run passes a $recover closure (ADR-104): in the generic failure
+     * arm, before the default settleFailed, it decides retry-vs-dead-letter and,
+     * when it handles the failure, returns the outcome that replaces FAILED.
+     *
+     * @param Closure(): ToolLoopResult                                 $loopCall
+     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
+     */
+    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null, ?string $ownerGuard = null): AgentRunResult
+    {
+        $runUuid = $handle !== null ? $handle->uuid : '';
+        $settled = false;
+
+        try {
+            $result = $loopCall();
+
+            if ($handle !== null) {
+                $settledOk = $this->persister->settleCompleted($handle, $result, $ownerGuard);
+                // Ownership-guarded on the queued path: if the run was reclaimed
+                // to another worker mid-loop, this completion must not overwrite
+                // its state — stop as LEASE_LOST rather than reporting COMPLETED.
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps());
+                }
+            }
+            $settled = true;
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::COMPLETED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                loopResult: $result,
+            );
+        } catch (RunCancellationRequestedException $cancelled) {
+            // ADR-103: the operator's cancel already won the guarded terminal
+            // transition — the row IS CANCELLED and its late settle would be
+            // discarded anyway, so none is attempted. Control flow, not
+            // failure: the loop stopped cooperatively at a step boundary.
+            $settled = true;
+            $this->logger?->info('Agent run stopped cooperatively after being cancelled', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::CANCELLED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $cancelled,
+            );
+        } catch (ToolApprovalRequiredException $approval) {
+            // ADR-084: a called tool requires human approval — control flow,
+            // not failure. Persist the suspended state so a later approve()
+            // can continue. Both branches below settle the run's fate, so the
+            // finally-guard must not run either way.
+            $settled = true;
+
+            if ($handle !== null && $this->persister->suspend($handle, $approval->state)) {
+                return new AgentRunResult(
+                    outcome: AgentRunOutcome::AWAITING_APPROVAL,
+                    runUuid: $runUuid,
+                    steps: $trace->getSteps(),
+                    suspendedState: $approval->state,
+                );
+            }
+
+            // Fail-closed (ADR-092): an approval-gated tool is side-effecting.
+            // Without stored state — the store refused or errored, a concurrent
+            // cancel already terminated the row, or the run was never persisted
+            // at all (null handle) — there is nothing to resume, so promising
+            // an approval flow would strand the client. Applied on EVERY path
+            // since ADR-101 (the old code silently ignored a failed
+            // re-suspension AND announced awaiting-approval for unpersisted
+            // runs).
+            if ($handle !== null) {
+                // Ownership-guarded so a reclaimed queued run is not clobbered by
+                // this worker's fail-closed settle.
+                $this->persister->settleFailed($handle, $approval, $ownerGuard);
+            }
+            $this->logger?->error('Agent run could not be suspended for approval; no resume is possible', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::SUSPEND_FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $approval,
+            );
+        } catch (ToolInputRequiredException $input) {
+            // ADR-105: a called tool requires typed user input — control flow,
+            // not failure (the input sibling of the approval arm above). Must be
+            // caught before the guardrail pair and the generic Throwable so a
+            // suspension is never recorded as a failed run. Both branches settle
+            // the run's fate, so $settled=true keeps the finally-guard off — a
+            // successfully-suspended WAITING_FOR_INPUT row is non-terminal and
+            // must not be flipped to FAILED.
+            $settled = true;
+
+            if ($handle !== null && $this->persister->suspendForInput($handle, $input->state)) {
+                return new AgentRunResult(
+                    outcome: AgentRunOutcome::AWAITING_INPUT,
+                    runUuid: $runUuid,
+                    steps: $trace->getSteps(),
+                    suspendedState: $input->state,
+                );
+            }
+
+            // Fail-closed (ADR-092/105): without stored state — the store
+            // refused or errored, a concurrent cancel terminated the row, or the
+            // run was never persisted (null handle) — there is nothing to resume,
+            // so promising an input flow would strand the client.
+            if ($handle !== null) {
+                // Ownership-guarded so a reclaimed queued run is not clobbered by
+                // this worker's fail-closed settle.
+                $this->persister->settleFailed($handle, $input, $ownerGuard);
+            }
+            $this->logger?->error('Agent run could not be suspended for input; no resume is possible', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::SUSPEND_FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $input,
+            );
+        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
+            // ADR-085/086: a guardrail verdict is a policy outcome, not a
+            // failure — and an approval that was required but never obtained
+            // is not recorded as an outright denial (ADR-092).
+            if ($handle !== null) {
+                $settledOk = $this->persister->settlePolicyStopped(
+                    $handle,
+                    $guardrail,
+                    $guardrail instanceof GuardrailApprovalRequiredException
+                        ? AgentRunTerminationReason::APPROVAL_DENIED
+                        : AgentRunTerminationReason::POLICY_DENIED,
+                    $ownerGuard,
+                );
+                // Ownership-guarded on the queued path: a run reclaimed to
+                // another worker must not be flipped to a policy-stopped terminal
+                // by this zombie worker — stop as LEASE_LOST.
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+                    $this->logger?->notice('Guardrail-stopped queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $guardrail);
+                }
+            }
+            $settled = true;
+            $this->logger?->warning('Agent run blocked by guardrail', ['exception' => $guardrail, 'run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: $guardrail instanceof GuardrailApprovalRequiredException
+                    ? AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED
+                    : AgentRunOutcome::GUARDRAIL_BLOCKED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                guardrailClass: $guardrail->guardrail,
+                error: $guardrail,
+            );
+        } catch (RunLeaseLostException $leaseLost) {
+            // ADR-104: the reaper reclaimed this run (or a cancel/settle won) and
+            // it belongs to another worker now. Stop WITHOUT settling — any
+            // settle here could destroy the new owner's in-flight state. Not a
+            // failure of the run; a loss of ownership by this worker.
+            $settled = true;
+            $this->logger?->info('Agent run worker lost its lease; stopping without settling', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::LEASE_LOST,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $leaseLost,
+            );
+        } catch (Throwable $e) {
+            // A queued run's recover closure decides retry-vs-dead-letter and,
+            // when it handles the failure, settles the row itself and returns
+            // the replacement outcome. Only an interactive run (no recover) or a
+            // recover that declines (null) falls through to the default settle.
+            if ($recover !== null) {
+                $recovery = $recover($e, $trace->getSteps());
+                if ($recovery instanceof AgentRunResult) {
+                    $settled = true;
+
+                    return $recovery;
+                }
+            }
+
+            if ($handle !== null) {
+                $settledOk = $this->persister->settleFailed($handle, $e, $ownerGuard);
+                if ($ownerGuard !== null && !$settledOk) {
+                    $settled = true;
+                    $this->logger?->notice('Failed queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $e);
+                }
+            }
+            $settled = true;
+            $this->logger?->error('Agent run failed', ['exception' => $e, 'run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: $trace->getSteps(),
+                error: $e,
+            );
+        } finally {
+            // A live-stream observer dying mid-run (client disconnect) can
+            // abandon the run before any branch settles it; mark it failed so
+            // no run is left stuck RUNNING. Mirrors StreamingDispatcher's
+            // finally-block settle. Guarded by $settled: a suspended run is
+            // WAITING_FOR_APPROVAL or WAITING_FOR_INPUT — both non-terminal — and
+            // settling it here would destroy its resumable state.
+            if ($handle !== null && !$settled) {
+                // Ownership-guarded so this safety-net settle cannot clobber a
+                // queued run the reaper reclaimed to another worker.
+                $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'), $ownerGuard);
+            }
+        }
+    }
+}

--- a/Classes/Service/Agent/AgentRunRequestCodec.php
+++ b/Classes/Service/Agent/AgentRunRequestCodec.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Skill;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\Repository\SkillRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
+use RuntimeException;
+
+/**
+ * Converts an {@see AgentRunRequest} to and from the JSON payload stored on a
+ * queued run row (ADR-102).
+ *
+ * The queue is the only place a request has to survive outside a process, so
+ * the two directions belong together: what {@see self::dehydrate()} writes is
+ * exactly what {@see self::rehydrate()} has to be able to read back, including
+ * the fields carried out-of-band because their own array forms drop them.
+ *
+ * Entities travel as uids and are re-loaded on the way back, so a run reflects
+ * the state at execution time rather than at enqueue time.
+ */
+final readonly class AgentRunRequestCodec
+{
+    public function __construct(
+        private LlmConfigurationRepository $configurationRepository,
+        private ?SkillRepository $skillRepository = null,
+        private ?PromptSnippetRepository $promptSnippetRepository = null,
+    ) {}
+
+    /**
+     * Serialise a request for the queued row (ADR-102). Entities travel as
+     * uids (the rehydrator re-loads them — the same identity-over-snapshot
+     * choice approve() makes for the configuration); messages and options use
+     * their established array forms (the SuspendedRunState precedent).
+     *
+     * @return array<string, mixed>
+     */
+    public function dehydrate(AgentRunRequest $request): array
+    {
+        $augmentation = $request->augmentation;
+
+        return [
+            'messages'         => array_map(
+                static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m,
+                $request->messages,
+            ),
+            // The FULL initiating actor (ADR-083), not just its backend-user id:
+            // a worker rehydrating this run must authorise with the identity that
+            // enqueued the work — admin flag, groups, service account — rather
+            // than the worker's absent ambient BE user.
+            'actor'            => $request->actor->toArray(),
+            'allowedToolNames' => $request->allowedToolNames,
+            'options'          => $request->options?->toArray(),
+            // ToolOptions::toArray() deliberately excludes the budget fields and
+            // the idempotency key (they are not provider API fields), but a
+            // queued run's budget PRE-FLIGHT has not happened yet — unlike the
+            // ADR-084 resume case that exclusion was designed for. Carry them
+            // out-of-band so run() and enqueue()+runQueued() of the same
+            // request hit the identical budget gate and dedup.
+            'plannedCost'      => $request->options?->getPlannedCost(),
+            'idempotencyKey'   => $request->options?->getIdempotencyKey(),
+            'maxIterations'    => $request->maxIterations,
+            'captureRaw'       => $request->captureRaw,
+            // null stays null: a non-null augmentation makes the loop bake the
+            // effective system prompt into the transcript (ADR-060 assembly),
+            // which a null-augmentation run() would not do — losing the
+            // distinction would silently change the prompt composition.
+            'augmentation'     => $augmentation === null ? null : [
+                'forcedSkillUids'   => array_values(array_filter(array_map(
+                    static fn(Skill $skill): int => $skill->getUid() ?? 0,
+                    $augmentation->forcedSkills,
+                ))),
+                'forcedSnippetUids' => array_values(array_filter(array_map(
+                    static fn(PromptSnippet $snippet): int => $snippet->getUid() ?? 0,
+                    $augmentation->forcedSnippets,
+                ))),
+                'dryRun'            => $augmentation->dryRun,
+            ],
+        ];
+    }
+
+    /**
+     * Rebuild the request from a claimed queued row (ADR-102). The
+     * configuration and the forced skills/snippets are re-loaded by uid — a
+     * configuration deleted while the run was queued fails the run, and a
+     * skill/snippet deleted meanwhile is simply no longer forced (the same
+     * live-resolution semantics the interactive path has).
+     */
+    public function rehydrate(AgentRun $run): AgentRunRequest
+    {
+        // The same typed absence approve() reports — here it is caught by
+        // runQueued()'s rehydration guard, which settles the run FAILED with a
+        // meaningful error class instead of letting it escape.
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw RunConfigurationGoneException::forRun($run->uuid);
+        }
+
+        $data = json_decode($run->queuedRequest ?? '', true);
+        if (!is_array($data)) {
+            throw new RuntimeException(sprintf('The stored request of queued run %s could not be decoded', $run->uuid), 2826462004);
+        }
+
+        $messages = [];
+        foreach (is_array($data['messages'] ?? null) ? $data['messages'] : [] as $message) {
+            if (is_array($message)) {
+                /** @var array<string, mixed> $message */
+                $messages[] = $message;
+            }
+        }
+
+        $allowed = null;
+        if (is_array($data['allowedToolNames'] ?? null)) {
+            $allowed = array_values(array_filter($data['allowedToolNames'], is_string(...)));
+        }
+
+        $options = null;
+        if (is_array($data['options'] ?? null)) {
+            /** @var array<string, mixed> $optionsData */
+            $optionsData = $data['options'];
+            // The initiator on the run row attributes the budget pre-flight,
+            // exactly as the interactive path does.
+            $options = ToolOptions::fromArray($optionsData, $run->beUser !== 0 ? $run->beUser : null);
+            // Re-inject the out-of-band budget/idempotency fields (see
+            // dehydrateRequest()): a queued run's budget pre-flight must be as
+            // strict as the direct path's, and its provider calls as
+            // deduplicatable.
+            $plannedCost = $data['plannedCost'] ?? null;
+            if (is_float($plannedCost) || is_int($plannedCost)) {
+                $options = $options->withPlannedCost((float)$plannedCost);
+            }
+            $idempotencyKey = $data['idempotencyKey'] ?? null;
+            if (is_string($idempotencyKey) && $idempotencyKey !== '') {
+                $options = $options->withIdempotencyKey($idempotencyKey);
+            }
+        }
+
+        $augmentation = null;
+        if (is_array($data['augmentation'] ?? null)) {
+            $augmentationData = $data['augmentation'];
+            $augmentation     = new RunAugmentation(
+                forcedSkills: $this->skillsByUids($this->uidList($augmentationData['forcedSkillUids'] ?? null)),
+                forcedSnippets: $this->snippetsByUids($this->uidList($augmentationData['forcedSnippetUids'] ?? null)),
+                dryRun: ($augmentationData['dryRun'] ?? false) === true,
+            );
+        }
+
+        // Restore the full initiating actor from the serialised request. A row
+        // queued before actors were persisted has no 'actor' key: fall back to
+        // the stored be_user id (the same single-int identity the pre-actor
+        // worker had), so an in-flight upgrade never loses or invents privilege.
+        $actorData = $data['actor'] ?? null;
+        if (is_array($actorData)) {
+            /** @var array<string, mixed> $actorData a serialised actor is a JSON object (string keys) */
+            $actor = AiActorContext::fromArray($actorData);
+        } else {
+            $actor = AiActorContext::backendUser($run->beUser);
+        }
+
+        return new AgentRunRequest(
+            configuration: $configuration,
+            messages: $messages,
+            actor: $actor,
+            allowedToolNames: $allowed,
+            options: $options,
+            maxIterations: is_int($data['maxIterations'] ?? null) ? $data['maxIterations'] : null,
+            augmentation: $augmentation,
+            captureRaw: ($data['captureRaw'] ?? false) === true,
+        );
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function uidList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $uids = [];
+        foreach ($value as $uid) {
+            if (is_int($uid) && $uid > 0) {
+                $uids[] = $uid;
+            }
+        }
+
+        return $uids;
+    }
+
+    /**
+     * Forced skills by uid, preserving order. Resolved without the enabled
+     * filter — forcing a skill overrides its global toggle, the same semantics
+     * the playground's force-inject control has.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<Skill>
+     */
+    private function skillsByUids(array $uids): array
+    {
+        if ($uids === [] || $this->skillRepository === null) {
+            return [];
+        }
+
+        $byUid = [];
+        foreach ($this->skillRepository->findAll() as $skill) {
+            if ($skill instanceof Skill && $skill->getUid() !== null) {
+                $byUid[$skill->getUid()] = $skill;
+            }
+        }
+
+        $skills = [];
+        foreach ($uids as $uid) {
+            if (isset($byUid[$uid])) {
+                $skills[] = $byUid[$uid];
+            }
+        }
+
+        return $skills;
+    }
+
+    /**
+     * @param list<int> $uids
+     *
+     * @return list<PromptSnippet>
+     */
+    private function snippetsByUids(array $uids): array
+    {
+        if ($uids === [] || $this->promptSnippetRepository === null) {
+            return [];
+        }
+
+        return $this->promptSnippetRepository->findByUids($uids);
+    }
+}

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -12,7 +12,6 @@ namespace Netresearch\NrLlm\Service\Agent;
 use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
-use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -21,28 +20,20 @@ use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
-use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
-use Netresearch\NrLlm\Exception\GuardrailViolationException;
-use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunCancellationRequestedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunLeaseLostException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
-use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
-use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
-use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\InputSchema;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
@@ -139,7 +130,28 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // builds one over the persister, logger and bus this runtime holds,
         // which is exactly what it was constructed with before.
         private ?QueuedRunFailureRecovery $failureRecovery = null,
+        // Drives a run from its first round to a settled outcome (ADR-084's
+        // catch order, ADR-103's cancellation probe, ADR-104's lease, ADR-111's
+        // write fence). Optional for the same reason as the collaborators
+        // above; a null builds one over the tool loop, persister, logger and
+        // the two resolvers this runtime already holds.
+        private ?AgentRunExecutor $runExecutor = null,
     ) {}
+
+    /**
+     * The executor for a run's lifecycle, falling back to one built from this
+     * runtime's own collaborators when none was injected.
+     */
+    private function runExecutor(): AgentRunExecutor
+    {
+        return $this->runExecutor ?? new AgentRunExecutor(
+            $this->toolLoop,
+            $this->persister,
+            $this->logger,
+            $this->actingBackendUserResolver,
+            $this->toolEffectResolver,
+        );
+    }
 
     /**
      * The recovery for a failed queued run, falling back to one built from this
@@ -159,24 +171,11 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         return $this->requestCodec ?? new AgentRunRequestCodec($this->configurationRepository);
     }
 
-    /**
-     * Build the tool-execution context for a run from its explicit actor: the
-     * one place the actor becomes a live acting backend user, identically on the
-     * synchronous and worker paths (ADR-083), so no tool reads the ambient
-     * `$GLOBALS['BE_USER']`.
-     */
-    private function toolContext(AiActorContext $actor): ToolExecutionContext
-    {
-        $resolver = $this->actingBackendUserResolver ?? new ActingBackendUserResolver();
-
-        return new ToolExecutionContext($actor, $resolver->resolve($actor));
-    }
-
     public function run(AgentRunRequest $request, ?Closure $onStep = null): AgentRunResult
     {
         $handle = $this->persister->begin($request->configuration, $request->actor->backendUserUid);
 
-        return $this->executeRequest($request, $handle, $onStep);
+        return $this->runExecutor()->executeRequest($request, $handle, $onStep);
     }
 
     public function enqueue(AgentRunRequest $request): string
@@ -285,54 +284,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             return $this->failureRecovery()->recover($handle, $runUuid, $workerIdentity, $e, $steps);
         };
 
-        return $this->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
-    }
-
-    /**
-     * The shared execution path behind {@see run()} and {@see runQueued()}:
-     * clamp the round cap, build the trace, drive the ladder.
-     *
-     * A queued run passes its worker identity as $leaseOwner (so each step
-     * boundary renews the lease and detects a reaper reclaim, ADR-104) and a
-     * $recover closure that decides retry-vs-dead-letter for a failure. An
-     * interactive run() passes neither: it holds no lease and surfaces failures
-     * to its caller unchanged.
-     *
-     * @param (Closure(RunStep): void)|null                             $onStep
-     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
-     */
-    private function executeRequest(
-        AgentRunRequest $request,
-        ?AgentRunHandle $handle,
-        ?Closure $onStep,
-        ?string $leaseOwner = null,
-        ?Closure $recover = null,
-    ): AgentRunResult {
-        $maxIterations = $request->maxIterations !== null
-            ? min($request->maxIterations, self::MAX_ITERATIONS)
-            : null;
-
-        $trace = $this->trace($handle, $onStep, $request->captureRaw, $leaseOwner);
-        // Resolve the run's explicit actor to a live acting backend user ONCE,
-        // identically whether this runs synchronously or in a worker (ADR-083).
-        $context = $this->toolContext($request->actor);
-
-        return $this->execute(
-            $handle,
-            $trace,
-            fn(): ToolLoopResult => $this->toolLoop->runLoop(
-                $request->messages,
-                $request->configuration,
-                $context,
-                $request->allowedToolNames,
-                $request->options,
-                $maxIterations,
-                $trace,
-                $request->augmentation,
-            ),
-            $recover,
-            $leaseOwner,
-        );
+        return $this->runExecutor()->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
     }
 
     /**
@@ -402,18 +354,16 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // who approved or denied, before the continuation's own events.
         $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
 
-        $trace = $this->trace($handle, $onStep, false);
         // Tools resume under the RUN OWNER's identity (ADR-083), not whoever is
         // approving: the owner is who the queued work acts for. Reconstructed
         // from the run row's initiating uid — the same fallback the request codec
         // uses — and resolved to a live user, so authorization is identical to
         // the original synchronous/worker execution.
-        $context = $this->toolContext(AiActorContext::backendUser($run->beUser));
-
-        return $this->execute(
+        return $this->runExecutor()->executeResume(
             $handle,
-            $trace,
-            fn(): ToolLoopResult => $this->toolLoop->resume(
+            $onStep,
+            AiActorContext::backendUser($run->beUser),
+            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resume(
                 $state,
                 $decision->approved,
                 $configuration,
@@ -488,15 +438,13 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // submitted, before the continuation's own events — never the values.
         $this->persister->recordInput($handle, $submission->submittedByBeUser);
 
-        $trace = $this->trace($handle, $onStep, false);
         // Tools resume under the RUN OWNER's identity (ADR-083), not the
         // submitter — same rule as approve().
-        $context = $this->toolContext(AiActorContext::backendUser($run->beUser));
-
-        return $this->execute(
+        return $this->runExecutor()->executeResume(
             $handle,
-            $trace,
-            fn(): ToolLoopResult => $this->toolLoop->resumeWithInput(
+            $onStep,
+            AiActorContext::backendUser($run->beUser),
+            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resumeWithInput(
                 $state,
                 $submission->data,
                 $configuration,
@@ -544,110 +492,6 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     }
 
     /**
-     * The trace every segment runs under: each recorded step reaches the live
-     * observer FIRST (preserving the streaming path's emit-before-persist
-     * order — a step is shown even when its persist fails), then the persisted
-     * event stream — and then the cancellation probe runs (ADR-103).
-     *
-     * The probe is what makes {@see cancel()} cooperative: the loop itself
-     * stays persistence-unaware (ADR-081), but every step boundary — after a
-     * provider response, after each tool execution, before the next round —
-     * records a step, and the probe checks the run row there. A run cancelled
-     * mid-flight therefore stops before the NEXT provider call or tool
-     * execution instead of running to completion with its outcome discarded.
-     * The step that just happened is still emitted and persisted: the audit
-     * stream stays complete up to the abort point. One indexed row read per
-     * step; steps are provider-call-slow, so the cost is negligible.
-     *
-     * For a queued run $leaseOwner is this worker's identity (ADR-104): after
-     * the cancellation check, the lease is renewed under an ownership guard
-     * BEFORE the step is persisted. If the renewal affects no row the worker no
-     * longer owns the run — the reaper reclaimed it and another worker may hold
-     * it now — so it stops WITHOUT writing the step, which would otherwise
-     * collide with the new owner's stream. Interactive runs pass null and never
-     * renew (they hold no lease).
-     *
-     * @param (Closure(RunStep): void)|null $onStep
-     */
-    private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw, ?string $leaseOwner = null): RunTrace
-    {
-        if ($handle === null && $onStep === null) {
-            return new RunTrace(captureRaw: $captureRaw);
-        }
-
-        return new RunTrace(
-            captureRaw: $captureRaw,
-            onRecord: function (RunStep $step) use ($handle, $onStep, $leaseOwner): void {
-                // The live observer sees the step FIRST (emit-before-persist),
-                // so a step is shown even when its persistence or the checks
-                // below abort the loop.
-                if ($onStep !== null) {
-                    $onStep($step);
-                }
-                if ($handle === null) {
-                    return;
-                }
-
-                // A single indexed read drives the cancellation probe (ADR-103).
-                // findRun is fail-soft (null on a store hiccup), so a read
-                // failure can never fabricate a cancellation.
-                if ($this->persister->findRun($handle->uuid)?->statusEnum() === AgentRunStatus::CANCELLED) {
-                    // Persist the step that already happened, then stop: the
-                    // audit stream stays complete up to the abort point. A
-                    // writing tool whose audit cannot be stored fails the run
-                    // (ADR-111) even mid-cancel — an unrecorded mutation is the
-                    // more serious condition than the cancellation.
-                    $this->recordStepFailClosedForWrites($handle, $step);
-
-                    throw RunCancellationRequestedException::forRun($handle->uuid);
-                }
-
-                // Heartbeat + lease-lost guard for a worker run (ADR-104). The
-                // renewal's ownership guard is the atomic check: 0 rows means
-                // the run was reclaimed/re-claimed/terminated — stop WITHOUT
-                // recording the step, so a zombie worker cannot append an event
-                // whose sequence collides with the new owner's stream. A completed
-                // WRITE step also CLEARS the in-flight fence set before it ran
-                // (ADR-111) in the same guarded write.
-                if ($leaseOwner !== null && !$this->renewOrClearFence($handle, $leaseOwner, $step)) {
-                    throw RunLeaseLostException::forRun($handle->uuid);
-                }
-
-                $this->recordStepFailClosedForWrites($handle, $step);
-            },
-            onBeforeTool: $leaseOwner === null || $handle === null ? null : function (string $toolName) use ($handle, $leaseOwner): void {
-                // Fence a WRITE before it runs (ADR-111): stamp its effect and
-                // renew the lease so a reap mid non-idempotent-write dead-letters
-                // instead of retrying. Read-only tools need no fence — repeating
-                // them is always safe. A lost lease stops the worker before the
-                // side effect, exactly like the heartbeat guard.
-                $effect = $this->toolEffectResolver?->effectFor($toolName) ?? ToolEffect::READ_ONLY;
-                if ($effect->isWrite()
-                    && !$this->persister->markPendingEffect($handle, $leaseOwner, $effect->value, time() + self::LEASE_SECONDS)
-                ) {
-                    throw RunLeaseLostException::forRun($handle->uuid);
-                }
-            },
-        );
-    }
-
-    /**
-     * Renew the lease at a step boundary and, for a completed WRITE step, clear
-     * the in-flight fence its {@see RunTrace::beforeToolExecution()} set — both in
-     * one ownership-guarded write (ADR-111). Returns false when the worker has
-     * lost the run, so the caller stops before recording the step.
-     */
-    private function renewOrClearFence(AgentRunHandle $handle, string $leaseOwner, RunStep $step): bool
-    {
-        $leaseExpires = time() + self::LEASE_SECONDS;
-        if ($this->stepEffect($step)->isWrite()) {
-            return $this->persister->markPendingEffect($handle, $leaseOwner, '', $leaseExpires);
-        }
-
-        return $this->persister->renewLease($handle, $leaseOwner, $leaseExpires);
-    }
-
-    /**
      * Whether a run may be retried given the effect fence in flight when it
      * failed (ADR-111). Empty (no tool fenced) or an unrecognised value is safe;
      * only a fenced NON_IDEMPOTENT_WRITE — a side effect that must not repeat —
@@ -658,264 +502,4 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         return ToolEffect::tryFrom($pendingEffect)?->isSafeToRetry() ?? true;
     }
 
-    /**
-     * Persist a step, failing the run when a WRITING tool's audit event could
-     * not be stored (ADR-111). Read-only and non-tool steps stay fail-soft: a
-     * store hiccup is logged inside {@see AgentRunPersister::recordStep()} and
-     * the run continues. A write is different — an unrecorded mutation must not
-     * be waved through, so it throws {@see AuditPersistenceFailedException}
-     * (non-retryable: the write already ran once).
-     */
-    private function recordStepFailClosedForWrites(AgentRunHandle $handle, RunStep $step): void
-    {
-        $persisted = $this->persister->recordStep($handle, $step);
-        if (!$persisted && $this->stepEffect($step)->isWrite()) {
-            throw AuditPersistenceFailedException::forRun($handle->uuid, $step->toolName ?? '');
-        }
-    }
-
-    /**
-     * The side effect of the tool a step recorded (ADR-111). Only KIND_TOOL
-     * steps carry an effect; everything else is read-only. A tool name that no
-     * longer resolves is treated as the strictest effect (fail-closed), and a
-     * runtime built without the resolver (bare positional test wiring only)
-     * treats every tool as read-only.
-     */
-    private function stepEffect(RunStep $step): ToolEffect
-    {
-        if ($step->kind !== RunStep::KIND_TOOL || $this->toolEffectResolver === null) {
-            return ToolEffect::READ_ONLY;
-        }
-
-        return $this->toolEffectResolver->effectFor($step->toolName ?? '');
-    }
-
-    /**
-     * The single lifecycle ladder (ADR-101; previously copied three times in
-     * the playground controller).
-     *
-     * Every branch both settles the persisted row and marks the run settled so
-     * the finally-guard cannot touch it — including a SUCCESSFUL suspension:
-     * WAITING_FOR_APPROVAL is non-terminal, so an unguarded finally-settle
-     * would flip a resumable run to FAILED and destroy its suspended state.
-     * The finally-guard exists for the abandoned-run case (a live-stream
-     * observer dying mid-run, mirroring StreamingDispatcher) and costs the
-     * settled paths nothing.
-     *
-     * A queued run passes a $recover closure (ADR-104): in the generic failure
-     * arm, before the default settleFailed, it decides retry-vs-dead-letter and,
-     * when it handles the failure, returns the outcome that replaces FAILED.
-     *
-     * @param Closure(): ToolLoopResult                                 $loopCall
-     * @param (Closure(Throwable, list<RunStep>): ?AgentRunResult)|null $recover
-     */
-    private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null, ?string $ownerGuard = null): AgentRunResult
-    {
-        $runUuid = $handle !== null ? $handle->uuid : '';
-        $settled = false;
-
-        try {
-            $result = $loopCall();
-
-            if ($handle !== null) {
-                $settledOk = $this->persister->settleCompleted($handle, $result, $ownerGuard);
-                // Ownership-guarded on the queued path: if the run was reclaimed
-                // to another worker mid-loop, this completion must not overwrite
-                // its state — stop as LEASE_LOST rather than reporting COMPLETED.
-                if ($ownerGuard !== null && !$settledOk) {
-                    $settled = true;
-
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps());
-                }
-            }
-            $settled = true;
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::COMPLETED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                loopResult: $result,
-            );
-        } catch (RunCancellationRequestedException $cancelled) {
-            // ADR-103: the operator's cancel already won the guarded terminal
-            // transition — the row IS CANCELLED and its late settle would be
-            // discarded anyway, so none is attempted. Control flow, not
-            // failure: the loop stopped cooperatively at a step boundary.
-            $settled = true;
-            $this->logger?->info('Agent run stopped cooperatively after being cancelled', ['run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::CANCELLED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                error: $cancelled,
-            );
-        } catch (ToolApprovalRequiredException $approval) {
-            // ADR-084: a called tool requires human approval — control flow,
-            // not failure. Persist the suspended state so a later approve()
-            // can continue. Both branches below settle the run's fate, so the
-            // finally-guard must not run either way.
-            $settled = true;
-
-            if ($handle !== null && $this->persister->suspend($handle, $approval->state)) {
-                return new AgentRunResult(
-                    outcome: AgentRunOutcome::AWAITING_APPROVAL,
-                    runUuid: $runUuid,
-                    steps: $trace->getSteps(),
-                    suspendedState: $approval->state,
-                );
-            }
-
-            // Fail-closed (ADR-092): an approval-gated tool is side-effecting.
-            // Without stored state — the store refused or errored, a concurrent
-            // cancel already terminated the row, or the run was never persisted
-            // at all (null handle) — there is nothing to resume, so promising
-            // an approval flow would strand the client. Applied on EVERY path
-            // since ADR-101 (the old code silently ignored a failed
-            // re-suspension AND announced awaiting-approval for unpersisted
-            // runs).
-            if ($handle !== null) {
-                // Ownership-guarded so a reclaimed queued run is not clobbered by
-                // this worker's fail-closed settle.
-                $this->persister->settleFailed($handle, $approval, $ownerGuard);
-            }
-            $this->logger?->error('Agent run could not be suspended for approval; no resume is possible', ['run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::SUSPEND_FAILED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                error: $approval,
-            );
-        } catch (ToolInputRequiredException $input) {
-            // ADR-105: a called tool requires typed user input — control flow,
-            // not failure (the input sibling of the approval arm above). Must be
-            // caught before the guardrail pair and the generic Throwable so a
-            // suspension is never recorded as a failed run. Both branches settle
-            // the run's fate, so $settled=true keeps the finally-guard off — a
-            // successfully-suspended WAITING_FOR_INPUT row is non-terminal and
-            // must not be flipped to FAILED.
-            $settled = true;
-
-            if ($handle !== null && $this->persister->suspendForInput($handle, $input->state)) {
-                return new AgentRunResult(
-                    outcome: AgentRunOutcome::AWAITING_INPUT,
-                    runUuid: $runUuid,
-                    steps: $trace->getSteps(),
-                    suspendedState: $input->state,
-                );
-            }
-
-            // Fail-closed (ADR-092/105): without stored state — the store
-            // refused or errored, a concurrent cancel terminated the row, or the
-            // run was never persisted (null handle) — there is nothing to resume,
-            // so promising an input flow would strand the client.
-            if ($handle !== null) {
-                // Ownership-guarded so a reclaimed queued run is not clobbered by
-                // this worker's fail-closed settle.
-                $this->persister->settleFailed($handle, $input, $ownerGuard);
-            }
-            $this->logger?->error('Agent run could not be suspended for input; no resume is possible', ['run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::SUSPEND_FAILED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                error: $input,
-            );
-        } catch (GuardrailViolationException|GuardrailApprovalRequiredException $guardrail) {
-            // ADR-085/086: a guardrail verdict is a policy outcome, not a
-            // failure — and an approval that was required but never obtained
-            // is not recorded as an outright denial (ADR-092).
-            if ($handle !== null) {
-                $settledOk = $this->persister->settlePolicyStopped(
-                    $handle,
-                    $guardrail,
-                    $guardrail instanceof GuardrailApprovalRequiredException
-                        ? AgentRunTerminationReason::APPROVAL_DENIED
-                        : AgentRunTerminationReason::POLICY_DENIED,
-                    $ownerGuard,
-                );
-                // Ownership-guarded on the queued path: a run reclaimed to
-                // another worker must not be flipped to a policy-stopped terminal
-                // by this zombie worker — stop as LEASE_LOST.
-                if ($ownerGuard !== null && !$settledOk) {
-                    $settled = true;
-                    $this->logger?->notice('Guardrail-stopped queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
-
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $guardrail);
-                }
-            }
-            $settled = true;
-            $this->logger?->warning('Agent run blocked by guardrail', ['exception' => $guardrail, 'run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: $guardrail instanceof GuardrailApprovalRequiredException
-                    ? AgentRunOutcome::GUARDRAIL_APPROVAL_REQUIRED
-                    : AgentRunOutcome::GUARDRAIL_BLOCKED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                guardrailClass: $guardrail->guardrail,
-                error: $guardrail,
-            );
-        } catch (RunLeaseLostException $leaseLost) {
-            // ADR-104: the reaper reclaimed this run (or a cancel/settle won) and
-            // it belongs to another worker now. Stop WITHOUT settling — any
-            // settle here could destroy the new owner's in-flight state. Not a
-            // failure of the run; a loss of ownership by this worker.
-            $settled = true;
-            $this->logger?->info('Agent run worker lost its lease; stopping without settling', ['run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::LEASE_LOST,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                error: $leaseLost,
-            );
-        } catch (Throwable $e) {
-            // A queued run's recover closure decides retry-vs-dead-letter and,
-            // when it handles the failure, settles the row itself and returns
-            // the replacement outcome. Only an interactive run (no recover) or a
-            // recover that declines (null) falls through to the default settle.
-            if ($recover !== null) {
-                $recovery = $recover($e, $trace->getSteps());
-                if ($recovery instanceof AgentRunResult) {
-                    $settled = true;
-
-                    return $recovery;
-                }
-            }
-
-            if ($handle !== null) {
-                $settledOk = $this->persister->settleFailed($handle, $e, $ownerGuard);
-                if ($ownerGuard !== null && !$settledOk) {
-                    $settled = true;
-                    $this->logger?->notice('Failed queued run was reclaimed; leaving it to its new owner', ['run' => $runUuid]);
-
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $e);
-                }
-            }
-            $settled = true;
-            $this->logger?->error('Agent run failed', ['exception' => $e, 'run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::FAILED,
-                runUuid: $runUuid,
-                steps: $trace->getSteps(),
-                error: $e,
-            );
-        } finally {
-            // A live-stream observer dying mid-run (client disconnect) can
-            // abandon the run before any branch settles it; mark it failed so
-            // no run is left stuck RUNNING. Mirrors StreamingDispatcher's
-            // finally-block settle. Guarded by $settled: a suspended run is
-            // WAITING_FOR_APPROVAL or WAITING_FOR_INPUT — both non-terminal — and
-            // settling it here would destroy its resumable state.
-            if ($handle !== null && !$settled) {
-                // Ownership-guarded so this safety-net settle cannot clobber a
-                // queued run the reaper reclaimed to another worker.
-                $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'), $ownerGuard);
-            }
-        }
-    }
 }

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -10,39 +10,18 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Agent;
 
 use Closure;
-use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
-use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
-use Netresearch\NrLlm\Domain\ValueObject\RunStep;
-use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
-use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
-use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
-use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
-use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
-use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
-use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
-use Netresearch\NrLlm\Service\Tool\InputSchema;
-use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
-use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Throwable;
 
 /**
  * The one place the agent-run lifecycle lives (ADR-101).
@@ -136,7 +115,47 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // above; a null builds one over the tool loop, persister, logger and
         // the two resolvers this runtime already holds.
         private ?AgentRunExecutor $runExecutor = null,
+        // Puts a run on the queue and picks it back up in a worker (ADR-102).
+        // Optional like the collaborators above; a null builds one over the
+        // same persister, codec, executor, recovery, logger and bus.
+        private ?QueuedRunCoordinator $queueCoordinator = null,
+        // Picks a suspended run back up on an approval or a submitted input
+        // (ADR-084/105). Optional like the collaborators above; a null builds
+        // one over the same persister, configuration repository, tool loop,
+        // executor and schema validator.
+        private ?ResumeCoordinator $resumeCoordinator = null,
     ) {}
+
+    /**
+     * The resume coordinator, falling back to one built from this runtime's own
+     * collaborators when none was injected.
+     */
+    private function resumeCoordinator(): ResumeCoordinator
+    {
+        return $this->resumeCoordinator ?? new ResumeCoordinator(
+            $this->persister,
+            $this->configurationRepository,
+            $this->toolLoop,
+            $this->runExecutor(),
+            $this->schemaValidator,
+        );
+    }
+
+    /**
+     * The queue coordinator, falling back to one built from this runtime's own
+     * collaborators when none was injected.
+     */
+    private function queueCoordinator(): QueuedRunCoordinator
+    {
+        return $this->queueCoordinator ?? new QueuedRunCoordinator(
+            $this->persister,
+            $this->requestCodec(),
+            $this->runExecutor(),
+            $this->failureRecovery(),
+            $this->logger,
+            $this->messageBus,
+        );
+    }
 
     /**
      * The executor for a run's lifecycle, falling back to one built from this
@@ -180,280 +199,22 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
     public function enqueue(AgentRunRequest $request): string
     {
-        if ($this->messageBus === null) {
-            throw RunEnqueueFailedException::forRun('');
-        }
-
-        try {
-            $requestJson = json_encode(
-                $this->requestCodec()->dehydrate($request),
-                JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
-            );
-        } catch (Throwable $e) {
-            // A non-encodable payload value (INF/NAN in a raw message array)
-            // must surface as the interface's documented failure type, not a
-            // bare JsonException. Nothing was stored yet — no cleanup needed.
-            $this->logger?->error('Agent run request could not be serialised for the queue', ['exception' => $e]);
-
-            throw RunEnqueueFailedException::forRun('');
-        }
-
-        // Fail-closed, unlike run(): a live run can proceed unpersisted, but a
-        // queued run without a stored row simply does not exist.
-        $handle = $this->persister->enqueue($request->configuration, $request->actor->backendUserUid, $requestJson);
-        if ($handle === null) {
-            throw RunEnqueueFailedException::forRun('');
-        }
-
-        try {
-            // The wake-up call. On the default SyncTransport the run executes
-            // right here; routed to the doctrine transport it executes in
-            // messenger:consume. The claim makes a duplicate dispatch harmless.
-            $this->messageBus->dispatch(new AgentRunQueuedMessage($handle->uuid));
-        } catch (Throwable $e) {
-            // On an async transport a failed dispatch would strand the row
-            // QUEUED forever (no message will ever arrive) — settle it failed
-            // so no orphan is left behind. On the sync transport a handler
-            // failure never reaches here (runQueued() settles outcomes itself
-            // and does not throw), so this is genuinely the transport failing.
-            $this->persister->settleFailed($handle, $e);
-            $this->logger?->error('Queued agent run could not be dispatched; the run was failed', ['run' => $handle->uuid, 'exception' => $e]);
-
-            throw RunEnqueueFailedException::forRun($handle->uuid);
-        }
-
-        return $handle->uuid;
+        return $this->queueCoordinator()->enqueue($request);
     }
 
     public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult
     {
-        $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::QUEUED || $run->queuedRequest === null) {
-            return null;
-        }
-
-        // Exactly one worker wins the guarded QUEUED -> RUNNING transition; a
-        // run cancelled while waiting is terminal and unclaimable (ADR-102).
-        $workerIdentity = $this->workerIdentity();
-        if (!$this->persister->claimQueued($run, $workerIdentity, time() + self::LEASE_SECONDS)) {
-            return null;
-        }
-
-        // Resolve the event-stream position from a FRESH row AFTER the claim.
-        // A first execution has no events (MAX = -1 -> sequence 0, identical to
-        // before ADR-104); a REQUEUED run carries the prior attempt's events, so
-        // starting at 0 would reuse sequences and corrupt the stream. Fail-closed
-        // like approve(): a null position settles the run FAILED rather than
-        // stranding it RUNNING (the claim is already won).
-        $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
-            $fallback = new AgentRunHandle($run->uid, $run->uuid);
-            $this->persister->settleFailed(
-                $fallback,
-                new RuntimeException(sprintf('The event-stream position of queued run %s could not be determined after the claim', $runUuid), 1784900002),
-            );
-            $this->logger?->error('Queued agent run position could not be resolved after the claim; the run was failed', ['run' => $runUuid]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::FAILED,
-                runUuid: $runUuid,
-                steps: [],
-                error: new RuntimeException('The event-stream position could not be determined after the queue claim', 1784900002),
-            );
-        }
-
-        try {
-            $request = $this->requestCodec()->rehydrate($run);
-        } catch (Throwable $e) {
-            $this->persister->settleFailed($handle, $e);
-            $this->logger?->error('Queued agent run could not be rehydrated; the run was failed', ['run' => $runUuid, 'exception' => $e]);
-
-            return new AgentRunResult(
-                outcome: AgentRunOutcome::FAILED,
-                runUuid: $runUuid,
-                steps: [],
-                error: $e,
-            );
-        }
-
-        // The heartbeat renews the lease under this worker's identity, and the
-        // recover closure decides retry-vs-dead-letter for a failure (ADR-104).
-        $recover = function (Throwable $e, array $steps) use ($handle, $runUuid, $workerIdentity): AgentRunResult {
-            /** @var list<RunStep> $steps the ladder always passes the accumulated step list */
-            return $this->failureRecovery()->recover($handle, $runUuid, $workerIdentity, $e, $steps);
-        };
-
-        return $this->runExecutor()->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
-    }
-
-    /**
-     * Which worker claimed a queued run — host + pid, for lease diagnostics.
-     */
-    private function workerIdentity(): string
-    {
-        $host = gethostname();
-
-        return substr(($host !== false ? $host : 'unknown') . ':' . getmypid(), 0, 64);
+        return $this->queueCoordinator()->runQueued($runUuid, $onStep);
     }
 
     public function approve(AiActorContext $actor, string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
     {
-        $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
-            throw RunNotAwaitingApprovalException::forRun($runUuid);
-        }
-        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
-            throw RunAccessDeniedException::forActor($actor, $runUuid);
-        }
-
-        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
-        if ($configuration === null) {
-            throw RunConfigurationGoneException::forRun($runUuid);
-        }
-
-        $decoded = json_decode($run->suspendedState, true);
-        if (!is_array($decoded)) {
-            throw CorruptSuspendedStateException::forRun($runUuid);
-        }
-        /** @var array<string, mixed> $decoded */
-        $state = SuspendedRunState::fromArray($decoded);
-
-        // Probe the event-stream position BEFORE the claim: a failure here
-        // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
-        // the approval can simply be retried (nothing was claimed or executed).
-        if ($this->persister->resumeHandle($run) === null) {
-            throw RunStateUnavailableException::forRun($runUuid);
-        }
-
-        // Atomically claim the run before executing its pending (approval-gated,
-        // possibly destructive) tool calls, so two concurrent Approve requests
-        // cannot both run them (ADR-084). Fail-closed on a store error too.
-        if (!$this->persister->claimResume($run)) {
-            throw RunAlreadyResumingException::forRun($runUuid);
-        }
-
-        // Re-resolve the position from a FRESH row snapshot AFTER winning the
-        // claim: a request that stalled between findRun and the claim may hold
-        // a stale position from before another approval's continuation
-        // appended events — writing there would duplicate sequences and
-        // interleave segments. The claim is won, so a failure now settles the
-        // run rather than stranding it RUNNING (fail-closed either way).
-        $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
-            $this->persister->settleFailed(
-                new AgentRunHandle($run->uid, $run->uuid),
-                new RuntimeException('The event-stream position could not be determined after the resume claim'),
-            );
-
-            throw RunStateUnavailableException::forRun($runUuid);
-        }
-
-        // The decision is part of the run's audit stream (best-effort, ADR-101):
-        // who approved or denied, before the continuation's own events.
-        $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
-
-        // Tools resume under the RUN OWNER's identity (ADR-083), not whoever is
-        // approving: the owner is who the queued work acts for. Reconstructed
-        // from the run row's initiating uid — the same fallback the request codec
-        // uses — and resolved to a live user, so authorization is identical to
-        // the original synchronous/worker execution.
-        return $this->runExecutor()->executeResume(
-            $handle,
-            $onStep,
-            AiActorContext::backendUser($run->beUser),
-            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resume(
-                $state,
-                $decision->approved,
-                $configuration,
-                $context,
-                null,
-                $trace,
-                $decision->decidedByBeUser,
-            ),
-        );
+        return $this->resumeCoordinator()->approve($actor, $runUuid, $decision, $onStep);
     }
 
     public function submitInput(AiActorContext $actor, string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
     {
-        $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
-            throw RunNotAwaitingInputException::forRun($runUuid);
-        }
-        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
-            throw RunAccessDeniedException::forActor($actor, $runUuid);
-        }
-
-        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
-        if ($configuration === null) {
-            throw RunConfigurationGoneException::forRun($runUuid);
-        }
-
-        $decoded = json_decode($run->suspendedState, true);
-        if (!is_array($decoded)) {
-            throw CorruptSuspendedStateException::forRun($runUuid);
-        }
-        /** @var array<string, mixed> $decoded */
-        $state = SuspendedRunState::fromArray($decoded);
-
-        // Well-formedness gate (ADR-105 M2): an input suspension with no target
-        // tool or a degenerate schema is corruption, never "accept anything".
-        // validate($data, []) returns true, so this path must be unreachable
-        // before the validation below — a corrupt row is a 500, not resumable.
-        if ($state->inputToolName === null || $state->inputToolName === '' || !InputSchema::isUsable($state->inputSchema)) {
-            throw CorruptSuspendedStateException::forRun($runUuid);
-        }
-
-        // DIVERGENCE from approve() (ADR-105): validate the submission BEFORE
-        // probing or claiming. A rejection leaves the run WAITING_FOR_INPUT with
-        // nothing claimed and no event recorded, so the user can simply resubmit.
-        $validator = $this->schemaValidator ?? new JsonSchemaValidator();
-        if (!$validator->validate($submission->data, $state->inputSchema)) {
-            throw InvalidInputSubmissionException::forRun($runUuid);
-        }
-
-        // From here the flow is identical to approve(): probe-before-claim,
-        // atomic claim, re-resolve the stream position from a fresh row.
-        if ($this->persister->resumeHandle($run) === null) {
-            throw RunStateUnavailableException::forRun($runUuid);
-        }
-
-        if (!$this->persister->claimResumeFromInput($run)) {
-            throw RunAlreadyResumingException::forRun($runUuid);
-        }
-
-        $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
-            $this->persister->settleFailed(
-                new AgentRunHandle($run->uid, $run->uuid),
-                new RuntimeException('The event-stream position could not be determined after the resume claim'),
-            );
-
-            throw RunStateUnavailableException::forRun($runUuid);
-        }
-
-        // The submission is part of the run's audit stream (best-effort): who
-        // submitted, before the continuation's own events — never the values.
-        $this->persister->recordInput($handle, $submission->submittedByBeUser);
-
-        // Tools resume under the RUN OWNER's identity (ADR-083), not the
-        // submitter — same rule as approve().
-        return $this->runExecutor()->executeResume(
-            $handle,
-            $onStep,
-            AiActorContext::backendUser($run->beUser),
-            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resumeWithInput(
-                $state,
-                $submission->data,
-                $configuration,
-                $context,
-                null,
-                $trace,
-                $submission->submittedByBeUser,
-            ),
-        );
+        return $this->resumeCoordinator()->submitInput($actor, $runUuid, $submission, $onStep);
     }
 
     public function cancel(AiActorContext $actor, string $runUuid): bool

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -23,7 +23,6 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
-use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
@@ -52,7 +51,6 @@ use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Throwable;
 
 /**
@@ -136,7 +134,21 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // holds — without forced skills or snippets, which only the queue path
         // resolves.
         private ?AgentRunRequestCodec $requestCodec = null,
+        // Decides retry-vs-dead-letter for a failed queued run (ADR-104).
+        // Optional for the same reason as the collaborators above; a null
+        // builds one over the persister, logger and bus this runtime holds,
+        // which is exactly what it was constructed with before.
+        private ?QueuedRunFailureRecovery $failureRecovery = null,
     ) {}
+
+    /**
+     * The recovery for a failed queued run, falling back to one built from this
+     * runtime's own collaborators when none was injected.
+     */
+    private function failureRecovery(): QueuedRunFailureRecovery
+    {
+        return $this->failureRecovery ?? new QueuedRunFailureRecovery($this->persister, $this->logger, $this->messageBus);
+    }
 
     /**
      * The codec for the queued-request payload, falling back to a bare instance
@@ -270,119 +282,10 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // recover closure decides retry-vs-dead-letter for a failure (ADR-104).
         $recover = function (Throwable $e, array $steps) use ($handle, $runUuid, $workerIdentity): AgentRunResult {
             /** @var list<RunStep> $steps the ladder always passes the accumulated step list */
-            return $this->recoverQueuedFailure($handle, $runUuid, $workerIdentity, $e, $steps);
+            return $this->failureRecovery()->recover($handle, $runUuid, $workerIdentity, $e, $steps);
         };
 
         return $this->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
-    }
-
-    /**
-     * Decide the fate of a FAILED queued run (ADR-104), invoked from the ladder
-     * BEFORE the default settleFailed. Returns the outcome that replaces the
-     * generic FAILED — for a queued run every branch settles the row itself, so
-     * the ladder never falls through to PROVIDER_FAILED. Fully fail-soft: it
-     * must never throw — {@see runQueued()} does not throw once the claim is
-     * won — so a failure of the recovery machinery itself dead-letters the run.
-     *
-     * @param list<RunStep> $steps
-     */
-    private function recoverQueuedFailure(AgentRunHandle $handle, string $runUuid, string $workerIdentity, Throwable $e, array $steps): AgentRunResult
-    {
-        try {
-            $class = FailureClassifier::classify($e);
-
-            // A class retrying cannot fix (auth, config, a 4xx client error):
-            // dead-letter immediately, distinct from PROVIDER_FAILED so it never
-            // reads as retryable.
-            if (!$class->isRetryable()) {
-                // Ownership-guarded like the requeue branch below: if this worker
-                // no longer owns the run (reaper reclaimed it), do NOT settle —
-                // return LEASE_LOST and leave the row to its current owner.
-                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
-                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
-
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
-                }
-                $this->logger?->warning('Queued agent run failed with a non-retryable error; dead-lettered', ['run' => $runUuid, 'class' => $class->value]);
-
-                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
-            }
-
-            // Retryable in principle — but is the requeue budget spent? Re-read
-            // the row; a null read (-1) forces the fail-closed dead-letter.
-            $currentRun = $this->persister->findRun($runUuid);
-
-            // A non-idempotent write was in flight when this failed (ADR-111): its
-            // side effect may already have landed, so a retry could double it.
-            // Dead-letter regardless of the retry budget — a retryable error class
-            // does not make a repeated write safe.
-            if ($currentRun instanceof AgentRun && !self::mayRetryAfterFence($currentRun->pendingEffect)) {
-                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
-                }
-                $this->logger?->warning('Queued agent run failed mid non-idempotent write; dead-lettered instead of retried (ADR-111)', ['run' => $runUuid]);
-
-                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
-            }
-
-            $count = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
-            if ($count < 0 || $count >= self::MAX_REQUEUES) {
-                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity)) {
-                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
-
-                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
-                }
-                $this->logger?->warning('Queued agent run exhausted its retry budget; dead-lettered', ['run' => $runUuid, 'requeueCount' => $count]);
-
-                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
-            }
-
-            // Requeue under an ownership guard. false => this worker no longer
-            // owns the run (the reaper reclaimed it, another worker holds it, or
-            // a concurrent cancel won). Do NOT settle: the row belongs to its
-            // current owner and settling it would destroy that owner's state.
-            if (!$this->persister->requeue($handle, $workerIdentity)) {
-                $this->logger?->notice('Queued agent run could not be requeued (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
-
-                return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
-            }
-
-            // The row is QUEUED again: wake a worker for the retry, backing off.
-            // A dispatch failure would strand the QUEUED row (async transport),
-            // so the outer catch dead-letters it (finishRun's guard covers
-            // QUEUED). The sync transport ignores the delay and re-executes
-            // in-process, bounded by MAX_REQUEUES.
-            $this->dispatchRequeue($handle->uuid, $count);
-
-            return new AgentRunResult(outcome: AgentRunOutcome::REQUEUED, runUuid: $runUuid, steps: $steps, error: $e);
-        } catch (Throwable $internal) {
-            $this->logger?->error('Queued agent run recovery failed; dead-lettering', ['run' => $runUuid, 'exception' => $internal]);
-            try {
-                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity);
-            } catch (Throwable) {
-                // The persister is itself fail-soft; nothing more can be done.
-            }
-
-            return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
-        }
-    }
-
-    /**
-     * Dispatch a delayed wake-up for a requeued run (ADR-104). Throws when no
-     * bus is wired — unreachable in practice (a queued run only exists when
-     * enqueue() dispatched, which requires the bus) but surfaced so the caller
-     * dead-letters rather than stranding a QUEUED row.
-     */
-    private function dispatchRequeue(string $uuid, int $priorRequeueCount): void
-    {
-        if ($this->messageBus === null) {
-            throw RunEnqueueFailedException::forRun($uuid);
-        }
-
-        // 2 ** $n widens to int|float under static analysis; the cap keeps the
-        // result well inside int range, so the cast is exact, not lossy.
-        $delayMs = (int)min(self::REQUEUE_BACKOFF_MS * (2 ** $priorRequeueCount), self::REQUEUE_BACKOFF_CAP_MS);
-        $this->messageBus->dispatch(new AgentRunQueuedMessage($uuid), [new DelayStamp($delayMs)]);
     }
 
     /**

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -15,14 +15,9 @@ use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
-use Netresearch\NrLlm\Domain\Model\PromptSnippet;
-use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
-use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
-use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
-use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
@@ -42,7 +37,6 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
-use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
@@ -51,7 +45,6 @@ use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\InputSchema;
-use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
@@ -120,8 +113,6 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         private LlmConfigurationRepository $configurationRepository,
         private ?LoggerInterface $logger = null,
         private ?MessageBusInterface $messageBus = null,
-        private ?SkillRepository $skillRepository = null,
-        private ?PromptSnippetRepository $promptSnippetRepository = null,
         // Validates a submitted input against a tool's declared schema (ADR-105).
         // Optional in the ctor only so the lean test wiring and the positional
         // construction sites keep working; submitInput() always validates,
@@ -138,7 +129,23 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // read-only — safe today (no builtin writes) and only reachable in bare
         // test construction, never in the autowired runtime.
         private ?ToolEffectResolver $toolEffectResolver = null,
+        // Serialises a request into, and back out of, the queued row (ADR-102).
+        // Optional in the ctor only for the positional test wiring, like the
+        // collaborators above; production autowires it, and a null builds a
+        // codec over the same configuration repository this runtime already
+        // holds — without forced skills or snippets, which only the queue path
+        // resolves.
+        private ?AgentRunRequestCodec $requestCodec = null,
     ) {}
+
+    /**
+     * The codec for the queued-request payload, falling back to a bare instance
+     * when none was injected.
+     */
+    private function requestCodec(): AgentRunRequestCodec
+    {
+        return $this->requestCodec ?? new AgentRunRequestCodec($this->configurationRepository);
+    }
 
     /**
      * Build the tool-execution context for a run from its explicit actor: the
@@ -168,7 +175,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
 
         try {
             $requestJson = json_encode(
-                $this->dehydrateRequest($request),
+                $this->requestCodec()->dehydrate($request),
                 JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
             );
         } catch (Throwable $e) {
@@ -246,7 +253,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         }
 
         try {
-            $request = $this->rehydrateRequest($run);
+            $request = $this->requestCodec()->rehydrate($run);
         } catch (Throwable $e) {
             $this->persister->settleFailed($handle, $e);
             $this->logger?->error('Queued agent run could not be rehydrated; the run was failed', ['run' => $runUuid, 'exception' => $e]);
@@ -426,213 +433,6 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     }
 
     /**
-     * Serialise a request for the queued row (ADR-102). Entities travel as
-     * uids (the rehydrator re-loads them — the same identity-over-snapshot
-     * choice approve() makes for the configuration); messages and options use
-     * their established array forms (the SuspendedRunState precedent).
-     *
-     * @return array<string, mixed>
-     */
-    private function dehydrateRequest(AgentRunRequest $request): array
-    {
-        $augmentation = $request->augmentation;
-
-        return [
-            'messages'         => array_map(
-                static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m,
-                $request->messages,
-            ),
-            // The FULL initiating actor (ADR-083), not just its backend-user id:
-            // a worker rehydrating this run must authorise with the identity that
-            // enqueued the work — admin flag, groups, service account — rather
-            // than the worker's absent ambient BE user.
-            'actor'            => $request->actor->toArray(),
-            'allowedToolNames' => $request->allowedToolNames,
-            'options'          => $request->options?->toArray(),
-            // ToolOptions::toArray() deliberately excludes the budget fields and
-            // the idempotency key (they are not provider API fields), but a
-            // queued run's budget PRE-FLIGHT has not happened yet — unlike the
-            // ADR-084 resume case that exclusion was designed for. Carry them
-            // out-of-band so run() and enqueue()+runQueued() of the same
-            // request hit the identical budget gate and dedup.
-            'plannedCost'      => $request->options?->getPlannedCost(),
-            'idempotencyKey'   => $request->options?->getIdempotencyKey(),
-            'maxIterations'    => $request->maxIterations,
-            'captureRaw'       => $request->captureRaw,
-            // null stays null: a non-null augmentation makes the loop bake the
-            // effective system prompt into the transcript (ADR-060 assembly),
-            // which a null-augmentation run() would not do — losing the
-            // distinction would silently change the prompt composition.
-            'augmentation'     => $augmentation === null ? null : [
-                'forcedSkillUids'   => array_values(array_filter(array_map(
-                    static fn(Skill $skill): int => $skill->getUid() ?? 0,
-                    $augmentation->forcedSkills,
-                ))),
-                'forcedSnippetUids' => array_values(array_filter(array_map(
-                    static fn(PromptSnippet $snippet): int => $snippet->getUid() ?? 0,
-                    $augmentation->forcedSnippets,
-                ))),
-                'dryRun'            => $augmentation->dryRun,
-            ],
-        ];
-    }
-
-    /**
-     * Rebuild the request from a claimed queued row (ADR-102). The
-     * configuration and the forced skills/snippets are re-loaded by uid — a
-     * configuration deleted while the run was queued fails the run, and a
-     * skill/snippet deleted meanwhile is simply no longer forced (the same
-     * live-resolution semantics the interactive path has).
-     */
-    private function rehydrateRequest(AgentRun $run): AgentRunRequest
-    {
-        // The same typed absence approve() reports — here it is caught by
-        // runQueued()'s rehydration guard, which settles the run FAILED with a
-        // meaningful error class instead of letting it escape.
-        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
-        if ($configuration === null) {
-            throw RunConfigurationGoneException::forRun($run->uuid);
-        }
-
-        $data = json_decode($run->queuedRequest ?? '', true);
-        if (!is_array($data)) {
-            throw new RuntimeException(sprintf('The stored request of queued run %s could not be decoded', $run->uuid), 2826462004);
-        }
-
-        $messages = [];
-        foreach (is_array($data['messages'] ?? null) ? $data['messages'] : [] as $message) {
-            if (is_array($message)) {
-                /** @var array<string, mixed> $message */
-                $messages[] = $message;
-            }
-        }
-
-        $allowed = null;
-        if (is_array($data['allowedToolNames'] ?? null)) {
-            $allowed = array_values(array_filter($data['allowedToolNames'], is_string(...)));
-        }
-
-        $options = null;
-        if (is_array($data['options'] ?? null)) {
-            /** @var array<string, mixed> $optionsData */
-            $optionsData = $data['options'];
-            // The initiator on the run row attributes the budget pre-flight,
-            // exactly as the interactive path does.
-            $options = ToolOptions::fromArray($optionsData, $run->beUser !== 0 ? $run->beUser : null);
-            // Re-inject the out-of-band budget/idempotency fields (see
-            // dehydrateRequest()): a queued run's budget pre-flight must be as
-            // strict as the direct path's, and its provider calls as
-            // deduplicatable.
-            $plannedCost = $data['plannedCost'] ?? null;
-            if (is_float($plannedCost) || is_int($plannedCost)) {
-                $options = $options->withPlannedCost((float)$plannedCost);
-            }
-            $idempotencyKey = $data['idempotencyKey'] ?? null;
-            if (is_string($idempotencyKey) && $idempotencyKey !== '') {
-                $options = $options->withIdempotencyKey($idempotencyKey);
-            }
-        }
-
-        $augmentation = null;
-        if (is_array($data['augmentation'] ?? null)) {
-            $augmentationData = $data['augmentation'];
-            $augmentation     = new RunAugmentation(
-                forcedSkills: $this->skillsByUids($this->uidList($augmentationData['forcedSkillUids'] ?? null)),
-                forcedSnippets: $this->snippetsByUids($this->uidList($augmentationData['forcedSnippetUids'] ?? null)),
-                dryRun: ($augmentationData['dryRun'] ?? false) === true,
-            );
-        }
-
-        // Restore the full initiating actor from the serialised request. A row
-        // queued before actors were persisted has no 'actor' key: fall back to
-        // the stored be_user id (the same single-int identity the pre-actor
-        // worker had), so an in-flight upgrade never loses or invents privilege.
-        $actorData = $data['actor'] ?? null;
-        if (is_array($actorData)) {
-            /** @var array<string, mixed> $actorData a serialised actor is a JSON object (string keys) */
-            $actor = AiActorContext::fromArray($actorData);
-        } else {
-            $actor = AiActorContext::backendUser($run->beUser);
-        }
-
-        return new AgentRunRequest(
-            configuration: $configuration,
-            messages: $messages,
-            actor: $actor,
-            allowedToolNames: $allowed,
-            options: $options,
-            maxIterations: is_int($data['maxIterations'] ?? null) ? $data['maxIterations'] : null,
-            augmentation: $augmentation,
-            captureRaw: ($data['captureRaw'] ?? false) === true,
-        );
-    }
-
-    /**
-     * @return list<int>
-     */
-    private function uidList(mixed $value): array
-    {
-        if (!is_array($value)) {
-            return [];
-        }
-
-        $uids = [];
-        foreach ($value as $uid) {
-            if (is_int($uid) && $uid > 0) {
-                $uids[] = $uid;
-            }
-        }
-
-        return $uids;
-    }
-
-    /**
-     * Forced skills by uid, preserving order. Resolved without the enabled
-     * filter — forcing a skill overrides its global toggle, the same semantics
-     * the playground's force-inject control has.
-     *
-     * @param list<int> $uids
-     *
-     * @return list<Skill>
-     */
-    private function skillsByUids(array $uids): array
-    {
-        if ($uids === [] || $this->skillRepository === null) {
-            return [];
-        }
-
-        $byUid = [];
-        foreach ($this->skillRepository->findAll() as $skill) {
-            if ($skill instanceof Skill && $skill->getUid() !== null) {
-                $byUid[$skill->getUid()] = $skill;
-            }
-        }
-
-        $skills = [];
-        foreach ($uids as $uid) {
-            if (isset($byUid[$uid])) {
-                $skills[] = $byUid[$uid];
-            }
-        }
-
-        return $skills;
-    }
-
-    /**
-     * @param list<int> $uids
-     *
-     * @return list<PromptSnippet>
-     */
-    private function snippetsByUids(array $uids): array
-    {
-        if ($uids === [] || $this->promptSnippetRepository === null) {
-            return [];
-        }
-
-        return $this->promptSnippetRepository->findByUids($uids);
-    }
-
-    /**
      * Which worker claimed a queued run — host + pid, for lease diagnostics.
      */
     private function workerIdentity(): string
@@ -702,7 +502,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         $trace = $this->trace($handle, $onStep, false);
         // Tools resume under the RUN OWNER's identity (ADR-083), not whoever is
         // approving: the owner is who the queued work acts for. Reconstructed
-        // from the run row's initiating uid — the same fallback rehydrateRequest()
+        // from the run row's initiating uid — the same fallback the request codec
         // uses — and resolved to a live user, so authorization is identical to
         // the original synchronous/worker execution.
         $context = $this->toolContext(AiActorContext::backendUser($run->beUser));

--- a/Classes/Service/Agent/QueuedRunCoordinator.php
+++ b/Classes/Service/Agent/QueuedRunCoordinator.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Closure;
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
+
+/**
+ * Puts a run on the queue and picks it back up in a worker (ADR-102).
+ *
+ * The two halves are one protocol and only make sense together: what
+ * {@see self::enqueue()} stores — a serialised request on a fail-closed row,
+ * dispatched only after the row exists — is what {@see self::runQueued()} has
+ * to be able to claim, position and rehydrate. Both are fail-closed in the same
+ * direction: a queued run that cannot be stored, dispatched, positioned or
+ * rehydrated is settled rather than left as an orphan a worker would later find
+ * in an impossible state.
+ *
+ * Claiming is the ordering guarantee: exactly one worker wins the guarded
+ * QUEUED -> RUNNING transition, and the event-stream position is resolved from
+ * a FRESH row afterwards so a requeued run continues its stream instead of
+ * reusing sequence numbers.
+ *
+ * What happens once a claimed run executes is not here — the executor drives
+ * it, and the failure recovery decides retry-versus-dead-letter.
+ */
+final readonly class QueuedRunCoordinator
+{
+    public function __construct(
+        private AgentRunPersister $persister,
+        private AgentRunRequestCodec $requestCodec,
+        private AgentRunExecutor $executor,
+        private QueuedRunFailureRecovery $failureRecovery,
+        private ?LoggerInterface $logger = null,
+        private ?MessageBusInterface $messageBus = null,
+    ) {}
+
+    public function enqueue(AgentRunRequest $request): string
+    {
+        if ($this->messageBus === null) {
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        try {
+            $requestJson = json_encode(
+                $this->requestCodec->dehydrate($request),
+                JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
+            );
+        } catch (Throwable $e) {
+            // A non-encodable payload value (INF/NAN in a raw message array)
+            // must surface as the interface's documented failure type, not a
+            // bare JsonException. Nothing was stored yet — no cleanup needed.
+            $this->logger?->error('Agent run request could not be serialised for the queue', ['exception' => $e]);
+
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        // Fail-closed, unlike run(): a live run can proceed unpersisted, but a
+        // queued run without a stored row simply does not exist.
+        $handle = $this->persister->enqueue($request->configuration, $request->actor->backendUserUid, $requestJson);
+        if ($handle === null) {
+            throw RunEnqueueFailedException::forRun('');
+        }
+
+        try {
+            // The wake-up call. On the default SyncTransport the run executes
+            // right here; routed to the doctrine transport it executes in
+            // messenger:consume. The claim makes a duplicate dispatch harmless.
+            $this->messageBus->dispatch(new AgentRunQueuedMessage($handle->uuid));
+        } catch (Throwable $e) {
+            // On an async transport a failed dispatch would strand the row
+            // QUEUED forever (no message will ever arrive) — settle it failed
+            // so no orphan is left behind. On the sync transport a handler
+            // failure never reaches here (runQueued() settles outcomes itself
+            // and does not throw), so this is genuinely the transport failing.
+            $this->persister->settleFailed($handle, $e);
+            $this->logger?->error('Queued agent run could not be dispatched; the run was failed', ['run' => $handle->uuid, 'exception' => $e]);
+
+            throw RunEnqueueFailedException::forRun($handle->uuid);
+        }
+
+        return $handle->uuid;
+    }
+
+    /**
+     * Claim and execute one queued run, or report that it is not claimable.
+     *
+     * Returns null when the row is gone, no longer QUEUED, or was won by
+     * another worker; an {@see AgentRunResult} in every other case, including
+     * the settled-FAILED ones. It does not throw once the claim is won —
+     * settling the row is how a failure is reported (ADR-104).
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::QUEUED || $run->queuedRequest === null) {
+            return null;
+        }
+
+        // Exactly one worker wins the guarded QUEUED -> RUNNING transition; a
+        // run cancelled while waiting is terminal and unclaimable (ADR-102).
+        $workerIdentity = $this->workerIdentity();
+        if (!$this->persister->claimQueued($run, $workerIdentity, time() + AgentRuntime::LEASE_SECONDS)) {
+            return null;
+        }
+
+        // Resolve the event-stream position from a FRESH row AFTER the claim.
+        // A first execution has no events (MAX = -1 -> sequence 0, identical to
+        // before ADR-104); a REQUEUED run carries the prior attempt's events, so
+        // starting at 0 would reuse sequences and corrupt the stream. Fail-closed
+        // like AgentRuntime::approve(): a null position settles the run FAILED rather than
+        // stranding it RUNNING (the claim is already won).
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $fallback = new AgentRunHandle($run->uid, $run->uuid);
+            $this->persister->settleFailed(
+                $fallback,
+                new RuntimeException(sprintf('The event-stream position of queued run %s could not be determined after the claim', $runUuid), 1784900002),
+            );
+            $this->logger?->error('Queued agent run position could not be resolved after the claim; the run was failed', ['run' => $runUuid]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: [],
+                error: new RuntimeException('The event-stream position could not be determined after the queue claim', 1784900002),
+            );
+        }
+
+        try {
+            $request = $this->requestCodec->rehydrate($run);
+        } catch (Throwable $e) {
+            $this->persister->settleFailed($handle, $e);
+            $this->logger?->error('Queued agent run could not be rehydrated; the run was failed', ['run' => $runUuid, 'exception' => $e]);
+
+            return new AgentRunResult(
+                outcome: AgentRunOutcome::FAILED,
+                runUuid: $runUuid,
+                steps: [],
+                error: $e,
+            );
+        }
+
+        // The heartbeat renews the lease under this worker's identity, and the
+        // recover closure decides retry-vs-dead-letter for a failure (ADR-104).
+        $recover = function (Throwable $e, array $steps) use ($handle, $runUuid, $workerIdentity): AgentRunResult {
+            /** @var list<RunStep> $steps the ladder always passes the accumulated step list */
+            return $this->failureRecovery->recover($handle, $runUuid, $workerIdentity, $e, $steps);
+        };
+
+        return $this->executor->executeRequest($request, $handle, $onStep, $workerIdentity, $recover);
+    }
+
+    /**
+     * Which worker claimed a queued run — host + pid, for lease diagnostics.
+     */
+    private function workerIdentity(): string
+    {
+        $host = gethostname();
+
+        return substr(($host !== false ? $host : 'unknown') . ':' . getmypid(), 0, 64);
+    }
+}

--- a/Classes/Service/Agent/QueuedRunFailureRecovery.php
+++ b/Classes/Service/Agent/QueuedRunFailureRecovery.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
+use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
+use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Throwable;
+
+/**
+ * What becomes of a queued run that failed (ADR-104): retry it, or stop.
+ *
+ * The decision has four inputs — whether the error class is retryable at all,
+ * whether a non-idempotent write was fenced in flight, how much of the requeue
+ * budget is left, and whether this worker still owns the row — and each of them
+ * can independently force a dead-letter. Keeping them in one place is what
+ * makes the ordering between them reviewable.
+ *
+ * Every path settles the row itself, so the caller's ladder never falls through
+ * to a generic failure. The class is fail-soft by contract: a failure of the
+ * recovery machinery dead-letters the run rather than escaping into a caller
+ * that, past the claim, does not throw.
+ *
+ * The retry budget and backoff remain {@see AgentRuntime}'s published
+ * constants; what moved here is the decision that reads them.
+ */
+final readonly class QueuedRunFailureRecovery
+{
+    public function __construct(
+        private AgentRunPersister $persister,
+        private ?LoggerInterface $logger = null,
+        private ?MessageBusInterface $messageBus = null,
+    ) {}
+
+    /**
+     * Decide the fate of a FAILED queued run (ADR-104), invoked from the ladder
+     * BEFORE the default settleFailed. Returns the outcome that replaces the
+     * generic FAILED — for a queued run every branch settles the row itself, so
+     * the ladder never falls through to PROVIDER_FAILED. Fully fail-soft: it
+     * must never throw — {@see AgentRuntime::runQueued()} does not throw once
+     * the claim is won — so a failure of the recovery machinery itself
+     * dead-letters the run.
+     *
+     * @param list<RunStep> $steps
+     */
+    public function recover(AgentRunHandle $handle, string $runUuid, string $workerIdentity, Throwable $e, array $steps): AgentRunResult
+    {
+        try {
+            $class = FailureClassifier::classify($e);
+
+            // A class retrying cannot fix (auth, config, a 4xx client error):
+            // dead-letter immediately, distinct from PROVIDER_FAILED so it never
+            // reads as retryable.
+            if (!$class->isRetryable()) {
+                // Ownership-guarded like the requeue branch below: if this worker
+                // no longer owns the run (reaper reclaimed it), do NOT settle —
+                // return LEASE_LOST and leave the row to its current owner.
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
+                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
+                $this->logger?->warning('Queued agent run failed with a non-retryable error; dead-lettered', ['run' => $runUuid, 'class' => $class->value]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // Retryable in principle — but is the requeue budget spent? Re-read
+            // the row; a null read (-1) forces the fail-closed dead-letter.
+            $currentRun = $this->persister->findRun($runUuid);
+
+            // A non-idempotent write was in flight when this failed (ADR-111): its
+            // side effect may already have landed, so a retry could double it.
+            // Dead-letter regardless of the retry budget — a retryable error class
+            // does not make a repeated write safe.
+            if ($currentRun instanceof AgentRun && !AgentRuntime::mayRetryAfterFence($currentRun->pendingEffect)) {
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
+                $this->logger?->warning('Queued agent run failed mid non-idempotent write; dead-lettered instead of retried (ADR-111)', ['run' => $runUuid]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            $count = $currentRun instanceof AgentRun ? $currentRun->requeueCount : -1;
+            if ($count < 0 || $count >= AgentRuntime::MAX_REQUEUES) {
+                if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity)) {
+                    $this->logger?->notice('Queued agent run could not be dead-lettered (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                    return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+                }
+                $this->logger?->warning('Queued agent run exhausted its retry budget; dead-lettered', ['run' => $runUuid, 'requeueCount' => $count]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // Requeue under an ownership guard. false => this worker no longer
+            // owns the run (the reaper reclaimed it, another worker holds it, or
+            // a concurrent cancel won). Do NOT settle: the row belongs to its
+            // current owner and settling it would destroy that owner's state.
+            if (!$this->persister->requeue($handle, $workerIdentity)) {
+                $this->logger?->notice('Queued agent run could not be requeued (ownership lost or already terminal); leaving it untouched', ['run' => $runUuid]);
+
+                return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
+            }
+
+            // The row is QUEUED again: wake a worker for the retry, backing off.
+            // A dispatch failure would strand the QUEUED row (async transport),
+            // so the outer catch dead-letters it (finishRun's guard covers
+            // QUEUED). The sync transport ignores the delay and re-executes
+            // in-process, bounded by MAX_REQUEUES.
+            $this->dispatchRequeue($handle->uuid, $count);
+
+            return new AgentRunResult(outcome: AgentRunOutcome::REQUEUED, runUuid: $runUuid, steps: $steps, error: $e);
+        } catch (Throwable $internal) {
+            $this->logger?->error('Queued agent run recovery failed; dead-lettering', ['run' => $runUuid, 'exception' => $internal]);
+            try {
+                $this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::RETRIES_EXHAUSTED, $workerIdentity);
+            } catch (Throwable) {
+                // The persister is itself fail-soft; nothing more can be done.
+            }
+
+            return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
+        }
+    }
+
+    /**
+     * Dispatch a delayed wake-up for a requeued run (ADR-104). Throws when no
+     * bus is wired — unreachable in practice (a queued run only exists when
+     * enqueue() dispatched, which requires the bus) but surfaced so the caller
+     * dead-letters rather than stranding a QUEUED row.
+     */
+    private function dispatchRequeue(string $uuid, int $priorRequeueCount): void
+    {
+        if ($this->messageBus === null) {
+            throw RunEnqueueFailedException::forRun($uuid);
+        }
+
+        // 2 ** $n widens to int|float under static analysis; the cap keeps the
+        // result well inside int range, so the cast is exact, not lossy.
+        $delayMs = (int)min(AgentRuntime::REQUEUE_BACKOFF_MS * (2 ** $priorRequeueCount), AgentRuntime::REQUEUE_BACKOFF_CAP_MS);
+        $this->messageBus->dispatch(new AgentRunQueuedMessage($uuid), [new DelayStamp($delayMs)]);
+    }
+}

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Closure;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
+use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
+use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\InputSchema;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use RuntimeException;
+
+/**
+ * Picks a suspended run back up: an approval decision (ADR-084) or a submitted
+ * input (ADR-105).
+ *
+ * Both follow the same claim protocol, and the order in it is the safety
+ * property: probe that a resume handle can be built at all, win the atomic
+ * claim so a second caller cannot resume the same run, then re-resolve the
+ * event-stream position from a FRESH row — the claim moved it. A position that
+ * cannot be resolved after the claim settles the run rather than leaving it
+ * RUNNING with nowhere to write.
+ *
+ * The one deliberate divergence is ADR-105's: a submitted input is validated
+ * against the tool's declared schema BEFORE anything is probed or claimed, so a
+ * rejection leaves the run WAITING_FOR_INPUT with nothing claimed and no event
+ * recorded and the user can simply resubmit. An approval has nothing to
+ * validate and claims first.
+ *
+ * Both refuse a caller that may not act on the run, and both resume tools under
+ * the RUN OWNER's identity rather than the approver's or the submitter's
+ * (ADR-083).
+ */
+final readonly class ResumeCoordinator
+{
+    public function __construct(
+        private AgentRunPersister $persister,
+        private LlmConfigurationRepository $configurationRepository,
+        private ToolLoopServiceInterface $toolLoop,
+        private AgentRunExecutor $executor,
+        // Validates a submitted input against a tool's declared schema
+        // (ADR-105). A null falls back to a fresh stateless validator;
+        // submitInput() always validates.
+        private ?JsonSchemaValidator $schemaValidator = null,
+    ) {}
+
+    /**
+     * Resume a run waiting on an approval decision (ADR-084).
+     *
+     * Claims first — an approval has nothing to validate — then continues the
+     * tool loop under the run OWNER's identity. Throws rather than returning a
+     * failed result when the run is not resumable: the caller distinguishes
+     * "wrong state", "not yours", "already resuming" and "corrupt state".
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    public function approve(AiActorContext $actor, string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
+            throw RunNotAwaitingApprovalException::forRun($runUuid);
+        }
+        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
+            throw RunAccessDeniedException::forActor($actor, $runUuid);
+        }
+
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw RunConfigurationGoneException::forRun($runUuid);
+        }
+
+        $decoded = json_decode($run->suspendedState, true);
+        if (!is_array($decoded)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+        /** @var array<string, mixed> $decoded */
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Probe the event-stream position BEFORE the claim: a failure here
+        // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
+        // the approval can simply be retried (nothing was claimed or executed).
+        if ($this->persister->resumeHandle($run) === null) {
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // Atomically claim the run before executing its pending (approval-gated,
+        // possibly destructive) tool calls, so two concurrent Approve requests
+        // cannot both run them (ADR-084). Fail-closed on a store error too.
+        if (!$this->persister->claimResume($run)) {
+            throw RunAlreadyResumingException::forRun($runUuid);
+        }
+
+        // Re-resolve the position from a FRESH row snapshot AFTER winning the
+        // claim: a request that stalled between findRun and the claim may hold
+        // a stale position from before another approval's continuation
+        // appended events — writing there would duplicate sequences and
+        // interleave segments. The claim is won, so a failure now settles the
+        // run rather than stranding it RUNNING (fail-closed either way).
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $this->persister->settleFailed(
+                new AgentRunHandle($run->uid, $run->uuid),
+                new RuntimeException('The event-stream position could not be determined after the resume claim'),
+            );
+
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // The decision is part of the run's audit stream (best-effort, ADR-101):
+        // who approved or denied, before the continuation's own events.
+        $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
+
+        // Tools resume under the RUN OWNER's identity (ADR-083), not whoever is
+        // approving: the owner is who the queued work acts for. Reconstructed
+        // from the run row's initiating uid — the same fallback the request codec
+        // uses — and resolved to a live user, so authorization is identical to
+        // the original synchronous/worker execution.
+        return $this->executor->executeResume(
+            $handle,
+            $onStep,
+            AiActorContext::backendUser($run->beUser),
+            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resume(
+                $state,
+                $decision->approved,
+                $configuration,
+                $context,
+                null,
+                $trace,
+                $decision->decidedByBeUser,
+            ),
+        );
+    }
+
+    /**
+     * Resume a run waiting on a submitted input (ADR-105).
+     *
+     * Validates the submission against the tool's declared schema BEFORE
+     * probing or claiming, so a rejection leaves the run WAITING_FOR_INPUT with
+     * nothing claimed and the user can resubmit. From there the flow is
+     * {@see self::approve()}'s.
+     *
+     * @param (Closure(RunStep): void)|null $onStep
+     */
+    public function submitInput(AiActorContext $actor, string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
+    {
+        $run = $this->persister->findRun($runUuid);
+        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
+            throw RunNotAwaitingInputException::forRun($runUuid);
+        }
+        if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
+            throw RunAccessDeniedException::forActor($actor, $runUuid);
+        }
+
+        $configuration = $this->configurationRepository->findByUid($run->configurationUid);
+        if ($configuration === null) {
+            throw RunConfigurationGoneException::forRun($runUuid);
+        }
+
+        $decoded = json_decode($run->suspendedState, true);
+        if (!is_array($decoded)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+        /** @var array<string, mixed> $decoded */
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Well-formedness gate (ADR-105 M2): an input suspension with no target
+        // tool or a degenerate schema is corruption, never "accept anything".
+        // validate($data, []) returns true, so this path must be unreachable
+        // before the validation below — a corrupt row is a 500, not resumable.
+        if ($state->inputToolName === null || $state->inputToolName === '' || !InputSchema::isUsable($state->inputSchema)) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+
+        // DIVERGENCE from approve() (ADR-105): validate the submission BEFORE
+        // probing or claiming. A rejection leaves the run WAITING_FOR_INPUT with
+        // nothing claimed and no event recorded, so the user can simply resubmit.
+        $validator = $this->schemaValidator ?? new JsonSchemaValidator();
+        if (!$validator->validate($submission->data, $state->inputSchema)) {
+            throw InvalidInputSubmissionException::forRun($runUuid);
+        }
+
+        // From here the flow is identical to approve(): probe-before-claim,
+        // atomic claim, re-resolve the stream position from a fresh row.
+        if ($this->persister->resumeHandle($run) === null) {
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        if (!$this->persister->claimResumeFromInput($run)) {
+            throw RunAlreadyResumingException::forRun($runUuid);
+        }
+
+        $claimed = $this->persister->findRun($runUuid);
+        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
+        if ($handle === null) {
+            $this->persister->settleFailed(
+                new AgentRunHandle($run->uid, $run->uuid),
+                new RuntimeException('The event-stream position could not be determined after the resume claim'),
+            );
+
+            throw RunStateUnavailableException::forRun($runUuid);
+        }
+
+        // The submission is part of the run's audit stream (best-effort): who
+        // submitted, before the continuation's own events — never the values.
+        $this->persister->recordInput($handle, $submission->submittedByBeUser);
+
+        // Tools resume under the RUN OWNER's identity (ADR-083), not the
+        // submitter — same rule as approve().
+        return $this->executor->executeResume(
+            $handle,
+            $onStep,
+            AiActorContext::backendUser($run->beUser),
+            fn(ToolExecutionContext $context, RunTrace $trace): ToolLoopResult => $this->toolLoop->resumeWithInput(
+                $state,
+                $submission->data,
+                $configuration,
+                $context,
+                null,
+                $trace,
+                $submission->submittedByBeUser,
+            ),
+        );
+    }
+}

--- a/Documentation/Adr/Adr103CooperativeCancellation.rst
+++ b/Documentation/Adr/Adr103CooperativeCancellation.rst
@@ -28,7 +28,7 @@ for exactly this: check the cancel flag *between* model and tool steps.
 Decision
 ========
 
-The AgentRuntime's trace hook gains a **cancellation probe**. Every step
+The run executor's trace hook gains a **cancellation probe**. Every step
 boundary — after a provider response, after each tool execution, before the
 next round — already records a step through the runtime's ``onRecord`` closure;
 the probe re-reads the run row there and, when it is CANCELLED, throws the

--- a/Documentation/Adr/Adr112LeaseBeforeOpWriteFence.rst
+++ b/Documentation/Adr/Adr112LeaseBeforeOpWriteFence.rst
@@ -57,7 +57,7 @@ retryable, everything else (including an unset or unrecognised value) is:
 - the stale-run reaper (:php:`ReapStaleAgentRunsCommand`) dead-letters a run
   reaped mid non-idempotent-write instead of reclaiming it onto the queue,
   regardless of the remaining retry budget;
-- the in-process recovery (:php:`AgentRuntime::recoverQueuedFailure()`)
+- the in-process recovery (:php:`QueuedRunFailureRecovery::recover()`)
   dead-letters such a run even when the failure class is otherwise retryable —
   a transient provider blip does not make a repeated write safe.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,24 +16,18 @@ governance audit trail.
 
 ## Next — agent runtime maturity
 
-1. **Decompose the agent runtime into focused internal services.**
-   `AgentRuntime` has grown through the hardening arc; split it along its
-   natural seams (authorization, request codec, queue coordination, lease
-   management, resume coordination, run execution, failure recovery, outcome
-   mapping) while staying one package (ADR-090). Behaviour-preserving; makes
-   the runtime testable per concern and safe to extend.
-2. **Make the tool loop's security collaborators mandatory.** The
+1. **Make the tool loop's security collaborators mandatory.** The
    `ToolLoopService` gates (tool-call policy, per-configuration allow-list,
    input schema validation) are optional constructor arguments today — absent
    wiring silently weakens the gate. Make them required, and give tests an
    explicit lean wiring (`Null*` implementations plus a `Testing` builder)
    instead of implicit absence. A container test pins the production wiring.
-3. **Conversation-level context-window management.** The tool loop already
+2. **Conversation-level context-window management.** The tool loop already
    bounds its transcript (ADR-107); conversations do not. Plan against the
    smallest reachable model window in the fallback chain — or re-fit when a
    fallback actually fires — so a long conversation degrades predictably
    instead of failing on the provider.
-4. **A first-class contract for side-effecting tools.** Promote the tool
+3. **A first-class contract for side-effecting tools.** Promote the tool
    effect declaration (read-only / idempotent write / non-idempotent write,
    ADR-111) into a tool-facing interface with an idempotency scope and an
    optional preview, so writing tools can be built against a contract instead

--- a/Tests/Unit/Service/Agent/AgentRunRequestCodecTest.php
+++ b/Tests/Unit/Service/Agent/AgentRunRequestCodecTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
+use Netresearch\NrLlm\Service\Agent\AgentRunRequestCodec;
+use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * The queued-request payload is the only place a run request has to survive
+ * outside a process, so what matters is that the two directions agree: every
+ * field {@see AgentRunRequestCodec::dehydrate()} writes must come back out of
+ * {@see AgentRunRequestCodec::rehydrate()} with the same meaning.
+ */
+#[CoversClass(AgentRunRequestCodec::class)]
+final class AgentRunRequestCodecTest extends TestCase
+{
+    private LlmConfigurationRepository&MockObject $configurationRepository;
+
+    private LlmConfiguration $configuration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = new LlmConfiguration();
+        $this->configuration->setIdentifier('test.configuration');
+
+        $this->configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+    }
+
+    private function codec(): AgentRunRequestCodec
+    {
+        return new AgentRunRequestCodec($this->configurationRepository);
+    }
+
+    /**
+     * A queued run row carrying the given serialised request.
+     */
+    private function queuedRun(string $payload, int $beUser = 7): AgentRun
+    {
+        return new AgentRun(
+            uid: 1,
+            uuid: 'run-uuid',
+            status: 'queued',
+            configurationUid: 42,
+            configurationIdentifier: 'test.configuration',
+            beUser: $beUser,
+            iterations: 0,
+            truncated: false,
+            totalPromptTokens: 0,
+            totalCompletionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: 0.0,
+            errorClass: '',
+            terminationReason: '',
+            startedAt: 0,
+            finishedAt: 0,
+            crdate: 0,
+            queuedRequest: $payload,
+        );
+    }
+
+    #[Test]
+    public function roundTripPreservesTheRequestFields(): void
+    {
+        $request = new AgentRunRequest(
+            configuration: $this->configuration,
+            messages: [['role' => 'user', 'content' => 'hello']],
+            actor: AiActorContext::backendUser(7),
+            allowedToolNames: ['read_page', 'read_record'],
+            options: new ToolOptions(temperature: 0.4),
+            maxIterations: 5,
+            captureRaw: true,
+        );
+
+        $payload = json_encode($this->codec()->dehydrate($request));
+        self::assertIsString($payload);
+
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+        $restored = $this->codec()->rehydrate($this->queuedRun($payload));
+
+        self::assertSame([['role' => 'user', 'content' => 'hello']], $restored->messages);
+        self::assertSame(['read_page', 'read_record'], $restored->allowedToolNames);
+        self::assertSame(5, $restored->maxIterations);
+        self::assertTrue($restored->captureRaw);
+        self::assertSame(7, $restored->actor->backendUserUid);
+        self::assertSame($this->configuration, $restored->configuration);
+    }
+
+    /**
+     * ToolOptions::toArray() drops the budget and idempotency fields, so the
+     * codec carries them out of band. A queued run must hit the same budget
+     * gate and the same provider-call dedup as the direct path.
+     */
+    #[Test]
+    public function roundTripCarriesTheBudgetAndIdempotencyFieldsOutOfBand(): void
+    {
+        $options = (new ToolOptions())
+            ->withPlannedCost(0.25)
+            ->withIdempotencyKey('idem-key-1');
+
+        $request = new AgentRunRequest(
+            configuration: $this->configuration,
+            messages: [],
+            actor: AiActorContext::backendUser(7),
+            options: $options,
+        );
+
+        $dehydrated = $this->codec()->dehydrate($request);
+        self::assertSame(0.25, $dehydrated['plannedCost']);
+        self::assertSame('idem-key-1', $dehydrated['idempotencyKey']);
+
+        $payload = json_encode($dehydrated);
+        self::assertIsString($payload);
+
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+        $restored = $this->codec()->rehydrate($this->queuedRun($payload));
+
+        self::assertNotNull($restored->options);
+        self::assertSame(0.25, $restored->options->getPlannedCost());
+        self::assertSame('idem-key-1', $restored->options->getIdempotencyKey());
+    }
+
+    /**
+     * A null augmentation must stay null: a non-null one makes the loop bake the
+     * effective system prompt into the transcript, which a null-augmentation run
+     * would not do.
+     */
+    #[Test]
+    public function aNullAugmentationSurvivesAsNull(): void
+    {
+        $request = new AgentRunRequest(
+            configuration: $this->configuration,
+            messages: [],
+            actor: AiActorContext::backendUser(7),
+        );
+
+        $dehydrated = $this->codec()->dehydrate($request);
+        self::assertNull($dehydrated['augmentation']);
+
+        $payload = json_encode($dehydrated);
+        self::assertIsString($payload);
+
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+        self::assertNull($this->codec()->rehydrate($this->queuedRun($payload))->augmentation);
+    }
+
+    /**
+     * A row queued before actors were persisted has no 'actor' key. It falls
+     * back to the stored be_user id, so an in-flight upgrade never loses or
+     * invents privilege.
+     */
+    #[Test]
+    public function aPayloadWithoutAnActorFallsBackToTheRunsBackendUser(): void
+    {
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+
+        $restored = $this->codec()->rehydrate($this->queuedRun('{"messages":[]}', beUser: 13));
+
+        self::assertSame(13, $restored->actor->backendUserUid);
+    }
+
+    #[Test]
+    public function aConfigurationDeletedWhileQueuedIsReportedAsGone(): void
+    {
+        $this->configurationRepository->method('findByUid')->willReturn(null);
+
+        $this->expectException(RunConfigurationGoneException::class);
+        $this->codec()->rehydrate($this->queuedRun('{"messages":[]}'));
+    }
+
+    #[Test]
+    public function anUndecodablePayloadIsRejected(): void
+    {
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+
+        $this->expectException(RuntimeException::class);
+        $this->codec()->rehydrate($this->queuedRun('not json'));
+    }
+}

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Service\Agent\AgentRunExecutor;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
@@ -43,6 +44,7 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\InputSubmission;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Agent\QueuedRunFailureRecovery;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
@@ -66,6 +68,8 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Throwable;
 
 #[CoversClass(AgentRuntime::class)]
+#[CoversClass(AgentRunExecutor::class)]
+#[CoversClass(QueuedRunFailureRecovery::class)]
 final class AgentRuntimeTest extends AbstractUnitTestCase
 {
     private RecordingAgentRunRepository $repository;

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -44,7 +44,9 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\InputSubmission;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Agent\QueuedRunCoordinator;
 use Netresearch\NrLlm\Service\Agent\QueuedRunFailureRecovery;
+use Netresearch\NrLlm\Service\Agent\ResumeCoordinator;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
@@ -70,6 +72,8 @@ use Throwable;
 #[CoversClass(AgentRuntime::class)]
 #[CoversClass(AgentRunExecutor::class)]
 #[CoversClass(QueuedRunFailureRecovery::class)]
+#[CoversClass(QueuedRunCoordinator::class)]
+#[CoversClass(ResumeCoordinator::class)]
 final class AgentRuntimeTest extends AbstractUnitTestCase
 {
     private RecordingAgentRunRepository $repository;


### PR DESCRIPTION
`ROADMAP.md` asked for `AgentRuntime` to be split along eight named seams. This does that. The class goes from **1218 lines to 266**, and what remains is the interface contract, the published constants, the retry predicate and delegation.

| seam | result |
|---|---|
| request codec | `AgentRunRequestCodec` |
| failure recovery | `QueuedRunFailureRecovery` |
| run execution | `AgentRunExecutor` |
| outcome mapping | inside the executor's ladder |
| lease management | inside the executor's ladder |
| queue coordination | `QueuedRunCoordinator` |
| resume coordination | `ResumeCoordinator` |
| authorization | no class — see below |

## The five classes

**`AgentRunRequestCodec`** — turning an `AgentRunRequest` into the JSON on a queued run row, and reading it back. The two directions are one contract: whatever `dehydrate()` writes, `rehydrate()` must read back with the same meaning. Two fields make that non-obvious — `ToolOptions::toArray()` deliberately drops the planned cost and the idempotency key, so the codec carries them out of band, or a queued run would meet a weaker budget gate than the same request run directly.

**`QueuedRunFailureRecovery`** — what becomes of a queued run that failed. Four conditions can each independently force a dead-letter rather than a retry: an error class retrying cannot fix, a non-idempotent write fenced in flight (ADR-111), an exhausted requeue budget, and a lost claim on the row. The order between them is the behaviour.

**`AgentRunExecutor`** — driving a run from its first round to a settled outcome: the catch order ADR-084 makes a hard guarantee, ADR-103's cancellation probe, ADR-104's lease heartbeat and lease-lost stop, ADR-111's write fence and fail-closed audit. It no longer knows where a run came from — a request, a claimed queue row and a resumed suspension all reach it as a handle, a trace and a closure producing the next tool-loop result, so the ordering guarantees hold identically on all three paths and can be exercised without a queue row, a resume claim or a provider.

`approve()` and `submitInput()` each used to rebuild the same sequence: trace over the claimed handle, tool context from the run OWNER rather than the approver or submitter (ADR-083), then the ladder. They now share one entry point that fixes that order in one place and takes only the tool-loop call that differs.

**`QueuedRunCoordinator`** — `enqueue()` and `runQueued()`. Two halves of one protocol: what `enqueue()` stores is what `runQueued()` has to claim, position and rehydrate, and both fail closed in the same direction, so a queued run that cannot be stored, dispatched, positioned or rehydrated is settled rather than left as an orphan a worker later finds in an impossible state.

**`ResumeCoordinator`** — `approve()` and `submitInput()`. Both follow the same claim protocol, and the order in it is the safety property: probe that a resume handle can be built, win the atomic claim, then re-resolve the event-stream position from a fresh row because the claim moved it. ADR-105's deliberate divergence — an input is validated against the tool's schema before anything is claimed, so a rejection leaves the run resumable — is now a divergence inside one class instead of a difference between two long methods to be found by reading both.

## Three seams that did not become classes

**Authorization** — nothing to extract. The guard is already a value-object method, `AiActorContext::mayActOnRun(AgentRun, ServiceAccountScope)`. What sits in `cancel()`, `events()` and `status()` is a find, that call, and a repository read; a class around it would be ceremony.

**Lease management** and **outcome mapping** live inside the executor's ladder. Renewing the lease, detecting a reaper reclaim, and mapping each caught exception to its `AgentRunOutcome` are steps of the same ordered sequence — separating them would move the ordering guarantee out of the place that has to honour it.

## What stays put deliberately

The five public constants and `mayRetryAfterFence()` remain on `AgentRuntime`: `ReapStaleAgentRunsCommand` and `ToolPlaygroundController` read them as published policy. The constructor does not shrink either — the accessor-with-fallback pattern this codebase uses requires every property to survive so a null-injected collaborator can be rebuilt from it.

## Breaking

`AgentRuntime`'s constructor drops `SkillRepository` and `PromptSnippetRepository`, which only the serialisation used. Both existing construction sites pass fewer positional arguments than that, and consumers go through `AgentRuntimeInterface`.

## Tests

Six new unit tests exercise the codec directly: the field-for-field round trip, the out-of-band budget and idempotency carry, a null augmentation staying null, the pre-actor payload falling back to the run's backend user, a configuration deleted while queued, and an undecodable payload.

The other four classes keep their existing coverage through `AgentRuntimeTest`, now with a `#[CoversClass]` each. That attribution is a fix, not bookkeeping: `QueuedRunFailureRecovery` had none, so its ~160 executed lines had silently dropped out of the reported coverage — both PHPUnit configs set `requireCoverageMetadata="false"`, which is why nothing went red. Repeating that for each extraction would have moved ~700 lines out of the number.

`AgentRunPersister` is `final readonly` and cannot be mocked, so a dedicated test for the persister-driven classes would duplicate the runtime test's fake-repository harness to assert what it already asserts.

Gates run locally on PHP 8.4 after each step and again on the rebased tree: unit (5672), functional sqlite (1293), phpstan, cgl, rector, fuzzy.

## Docs

`Adr112LeaseBeforeOpWriteFence.rst` named `AgentRuntime::recoverQueuedFailure()`, a method that had already ceased to exist; `Adr103CooperativeCancellation.rst` named the runtime's trace hook. Both now name the class that owns the behaviour. The roadmap item is removed rather than marked shipped — that file says outright that anything shipped belongs in the changelog.

## SonarCloud

Eight findings, every one on code that moved unchanged — Sonar measures a new file as new code:

| rule | where | |
|---|---|---|
| `php:S3776` | `AgentRunExecutor::execute()` | cognitive complexity 45 |
| `php:S1142` | `AgentRunExecutor::execute()` | 13 returns |
| `php:S3776` | `AgentRunExecutor::executeRequest()` | cognitive complexity 17 |
| `php:S3776` | `AgentRunRequestCodec::rehydrate()` | cognitive complexity 20 |
| `php:S112` | `AgentRunRequestCodec::rehydrate()` | generic `RuntimeException` |
| `php:S3776` | `QueuedRunFailureRecovery::recover()` | cognitive complexity 16 |
| `php:S1142` | `QueuedRunFailureRecovery::recover()` | 9 returns |
| `php:S1142` | `QueuedRunCoordinator::runQueued()` | 5 returns |

`execute()`'s 45 and its 13 returns are the ADR-084 catch ladder itself — six ordered catch arms, each with its own ownership-guarded settle and its own outcome. Splitting it to satisfy a threshold would take the ordering guarantee apart, which is the opposite of what this change is for. The guard-clause returns are the style this codebase uses deliberately. These want a won't-fix in the SonarCloud UI, not a code change.